### PR TITLE
fix(examples): add missing prerequisites and KWOK stage-fast in setup.sh

### DIFF
--- a/examples/self-hosted-local-development/setup.sh
+++ b/examples/self-hosted-local-development/setup.sh
@@ -182,6 +182,12 @@ check_tool docker "Install from https://www.docker.com/get-started"
 check_tool k3d "Install with: brew install k3d (or see https://k3d.io)"
 check_tool kubectl "Install from https://kubernetes.io/docs/tasks/tools/"
 check_tool helm "Install with: brew install helm (or see https://helm.sh)"
+check_tool helmfile "Install with: brew install helmfile (or see https://helmfile.readthedocs.io)"
+
+if ! helm plugin list 2>/dev/null | grep -q "^diff"; then
+    log_error "helm-diff plugin is not installed. Install with: helm plugin install https://github.com/databus23/helm-diff"
+    exit 1
+fi
 
 if ! docker info &> /dev/null; then
     log_error "Docker is not running. Please start Docker and try again."
@@ -213,6 +219,7 @@ else
     log_info "Installing KWOK controller..."
     kubectl apply -f https://github.com/kubernetes-sigs/kwok/releases/download/v0.7.0/kwok.yaml 2>&1 | grep -v "FlowSchema" || true
     kubectl wait --for=condition=Available deployment/kwok-controller -n kube-system --timeout=60s
+    kubectl apply -f https://github.com/kubernetes-sigs/kwok/releases/download/v0.7.0/stage-fast.yaml
     log_info "KWOK controller is ready."
 fi
 


### PR DESCRIPTION
## Customer Summary

Users who run setup.sh and then follow the next-step instructions will hit errors if helmfile or helm-diff is not installed. The script also did not apply the KWOK stage-fast manifest, which causes pods to stay stuck after helmfile sync.

## Summary

Two fixes to setup.sh, both found while reviewing the script after #4.

First, helmfile and helm-diff were added to the pre-flight checks. The summary section tells users to run HELMFILE_ENV=local helmfile sync, but the script never checked that those tools were present.

Second, stage-fast.yaml was added to the KWOK install step. Without it, KWOK nodes do not simulate fast pod-lifecycle transitions and pods appear stuck in Pending after helmfile sync.

## For the Reviewer

Both changes are additive and follow the existing patterns in the file. The KWOK manifest URL uses the same pinned version (v0.7.0) already in the file.

## For QA

Run setup.sh without helmfile installed and confirm it exits early with a clear error message.

Run setup.sh on a clean machine and confirm pods reach Running after helmfile sync.

## Issues

Related to #4

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

JIRA: NO-REF
NVBug: none