### PR TITLE
 fix(load-tests): honor INVOKE_HOST in supreme_http_test

### DIFF
--- a/examples/load-tests/functions/supreme_http_test.js
+++ b/examples/load-tests/functions/supreme_http_test.js
@@ -62,6 +62,10 @@ const params = {
     },
 };
 
+if (__ENV.INVOKE_HOST) {
+    params.headers['Host'] = __ENV.INVOKE_HOST;
+}
+
 export default function() {
     let response
 


### PR DESCRIPTION
## Summary
  - `run_http_self_managed_test.sh` from [http load-testing docs](https://docs.nvidia.com/nvcf/http-load-testing#create-your-run-script) exports `INVOKE_HOST=invocation.<gateway>` and forwards it via `-e`, but `supreme_http_test.js` never read it, so all requests sent `Host: <gateway>` and were 404'd by the NVCF gateway's host-based routing.
  - Set `params.headers.Host = __ENV.INVOKE_HOST` when the variable is provided. k6 promotes a `Host` header to `req.Host`, so the request now lands on the `invocation.*` vhost.
  - Gated on `INVOKE_HOST` being set so other consumers of this script are unaffected.



## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
