### PR TITLE
docs(architecture): add ARCHITECTURE.md with three-plane component overview

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -1,0 +1,97 @@
+# NVCF Architecture
+
+NVCF is built around three independently scalable planes connected through NATS JetStream as the shared messaging layer. A single control plane manages multiple GPU worker clusters, each registered via the NVIDIA Cluster Agent (NVCA).
+
+## Three-Plane Overview
+
+The diagram below shows the primary components and how requests flow across planes. The control plane contains additional services beyond those shown — see the [manifest page](https://docs.nvidia.com/nvcf/manifest#control-plane-components-1) for the full component list.
+
+![NVCF Three-Plane Architecture](assets/architecture-overview.svg)
+
+## Component Responsibilities
+
+For a full breakdown of component responsibilities by plane, see the [manifest page](https://docs.nvidia.com/nvcf/manifest#control-plane-components-1).
+
+## Single Request Lifecycle
+
+A synchronous HTTP function invocation flows through all three planes:
+
+```mermaid
+sequenceDiagram
+    participant C as Caller (curl / CLI)
+    participant IS as Invocation Service
+    participant RL as RateLimiter
+    participant NATS as NATS JetStream
+    participant NVCA as NVIDIA Cluster Agent
+    participant FP as Function Pod
+
+    C->>IS: POST /v2/nvcf/exec/functions/{id}
+    IS->>RL: validate auth + check rate limit
+    IS->>NATS: publish request (Create.NVCA.*.{clusterID}.*.*)
+    NATS->>NVCA: deliver message
+    NVCA->>NVCA: create ICMSRequest CR
+    NVCA->>FP: create Pod or Helm release
+    FP->>IS: ConnectOnce (WorkerService gRPC)
+    IS->>FP: deliver request payload
+    FP->>IS: return response (WorkerService gRPC)
+    IS->>C: return response
+    NVCA->>NVCA: receive Terminate signal, GC pod
+```
+
+## Scale-to-Zero
+
+NVCF uses NATS JetStream as a durable request buffer, enabling true scale-to-zero without dropping requests:
+
+1. Autoscaler detects zero utilization and drives desired instance count to 0.
+2. No function pods are running.
+3. A new request arrives and is published to the NATS JetStream stream. The stream persists it durably.
+4. Autoscaler detects queue depth > 0 and sets desired instances to 1 or more.
+5. NVCA receives a creation message and launches the pod.
+6. Pod connects via WorkerService gRPC and pulls the buffered message.
+7. Response is returned to the caller through the still-open Invocation Service connection.
+
+## Multi-Cluster Routing
+
+Each GPU cluster runs its own NVCA instance. NATS JetStream subjects are scoped per cluster:
+
+```
+Creation stream:    Create.NVCA.*.{clusterID}.*.*
+Termination:        Terminate.NVCA.{clusterID}
+Consumer name:      {streamName}-{clusterID}   (durable, per cluster)
+```
+
+Creation messages are only delivered to the consumer of the addressed cluster. The invocation plane selects the target cluster based on the function deployment specification (GPU type, region, cluster group).
+
+## Function Workload Types
+
+NVCF supports four workload types on the compute plane:
+
+| Type | Packaging | Invocation | Use case |
+|------|-----------|------------|----------|
+| Container function | Docker image | HTTP / gRPC / streaming | Long-running inference service |
+| Helm function | Helm chart | HTTP | Multi-container or operator-based workload |
+| Container task | Docker image | Async (run-to-completion) | Batch inference, fine-tuning |
+| Helm task | Helm chart | Async (run-to-completion) | Distributed batch jobs |
+
+## Key Custom Resource Definitions
+
+| CRD | API Group | Purpose |
+|-----|-----------|---------|
+| `NVCFBackend` | `nvcf/v1` | Cluster-level spec (NVCA image, GPU discovery, feature flags) |
+| `ICMSRequest` | `nvca/v2beta1` | Per-request state machine (Pending -> Completed/Failed) |
+| `MiniService` | `nvca/v1alpha1` | Per-Helm-function lifecycle (Installing -> Running -> Failed) |
+
+## Per-Component Documentation
+
+Each component ships an `AGENTS.md` with detailed internals, data flows, and API contracts:
+
+- [`src/compute-plane-services/nvca/AGENTS.md`](../../src/compute-plane-services/nvca/AGENTS.md)
+- [`src/compute-plane-services/ess-agent/AGENTS.md`](../../src/compute-plane-services/ess-agent/AGENTS.md)
+- [`src/compute-plane-services/byoo-otel-collector/AGENTS.md`](../../src/compute-plane-services/byoo-otel-collector/AGENTS.md)
+- [`src/invocation-plane-services/http-invocation/AGENTS.md`](../../src/invocation-plane-services/http-invocation/AGENTS.md)
+- [`src/invocation-plane-services/grpc-proxy/AGENTS.md`](../../src/invocation-plane-services/grpc-proxy/AGENTS.md)
+- [`src/invocation-plane-services/llm-gateway/AGENTS.md`](../../src/invocation-plane-services/llm-gateway/AGENTS.md)
+- [`src/invocation-plane-services/ratelimiter/AGENTS.md`](../../src/invocation-plane-services/ratelimiter/AGENTS.md)
+- [`src/invocation-plane-services/nats-auth-callout/AGENTS.md`](../../src/invocation-plane-services/nats-auth-callout/AGENTS.md)
+- [`src/control-plane-services/function-autoscaler/AGENTS.md`](../../src/control-plane-services/function-autoscaler/AGENTS.md)
+- [`examples/AGENTS.md`](../../examples/AGENTS.md)

--- a/docs/dev/assets/architecture-overview.svg
+++ b/docs/dev/assets/architecture-overview.svg
@@ -1,0 +1,123 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="980" height="680" viewBox="0 0 980 680" font-family="Inter, Segoe UI, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#555"/>
+    </marker>
+    <marker id="arrow-green" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#76B900"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="980" height="680" fill="#fafafa"/>
+
+  <!-- ===== CONTROL PLANE ===== -->
+  <rect x="200" y="20" width="740" height="175" rx="8" fill="#f0f7e6" stroke="#76B900" stroke-width="2"/>
+  <text x="570" y="45" text-anchor="middle" font-size="13" font-weight="bold" fill="#3d6600">Control Plane</text>
+  <text x="570" y="60" text-anchor="middle" font-size="10" fill="#666">(partial — see manifest for full component list)</text>
+
+  <!-- Control plane components -->
+  <rect x="220" y="70" width="130" height="50" rx="5" fill="#fff" stroke="#76B900" stroke-width="1.5"/>
+  <text x="285" y="91" text-anchor="middle" font-size="11" font-weight="bold" fill="#333">NVCF API</text>
+  <text x="285" y="107" text-anchor="middle" font-size="10" fill="#555">function lifecycle</text>
+
+  <rect x="370" y="70" width="130" height="50" rx="5" fill="#fff" stroke="#76B900" stroke-width="1.5"/>
+  <text x="435" y="91" text-anchor="middle" font-size="11" font-weight="bold" fill="#333">Autoscaler</text>
+  <text x="435" y="107" text-anchor="middle" font-size="10" fill="#555">scale-up / scale-down</text>
+
+  <rect x="520" y="70" width="130" height="50" rx="5" fill="#fff" stroke="#76B900" stroke-width="1.5"/>
+  <text x="585" y="91" text-anchor="middle" font-size="11" font-weight="bold" fill="#333">Helm ReVal</text>
+  <text x="585" y="107" text-anchor="middle" font-size="10" fill="#555">chart validation</text>
+
+  <rect x="670" y="70" width="100" height="50" rx="5" fill="#fff" stroke="#76B900" stroke-width="1.5"/>
+  <text x="720" y="91" text-anchor="middle" font-size="11" font-weight="bold" fill="#333">OpenBao</text>
+  <text x="720" y="107" text-anchor="middle" font-size="10" fill="#555">secrets</text>
+
+  <rect x="785" y="70" width="100" height="50" rx="5" fill="#fff" stroke="#76B900" stroke-width="1.5"/>
+  <text x="835" y="91" text-anchor="middle" font-size="11" font-weight="bold" fill="#333">Cassandra</text>
+  <text x="835" y="107" text-anchor="middle" font-size="10" fill="#555">persistent state</text>
+
+  <text x="570" y="160" text-anchor="middle" font-size="10" fill="#888">+ additional services: SIS, ESS API, API Keys, notary-service, …</text>
+
+  <!-- ===== CALLER ===== -->
+  <rect x="20" y="270" width="120" height="70" rx="8" fill="#fff8e1" stroke="#f9a825" stroke-width="2"/>
+  <text x="80" y="298" text-anchor="middle" font-size="12" font-weight="bold" fill="#5d4037">Caller</text>
+  <text x="80" y="316" text-anchor="middle" font-size="10" fill="#5d4037">curl / CLI</text>
+
+  <!-- ===== INVOCATION PLANE ===== -->
+  <rect x="200" y="235" width="740" height="210" rx="8" fill="#e8f4fd" stroke="#1565C0" stroke-width="2"/>
+  <text x="570" y="260" text-anchor="middle" font-size="13" font-weight="bold" fill="#0d47a1">Invocation Plane</text>
+
+  <!-- Invocation components -->
+  <rect x="220" y="270" width="150" height="50" rx="5" fill="#fff" stroke="#1565C0" stroke-width="1.5"/>
+  <text x="295" y="291" text-anchor="middle" font-size="11" font-weight="bold" fill="#333">Invocation Service</text>
+  <text x="295" y="307" text-anchor="middle" font-size="10" fill="#555">HTTP intake, NATS pub</text>
+
+  <rect x="390" y="270" width="130" height="50" rx="5" fill="#fff" stroke="#1565C0" stroke-width="1.5"/>
+  <text x="455" y="291" text-anchor="middle" font-size="11" font-weight="bold" fill="#333">gRPC Proxy</text>
+  <text x="455" y="307" text-anchor="middle" font-size="10" fill="#555">gRPC forwarding</text>
+
+  <rect x="540" y="270" width="130" height="50" rx="5" fill="#fff" stroke="#1565C0" stroke-width="1.5"/>
+  <text x="605" y="291" text-anchor="middle" font-size="11" font-weight="bold" fill="#333">RateLimiter</text>
+  <text x="605" y="307" text-anchor="middle" font-size="10" fill="#555">per-function limits</text>
+
+  <rect x="690" y="270" width="130" height="50" rx="5" fill="#fff" stroke="#1565C0" stroke-width="1.5"/>
+  <text x="755" y="291" text-anchor="middle" font-size="11" font-weight="bold" fill="#333">LLM API Gateway</text>
+  <text x="755" y="307" text-anchor="middle" font-size="10" fill="#555">OpenAI-compatible</text>
+
+  <rect x="310" y="340" width="160" height="50" rx="5" fill="#fff" stroke="#1565C0" stroke-width="1.5"/>
+  <text x="390" y="361" text-anchor="middle" font-size="11" font-weight="bold" fill="#333">NATS JetStream</text>
+  <text x="390" y="377" text-anchor="middle" font-size="10" fill="#555">Create.NVCA.*.{clusterID}.*.*</text>
+
+  <rect x="500" y="340" width="160" height="50" rx="5" fill="#fff" stroke="#1565C0" stroke-width="1.5"/>
+  <text x="580" y="361" text-anchor="middle" font-size="11" font-weight="bold" fill="#333">NATS Auth Callout</text>
+  <text x="580" y="377" text-anchor="middle" font-size="10" fill="#555">NKey / OIDC / webhook</text>
+
+  <!-- ===== GPU CLUSTER A ===== -->
+  <rect x="160" y="490" width="300" height="170" rx="8" fill="#fce4ec" stroke="#c62828" stroke-width="2"/>
+  <text x="310" y="515" text-anchor="middle" font-size="13" font-weight="bold" fill="#b71c1c">GPU Cluster A</text>
+  <text x="310" y="531" text-anchor="middle" font-size="10" fill="#888">(e.g. on-prem H100)</text>
+
+  <rect x="185" y="545" width="250" height="45" rx="5" fill="#fff" stroke="#c62828" stroke-width="1.5"/>
+  <text x="310" y="564" text-anchor="middle" font-size="11" font-weight="bold" fill="#333">NVIDIA Cluster Agent (NVCA)</text>
+  <text x="310" y="580" text-anchor="middle" font-size="10" fill="#555">job dispatch · pod lifecycle</text>
+
+  <rect x="185" y="605" width="250" height="40" rx="5" fill="#fff" stroke="#c62828" stroke-width="1.5"/>
+  <text x="310" y="625" text-anchor="middle" font-size="11" font-weight="bold" fill="#333">Function Pods</text>
+  <text x="310" y="640" text-anchor="middle" font-size="10" fill="#555">container or Helm chart</text>
+
+  <!-- ===== GPU CLUSTER B ===== -->
+  <rect x="510" y="490" width="300" height="170" rx="8" fill="#fce4ec" stroke="#c62828" stroke-width="2"/>
+  <text x="660" y="515" text-anchor="middle" font-size="13" font-weight="bold" fill="#b71c1c">GPU Cluster B</text>
+  <text x="660" y="531" text-anchor="middle" font-size="10" fill="#888">(e.g. cloud H200)</text>
+
+  <rect x="535" y="545" width="250" height="45" rx="5" fill="#fff" stroke="#c62828" stroke-width="1.5"/>
+  <text x="660" y="564" text-anchor="middle" font-size="11" font-weight="bold" fill="#333">NVIDIA Cluster Agent (NVCA)</text>
+  <text x="660" y="580" text-anchor="middle" font-size="10" fill="#555">job dispatch · pod lifecycle</text>
+
+  <rect x="535" y="605" width="250" height="40" rx="5" fill="#fff" stroke="#c62828" stroke-width="1.5"/>
+  <text x="660" y="625" text-anchor="middle" font-size="11" font-weight="bold" fill="#333">Function Pods</text>
+  <text x="660" y="640" text-anchor="middle" font-size="10" fill="#555">container or Helm chart</text>
+
+  <!-- more clusters indicator -->
+  <text x="845" y="580" text-anchor="middle" font-size="20" fill="#999">· · ·</text>
+
+  <!-- ===== ARROWS ===== -->
+
+  <!-- Caller -> Invocation Plane -->
+  <line x1="140" y1="305" x2="198" y2="305" stroke="#555" stroke-width="1.8" marker-end="url(#arrow)" stroke-dasharray="5,3"/>
+  <text x="168" y="297" text-anchor="middle" font-size="9" fill="#555">HTTP/gRPC</text>
+
+  <!-- Control Plane -> Invocation Plane (autoscale) -->
+  <line x1="420" y1="195" x2="420" y2="233" stroke="#76B900" stroke-width="1.8" marker-end="url(#arrow-green)"/>
+  <text x="460" y="220" font-size="9" fill="#76B900">autoscale decisions</text>
+
+  <!-- Invocation Plane -> GPU Clusters (job dispatch) -->
+  <line x1="390" y1="393" x2="350" y2="488" stroke="#555" stroke-width="1.8" marker-end="url(#arrow)"/>
+  <line x1="420" y1="393" x2="620" y2="488" stroke="#555" stroke-width="1.8" marker-end="url(#arrow)"/>
+  <text x="380" y="455" font-size="9" fill="#555">job dispatch</text>
+
+  <!-- GPU Clusters -> Control Plane (heartbeat) -->
+  <path d="M 310 490 Q 260 380 280 195" fill="none" stroke="#76B900" stroke-width="1.5" stroke-dasharray="6,3" marker-end="url(#arrow-green)"/>
+  <text x="195" y="360" font-size="9" fill="#76B900" transform="rotate(-80 195 360)">heartbeat + registration</text>
+</svg>

--- a/fern/versions/main.yml
+++ b/fern/versions/main.yml
@@ -212,6 +212,8 @@ navigation:
   - section: Development
     skip-slug: true
     contents:
+      - page: Architecture Overview
+        path: ../../docs/dev/architecture.md
       - page: Local Development
         path: ../../docs/user/local-development.md
       - page: Fake GPU Operator


### PR DESCRIPTION
## TL;DR

Adds `ARCHITECTURE.md` at the repository root covering the three-plane topology, component responsibilities, single-request lifecycle, scale-to-zero mechanism, multi-cluster routing, workload types, and CRD hierarchy.

## Additional Details

New contributors currently reconstruct the full architecture picture by reading across multiple `AGENTS.md` files, the helmfile, proto definitions, and source code. A single canonical document at the repo root lowers the onboarding barrier and gives a shared reference for design discussions.

Every claim in the document is directly derived from source:
- NATS subjects from `src/compute-plane-services/nvca/pkg/queue/nats/client.go`
- CRD names from `src/compute-plane-services/nvca/pkg/apis/`
- Request lifecycle from `nvca/internal/miniservice/` and `http-invocation` crates
- Scale-to-zero description from autoscaler Rust loop + NATS JetStream durable consumer behavior

## For the Reviewer

The ASCII diagram is intentionally text-based (no external image dependency). If the team prefers Mermaid, happy to convert.

## For QA

Documentation only - no behavior change.

## Issues

NO-REF

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.