### PR TITLE
feat(examples): Ray Serve Helm chart sample for NVCF functions

### DIFF
--- a/examples/function-samples/helmchart-samples/ray-serve-sample/README.md
+++ b/examples/function-samples/helmchart-samples/ray-serve-sample/README.md
@@ -1,0 +1,130 @@
+# Ray Serve Sample
+
+This sample demonstrates how to run a [Ray Serve](https://docs.ray.io/en/latest/serve/index.html) application as an NVCF Helm function. It deploys a single Ray head pod that starts Ray Serve and exposes an inference endpoint that NVCF routes to. No KubeRay operator is required.
+
+## What this sample shows
+
+- Ray Serve running inside a single Kubernetes pod (Ray head node)
+- An `entrypoint` Service on port 8000 that NVCF uses for invocation routing
+- GPU resource requests wired through `nvidia.com/gpu` extended resources
+- A ConfigMap-mounted Python app so the serve logic is easy to swap out without rebuilding an image
+- Kubernetes liveness and readiness probes on `/health` so NVCF knows when the pod is ready to accept requests
+
+## Prerequisites
+
+- A Kubernetes cluster with `nvidia.com/gpu` extended resources (real or fake via [fake-gpu-operator](https://github.com/run-ai/fake-gpu-operator)) when `gpu.count > 0`
+- `helm` >= 3.12
+- For NVCF deployment: a self-managed NVCF control plane (see [self-hosted-local-development](../../../self-hosted-local-development/))
+
+> **Apple Silicon note:** The default image tag (`2.40.0-py310-gpu`) is AMD64-only. For local testing on macOS ARM64 (k3d, kind), use the `-aarch64` variant: `--set image.tag=2.40.0-py310-aarch64`.
+
+## Deploying locally (plain Kubernetes)
+
+For CPU-only testing on AMD64, disable GPU requests:
+
+```bash
+helm install ray-serve-sample ./ray-serve \
+  --set gpu.count=0 \
+  --set image.tag=2.40.0-py310
+```
+
+On Apple Silicon (ARM64), use the aarch64 tag:
+
+```bash
+helm install ray-serve-sample ./ray-serve \
+  --set gpu.count=0 \
+  --set image.tag=2.40.0-py310-aarch64 \
+  --set resources.requests.memory=2Gi \
+  --set resources.limits.memory=4Gi
+```
+
+Verify the pod is running and Ray Serve is ready:
+
+```bash
+kubectl get pods -l app.kubernetes.io/name=ray-serve-sample
+kubectl logs -l app.kubernetes.io/name=ray-serve-sample --follow
+```
+
+Test the inference endpoint directly:
+
+```bash
+kubectl port-forward svc/entrypoint 8000:8000 &
+curl -s -X POST http://localhost:8000/infer \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt": "Hello, Ray Serve on NVCF"}'
+# {"echo": {"prompt": "Hello, Ray Serve on NVCF"}}
+
+curl -s http://localhost:8000/health
+# {"status": "ok"}
+
+kill %1
+```
+
+## Deploying on self-managed NVCF
+
+Package and push the chart to an OCI registry your cluster can reach:
+
+```bash
+helm package ray-serve
+helm push ray-serve-0.1.0.tgz oci://<your-registry>/<namespace>
+```
+
+Register registry credentials with `nvcf-cli`:
+
+```bash
+nvcf-cli registry add \
+  --hostname <your-registry> \
+  --username <user> \
+  --password <pass> \
+  --artifact-type HELM \
+  --artifact-type CONTAINER
+```
+
+Create and deploy the function:
+
+```bash
+nvcf-cli function create \
+  --name ray-serve-sample \
+  --helm-chart <your-registry>/<namespace>/ray-serve:0.1.0 \
+  --helm-chart-service entrypoint \
+  --inference-url /infer \
+  --inference-port 8000 \
+  --health-uri /health \
+  --health-port 8000
+
+nvcf-cli function deploy create \
+  --function-id <function-id> \
+  --version-id <version-id> \
+  --gpu H100 \
+  --instance-type NCP.GPU.H100_1x \
+  --min-instances 1 \
+  --max-instances 1
+```
+
+## Extending this sample for real models
+
+Replace the `InferenceDeployment` body in the ConfigMap (`templates/configmap.yaml`) with your model loading and inference logic. For example, to serve a Hugging Face model:
+
+```python
+def __init__(self):
+    from transformers import pipeline
+    self.model = pipeline("text-generation", model="meta-llama/Llama-3.2-1B", device=0)
+
+@app.post("/infer")
+async def infer(self, request: Request) -> JSONResponse:
+    body = await request.json()
+    result = self.model(body.get("prompt", ""), max_new_tokens=256)
+    return JSONResponse({"generated_text": result[0]["generated_text"]})
+```
+
+For multi-GPU or multi-node Ray clusters, see the [KubeRay documentation](https://docs.ray.io/en/latest/cluster/kubernetes/index.html) and the [multi-node-helm-function-test](../multi-node-helm-function-test/) sample.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `ray-serve/Chart.yaml` | Helm chart metadata |
+| `ray-serve/values.yaml` | Configurable defaults (image, GPU count, resources) |
+| `ray-serve/templates/configmap.yaml` | Ray Serve application code (swap this for your model) |
+| `ray-serve/templates/deployment.yaml` | Ray head pod with serve startup sequence |
+| `ray-serve/templates/service.yaml` | `entrypoint` Service that NVCF routes invocations to |

--- a/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/Chart.yaml
+++ b/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/Chart.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+appVersion: "0.1.0"
+description: A Helm chart for deploying a Ray Serve application as an NVCF function
+name: ray-serve
+version: "0.1.0"

--- a/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/templates/configmap.yaml
+++ b/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/templates/configmap.yaml
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-app
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  serve_app.py: |
+    """
+    Ray Serve application for NVCF.
+
+    This example shows the minimal structure for a Ray Serve deployment that
+    works as an NVCF Helm function. Replace the InferenceDeployment body with
+    your model loading and inference logic.
+
+    NVCF routes requests to the 'entrypoint' Service on inferencePort. Ray Serve
+    binds to 0.0.0.0 on that same port and dispatches to the decorated handler.
+    """
+    import time
+    import ray
+    from ray import serve
+    from ray.serve.config import HTTPOptions
+    from fastapi import FastAPI, Request
+    from fastapi.responses import JSONResponse
+
+    ray.init(address="auto", ignore_reinit_error=True)
+
+    # serve.start() must be called explicitly to bind to 0.0.0.0; serve.run() alone
+    # defaults the HTTP proxy to 127.0.0.1 which is unreachable from outside the pod.
+    serve.start(http_options=HTTPOptions(host="0.0.0.0", port={{ .Values.inferencePort }}))
+
+    app = FastAPI()
+
+    @serve.deployment(
+        num_replicas=1,
+        ray_actor_options={"num_gpus": {{ .Values.gpu.count }}},
+    )
+    @serve.ingress(app)
+    class InferenceDeployment:
+        def __init__(self):
+            # Replace with your model loading logic, e.g.:
+            #   from transformers import pipeline
+            #   self.model = pipeline("text-generation", model="gpt2", device=0)
+            pass
+
+        @app.post("/infer")
+        async def infer(self, request: Request) -> JSONResponse:
+            body = await request.json()
+            # Replace with your model inference call, e.g.:
+            #   result = self.model(body.get("prompt", ""), max_new_tokens=100)
+            #   return JSONResponse({"generated_text": result[0]["generated_text"]})
+            return JSONResponse({"echo": body})
+
+        @app.get("/health")
+        async def health(self) -> JSONResponse:
+            return JSONResponse({"status": "ok"})
+
+    serve.run(InferenceDeployment.bind())
+
+    while True:
+        time.sleep(3600)

--- a/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/templates/deployment.yaml
+++ b/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/templates/deployment.yaml
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Release.Name }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      {{- if .Values.ngcImagePullSecretName }}
+      imagePullSecrets:
+        - name: {{ .Values.ngcImagePullSecretName }}
+      {{- end }}
+      containers:
+        - name: ray-serve
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["bash", "-c"]
+          args:
+            - |
+              ray start --head --port=6379 --dashboard-host=0.0.0.0 --block &
+              until ray health-check 2>/dev/null; do sleep 2; done
+              python /app/serve_app.py
+          ports:
+            - name: inference
+              containerPort: {{ .Values.inferencePort }}
+              protocol: TCP
+            - name: ray-client
+              containerPort: 10001
+              protocol: TCP
+            - name: dashboard
+              containerPort: 8265
+              protocol: TCP
+          resources:
+            requests:
+              cpu: {{ .Values.resources.requests.cpu | quote }}
+              memory: {{ .Values.resources.requests.memory | quote }}
+              {{- if gt (int .Values.gpu.count) 0 }}
+              {{ .Values.gpu.product }}: {{ .Values.gpu.count | quote }}
+              {{- end }}
+            limits:
+              cpu: {{ .Values.resources.limits.cpu | quote }}
+              memory: {{ .Values.resources.limits.memory | quote }}
+              {{- if gt (int .Values.gpu.count) 0 }}
+              {{ .Values.gpu.product }}: {{ .Values.gpu.count | quote }}
+              {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.inferencePort }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.inferencePort }}
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            failureThreshold: 4
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      volumes:
+        - name: app
+          configMap:
+            name: {{ .Release.Name }}-app

--- a/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/templates/service.yaml
+++ b/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/templates/service.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: entrypoint
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  ports:
+    - port: 8000
+      targetPort: {{ .Values.inferencePort }}
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/values.yaml
+++ b/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/values.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ngcImagePullSecretName: ""
+
+image:
+  repository: "rayproject/ray"
+  tag: "2.40.0-py310-gpu"
+  pullPolicy: "IfNotPresent"
+
+inferencePort: 8000
+
+# Number of GPUs to request per Ray head pod.
+# Set to 0 for CPU-only testing.
+gpu:
+  count: 1
+  product: "nvidia.com/gpu"
+
+resources:
+  requests:
+    cpu: "2"
+    memory: "8Gi"
+  limits:
+    cpu: "4"
+    memory: "16Gi"


### PR DESCRIPTION
## Summary

- Adds a self-contained Helm chart that deploys Ray Serve as an NVCF Helm function without requiring the KubeRay operator
- Single Ray head pod with ConfigMap-mounted serve app (`/infer` POST, `/health` GET) so model logic can be swapped without rebuilding an image
- `entrypoint` Service on port 8000 satisfies NVCF's invocation routing requirement
- GPU resource requests via `nvidia.com/gpu`; `--set gpu.count=0` for CPU-only local testing
- Includes ARM64 install path for Apple Silicon development

## Test plan

- [x] `helm lint`: 0 failures, 0 errors
- [x] `helm template`: all four objects render correctly (Deployment, ConfigMap, Service, labels/selectors consistent)
- [x] Live deploy on k3d ARM64 with `rayproject/ray:2.40.0-py310-aarch64`, `gpu.count=0`
- [x] Pod reached `1/1 Running` with readiness probes passing
- [x] `GET /health` via `kubectl port-forward svc/entrypoint` returns `{"status": "ok"}` HTTP 200
- [x] `POST /infer` with `{"prompt": "Hello Ray Serve on NVCF"}` returns `{"echo": {"prompt": "Hello Ray Serve on NVCF"}}` HTTP 200
- [x] Ray Serve logs confirm: `Application 'default' is ready at http://0.0.0.0:8000/`

## Files

| File | Purpose |
|------|---------|
| `ray-serve/Chart.yaml` | Helm chart metadata, version 0.1.0 |
| `ray-serve/values.yaml` | Defaults: image, GPU count, resource requests |
| `ray-serve/templates/deployment.yaml` | Ray head pod startup sequence |
| `ray-serve/templates/configmap.yaml` | Echo inference app (replace body for real models) |
| `ray-serve/templates/service.yaml` | `entrypoint` Service on port 8000 |
| `README.md` | Deploy instructions for plain K8s and self-managed NVCF |