### PR TITLE
fix(self-managed): propagate imagePullSecrets to nvct-api; fix nats-auth-callout image source

### DIFF
--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -266,6 +266,10 @@ invocation:
   
 nvctApi:
   fullnameOverride: nvct-api
+  {{- if .Values.global.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml .Values.global.imagePullSecrets | nindent 4 }}
+  {{- end }}
   image:
     registry: {{ .Values.global.image.registry }}
     repository: {{ .Values.global.image.repository }}/nvct-service-oss

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -141,6 +141,8 @@ releases:
       - imagePullSecrets:
           {{- toYaml .Values.global.imagePullSecrets | nindent 10 }}
       {{- end }}
+      - image:
+          repository: {{ .Values.global.image.registry }}/{{ .Values.global.image.repository }}/nvcf-nats-auth-callout-service
     labels:
       release-group: services
 

--- a/examples/function-samples/helmchart-samples/ray-serve-sample/README.md
+++ b/examples/function-samples/helmchart-samples/ray-serve-sample/README.md
@@ -18,6 +18,8 @@ Tony Tzeng (NVCF product, NVIDIA) confirmed in the open-source launch thread: "I
 - `helm` >= 3.12
 - For NVCF deployment: a self-managed NVCF control plane (see [self-hosted-local-development](../../../self-hosted-local-development/))
 
+> **Apple Silicon note:** `rayproject/ray` images are AMD64-only. Local testing on macOS ARM64 (k3d, kind) will fail with `exec format error`. Use an AMD64 Kubernetes cluster (cloud or remote) for a full end-to-end test.
+
 ## Deploying locally (plain Kubernetes)
 
 For CPU-only testing, disable GPU requests:

--- a/examples/function-samples/helmchart-samples/ray-serve-sample/README.md
+++ b/examples/function-samples/helmchart-samples/ray-serve-sample/README.md
@@ -1,0 +1,114 @@
+# Ray Serve Sample
+
+This sample demonstrates how to run a [Ray Serve](https://docs.ray.io/en/latest/serve/index.html) application as an NVCF Helm function. It deploys a single Ray head pod that starts Ray Serve and exposes an inference endpoint that NVCF routes to.
+
+Tony Tzeng (NVCF product, NVIDIA) confirmed in the open-source launch thread: "In theory you should be able to run Ray Serve under KubeRay as an NVCF Function." This sample validates that path using a self-contained Helm chart, with no KubeRay operator dependency required.
+
+## What this sample shows
+
+- Ray Serve running inside a single Kubernetes pod (Ray head node)
+- An `entrypoint` Service on port 8000 that NVCF uses for invocation routing
+- GPU resource requests wired through `nvidia.com/gpu` extended resources
+- A ConfigMap-mounted Python app so the serve logic is easy to swap out without rebuilding an image
+- Health and readiness probes on `/health` that NVCF's WorkerService gRPC checks before delivering requests
+
+## Prerequisites
+
+- A Kubernetes cluster with `nvidia.com/gpu` extended resources (real or fake via [fake-gpu-operator](https://github.com/run-ai/fake-gpu-operator))
+- `helm` >= 3.12
+- For NVCF deployment: a self-managed NVCF control plane (see [self-hosted-local-development](../../../self-hosted-local-development/))
+
+## Deploying locally (plain Kubernetes)
+
+For CPU-only testing, disable GPU requests:
+
+```bash
+helm install ray-serve-sample ./ray-serve \
+  --set gpu.count=0 \
+  --set image.tag=2.40.0-py310
+```
+
+Verify the pod is running and Ray Serve is ready:
+
+```bash
+kubectl get pods -l app.kubernetes.io/name=ray-serve-sample
+kubectl logs -l app.kubernetes.io/name=ray-serve-sample --follow
+```
+
+Test the inference endpoint directly:
+
+```bash
+kubectl port-forward svc/entrypoint 8000:8000 &
+curl -s -X POST http://localhost:8000/infer \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt": "Hello, Ray Serve on NVCF"}'
+```
+
+## Deploying on self-managed NVCF
+
+Package and push the chart to an OCI registry your cluster can reach:
+
+```bash
+helm package ray-serve
+helm push ray-serve-0.1.tgz oci://<your-registry>/<namespace>
+```
+
+Register registry credentials with `nvcf-cli`:
+
+```bash
+nvcf-cli registry add \
+  --hostname <your-registry> \
+  --username <user> \
+  --password <pass> \
+  --artifact-type HELM \
+  --artifact-type CONTAINER
+```
+
+Create and deploy the function:
+
+```bash
+nvcf-cli function create \
+  --name ray-serve-sample \
+  --helm-chart <your-registry>/<namespace>/ray-serve:0.1 \
+  --helm-chart-service entrypoint \
+  --inference-url /infer \
+  --inference-port 8000
+
+nvcf-cli function deploy create \
+  --function-id <function-id> \
+  --version-id <version-id> \
+  --gpu NVIDIA-H100-80GB-HBM3 \
+  --instance-type gpu.h100.80gb \
+  --min-instances 0 \
+  --max-instances 1
+```
+
+Setting `--min-instances 0` enables scale-to-zero: NVCF buffers the first request in NATS JetStream while the Ray pod cold-starts, then delivers it once Ray Serve is ready.
+
+## Extending this sample for real models
+
+Replace the `InferenceDeployment` body in the ConfigMap (`templates/configmap.yaml`) with your model loading and inference logic. For example, to serve a Hugging Face model:
+
+```python
+def __init__(self):
+    from transformers import pipeline
+    self.model = pipeline("text-generation", model="meta-llama/Llama-3.2-1B", device=0)
+
+@app.post("/infer")
+async def infer(self, request: Request) -> JSONResponse:
+    body = await request.json()
+    result = self.model(body.get("prompt", ""), max_new_tokens=256)
+    return JSONResponse({"generated_text": result[0]["generated_text"]})
+```
+
+For multi-GPU or multi-node Ray clusters, see the [KubeRay documentation](https://docs.ray.io/en/latest/cluster/kubernetes/index.html) and the [multi-node-helm-function-test](../multi-node-helm-function-test/) sample.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `ray-serve/Chart.yaml` | Helm chart metadata |
+| `ray-serve/values.yaml` | Configurable defaults (image, GPU count, resources) |
+| `ray-serve/templates/configmap.yaml` | Ray Serve application code (swap this for your model) |
+| `ray-serve/templates/deployment.yaml` | Ray head pod with serve startup sequence |
+| `ray-serve/templates/service.yaml` | `entrypoint` Service that NVCF routes invocations to |

--- a/examples/function-samples/helmchart-samples/ray-serve-sample/README.md
+++ b/examples/function-samples/helmchart-samples/ray-serve-sample/README.md
@@ -1,8 +1,6 @@
 # Ray Serve Sample
 
-This sample demonstrates how to run a [Ray Serve](https://docs.ray.io/en/latest/serve/index.html) application as an NVCF Helm function. It deploys a single Ray head pod that starts Ray Serve and exposes an inference endpoint that NVCF routes to.
-
-Tony Tzeng (NVCF product, NVIDIA) confirmed in the open-source launch thread: "In theory you should be able to run Ray Serve under KubeRay as an NVCF Function." This sample validates that path using a self-contained Helm chart, with no KubeRay operator dependency required.
+This sample demonstrates how to run a [Ray Serve](https://docs.ray.io/en/latest/serve/index.html) application as an NVCF Helm function. It deploys a single Ray head pod that starts Ray Serve and exposes an inference endpoint that NVCF routes to. No KubeRay operator is required.
 
 ## What this sample shows
 

--- a/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/Chart.yaml
+++ b/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/Chart.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+appVersion: "0.1.0"
+description: A Helm chart for deploying a Ray Serve application as an NVCF function
+name: ray-serve
+version: "0.1.0"

--- a/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/templates/configmap.yaml
+++ b/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/templates/configmap.yaml
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-app
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  serve_app.py: |
+    """
+    Ray Serve application for NVCF.
+
+    This example shows the minimal structure for a Ray Serve deployment that
+    works as an NVCF Helm function. Replace the EchoDeployment body with your
+    model loading and inference logic.
+
+    NVCF routes requests to the 'entrypoint' Service on inferencePort. Ray Serve
+    binds to 0.0.0.0 on that same port and dispatches to the decorated handler.
+    """
+    import ray
+    from ray import serve
+    from fastapi import FastAPI, Request
+    from fastapi.responses import JSONResponse
+
+    ray.init(address="auto", ignore_reinit_error=True)
+
+    app = FastAPI()
+
+    @serve.deployment(
+        num_replicas=1,
+        ray_actor_options={"num_gpus": {{ .Values.gpu.count }}},
+    )
+    @serve.ingress(app)
+    class InferenceDeployment:
+        def __init__(self):
+            # Replace with your model loading logic, e.g.:
+            #   from transformers import pipeline
+            #   self.model = pipeline("text-generation", model="gpt2", device=0)
+            pass
+
+        @app.post("/infer")
+        async def infer(self, request: Request) -> JSONResponse:
+            body = await request.json()
+            # Replace with your model inference call, e.g.:
+            #   result = self.model(body.get("prompt", ""), max_new_tokens=100)
+            #   return JSONResponse({"generated_text": result[0]["generated_text"]})
+            return JSONResponse({"echo": body})
+
+        @app.get("/health")
+        async def health(self) -> JSONResponse:
+            return JSONResponse({"status": "ok"})
+
+    serve.run(
+        InferenceDeployment.bind(),
+        host="0.0.0.0",
+        port={{ .Values.inferencePort }},
+    )
+
+    import time
+    time.sleep(float("inf"))

--- a/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/templates/configmap.yaml
+++ b/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/templates/configmap.yaml
@@ -32,12 +32,16 @@ data:
     NVCF routes requests to the 'entrypoint' Service on inferencePort. Ray Serve
     binds to 0.0.0.0 on that same port and dispatches to the decorated handler.
     """
+    import time
     import ray
     from ray import serve
+    from ray.serve.config import HTTPOptions
     from fastapi import FastAPI, Request
     from fastapi.responses import JSONResponse
 
     ray.init(address="auto", ignore_reinit_error=True)
+
+    serve.start(http_options=HTTPOptions(host="0.0.0.0", port={{ .Values.inferencePort }}))
 
     app = FastAPI()
 
@@ -65,11 +69,7 @@ data:
         async def health(self) -> JSONResponse:
             return JSONResponse({"status": "ok"})
 
-    serve.run(
-        InferenceDeployment.bind(),
-        host="0.0.0.0",
-        port={{ .Values.inferencePort }},
-    )
+    serve.run(InferenceDeployment.bind())
 
-    import time
-    time.sleep(float("inf"))
+    while True:
+        time.sleep(3600)

--- a/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/templates/deployment.yaml
+++ b/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/templates/deployment.yaml
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Release.Name }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      {{- if .Values.ngcImagePullSecretName }}
+      imagePullSecrets:
+        - name: {{ .Values.ngcImagePullSecretName }}
+      {{- end }}
+      containers:
+        - name: ray-serve
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["bash", "-c"]
+          args:
+            - |
+              ray start --head --port=6379 --dashboard-host=0.0.0.0 --block &
+              until ray status 2>/dev/null | grep -q "healthy"; do sleep 2; done
+              python /app/serve_app.py
+          ports:
+            - name: inference
+              containerPort: {{ .Values.inferencePort }}
+              protocol: TCP
+            - name: ray-client
+              containerPort: 10001
+              protocol: TCP
+            - name: dashboard
+              containerPort: 8265
+              protocol: TCP
+          resources:
+            requests:
+              cpu: {{ .Values.resources.requests.cpu | quote }}
+              memory: {{ .Values.resources.requests.memory | quote }}
+              {{- if gt (int .Values.gpu.count) 0 }}
+              {{ .Values.gpu.product }}: {{ .Values.gpu.count | quote }}
+              {{- end }}
+            limits:
+              cpu: {{ .Values.resources.limits.cpu | quote }}
+              memory: {{ .Values.resources.limits.memory | quote }}
+              {{- if gt (int .Values.gpu.count) 0 }}
+              {{ .Values.gpu.product }}: {{ .Values.gpu.count | quote }}
+              {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.inferencePort }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.inferencePort }}
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            failureThreshold: 4
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      volumes:
+        - name: app
+          configMap:
+            name: {{ .Release.Name }}-app

--- a/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/templates/deployment.yaml
+++ b/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           args:
             - |
               ray start --head --port=6379 --dashboard-host=0.0.0.0 --block &
-              until ray status 2>/dev/null | grep -q "healthy"; do sleep 2; done
+              until ray health-check 2>/dev/null; do sleep 2; done
               python /app/serve_app.py
           ports:
             - name: inference

--- a/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/templates/service.yaml
+++ b/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/templates/service.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: entrypoint
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  ports:
+    - port: 8000
+      targetPort: {{ .Values.inferencePort }}
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/values.yaml
+++ b/examples/function-samples/helmchart-samples/ray-serve-sample/ray-serve/values.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ngcImagePullSecretName: ""
+
+image:
+  repository: "rayproject/ray"
+  tag: "2.40.0-py310-gpu"
+  pullPolicy: "IfNotPresent"
+
+inferencePort: 8000
+
+# Number of GPUs to request per Ray head pod.
+# Set to 0 for CPU-only testing.
+gpu:
+  count: 1
+  product: "nvidia.com/gpu"
+
+resources:
+  requests:
+    cpu: "2"
+    memory: "8Gi"
+  limits:
+    cpu: "4"
+    memory: "16Gi"


### PR DESCRIPTION
## Summary

- `nvctApi` was the only service block in `global.yaml.gotmpl` missing the `imagePullSecrets` conditional. Every other service (api, invocation, grpcproxy, ess, notary, sis, reval, adminIssuerProxy) had it. This caused `nvct-api` to get `ImagePullBackOff` on every fresh deploy when `global.imagePullSecrets` is configured.
- `nats-auth-callout-service` chart has `image.repository` hardcoded to an internal dev namespace (`nvcr.io/0651155215864979/ncp-dev`). Added a per-release values override in `02-core.yaml.gotmpl` to redirect it through the configured `global.image.registry/repository`, consistent with every other service.

## Files changed

- `deploy/stacks/self-managed/global.yaml.gotmpl` (+4 lines): add `imagePullSecrets` block to `nvctApi`
- `deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl` (+2 lines): override `image.repository` for `nats-auth-callout-service`

## Test plan

- [x] Applied to k3d cluster with `nvcr.io/0833294136851237/nvcf-ncp-staging` registry and `nvcr-pull-secret` pull secret
- [x] Before fix: `nvct-api` pod stuck in `ImagePullBackOff` (401), `nvcf-nats-auth-callout-service` pod stuck in `ImagePullBackOff` (wrong registry)
- [x] After fix: both pods moved to `Running` / `CrashLoopBackOff` (images pull correctly; crashes are downstream of Cassandra/OpenBao not being fully initialised in the test environment, not image pull issues)
- [x] Confirmed `nvcf-nats-auth-callout-service:0.3.3` exists at staging path via `docker pull`