### PR TITLE
fix(self-managed): propagate imagePullSecrets to nvct-api; fix nats-auth-callout image source

### DIFF
--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -266,6 +266,10 @@ invocation:
   
 nvctApi:
   fullnameOverride: nvct-api
+  {{- if .Values.global.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml .Values.global.imagePullSecrets | nindent 4 }}
+  {{- end }}
   image:
     registry: {{ .Values.global.image.registry }}
     repository: {{ .Values.global.image.repository }}/nvct-service-oss


### PR DESCRIPTION
## Summary

- `nvctApi` was the only service block in `global.yaml.gotmpl` missing the `imagePullSecrets` conditional. Every other service (api, invocation, grpcproxy, ess, notary, sis, reval, adminIssuerProxy) had it. This caused `nvct-api` to get `ImagePullBackOff` on every fresh deploy when `global.imagePullSecrets` is configured.
- `nats-auth-callout-service` chart has `image.repository` hardcoded to an internal dev namespace (`nvcr.io/0651155215864979/ncp-dev`). Added a per-release values override in `02-core.yaml.gotmpl` to redirect it through the configured `global.image.registry/repository`, consistent with every other service.

## Files changed

- `deploy/stacks/self-managed/global.yaml.gotmpl` (+4 lines): add `imagePullSecrets` block to `nvctApi`
- `deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl` (+2 lines): override `image.repository` for `nats-auth-callout-service`

## Test plan

- [x] Applied to k3d cluster with `nvcr.io/0833294136851237/nvcf-ncp-staging` registry and `nvcr-pull-secret` pull secret
- [x] Before fix: `nvct-api` pod stuck in `ImagePullBackOff` (401), `nvcf-nats-auth-callout-service` pod stuck in `ImagePullBackOff` (wrong registry)
- [x] After fix: both pods moved from `ImagePullBackOff` to `Running`
- [x] Confirmed `nvcf-nats-auth-callout-service:0.3.3` exists at staging path via `docker pull`