### PR TITLE
docs(readme): link roadmap issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![NVCF banner](docs/user/images/nvcf-banner.svg)
 
-[Preview docs](https://nvidia-nvcf.docs.buildwithfern.com/nvcf/overview) | [Public docs](https://docs.nvidia.com/nvcf/overview) | [Installation](docs/user/installation.md) | [API Reference](docs/user/api.md) | [Contributing](CONTRIBUTING.md) | [build.nvidia.com Powered By NVCF](https://build.nvidia.com/)
+[Docs](https://docs.nvidia.com/nvcf/overview) | [Roadmap](https://github.com/NVIDIA/nvcf/issues/27) | [Installation](docs/user/installation.md) | [API Reference](docs/user/api.md) | [Contributing](CONTRIBUTING.md) | [build.nvidia.com Powered By NVCF](https://build.nvidia.com/)
 
 # NVIDIA Cloud Functions
 


### PR DESCRIPTION
## Customer Summary (required for feat, fix, and perf PRs)
Not customer visible.

## TL;DR
Update the README front-page links so docs are presented as a single `Docs` link and the public roadmap issue is discoverable from the repository front page.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
- Replaces the separate preview and public docs links with one `Docs` link to the public docs.
- Adds a `Roadmap` link to the new public roadmap issue, #27.
- Created #27 from the Q2/Q3 2026 Roadmap

## For the Reviewer
Please review the top link row in `README.md`.

Maintainer action needed: apply the `roadmap` and `no-stale` labels to #27. The issue was created successfully, but this account does not have permission to add labels (`AddLabelsToLabelable`).

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
- Ran `git diff --check`.
- QA needed: No. Documentation-only README link change.

## Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Relates to #27

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes. Documentation-only change verified with `git diff --check`.
- [x] The documentation is up to date with these changes.
