### PR TITLE
fix(icms-translate): inject SPOT_ENVIRONMENT into task worker init container

### DIFF
--- a/src/libraries/go/lib/pkg/icms-translate/translate/common/env.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/common/env.go
@@ -28,8 +28,9 @@ const (
 	InstanceTypeNameEnvVar   = "INSTANCE_TYPE_NAME"
 	InstanceTypeValueEnvVar  = "INSTANCE_TYPE_VALUE"
 
-	ICMSEnvironmentEnv = "ICMS_ENVIRONMENT"
-	GPUNameEnv         = "GPU_NAME"
+	ICMSEnvironmentEnv  = "ICMS_ENVIRONMENT"
+	SpotEnvironmentEnv  = "SPOT_ENVIRONMENT"
+	GPUNameEnv          = "GPU_NAME"
 	GPUCountEnv        = "ATTACHED_GPU_COUNT"
 
 	CloudProviderEnv = "NVCF_CLOUD_PROVIDER"

--- a/src/libraries/go/lib/pkg/icms-translate/translate/task/translate.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/task/translate.go
@@ -78,6 +78,7 @@ func translateContainer(t CreationQueueMessage, tcfg TranslateConfig) (objs []me
 	}
 
 	allEnvSet[common.ICMSEnvironmentEnv] = launchSpec.ICMSEnvironment
+	allEnvSet[common.SpotEnvironmentEnv] = launchSpec.SpotEnvironment
 	allEnvSet[common.CloudProviderEnvDep] = launchSpec.CloudProvider //nolint:staticcheck // SA1019: deprecated env var for backward compatibility
 	allEnvSet[common.CloudProviderEnv] = launchSpec.CloudProvider
 	allEnvSet[common.GPUNameEnv] = t.GPUType

--- a/src/libraries/go/lib/pkg/icms-translate/translate/task/types.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/task/types.go
@@ -60,6 +60,7 @@ type LaunchSpecification struct {
 	TerminationGracePeriodDuration string                        `json:"terminationGracePeriodDuration"`
 	ResultHandlingStrategy         common.ResultHandlingStrategy `json:"resultHandlingStrategy"`
 	ICMSEnvironment                string                        `json:"icmsEnvironment"`
+	SpotEnvironment                string                        `json:"spotEnvironment"`
 	// Telemetry configuration metadata.
 	Telemetries *common.TelemetriesLaunchSpecification `json:"telemetries,omitempty"`
 


### PR DESCRIPTION
## Summary
Add `SpotEnvironment` to the task `LaunchSpecification` type and wire it through to `allEnvSet` so the worker init container receives `SPOT_ENVIRONMENT` as a Kubernetes env var.

The field was present in the NATS message payload but absent from the deserialized struct, so `SPOT_ENVIRONMENT` was never injected and the init container always saw an empty value.

Also adds `SpotEnvironmentEnv = "SPOT_ENVIRONMENT"` constant to `common/env.go` to match the pattern used by all adjacent env var assignments.

**Note:** the function container translate path (`translate/function/`) has the same gap and needs a follow-up fix.

## Testing
Validated end-to-end: `SPOT_ENVIRONMENT` now appears on the init container and task pods complete successfully.

## Related Issues
None