### PR TITLE
docs(examples): add ray-serve and dynamo-operator to sample index

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,8 @@ Functions are long-running services that respond to HTTP or gRPC invocations.
 | [vLLM OTLP Exporter](function-samples/vllm-otlp-exporter-sample/) | vLLM inference with OpenTelemetry (OTLP) metric exporting for BYO Observability. |
 | [Inference Helm Chart](function-samples/helmchart-samples/inference-test-sample/) | Helm chart that deploys the FastAPI Echo sample on a Kubernetes cluster. |
 | [Multi-Node Helm Function](function-samples/helmchart-samples/multi-node-helm-function-test/) | Multi-node Helm chart for running NCCL and GPU bandwidth tests via NVCF. |
+| [Ray Serve Helm Chart](function-samples/helmchart-samples/ray-serve-sample/) | Helm chart that deploys a Ray Serve application as an NVCF function. |
+| [Dynamo Operator Sample](function-samples/helmchart-samples/dynamo-operator-sample/) | Helm chart for a vLLM disaggregated router deployed through NVCF. |
 | [Load Tester Supreme](function-samples/load-tester-supreme/) | HTTP and gRPC echo servers designed for load and throughput testing. |
 
 ## Task Samples


### PR DESCRIPTION
## TL;DR

Add two existing helm chart function samples to the top-level `examples/README.md` index: Ray Serve and Dynamo Operator. Both directories already live under `examples/function-samples/helmchart-samples/` with README and chart assets, but were not listed in the Function Samples table, so contributors could miss them when browsing the repo.

## Additional Details

The `examples/README.md` file is the entry point for self-hosted sample discovery. Several helm chart samples are indexed there (for example `inference-test-sample` and `multi-node-helm-function-test`), but `ray-serve-sample` and `dynamo-operator-sample` were omitted despite being present in the tree.

This change adds one table row per sample with a relative link and a short description consistent with existing index entries:

- `ray-serve-sample`: Ray Serve deployed as an NVCF Helm function
- `dynamo-operator-sample`: vLLM disaggregated router deployed through NVCF

No sample code, charts, or runtime behavior is modified. No Fern navigation or `docs/user/` pages are affected.

Limitations: This PR does not expand the thin `vllm-otlp-exporter-sample` README or add new samples. Those are separate follow-up contributions.

## For the Reviewer

Please review only `examples/README.md`. The diff is two inserted table rows placed after the Multi-Node Helm Function entry and before Load Tester Supreme.

Verify that:

- Link paths match existing directories
- Descriptions match the intent of each sample's local README

No maintainer action is required beyond a quick path and wording check.

## For QA

Verification steps run locally:

```bash
git diff --check
git diff examples/README.md
test -f examples/function-samples/helmchart-samples/ray-serve-sample/README.md
test -f examples/function-samples/helmchart-samples/dynamo-operator-sample/README.md
```

Results:

- `git diff --check`: passed (no trailing whitespace)
- Linked README paths: both exist
- Diff scope: 1 file, 2 lines added

Is QA Needed? No runtime QA. Docs-only index update; no cluster deploy or Bazel build required.

## Issues

- NO-REF

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes. (N/A: documentation index only; no executable code changed.)
- [x] The documentation is up to date with these changes.