### PR TITLE
fix(migrations): skip non-directory entries under keyspaces/

### DIFF
--- a/migrations/cassandra/execute_sqls.sh
+++ b/migrations/cassandra/execute_sqls.sh
@@ -54,6 +54,10 @@ echo "Pre-processing SQL files with environment variable substitution..."
 echo "Allowed variables: ${ENVSUBST_VARS}"
 
 for keyspace_dir in /app/keyspaces/*; do
+  # Only directories are keyspaces. keyspaces/ also holds README.md, which would
+  # otherwise become a keyspace named README.md and fail the migrate call below.
+  [ -d "$keyspace_dir" ] || continue
+
   keyspace_name=$(basename "$keyspace_dir")
   mkdir -p "$TEMP_KEYSPACES/$keyspace_name"
 
@@ -73,6 +77,8 @@ echo "SQL files pre-processed successfully"
 #
 for each in $TEMP_KEYSPACES/*
 do
+  [ -d "${each}" ] || continue
+
   migration_table_name=`basename ${each}`
   echo "Applying ${each}"
   migrate \


### PR DESCRIPTION
## TL;DR

`migrations/cassandra/keyspaces/` holds `README.md` alongside the four keyspace directories, and `execute_sqls.sh` iterated over every entry, so `README.md` was treated as a keyspace and aborted the migration run. This guards both loops with `[ -d ]` so only directories are treated as keyspaces.

## Additional Details

`README.md` was passed to `migrate` as `x-migrations-table=README.md`. The golang-migrate Cassandra driver reads the dot in that value as `keyspace.table`, so it tried to open a keyspace named `README`, which Cassandra lowercases:

```
Successfully initialized the db
SQL files pre-processed successfully
error: failed to open database: Keyspace 'readme' doesn't exist
Migration failed for /tmp/keyspaces/README.md
```

`execute_sqls.sh` then exits 1, which fails the `cassandra-helm-nvcf-cassandra-migrations` Helm hook job and leaves the `cassandra` release in a `failed` state.

The first loop also creates an empty `/tmp/keyspaces/README.md` directory on the way through, which is why the guard is applied to both loops rather than only the one that calls `migrate`. The `[ -d ]` form was chosen over a `.dockerignore` for `*.md` because it also covers any other non-directory file added to `keyspaces/` later.

The four real keyspaces (`api_keys_api`, `ess_api`, `nvcf_api`, `sis_api`) are unaffected.

## For the Reviewer

Single file, six lines, no behaviour change for directories.

This fixes the `keyspaces/README.md` defect, now tracked as #235 (split out of #190 at maintainer request). The base-image defect (#190, the `FROM bitnami/cassandra:5.0.6` base no longer resolving, since Bitnami withdrew their public catalog in Aug 2025) is deliberately not addressed here, because the right replacement looks like a maintainer decision rather than something to presume: `bitnamilegacy/cassandra:5.0.5-debian-12-r7` builds and runs, but it is a version downgrade, and an internal mirror may be preferred. Happy to follow up with a PR once you indicate a direction.

## For QA

Verified against the fixed image built with `README.md` present in `keyspaces/`:

```
--- loop with the [ -d ] guard (this PR):
  SKIP (not a dir): README.md
  keyspace: api_keys_api
  keyspace: ess_api
  keyspace: nvcf_api
  keyspace: sis_api
--- same loop without the guard (current main):
  keyspace: README.md          <- the bug
  keyspace: api_keys_api
  ...
```

End to end, against Cassandra 5.0.x running in a local k3d cluster: with `README.md` present in the build context the migrations hook job fails as quoted above; with the same image built from a context where `README.md` is removed, the job completes and the schema applies. This change makes the `README.md`-present case behave like the `README.md`-absent case.

`bash -n migrations/cassandra/execute_sqls.sh` is clean.

QA needed: no, beyond a normal migrations run.

## Issues:

- Fixes #235

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

On tests: there is no existing test harness for the shell scripts under `migrations/` (no BUILD target, no bats or shell test suite, and no migrations entry in `tools/ci/subproject-validations.yaml`), so there was no natural place to add one for a six-line guard. Happy to add coverage if you want a harness introduced, or to fold it into whatever you would prefer here.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration handling by ignoring unexpected files in keyspace directories.
  * Prevented non-keyspace files from interrupting migration processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->