### PR TITLE
ci(bazel): unblock GHA bazel matrix (downloader try-import + cacheless retry)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -35,7 +35,13 @@ common --enable_platform_specific_config
 # shared CI runner IP (429), which failed the Bazel validate jobs. This also
 # covers transitive module maven installs (e.g. contrib_rules_jvm_deps) that our
 # own maven.install repositories cannot repoint.
-common --downloader_config=tools/bazel/downloader.cfg
+#
+# The reroute targets an internal Artifactory host, so it lives in an
+# un-mirrored internal bazelrc rather than here: the public GitHub mirror never
+# ships that host, and GitHub-hosted runners cannot reach it (and do not share
+# the rate-limited runner IP). try-import is a no-op when the file is absent, so
+# public builds go straight to Maven Central and internal builds get the mirror.
+try-import %workspace%/tools/bazel/internal.bazelrc
 
 # Remote cache on by default for every developer. Pulls hits from the
 # configured remote cache (read-only), falls back to local execution on any


### PR DESCRIPTION
GitLab is frozen (cutover), so landing the GHA bazel fixes directly here.

Two failures on the public matrix:
- umbrella-phase1: `bazel version` dies on `Unable to find downloader config file tools/bazel/downloader.cfg` (internal-only Artifactory reroute, not mirrored). Fixed here: .bazelrc moves it behind a try-import of an un-mirrored internal.bazelrc (a no-op when absent).
- nvca: `Failed to query remote execution capabilities: General OpenSslEngine problem` (remote-cache TLS). Fix is the cacheless-retry in .github/workflows/bazel.yml — pending (needs a token with the workflow scope; see PR notes).

.bazelrc is included. bazel.yml to follow.