### PR TITLE
fix(vanity-gateway): extend HTTP latency histogram buckets

### DIFF
--- a/src/invocation-plane-services/vanity-gateway/middleware/metrics.go
+++ b/src/invocation-plane-services/vanity-gateway/middleware/metrics.go
@@ -30,6 +30,11 @@ var (
 	setupHTTPMetricsErr  error
 )
 
+var httpDurationHistogramBoundaries = []float64{
+	0.1, 0.25, 0.5, 0.75, 1, 2, 5, 10,
+	15, 30, 60, 120, 300, 600, 900,
+}
+
 func SetupHTTPMetrics() error {
 	setupHTTPMetricsOnce.Do(func() {
 		exporter, err := otelprom.New()
@@ -38,9 +43,26 @@ func SetupHTTPMetrics() error {
 			return
 		}
 
-		provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(exporter))
+		provider := newHTTPMeterProvider(exporter)
 		otel.SetMeterProvider(provider)
 	})
 
 	return setupHTTPMetricsErr
+}
+
+func newHTTPMeterProvider(reader sdkmetric.Reader) *sdkmetric.MeterProvider {
+	return sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(reader),
+		sdkmetric.WithView(httpDurationHistogramView("http.server.request.duration")),
+		sdkmetric.WithView(httpDurationHistogramView("http.client.request.duration")),
+	)
+}
+
+func httpDurationHistogramView(name string) sdkmetric.View {
+	return sdkmetric.NewView(
+		sdkmetric.Instrument{Name: name},
+		sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
+			Boundaries: httpDurationHistogramBoundaries,
+		}},
+	)
 }

--- a/src/invocation-plane-services/vanity-gateway/middleware/metrics_test.go
+++ b/src/invocation-plane-services/vanity-gateway/middleware/metrics_test.go
@@ -79,6 +79,33 @@ func TestServerTelemetryMiddlewareRecordsStatusAndRouteMetrics(t *testing.T) {
 	}))
 }
 
+func TestHTTPDurationHistogramBoundaries(t *testing.T) {
+	expectedBoundaries := []float64{
+		0.1, 0.25, 0.5, 0.75, 1, 2, 5, 10,
+		15, 30, 60, 120, 300, 600, 900,
+	}
+	reader := sdkmetric.NewManualReader()
+	provider := newHTTPMeterProvider(reader)
+	t.Cleanup(func() {
+		require.NoError(t, provider.Shutdown(context.Background()))
+	})
+
+	handler := ServerTelemetryMiddleware(otelhttp.WithMeterProvider(provider))(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client := &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport, otelhttp.WithMeterProvider(provider))}
+	response, err := client.Get(server.URL)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+
+	metrics := collectMetrics(t, reader)
+	require.Equal(t, expectedBoundaries, histogramBounds(t, metrics, "http.server.request.duration"))
+	require.Equal(t, expectedBoundaries, histogramBounds(t, metrics, "http.client.request.duration"))
+}
+
 func TestAddOpenAIRequestMetricAttributesCopiesModelName(t *testing.T) {
 	const value = "meta/llama-3"
 	// Model names parsed by goccy/go-json can share the request body's backing storage.
@@ -139,6 +166,23 @@ func histogramHasAttributes(data metricdata.Aggregation, want map[attribute.Key]
 		}
 	}
 	return false
+}
+
+func histogramBounds(t *testing.T, metrics []metricdata.Metrics, name string) []float64 {
+	t.Helper()
+
+	for _, metric := range metrics {
+		if metric.Name != name {
+			continue
+		}
+		histogram, ok := metric.Data.(metricdata.Histogram[float64])
+		if ok && len(histogram.DataPoints) > 0 {
+			return histogram.DataPoints[0].Bounds
+		}
+	}
+
+	require.FailNow(t, "histogram not found", name)
+	return nil
 }
 
 func dataPointHasAttributes(attrs attribute.Set, want map[attribute.Key]attribute.Value) bool {


### PR DESCRIPTION
## Why

The default OpenTelemetry HTTP duration histogram ends at 10 seconds. Long-running request quantiles therefore collapse into the overflow bucket and appear pinned at the last finite boundary.

## What changed

- Override the server and client HTTP duration histograms with explicit boundaries through 900 seconds.
- Use 0.1, 0.25, 0.5, 0.75, 1, 2, 5, 10, 15, 30, 60, 120, 300, 600, and 900-second boundaries.
- Add an integration test that asserts the exported bounds for both real `otelhttp` instruments.

## Customer Release Notes

AI API Gateway latency metrics now distinguish long-running requests up to 15 minutes instead of saturating at 10 seconds.

## Plan Summary

Not applicable.

## Usage

No operator action is required. Existing Grafana percentile queries continue to work.

## Testing

- `go test ./middleware`
- `bazel test //middleware:middleware_test --remote_cache=`

## Notes

Historical samples remain unchanged. Requests beyond 900 seconds still use the overflow bucket.

## References

NO-REF

## Related Merge Requests/Pull Requests

None.

## Dependencies

None.
