### PR TITLE
ci: add stable bazel verification check

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -282,3 +282,36 @@ jobs:
             [ "$CACHE_UPLOAD" = "true" ] || FLAGS+=(--remote_upload_local_results=false)
           fi
           bazel test "${FLAGS[@]}" --flaky_test_attempts=3 //...
+
+  bazel-verification:
+    name: bazel verification
+    needs: [detect, bazel]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Bazel workflow result
+        env:
+          DETECT_RESULT: ${{ needs.detect.result }}
+          BAZEL_RESULT: ${{ needs.bazel.result }}
+          BAZEL_ANY: ${{ needs.detect.outputs.any }}
+        run: |
+          set -euo pipefail
+
+          echo "detect result: ${DETECT_RESULT}"
+          echo "bazel result: ${BAZEL_RESULT}"
+          echo "bazel selected subtrees: ${BAZEL_ANY}"
+
+          if [ "${DETECT_RESULT}" != "success" ]; then
+            echo "detect changed subtrees did not complete successfully"
+            exit 1
+          fi
+
+          if [ "${BAZEL_ANY}" != "true" ]; then
+            echo "no Bazel-relevant subtrees selected"
+            exit 0
+          fi
+
+          if [ "${BAZEL_RESULT}" != "success" ]; then
+            echo "one or more Bazel matrix rows failed, were cancelled, or were skipped"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- add a stable bazel verification job after the dynamic Bazel matrix
- make the static check pass when no Bazel subtrees are selected and fail when detect or any selected Bazel matrix row fails
- provide a single check name that branch rulesets can require for merge queue gating

## Validation
- git diff --check
- parsed .github/workflows/bazel.yml with Ruby YAML.load_file

NO-REF