### PR TITLE
docs(agents): remove dead skill and file references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,13 +16,8 @@ Useful pointers:
 - `BAZEL.md` for the contributor-facing Bazel build path
 - `docs/AGENTS.md` for in-repo user and developer documentation
 - `tools/AGENTS.md` for repo tooling
-- `deploy/helm/AGENTS.md` for native Helm chart guidance
-- `migrations/AGENTS.md` for native migration image guidance
 - `imports.yaml` for subtree ownership and commit pins
 - `.cursor/skills/documentation-style/SKILL.md` for docs style
-- `.cursor/skills/nvcf-gitlab-subproject-ci/SKILL.md` for native subproject CI
-  (read before editing `.gitlab-ci.yml`, `subproject-validations.yaml`, or
-  `generated-release-jobs.yml`)
 - `.cursor/skills/` for root dev-skill symlink fanout
 - `ai-tooling/user/skills/` and `ai-tooling/dev/skills/` for public skills
 
@@ -206,16 +201,8 @@ manually before finishing.
 
 | Skill | Location | Purpose |
 |-------|----------|---------|
-| `bazel-go-gazelle` | `ai-tooling/dev/skills/` | Wire Go modules into Bazel with rules_go and Gazelle |
-| `bazel-java-maven` | `ai-tooling/dev/skills/` | Wire Java and Spring Boot services into Bazel with Maven artifacts |
-| `bazel-gitlab-child-pipelines` | `ai-tooling/dev/skills/` | Generic Bazel parent-child pipeline pattern; for this repo prefer `nvcf-gitlab-subproject-ci` |
-| `bazel-monorepo-bootstrap` | `ai-tooling/dev/skills/` | Bootstrap Bazel in an existing polyglot monorepo |
-| `bazel-oci-images` | `ai-tooling/dev/skills/` | Build multi-arch OCI images from Bazel binaries |
-| `bazel-rust-crate-universe` | `ai-tooling/dev/skills/` | Wire Rust services into Bazel with crate_universe |
-| `nvcf-gitlab-subproject-ci` | `ai-tooling/dev/skills/` | Native subproject CI via generated child pipeline (not root `.gitlab-ci.yml`) |
 | `documentation-style` | `ai-tooling/dev/skills/` | NVCF documentation conventions (no bold, no emojis, no em-dash) |
 | `nvcf-explore-stack` | `ai-tooling/dev/skills/` | Navigate the self-hosted stack topology and dependency graph |
-| `official-docs-style` | `ai-tooling/dev/skills/` | External-facing NVCF user documentation voice and structure |
 | `nvcf-self-managed-cli` | `ai-tooling/user/skills/` | Install, operate, and manage self-managed NVCF through `nvcf-cli` |
 | `nvcf-self-managed-installation` | `ai-tooling/user/skills/` | Install and deploy the self-managed NVCF stack |
 | `nvcf-self-managed-prerequisite` | `ai-tooling/user/skills/` | Install cluster-level prerequisites such as KAI Scheduler and SMB CSI driver |
@@ -232,7 +219,7 @@ build, test, helm-lint, or release validation jobs go.
 | License scan, bazel-smoke, docs, OSS snapshot | root `.gitlab-ci.yml` only |
 
 Before adding or moving any CI job for a path under `src/`, `deploy/helm/`, or
-`migrations/`, read `nvcf-gitlab-subproject-ci` (`.cursor/skills/` symlink).
+`migrations/`, read this section in full.
 Do not add per-service jobs to root `.gitlab-ci.yml` and do not recreate
 `src/**/.gitlab-ci.yml`, `deploy/helm/**/.gitlab-ci.yml`, or
 `migrations/**/.gitlab-ci.yml` for native subprojects. Helm CI-only values

--- a/BAZEL.md
+++ b/BAZEL.md
@@ -5,20 +5,6 @@ NVCF umbrella repo. Bazel is the build engine for the native subtrees in
 Phase 1; upstream-owned subtrees keep their existing build paths until they go
 native.
 
-For the design rationale (why Bazel and why phased rollout), see the merge
-request that introduced this scaffolding and the Bazel skill set under
-`.claude/skills/bazel-*`. The skills cover the
-patterns this repo already uses and the ones future phases will need:
-
-| Skill | Use it for |
-|---|---|
-| `bazel-monorepo-bootstrap` | Re-bootstrapping or auditing root files (`MODULE.bazel`, `.bazelrc`, `tools/workspace_status.sh`, `ci/Dockerfile.bazel`) |
-| `bazel-go-gazelle` | Adding or maintaining Go subtrees (Phase 2) |
-| `bazel-oci-images` | Adding `rules_oci` images for new services |
-| `bazel-java-maven` | Onboarding Java services (e.g. `llm-api-gateway`) |
-| `bazel-rust-crate-universe` | Onboarding Rust services (e.g. `parsec`) |
-| `bazel-gitlab-child-pipelines` | Wiring a new service into the Bazel CI flow |
-
 ## Phase 1 scope
 
 Bazel currently builds, tests, and packages:
@@ -171,8 +157,7 @@ Do not run `bazel sync --only=...` here. `bazel sync` is a WORKSPACE-mode
 command and Bazel 8 rejects it on bzlmod-only repos with
 `ERROR: WORKSPACE has to be enabled for sync command to work`.
 
-Commit any diffs to `Cargo.lock` and `MODULE.bazel.lock`. See the
-`bazel-rust-crate-universe` skill for the full onboarding flow.
+Commit any diffs to `Cargo.lock` and `MODULE.bazel.lock`.
 
 ### Build graph queries (useful for review)
 

--- a/ai-tooling/README.md
+++ b/ai-tooling/README.md
@@ -6,15 +6,8 @@ Public agent skills for users and developers working with NVIDIA Cloud Functions
 
 | Skill | Description |
 |-------|-------------|
-| [bazel-go-gazelle](dev/skills/bazel-go-gazelle/SKILL.md) | Wire Go modules into Bazel with rules_go and Gazelle |
-| [bazel-gitlab-child-pipelines](dev/skills/bazel-gitlab-child-pipelines/SKILL.md) | Generic Bazel parent-child pipeline pattern. For nvcf/nvcf native subprojects, prefer `nvcf-gitlab-subproject-ci` |
-| [bazel-java-maven](dev/skills/bazel-java-maven/SKILL.md) | Wire Java and Spring Boot services into Bazel with Maven artifacts |
-| [bazel-monorepo-bootstrap](dev/skills/bazel-monorepo-bootstrap/SKILL.md) | Bootstrap Bazel in an existing polyglot monorepo |
-| [bazel-oci-images](dev/skills/bazel-oci-images/SKILL.md) | Build multi-arch OCI images from Bazel binaries |
-| [bazel-rust-crate-universe](dev/skills/bazel-rust-crate-universe/SKILL.md) | Wire Rust services into Bazel with crate_universe |
 | [documentation-style](dev/skills/documentation-style/SKILL.md) | NVCF documentation conventions for public repo prose |
 | [nvcf-explore-stack](dev/skills/nvcf-explore-stack/SKILL.md) | Navigate the self-hosted stack topology, helmfile dependency graph, chart ownership, and deployment order |
-| [nvcf-gitlab-subproject-ci](dev/skills/nvcf-gitlab-subproject-ci/SKILL.md) | Maintain native subproject CI through `tools/ci/subproject-validations.yaml` and the generated child pipeline |
 | [nvcf-self-managed-installation](user/skills/nvcf-self-managed-installation/SKILL.md) | Install and deploy the nvcf-self-managed-stack helmfile bundle: installation, teardown, values overrides, pull secrets, debugging |
 | [nvcf-self-managed-cli](user/skills/nvcf-self-managed-cli/SKILL.md) | Standalone NVCF CLI (`nvcf-cli`) for self-managed/self-hosted deployments: install, status, add compute plane, teardown, function lifecycle, invocation, and API keys |
 | [nvcf-self-managed-prerequisite](user/skills/nvcf-self-managed-prerequisite/SKILL.md) | Install the cluster-level prerequisites NVCA needs: KAI Scheduler (with queue-quota patch) and the SMB CSI driver. Cloud-neutral helm installs pinned to NVCF-validated versions |

--- a/tools/collect-dependencies/README.md
+++ b/tools/collect-dependencies/README.md
@@ -22,8 +22,7 @@ go run ./tools/collect-dependencies -l helm
 
 ## Outputs
 
-- [`../../dependencies.md`](../../dependencies.md): Shared rollup for Go modules, Rust crates, Python packages, Java Maven coordinates, and Helm chart dependencies. Entries are deduped and grouped by normalized license expression. Each bullet keeps a language tag, and MPL groups keep the explicit version (`MPL-1.0`, `MPL-1.1`, `MPL-2.0`) in the heading.
-- [`../../dependencies-java.md`](../../dependencies-java.md): Existing Java-only grouped snapshot kept at the repo root for reference. The generator no longer rewrites this file. Java dependencies now flow into `../../dependencies.md`.
+- [`../../dependencies.md`](../../dependencies.md): Shared rollup for Go modules, Rust crates, Python packages, Java Maven coordinates, and Helm chart dependencies, including Java. Entries are deduped and grouped by normalized license expression. Each bullet keeps a language tag, and MPL groups keep the explicit version (`MPL-1.0`, `MPL-1.1`, `MPL-2.0`) in the heading.
 
 Regenerate when imported trees or their dependency manifests change.
 


### PR DESCRIPTION
TL;DR
AGENTS.md, ai-tooling/README.md, and BAZEL.md listed skills and files that never existed on disk (several bazel-* skills, nvcf-gitlab-subproject-ci, official-docs-style, deploy/helm/AGENTS.md, migrations/AGENTS.md, dependencies-java.md). Removed the dead entries so the guidance matches what is actually in the repo.

For the Reviewer
Checked with grep that no other file still references the removed names, and ran rumdl on the changed files.

Issues
NO-REF
