### PR TITLE
chore(examples): fix typo in task sample output logs

### DIFF
--- a/examples/task-samples/task-byoo-sample/main.py
+++ b/examples/task-samples/task-byoo-sample/main.py
@@ -364,7 +364,7 @@ if __name__ == "__main__":
                 task_progress_gauge.set(dummy_percent_complete)
 
             logger.info(
-                f"Ouput result: {output_folder_name}, task progress: {dummy_percent_complete}%"
+                f"Output result: {output_folder_name}, task progress: {dummy_percent_complete}%"
             )
 
             time.sleep(DELAY_BETWEEN_RESULTS_IN_MINUTES * 60)

--- a/examples/task-samples/task-simple-sample/main.py
+++ b/examples/task-samples/task-simple-sample/main.py
@@ -227,7 +227,7 @@ if __name__ == "__main__":
             # update progress file to tell NVCT that file is created
             dummy_percent_complete = int((i+1) / NUM_OF_RESULTS * 100)
             update_task_progress_file(dummy_percent_complete, PROGRESS_FILE, output_folder_name, metadata)
-            print(f"Ouput result: {output_folder_name}, task progress: {dummy_percent_complete}%")
+            print(f"Output result: {output_folder_name}, task progress: {dummy_percent_complete}%")
 
         except Exception as e:
             print(f"Exception occurs: {e}")


### PR DESCRIPTION
TL;DR
Fixed "Ouput" to "Output" in the two task sample scripts (task-simple-sample and task-byoo-sample).

For the Reviewer
Small typo fix, verified with py_compile that both files still parse.

Issues
NO-REF
