### PR TITLE
chore: fix typos in native service comments and strings

### DIFF
--- a/deploy/helm/container-cache/deploy/files/logging-formats.conf
+++ b/deploy/helm/container-cache/deploy/files/logging-formats.conf
@@ -14,7 +14,7 @@
 # limitations under the License.
         # Logging Configurations
 
-        # Mulitple logging configurations are required to enable logging of service specific parameters
+        # Multiple logging configurations are required to enable logging of service specific parameters
         # log_format only takes literal strings and variables cause double-encoding issues
         # Each format adds service specific parameters
 

--- a/deploy/helm/container-cache/deploy/files/lua/lua-ssl.lua
+++ b/deploy/helm/container-cache/deploy/files/lua/lua-ssl.lua
@@ -14,7 +14,7 @@
 -- limitations under the License.
 -- generate and cache an (expiring) CA bundle based on the
 -- intermediate CA we have from vault and our private key.
--- use it to MITM the incomming TLS connection and masquerade
+-- use it to MITM the incoming TLS connection and masquerade
 -- as which ever host the client asked for. this requires the
 -- client to accept the CA chain from vault.
 local ssl            = require "ngx.ssl"

--- a/deploy/helm/container-cache/deploy/files/proxy-cache.conf
+++ b/deploy/helm/container-cache/deploy/files/proxy-cache.conf
@@ -139,7 +139,7 @@
               end
               local headers, err = ngx.resp.get_headers()
               if ngx.status == 200 and ngx.var.request_method == "HEAD" and headers["content-length"] == nil and ngx.var.request_uri ~= '/' then
-                -- This change should be reomved when OMPE-36810 is fixed.
+                -- This change should be removed when OMPE-36810 is fixed.
                 ngx.shared.head_request_cache:delete(ngx.var.request_uri)
                 ngx.log(ngx.ERR, "Bad state. Content-Length missing in HEAD response.")
                 ngx.status = 429

--- a/src/compute-plane-services/byoo-otel-collector/generator/README.md
+++ b/src/compute-plane-services/byoo-otel-collector/generator/README.md
@@ -7,7 +7,7 @@ This CLI tool turns a structured YAML specification into a human-readable Markdo
 
 uv
 
-run uv sync to download the dependecy 
+run uv sync to download the dependency 
 ```
 uv sync
 ```
@@ -22,7 +22,7 @@ uv run -m generator -do doc -to gen
 | Option / Flag                     | Type      | Default                              | Description                                                                                       |
 | --------------------------------- | --------- | ------------------------------------ | ------------------------------------------------------------------------------------------------- |
 | `-do`, `--document-output-dir` **(required)**  | Path      | –                                    | Target directory where the Markdown file will be written. It will be created if it does not exist.|
-| `-to`, `--template-output-dir` **(required)**  | Path      | –                                    | Target directory where the comfig template files will be written. It will be created if it does not exist.|
+| `-to`, `--template-output-dir` **(required)**  | Path      | –                                    | Target directory where the config template files will be written. It will be created if it does not exist.|
 | `-c`, `--config`                  | Path      | `source-config.yaml`       | YAML file that defines global attributes and metric lists.                                        |
 | `-df`, `--document-filename`      | string    | `README.md`                          | Name of the generated file (relative to `--output`).                                              |
 | `-h`, `--help`                    | –         | –                                    | Show the built-in help message.                                                                   |

--- a/src/compute-plane-services/byoo-otel-collector/generator/template_helper.py
+++ b/src/compute-plane-services/byoo-otel-collector/generator/template_helper.py
@@ -25,7 +25,7 @@ from templates.prometheus_config_generator import PrometheusConfigGenerator
 
 class SilentUndefined(Undefined):
     '''
-    Dont break pageloads because vars arent there!
+    Dont break pageloads because vars aren't there!
     '''
     def _fail_with_undefined_error(self, *args, **kwargs):
         return None
@@ -101,4 +101,4 @@ class TemplateBuilder:
             with open(f"{self.output_folder}/generated_{source_template}", "w", encoding="utf-8") as f:
                 f.write(rendered_yaml)
 
-            print(f"Config templates gererated at {self.output_folder}/generated_{source_template}")
+            print(f"Config templates generated at {self.output_folder}/generated_{source_template}")

--- a/src/compute-plane-services/byoo-otel-collector/validator/cli/README.md
+++ b/src/compute-plane-services/byoo-otel-collector/validator/cli/README.md
@@ -139,7 +139,7 @@ INFO       - opentelemetry-collector       : Valid with warnings
 INFO     ###########################################################
 ```
 
-Vaidate the metrics against to the golden metrics
+Validate the metrics against to the golden metrics
 - Check the golden metrics in ../golden for reference
 ``` bash
 > uv run -m src.validator --cloud-provider=non-gfn --wrapper-type=function --workload-type=container --golden aadb8822-7992-4d63-a771-76bdb7d2f402

--- a/src/compute-plane-services/ess-agent/README.md
+++ b/src/compute-plane-services/ess-agent/README.md
@@ -275,7 +275,7 @@ Will occur when a bad/invalid JWT token used (401), token does not have access t
 When encountered the agent will exit with code 1 as there is no recovery without outside changes applied.
 
 #### 3. 429 Rate-limited
-Too many requests to ESS API have occured from the same IP address.
+Too many requests to ESS API have occurred from the same IP address.
  The agent will exponentially retry for up to 10 minutes and exit is time limit is reached.
 
 #### 4. 50x Server Error
@@ -312,9 +312,9 @@ Similar to 40x errors, the agent will stop rendering the template and reset the 
 
 #### 3. 50x Server Errors
 
-50x errors will use an exponential retry policy starting at 500 miliseconds (e.g. 500ms, 1s, 2s, 4s...) with a max retry duration of 1 minute until a total of 10 minutes has passed.
+50x errors will use an exponential retry policy starting at 500 milliseconds (e.g. 500ms, 1s, 2s, 4s...) with a max retry duration of 1 minute until a total of 10 minutes has passed.
 
-If the 10 minute max duration is reached, retries will be stopped and the refresh secret cadence will be restarted. If this event occurs the total duration betwen secret fetches is 25 minutes (10 retry max + 15 minute refresh cadence).
+If the 10 minute max duration is reached, retries will be stopped and the refresh secret cadence will be restarted. If this event occurs the total duration between secret fetches is 25 minutes (10 retry max + 15 minute refresh cadence).
 
 Note: Exponential retries do not increment the `ess_templates_request_total` metric with `status="fail"` only the first API call failure will be tracked.
 

--- a/src/compute-plane-services/nvca/internal/miniservice/controller.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/controller.go
@@ -415,7 +415,7 @@ func (r *Reconciler) newNVLinkOptMetricsRunnable(mgr ctrl.Manager) manager.Runna
 	})
 }
 
-// updateNVLinkOptMetrics is a helper for the NVLink opt metrics runnable that actuall updates metrics.
+// updateNVLinkOptMetrics is a helper for the NVLink opt metrics runnable that actually updates metrics.
 func (r *Reconciler) updateNVLinkOptMetrics(ctx context.Context) error {
 	log := logf.FromContext(ctx)
 

--- a/src/compute-plane-services/nvca/pkg/featureflag/featureflag_test.go
+++ b/src/compute-plane-services/nvca/pkg/featureflag/featureflag_test.go
@@ -40,7 +40,7 @@ func TestFeatureFlags(t *testing.T) {
 	assert.True(t, ClusterTargeting.Enabled())
 	assert.True(t, HelmSharedStorage.Enabled())
 
-	// Disable/Enable cluster targetting
+	// Disable/Enable cluster targeting
 	_ = parseFlags(fmt.Sprintf("-%s", ClusterTargeting.Key))
 	assert.False(t, ClusterTargeting.Enabled())
 	_ = parseFlags(fmt.Sprintf("+%s", ClusterTargeting.Key))

--- a/src/compute-plane-services/nvca/pkg/nvca/agent.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/agent.go
@@ -199,7 +199,7 @@ type AgentOptions struct {
 	// for third party registry cred updates.
 	ImageCredentialHelperImage string
 
-	// K8sTimeConfig configures intervals, timeouts, thresholds for various K8s occurances.
+	// K8sTimeConfig configures intervals, timeouts, thresholds for various K8s occurrences.
 	K8sTimeConfig *k8sutil.TimeConfig
 
 	// MinHealthcheckRefreshWait forces the NVCA internal healthchecker

--- a/src/compute-plane-services/nvca/pkg/nvca/backendk8scache.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/backendk8scache.go
@@ -227,7 +227,7 @@ type BackendK8sCache struct {
 	taskEnvOverrides     map[string]string
 }
 
-// BackendK8sCacheBuilder builds Backendk8sCache and start related egde K8s
+// BackendK8sCacheBuilder builds Backendk8sCache and start related edge K8s
 // informers, monitored K8s events are sent to a event channel that is
 // returned by Start()
 type BackendK8sCacheBuilder struct {

--- a/src/compute-plane-services/nvca/pkg/nvca/computebackend.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/computebackend.go
@@ -68,7 +68,7 @@ type K8sArtifactHelper interface {
 	GetICMSRequestUpdatesForCreatePodRequest(ctx context.Context,
 		st nvcav2beta1.InstanceStatus, req *nvcav2beta1.ICMSRequest) (types.ICMSRequestUpdateInfo, error)
 
-	// CreatePodArtifact creates a PodArtifact as specfied by the inputs podArt
+	// CreatePodArtifact creates a PodArtifact as specified by the inputs podArt
 	CreatePodArtifact(ctx context.Context, podArt function.LaunchArtifact, mf mutateFunc) error
 
 	// GetErroredPodLogs returns the pod logs of the failed instance container or the static error message for Utils / Init if one exists

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/agent.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/agent.go
@@ -696,7 +696,7 @@ func (a *Agent) startEventProcessingWorkers(ctx context.Context) error {
 	}
 
 	// create and initialize queues before start goroutines
-	// to aovid a data race
+	// to avoid a data race
 	a.resourceEventWorkerQueues = make(map[string]workqueue.TypedRateLimitingInterface[any])
 	for _, eventName := range getAgentEvents() {
 		a.resourceEventWorkerQueues[eventName] =

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/cli.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/cli.go
@@ -84,7 +84,7 @@ func NewOperatorCommand() *cli.Command {
 				Name:    "kubeconfig",
 				EnvVars: []string{"KUBECONFIG"},
 				Value:   "",
-				Usage:   "'kubeconfig' is the KUBECONFIG path for bakend K8s cluster",
+				Usage:   "'kubeconfig' is the KUBECONFIG path for backend K8s cluster",
 			},
 			&cli.StringFlag{
 				Name:  "listen",

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/nvcaagent_reconcile.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/nvcaagent_reconcile.go
@@ -2555,7 +2555,7 @@ func completeInternalPersistentStorageConfig(ctx context.Context, nb *nvidiaiov1
 	return dto, nil
 }
 
-// returns a string of the internal persisten storage configuration base64 encoded
+// returns a string of the internal persistent storage configuration base64 encoded
 func getInternalPersistentStorageConfig(ctx context.Context, nb *nvidiaiov1.NVCFBackend) (string, error) {
 	log := core.GetLogger(ctx)
 	dto, err := completeInternalPersistentStorageConfig(ctx, nb)

--- a/src/compute-plane-services/nvca/pkg/queue/sqs/sqs.go
+++ b/src/compute-plane-services/nvca/pkg/queue/sqs/sqs.go
@@ -59,7 +59,7 @@ func getAWSRegion(ctx context.Context, queueURL string) string {
 			return id
 		}
 	}
-	log.Warnf("mising AWS region in URL (%v), returning %v", queueURL, defaultAWSRegion)
+	log.Warnf("missing AWS region in URL (%v), returning %v", queueURL, defaultAWSRegion)
 	return defaultAWSRegion
 }
 

--- a/src/compute-plane-services/nvca/pkg/storage/modelcache_cleanup.go
+++ b/src/compute-plane-services/nvca/pkg/storage/modelcache_cleanup.go
@@ -275,7 +275,7 @@ func (r *Reconciler) cleanupIdleModelCaches(ctx context.Context) error { //nolin
 		if pv.Annotations == nil {
 			continue
 		}
-		// Collect existing primaray PV cache handles.
+		// Collect existing primary PV cache handles.
 		if pv.Labels != nil {
 			cacheHandle := pv.Labels[modelCacheHandleLabelKey]
 			if _, ok := r.initStatuses.get(cacheHandle); cacheHandle != "" && ok {

--- a/src/compute-plane-services/nvca/pkg/webhook/miniservice_mutating_webhook.go
+++ b/src/compute-plane-services/nvca/pkg/webhook/miniservice_mutating_webhook.go
@@ -72,7 +72,7 @@ type miniserviceMutatingWebhook struct {
 	scheme  *runtime.Scheme
 	decoder runtime.Decoder
 
-	// Shim for shared storage mutating webhook that needed object annoations applied by this webhook.
+	// Shim for shared storage mutating webhook that needed object annotations applied by this webhook.
 	// Since NVCA cannot guarantee webhook execution order, its mutate() method is called here.
 	sharedStorageMutator *helmStorageMutatingWebhook
 

--- a/src/compute-plane-services/nvca/scripts/ci_check_codegen
+++ b/src/compute-plane-services/nvca/scripts/ci_check_codegen
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 #
-# This script exit non-zero if K8s codegen genarated code has uncommitted
+# This script exit non-zero if K8s codegen generated code has uncommitted
 # changes.
 set -eu -o pipefail
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"

--- a/src/compute-plane-services/nvsnap/internal/db/checkpoint.go
+++ b/src/compute-plane-services/nvsnap/internal/db/checkpoint.go
@@ -414,7 +414,7 @@ func (d *DB) GetCheckpoint(id string) (*Checkpoint, error) {
 //   - EngineFlags: canonicalized server-side (sorted, --model* stripped),
 //     compared as the JSON-array string stored on the row
 //   - DriverMajor: if > 0, exact match; if 0, match any
-//   - Hash: only rows with non-empty Hash are returned (a restoreable
+//   - Hash: only rows with non-empty Hash are returned (a restorable
 //     artifact must have a content hash, otherwise NVCA can't stamp
 //     nvsnap.io/restore-from)
 //

--- a/src/compute-plane-services/nvsnap/internal/server/server.go
+++ b/src/compute-plane-services/nvsnap/internal/server/server.go
@@ -219,7 +219,7 @@ func (s *Server) setupRoutes() {
 	api.HandleFunc("/checkpoints/register", s.registerCheckpoint).Methods("POST")
 	// nvsnap#59: content-addressed lookup. NVCA's Hook A POSTs the
 	// canonical workload identity (imageRef + modelID + flags +
-	// driverMajor) here to find a restoreable artifact across fvIDs.
+	// driverMajor) here to find a restorable artifact across fvIDs.
 	// Returns matches sorted freshest-first. Indexed by hash + image_ref
 	// in the catalog DB.
 	api.HandleFunc("/checkpoints/lookup", s.lookupCheckpoint).Methods("POST")

--- a/src/compute-plane-services/nvsnap/internal/webhook/mutate_test.go
+++ b/src/compute-plane-services/nvsnap/internal/webhook/mutate_test.go
@@ -550,7 +550,7 @@ func TestMutate_OverlayCoversAllVolumes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Both volumes must have been overlayed (one call each, in
+	// Both volumes must have been overlaid (one call each, in
 	// section order: hostPath first, then rootfs-extract).
 	if got, want := len(overlay.calls), 2; got != want {
 		t.Fatalf("PrepareOverlay calls = %d, want %d (vols=%+v)", got, want, overlay.calls)

--- a/src/compute-plane-services/worker-task/internal/secrets/secrets.go
+++ b/src/compute-plane-services/worker-task/internal/secrets/secrets.go
@@ -90,7 +90,7 @@ func (s *Secrets) load() error {
 	return nil
 }
 
-// Watch for updates in secret file and rotate them in memeory.
+// Watch for updates in secret file and rotate them in memory.
 func (s *Secrets) rotateSecrets(ctx context.Context) {
 	zap.L().Info("Starting to watch for secrets update")
 

--- a/src/compute-plane-services/worker-task/internal/worker/worker.go
+++ b/src/compute-plane-services/worker-task/internal/worker/worker.go
@@ -441,7 +441,7 @@ func (w *NVCTWorker) workSession(ctx context.Context) error {
 }
 
 func (w *NVCTWorker) PreStopCheck(ctx context.Context) error {
-	zap.L().Info("Recived termination signal, checking progress file")
+	zap.L().Info("Received termination signal, checking progress file")
 	progressData, err := progress.ParseProgressFile(w.config.ProgressFilePath)
 	if err != nil {
 		w.handleWorkerTermination(ctx)

--- a/src/control-plane-services/function-autoscaler/crates/server/src/settings/README.md
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/settings/README.md
@@ -69,7 +69,7 @@ cargo run --bin server -- -c settings.toml
 
 ## 1.2. Environment variables
 
-Any setting can be overriden by an environment variable with the same path name.  In this
+Any setting can be overridden by an environment variable with the same path name.  In this
 example,
 ```
 SERVER__TONIC__INITIAL_STREAM_WINDOW_SIZE=1234 cargo run --bin server
@@ -103,7 +103,7 @@ We use the standard `clap` crate to parse the command line.  Thus, you can use t
 decorator to interpret the struct attributes as cli args.  See [docs](https://docs.rs/clap/latest/clap/#macros).
 
 ```
-Any setting can be overriden on the command line by passing it as an override at the end of the command:
+Any setting can be overridden on the command line by passing it as an override at the end of the command:
 ```
 cargo run --bin server -- --port 50002 -c settings.toml -- tonic_settings.request_timeout=100
 ```

--- a/src/control-plane-services/helm-reval/reval/helm_template_test.go
+++ b/src/control-plane-services/helm-reval/reval/helm_template_test.go
@@ -30,7 +30,7 @@ func Test_isErrHTTPAuthIssue(t *testing.T) {
 	assert.False(t, isErrHTTPAuthIssue(fmt.Errorf("failed to fetch blah")))
 	assert.False(t, isErrHTTPAuthIssue(fmt.Errorf("failed to fetch blah : 400 bad request")))
 	assert.True(t, isErrHTTPAuthIssue(fmt.Errorf("failed to fetch blah : 401 invalid creds")))
-	assert.True(t, isErrHTTPAuthIssue(fmt.Errorf("failed to fetch blah : 403 unathorized")))
+	assert.True(t, isErrHTTPAuthIssue(fmt.Errorf("failed to fetch blah : 403 unauthorized")))
 }
 
 func Test_ngcHostRe(t *testing.T) {

--- a/src/invocation-plane-services/http-invocation/crates/server/resources/settings.yaml
+++ b/src/invocation-plane-services/http-invocation/crates/server/resources/settings.yaml
@@ -17,7 +17,7 @@ server:
     endpoint_ip: http://127.0.0.1
     endpoint_port: 8282
     headers:
-      lightstep-access-token: LIGHTSTEP_ACCESS_TOKEN # this is a standin value only; is set progammatically in server.rs
+      lightstep-access-token: LIGHTSTEP_ACCESS_TOKEN # this is a standin value only; is set programmatically in server.rs
       organization: default
       stream-name: default
     service_name: nvcf_invocation_service

--- a/src/invocation-plane-services/http-invocation/crates/server/tests/test_error_codes.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/tests/test_error_codes.rs
@@ -65,7 +65,7 @@ async fn test_request_id_not_found() -> anyhow::Result<()> {
     assert_eq!(response.status(), StatusCode::OK);
     assert!(response.headers().get("nvcf-reqid").is_some());
 
-    // Lookup the request id that just finished (and should've been dequed)
+    // Lookup the request id that just finished (and should've been dequeued)
     let request_id: String = response
         .headers()
         .get("nvcf-reqid")

--- a/src/libraries/go/lib/pkg/core/kubeconfigurator.go
+++ b/src/libraries/go/lib/pkg/core/kubeconfigurator.go
@@ -113,7 +113,7 @@ type TokenFetcher interface {
 // TokenKubeConfigurator implements KubeConfigurator by building
 // rest.Config use the bear token retrieved from a tokenFetcher. It
 // checks token update at given `Interval`, and only sends new
-// kubeconfig down to the channel if cached token get's changed.
+// kubeconfig down to the channel if cached token gets changed.
 type TokenKubeConfigurator struct {
 	masterURL string
 	fetcher   TokenFetcher

--- a/src/libraries/go/lib/pkg/nvkit/audit/audit.go
+++ b/src/libraries/go/lib/pkg/nvkit/audit/audit.go
@@ -43,7 +43,7 @@ type AuditLog struct {
 	Hmac    string       `json:"hmac"`
 }
 
-// AuditPayload contains the actual information provided by the component generting the audit event
+// AuditPayload contains the actual information provided by the component generating the audit event
 type AuditPayload struct {
 	Timestamp       time.Time        `json:"timestamp"`
 	ParentAuditID   string           `json:"parentAuditId"`

--- a/src/libraries/go/lib/pkg/nvkit/auth/authn_test.go
+++ b/src/libraries/go/lib/pkg/nvkit/auth/authn_test.go
@@ -195,7 +195,7 @@ func TestAuthnConfig_HttpClientWithAuth(t *testing.T) {
 			} else {
 				assert.NotEqual(t, httpClient, clientWithAuth, tc.desc)
 				expectedNumCalls = 2
-				// If refresh interval is configured wait for atleast one background refresh to trigger
+				// If refresh interval is configured wait for at least one background refresh to trigger
 				if tc.cfg.RefreshConfig.Interval > 0 {
 					time.Sleep(time.Duration(2*tc.cfg.RefreshConfig.Interval) * time.Second)
 					// Remove the refresh job to avoid race condition with httpmock call during Deactivation

--- a/src/libraries/go/lib/pkg/nvkit/errors/errors.go
+++ b/src/libraries/go/lib/pkg/nvkit/errors/errors.go
@@ -35,7 +35,7 @@ import (
 var (
 	ErrBadConfig                 = fmt.Errorf("bad config")
 	ErrInvalidConfig             = fmt.Errorf("invalid config")
-	ErrUninitializedConfig       = fmt.Errorf("unintialized config")
+	ErrUninitializedConfig       = fmt.Errorf("uninitialized config")
 	ErrBadCerts                  = fmt.Errorf("bad certs")
 	ErrCertAndKeyRequired        = fmt.Errorf("missing cert or key file when tls is enabled")
 	ErrCertOrKeyFileMissing      = fmt.Errorf("either both tls cert path and tls key path should be provided or none")

--- a/src/libraries/go/lib/pkg/nvkit/scripts/code_coverage.sh
+++ b/src/libraries/go/lib/pkg/nvkit/scripts/code_coverage.sh
@@ -12,7 +12,7 @@ function main() {
   # Run tests
   goTest
 
-  # Remove unused dependecies
+  # Remove unused dependencies
   go mod tidy
 }
 

--- a/src/libraries/go/lib/pkg/oauth/jwtcache.go
+++ b/src/libraries/go/lib/pkg/oauth/jwtcache.go
@@ -48,7 +48,7 @@ type tokenVerifier interface {
 }
 
 type JWTCache struct {
-	// Followings are immutable configurations.
+	// Following are immutable configurations.
 
 	fetcher tokenFetcher
 	// nowFunc returns current time, inject as dependency for testing.
@@ -56,7 +56,7 @@ type JWTCache struct {
 	expiryMargin time.Duration
 	jwtVerifier  tokenVerifier
 
-	// sync.Mutex protects followings mutable states
+	// sync.Mutex protects following mutable states
 	sync.Mutex
 	token  string
 	expiry *time.Time

--- a/src/libraries/go/lib/pkg/oauth/jwtcache_test.go
+++ b/src/libraries/go/lib/pkg/oauth/jwtcache_test.go
@@ -211,7 +211,7 @@ func TestJWTCache(t *testing.T) {
 	assert.Contains(t, err.Error(), "rate limited")
 
 	mockTime = timeFromString("2020-12-09T22:00:03-07:00").Time
-	log.Infof("Test 3nd attempt at %v, server error", mockTime)
+	log.Infof("Test 3rd attempt at %v, server error", mockTime)
 	_, err = cache.FetchToken(ctx)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "server error")

--- a/src/libraries/go/lib/pkg/types/nvca/config/types.go
+++ b/src/libraries/go/lib/pkg/types/nvca/config/types.go
@@ -291,7 +291,7 @@ type AgentConfig struct {
 	FunctionDeploymentStagesProdOAuthTokenURL              string `yaml:",omitempty"`
 	FunctionDeploymentStagesProdOAuthPublicKeysetEndpoint  string `yaml:",omitempty"`
 
-	// NVCA Operater version
+	// NVCA Operator version
 	OperatorVersion string `yaml:",omitempty"`
 	// Kubernetes version override
 	KubernetesVersionOverride string `yaml:",omitempty"`

--- a/src/libraries/go/worker/semaphore/semaphore.go
+++ b/src/libraries/go/worker/semaphore/semaphore.go
@@ -83,7 +83,7 @@ func (s *Weighted) Acquire(ctx context.Context, n int64) error {
 		select {
 		case <-ready:
 			// Acquired the semaphore after we were canceled.  Rather than trying to
-			// fix up the queue, just pretend we didn't notice the cancelation.
+			// fix up the queue, just pretend we didn't notice the cancellation.
 			err = nil
 		default:
 			isFront := s.waiters.Front() == elem

--- a/src/libraries/go/worker/utils/utils_test.go
+++ b/src/libraries/go/worker/utils/utils_test.go
@@ -60,7 +60,7 @@ func TestGetDirectorySize(t *testing.T) {
 		}
 	}
 
-	// Get dir size and compare resutls
+	// Get dir size and compare results
 	dirSize, err := GetDirectorySize(testDir)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
TL;DR
Fixed spelling mistakes in comments, log/error messages, and doc strings across nvca, nvsnap, worker-task, ess-agent, byoo-otel-collector, helm-reval, function-autoscaler, http-invocation, the shared Go libraries, and the container-cache Helm chart. Comment and string content only, no identifier, field, or flag was renamed.

For the Reviewer
Verified with gofmt, py_compile, bash -n, and codespell that nothing else regressed. Deliberately left out a few codespell hits that turned out to be real identifiers already used consistently across the codebase (overrideable, unprobableReason, allReady) since fixing only the prose next to them would make things worse, not better. Also left out the vendored consul-template/vault SDK source under ess-agent, Kubernetes-generated files, and the vendored OpenAI OpenAPI spec in vanity-gateway.

Issues
NO-REF