### PR TITLE
feat(migrations): add event_ledger keyspace Cassandra migration

### DIFF
--- a/migrations/cassandra/keyspaces/event_ledger/01_init_keyspace.up.sql
+++ b/migrations/cassandra/keyspaces/event_ledger/01_init_keyspace.up.sql
@@ -1,0 +1,2 @@
+{{ $replicaCount := envOrDefault "REPLICA_COUNT" "3" }}
+CREATE KEYSPACE IF NOT EXISTS event_ledger WITH replication = {'class': 'NetworkTopologyStrategy', 'ncp': '{{ $replicaCount }}' }  AND durable_writes = true;

--- a/migrations/cassandra/keyspaces/event_ledger/02_init_roles.up.sql
+++ b/migrations/cassandra/keyspaces/event_ledger/02_init_roles.up.sql
@@ -1,0 +1,8 @@
+CREATE ROLE IF NOT EXISTS event_ledger_app_access;
+GRANT SELECT, MODIFY on keyspace event_ledger to event_ledger_app_access;
+GRANT SELECT on keyspace system to event_ledger_app_access;
+
+CREATE ROLE IF NOT EXISTS event_ledger_app_v0 with login = true and password = '${SERVICE_ROLE_PASSWORD}';
+
+INSERT INTO system_auth.role_members (role, member) VALUES ('event_ledger_app_access', 'event_ledger_app_v0');
+UPDATE system_auth.roles SET member_of = member_of + {'event_ledger_app_access'} where role = 'event_ledger_app_v0';

--- a/migrations/cassandra/keyspaces/event_ledger/03_init_tables.up.sql
+++ b/migrations/cassandra/keyspaces/event_ledger/03_init_tables.up.sql
@@ -1,0 +1,29 @@
+-- Canonical schema for event_ledger keyspace.
+
+-- Table for K8s events coming from the v3 endpoint
+-- Stores one row per unique (namespace, context, event_name) combination
+-- Multiple event_names per context are retained
+CREATE TABLE IF NOT EXISTS event_ledger.events_v3 (
+    namespace TEXT,
+    context TEXT,
+    event_name TEXT,
+    source TEXT,
+    details BLOB,  -- Free-form JSON
+    timestamp TIMESTAMP,
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP,
+    PRIMARY KEY ((namespace, context), event_name)
+);
+
+-- Stats table for latest event per namespace+context
+-- Only stores the MOST RECENT event name (replaces on any new event regardless of event_name)
+-- For full details, query events_v3
+CREATE TABLE IF NOT EXISTS event_ledger.stats_v3 (
+    namespace TEXT,
+    context TEXT,
+    event_name TEXT,       -- The latest event name
+    timestamp TIMESTAMP,
+    created_at TIMESTAMP,  -- When this namespace+context first got an event
+    updated_at TIMESTAMP,  -- When last updated
+    PRIMARY KEY ((namespace), context)
+);


### PR DESCRIPTION
## Why

The event_ledger keyspace migration files were missing from the repository. This adds the Cassandra DDL needed to provision the keyspace on fresh installations.

The `failed_cloudevents` and `retry_leader` tables are intentionally excluded as they are not required.

## What changed

Added `migrations/cassandra/keyspaces/event_ledger/` with three migration files:
- `01_init_keyspace.up.sql`: creates the keyspace with NetworkTopologyStrategy replication
- `02_init_roles.up.sql`: creates the application role and grants
- `03_init_tables.up.sql`: creates the `events_v3` and `stats_v3` tables

## Customer Release Notes

Not customer visible.

## Plan Summary

Not applicable.

## Usage

Not applicable.

## Testing

Migration files follow the same clean-slate conventions as other keyspaces in this directory.

## Notes

None.

## References

Closes #169

## Related Merge Requests/Pull Requests

None.

## Dependencies

None.

Github commit:
feat(migrations): add event_ledger keyspace Cassandra migration

Adds Cassandra DDL migration files for the event_ledger keyspace, including keyspace creation, role grants, and the events_v3 and stats_v3 tables.