### PR TITLE
ci: add CodeQL security scanning and CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,53 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# CodeRabbit configuration for NVIDIA/nvcf.
+# Docs: https://docs.coderabbit.ai/reference/configuration
+language: en-US
+early_access: false
+reviews:
+  # "chill" keeps the reviewer focused on substantive issues over nits.
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+  # Skip generated, vendored, and binary-ish files so review focuses on
+  # human-authored source. Mirrors the repo's Sonar exclusions.
+  path_filters:
+    - "!**/vendor/**"
+    - "!**/testdata/**"
+    - "!**/*.pb.go"
+    - "!**/zz_generated.*"
+    - "!**/*_generated.go"
+    - "!**/MODULE.bazel.lock"
+    - "!**/*.tgz"
+    - "!**/*.png"
+    - "!**/*.jpg"
+    - "!tools/ci/generated-release-jobs.yml"
+  path_instructions:
+    - path: "src/**/*.go"
+      instructions: >-
+        Check Go error wrapping (%w), structured logging with required context
+        fields (request/function/cluster/org id), and that request-handling
+        changes add logs, tracing, and RED metrics per AGENTS.md.
+    - path: "src/**/*.rs"
+      instructions: >-
+        Check error handling, tracing spans on cross-service calls, and that
+        no secrets or full request bodies are logged.
+    - path: "**/*.sql"
+      instructions: >-
+        Cassandra DDL migrations are forward-only and one keyspace per
+        subdirectory. Flag destructive statements and missing IF NOT EXISTS.
+  tools:
+    shellcheck:
+      enabled: true
+    yamllint:
+      enabled: true
+    golangci-lint:
+      enabled: true
+chat:
+  auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,7 +16,7 @@ reviews:
     base_branches:
       - main
   # Skip generated, vendored, and binary-ish files so review focuses on
-  # human-authored source. Mirrors the repo's Sonar exclusions.
+  # human-authored source.
   path_filters:
     - "!**/vendor/**"
     - "!**/testdata/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # CodeQL does not need the repo token after checkout.
+          persist-credentials: false
 
       - name: CodeQL Analysis
         uses: NVIDIA/dsx-github-actions/.github/actions/codeql-scan@9a9ce3a7770a8b53d2726afa920be3276bc3ddd7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+name: codeql
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly full scan, Monday 03:27 UTC.
+    - cron: "27 3 * * 1"
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  analyze:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      # Keep one language's failure from cancelling the others.
+      fail-fast: false
+      matrix:
+        include:
+          # Go is a traced language and does not support build-mode none, so it
+          # autobuilds. Rust has no autobuilder and uses buildless extraction.
+          - language: go
+            build-mode: autobuild
+          - language: rust
+            build-mode: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: CodeQL Analysis
+        uses: NVIDIA/dsx-github-actions/.github/actions/codeql-scan@9a9ce3a7770a8b53d2726afa920be3276bc3ddd7
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          upload-sarif: true
+          post-pr-comment: true
+          # Non-blocking during rollout: findings surface in the Security tab and
+          # as a PR comment, but do not gate merges yet. Tighten once triaged.
+          fail-on-findings: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,29 @@ name: codeql
 on:
   push:
     branches: [main]
+    # Only run when compiled source or this workflow changes. Docs, charts,
+    # migrations, and other non-code PRs skip the scan (the Go autobuild is
+    # expensive). The weekly schedule still does a full unconditional scan.
+    paths:
+      - "src/**"
+      - "**/*.go"
+      - "**/*.rs"
+      - "**/go.mod"
+      - "**/go.sum"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".github/workflows/codeql.yml"
   pull_request:
     branches: [main]
+    paths:
+      - "src/**"
+      - "**/*.go"
+      - "**/*.rs"
+      - "**/go.mod"
+      - "**/go.sum"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".github/workflows/codeql.yml"
   schedule:
     # Weekly full scan, Monday 03:27 UTC.
     - cron: "27 3 * * 1"


### PR DESCRIPTION
## Why
The public mirror runs TruffleHog secret scanning (dsx) but has no static analysis or AI code review. Adopt the GitHub-native pair.

## What changed
- `.github/workflows/codeql.yml`: dsx `codeql-scan` for Go (autobuild) and Rust (buildless `none`), on PRs/main/weekly, non-blocking during rollout.
- `.coderabbit.yaml`: path filters and AGENTS.md-aligned review instructions.

## Why not SonarQube
The internal `sonar.nvidia.com` is not reachable from GitHub-hosted runners, and the failing trial hit a 403 from sonarcloud.io (the token is not a SonarQube Cloud token). CodeQL covers the SAST overlap, so Sonar is deferred (see #210).

## Customer Release Notes
Not customer visible.

## Testing
Workflow runs on this PR: review the CodeQL Go/Rust matrix and the CodeRabbit review.

## References
Relates to NVIDIA/nvcf#210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated security scanning using CodeQL for changes targeting the main branch, with optimized path-based triggering on pushes and pull requests.
  * Added a weekly scheduled full CodeQL scan.
* **Chores**
  * Added a CodeRabbit configuration to streamline reviews (high-level summaries, review status) and focus only on relevant files.
  * Enabled automated code-quality checks for shell scripts, YAML, and Go, and turned on chat auto-replies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->