### PR TITLE
ci: fix secret-scan failure in the merge queue

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -36,6 +36,13 @@ jobs:
         # No repository secrets or custom env vars are required; PR comments are disabled.
         uses: NVIDIA/dsx-github-actions/.github/actions/trufflehog-scan@9a9ce3a7770a8b53d2726afa920be3276bc3ddd7
         with:
+          # On merge_group there is no push/PR context for TruffleHog to derive a
+          # diff range from, so it errors with "BASE == HEAD" and fails the gate,
+          # blocking the merge queue. Pass the merge queue's base..head range
+          # explicitly. push and pull_request events keep the empty defaults so
+          # the action uses its own event-based range.
+          base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || '' }}
+          head: ${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || '' }}
           extra-args: '--results=verified,unknown'
           post-pr-comment: 'false'
           fail-on-findings: 'true'


### PR DESCRIPTION
## Why
The `secret-scan` workflow passes on push/PR but fails on `merge_group`, blocking the merge queue for every PR. TruffleHog has no diff range in the merge-queue context (`BASE == HEAD`), the step errors, and the action Quality Gate (`fail-on-findings: true`) fails the job.

## What changed
Pass the merge queue's `base_sha`..`head_sha` to the dsx trufflehog-scan action on `merge_group` events. push/pull_request keep the empty defaults so the action uses its own event-based range.

## Customer Release Notes
Not customer visible.

## Testing
`pull_request` secret-scan passes on this PR (empty defaults, no secrets). The merge-queue `merge_group` run uses this PR's fixed workflow, so it validates the fix as it merges.

## References
Closes #211