### PR TITLE
docs(agents): note tools/ci/subproject-validations.yaml is internal

### DIFF
--- a/src/compute-plane-services/byoo-otel-collector/AGENTS.md
+++ b/src/compute-plane-services/byoo-otel-collector/AGENTS.md
@@ -24,7 +24,8 @@ Run `make update-config-template` after changing templates under
 template source, generator logic, or supported backend examples.
 
 CI subproject id: `byoo-otel-collector`. The umbrella CI lane is declared in
-`tools/ci/subproject-validations.yaml`; current custom checks include
+`tools/ci/subproject-validations.yaml`, an internal GitLab CI config not
+present in this public snapshot; current custom checks include
 `check-version-modified`, generated example drift, generated config drift, and
 otelconfig validation. Do not add a subtree `.gitlab-ci.yml`.
 

--- a/src/compute-plane-services/ess-agent/AGENTS.md
+++ b/src/compute-plane-services/ess-agent/AGENTS.md
@@ -28,7 +28,8 @@ bazel mod tidy
 ```
 
 CI subproject id: `ess-agent`. Native Bazel validation and release wiring live
-in `tools/ci/subproject-validations.yaml`.
+in `tools/ci/subproject-validations.yaml`, an internal GitLab CI config not
+present in this public snapshot.
 
 ## Local Gotchas
 

--- a/src/compute-plane-services/image-credential-helper/AGENTS.md
+++ b/src/compute-plane-services/image-credential-helper/AGENTS.md
@@ -33,7 +33,8 @@ make shellcheck
 ```
 
 CI subproject id: `image-credential-helper`. Native CI and release wiring live
-in `tools/ci/subproject-validations.yaml`.
+in `tools/ci/subproject-validations.yaml`, an internal GitLab CI config not
+present in this public snapshot.
 
 ## Local Gotchas
 

--- a/src/control-plane-services/function-autoscaler/AGENTS.md
+++ b/src/control-plane-services/function-autoscaler/AGENTS.md
@@ -47,4 +47,5 @@ cargo deny check advisories
 ```
 
 CI subproject id: `function-autoscaler`. Native Bazel validation and release
-wiring live in `tools/ci/subproject-validations.yaml`.
+wiring live in `tools/ci/subproject-validations.yaml`, an internal GitLab CI
+config not present in this public snapshot.

--- a/src/control-plane-services/nats-auth-callout/AGENTS.md
+++ b/src/control-plane-services/nats-auth-callout/AGENTS.md
@@ -34,7 +34,8 @@ make dev-swagger
 ```
 
 CI subproject id: `nats-auth-callout`. Native Bazel validation and release
-wiring live in `tools/ci/subproject-validations.yaml`.
+wiring live in `tools/ci/subproject-validations.yaml`, an internal GitLab CI
+config not present in this public snapshot.
 
 ## Plugin Work
 

--- a/src/invocation-plane-services/grpc-proxy/AGENTS.md
+++ b/src/invocation-plane-services/grpc-proxy/AGENTS.md
@@ -25,7 +25,8 @@ bazel run //nvidia-internal:image_push_ncp_dev
 ```
 
 CI subproject id: `grpc-proxy`. Native Bazel validation and release wiring live
-in `tools/ci/subproject-validations.yaml`.
+in `tools/ci/subproject-validations.yaml`, an internal GitLab CI config not
+present in this public snapshot.
 
 ## Local Gotchas
 

--- a/src/invocation-plane-services/http-invocation/AGENTS.md
+++ b/src/invocation-plane-services/http-invocation/AGENTS.md
@@ -29,7 +29,8 @@ CARGO_BAZEL_REPIN=1 bazel sync --only=nvcf_invocation_crates
 ```
 
 CI subproject id: `http-invocation`. Native Bazel validation and release wiring
-live in `tools/ci/subproject-validations.yaml`.
+live in `tools/ci/subproject-validations.yaml`, an internal GitLab CI config
+not present in this public snapshot.
 
 ## Cargo Development
 

--- a/src/invocation-plane-services/llm-api-gateway/AGENTS.md
+++ b/src/invocation-plane-services/llm-api-gateway/AGENTS.md
@@ -27,7 +27,8 @@ bazel test //... --flaky_test_attempts=3
 
 CI subproject id: `llm-api-gateway`. Release wiring publishes both the main
 gateway image and the rate-limit sync worker image through
-`tools/ci/subproject-validations.yaml`.
+`tools/ci/subproject-validations.yaml`, an internal GitLab CI config not
+present in this public snapshot.
 
 ## Local Gotchas
 

--- a/src/invocation-plane-services/ratelimiter/AGENTS.md
+++ b/src/invocation-plane-services/ratelimiter/AGENTS.md
@@ -23,7 +23,8 @@ bazel test //... --flaky_test_attempts=3
 ```
 
 CI subproject id: `ratelimiter`. Native Bazel validation and release wiring
-live in `tools/ci/subproject-validations.yaml`.
+live in `tools/ci/subproject-validations.yaml`, an internal GitLab CI config
+not present in this public snapshot.
 
 ## Proto and Test Gotchas
 

--- a/src/libraries/go/lib/AGENTS.md
+++ b/src/libraries/go/lib/AGENTS.md
@@ -66,7 +66,8 @@ module's `.golangci.yml`. `make lint` still runs the same module-scoped
 ## Root CI
 
 Root CI generates the `go-lib` subproject validation pipeline from
-`tools/ci/subproject-validations.yaml`.
+`tools/ci/subproject-validations.yaml`, an internal GitLab CI config not
+present in this public snapshot.
 
 The current subproject checks are:
 

--- a/src/libraries/go/worker/AGENTS.md
+++ b/src/libraries/go/worker/AGENTS.md
@@ -20,7 +20,8 @@ go build ./...
 ```
 
 CI subproject id: `go-worker`. The umbrella uses the `go-tool` profile in
-`tools/ci/subproject-validations.yaml`.
+`tools/ci/subproject-validations.yaml`, an internal GitLab CI config not
+present in this public snapshot.
 
 ## Local Gotchas
 


### PR DESCRIPTION
## TL;DR
11 native service AGENTS.md files (byoo-otel-collector, ess-agent, image-credential-helper, function-autoscaler, nats-auth-callout, grpc-proxy, http-invocation, llm-api-gateway, ratelimiter, libraries/go/lib, libraries/go/worker) tell agents that CI wiring lives in tools/ci/subproject-validations.yaml. That file does not exist in this public repository: it was removed from the OSS snapshot by the automated sync bot in commit c59a7cdb ("chore: sync synthetic imports") and never restored. Added a short inline note to each reference so a contributor working from this public checkout knows not to go looking for it here.

## For the Reviewer
Verified with git log that tools/ci/subproject-validations.yaml has no history in this repo other than its removal, and confirmed with grep that these are the only 11 native AGENTS.md files referencing it. No wording or instructions were removed, only the clarifying note was added.

## Issues
NO-REF

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.