### PR TITLE
fix(function-autoscaler): avoid startup health panic

### DIFF
--- a/src/control-plane-services/function-autoscaler/crates/server/src/health/mod.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/health/mod.rs
@@ -239,9 +239,9 @@ impl Health {
         self.set_component_health(component_name, HealthStatus::Unhealthy, message);
     }
 
-    /// Register a health checker service and immediately run one check to set the initial state.
+    /// Register a health checker service and run one check to set the initial state before returning.
     /// Subsequent checks run on the background monitoring interval (every 30s).
-    pub fn register_health_checker(&self, checker: Arc<dyn HealthChecker>) {
+    pub async fn register_health_checker(&self, checker: Arc<dyn HealthChecker>) {
         let component_name = checker.component_name().to_string();
 
         // Register the component as unhealthy until proven otherwise
@@ -253,17 +253,12 @@ impl Health {
             checkers.push(checker.clone());
         }
 
-        // Run one check in the background so the state reflects reality before the
-        // monitoring loop has had a chance to tick.
-        let health = self.clone();
-        tokio::spawn(async move {
-            let result = checker.health().await;
-            if result.is_healthy {
-                health.set_component_healthy(&component_name, result.message);
-            } else {
-                health.set_component_unhealthy(&component_name, result.message);
-            }
-        });
+        let result = checker.health().await;
+        if result.is_healthy {
+            self.set_component_healthy(&component_name, result.message);
+        } else {
+            self.set_component_unhealthy(&component_name, result.message);
+        }
     }
 
     /// Start the background health monitoring task
@@ -375,10 +370,10 @@ mod tests {
     async fn test_health_checker() {
         let health = Arc::new(Health::new());
         let health_clone = health.clone();
-        health.register_health_checker(Arc::new(MockHealthChecker::new()));
+        health
+            .register_health_checker(Arc::new(MockHealthChecker::new()))
+            .await;
         health.start_health_monitoring(Duration::from_secs(1));
-        // Give the spawned initial check task a moment to complete.
-        tokio::time::sleep(Duration::from_millis(50)).await;
         let health_info = health_clone.get_health();
         assert_eq!(health_info.overall_status, HealthStatus::Healthy);
         assert_eq!(

--- a/src/control-plane-services/function-autoscaler/crates/server/src/server.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/server.rs
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-use rs_autoscaler::health::HealthStatus;
 use rs_autoscaler::{
     health::Health,
     metrics,
@@ -127,7 +126,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cassandra_service_manager =
         startup::wait_for_cassandra(&config.cassandra, secrets_file_watcher.clone()).await;
 
-    health.register_health_checker(cassandra_service_manager.clone());
+    health
+        .register_health_checker(cassandra_service_manager.clone())
+        .await;
 
     tracing::info!("Initializing TimeseriesDb client (waiting with exponential backoff until up)");
     let timeseries_db_credential_provider = if !config.timeseries_db.disable_auth {
@@ -149,7 +150,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         startup::wait_for_timeseries_db(&config.timeseries_db, timeseries_db_credential_provider)
             .await?;
 
-    health.register_health_checker(timeseries_db_client.clone());
+    health
+        .register_health_checker(timeseries_db_client.clone())
+        .await;
 
     // Start coordinated health monitoring for all registered services
     health
@@ -172,23 +175,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let health_monitor = Arc::clone(&health);
     let node_id_health = node_id.clone();
 
-    tracing::info!(
-        "Creating a new node entry for {} if not exists",
-        node_id_health
-    );
-    // Create a new node entry in Cassandra
+    tracing::info!("Reporting initial node health for {}", node_id_health);
     let current_health = health_monitor.get_health();
-    if current_health.overall_status == HealthStatus::Healthy {
-        work::create_new_node(
-            &node_id_health,
-            &HealthStatus::Healthy,
-            &cassandra_health_manager,
-        )
-        .await?;
-    } else {
-        panic!(
-            "Node is not healthy, cannot start service: {:?}",
-            current_health.overall_status
+    if let Err(e) = work::create_new_node(
+        &node_id_health,
+        &current_health.overall_status,
+        &cassandra_health_manager,
+    )
+    .await
+    {
+        tracing::warn!(
+            error = %e,
+            health = ?current_health.overall_status,
+            "Initial node health report failed; background health reporting will retry"
         );
     }
 


### PR DESCRIPTION
## TL;DR
Prevents function autoscaler from panicking during startup when dependency health is still settling.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
- Runs the initial health checker call before registration returns, so startup sees the latest health state.
- Removes the fail-fast panic on initial unhealthy status and lets readiness keep the pod out of service until dependencies are healthy.
- Leaves node health reporting to retry in the background if the first report fails.

## For the Reviewer
- Please focus on `server.rs` startup flow and `health/mod.rs` registration behavior.
- The intent is to avoid CrashLoop restarts during fresh dependency startup without marking the service ready early.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
`cargo fmt -p rs-autoscaler`

`cargo test -p rs-autoscaler`

Result: 107 passed, 0 failed, 11 ignored.

## Issues
Relates to #15

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Health checks now complete their initial assessment before startup continues, providing more accurate service status.
  * Node health reporting no longer causes startup to panic when the initial health state is unhealthy or reporting fails.
  * Startup now logs health-reporting failures and continues running gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->