### PR TITLE
fix(operator): render raw OAuth secret file for otel collector

### DIFF
--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/vault_config_data_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/vault_config_data_test.go
@@ -235,9 +235,44 @@ func TestGetVaultConfigData_TemplateUsesOAuthClientMountPath(t *testing.T) {
 	// Template uses OAuthClientMountPath from VaultConfig
 	if assert.Contains(t, configData, "template.hcl") {
 		expected := `{{ with secret "nvidia/services/oauth/clients/template-client-id/kv/secret" }}
-OAUTH_CLIENT_SECRET_KEY={{ .Data.data.secret }}
+{{ .Data.data.secret }}
 {{ end }}`
 		assert.Equal(t, expected, configData["template.hcl"])
+	}
+}
+
+// Guard: the otel collector reads the rendered secret file whole as the
+// client secret (no dotenv parsing), so the template must render the bare
+// secret — a KEY= prefix breaks its token fetch with 401. The agent's
+// fetcher accepts both forms, so raw is safe for all consumers.
+func TestGetVaultConfigData_TemplateRendersRawSecretForOTelCollector(t *testing.T) {
+	nb := &nvidiaiov1.NVCFBackend{
+		Spec: nvidiaiov1.NVCFBackendSpec{
+			NVCFBackendSpecT: nvidiaiov1.NVCFBackendSpecT{
+				Version: "3.0.7",
+				ClusterConfig: nvidiaiov1.ClusterConfig{
+					ClusterName: "test-cluster",
+				},
+				VaultConfig: nvidiaiov1.VaultConfig{
+					OAuthClientMountPath: "nvidia/services/oauth/clients/test-client-id/kv/secret",
+				},
+				OAuthConfig: nvidiaiov1.OAuthConfig{
+					ClientID: "test-client-id",
+				},
+			},
+		},
+	}
+
+	configData := getVaultConfigData(nb)
+
+	if assert.Contains(t, configData, "template.hcl") {
+		tpl := configData["template.hcl"]
+		assert.NotContains(t, tpl, "OAUTH_CLIENT_SECRET_KEY=",
+			"secret template must render the bare secret: the otel collector reads the file whole as client_secret")
+		expected := `{{ with secret "nvidia/services/oauth/clients/test-client-id/kv/secret" }}
+{{ .Data.data.secret }}
+{{ end }}`
+		assert.Equal(t, expected, tpl)
 	}
 }
 

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/vault_config_data_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/vault_config_data_test.go
@@ -233,12 +233,11 @@ func TestGetVaultConfigData_TemplateUsesOAuthClientMountPath(t *testing.T) {
 	configData := getVaultConfigData(nb)
 
 	// Template uses OAuthClientMountPath from VaultConfig
-	if assert.Contains(t, configData, "template.hcl") {
-		expected := `{{ with secret "nvidia/services/oauth/clients/template-client-id/kv/secret" }}
+	require.Contains(t, configData, "template.hcl")
+	expected := `{{ with secret "nvidia/services/oauth/clients/template-client-id/kv/secret" }}
 {{ .Data.data.secret }}
 {{ end }}`
-		assert.Equal(t, expected, configData["template.hcl"])
-	}
+	assert.Equal(t, expected, configData["template.hcl"])
 }
 
 // Guard: the otel collector reads the rendered secret file whole as the
@@ -265,15 +264,14 @@ func TestGetVaultConfigData_TemplateRendersRawSecretForOTelCollector(t *testing.
 
 	configData := getVaultConfigData(nb)
 
-	if assert.Contains(t, configData, "template.hcl") {
-		tpl := configData["template.hcl"]
-		assert.NotContains(t, tpl, "OAUTH_CLIENT_SECRET_KEY=",
-			"secret template must render the bare secret: the otel collector reads the file whole as client_secret")
-		expected := `{{ with secret "nvidia/services/oauth/clients/test-client-id/kv/secret" }}
+	require.Contains(t, configData, "template.hcl")
+	tpl := configData["template.hcl"]
+	assert.NotContains(t, tpl, "OAUTH_CLIENT_SECRET_KEY=",
+		"secret template must render the bare secret: the otel collector reads the file whole as client_secret")
+	expected := `{{ with secret "nvidia/services/oauth/clients/test-client-id/kv/secret" }}
 {{ .Data.data.secret }}
 {{ end }}`
-		assert.Equal(t, expected, tpl)
-	}
+	assert.Equal(t, expected, tpl)
 }
 
 func TestGetVaultConfigData_ConfigInitAndNonInit(t *testing.T) {

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/vault_reconcile.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/vault_reconcile.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	nvidiaiov1 "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvcf/v1"
-	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/auth"
 )
 
 const (
@@ -99,10 +98,13 @@ func getVaultConfigData(nb *nvidiaiov1.NVCFBackend) map[string]string {
 	// Get OAuth mount path from CRD spec (set by helm chart or ngcclient)
 	vaultSecretPath := getOAuthClientMountPath(nb)
 
-	// Generate template with OAuth names (NVCA handles backwards compatibility)
-	temCfg := fmt.Sprintf("{{ with secret %q }}\n%s={{ %s }}\n{{ end }}",
+	// Render the bare secret, no KEY= prefix: the otel collector's
+	// oauth2client extension reads client_secret_file whole (no dotenv
+	// parsing), so any prefix breaks its token fetch with 401. The agent's
+	// fetcher parses both forms, and its client ID comes from config/env.
+	temCfg := fmt.Sprintf("{{ with secret %q }}\n{{ %s }}\n{{ end }}",
 		vaultSecretPath,
-		auth.ClientSecretEnv, secretDataPath)
+		secretDataPath)
 
 	return map[string]string{
 		"config-init.hcl": cfgTplInit,


### PR DESCRIPTION
## TL;DR
The otel-collector sidecar could not authenticate to the OAuth token endpoint (401 on every token fetch), so exported k8s events were dropped. Cause: the vault-agent template renders the secret file in dotenv format, but the collector's `oauth2client` extension reads `client_secret_file` whole, with no dotenv parsing — it presented the literal `OAUTH_CLIENT_SECRET_KEY=<secret>` string as the client secret. This PR reverts the template to render the bare secret and adds a guard test locking that contract.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
- Regression from an earlier fix that switched the rendered file to dotenv format while wiring the agent's OAuth client ID/secret from env vars. That fix did not depend on the file format: the client ID is never read from this file, and the agent's secret parser handles the raw form via a whole-file fallback. The env wiring stays; only the format half is reverted.
- The raw form is safe for every consumer of the file: the agent token fetchers (icms/fnds/helm-reval share one parser) accept both formats; the collector requires raw.
- Local repro: the collector binary against a mock OAuth token endpoint returns 401 with a dotenv-format secret file and exports successfully with a raw one, with no collector change.

## For the Reviewer
- The behavioral change is one line in `vault_reconcile.go` (`getVaultConfigData`, the `temCfg` template); the rest is the guard test and comments documenting the two-reader contract.
- Please check the contract comment reads correctly against your knowledge of other consumers of `oauth-client-secrets.env`.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
- QA needed: yes — in a staging cluster using OAuth Client

## Issues
Fixes #223 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected OAuth client secret rendering for the OTel collector to ensure secret files contain only the raw secret value (no environment-variable style prefix).
* **Tests**
  * Updated and added template-rendering assertions to verify the OAuth client and OTel-related Vault templates match the expected raw-secret output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->