### PR TITLE
feat(helm-model): select model cache backend by storage class

### DIFF
--- a/docs/dev/sdd-central-model-cache-service.md
+++ b/docs/dev/sdd-central-model-cache-service.md
@@ -65,8 +65,10 @@ per-pod fallback described separately.
    The lease holder creates the writer Job and the read-write PVC in the control
    namespace; non-holders wait.
 3. On writer success the reconciler records a durable marker (see below) and
-   tears down the writer Job, its pods, the read-write PVC, and the lease
-   (`cleanupInitModelCache`). The marker survives.
+   tears down the temporary initialization resources: the writer Job, its
+   pods, and the lease (`cleanupInitModelCache`). The read-write PVC is also
+   deleted for nvmesh and samba, but retained for sharedfs, where it is
+   itself the durable marker. The marker survives.
 
 ### Durable markers
 
@@ -189,6 +191,23 @@ Metrics (`internal/metrics`), all labeled by `backend`:
 Tracing: `nvca.modelcache.reconcile` span per request (with a
 `nvcf.modelcache.backend` attribute) and a `nvca.modelcache.samba.ensure_infra`
 child span around per-handle Samba provisioning.
+
+## Known gaps and fast-follows
+
+- sharedfs reader binding assumes the class exposes one shared filesystem:
+  separately provisioned PVCs on the same StorageClass do not share data on
+  provisioners that create per-claim access points, subvolumes, or
+  directories (EFS access points, CephFS subvolumes, some NFS provisioners).
+  Classes backed by a single share (for example an SMB class pointing at one
+  server share) work. The capability probe validates bindability, not
+  data-sharing; the fast-follow is a write-through-one-claim /
+  read-through-another probe, and deriving reader PVs from the writer's bound
+  volume where the driver supports it.
+- The per-handle Samba infrastructure is create-once: image, resource, and
+  cache-size changes do not reconcile onto an existing server or expand its
+  backing PVC.
+- The ephemeral init env forwards the full launch environment; it should be
+  narrowed to the variables the model-cache-init container actually consumes.
 
 ## Key invariants
 

--- a/docs/dev/sdd-central-model-cache-service.md
+++ b/docs/dev/sdd-central-model-cache-service.md
@@ -1,0 +1,202 @@
+# SDD: Central Model Cache Service
+
+## Status
+
+Implemented in NVCA. This document describes the model cache design as built in
+`pkg/storage` (the model cache StorageRequest controller), `pkg/webhook`
+(workload volume injection), and `internal/metrics` (observability).
+
+## Goal
+
+A function or task can declare a model cache by `cacheHandle`. The first workload
+that needs a given handle downloads the model once; every later workload for the
+same handle, in any namespace, attaches the already-downloaded copy read-only
+instead of downloading again. Caching is best-effort: if the cache cannot be
+provisioned the workload still runs, just without a shared cache.
+
+The service is folded into NVCA rather than run as a standalone operator. It
+reuses NVCA's existing machinery: a control namespace, a per-cacheHandle
+StorageRequest of type `modelcache`, a single-writer lease, an init/writer Job,
+and the mutating webhook that mounts the cache into workload pods.
+
+## Terminology
+
+- cacheHandle: content hash identifying a model cache, supplied in the request
+  `CacheLaunchSpecification` (`cacheHandle`, `cacheSize`).
+- Control namespace: `nvca-modelcache-init`. Holds writer Jobs, the init lease,
+  backend infrastructure, and durable markers.
+- Backend: the storage mechanism used to hold and share the cache. One of
+  `nvmesh`, `sharedfs`, `samba`, `ephemeral`.
+- Writer: the single init Job that downloads the model into the backend.
+- Reader: the per-namespace read-only volume a workload mounts.
+- Durable marker: a cluster-scoped object whose existence means "this handle is
+  populated", used so any namespace and any agent restart can detect a populated
+  cache without depending on in-memory state.
+
+## Backend selection
+
+The miniservice reconciler selects a backend once per request via
+`SelectHelmCacheBackend` (`pkg/storage/cachebackend.go`) and stamps it on the
+`StorageRequest.spec.modelCache.backend`. Selection is deterministic on cluster
+state and feature flags:
+
+1. `CachingSupport` disabled: no cache (`none`).
+2. `nvcf-sc-30` StorageClass exists (NVMesh 3.x): `nvmesh`.
+3. `nvcf-miniservice-sc` StorageClass exists (operator-provided third-party shared
+   storage): `sharedfs`.
+4. `HelmSharedStorage` flag enabled: `samba`.
+5. Otherwise: `ephemeral`.
+
+NVCA never creates `nvcf-miniservice-sc`. That StorageClass is exclusively the
+operator's signal that third-party shared storage is present (branch 3 above).
+The Samba backend (branch 4) is self-contained and creates no StorageClass.
+
+## Lifecycle shared by all shared backends
+
+The shared backends (nvmesh, sharedfs, samba) share one lifecycle; only the
+backing store and the per-namespace reader differ. The ephemeral backend is a
+per-pod fallback described separately.
+
+### Populate (single writer)
+
+1. The reconciler resolves the request into a writer Job and a read-write cache
+   PVC (`findAndDecodeCacheArtifacts`), sized from the payload `cacheSize`.
+2. A per-cacheHandle lease (`modelcache-init-<handle>`) elects a single writer.
+   The lease holder creates the writer Job and the read-write PVC in the control
+   namespace; non-holders wait.
+3. On writer success the reconciler records a durable marker (see below) and
+   tears down the writer Job, its pods, the read-write PVC, and the lease
+   (`cleanupInitModelCache`). The marker survives.
+
+### Durable markers
+
+The marker is what makes a cache reusable across namespaces and across agent
+restarts. It differs by backend because the reader-attach mechanism differs:
+
+- nvmesh: the writer's bound PV is retained (relabeled with
+  `nvca.nvcf.nvidia.io/modelcache-primary-pv`, reclaim policy Retain) as the
+  primary PV. Secondary reader PVs are copies of it with the CSI VolumeHandle
+  rewritten per namespace.
+- samba and sharedfs: a `nvca.nvcf.nvidia.io/modelcache-populated=true` label on
+  a durable per-handle PVC (the Samba backing PVC for samba; the retained writer
+  PVC for sharedfs). Readers gate on this label.
+
+Consumers check the marker before deciding to run init. If it exists they skip
+the writer entirely and attach a reader. This is deliberately not dependent on
+the init lease or any in-memory fan-out, both of which are lost on restart.
+
+### Reader attach (per namespace)
+
+- nvmesh: a secondary PV (copy of the primary, VolumeHandle rewritten for the
+  namespace) plus a read-only PVC.
+- samba: a static SMB CSI PV pointing at the per-handle Samba share, read-only,
+  plus a read-only PVC.
+- sharedfs: a read-only PVC on the shared class; the class itself shares data
+  across namespaces, so no per-namespace PV plumbing is needed.
+
+## Samba backend (Samba over NVMesh)
+
+Selected when no NVMesh 3.x or operator shared storage exists but
+`HelmSharedStorage` is on. NVMesh block storage is ReadWriteOnce, so it cannot be
+shared read-only across namespaces directly. The Samba backend re-exports an
+`nvcf-sc` volume over SMB, which supports ReadWriteMany and ReadOnlyMany.
+
+Each cacheHandle gets its own Samba server and its own backing volume. There is
+no single shared server or global data PVC: a single fixed-size volume cannot be
+sized for an unknown, growing set of models, and hot-adding per-handle volumes
+to one shared server would force pod restarts that drop every other handle's live
+mounts. Per-handle servers isolate lifecycle and sizing and are reclaimed
+independently.
+
+Per cacheHandle (`cachebackend_samba.go`, `EnsureSambaModelCacheInfra`):
+
+- Backing PVC `samba-<cacheHandle>` on `nvcf-sc`, sized to the request
+  `cacheSize`. Its existence is the reuse signal; its
+  `modelcache-populated` label is the safe-to-attach signal.
+- Deployment `samba-<cacheHandle>` mounting that PVC, exporting a single SMB
+  share (`cache`).
+- Service `samba-<cacheHandle>` for stable in-cluster DNS.
+- NetworkPolicy `samba-<cacheHandle>` restricting ingress to the SMB port.
+- Shared read-write and read-only credentials Secrets (reused across handles).
+
+The writer mounts the share read-write over static SMB CSI and populates it; per
+namespace readers mount the same share read-only as a distinct unprivileged user.
+Resource names are `samba-<cacheHandle>`; when a handle would exceed the 63
+character name limit a stable hashed suffix is used.
+
+## Workload volume injection
+
+The mutating webhook (`pkg/webhook/helm_storage_webhook.go`) injects the cache
+into workload pods. When a pod carries the
+`nvca.nvcf.nvidia.io/storage-modelcache-pvc-name` annotation the webhook adds a
+`model-data` volume bound to the read-only cache PVC and mounts it at the model
+paths.
+
+The shared-storage volumes use a drop-and-re-add pattern on every admission. The
+model cache volume participates in the same drop-and-re-add
+(`getModelCacheDropReservedFunc`) so the post-admission volume and mount order is
+deterministic and identical across CREATE and UPDATE. Without this, a controller
+that re-submits an already-mutated pod (for example the KAI scheduler pod-grouper)
+would produce a reordered volume list, which the API server rejects as an
+immutable-field change, leaving the workload pod unschedulable.
+
+## Ephemeral backend (per-pod fallback)
+
+When no shared backend is available (`ephemeral`), the webhook injects a
+`model-data` emptyDir and a model-cache-init init container that downloads the
+model into it. Workload containers see the cache at the same mount paths as the
+shared path, so the workload is backend-agnostic. There is no cross-namespace
+sharing in this mode.
+
+## Garbage collection
+
+A periodic sweep (`cleanupIdleModelCaches`) reclaims caches that no active
+StorageRequest references and that have been idle past
+`ModelCacheIdlePeriod`:
+
+- nvmesh: retained primary PVs are deleted.
+- samba: per-handle server (Deployment, Service, NetworkPolicy) and backing PVC
+  are deleted (`DeleteSambaModelCacheInfra`), keyed on a last-referenced
+  annotation updated whenever a consumer attaches.
+
+Per-StorageRequest deletion (`doCleanupModelCacheNVMesh`) removes that request's
+own reader objects but never the shared per-handle backing store, which is kept
+for reuse and reclaimed only by the idle sweep.
+
+## Non-blocking volume detach
+
+Cleanup must delete the writer read-write PVC only after its volume detaches, but
+the model cache controller runs a single reconcile worker. The detach check is a
+single-shot probe (`isVolumeDetached`): if the volume is still attached the
+cleanup returns a short requeue instead of polling in-reconcile. This prevents
+one stuck cleanup from starving every other StorageRequest, including the
+terminating-namespace finalizer escape hatch.
+
+## Observability
+
+Metrics (`internal/metrics`), all labeled by `backend`:
+
+- `nvca_model_cache_backends` (gauge): caches currently provisioned per backend.
+  Answers "how many Samba caches exist". Refreshed by the idle sweep.
+- `nvca_model_cache_backend_selected_total`: backend chosen per request.
+- `nvca_model_cache_populate_total`: the single-writer download ran.
+- `nvca_model_cache_reuse_total`: an existing cache was attached without a
+  download.
+- `nvca_model_cache_reclaimed_total`: idle caches reclaimed by GC.
+- `nvca_model_cache_result_total`: success or failure by failure reason and
+  backend.
+
+Tracing: `nvca.modelcache.reconcile` span per request (with a
+`nvcf.modelcache.backend` attribute) and a `nvca.modelcache.samba.ensure_infra`
+child span around per-handle Samba provisioning.
+
+## Key invariants
+
+- NVCA never creates `nvcf-miniservice-sc`.
+- Exactly one primary PV per handle for nvmesh; exactly one backing PVC per
+  handle for samba.
+- The Samba backing PVC is not labeled with the cache-handle label, so the
+  init-writer cleanup (which deletes handle-labeled PVCs) never removes it.
+- Reuse and safe-to-attach are decided from durable cluster state, never from
+  in-memory fan-out.
+- Webhook volume injection is order-stable across CREATE and UPDATE.

--- a/src/compute-plane-services/nvca/internal/metrics/METRICS.md
+++ b/src/compute-plane-services/nvca/internal/metrics/METRICS.md
@@ -574,8 +574,9 @@ rate(nvca_k8s_api_failure_total[5m]) > 0.1
 - `nvca_version` - NVCA version
 - `result` - Operation result: `success` or `failure`
 - `failure_reason` - Specific failure reason (empty string for success)
+- `backend` - Model cache backend: `nvmesh`, `sharedfs`, `samba`, `ephemeral` (empty when not yet known, e.g. early validation failures)
 
-**Note:** This metric uses 3 labels (excluding `nvca_nca_id`) for backwards compatibility with storage metrics.
+**Note:** This metric uses the storage labels (excluding `nvca_nca_id`) for backwards compatibility with storage metrics.
 
 **Failure Reasons:**
 | Reason | Description |
@@ -610,6 +611,62 @@ sum by (nvca_cluster_name) (rate(nvca_model_cache_result_total[5m]))
 sum(rate(nvca_model_cache_result_total{result="failure"}[5m])) /
 sum(rate(nvca_model_cache_result_total[5m])) > 0.1
 ```
+
+### `nvca_model_cache_backends`
+
+**Type:** Gauge
+
+**Description:** Number of model caches currently provisioned, by backend. For Samba this is the count of per-handle backing PVCs / servers ("how many Samba caches exist"); for NVMesh it is the count of retained primary PVs. Refreshed by the periodic idle-cleanup sweep.
+
+**Labels:** storage labels + `backend`.
+
+### `nvca_model_cache_backend_selected_total`
+
+**Type:** Counter
+
+**Description:** Total model cache requests by the backend selected for them (recorded once per request). Shows the backend mix across the fleet.
+
+**Labels:** storage labels + `backend`.
+
+### `nvca_model_cache_populate_total`
+
+**Type:** Counter
+
+**Description:** Total model cache populates, i.e. the single-writer download actually ran, by backend.
+
+**Labels:** storage labels + `backend`.
+
+### `nvca_model_cache_reuse_total`
+
+**Type:** Counter
+
+**Description:** Total model cache reuses, i.e. an already-populated cache was attached without a download (cache effectiveness), by backend.
+
+**Labels:** storage labels + `backend`.
+
+### `nvca_model_cache_reclaimed_total`
+
+**Type:** Counter
+
+**Description:** Total idle model caches reclaimed by garbage collection, by backend.
+
+**Labels:** storage labels + `backend`.
+
+**Usage:**
+
+```promql
+# How many Samba caches are currently provisioned
+nvca_model_cache_backends{backend="samba"}
+
+# Cache reuse ratio (effectiveness)
+sum(rate(nvca_model_cache_reuse_total[1h])) /
+(sum(rate(nvca_model_cache_reuse_total[1h])) + sum(rate(nvca_model_cache_populate_total[1h])))
+
+# Backend mix
+sum by (backend) (increase(nvca_model_cache_backend_selected_total[1h]))
+```
+
+**Tracing:** model cache reconciliation emits a `nvca.modelcache.reconcile` span per request (with a `nvcf.modelcache.backend` attribute), and a `nvca.modelcache.samba.ensure_infra` child span around per-handle Samba server provisioning.
 
 ---
 

--- a/src/compute-plane-services/nvca/internal/metrics/metrics.go
+++ b/src/compute-plane-services/nvca/internal/metrics/metrics.go
@@ -71,7 +71,12 @@ const (
 	GCCleanerRunTotalMetricName            = "nvca_gc_cleaner_run_total"
 
 	// Model cache metrics
-	ModelCacheResultTotalMetricName = "nvca_model_cache_result_total"
+	ModelCacheResultTotalMetricName          = "nvca_model_cache_result_total"
+	ModelCacheBackendsMetricName             = "nvca_model_cache_backends"
+	ModelCacheBackendSelectedTotalMetricName = "nvca_model_cache_backend_selected_total"
+	ModelCachePopulateTotalMetricName        = "nvca_model_cache_populate_total"
+	ModelCacheReuseTotalMetricName           = "nvca_model_cache_reuse_total"
+	ModelCacheReclaimedTotalMetricName       = "nvca_model_cache_reclaimed_total"
 
 	// Cluster attribute metrics
 	KataRuntimeIsolationEnabledMetricName = "nvca_kata_runtime_isolation_enabled"
@@ -148,6 +153,7 @@ const (
 	// Model cache labels
 	ResultLabel        = "result"
 	FailureReasonLabel = "failure_reason"
+	BackendLabel       = "backend"
 
 	// Workload result labels
 	WorkloadTypeLabel    = "workload_type"
@@ -282,7 +288,12 @@ type Metrics struct {
 	GCCleanerRunTotal            *prometheus.CounterVec
 
 	// Model cache metrics
-	ModelCacheResultTotal *prometheus.CounterVec
+	ModelCacheResultTotal          *prometheus.CounterVec
+	ModelCacheBackends             *prometheus.GaugeVec
+	ModelCacheBackendSelectedTotal *prometheus.CounterVec
+	ModelCachePopulateTotal        *prometheus.CounterVec
+	ModelCacheReuseTotal           *prometheus.CounterVec
+	ModelCacheReclaimedTotal       *prometheus.CounterVec
 
 	// Cluster attribute metrics
 	KataRuntimeIsolationEnabled *prometheus.GaugeVec
@@ -361,6 +372,11 @@ func (m *Metrics) Destroy() {
 	prometheus.Unregister(m.OrphanedResourceCleanupTotal)
 	prometheus.Unregister(m.GCCleanerRunTotal)
 	prometheus.Unregister(m.ModelCacheResultTotal)
+	prometheus.Unregister(m.ModelCacheBackends)
+	prometheus.Unregister(m.ModelCacheBackendSelectedTotal)
+	prometheus.Unregister(m.ModelCachePopulateTotal)
+	prometheus.Unregister(m.ModelCacheReuseTotal)
+	prometheus.Unregister(m.ModelCacheReclaimedTotal)
 	prometheus.Unregister(m.KataRuntimeIsolationEnabled)
 	prometheus.Unregister(m.MaintenanceModeState)
 	prometheus.Unregister(m.ClusterValidatorReady)
@@ -675,14 +691,56 @@ func NewDefaultMetrics(ncaID, clusterName, clusterGroup, version string, opts ..
 	// Model cache metrics (uses storage labels for backwards compatibility)
 	m.ModelCacheResultTotal = promFactory.NewCounterVec(prometheus.CounterOpts{
 		Name: ModelCacheResultTotalMetricName,
-		Help: "Total number of model cache operations by result. " +
+		Help: "Total number of model cache operations by result and backend. " +
 			"result is 'success' or 'failure', failure_reason is set only on failure.",
-	}, withStorageLabels(ResultLabel, FailureReasonLabel))
+	}, withStorageLabels(ResultLabel, FailureReasonLabel, BackendLabel))
 
-	// Initialize model cache metrics to zero for known result/failure_reason combinations
-	m.ModelCacheResultTotal.WithLabelValues(m.withStorageLabelValues(modelcachetypes.ResultSuccess, "")...)
+	// nvca_model_cache_backends: a gauge of how many distinct caches are
+	// currently provisioned per backend (e.g. how many Samba backing PVCs/servers
+	// exist). Refreshed by the periodic idle-cleanup sweep.
+	m.ModelCacheBackends = promFactory.NewGaugeVec(prometheus.GaugeOpts{
+		Name: ModelCacheBackendsMetricName,
+		Help: "Number of model caches currently provisioned, by backend.",
+	}, withStorageLabels(BackendLabel))
+
+	m.ModelCacheBackendSelectedTotal = promFactory.NewCounterVec(prometheus.CounterOpts{
+		Name: ModelCacheBackendSelectedTotalMetricName,
+		Help: "Total model cache requests by selected backend.",
+	}, withStorageLabels(BackendLabel))
+
+	m.ModelCachePopulateTotal = promFactory.NewCounterVec(prometheus.CounterOpts{
+		Name: ModelCachePopulateTotalMetricName,
+		Help: "Total model cache populates (the single-writer download ran), by backend.",
+	}, withStorageLabels(BackendLabel))
+
+	m.ModelCacheReuseTotal = promFactory.NewCounterVec(prometheus.CounterOpts{
+		Name: ModelCacheReuseTotalMetricName,
+		Help: "Total model cache reuses (an already-populated cache was attached without a download), by backend.",
+	}, withStorageLabels(BackendLabel))
+
+	m.ModelCacheReclaimedTotal = promFactory.NewCounterVec(prometheus.CounterOpts{
+		Name: ModelCacheReclaimedTotalMetricName,
+		Help: "Total idle model caches reclaimed by garbage collection, by backend.",
+	}, withStorageLabels(BackendLabel))
+
+	// Initialize model cache metrics to zero for known label combinations.
+	m.ModelCacheResultTotal.WithLabelValues(m.withStorageLabelValues(modelcachetypes.ResultSuccess, "", "")...)
+	for _, b := range types.AllSelectableHelmCacheBackends {
+		backend := string(b)
+		m.ModelCacheResultTotal.WithLabelValues(m.withStorageLabelValues(modelcachetypes.ResultSuccess, "", backend)...)
+		for _, reason := range modelcachetypes.AllFailureReasons {
+			m.ModelCacheResultTotal.WithLabelValues(m.withStorageLabelValues(modelcachetypes.ResultFailure, reason, backend)...)
+		}
+		m.ModelCacheBackends.WithLabelValues(m.withStorageLabelValues(backend)...).Set(0)
+		m.ModelCacheBackendSelectedTotal.WithLabelValues(m.withStorageLabelValues(backend)...)
+		m.ModelCachePopulateTotal.WithLabelValues(m.withStorageLabelValues(backend)...)
+		m.ModelCacheReuseTotal.WithLabelValues(m.withStorageLabelValues(backend)...)
+		m.ModelCacheReclaimedTotal.WithLabelValues(m.withStorageLabelValues(backend)...)
+	}
+	// Also keep the no-backend failure series (validation failures before a
+	// backend is known).
 	for _, reason := range modelcachetypes.AllFailureReasons {
-		m.ModelCacheResultTotal.WithLabelValues(m.withStorageLabelValues(modelcachetypes.ResultFailure, reason)...)
+		m.ModelCacheResultTotal.WithLabelValues(m.withStorageLabelValues(modelcachetypes.ResultFailure, reason, "")...)
 	}
 
 	// Cluster attribute metrics
@@ -1048,11 +1106,56 @@ func (m *Metrics) RecordGCCleanerRun(cleanerName, status string) {
 // RecordModelCacheResult records a model cache operation result.
 // result should be "success" or "failure".
 // failureReason should be empty string for success, or one of the defined failure reasons for failure.
-func (m *Metrics) RecordModelCacheResult(result, failureReason string) {
+// backend is the model cache backend (nvmesh/sharedfs/samba/ephemeral) or "" when not yet known.
+func (m *Metrics) RecordModelCacheResult(result, failureReason, backend string) {
 	if m == nil {
 		return
 	}
-	m.ModelCacheResultTotal.WithLabelValues(m.withStorageLabelValues(result, failureReason)...).Inc()
+	m.ModelCacheResultTotal.WithLabelValues(m.withStorageLabelValues(result, failureReason, backend)...).Inc()
+}
+
+// RecordModelCacheBackendSelected increments the per-backend selection counter.
+func (m *Metrics) RecordModelCacheBackendSelected(backend string) {
+	if m == nil {
+		return
+	}
+	m.ModelCacheBackendSelectedTotal.WithLabelValues(m.withStorageLabelValues(backend)...).Inc()
+}
+
+// RecordModelCachePopulate increments the per-backend populate counter (a
+// single-writer download actually ran).
+func (m *Metrics) RecordModelCachePopulate(backend string) {
+	if m == nil {
+		return
+	}
+	m.ModelCachePopulateTotal.WithLabelValues(m.withStorageLabelValues(backend)...).Inc()
+}
+
+// RecordModelCacheReuse increments the per-backend reuse counter (a consumer
+// attached an already-populated cache without downloading).
+func (m *Metrics) RecordModelCacheReuse(backend string) {
+	if m == nil {
+		return
+	}
+	m.ModelCacheReuseTotal.WithLabelValues(m.withStorageLabelValues(backend)...).Inc()
+}
+
+// RecordModelCacheReclaimed increments the per-backend GC reclaim counter.
+func (m *Metrics) RecordModelCacheReclaimed(backend string) {
+	if m == nil {
+		return
+	}
+	m.ModelCacheReclaimedTotal.WithLabelValues(m.withStorageLabelValues(backend)...).Inc()
+}
+
+// SetModelCacheBackendCount sets the gauge of currently-provisioned caches for a
+// backend. Called from the periodic idle-cleanup sweep, which already lists the
+// relevant objects.
+func (m *Metrics) SetModelCacheBackendCount(backend string, count int) {
+	if m == nil {
+		return
+	}
+	m.ModelCacheBackends.WithLabelValues(m.withStorageLabelValues(backend)...).Set(float64(count))
 }
 
 // SetKataRuntimeIsolationEnabled sets the Kata runtime isolation gauge.

--- a/src/compute-plane-services/nvca/internal/metrics/metrics_test.go
+++ b/src/compute-plane-services/nvca/internal/metrics/metrics_test.go
@@ -917,7 +917,7 @@ func TestModelCacheResultMetric(t *testing.T) {
 	require.NotNil(t, metrics.ModelCacheResultTotal)
 
 	t.Run("RecordSuccess", func(t *testing.T) {
-		metrics.RecordModelCacheResult("success", "")
+		metrics.RecordModelCacheResult("success", "", "nvmesh")
 
 		metricFamilies, err := reg.Gather()
 		require.NoError(t, err)
@@ -928,18 +928,20 @@ func TestModelCacheResultMetric(t *testing.T) {
 				found = true
 				require.Greater(t, len(mf.Metric), 0)
 
-				// Find the success metric
+				// Find the success metric for the nvmesh backend.
 				for _, metric := range mf.Metric {
-					var resultLabel, reasonLabel string
+					var resultLabel, reasonLabel, backendLabel string
 					for _, label := range metric.Label {
-						if *label.Name == ResultLabel {
+						switch *label.Name {
+						case ResultLabel:
 							resultLabel = *label.Value
-						}
-						if *label.Name == FailureReasonLabel {
+						case FailureReasonLabel:
 							reasonLabel = *label.Value
+						case BackendLabel:
+							backendLabel = *label.Value
 						}
 					}
-					if resultLabel == "success" {
+					if resultLabel == "success" && backendLabel == "nvmesh" {
 						assert.Equal(t, "", reasonLabel, "Success should have empty failure_reason")
 						assert.Equal(t, float64(1), *metric.Counter.Value)
 					}
@@ -950,7 +952,7 @@ func TestModelCacheResultMetric(t *testing.T) {
 	})
 
 	t.Run("RecordFailure", func(t *testing.T) {
-		metrics.RecordModelCacheResult("failure", "pvc_bind_failed")
+		metrics.RecordModelCacheResult("failure", "pvc_bind_failed", "samba")
 
 		metricFamilies, err := reg.Gather()
 		require.NoError(t, err)
@@ -959,23 +961,25 @@ func TestModelCacheResultMetric(t *testing.T) {
 		for _, mf := range metricFamilies {
 			if *mf.Name == ModelCacheResultTotalMetricName {
 				for _, metric := range mf.Metric {
-					var resultLabel, reasonLabel string
+					var resultLabel, reasonLabel, backendLabel string
 					for _, label := range metric.Label {
-						if *label.Name == ResultLabel {
+						switch *label.Name {
+						case ResultLabel:
 							resultLabel = *label.Value
-						}
-						if *label.Name == FailureReasonLabel {
+						case FailureReasonLabel:
 							reasonLabel = *label.Value
+						case BackendLabel:
+							backendLabel = *label.Value
 						}
 					}
-					if resultLabel == "failure" && reasonLabel == "pvc_bind_failed" {
+					if resultLabel == "failure" && reasonLabel == "pvc_bind_failed" && backendLabel == "samba" {
 						found = true
 						assert.Equal(t, float64(1), *metric.Counter.Value)
 					}
 				}
 			}
 		}
-		assert.True(t, found, "Failure metric with pvc_bind_failed reason should be found")
+		assert.True(t, found, "Failure metric with pvc_bind_failed reason and samba backend should be found")
 	})
 }
 
@@ -984,11 +988,19 @@ func TestModelCacheResultMetricNilSafety(t *testing.T) {
 	var metrics *Metrics
 
 	assert.NotPanics(t, func() {
-		metrics.RecordModelCacheResult("success", "")
+		metrics.RecordModelCacheResult("success", "", "nvmesh")
 	})
 
 	assert.NotPanics(t, func() {
-		metrics.RecordModelCacheResult("failure", "pvc_bind_failed")
+		metrics.RecordModelCacheResult("failure", "pvc_bind_failed", "samba")
+	})
+
+	assert.NotPanics(t, func() {
+		metrics.RecordModelCacheBackendSelected("samba")
+		metrics.RecordModelCachePopulate("samba")
+		metrics.RecordModelCacheReuse("samba")
+		metrics.RecordModelCacheReclaimed("samba")
+		metrics.SetModelCacheBackendCount("samba", 3)
 	})
 }
 
@@ -1001,18 +1013,19 @@ func TestModelCacheResultMetricLabels(t *testing.T) {
 	t.Cleanup(func() { metrics.Destroy() })
 	require.NotNil(t, metrics)
 
-	metrics.RecordModelCacheResult("failure", "image_pull")
+	metrics.RecordModelCacheResult("failure", "image_pull", "nvmesh")
 
 	metricFamilies, err := reg.Gather()
 	require.NoError(t, err)
 
-	// Should have: ClusterName, ClusterGroup, Version, Result, FailureReason (no NCAID for storage metrics)
+	// Should have: ClusterName, ClusterGroup, Version, Result, FailureReason, Backend (no NCAID for storage metrics)
 	expectedLabels := map[string]string{
 		ClusterNameLabel:   "test-cluster",
 		ClusterGroupLabel:  "test-group",
 		VersionLabel:       "v1.0.0",
 		ResultLabel:        "failure",
 		FailureReasonLabel: "image_pull",
+		BackendLabel:       "nvmesh",
 	}
 
 	found := false
@@ -1024,7 +1037,8 @@ func TestModelCacheResultMetricLabels(t *testing.T) {
 				for _, label := range metric.Label {
 					actualLabels[*label.Name] = *label.Value
 				}
-				if actualLabels[ResultLabel] == "failure" && actualLabels[FailureReasonLabel] == "image_pull" {
+				if actualLabels[ResultLabel] == "failure" && actualLabels[FailureReasonLabel] == "image_pull" &&
+					actualLabels[BackendLabel] == "nvmesh" {
 					found = true
 					for expectedName, expectedValue := range expectedLabels {
 						actualValue, exists := actualLabels[expectedName]
@@ -1051,7 +1065,7 @@ func TestModelCacheResultMetricFailureReasons(t *testing.T) {
 			metrics := FromContext(ctx)
 			require.NotNil(t, metrics)
 
-			metrics.RecordModelCacheResult("failure", reason)
+			metrics.RecordModelCacheResult("failure", reason, "nvmesh")
 
 			metricFamilies, err := reg.Gather()
 			require.NoError(t, err)
@@ -1060,11 +1074,18 @@ func TestModelCacheResultMetricFailureReasons(t *testing.T) {
 			for _, mf := range metricFamilies {
 				if *mf.Name == ModelCacheResultTotalMetricName {
 					for _, metric := range mf.Metric {
+						var reasonLabel, backendLabel string
 						for _, label := range metric.Label {
-							if *label.Name == FailureReasonLabel && *label.Value == reason {
-								found = true
-								assert.Equal(t, float64(1), *metric.Counter.Value)
+							switch *label.Name {
+							case FailureReasonLabel:
+								reasonLabel = *label.Value
+							case BackendLabel:
+								backendLabel = *label.Value
 							}
+						}
+						if reasonLabel == reason && backendLabel == "nvmesh" {
+							found = true
+							assert.Equal(t, float64(1), *metric.Counter.Value)
 						}
 					}
 				}
@@ -1540,6 +1561,23 @@ func TestMetricsInitializedToZero(t *testing.T) {
 			value, found := findMetricValue(K8sAPIFailureTotalMetricName, "resource", resource)
 			assert.True(t, found, "K8sAPIFailureTotal should be initialized for resource %s", resource)
 			assert.Equal(t, float64(0), value, "K8sAPIFailureTotal should be zero for resource %s", resource)
+		}
+	})
+
+	t.Run("ModelCache backend counters initialized to zero", func(t *testing.T) {
+		counters := []string{
+			ModelCacheBackendSelectedTotalMetricName,
+			ModelCachePopulateTotalMetricName,
+			ModelCacheReuseTotalMetricName,
+			ModelCacheReclaimedTotalMetricName,
+		}
+		backends := []string{"nvmesh", "sharedfs", "samba", "ephemeral"}
+		for _, name := range counters {
+			for _, backend := range backends {
+				value, found := findMetricValue(name, BackendLabel, backend)
+				assert.True(t, found, "%s should be initialized for backend %s", name, backend)
+				assert.Equal(t, float64(0), value, "%s should be zero for backend %s", name, backend)
+			}
 		}
 	})
 

--- a/src/compute-plane-services/nvca/internal/metrics/modelcachetypes/types.go
+++ b/src/compute-plane-services/nvca/internal/metrics/modelcachetypes/types.go
@@ -55,3 +55,7 @@ var AllFailureReasons = []string{
 	ReasonAdmissionRejected,
 	ReasonInitJobFailed,
 }
+
+// Backend label values come from the HelmCacheBackend constants in pkg/types
+// (shared with pkg/storage); callers pass string(backend) directly. See
+// nvcatypes.AllSelectableHelmCacheBackends for the pre-initialization set.

--- a/src/compute-plane-services/nvca/internal/miniservice/BUILD.bazel
+++ b/src/compute-plane-services/nvca/internal/miniservice/BUILD.bazel
@@ -126,6 +126,8 @@ go_test(
         "metadata_configmap_test.go",
         "mutate_test.go",
         "prereqs_test.go",
+        "reconcile_modelcache_test.go",
+        "reconcile_storagerequests_test.go",
         "reconcile_test.go",
         "reconcile_update_test.go",
         "reval_client_test.go",

--- a/src/compute-plane-services/nvca/internal/miniservice/metadata_configmap.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/metadata_configmap.go
@@ -49,6 +49,7 @@ type MetadataInput struct {
 	EnvVars                       []corev1.EnvVar
 	OTelCollectorEnvVars          []corev1.EnvVar
 	TerminationGracePeriodSeconds *int64
+	ModelCacheInitEnv             map[string]string
 }
 
 // buildMiniserviceMetadata constructs a MiniserviceMetadata from the controller's
@@ -84,6 +85,7 @@ func (r *Reconciler) buildMiniserviceMetadata(
 		Tolerations:                   r.cfg.Workload.Tolerations,
 		ImagePullSecretNames:          secretNames,
 		TerminationGracePeriodSeconds: in.TerminationGracePeriodSeconds,
+		ModelCacheInitEnv:             in.ModelCacheInitEnv,
 	}
 
 	meta.Labels, meta.Annotations = newGeneralObjectLabelsAndAnnotations(

--- a/src/compute-plane-services/nvca/internal/miniservice/reconcile.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/reconcile.go
@@ -666,10 +666,22 @@ func (r *Reconciler) doInstall(ctx context.Context,
 			k8sutil.BYOOMetricsEgressTargetLabelValue
 	}
 
+	// Select the model cache backend ONCE per reconcile and use the same value
+	// for both StorageRequest creation (below) and the ephemeral annotation
+	// (further down). Selecting twice would race a StorageClass change between
+	// the two calls and could both create a ModelCacheRequest and inject the
+	// ephemeral init container, or neither.
+	// Non-terminal on purpose: this is a StorageClass API lookup, so a
+	// transient error (timeout, rate-limit) must be retried.
+	cacheBackend, err := nvcastorage.SelectHelmCacheBackend(ctx, r.Client, r.FeatureFlagFetcher)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("select helm cache backend: %w", err)
+	}
+
 	// Create storage requests if configured for the cluster.
 	stDone, err := r.doStorageRequests(ctx,
 		ms, icmsReq, infraObjectMutators,
-		workerPullSecrets, cacheInitJob, cacheInitPVC,
+		workerPullSecrets, cacheInitJob, cacheInitPVC, cacheBackend,
 	)
 	if err != nil || !stDone {
 		return reconcile.Result{}, err
@@ -695,6 +707,21 @@ func (r *Reconciler) doInstall(ctx context.Context,
 			log.V(1).Info("Conflict updating ICMSRequest status with cache reference, will requeue")
 			return reconcile.Result{Requeue: true}, nil
 		}
+	}
+
+	// The NVMesh, shared-FS, and Samba backends all populate via a
+	// ModelCacheRequest handled by the storage controller (see
+	// doStorageRequests / makeStorageRequests), mounted through the
+	// ModelCacheRequest ROPVCName annotation. Only the ephemeral backend is
+	// handled here: inject a per-pod model-cache-init init container via the
+	// webhook (no shared cache backend available).
+	if cacheLaunchRequested(icmsReq) && cacheBackend == nvcastorage.HelmCacheBackendEphemeral {
+		initEnv, initImage, err := ephemeralModelCacheInitEnv(ms, icmsReq)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		metaInput.PodAnnotations[nvcastorage.WebhookEphemeralModelCacheInitImageAnnotationKey] = initImage
+		metaInput.ModelCacheInitEnv = initEnv
 	}
 
 	// BYOO-specific mutators.
@@ -2026,4 +2053,50 @@ func updateResourcesStatus(ms *v1alpha1.MiniService, resources []v1alpha1.Resour
 		ms.Status.RenderDetails = &v1alpha1.RenderDetailsStatus{}
 	}
 	ms.Status.RenderDetails.Resources = resources
+}
+
+// cacheLaunchRequested reports whether the request asks for model caching
+// (a CacheLaunchSpecification with a positive size).
+func cacheLaunchRequested(icmsReq *nvcav2beta1.ICMSRequest) bool {
+	if icmsReq == nil {
+		return false
+	}
+	var cls *common.CacheLaunchSpecification
+	switch {
+	case icmsReq.Spec.CreationMsgInfo.FunctionLaunchSpecification != nil:
+		cls = icmsReq.Spec.CreationMsgInfo.FunctionLaunchSpecification.CacheLaunchSpecification
+	case icmsReq.Spec.CreationMsgInfo.TaskLaunchSpecification != nil:
+		cls = icmsReq.Spec.CreationMsgInfo.TaskLaunchSpecification.CacheLaunchSpecification
+	default:
+		return false
+	}
+	return cls != nil && cls.CacheSize > 0
+}
+
+// ephemeralModelCacheInitEnv materializes the launch env (plus INSTANCE_ID)
+// consumed by the ephemeral model-cache-init container and returns it with
+// the init image. The env travels to the webhook inside the miniservice
+// metadata ConfigMap (MiniserviceMetadata.ModelCacheInitEnv) instead of a
+// dedicated per-instance ConfigMap.
+func ephemeralModelCacheInitEnv(
+	ms *v1alpha1.MiniService,
+	icmsReq *nvcav2beta1.ICMSRequest,
+) (map[string]string, string, error) {
+	envSet, err := parseWorkloadEnvSet(icmsReq)
+	if err != nil {
+		return nil, "", fmt.Errorf("decode launch env for model cache init: %w", err)
+	}
+
+	initImage := envSet[common.InitImageEnv]
+	if initImage == "" {
+		return nil, "", fmt.Errorf("missing %s in launch environment", common.InitImageEnv)
+	}
+
+	data := maps.Clone(envSet)
+	if data == nil {
+		data = map[string]string{}
+	}
+	data["INSTANCE_ID"] = ms.Name
+
+	return data, initImage, nil
 }

--- a/src/compute-plane-services/nvca/internal/miniservice/reconcile.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/reconcile.go
@@ -671,11 +671,17 @@ func (r *Reconciler) doInstall(ctx context.Context,
 	// (further down). Selecting twice would race a StorageClass change between
 	// the two calls and could both create a ModelCacheRequest and inject the
 	// ephemeral init container, or neither.
+	// Skip the lookup entirely when the launch does not request caching: the
+	// selection needs a StorageClass API call, and a transient API error must
+	// not fail or delay installs that never cache.
 	// Non-terminal on purpose: this is a StorageClass API lookup, so a
 	// transient error (timeout, rate-limit) must be retried.
-	cacheBackend, err := nvcastorage.SelectHelmCacheBackend(ctx, r.Client, r.FeatureFlagFetcher)
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("select helm cache backend: %w", err)
+	cacheBackend := nvcastorage.HelmCacheBackendNone
+	if cacheLaunchRequested(icmsReq) {
+		cacheBackend, err = nvcastorage.SelectHelmCacheBackend(ctx, r.Client, r.FeatureFlagFetcher)
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("select helm cache backend: %w", err)
+		}
 	}
 
 	// Create storage requests if configured for the cluster.

--- a/src/compute-plane-services/nvca/internal/miniservice/reconcile_modelcache_test.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/reconcile_modelcache_test.go
@@ -1,0 +1,58 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mscontroller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	nvcav2beta1 "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/v2beta1"
+	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/common"
+	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function"
+)
+
+func TestCacheLaunchRequested(t *testing.T) {
+	withSize := func(size int64) *nvcav2beta1.ICMSRequest {
+		return &nvcav2beta1.ICMSRequest{
+			Spec: nvcav2beta1.ICMSRequestSpec{
+				CreationMsgInfo: nvcav2beta1.ICMSCreationMessageInfo{
+					FunctionLaunchSpecification: &function.LaunchSpecification{
+						CacheLaunchSpecification: &common.CacheLaunchSpecification{
+							CacheHandle: "handle",
+							CacheSize:   size,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	assert.True(t, cacheLaunchRequested(withSize(10)), "positive cache size")
+	assert.False(t, cacheLaunchRequested(withSize(0)), "zero cache size")
+	assert.False(t, cacheLaunchRequested(nil), "nil request")
+
+	noCacheSpec := &nvcav2beta1.ICMSRequest{
+		Spec: nvcav2beta1.ICMSRequestSpec{
+			CreationMsgInfo: nvcav2beta1.ICMSCreationMessageInfo{
+				FunctionLaunchSpecification: &function.LaunchSpecification{},
+			},
+		},
+	}
+	assert.False(t, cacheLaunchRequested(noCacheSpec), "no cache spec")
+}

--- a/src/compute-plane-services/nvca/internal/miniservice/reconcile_storagerequests.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/reconcile_storagerequests.go
@@ -43,13 +43,16 @@ func (r *Reconciler) doStorageRequests(ctx context.Context,
 	workerImagePullSecrets []*corev1.Secret,
 	cacheInitJob *batchv1.Job,
 	cacheInitPVC *corev1.PersistentVolumeClaim,
+	cacheBackend nvcastorage.HelmCacheBackend,
 ) (allReady bool, err error) {
 	log := logf.FromContext(ctx)
 
-	sts, err := r.makeStorageRequests(icmsReq, workerImagePullSecrets, cacheInitJob, cacheInitPVC)
+	sts, err := r.makeStorageRequests(icmsReq, workerImagePullSecrets, cacheInitJob, cacheInitPVC, cacheBackend)
 	if err != nil {
 		log.Error(err, "Failed to make StorageRequests")
-		return false, reconcile.TerminalError(err)
+		// makeStorageRequests marks genuinely terminal errors (invalid spec)
+		// with reconcile.TerminalError itself; anything else is retried.
+		return false, err
 	}
 	stNames := sets.New[string]()
 	for _, st := range sts {
@@ -130,15 +133,28 @@ func (r *Reconciler) makeStorageRequests(
 	workerImagePullSecrets []*corev1.Secret,
 	cacheInitJob *batchv1.Job,
 	cacheInitPVC *corev1.PersistentVolumeClaim,
+	backend nvcastorage.HelmCacheBackend,
 ) (sts []*nvcav2beta1.StorageRequest, err error) {
-	if r.FeatureFlagFetcher.IsFeatureFlagEnabled(featureflag.CachingSupport) &&
-		r.FeatureFlagFetcher.IsFeatureFlagEnabled(featureflag.HelmCachingSupport) &&
-		cacheInitJob != nil && cacheInitPVC != nil {
-		st, err := nvcastorage.NewModelCacheStorageRequest(icmsReq, r.FeatureFlagFetcher)
-		if err != nil {
-			return nil, err
+	// The caching backend is selected ONCE per reconcile by the caller
+	// (SelectHelmCacheBackend in doInstall) and passed in, so StorageRequest
+	// creation and the ephemeral annotation decision always agree even if the
+	// cluster's storage classes change mid-reconcile.
+	// NVMesh, shared-FS, and Samba all populate the cache via a ModelCacheRequest;
+	// the Backend field tells the storage controller which populate path to run
+	// (Samba stands up its own server and serves via static PVs). Only the
+	// ephemeral backend is handled outside the storage controller.
+	switch backend {
+	case nvcastorage.HelmCacheBackendNVMesh, nvcastorage.HelmCacheBackendSharedFS, nvcastorage.HelmCacheBackendSamba:
+		if cacheInitJob != nil && cacheInitPVC != nil {
+			st, err := nvcastorage.NewModelCacheStorageRequest(icmsReq, r.FeatureFlagFetcher)
+			if err != nil {
+				// Invalid cache spec is not retryable; keep it terminal (the
+				// caller no longer wraps makeStorageRequests errors as terminal).
+				return nil, reconcile.TerminalError(err)
+			}
+			st.Spec.ModelCache.Backend = string(backend)
+			sts = append(sts, st)
 		}
-		sts = append(sts, st)
 	}
 	if r.FeatureFlagFetcher.IsFeatureFlagEnabled(&featureflag.HelmSharedStorage.FeatureFlag) {
 		sts = append(sts, nvcastorage.NewSharedStorageRequest(icmsReq, r.FeatureFlagFetcher, r.cfg,

--- a/src/compute-plane-services/nvca/internal/miniservice/reconcile_storagerequests.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/reconcile_storagerequests.go
@@ -136,16 +136,19 @@ func (r *Reconciler) makeStorageRequests(
 	backend nvcastorage.HelmCacheBackend,
 ) (sts []*nvcav2beta1.StorageRequest, err error) {
 	// The caching backend is selected ONCE per reconcile by the caller
-	// (SelectHelmCacheBackend in doInstall) and passed in, so StorageRequest
-	// creation and the ephemeral annotation decision always agree even if the
-	// cluster's storage classes change mid-reconcile.
+	// (SelectHelmCacheBackend in doInstall, gated on cacheLaunchRequested) and
+	// passed in, so StorageRequest creation and the ephemeral annotation
+	// decision always agree even if the cluster's storage classes change
+	// mid-reconcile.
 	// NVMesh, shared-FS, and Samba all populate the cache via a ModelCacheRequest;
 	// the Backend field tells the storage controller which populate path to run
 	// (Samba stands up its own server and serves via static PVs). Only the
 	// ephemeral backend is handled outside the storage controller.
+	// cacheLaunchRequested is the same predicate that gates the ephemeral
+	// injection, so a request either caches on every backend or on none.
 	switch backend {
 	case nvcastorage.HelmCacheBackendNVMesh, nvcastorage.HelmCacheBackendSharedFS, nvcastorage.HelmCacheBackendSamba:
-		if cacheInitJob != nil && cacheInitPVC != nil {
+		if cacheInitJob != nil && cacheInitPVC != nil && cacheLaunchRequested(icmsReq) {
 			st, err := nvcastorage.NewModelCacheStorageRequest(icmsReq, r.FeatureFlagFetcher)
 			if err != nil {
 				// Invalid cache spec is not retryable; keep it terminal (the

--- a/src/compute-plane-services/nvca/internal/miniservice/reconcile_storagerequests_test.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/reconcile_storagerequests_test.go
@@ -57,6 +57,7 @@ func TestMakeStorageRequests_BackendHandling(t *testing.T) {
 			CacheLaunchSpecification: &common.CacheLaunchSpecification{
 				CacheArtifacts: true,
 				CacheHandle:    "h1",
+				CacheSize:      262144000,
 			},
 		}
 		sts, err := r.makeStorageRequests(icmsReq, nil, job, pvc, nvcastorage.HelmCacheBackendSamba)
@@ -69,11 +70,31 @@ func TestMakeStorageRequests_BackendHandling(t *testing.T) {
 	t.Run("invalid cache spec is terminal", func(t *testing.T) {
 		icmsReq := &nvcav2beta1.ICMSRequest{}
 		icmsReq.Spec.Action = common.FunctionCreationAction
-		icmsReq.Spec.CreationMsgInfo.FunctionLaunchSpecification = &function.LaunchSpecification{}
+		// Requests caching (size > 0) but is invalid: no cache handle.
+		icmsReq.Spec.CreationMsgInfo.FunctionLaunchSpecification = &function.LaunchSpecification{
+			CacheLaunchSpecification: &common.CacheLaunchSpecification{
+				CacheArtifacts: true,
+				CacheSize:      262144000,
+			},
+		}
 		_, err := r.makeStorageRequests(icmsReq, nil, job, pvc, nvcastorage.HelmCacheBackendSamba)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, reconcile.TerminalError(nil)),
 			"invalid cache spec must be terminal, not retried")
+	})
+
+	t.Run("cache spec without a requested size emits no ModelCacheRequest", func(t *testing.T) {
+		icmsReq := &nvcav2beta1.ICMSRequest{}
+		icmsReq.Spec.Action = common.FunctionCreationAction
+		icmsReq.Spec.CreationMsgInfo.FunctionLaunchSpecification = &function.LaunchSpecification{
+			CacheLaunchSpecification: &common.CacheLaunchSpecification{
+				CacheArtifacts: true,
+				CacheHandle:    "h1",
+			},
+		}
+		sts, err := r.makeStorageRequests(icmsReq, nil, job, pvc, nvcastorage.HelmCacheBackendSamba)
+		require.NoError(t, err)
+		assert.Empty(t, sts, "cacheLaunchRequested gates durable backends like the ephemeral path")
 	})
 
 	t.Run("ephemeral backend emits no ModelCacheRequest", func(t *testing.T) {

--- a/src/compute-plane-services/nvca/internal/miniservice/reconcile_storagerequests_test.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/reconcile_storagerequests_test.go
@@ -1,0 +1,86 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mscontroller
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/common"
+	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function"
+
+	nvcav2beta1 "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/v2beta1"
+	featureflagmock "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/featureflag/mock"
+	nvcastorage "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/storage"
+)
+
+// The cache backend is selected ONCE per reconcile by the caller (doInstall)
+// and passed into makeStorageRequests, so the ModelCacheRequest decision and
+// the ephemeral-annotation decision can never disagree (no second StorageClass
+// lookup to race). These tests cover makeStorageRequests's contract given a
+// backend: tag the ModelCacheRequest with it, keep invalid cache specs
+// terminal, and emit no ModelCacheRequest for the ephemeral backend.
+func TestMakeStorageRequests_BackendHandling(t *testing.T) {
+	r := &Reconciler{
+		ControllerOptions: ControllerOptions{
+			FeatureFlagFetcher: &featureflagmock.Fetcher{},
+		},
+	}
+	job := &batchv1.Job{}
+	pvc := &corev1.PersistentVolumeClaim{}
+
+	t.Run("samba backend tags the ModelCacheRequest", func(t *testing.T) {
+		icmsReq := &nvcav2beta1.ICMSRequest{}
+		icmsReq.Spec.Action = common.FunctionCreationAction
+		icmsReq.Spec.CreationMsgInfo.FunctionLaunchSpecification = &function.LaunchSpecification{
+			CacheLaunchSpecification: &common.CacheLaunchSpecification{
+				CacheArtifacts: true,
+				CacheHandle:    "h1",
+			},
+		}
+		sts, err := r.makeStorageRequests(icmsReq, nil, job, pvc, nvcastorage.HelmCacheBackendSamba)
+		require.NoError(t, err)
+		require.Len(t, sts, 1)
+		require.NotNil(t, sts[0].Spec.ModelCache)
+		assert.Equal(t, string(nvcastorage.HelmCacheBackendSamba), sts[0].Spec.ModelCache.Backend)
+	})
+
+	t.Run("invalid cache spec is terminal", func(t *testing.T) {
+		icmsReq := &nvcav2beta1.ICMSRequest{}
+		icmsReq.Spec.Action = common.FunctionCreationAction
+		icmsReq.Spec.CreationMsgInfo.FunctionLaunchSpecification = &function.LaunchSpecification{}
+		_, err := r.makeStorageRequests(icmsReq, nil, job, pvc, nvcastorage.HelmCacheBackendSamba)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, reconcile.TerminalError(nil)),
+			"invalid cache spec must be terminal, not retried")
+	})
+
+	t.Run("ephemeral backend emits no ModelCacheRequest", func(t *testing.T) {
+		icmsReq := &nvcav2beta1.ICMSRequest{}
+		icmsReq.Spec.Action = common.FunctionCreationAction
+		sts, err := r.makeStorageRequests(icmsReq, nil, job, pvc, nvcastorage.HelmCacheBackendEphemeral)
+		require.NoError(t, err)
+		assert.Empty(t, sts)
+	})
+}

--- a/src/compute-plane-services/nvca/pkg/apis/nvca/v1/cache_types.go
+++ b/src/compute-plane-services/nvca/pkg/apis/nvca/v1/cache_types.go
@@ -71,9 +71,10 @@ type ModelCacheSpec struct {
 	CacheHandle string                `json:"cacheHandle"`
 	Encryption  *ModelCacheEncryption `json:"encryption,omitempty"`
 	// Backend selects the storage backend used to populate and expose the
-	// cache: "nvmesh" (NVMesh 3.x, nvcf-sc-30) or "sharedfs" (a shared
-	// filesystem class, nvcf-miniservice-sc). Empty is treated as "nvmesh" for
-	// backward compatibility.
+	// cache: "nvmesh" (NVMesh 3.x, nvcf-sc-30), "sharedfs" (a shared
+	// filesystem class, nvcf-miniservice-sc), or "samba" (NVCA-managed Samba
+	// server). Empty is treated as "nvmesh" for backward compatibility; any
+	// other value fails the request with a terminal validation error.
 	Backend string `json:"backend,omitempty"`
 }
 

--- a/src/compute-plane-services/nvca/pkg/apis/nvca/v1/cache_types.go
+++ b/src/compute-plane-services/nvca/pkg/apis/nvca/v1/cache_types.go
@@ -70,6 +70,11 @@ func (sType StorageRequestType) Name() string {
 type ModelCacheSpec struct {
 	CacheHandle string                `json:"cacheHandle"`
 	Encryption  *ModelCacheEncryption `json:"encryption,omitempty"`
+	// Backend selects the storage backend used to populate and expose the
+	// cache: "nvmesh" (NVMesh 3.x, nvcf-sc-30) or "sharedfs" (a shared
+	// filesystem class, nvcf-miniservice-sc). Empty is treated as "nvmesh" for
+	// backward compatibility.
+	Backend string `json:"backend,omitempty"`
 }
 
 type ModelCacheEncryption struct {

--- a/src/compute-plane-services/nvca/pkg/apis/nvca/v2beta1/conversion.go
+++ b/src/compute-plane-services/nvca/pkg/apis/nvca/v2beta1/conversion.go
@@ -84,6 +84,7 @@ func storageRequestSpecFromV1(s *nvcav1.StorageRequestSpec) StorageRequestSpec {
 	if s.ModelCache != nil {
 		out.ModelCache = &ModelCacheSpec{
 			CacheHandle: s.ModelCache.CacheHandle,
+			Backend:     s.ModelCache.Backend,
 			Encryption:  nil,
 		}
 		if s.ModelCache.Encryption != nil {
@@ -111,6 +112,7 @@ func storageRequestSpecToV1(s *StorageRequestSpec) nvcav1.StorageRequestSpec {
 	if s.ModelCache != nil {
 		out.ModelCache = &nvcav1.ModelCacheSpec{
 			CacheHandle: s.ModelCache.CacheHandle,
+			Backend:     s.ModelCache.Backend,
 			Encryption:  nil,
 		}
 		if s.ModelCache.Encryption != nil {

--- a/src/compute-plane-services/nvca/pkg/apis/nvca/v2beta1/conversion_test.go
+++ b/src/compute-plane-services/nvca/pkg/apis/nvca/v2beta1/conversion_test.go
@@ -53,3 +53,23 @@ func TestStorageRequestRoundTripPreservesSMBServerPodTolerations(t *testing.T) {
 		roundTripped.Spec.SharedStorage.Server.SMBServerPodTolerations,
 	)
 }
+
+func TestStorageRequestRoundTripPreservesModelCacheBackend(t *testing.T) {
+	original := &StorageRequest{
+		Spec: StorageRequestSpec{
+			ModelCache: &ModelCacheSpec{
+				CacheHandle: "handle-1",
+				Backend:     "sharedfs",
+			},
+		},
+	}
+
+	toV1 := StorageRequestToV1(original)
+	require.NotNil(t, toV1.Spec.ModelCache)
+	assert.Equal(t, "sharedfs", toV1.Spec.ModelCache.Backend)
+
+	roundTripped := StorageRequestFromV1(toV1)
+	require.NotNil(t, roundTripped.Spec.ModelCache)
+	assert.Equal(t, "handle-1", roundTripped.Spec.ModelCache.CacheHandle)
+	assert.Equal(t, "sharedfs", roundTripped.Spec.ModelCache.Backend)
+}

--- a/src/compute-plane-services/nvca/pkg/apis/nvca/v2beta1/storage_types.go
+++ b/src/compute-plane-services/nvca/pkg/apis/nvca/v2beta1/storage_types.go
@@ -70,6 +70,12 @@ func (sType StorageRequestType) Name() string {
 type ModelCacheSpec struct {
 	CacheHandle string                `json:"cacheHandle"`
 	Encryption  *ModelCacheEncryption `json:"encryption,omitempty"`
+	// Backend selects the storage backend used to populate and expose the
+	// cache: "nvmesh" (NVMesh 3.x, nvcf-sc-30) or "sharedfs" (a shared
+	// filesystem class, nvcf-miniservice-sc, including the Samba-backed case). Empty
+	// is treated as "nvmesh" for backward compatibility. Set by the reconciler
+	// from SelectHelmCacheBackend.
+	Backend string `json:"backend,omitempty"`
 }
 
 type ModelCacheEncryption struct {

--- a/src/compute-plane-services/nvca/pkg/apis/nvca/v2beta1/storage_types.go
+++ b/src/compute-plane-services/nvca/pkg/apis/nvca/v2beta1/storage_types.go
@@ -71,10 +71,14 @@ type ModelCacheSpec struct {
 	CacheHandle string                `json:"cacheHandle"`
 	Encryption  *ModelCacheEncryption `json:"encryption,omitempty"`
 	// Backend selects the storage backend used to populate and expose the
-	// cache: "nvmesh" (NVMesh 3.x, nvcf-sc-30) or "sharedfs" (a shared
-	// filesystem class, nvcf-miniservice-sc, including the Samba-backed case). Empty
-	// is treated as "nvmesh" for backward compatibility. Set by the reconciler
-	// from SelectHelmCacheBackend.
+	// cache. Serialized values emitted by SelectHelmCacheBackend for
+	// ModelCacheRequests: "nvmesh" (NVMesh 3.x, nvcf-sc-30), "sharedfs" (a
+	// shared filesystem class, nvcf-miniservice-sc), or "samba" (NVCA-managed
+	// Samba server on block storage). "ephemeral" and "none" never reach a
+	// StorageRequest (ephemeral is a per-pod webhook fallback; none means
+	// caching disabled). Empty is treated as "nvmesh" for backward
+	// compatibility; any other value fails the request with a terminal
+	// validation error.
 	Backend string `json:"backend,omitempty"`
 }
 

--- a/src/compute-plane-services/nvca/pkg/featureflag/featureflag.go
+++ b/src/compute-plane-services/nvca/pkg/featureflag/featureflag.go
@@ -60,7 +60,6 @@ var (
 	KAIScheduler                  = newFeatureFlag("KAIScheduler", newBool(false))
 	HelmCustomAnnotations         = newFeatureFlag("HelmCustomAnnotations", newBool(false))
 	MaxSQSBatchPull               = newFeatureFlag("MaxSQSBatchPull", newBool(true))
-	HelmCachingSupport            = newFeatureFlag("HelmCachingSupport", newBool(false))
 	CordonMaintenance             = newFeatureFlag("CordonMaintenance", newBool(false))
 	CordonAndDrainMaintenance     = newFeatureFlag("CordonAndDrainMaintenance", newBool(false))
 	// AckTaskRequestAfterPodsScheduled instructs the agent to only acknowledge ICMS requests with ICMS

--- a/src/compute-plane-services/nvca/pkg/nvca/BUILD.bazel
+++ b/src/compute-plane-services/nvca/pkg/nvca/BUILD.bazel
@@ -156,6 +156,7 @@ go_test(
     name = "nvca_test",
     srcs = [
         "agent_http_debug_test.go",
+        "agent_manager_test.go",
         "agent_metrics_test.go",
         "agent_self_destruct_test.go",
         "agent_test.go",
@@ -219,6 +220,7 @@ go_test(
         "//internal/util/k8sutil",
         "//internal/util/k8sutil/mock",
         "//internal/util/translate",
+        "//pkg/apis/nvca/v1:nvca",
         "//pkg/apis/nvca/v1alpha1",
         "//pkg/apis/nvca/v2beta1",
         "//pkg/client/clientset/versioned/fake",

--- a/src/compute-plane-services/nvca/pkg/nvca/agent_manager.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/agent_manager.go
@@ -63,6 +63,23 @@ func init() {
 
 // startControllerManagerForAgent creates and starts a controller-runtime manager
 // for auxiliary CRD controllers.
+// storageControllerTypes returns the StorageRequest controller types to
+// register with the agent's controller manager. The model-cache controller is
+// included only when caching is enabled, since it backs all storage-class-
+// selected cache backends (NVMesh / shared-FS / Samba). Callers pass the stable
+// agent-level caching flag (a.CachingSupportEnabled), not a live feature-flag
+// lookup, so the set is deterministic for the lifetime of the agent.
+func storageControllerTypes(cachingEnabled bool) []nvcav1new.StorageRequestType {
+	sts := []nvcav1new.StorageRequestType{
+		nvcav1new.SharedStorageRequest,
+		nvcav1new.InternalPersistentStorageRequest,
+	}
+	if cachingEnabled {
+		sts = append(sts, nvcav1new.ModelCacheRequest)
+	}
+	return sts
+}
+
 func startControllerManagerForAgent(
 	ctx context.Context,
 	a *Agent,
@@ -97,14 +114,15 @@ func startControllerManagerForAgent(
 		return fmt.Errorf("create controller manager: %v", err)
 	}
 
-	// Create storage controllers for each type
-	sts := []nvcav1new.StorageRequestType{
-		nvcav1new.SharedStorageRequest,
-		nvcav1new.InternalPersistentStorageRequest,
-	}
-	if a.FeatureFlagFetcher.IsFeatureFlagEnabled(featureflag.HelmCachingSupport) {
-		sts = append(sts, nvcav1new.ModelCacheRequest)
-	}
+	// Create storage controllers for each type. The model-cache controller
+	// backs every storage-class-selected cache backend (NVMesh / shared-FS /
+	// Samba), so it is registered whenever caching is enabled.
+	cachingEnabled := a.CachingSupportEnabled
+	sts := storageControllerTypes(cachingEnabled)
+	log.WithField("controllers", sts).
+		WithField("caching_support_enabled", cachingEnabled).
+		WithField("caching_support_flag", a.FeatureFlagFetcher.IsFeatureFlagEnabled(featureflag.CachingSupport)).
+		Info("Registering storage controllers")
 	for _, st := range sts {
 		if err := storage.BuildController(a.Config, st, mgr,
 			a.ClusterName,
@@ -119,6 +137,7 @@ func startControllerManagerForAgent(
 			log.WithError(err).Errorf("Failed to create storage controller %s", st)
 			return fmt.Errorf("create storage controller %s: %v", st, err)
 		}
+		log.WithField("type", st).Info("Registered storage controller")
 	}
 
 	log.Info("Starting MiniService controller")

--- a/src/compute-plane-services/nvca/pkg/nvca/agent_manager_test.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/agent_manager_test.go
@@ -1,0 +1,46 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvca
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	nvcav1new "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/v1"
+)
+
+func TestStorageControllerTypes(t *testing.T) {
+	// Shared-storage and internal-persistent-storage controllers always
+	// register; the model-cache controller is gated on caching being enabled.
+	base := storageControllerTypes(false)
+	assert.Equal(t, []nvcav1new.StorageRequestType{
+		nvcav1new.SharedStorageRequest,
+		nvcav1new.InternalPersistentStorageRequest,
+	}, base, "caching off must not register the model-cache controller")
+	assert.NotContains(t, base, nvcav1new.ModelCacheRequest)
+
+	withCache := storageControllerTypes(true)
+	assert.Contains(t, withCache, nvcav1new.ModelCacheRequest,
+		"caching on must register the model-cache controller")
+	assert.Equal(t, []nvcav1new.StorageRequestType{
+		nvcav1new.SharedStorageRequest,
+		nvcav1new.InternalPersistentStorageRequest,
+		nvcav1new.ModelCacheRequest,
+	}, withCache)
+}

--- a/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend.go
@@ -747,8 +747,11 @@ func (c K8sComputeBackend) doHelmChartStorageRequests(ctx context.Context,
 	metrics := nvcametrics.FromContext(ctx)
 
 	var sts []*nvcav2beta1.StorageRequest
-	if needsCaching && c.bk8s.cachingSupportEnabled &&
-		c.bk8s.featureFlagFetcher.IsFeatureFlagEnabled(featureflag.HelmCachingSupport) {
+	// NOTE: doHelmChartStorageRequests has no callers (dead code); the active
+	// helm storage-request path is the miniservice reconciler. The
+	// HelmCachingSupport sub-gate is dropped here only so this compiles after
+	// the flag is removed; backend selection lives in makeStorageRequests.
+	if needsCaching && c.bk8s.cachingSupportEnabled {
 		st, err := nvcastorage.NewModelCacheStorageRequest(req, c.bk8s.featureFlagFetcher)
 		if err != nil {
 			return nil, nil, err

--- a/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache.go
@@ -209,7 +209,7 @@ func (c K8sComputeBackend) SetupModelCachingForRequest(ctx context.Context,
 			c.bk8s.eventRecorder.Eventf(req, v1.EventTypeWarning,
 				string(types.EventCategoryModelCaching), "%v failed, resort to non-caching", initJob.Name)
 			reason := c.getInitCacheJobFailureReason(ctx, initJob)
-			metrics.RecordModelCacheResult(modelcachetypes.ResultFailure, reason)
+			metrics.RecordModelCacheResult(modelcachetypes.ResultFailure, reason, string(types.HelmCacheBackendNVMesh))
 			return ModelCachingFailed, ""
 		case InitCacheJobCompleted:
 			mc := ModelCachingInProgress
@@ -223,7 +223,7 @@ func (c K8sComputeBackend) SetupModelCachingForRequest(ctx context.Context,
 				c.bk8s.eventRecorder.Event(req, v1.EventTypeWarning,
 					string(types.EventCategoryModelCaching), "failed pvc setup, resort to non-caching")
 				metrics.EventErrorTotal.WithLabelValues(metrics.WithDefaultLabelValues(EventModelCachingFailed)...).Inc()
-				metrics.RecordModelCacheResult(modelcachetypes.ResultFailure, modelcachetypes.ReasonPVCSetupFailed)
+				metrics.RecordModelCacheResult(modelcachetypes.ResultFailure, modelcachetypes.ReasonPVCSetupFailed, string(types.HelmCacheBackendNVMesh))
 				mc = ModelCachingFailed
 			}
 			return mc, ""
@@ -250,7 +250,7 @@ func (c K8sComputeBackend) SetupModelCachingForRequest(ctx context.Context,
 			string(types.EventCategoryModelCaching), "%v bind failed, resort to non-caching", roPVCName)
 		metrics.EventErrorTotal.WithLabelValues(metrics.WithDefaultLabelValues(EventPVCModelCachingError)...).Inc()
 		metrics.EventErrorTotal.WithLabelValues(metrics.WithDefaultLabelValues(EventModelCachingFailed)...).Inc()
-		metrics.RecordModelCacheResult(modelcachetypes.ResultFailure, modelcachetypes.ReasonPVCBindFailed)
+		metrics.RecordModelCacheResult(modelcachetypes.ResultFailure, modelcachetypes.ReasonPVCBindFailed, string(types.HelmCacheBackendNVMesh))
 		return ModelCachingFailed, ""
 	case PVCFoundBound:
 		log.Infof("ROPVC %v setup completed, Modelcaching will be enabled for request %v/%v", roPVCName, req.Namespace, req.Name)
@@ -265,7 +265,7 @@ func (c K8sComputeBackend) SetupModelCachingForRequest(ctx context.Context,
 				c.bk8s.podInstanceNamespace, initJob.Name)
 		}
 		metrics.EventErrorTotal.WithLabelValues(metrics.WithDefaultLabelValues(EventModelCachingSuccess)...).Inc()
-		metrics.RecordModelCacheResult(modelcachetypes.ResultSuccess, "")
+		metrics.RecordModelCacheResult(modelcachetypes.ResultSuccess, "", string(types.HelmCacheBackendNVMesh))
 		return ModelCachingCompleted, roPVCName
 	}
 	// Never reached

--- a/src/compute-plane-services/nvca/pkg/storage/BUILD.bazel
+++ b/src/compute-plane-services/nvca/pkg/storage/BUILD.bazel
@@ -6,6 +6,8 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "storage",
     srcs = [
+        "cachebackend.go",
+        "cachebackend_samba.go",
         "controller.go",
         "controller_modelcache.go",
         "modelcache.go",
@@ -37,6 +39,7 @@ go_library(
         "//pkg/nodefeatures",
         "//pkg/nvca/enforce/kaischeduler",
         "//pkg/nvca/health",
+        "//pkg/storage/cacheprobe",
         "//pkg/types",
         "//vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/core",
         "//vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/common",
@@ -71,7 +74,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/runtime",
         "//vendor/k8s.io/apimachinery/pkg/util/sets",
         "//vendor/k8s.io/apimachinery/pkg/util/strategicpatch",
-        "//vendor/k8s.io/apimachinery/pkg/util/wait",
         "//vendor/k8s.io/client-go/tools/record",
         "//vendor/k8s.io/client-go/util/retry",
         "//vendor/sigs.k8s.io/controller-runtime",
@@ -95,6 +97,8 @@ alias(
 go_test(
     name = "storage_test",
     srcs = [
+        "cachebackend_samba_test.go",
+        "cachebackend_test.go",
         "controller_test.go",
         "modelcache_cleanup_test.go",
         "modelcache_nvmesh_encrypt_test.go",
@@ -135,6 +139,7 @@ go_test(
         "//pkg/featureflag",
         "//pkg/featureflag/mock",
         "//pkg/nodefeatures",
+        "//pkg/storage/cacheprobe",
         "//pkg/types",
         "//vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/core",
         "//vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/common",
@@ -166,6 +171,8 @@ go_test(
         "//vendor/sigs.k8s.io/controller-runtime",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client/fake",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client/interceptor",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/config",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/log",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/manager",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/reconcile",

--- a/src/compute-plane-services/nvca/pkg/storage/cachebackend.go
+++ b/src/compute-plane-services/nvca/pkg/storage/cachebackend.go
@@ -1,0 +1,119 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/featureflag"
+	nvcatypes "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/types"
+)
+
+// HelmCacheBackend identifies the storage backend selected for the Helm model
+// cache. The backend is resolved from the CachingSupport gate plus the storage
+// classes available in the cluster, replacing the old HelmCachingSupport flag.
+// The type and values live in pkg/types so metrics can share them; they are
+// aliased here for the storage-facing API.
+type HelmCacheBackend = nvcatypes.HelmCacheBackend
+
+const (
+	// HelmCacheBackendNone means caching is disabled (CachingSupport off).
+	HelmCacheBackendNone = nvcatypes.HelmCacheBackendNone
+	// HelmCacheBackendNVMesh uses NVMesh 3.x cross-namespace PV sharing
+	// (the existing doModelCacheNVMesh path).
+	HelmCacheBackendNVMesh = nvcatypes.HelmCacheBackendNVMesh
+	// HelmCacheBackendSharedFS uses an operator-provided shared (RWX/ROX)
+	// storage class (nvcf-miniservice-sc): WEKA, EFS, CephFS, external NFS, etc.
+	HelmCacheBackendSharedFS = nvcatypes.HelmCacheBackendSharedFS
+	// HelmCacheBackendSamba deploys a Samba server (on block storage) and
+	// creates nvcf-miniservice-sc pointing at it, then caches via the shared-FS path.
+	HelmCacheBackendSamba = nvcatypes.HelmCacheBackendSamba
+	// HelmCacheBackendEphemeral is the per-pod emptyDir fallback when no
+	// shared cache backend is available.
+	HelmCacheBackendEphemeral = nvcatypes.HelmCacheBackendEphemeral
+)
+
+const (
+	// NVMeshStorageClassName, when present in the cluster, signals that
+	// NVMesh 3.x (with cross-namespace PV sharing) is installed.
+	NVMeshStorageClassName = "nvcf-sc-30"
+	// HelmCacheSharedStorageClassName is the shared storage class used for
+	// non-NVMesh cross-namespace model caching. It is either pre-provisioned
+	// by the operator or created by NVCA pointing at a Samba server.
+	HelmCacheSharedStorageClassName = "nvcf-miniservice-sc"
+)
+
+// SelectHelmCacheBackend resolves the Helm model-cache storage backend. All
+// caching is gated on CachingSupport; the mechanism is then chosen by which
+// storage class the cluster provides, falling back to Samba (when
+// HelmSharedStorage is enabled) and finally to a per-pod ephemeral cache:
+//
+//  1. nvcf-sc-30 present    -> NVMesh 3.x installed      -> NVMesh
+//  2. nvcf-miniservice-sc present  -> operator shared storage   -> SharedFS
+//  3. HelmSharedStorage on  -> NVCA deploys Samba         -> Samba
+//  4. otherwise             -> per-pod emptyDir fallback  -> Ephemeral
+func SelectHelmCacheBackend(
+	ctx context.Context,
+	c client.Client,
+	ff featureflag.Fetcher,
+) (HelmCacheBackend, error) {
+	if !ff.IsFeatureFlagEnabled(featureflag.CachingSupport) {
+		return HelmCacheBackendNone, nil
+	}
+
+	nvmeshPresent, err := storageClassExists(ctx, c, NVMeshStorageClassName)
+	if err != nil {
+		return "", err
+	}
+	if nvmeshPresent {
+		return HelmCacheBackendNVMesh, nil
+	}
+
+	sharedPresent, err := storageClassExists(ctx, c, HelmCacheSharedStorageClassName)
+	if err != nil {
+		return "", err
+	}
+	if sharedPresent {
+		return HelmCacheBackendSharedFS, nil
+	}
+
+	if ff.IsFeatureFlagEnabled(&featureflag.HelmSharedStorage.FeatureFlag) {
+		return HelmCacheBackendSamba, nil
+	}
+
+	return HelmCacheBackendEphemeral, nil
+}
+
+// storageClassExists reports whether a cluster-scoped StorageClass exists,
+// treating NotFound as a clean negative.
+func storageClassExists(ctx context.Context, c client.Client, name string) (bool, error) {
+	sc := &storagev1.StorageClass{}
+	switch err := c.Get(ctx, client.ObjectKey{Name: name}, sc); {
+	case apierrors.IsNotFound(err):
+		return false, nil
+	case err != nil:
+		return false, fmt.Errorf("get storageclass %q: %w", name, err)
+	default:
+		return true, nil
+	}
+}

--- a/src/compute-plane-services/nvca/pkg/storage/cachebackend_samba.go
+++ b/src/compute-plane-services/nvca/pkg/storage/cachebackend_samba.go
@@ -1,0 +1,507 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"strconv"
+
+	"github.com/google/uuid"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// Samba-on-NVMesh model cache backend (HelmCacheBackendSamba).
+//
+// Selected when CachingSupport is on, neither nvcf-sc-30 (NVMesh 3.x) nor an
+// operator-provided nvcf-miniservice-sc exists, and HelmSharedStorage is enabled.
+//
+// Each cacheHandle gets its OWN Samba server (Deployment + Service) backed by
+// its OWN nvcf-sc (NVMesh) data PVC, sized to the function's cacheSize, and
+// exporting a single SMB share. There is no shared/global data PVC: a single
+// fixed-size volume cannot be sized for an unknown set of models, and hot-adding
+// per-handle volumes to one shared server would force pod restarts that drop
+// every other handle's live mounts. Per-handle servers isolate lifecycle and
+// sizing and can be garbage-collected independently when a handle goes idle.
+//
+// The per-handle backing PVC (samba-<cacheHandle>) is the durable reuse marker:
+// if it already exists the cache is reused instead of re-provisioned, and a
+// cachePopulatedLabelKey label on it (stamped by the writer on success) signals
+// that readers may safely attach. NVCA does NOT create nvcf-miniservice-sc: that
+// StorageClass is exclusively the operator's signal that 3rd-party shared
+// storage is present (backend 2). Writer/reader volumes are static SMB PVs bound
+// to the per-handle Samba share, with no StorageClass of their own.
+const (
+	//nolint:gosec
+	SambaModelCacheReadWriteSecretName = "nvcf-helm-cache-smb-rw-creds"
+	//nolint:gosec
+	SambaModelCacheReadOnlySecretName = "nvcf-helm-cache-smb-ro-creds"
+	// SambaModelCacheShareName is the SMB share each per-handle server exports.
+	SambaModelCacheShareName = "cache"
+	// SambaModelCacheDataStorageClassName is the NVMesh block-storage class
+	// backing each per-handle Samba data PVC (Samba over NVMesh; never ephemeral).
+	SambaModelCacheDataStorageClassName = "nvcf-sc"
+
+	sambaModelCacheDataMountPath = "/shared-data"
+	sambaModelCacheServerPort    = 445
+	sambaModelCacheMetricsPort   = 9922
+
+	// SMB user ids for the Samba model cache servers. The writer mounts RW; the
+	// readers mount RO (a distinct unprivileged user) so a compromised workload
+	// cannot write to the shared cache. Credentials are shared across per-handle
+	// servers (each share is isolated by its own server + PVC).
+	sambaModelCacheRWUsername = "nvcf-helmcache-rw"
+	sambaModelCacheROUsername = "nvcf-helmcache-ro"
+	sambaModelCacheRWUID      = uint16(1000)
+	sambaModelCacheROUID      = uint16(1001)
+	sambaModelCacheGID        = uint16(1000)
+	sambaModelCacheRWDirMode  = "0775"
+	sambaModelCacheRWFileMode = "0664"
+	sambaModelCacheRODirMode  = "0555"
+	sambaModelCacheROFileMode = "0444"
+
+	// sambaModelCacheComponentLabelKey marks the per-handle Samba backing PVC so
+	// idle GC (cleanupIdleModelCaches) can list candidate caches. The cacheHandle
+	// is carried as an ANNOTATION (sambaModelCacheHandleAnnotationKey), not a
+	// label, so the backing PVC is not matched by cleanupInitModelCache, which
+	// deletes the (handle-labeled) ephemeral writer PVC.
+	sambaModelCacheComponentLabelKey   = fqdnPrefix + "/modelcache-samba-backing"
+	sambaModelCacheComponentLabelValue = "true"
+	sambaModelCacheHandleAnnotationKey = fqdnPrefix + "/modelcache-samba-handle"
+)
+
+// defaultSambaModelCacheDataSize backs the per-handle data PVC only when the
+// request carries no cacheSize. nvcf-sc supports expansion, so this is a
+// starting point, not a ceiling.
+var defaultSambaModelCacheDataSize = resource.MustParse("100Gi")
+
+// sambaModelCacheResourceName derives the per-cacheHandle name shared by the
+// Samba server Deployment, its Service, its backing data PVC, and its
+// NetworkPolicy. The cacheHandle is a content hash and is normally DNS-safe;
+// the 63-char limit is guarded defensively with a stable hashed suffix.
+func sambaModelCacheResourceName(cacheHandle string) string {
+	name := "samba-" + cacheHandle
+	if len(name) <= 63 {
+		return name
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(cacheHandle))
+	return fmt.Sprintf("samba-%s-%08x", cacheHandle[:48], h.Sum32())
+}
+
+// SambaModelCacheBackingPVCName is the per-handle nvcf-sc data PVC that holds
+// the cache bytes behind the Samba share. Its existence is the reuse signal.
+func SambaModelCacheBackingPVCName(cacheHandle string) string {
+	return sambaModelCacheResourceName(cacheHandle)
+}
+
+// sambaModelCacheWriterPVName is the static SMB plumbing PV the writer's RW PVC
+// binds to for a handle.
+func sambaModelCacheWriterPVName(cacheHandle string) string {
+	return "samba-rw-pv-" + cacheHandle
+}
+
+// EnsureSambaModelCacheInfra performs the idempotent bootstrap of the per-handle
+// Samba model cache server in the model cache control namespace: the shared
+// RW/RO credentials Secrets, the per-handle nvcf-sc data PVC (sized to size),
+// the per-handle Samba Deployment, its fronting Service, and an ingress
+// NetworkPolicy. It returns ready=true once that Deployment is available. It
+// intentionally creates NO StorageClass; cache volumes are static SMB PVs bound
+// to the per-handle share (see newSambaModelCachePV).
+func EnsureSambaModelCacheInfra(
+	ctx context.Context,
+	c client.Client,
+	cacheHandle string,
+	image string,
+	resources corev1.ResourceRequirements,
+	size resource.Quantity,
+) (ready bool, err error) {
+	log := logf.FromContext(ctx).WithValues("backend", HelmCacheBackendSamba,
+		"namespace", ModelCacheInitNamespace, "cacheHandle", cacheHandle)
+
+	if image == "" {
+		return false, fmt.Errorf("samba model cache server image is not configured")
+	}
+	if cacheHandle == "" {
+		return false, fmt.Errorf("samba model cache cacheHandle is not set")
+	}
+	if size.IsZero() {
+		size = defaultSambaModelCacheDataSize
+	}
+
+	rwSecret, roSecret := newSambaModelCacheSecrets()
+	objs := []client.Object{
+		NewModelCacheInitNamespace(),
+		rwSecret,
+		roSecret,
+		newSambaModelCacheDataPVC(cacheHandle, size),
+		newSambaModelCacheDeployment(cacheHandle, image, resources),
+		newSambaModelCacheService(cacheHandle),
+		newSambaModelCacheNetworkPolicy(cacheHandle),
+	}
+	for _, obj := range objs {
+		if err := ensureCreated(ctx, c, obj); err != nil {
+			return false, fmt.Errorf("ensure samba model cache %T: %w", obj, err)
+		}
+	}
+
+	dep := &appsv1.Deployment{}
+	if err := c.Get(ctx, client.ObjectKey{Namespace: ModelCacheInitNamespace, Name: sambaModelCacheResourceName(cacheHandle)}, dep); err != nil {
+		return false, fmt.Errorf("get samba deployment: %w", err)
+	}
+	if dep.Status.AvailableReplicas < 1 {
+		log.V(1).Info("Samba model cache server not yet available, waiting")
+		return false, nil
+	}
+	log.V(1).Info("Samba model cache server ready")
+	return true, nil
+}
+
+// ensureCreated creates obj, treating AlreadyExists as success so the bootstrap
+// is idempotent across reconciles.
+func ensureCreated(ctx context.Context, c client.Client, obj client.Object) error {
+	if err := c.Create(ctx, obj); err != nil && !k8serrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+// sambaModelCacheSelector is the unique pod selector for a handle's Samba server.
+func sambaModelCacheSelector(cacheHandle string) map[string]string {
+	return map[string]string{"app.kubernetes.io/name": sambaModelCacheResourceName(cacheHandle)}
+}
+
+// sambaModelCacheServiceDNS is the stable in-cluster DNS name of a handle's
+// Samba Service, used as the host in the static PV SMB source.
+func sambaModelCacheServiceDNS(cacheHandle string) string {
+	return fmt.Sprintf("%s.%s.svc.cluster.local", sambaModelCacheResourceName(cacheHandle), ModelCacheInitNamespace)
+}
+
+// sambaModelCacheShareRoot is the SMB source for a handle's share. Each handle
+// has its own server and backing PVC, so the share root IS the cache root; no
+// per-handle subdirectory is needed.
+func sambaModelCacheShareRoot(cacheHandle string) string {
+	return fmt.Sprintf("//%s/%s", sambaModelCacheServiceDNS(cacheHandle), SambaModelCacheShareName)
+}
+
+func newSambaModelCacheSecrets() (rw, ro *corev1.Secret) {
+	mk := func(name, user string, uid uint16) *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ModelCacheInitNamespace},
+			Data: map[string][]byte{
+				"username": []byte(user),
+				"password": []byte(uuid.New().String()),
+				"uid":      []byte(strconv.Itoa(int(uid))),
+				"gid":      []byte(strconv.Itoa(int(sambaModelCacheGID))),
+			},
+		}
+	}
+	return mk(SambaModelCacheReadWriteSecretName, sambaModelCacheRWUsername, sambaModelCacheRWUID),
+		mk(SambaModelCacheReadOnlySecretName, sambaModelCacheROUsername, sambaModelCacheROUID)
+}
+
+// newSambaModelCacheDataPVC builds the per-handle nvcf-sc data PVC. The PVC is
+// not labeled with modelCacheHandleLabelKey on purpose: cleanupInitModelCache
+// deletes the (handle-labeled) ephemeral writer RW PVC, and labeling the durable
+// backing PVC with the same handle would collide with that single-PVC cleanup.
+func newSambaModelCacheDataPVC(cacheHandle string, size resource.Quantity) *corev1.PersistentVolumeClaim {
+	storageClassName := SambaModelCacheDataStorageClassName
+	labels := sambaModelCacheSelector(cacheHandle)
+	labels[sambaModelCacheComponentLabelKey] = sambaModelCacheComponentLabelValue
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        SambaModelCacheBackingPVCName(cacheHandle),
+			Namespace:   ModelCacheInitNamespace,
+			Labels:      labels,
+			Annotations: map[string]string{sambaModelCacheHandleAnnotationKey: cacheHandle},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			StorageClassName: &storageClassName,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: size},
+			},
+		},
+	}
+}
+
+// DeleteSambaModelCacheInfra removes the per-handle Samba server (Deployment,
+// Service, NetworkPolicy) and its backing data PVC. The Deployment is deleted
+// first so the server pod releases the PVC before it is removed. Shared
+// credentials Secrets are left in place for other handles. Not-found is success.
+//
+// It also sweeps the handle's static SMB PVs (the writer plumbing PV and any
+// reader PVs whose namespace was deleted without a StorageRequest cleanup).
+// Static PVs have no provisioner, so a Released one is never removed by the PV
+// controller and would leak forever.
+func DeleteSambaModelCacheInfra(ctx context.Context, c client.Client, cacheHandle string) error {
+	name := sambaModelCacheResourceName(cacheHandle)
+	objs := []client.Object{
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ModelCacheInitNamespace}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ModelCacheInitNamespace}},
+		&netv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ModelCacheInitNamespace}},
+		&corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ModelCacheInitNamespace}},
+	}
+	for _, obj := range objs {
+		if err := c.Delete(ctx, obj); err != nil && !k8serrors.IsNotFound(err) {
+			return fmt.Errorf("delete samba model cache %T %s: %w", obj, name, err)
+		}
+	}
+
+	pvs := &corev1.PersistentVolumeList{}
+	if err := c.List(ctx, pvs, client.MatchingLabels{modelCacheHandleLabelKey: cacheHandle}); err != nil {
+		return fmt.Errorf("list samba model cache PVs for %s: %w", cacheHandle, err)
+	}
+	for i := range pvs.Items {
+		pv := &pvs.Items[i]
+		// Only this backend's static SMB PVs; never NVMesh primary/secondary PVs
+		// that share the handle label.
+		if pv.Spec.CSI == nil || pv.Spec.CSI.Driver != SMBCSIDriverName {
+			continue
+		}
+		if err := c.Delete(ctx, pv); err != nil && !k8serrors.IsNotFound(err) {
+			return fmt.Errorf("delete samba model cache PV %s: %w", pv.Name, err)
+		}
+	}
+	return nil
+}
+
+func newSambaModelCacheDeployment(cacheHandle, image string, resources corev1.ResourceRequirements) *appsv1.Deployment {
+	replicas := int32(1)
+	secretEnv := func(name, secret, key string) corev1.EnvVar {
+		return corev1.EnvVar{
+			Name: name,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					Key:                  key,
+					LocalObjectReference: corev1.LocalObjectReference{Name: secret},
+				},
+			},
+		}
+	}
+
+	podSpec := corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:  SMBServerContainerName,
+				Image: image,
+				// dperson/samba-style args (matching newSMBPod): an RW user and a
+				// distinct RO user, both exporting the "cache" share rooted on the
+				// per-handle data PVC.
+				Args: []string{
+					"-w", "NVIDIA",
+					"-u", "$(USERNAME);$(PASSWORD);$(UID);smb;$(GID)",
+					"-u", "$(ROUSERNAME);$(ROPASSWORD);$(ROUID);smb;$(ROGID)",
+					"-p", "-g", "log level = 3",
+					"-G", "share;log level = 3",
+					"-s", fmt.Sprintf("%[1]s;%[2]s/%[1]s;yes;no;no;$(USERNAME),$(ROUSERNAME);;$(USERNAME);none",
+						SambaModelCacheShareName, sambaModelCacheDataMountPath),
+				},
+				Env: []corev1.EnvVar{
+					{Name: "GROUPID", Value: strconv.Itoa(int(sambaModelCacheGID))},
+					secretEnv("USERNAME", SambaModelCacheReadWriteSecretName, "username"),
+					secretEnv("PASSWORD", SambaModelCacheReadWriteSecretName, "password"),
+					secretEnv("UID", SambaModelCacheReadWriteSecretName, "uid"),
+					secretEnv("GID", SambaModelCacheReadWriteSecretName, "gid"),
+					secretEnv("ROUSERNAME", SambaModelCacheReadOnlySecretName, "username"),
+					secretEnv("ROPASSWORD", SambaModelCacheReadOnlySecretName, "password"),
+					secretEnv("ROUID", SambaModelCacheReadOnlySecretName, "uid"),
+					secretEnv("ROGID", SambaModelCacheReadOnlySecretName, "gid"),
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "data-volume", MountPath: sambaModelCacheDataMountPath},
+				},
+				Ports: []corev1.ContainerPort{
+					{ContainerPort: sambaModelCacheServerPort},
+					{Name: "metrics", ContainerPort: sambaModelCacheMetricsPort},
+				},
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt(sambaModelCacheServerPort)},
+					},
+					InitialDelaySeconds: 3,
+				},
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt(sambaModelCacheServerPort)},
+					},
+					InitialDelaySeconds: 30,
+				},
+				Resources: *resources.DeepCopy(),
+			},
+		},
+		Volumes: []corev1.Volume{
+			{
+				Name: "data-volume",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: SambaModelCacheBackingPVCName(cacheHandle),
+					},
+				},
+			},
+		},
+	}
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sambaModelCacheResourceName(cacheHandle),
+			Namespace: ModelCacheInitNamespace,
+			Labels:    sambaModelCacheSelector(cacheHandle),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: sambaModelCacheSelector(cacheHandle)},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: sambaModelCacheSelector(cacheHandle)},
+				Spec:       podSpec,
+			},
+		},
+	}
+}
+
+func newSambaModelCacheService(cacheHandle string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sambaModelCacheResourceName(cacheHandle),
+			Namespace: ModelCacheInitNamespace,
+			Labels:    sambaModelCacheSelector(cacheHandle),
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: sambaModelCacheSelector(cacheHandle),
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "smb",
+					Port:       sambaModelCacheServerPort,
+					TargetPort: intstr.FromInt(sambaModelCacheServerPort),
+				},
+			},
+		},
+	}
+}
+
+// newSambaModelCacheNetworkPolicy restricts inbound traffic to a handle's Samba
+// server to the SMB port. Mirrors the SharedStorage SMB server ingress policy
+// (allow-ingress-sharedstorage), which is likewise port-only with no "from"
+// clause: SMB mounts are performed by the kubelet/CSI node plugin from the
+// node's HOST network namespace, so a pod-selector or namespace-selector peer
+// would not match the real traffic source and would break every mount. Access
+// control is enforced by the SMB credentials (distinct RW and RO users).
+func newSambaModelCacheNetworkPolicy(cacheHandle string) *netv1.NetworkPolicy {
+	smbPort := intstr.FromInt(sambaModelCacheServerPort)
+	tcp := corev1.ProtocolTCP
+	return &netv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sambaModelCacheResourceName(cacheHandle),
+			Namespace: ModelCacheInitNamespace,
+		},
+		Spec: netv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: sambaModelCacheSelector(cacheHandle)},
+			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeIngress},
+			Ingress: []netv1.NetworkPolicyIngressRule{
+				{Ports: []netv1.NetworkPolicyPort{{Port: &smbPort, Protocol: &tcp}}},
+			},
+		},
+	}
+}
+
+// newSambaModelCachePV builds a static SMB CSI PersistentVolume bound (by
+// ClaimRef) to the named PVC, pointing at the per-handle Samba share root. The
+// writer (readOnly=false) mounts RW; readers (readOnly=true) mount RO as a
+// distinct unprivileged user. The CSI secret refs point at the control-namespace
+// creds Secrets, so no secret copies are needed in workload namespaces.
+func newSambaModelCachePV(pvName, pvcName, pvcNamespace, cacheHandle string, readOnly bool, capacity resource.Quantity) *corev1.PersistentVolume {
+	uid, gid := sambaModelCacheRWUID, sambaModelCacheGID
+	dirMode, fileMode := sambaModelCacheRWDirMode, sambaModelCacheRWFileMode
+	secret := SambaModelCacheReadWriteSecretName
+	accessMode := corev1.ReadWriteMany
+	if readOnly {
+		uid, dirMode, fileMode = sambaModelCacheROUID, sambaModelCacheRODirMode, sambaModelCacheROFileMode
+		secret = SambaModelCacheReadOnlySecretName
+		accessMode = corev1.ReadOnlyMany
+	}
+	source := sambaModelCacheShareRoot(cacheHandle)
+	secretRef := &corev1.SecretReference{Name: secret, Namespace: ModelCacheInitNamespace}
+	emptySC := ""
+	return &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   pvName,
+			Labels: map[string]string{modelCacheHandleLabelKey: cacheHandle},
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			Capacity:                      corev1.ResourceList{corev1.ResourceStorage: capacity},
+			AccessModes:                   []corev1.PersistentVolumeAccessMode{accessMode},
+			StorageClassName:              emptySC,
+			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
+			ClaimRef: &corev1.ObjectReference{
+				APIVersion: "v1",
+				Kind:       "PersistentVolumeClaim",
+				Name:       pvcName,
+				Namespace:  pvcNamespace,
+			},
+			MountOptions: []string{
+				fmt.Sprintf("dir_mode=%s", dirMode),
+				fmt.Sprintf("file_mode=%s", fileMode),
+				fmt.Sprintf("uid=%d", uid),
+				fmt.Sprintf("gid=%d", gid),
+				"noperm", "mfsymlinks", "cache=strict", "noserverino", "vers=3.1.1",
+			},
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					Driver: SMBCSIDriverName,
+					// Unique per PV: the static SMB CSI driver dedups by VolumeHandle,
+					// so every writer/reader PV for the share must carry a distinct one.
+					VolumeHandle:         fmt.Sprintf("%s#%s", source, pvName),
+					NodeStageSecretRef:   secretRef,
+					NodePublishSecretRef: secretRef,
+					VolumeAttributes:     map[string]string{"source": source},
+				},
+			},
+		},
+	}
+}
+
+// newSambaModelCachePVC builds a static PVC bound (by volumeName) to the given
+// Samba model cache PV. storageClassName is empty so no dynamic provisioning or
+// default-class injection occurs.
+func newSambaModelCachePVC(pvcName, pvcNamespace, pvName string, readOnly bool, capacity resource.Quantity) *corev1.PersistentVolumeClaim {
+	accessMode := corev1.ReadWriteMany
+	if readOnly {
+		accessMode = corev1.ReadOnlyMany
+	}
+	emptySC := ""
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: pvcNamespace},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{accessMode},
+			StorageClassName: &emptySC,
+			VolumeName:       pvName,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: capacity},
+			},
+		},
+	}
+}

--- a/src/compute-plane-services/nvca/pkg/storage/cachebackend_samba.go
+++ b/src/compute-plane-services/nvca/pkg/storage/cachebackend_samba.go
@@ -196,9 +196,11 @@ func sambaModelCacheSelector(cacheHandle string) map[string]string {
 }
 
 // sambaModelCacheServiceDNS is the stable in-cluster DNS name of a handle's
-// Samba Service, used as the host in the static PV SMB source.
+// Samba Service, used as the host in the static PV SMB source. The name stops
+// at .svc (no cluster domain suffix) because the cluster domain is
+// configurable and .svc resolves in any cluster.
 func sambaModelCacheServiceDNS(cacheHandle string) string {
-	return fmt.Sprintf("%s.%s.svc.cluster.local", sambaModelCacheResourceName(cacheHandle), ModelCacheInitNamespace)
+	return fmt.Sprintf("%s.%s.svc", sambaModelCacheResourceName(cacheHandle), ModelCacheInitNamespace)
 }
 
 // sambaModelCacheShareRoot is the SMB source for a handle's share. Each handle
@@ -374,6 +376,11 @@ func newSambaModelCacheDeployment(cacheHandle, image string, resources corev1.Re
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
+			// The server owns a single RWO backing PVC, so a rolling update
+			// would start a second pod against the same volume and block on
+			// multi-attach (or serve the share twice). Recreate stops the old
+			// pod before starting the new one.
+			Strategy: appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType},
 			Selector: &metav1.LabelSelector{MatchLabels: sambaModelCacheSelector(cacheHandle)},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: sambaModelCacheSelector(cacheHandle)},

--- a/src/compute-plane-services/nvca/pkg/storage/cachebackend_samba_test.go
+++ b/src/compute-plane-services/nvca/pkg/storage/cachebackend_samba_test.go
@@ -250,7 +250,7 @@ func TestNewSambaModelCachePV_RWandRO(t *testing.T) {
 	// Each handle has its own per-handle server, so the share root IS the cache
 	// root (no per-handle subdir). Both writer and readers mount the share root;
 	// access is differentiated by RW vs RO credentials.
-	root := "//" + sambaModelCacheResourceName(handle) + "." + ModelCacheInitNamespace + ".svc.cluster.local/" + SambaModelCacheShareName
+	root := "//" + sambaModelCacheResourceName(handle) + "." + ModelCacheInitNamespace + ".svc/" + SambaModelCacheShareName
 
 	rw := newSambaModelCachePV("rw-pv", "rw-pvc-"+handle, ModelCacheInitNamespace, handle, false, cap1)
 	assert.Equal(t, []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}, rw.Spec.AccessModes)

--- a/src/compute-plane-services/nvca/pkg/storage/cachebackend_samba_test.go
+++ b/src/compute-plane-services/nvca/pkg/storage/cachebackend_samba_test.go
@@ -1,0 +1,289 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func sambaInfraClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	sch := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(sch))
+	require.NoError(t, appsv1.AddToScheme(sch))
+	require.NoError(t, storagev1.AddToScheme(sch))
+	require.NoError(t, netv1.AddToScheme(sch))
+	return fake.NewClientBuilder().WithScheme(sch).
+		WithStatusSubresource(&appsv1.Deployment{}).
+		WithObjects(objs...).Build()
+}
+
+func TestEnsureSambaModelCacheInfra_RequiresImage(t *testing.T) {
+	c := sambaInfraClient(t)
+	_, err := EnsureSambaModelCacheInfra(t.Context(), c, "h1", "", corev1.ResourceRequirements{}, resource.MustParse("1Gi"))
+	require.Error(t, err)
+}
+
+func TestEnsureSambaModelCacheInfra_RequiresCacheHandle(t *testing.T) {
+	c := sambaInfraClient(t)
+	_, err := EnsureSambaModelCacheInfra(t.Context(), c, "", "samba:latest", corev1.ResourceRequirements{}, resource.MustParse("1Gi"))
+	require.Error(t, err)
+}
+
+func TestEnsureSambaModelCacheInfra_PerHandle_SizedFromCacheSize_NeverCreatesStorageClass(t *testing.T) {
+	ctx := t.Context()
+	c := sambaInfraClient(t)
+	handle := "abc123handle"
+	size := resource.MustParse("7Gi")
+	name := sambaModelCacheResourceName(handle)
+
+	// First pass: server not yet available -> not ready, but resources created.
+	ready, err := EnsureSambaModelCacheInfra(ctx, c, handle, "samba:latest", corev1.ResourceRequirements{}, size)
+	require.NoError(t, err)
+	assert.False(t, ready, "not ready until the per-handle server is available")
+
+	// Shared RW + RO creds secrets.
+	for _, sname := range []string{SambaModelCacheReadWriteSecretName, SambaModelCacheReadOnlySecretName} {
+		s := &corev1.Secret{}
+		require.NoError(t, c.Get(ctx, client.ObjectKey{Namespace: ModelCacheInitNamespace, Name: sname}, s), sname)
+		assert.NotEmpty(t, s.Data["password"])
+	}
+
+	// Per-handle backing PVC on nvcf-sc, sized to cacheSize, named samba-<handle>,
+	// carrying the GC component label + handle annotation but NOT the cache-handle
+	// label (that would collide with init-writer-PVC cleanup).
+	pvc := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Namespace: ModelCacheInitNamespace, Name: SambaModelCacheBackingPVCName(handle)}, pvc))
+	require.NotNil(t, pvc.Spec.StorageClassName)
+	assert.Equal(t, SambaModelCacheDataStorageClassName, *pvc.Spec.StorageClassName)
+	assert.True(t, size.Equal(pvc.Spec.Resources.Requests[corev1.ResourceStorage]), "backing PVC sized to cacheSize")
+	assert.Equal(t, sambaModelCacheComponentLabelValue, pvc.Labels[sambaModelCacheComponentLabelKey])
+	assert.Equal(t, handle, pvc.Annotations[sambaModelCacheHandleAnnotationKey])
+	assert.Empty(t, pvc.Labels[modelCacheHandleLabelKey], "backing PVC must not carry the cache-handle label")
+
+	// Per-handle Service + NetworkPolicy + Deployment, all named samba-<handle>.
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Namespace: ModelCacheInitNamespace, Name: name}, &corev1.Service{}))
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Namespace: ModelCacheInitNamespace, Name: name}, &netv1.NetworkPolicy{}))
+	dep := &appsv1.Deployment{}
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Namespace: ModelCacheInitNamespace, Name: name}, dep))
+	assert.Equal(t, "samba:latest", dep.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, SambaModelCacheBackingPVCName(handle),
+		dep.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName, "server mounts its own backing PVC")
+
+	// CRITICAL regression guard: NVCA must NEVER create nvcf-miniservice-sc (operator's
+	// branch-2 class) or any StorageClass.
+	scl := &storagev1.StorageClassList{}
+	require.NoError(t, c.List(ctx, scl))
+	assert.Empty(t, scl.Items, "Samba backend must not create any StorageClass")
+
+	// Mark available; second pass -> ready, still no StorageClass.
+	dep.Status.AvailableReplicas = 1
+	require.NoError(t, c.Status().Update(ctx, dep))
+	ready, err = EnsureSambaModelCacheInfra(ctx, c, handle, "samba:latest", corev1.ResourceRequirements{}, size)
+	require.NoError(t, err)
+	assert.True(t, ready)
+	require.NoError(t, c.List(ctx, scl))
+	assert.Empty(t, scl.Items, "still no StorageClass after the server is ready")
+	err = c.Get(ctx, client.ObjectKey{Name: HelmCacheSharedStorageClassName}, &storagev1.StorageClass{})
+	assert.True(t, apierrors.IsNotFound(err), "nvcf-miniservice-sc must not exist")
+}
+
+func TestEnsureSambaModelCacheInfra_Idempotent(t *testing.T) {
+	ctx := t.Context()
+	c := sambaInfraClient(t)
+	handle := "idempotent-handle"
+	size := resource.MustParse("1Gi")
+	_, err := EnsureSambaModelCacheInfra(ctx, c, handle, "samba:latest", corev1.ResourceRequirements{}, size)
+	require.NoError(t, err)
+	_, err = EnsureSambaModelCacheInfra(ctx, c, handle, "samba:latest", corev1.ResourceRequirements{}, size)
+	require.NoError(t, err)
+	deps := &appsv1.DeploymentList{}
+	require.NoError(t, c.List(ctx, deps, client.InNamespace(ModelCacheInitNamespace)))
+	count := 0
+	for _, d := range deps.Items {
+		if d.Name == sambaModelCacheResourceName(handle) {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count)
+}
+
+// TestEnsureSambaModelCacheInfra_DistinctHandlesDistinctServers proves two
+// cacheHandles get independent servers + backing PVCs (no shared global PVC).
+func TestEnsureSambaModelCacheInfra_DistinctHandlesDistinctServers(t *testing.T) {
+	ctx := t.Context()
+	c := sambaInfraClient(t)
+	_, err := EnsureSambaModelCacheInfra(ctx, c, "handle-a", "samba:latest", corev1.ResourceRequirements{}, resource.MustParse("1Gi"))
+	require.NoError(t, err)
+	_, err = EnsureSambaModelCacheInfra(ctx, c, "handle-b", "samba:latest", corev1.ResourceRequirements{}, resource.MustParse("2Gi"))
+	require.NoError(t, err)
+
+	for _, h := range []string{"handle-a", "handle-b"} {
+		require.NoError(t, c.Get(ctx, client.ObjectKey{Namespace: ModelCacheInitNamespace, Name: sambaModelCacheResourceName(h)}, &appsv1.Deployment{}), h)
+		require.NoError(t, c.Get(ctx, client.ObjectKey{Namespace: ModelCacheInitNamespace, Name: SambaModelCacheBackingPVCName(h)}, &corev1.PersistentVolumeClaim{}), h)
+	}
+	assert.NotEqual(t, sambaModelCacheResourceName("handle-a"), sambaModelCacheResourceName("handle-b"))
+}
+
+func TestDeleteSambaModelCacheInfra(t *testing.T) {
+	ctx := t.Context()
+	handle := "delete-me"
+	// Static SMB PVs for the handle (writer plumbing + an orphaned reader whose
+	// namespace vanished) must be swept; a same-handle PV from another driver
+	// (an NVMesh primary) must be untouched.
+	cap1 := resource.MustParse("1Gi")
+	rwPV := newSambaModelCachePV(sambaModelCacheWriterPVName(handle), "rw-pvc-"+handle, ModelCacheInitNamespace, handle, false, cap1)
+	roPV := newSambaModelCachePV("samba-ro-pv-gone-ns-"+handle, "ro-pvc-"+handle, "gone-ns", handle, true, cap1)
+	otherDriverPV := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "primary-" + handle,
+			Labels: map[string]string{modelCacheHandleLabelKey: handle},
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			Capacity:    corev1.ResourceList{corev1.ResourceStorage: cap1},
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{Driver: "nvmesh-csi.excelero.com", VolumeHandle: "vh"},
+			},
+		},
+	}
+	c := sambaInfraClient(t, rwPV, roPV, otherDriverPV)
+	_, err := EnsureSambaModelCacheInfra(ctx, c, handle, "samba:latest", corev1.ResourceRequirements{}, resource.MustParse("1Gi"))
+	require.NoError(t, err)
+
+	require.NoError(t, DeleteSambaModelCacheInfra(ctx, c, handle))
+
+	name := sambaModelCacheResourceName(handle)
+	for _, obj := range []client.Object{&appsv1.Deployment{}, &corev1.Service{}, &netv1.NetworkPolicy{}, &corev1.PersistentVolumeClaim{}} {
+		err := c.Get(ctx, client.ObjectKey{Namespace: ModelCacheInitNamespace, Name: name}, obj)
+		assert.True(t, apierrors.IsNotFound(err), "%T should be deleted", obj)
+	}
+	// The handle's static SMB PVs are swept (static PVs are never reclaimed by
+	// the PV controller, so leaving them leaks).
+	for _, pvName := range []string{rwPV.Name, roPV.Name} {
+		err := c.Get(ctx, client.ObjectKey{Name: pvName}, &corev1.PersistentVolume{})
+		assert.True(t, apierrors.IsNotFound(err), "static SMB PV %s should be swept", pvName)
+	}
+	// Same-handle PVs from other drivers are untouched.
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: otherDriverPV.Name}, &corev1.PersistentVolume{}))
+	// Shared creds secrets are retained for other handles.
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Namespace: ModelCacheInitNamespace, Name: SambaModelCacheReadWriteSecretName}, &corev1.Secret{}))
+
+	// Idempotent: deleting again is not an error.
+	require.NoError(t, DeleteSambaModelCacheInfra(ctx, c, handle))
+}
+
+func TestEnsureSambaModelCacheInfra_CreateErrorWrapped(t *testing.T) {
+	sch := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(sch))
+	require.NoError(t, appsv1.AddToScheme(sch))
+	require.NoError(t, netv1.AddToScheme(sch))
+	c := fake.NewClientBuilder().WithScheme(sch).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.CreateOption) error {
+				if _, ok := obj.(*corev1.Secret); ok {
+					return errors.New("boom")
+				}
+				return nil
+			},
+		}).Build()
+	_, err := EnsureSambaModelCacheInfra(t.Context(), c, "h1", "samba:latest", corev1.ResourceRequirements{}, resource.MustParse("1Gi"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ensure samba model cache")
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestEnsureSambaModelCacheInfra_GetDeploymentErrorWrapped(t *testing.T) {
+	sch := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(sch))
+	require.NoError(t, appsv1.AddToScheme(sch))
+	require.NoError(t, netv1.AddToScheme(sch))
+	c := fake.NewClientBuilder().WithScheme(sch).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				if _, ok := obj.(*appsv1.Deployment); ok {
+					return errors.New("get-boom")
+				}
+				return apierrors.NewNotFound(schema.GroupResource{}, key.Name)
+			},
+		}).Build()
+	_, err := EnsureSambaModelCacheInfra(t.Context(), c, "h1", "samba:latest", corev1.ResourceRequirements{}, resource.MustParse("1Gi"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "get samba deployment")
+}
+
+func TestNewSambaModelCachePV_RWandRO(t *testing.T) {
+	cap1 := resource.MustParse("1Gi")
+	handle := "abc123"
+	// Each handle has its own per-handle server, so the share root IS the cache
+	// root (no per-handle subdir). Both writer and readers mount the share root;
+	// access is differentiated by RW vs RO credentials.
+	root := "//" + sambaModelCacheResourceName(handle) + "." + ModelCacheInitNamespace + ".svc.cluster.local/" + SambaModelCacheShareName
+
+	rw := newSambaModelCachePV("rw-pv", "rw-pvc-"+handle, ModelCacheInitNamespace, handle, false, cap1)
+	assert.Equal(t, []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}, rw.Spec.AccessModes)
+	assert.Equal(t, "", rw.Spec.StorageClassName, "static PV must not reference a StorageClass")
+	assert.Equal(t, SMBCSIDriverName, rw.Spec.CSI.Driver)
+	assert.Equal(t, root, rw.Spec.CSI.VolumeAttributes["source"], "writer mounts the per-handle share root")
+	assert.Equal(t, SambaModelCacheReadWriteSecretName, rw.Spec.CSI.NodeStageSecretRef.Name)
+	assert.Equal(t, ModelCacheInitNamespace, rw.Spec.CSI.NodeStageSecretRef.Namespace)
+	require.NotNil(t, rw.Spec.ClaimRef)
+	assert.Equal(t, "rw-pvc-"+handle, rw.Spec.ClaimRef.Name)
+
+	// Reader mounts the same per-handle share root, read-only, as a distinct user.
+	ro := newSambaModelCachePV("ro-pv", "ro-pvc-"+handle, "workload-ns", handle, true, cap1)
+	assert.Equal(t, []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany}, ro.Spec.AccessModes)
+	assert.Equal(t, root, ro.Spec.CSI.VolumeAttributes["source"], "reader mounts the per-handle share root")
+	assert.Equal(t, SambaModelCacheReadOnlySecretName, ro.Spec.CSI.NodeStageSecretRef.Name)
+	assert.Equal(t, "workload-ns", ro.Spec.ClaimRef.Namespace)
+	// VolumeHandle must be unique per PV (the static SMB CSI driver dedups by it).
+	assert.NotEqual(t, rw.Spec.CSI.VolumeHandle, ro.Spec.CSI.VolumeHandle)
+
+	pvc := newSambaModelCachePVC("ro-pvc-"+handle, "workload-ns", "ro-pv", true, cap1)
+	require.NotNil(t, pvc.Spec.StorageClassName)
+	assert.Equal(t, "", *pvc.Spec.StorageClassName, "static PVC must not trigger dynamic provisioning")
+	assert.Equal(t, "ro-pv", pvc.Spec.VolumeName)
+}
+
+func TestSambaModelCacheResourceName_LongHandleBounded(t *testing.T) {
+	long := ""
+	for range 80 {
+		long += "a"
+	}
+	name := sambaModelCacheResourceName(long)
+	assert.LessOrEqual(t, len(name), 63, "name must respect the 63-char limit")
+	// Stable: same input yields same name.
+	assert.Equal(t, name, sambaModelCacheResourceName(long))
+}

--- a/src/compute-plane-services/nvca/pkg/storage/cachebackend_test.go
+++ b/src/compute-plane-services/nvca/pkg/storage/cachebackend_test.go
@@ -1,0 +1,120 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/featureflag"
+	featureflagmock "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/featureflag/mock"
+)
+
+func storageClass(name string) *storagev1.StorageClass {
+	return &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: name}}
+}
+
+func cacheBackendClient(t *testing.T, scs ...*storagev1.StorageClass) *fake.ClientBuilder {
+	t.Helper()
+	sch := runtime.NewScheme()
+	require.NoError(t, storagev1.AddToScheme(sch))
+	b := fake.NewClientBuilder().WithScheme(sch)
+	for _, sc := range scs {
+		b = b.WithObjects(sc)
+	}
+	return b
+}
+
+func TestSelectHelmCacheBackend(t *testing.T) {
+	cachingOnly := []*featureflag.FeatureFlag{featureflag.CachingSupport}
+	cachingAndSamba := []*featureflag.FeatureFlag{
+		featureflag.CachingSupport,
+		&featureflag.HelmSharedStorage.FeatureFlag,
+	}
+
+	tests := []struct {
+		name           string
+		flags          []*featureflag.FeatureFlag
+		storageClasses []*storagev1.StorageClass
+		want           HelmCacheBackend
+	}{
+		{
+			name:  "caching disabled -> none",
+			flags: nil,
+			// nvcf-sc-30 present but caching off: still none.
+			storageClasses: []*storagev1.StorageClass{storageClass(NVMeshStorageClassName)},
+			want:           HelmCacheBackendNone,
+		},
+		{
+			name:           "nvcf-sc-30 present -> nvmesh",
+			flags:          cachingOnly,
+			storageClasses: []*storagev1.StorageClass{storageClass(NVMeshStorageClassName)},
+			want:           HelmCacheBackendNVMesh,
+		},
+		{
+			name:           "nvcf-miniservice-sc present -> sharedfs",
+			flags:          cachingOnly,
+			storageClasses: []*storagev1.StorageClass{storageClass(HelmCacheSharedStorageClassName)},
+			want:           HelmCacheBackendSharedFS,
+		},
+		{
+			name:  "both classes present -> nvmesh wins",
+			flags: cachingOnly,
+			storageClasses: []*storagev1.StorageClass{
+				storageClass(NVMeshStorageClassName),
+				storageClass(HelmCacheSharedStorageClassName),
+			},
+			want: HelmCacheBackendNVMesh,
+		},
+		{
+			name:           "no shared class, HelmSharedStorage on -> samba",
+			flags:          cachingAndSamba,
+			storageClasses: nil,
+			want:           HelmCacheBackendSamba,
+		},
+		{
+			name:           "no shared class, HelmSharedStorage off -> ephemeral",
+			flags:          cachingOnly,
+			storageClasses: nil,
+			want:           HelmCacheBackendEphemeral,
+		},
+		{
+			name:           "nvcf-miniservice-sc takes precedence over samba",
+			flags:          cachingAndSamba,
+			storageClasses: []*storagev1.StorageClass{storageClass(HelmCacheSharedStorageClassName)},
+			want:           HelmCacheBackendSharedFS,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := cacheBackendClient(t, tt.storageClasses...).Build()
+			ff := &featureflagmock.Fetcher{EnabledFFs: tt.flags}
+
+			got, err := SelectHelmCacheBackend(t.Context(), c, ff)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/src/compute-plane-services/nvca/pkg/storage/cacheprobe/BUILD.bazel
+++ b/src/compute-plane-services/nvca/pkg/storage/cacheprobe/BUILD.bazel
@@ -1,0 +1,43 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "cacheprobe",
+    srcs = [
+        "configmap.go",
+        "probe.go",
+    ],
+    importpath = "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/storage/cacheprobe",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/k8s.io/api/core/v1:core",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/log",
+    ],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":cacheprobe",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "cacheprobe_test",
+    srcs = ["cacheprobe_test.go"],
+    embed = [":cacheprobe"],
+    deps = [
+        "//vendor/github.com/stretchr/testify/assert",
+        "//vendor/github.com/stretchr/testify/require",
+        "//vendor/k8s.io/api/core/v1:core",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
+        "//vendor/k8s.io/apimachinery/pkg/runtime",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client/fake",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client/interceptor",
+    ],
+)

--- a/src/compute-plane-services/nvca/pkg/storage/cacheprobe/cacheprobe_test.go
+++ b/src/compute-plane-services/nvca/pkg/storage/cacheprobe/cacheprobe_test.go
@@ -1,0 +1,212 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cacheprobe
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func newFakeClient(t *testing.T, objs ...runtime.Object) *fake.ClientBuilder {
+	t.Helper()
+	sch := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(sch))
+	b := fake.NewClientBuilder().WithScheme(sch)
+	for _, o := range objs {
+		b = b.WithRuntimeObjects(o)
+	}
+	return b
+}
+
+const probeNS = "model-cache-system"
+
+func TestStateStore_SaveLoadGetStrategy(t *testing.T) {
+	c := newFakeClient(t).Build()
+	store := NewStateStore(c, probeNS)
+	sc := "nvcf-miniservice-sc"
+
+	// No ConfigMap yet -> fallback.
+	got, err := store.GetStrategy(t.Context(), sc)
+	require.NoError(t, err)
+	assert.Equal(t, StrategyFallback, got)
+
+	// Persist ROX supported -> GetStrategy returns ROX, round-trips via Load.
+	results := map[string]Result{
+		ResultKey(sc, StrategyROX): {State: StateSupported, CheckedAt: time.Now(), TTL: 3600},
+		ResultKey(sc, StrategyRWX): {State: StateSupported, CheckedAt: time.Now(), TTL: 3600},
+	}
+	require.NoError(t, store.Save(t.Context(), results))
+
+	loaded, err := store.Load(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, StateSupported, loaded[ResultKey(sc, StrategyROX)].State)
+
+	got, err = store.GetStrategy(t.Context(), sc)
+	require.NoError(t, err)
+	assert.Equal(t, StrategyROX, got, "ROX preferred when both supported")
+
+	// Only RWX supported -> RWX.
+	require.NoError(t, store.Save(t.Context(), map[string]Result{
+		ResultKey(sc, StrategyROX): {State: StateUnsupported, CheckedAt: time.Now(), TTL: 3600},
+		ResultKey(sc, StrategyRWX): {State: StateSupported, CheckedAt: time.Now(), TTL: 3600},
+	}))
+	got, err = store.GetStrategy(t.Context(), sc)
+	require.NoError(t, err)
+	assert.Equal(t, StrategyRWX, got)
+
+	// Expired ROX -> fallback.
+	require.NoError(t, store.Save(t.Context(), map[string]Result{
+		ResultKey(sc, StrategyROX): {State: StateSupported, CheckedAt: time.Now().Add(-2 * time.Hour), TTL: 60},
+	}))
+	got, err = store.GetStrategy(t.Context(), sc)
+	require.NoError(t, err)
+	assert.Equal(t, StrategyFallback, got)
+}
+
+func TestIsExpired(t *testing.T) {
+	assert.False(t, isExpired(Result{TTL: 0, CheckedAt: time.Now().Add(-24 * time.Hour)}), "TTL<=0 never expires")
+	assert.False(t, isExpired(Result{TTL: 3600, CheckedAt: time.Now()}))
+	assert.True(t, isExpired(Result{TTL: 60, CheckedAt: time.Now().Add(-2 * time.Minute)}))
+}
+
+func TestProber_createProbePVC(t *testing.T) {
+	c := newFakeClient(t).Build()
+	p := NewProber(c, probeNS, "nvcf-miniservice-sc", 3600)
+
+	require.NoError(t, p.createProbePVC(t.Context(), "probe-pvc", corev1.ReadOnlyMany))
+
+	pvc := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, c.Get(t.Context(), client.ObjectKey{Name: "probe-pvc", Namespace: probeNS}, pvc))
+	assert.Equal(t, []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany}, pvc.Spec.AccessModes)
+	require.NotNil(t, pvc.Spec.StorageClassName)
+	assert.Equal(t, "nvcf-miniservice-sc", *pvc.Spec.StorageClassName)
+
+	// Idempotent: re-create returns no error.
+	assert.NoError(t, p.createProbePVC(t.Context(), "probe-pvc", corev1.ReadOnlyMany))
+}
+
+func TestProber_cleanupProbe(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "probe-pod", Namespace: probeNS}}
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "probe-pvc", Namespace: probeNS},
+		Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: "probe-pv"},
+	}
+	// Simulates a Retain-reclaim class: the PV outlives the PVC deletion and
+	// must be deleted explicitly, or one Released PV accumulates per probe.
+	pv := &corev1.PersistentVolume{ObjectMeta: metav1.ObjectMeta{Name: "probe-pv"}}
+	c := newFakeClient(t, pod, pvc, pv).Build()
+	p := NewProber(c, probeNS, "nvcf-miniservice-sc", 3600)
+
+	p.cleanupProbe(t.Context(), "probe-pod", "probe-pvc")
+
+	for name, obj := range map[string]client.Object{
+		"pod": &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "probe-pod", Namespace: probeNS}},
+		"pvc": &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "probe-pvc", Namespace: probeNS}},
+		"pv":  &corev1.PersistentVolume{ObjectMeta: metav1.ObjectMeta{Name: "probe-pv"}},
+	} {
+		err := c.Get(t.Context(), client.ObjectKeyFromObject(obj), obj)
+		assert.Truef(t, apierrors.IsNotFound(err), "%s must be deleted by cleanupProbe", name)
+	}
+
+	// Cleanup with nothing left is a no-op (all NotFound tolerated).
+	p.cleanupProbe(t.Context(), "probe-pod", "probe-pvc")
+}
+
+func TestProber_waitForPodRunning(t *testing.T) {
+	running := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "running", Namespace: probeNS},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	failed := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "failed", Namespace: probeNS},
+		Status:     corev1.PodStatus{Phase: corev1.PodFailed, Message: "boom"},
+	}
+	c := newFakeClient(t, running, failed).Build()
+	p := NewProber(c, probeNS, "nvcf-miniservice-sc", 3600)
+
+	assert.NoError(t, p.waitForPodRunning(t.Context(), "running"))
+	assert.Error(t, p.waitForPodRunning(t.Context(), "failed"))
+}
+
+func TestStateStore_HasFreshResult(t *testing.T) {
+	c := newFakeClient(t).Build()
+	store := NewStateStore(c, probeNS)
+	sc := "nvcf-miniservice-sc"
+
+	// No results yet -> not fresh (caller should probe).
+	fresh, err := store.HasFreshResult(t.Context(), sc)
+	require.NoError(t, err)
+	assert.False(t, fresh)
+
+	// A fresh negative (Unsupported) result is still "fresh": GetStrategy
+	// returns Fallback, but the class should not be re-probed until TTL elapses.
+	require.NoError(t, store.Save(t.Context(), map[string]Result{
+		ResultKey(sc, StrategyROX): {State: StateUnsupported, CheckedAt: time.Now(), TTL: 3600},
+		ResultKey(sc, StrategyRWX): {State: StateUnsupported, CheckedAt: time.Now(), TTL: 3600},
+	}))
+	got, err := store.GetStrategy(t.Context(), sc)
+	require.NoError(t, err)
+	assert.Equal(t, StrategyFallback, got)
+	fresh, err = store.HasFreshResult(t.Context(), sc)
+	require.NoError(t, err)
+	assert.True(t, fresh, "fresh negative result must be honoured (no re-probe)")
+
+	// Once the negative result expires, it is no longer fresh -> re-probe.
+	require.NoError(t, store.Save(t.Context(), map[string]Result{
+		ResultKey(sc, StrategyROX): {State: StateUnsupported, CheckedAt: time.Now().Add(-2 * time.Hour), TTL: 60},
+		ResultKey(sc, StrategyRWX): {State: StateUnsupported, CheckedAt: time.Now().Add(-2 * time.Hour), TTL: 60},
+	}))
+	fresh, err = store.HasFreshResult(t.Context(), sc)
+	require.NoError(t, err)
+	assert.False(t, fresh, "expired result must not be considered fresh")
+}
+
+// TestProbeAccessMode_UnsupportedTTLCapped guards the negative-result TTL cap:
+// a failed probe may be a transient environment problem, so it must not carry
+// the full positive TTL and suppress re-probing (which would cascade terminal
+// failures onto every storage request for that window).
+func TestProbeAccessMode_UnsupportedTTLCapped(t *testing.T) {
+	c := newFakeClient(t).WithInterceptorFuncs(interceptor.Funcs{
+		Create: func(context.Context, client.WithWatch, client.Object, ...client.CreateOption) error {
+			return errors.New("apiserver timeout")
+		},
+	}).Build()
+	p := NewProber(c, probeNS, "some-sc", 3600)
+
+	res := p.ProbeAccessMode(context.Background(), corev1.ReadOnlyMany)
+	assert.Equal(t, StateUnsupported, res.State)
+	assert.Equal(t, UnsupportedResultTTLSeconds, res.TTL,
+		"negative results must carry the capped TTL, not the positive TTL")
+
+	// A prober configured with a TTL below the cap keeps its own (shorter) TTL.
+	pShort := NewProber(c, probeNS, "some-sc", 60)
+	res = pShort.ProbeAccessMode(context.Background(), corev1.ReadOnlyMany)
+	assert.Equal(t, 60, res.TTL)
+}

--- a/src/compute-plane-services/nvca/pkg/storage/cacheprobe/cacheprobe_test.go
+++ b/src/compute-plane-services/nvca/pkg/storage/cacheprobe/cacheprobe_test.go
@@ -108,8 +108,9 @@ func TestProber_createProbePVC(t *testing.T) {
 	require.NotNil(t, pvc.Spec.StorageClassName)
 	assert.Equal(t, "nvcf-miniservice-sc", *pvc.Spec.StorageClassName)
 
-	// Idempotent: re-create returns no error.
-	assert.NoError(t, p.createProbePVC(t.Context(), "probe-pvc", corev1.ReadOnlyMany))
+	// Re-create errors with AlreadyExists: leftovers are deleted before each
+	// probe run, so an existing PVC must not be silently reused.
+	assert.True(t, apierrors.IsAlreadyExists(p.createProbePVC(t.Context(), "probe-pvc", corev1.ReadOnlyMany)))
 }
 
 func TestProber_cleanupProbe(t *testing.T) {

--- a/src/compute-plane-services/nvca/pkg/storage/cacheprobe/configmap.go
+++ b/src/compute-plane-services/nvca/pkg/storage/cacheprobe/configmap.go
@@ -1,0 +1,154 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cacheprobe
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ProbeConfigMapName is the ConfigMap that persists probe results in the
+// control namespace.
+const ProbeConfigMapName = "model-cache-probe-results"
+
+// StateStore persists probe results in a ConfigMap so the strategy survives
+// restarts and is reused within its TTL instead of re-probing every reconcile.
+type StateStore struct {
+	client    client.Client
+	namespace string
+}
+
+// NewStateStore creates a StateStore backed by a ConfigMap in the given namespace.
+func NewStateStore(c client.Client, namespace string) *StateStore {
+	return &StateStore{client: c, namespace: namespace}
+}
+
+// Save writes probe results to the ConfigMap, creating it if necessary.
+func (s *StateStore) Save(ctx context.Context, results map[string]Result) error {
+	data := make(map[string]string, len(results))
+	for key, result := range results {
+		b, err := json.Marshal(result)
+		if err != nil {
+			return fmt.Errorf("marshal probe result for %s: %w", key, err)
+		}
+		data[key] = string(b)
+	}
+
+	cm := &corev1.ConfigMap{}
+	err := s.client.Get(ctx, client.ObjectKey{Name: ProbeConfigMapName, Namespace: s.namespace}, cm)
+	if apierrors.IsNotFound(err) {
+		cm = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ProbeConfigMapName,
+				Namespace: s.namespace,
+				Labels:    map[string]string{managedByLabel: managedByValue, probeLabel: "true"},
+			},
+			Data: data,
+		}
+		if createErr := s.client.Create(ctx, cm); createErr != nil {
+			return fmt.Errorf("create probe ConfigMap: %w", createErr)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get probe ConfigMap: %w", err)
+	}
+
+	cm.Data = data
+	if err := s.client.Update(ctx, cm); err != nil {
+		return fmt.Errorf("update probe ConfigMap: %w", err)
+	}
+	return nil
+}
+
+// Load reads persisted probe results from the ConfigMap. Missing ConfigMap
+// yields a nil map (no results yet).
+func (s *StateStore) Load(ctx context.Context) (map[string]Result, error) {
+	cm := &corev1.ConfigMap{}
+	if err := s.client.Get(ctx, client.ObjectKey{Name: ProbeConfigMapName, Namespace: s.namespace}, cm); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get probe ConfigMap: %w", err)
+	}
+
+	results := make(map[string]Result, len(cm.Data))
+	for key, val := range cm.Data {
+		var r Result
+		if err := json.Unmarshal([]byte(val), &r); err != nil {
+			return nil, fmt.Errorf("unmarshal probe result for %s: %w", key, err)
+		}
+		results[key] = r
+	}
+	return results, nil
+}
+
+// GetStrategy returns the best persisted, unexpired strategy for the storage
+// class, or StrategyFallback when results are missing/expired (signalling the
+// caller to re-probe).
+func (s *StateStore) GetStrategy(ctx context.Context, storageClassName string) (AccessModeStrategy, error) {
+	results, err := s.Load(ctx)
+	if err != nil {
+		return StrategyFallback, err
+	}
+	if results == nil {
+		return StrategyFallback, nil
+	}
+
+	if r, ok := results[ResultKey(storageClassName, StrategyROX)]; ok && r.State == StateSupported && !isExpired(r) {
+		return StrategyROX, nil
+	}
+	if r, ok := results[ResultKey(storageClassName, StrategyRWX)]; ok && r.State == StateSupported && !isExpired(r) {
+		return StrategyRWX, nil
+	}
+	return StrategyFallback, nil
+}
+
+// HasFreshResult reports whether an unexpired probe result (of any state,
+// supported or unsupported) exists for the storage class. Callers use this to
+// honour the TTL of a negative (Unsupported) result: GetStrategy returns
+// StrategyFallback both when results are missing/expired and when a fresh probe
+// determined the class is unsupported, so a Fallback result alone does not mean
+// "re-probe". A fresh negative result means the class was recently probed and
+// found unusable, and should not be re-probed until its TTL elapses.
+func (s *StateStore) HasFreshResult(ctx context.Context, storageClassName string) (bool, error) {
+	results, err := s.Load(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, strategy := range []AccessModeStrategy{StrategyROX, StrategyRWX} {
+		if r, ok := results[ResultKey(storageClassName, strategy)]; ok && !isExpired(r) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func isExpired(r Result) bool {
+	if r.TTL <= 0 {
+		return false
+	}
+	return time.Since(r.CheckedAt) > time.Duration(r.TTL)*time.Second
+}

--- a/src/compute-plane-services/nvca/pkg/storage/cacheprobe/probe.go
+++ b/src/compute-plane-services/nvca/pkg/storage/cacheprobe/probe.go
@@ -1,0 +1,323 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cacheprobe runs runtime CSI capability probes against a Helm model
+// cache storage class to decide the reader access-mode strategy (ROX preferred,
+// RWX fallback) for non-NVMesh shared-filesystem backends (nvcf-miniservice-sc).
+package cacheprobe
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	// ProbeTimeout bounds how long a single probe waits for its pod to run.
+	ProbeTimeout = 60 * time.Second
+	// ProbePollInterval is the probe pod status poll cadence.
+	ProbePollInterval = 2 * time.Second
+	// ProbePVCSize is the (tiny) size requested for probe PVCs.
+	ProbePVCSize = "1Gi"
+	// UnsupportedResultTTLSeconds caps the TTL of Unsupported probe results. A
+	// negative result cannot be distinguished from a transient failure (CSI
+	// driver briefly unavailable, apiserver timeout, node pressure), so honoring
+	// the full positive TTL would let one bad probe poison every storage request
+	// for that whole window. Re-probe soon instead; a genuinely unsupported
+	// class just re-fails a cheap probe every few minutes.
+	UnsupportedResultTTLSeconds = 300
+	// DefaultProbeImage is the image used by the probe pod. Override via
+	// Prober.Image for air-gapped clusters.
+	DefaultProbeImage = "busybox:1.36"
+
+	managedByLabel = "app.kubernetes.io/managed-by"
+	managedByValue = "nvca"
+	probeLabel     = "cache.nvcf.nvidia.com/probe"
+)
+
+// ProbeState represents the result of a capability probe.
+type ProbeState string
+
+const (
+	StateUnknown     ProbeState = "Unknown"
+	StateProbing     ProbeState = "Probing"
+	StateSupported   ProbeState = "Supported"
+	StateUnsupported ProbeState = "Unsupported"
+)
+
+// AccessModeStrategy is the chosen read strategy based on probe results.
+type AccessModeStrategy string
+
+const (
+	// StrategyROX: readers mount ReadOnlyMany (preferred).
+	StrategyROX AccessModeStrategy = "ROX"
+	// StrategyRWX: readers mount ReadWriteMany in read-only mode.
+	StrategyRWX AccessModeStrategy = "RWX"
+	// StrategyFallback: no shared access mode works; caller falls back to
+	// non-shared (per-pod) behavior.
+	StrategyFallback AccessModeStrategy = "Fallback"
+)
+
+// Result holds the outcome of probing a single access mode.
+type Result struct {
+	State     ProbeState `json:"state"`
+	CheckedAt time.Time  `json:"checkedAt"`
+	Reason    string     `json:"reason,omitempty"`
+	TTL       int        `json:"ttlSeconds"`
+}
+
+// Prober performs runtime CSI capability probes against a storage class by
+// creating a tiny PVC + pod for each candidate access mode.
+type Prober struct {
+	client           client.Client
+	namespace        string
+	storageClassName string
+	ttlSeconds       int
+	// Image is the probe pod image; defaults to DefaultProbeImage.
+	Image string
+}
+
+// NewProber creates a Prober for the given storage class.
+func NewProber(c client.Client, namespace, storageClassName string, ttlSeconds int) *Prober {
+	return &Prober{
+		client:           c,
+		namespace:        namespace,
+		storageClassName: storageClassName,
+		ttlSeconds:       ttlSeconds,
+		Image:            DefaultProbeImage,
+	}
+}
+
+// ProbeAccessMode tests whether the storage class supports the given access
+// mode by creating a tiny PVC and a pod that mounts it; Supported if the pod
+// reaches Running/Succeeded within the timeout. Probe resources are always
+// cleaned up.
+func (p *Prober) ProbeAccessMode(ctx context.Context, mode corev1.PersistentVolumeAccessMode) Result {
+	logger := log.FromContext(ctx).WithValues("storageClass", p.storageClassName, "accessMode", string(mode))
+	logger.Info("starting CSI capability probe")
+
+	suffix := accessModeSuffix(mode)
+	pvcName := fmt.Sprintf("probe-%s-%s", p.storageClassName, suffix)
+	podName := fmt.Sprintf("probe-%s-%s", p.storageClassName, suffix)
+
+	result := Result{State: StateProbing, CheckedAt: time.Now(), TTL: p.ttlSeconds}
+
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		p.cleanupProbe(cleanupCtx, podName, pvcName)
+	}()
+
+	// Unsupported results carry a capped TTL (see UnsupportedResultTTLSeconds):
+	// a failed probe may be a transient environment problem, not a property of
+	// the storage class, and must not suppress re-probing for the full window.
+	if err := p.createProbePVC(ctx, pvcName, mode); err != nil {
+		result.State, result.Reason = StateUnsupported, fmt.Sprintf("PVC creation failed: %v", err)
+		result.TTL = min(p.ttlSeconds, UnsupportedResultTTLSeconds)
+		return result
+	}
+	if err := p.createProbePod(ctx, podName, pvcName); err != nil {
+		result.State, result.Reason = StateUnsupported, fmt.Sprintf("Pod creation failed: %v", err)
+		result.TTL = min(p.ttlSeconds, UnsupportedResultTTLSeconds)
+		return result
+	}
+	if err := p.waitForPodRunning(ctx, podName); err != nil {
+		logger.Info("probe pod did not reach Running", "error", err)
+		result.State, result.Reason = StateUnsupported, fmt.Sprintf("Pod did not reach Running: %v", err)
+		result.TTL = min(p.ttlSeconds, UnsupportedResultTTLSeconds)
+		return result
+	}
+
+	logger.Info("probe succeeded")
+	result.State = StateSupported
+	return result
+}
+
+// DetermineStrategy probes ROX then RWX and returns the best supported strategy
+// (or StrategyFallback), along with the per-mode results keyed by
+// "<storageClass>_<MODE>".
+func (p *Prober) DetermineStrategy(ctx context.Context) (AccessModeStrategy, map[string]Result) {
+	results := make(map[string]Result)
+
+	rox := p.ProbeAccessMode(ctx, corev1.ReadOnlyMany)
+	results[ResultKey(p.storageClassName, StrategyROX)] = rox
+	if rox.State == StateSupported {
+		return StrategyROX, results
+	}
+
+	rwx := p.ProbeAccessMode(ctx, corev1.ReadWriteMany)
+	results[ResultKey(p.storageClassName, StrategyRWX)] = rwx
+	if rwx.State == StateSupported {
+		return StrategyRWX, results
+	}
+
+	return StrategyFallback, results
+}
+
+// ResultKey is the map/ConfigMap key for a storage class + strategy result.
+func ResultKey(storageClassName string, strategy AccessModeStrategy) string {
+	return fmt.Sprintf("%s_%s", storageClassName, strategy)
+}
+
+func (p *Prober) probeLabels() map[string]string {
+	return map[string]string{managedByLabel: managedByValue, probeLabel: "true"}
+}
+
+func (p *Prober) createProbePVC(ctx context.Context, name string, mode corev1.PersistentVolumeAccessMode) error {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: p.namespace, Labels: p.probeLabels()},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{mode},
+			StorageClassName: &p.storageClassName,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(ProbePVCSize)},
+			},
+		},
+	}
+	if err := p.client.Create(ctx, pvc); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+func (p *Prober) createProbePod(ctx context.Context, name, pvcName string) error {
+	image := p.Image
+	if image == "" {
+		image = DefaultProbeImage
+	}
+	automount := false
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: p.namespace, Labels: p.probeLabels()},
+		Spec: corev1.PodSpec{
+			AutomountServiceAccountToken: &automount,
+			RestartPolicy:                corev1.RestartPolicyNever,
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: boolPtr(true),
+				RunAsUser:    int64Ptr(1000),
+				RunAsGroup:   int64Ptr(1000),
+				FSGroup:      int64Ptr(1000),
+			},
+			Containers: []corev1.Container{{
+				Name:  "probe",
+				Image: image,
+				// Exit immediately: a successful mount + start is the signal.
+				// waitForPodRunning accepts PodSucceeded, so there is no need to
+				// keep the pod alive (which would only delay probe cleanup).
+				Command: []string{"sh", "-c", "echo probe-ok"},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("16Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("50m"),
+						corev1.ResourceMemory: resource.MustParse("32Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					ReadOnlyRootFilesystem: boolPtr(true),
+					Capabilities:           &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+				},
+				VolumeMounts: []corev1.VolumeMount{{Name: "probe-vol", MountPath: "/mnt/probe"}},
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "probe-vol",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+				},
+			}},
+		},
+	}
+	if err := p.client.Create(ctx, pod); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+func (p *Prober) waitForPodRunning(ctx context.Context, name string) error {
+	ctx, cancel := context.WithTimeout(ctx, ProbeTimeout)
+	defer cancel()
+
+	return wait.PollUntilContextCancel(ctx, ProbePollInterval, true, func(ctx context.Context) (bool, error) {
+		pod := &corev1.Pod{}
+		if err := p.client.Get(ctx, client.ObjectKey{Namespace: p.namespace, Name: name}, pod); err != nil {
+			return false, nil
+		}
+		switch pod.Status.Phase {
+		case corev1.PodRunning, corev1.PodSucceeded:
+			return true, nil
+		case corev1.PodFailed:
+			return false, fmt.Errorf("probe pod failed: %s", pod.Status.Message)
+		default:
+			return false, nil
+		}
+	})
+}
+
+func (p *Prober) cleanupProbe(ctx context.Context, podName, pvcName string) {
+	logger := log.FromContext(ctx)
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: p.namespace}}
+	if err := p.client.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
+		logger.Error(err, "failed to delete probe pod", "pod", podName)
+	}
+
+	// Record the bound PV before deleting the PVC so it can be deleted
+	// explicitly below.
+	boundPVName := ""
+	pvc := &corev1.PersistentVolumeClaim{}
+	if err := p.client.Get(ctx, client.ObjectKey{Namespace: p.namespace, Name: pvcName}, pvc); err == nil {
+		boundPVName = pvc.Spec.VolumeName
+	} else if !apierrors.IsNotFound(err) {
+		logger.Error(err, "failed to get probe PVC before cleanup", "pvc", pvcName)
+	}
+	pvc = &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: p.namespace}}
+	if err := p.client.Delete(ctx, pvc); err != nil && !apierrors.IsNotFound(err) {
+		logger.Error(err, "failed to delete probe PVC", "pvc", pvcName)
+	}
+
+	// A storage class with reclaimPolicy Delete removes the PV with the PVC,
+	// but a Retain class leaves one Released PV object per probe. Delete the
+	// PV explicitly; NotFound is the normal Delete-reclaim case.
+	if boundPVName != "" {
+		pv := &corev1.PersistentVolume{ObjectMeta: metav1.ObjectMeta{Name: boundPVName}}
+		if err := p.client.Delete(ctx, pv); err != nil && !apierrors.IsNotFound(err) {
+			logger.Error(err, "failed to delete probe PV", "pv", boundPVName)
+		}
+	}
+}
+
+func accessModeSuffix(mode corev1.PersistentVolumeAccessMode) string {
+	switch mode {
+	case corev1.ReadOnlyMany:
+		return "rox"
+	case corev1.ReadWriteMany:
+		return "rwx"
+	default:
+		return "unknown"
+	}
+}
+
+func boolPtr(b bool) *bool    { return &b }
+func int64Ptr(i int64) *int64 { return &i }

--- a/src/compute-plane-services/nvca/pkg/storage/cacheprobe/probe.go
+++ b/src/compute-plane-services/nvca/pkg/storage/cacheprobe/probe.go
@@ -130,6 +130,13 @@ func (p *Prober) ProbeAccessMode(ctx context.Context, mode corev1.PersistentVolu
 		p.cleanupProbe(cleanupCtx, podName, pvcName)
 	}()
 
+	// A crashed prior run can leave a completed probe pod/PVC behind, and a
+	// stale Succeeded pod must not be accepted as the current probe's result.
+	// Delete leftovers first; if deletion has not finished by the time the
+	// creates below run, they fail with AlreadyExists and the probe returns a
+	// short-TTL Unsupported result and retries, never a stale success.
+	p.cleanupProbe(ctx, podName, pvcName)
+
 	// Unsupported results carry a capped TTL (see UnsupportedResultTTLSeconds):
 	// a failed probe may be a transient environment problem, not a property of
 	// the storage class, and must not suppress re-probing for the full window.
@@ -196,10 +203,10 @@ func (p *Prober) createProbePVC(ctx context.Context, name string, mode corev1.Pe
 			},
 		},
 	}
-	if err := p.client.Create(ctx, pvc); err != nil && !apierrors.IsAlreadyExists(err) {
-		return err
-	}
-	return nil
+	// No AlreadyExists tolerance: leftovers are deleted before each probe run,
+	// so an existing object means that deletion is still in flight, and reusing
+	// it could accept a stale prior result.
+	return p.client.Create(ctx, pvc)
 }
 
 func (p *Prober) createProbePod(ctx context.Context, name, pvcName string) error {
@@ -250,10 +257,8 @@ func (p *Prober) createProbePod(ctx context.Context, name, pvcName string) error
 			}},
 		},
 	}
-	if err := p.client.Create(ctx, pod); err != nil && !apierrors.IsAlreadyExists(err) {
-		return err
-	}
-	return nil
+	// See createProbePVC for why AlreadyExists is not tolerated here.
+	return p.client.Create(ctx, pod)
 }
 
 func (p *Prober) waitForPodRunning(ctx context.Context, name string) error {

--- a/src/compute-plane-services/nvca/pkg/storage/controller_modelcache.go
+++ b/src/compute-plane-services/nvca/pkg/storage/controller_modelcache.go
@@ -98,7 +98,7 @@ func buildControllerModelCache(r *Reconciler, mgr ctrl.Manager, _ ControllerOpti
 		return acceptEvent
 	}))
 	fanOutEventHandler := handler.TypedEnqueueRequestsFromMapFunc(getModelCacheFanOutEventHandlerMapFunc(mgr.GetClient()))
-	return builder.
+	err := builder.
 		ControllerManagedBy(mgr).
 		Named(string(storageReqType)).
 		For(&nvcav1new.StorageRequest{}, fanOutPredicateOption).
@@ -108,6 +108,8 @@ func buildControllerModelCache(r *Reconciler, mgr ctrl.Manager, _ ControllerOpti
 		Watches(&coordv1.Lease{}, fanOutEventHandler).
 		Watches(&corev1.PersistentVolume{}, fanOutEventHandler).
 		Complete(r)
+	logf.Log.Info("buildControllerModelCache: controller registration complete", "type", string(storageReqType), "error", err)
+	return err
 }
 
 func checkModelCacheFanOutEvent(obj client.Object) (

--- a/src/compute-plane-services/nvca/pkg/storage/modelcache.go
+++ b/src/compute-plane-services/nvca/pkg/storage/modelcache.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	otelattr "go.opentelemetry.io/otel/attribute"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	batchv1 "k8s.io/api/batch/v1"
 	coordv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -36,15 +38,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	modelcachetypes "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/metrics/modelcachetypes"
+	nvcaotel "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/otel"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/util/k8sutil"
 	nvcav1new "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/v1"
 	nvcav2beta1 "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/v2beta1"
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/storage/cacheprobe"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/types"
 )
 
@@ -82,6 +85,17 @@ const (
 	primaryPVLabelKey   = fqdnPrefix + "/modelcache-primary-pv"
 	primaryPVLabelValue = "true"
 
+	// cachePopulatedLabelKey marks a per-handle backing PVC as holding a fully
+	// populated cache. It is the durable, restart-safe "cache populated" signal
+	// for the backends that key reuse on a PVC rather than an NVMesh primary PV:
+	// the Samba per-handle backing PVC (samba-<handle>) and the shared-FS retained
+	// writer PVC. Consumers check it before deciding to run the single-writer
+	// init, so a cold reconcile (e.g. after an agent restart, when the in-memory
+	// init-status fan-out is empty) never re-runs the writer or hangs on the
+	// lease. It is the PVC analogue of the primaryPVLabelKey marker.
+	cachePopulatedLabelKey   = fqdnPrefix + "/modelcache-populated"
+	cachePopulatedLabelValue = "true"
+
 	// The annotation applied to primary PV's that denotes the last time
 	// a function or task referenced it.
 	// If now + modelCacheIdlePeriod > this value and no model cache storage requests
@@ -96,14 +110,16 @@ const (
 )
 
 // terminalErrorWithMetric records a model cache failure metric and returns a terminal error.
+// These cover early/validation failures where the backend is not necessarily
+// known, so the backend label is left empty.
 func (r *Reconciler) terminalErrorWithMetric(reason, msg string) error {
-	r.metrics.RecordModelCacheResult(modelcachetypes.ResultFailure, reason)
+	r.metrics.RecordModelCacheResult(modelcachetypes.ResultFailure, reason, "")
 	return reconcile.TerminalError(errors.New(msg))
 }
 
 // terminalErrorWithMetricErr records a model cache failure metric and returns a terminal error wrapping the given error.
 func (r *Reconciler) terminalErrorWithMetricErr(reason string, err error) error {
-	r.metrics.RecordModelCacheResult(modelcachetypes.ResultFailure, reason)
+	r.metrics.RecordModelCacheResult(modelcachetypes.ResultFailure, reason, "")
 	return reconcile.TerminalError(err)
 }
 
@@ -126,17 +142,66 @@ func mapPodIssuesToFailureReason(podIssues sets.Set[string]) string {
 	return modelcachetypes.ReasonInitJobFailed
 }
 
+// modelCacheTracer traces model cache reconciliation.
+var modelCacheTracer = nvcaotel.NewTracer(nvcaotel.WithName(
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/storage/modelcache"))
+
+// doModelCache wraps the model cache reconcile in an inbound span (nesting under
+// the per-request parent span established from the ICMS trace context in
+// Reconcile) and delegates to doModelCacheRouted.
 func (r *Reconciler) doModelCache(ctx context.Context,
 	st nvcav1new.StorageRequest, stCopy *nvcav1new.StorageRequest,
 	icmsReq *nvcav2beta1.ICMSRequest,
 ) (reconcile.Result, error) {
-	res, err := r.doModelCacheNVMesh(ctx, st, stCopy, icmsReq)
+	var res reconcile.Result
+	err := nvcaotel.InvokeWithSpan(ctx, modelCacheTracer, "nvca.modelcache.reconcile",
+		func(ctx context.Context) error {
+			var e error
+			res, e = r.doModelCacheRouted(ctx, st, stCopy, icmsReq)
+			return e
+		},
+		oteltrace.WithAttributes(nvcaotel.GetOTelAttributesFromICMSRequest(icmsReq)...),
+	)
+	return res, err
+}
+
+func (r *Reconciler) doModelCacheRouted(ctx context.Context,
+	st nvcav1new.StorageRequest, stCopy *nvcav1new.StorageRequest,
+	icmsReq *nvcav2beta1.ICMSRequest,
+) (reconcile.Result, error) {
+	// Select the populate path by the backend stamped on the request by the
+	// miniservice reconciler (SelectHelmCacheBackend). Empty backend defaults to
+	// NVMesh for backward compatibility.
+	var res reconcile.Result
+	var err error
+	backend := ""
+	if stCopy.Spec.ModelCache != nil {
+		backend = stCopy.Spec.ModelCache.Backend
+	}
+	selectedBackend := backend
+	if selectedBackend == "" {
+		selectedBackend = string(HelmCacheBackendNVMesh)
+	}
+	// Tag the reconcile span with the selected backend for filtering.
+	oteltrace.SpanFromContext(ctx).SetAttributes(otelattr.String("nvcf.modelcache.backend", selectedBackend))
+	// Record the selected backend once, on the first reconcile of the request.
+	if st.Status.Phase == nvcav1new.StorageUnknown {
+		r.metrics.RecordModelCacheBackendSelected(selectedBackend)
+	}
+	switch backend {
+	case string(HelmCacheBackendSharedFS):
+		res, err = r.doModelCacheSharedFS(ctx, st, stCopy, icmsReq)
+	case string(HelmCacheBackendSamba):
+		res, err = r.doModelCacheSamba(ctx, st, stCopy, icmsReq)
+	default:
+		res, err = r.doModelCacheNVMesh(ctx, st, stCopy, icmsReq)
+	}
 	if isTerminal(err) {
 		stCopy.Status.Phase = nvcav1new.StorageFailed
 	}
 
 	if stCopy.Status.Phase == nvcav1new.StorageFailed {
-		if errs := r.cleanupInitModelCache(ctx, stCopy); len(errs) == 0 {
+		if errs := r.cleanupInitModelCache(ctx, stCopy, false); len(errs) == 0 {
 			meta.SetStatusCondition(&st.Status.Conditions, metav1.Condition{
 				Type:    ConditionTypeCleanupSuccessful,
 				Status:  metav1.ConditionTrue,
@@ -153,6 +218,358 @@ func (r *Reconciler) doModelCache(ctx context.Context,
 	}
 
 	return res, err
+}
+
+// sharedFSProbeTTLSeconds is how long a cached CSI ROX/RWX probe result for
+// nvcf-miniservice-sc is reused before re-probing.
+const sharedFSProbeTTLSeconds = 3600
+
+// resolveSharedFSStrategy returns the cached probe strategy for nvcf-miniservice-sc,
+// re-probing (and persisting the result) when no valid cached strategy exists.
+func (r *Reconciler) resolveSharedFSStrategy(ctx context.Context) (cacheprobe.AccessModeStrategy, error) {
+	log := logf.FromContext(ctx)
+	store := cacheprobe.NewStateStore(r.Client, ModelCacheInitNamespace)
+	strategy, err := store.GetStrategy(ctx, HelmCacheSharedStorageClassName)
+	if err != nil {
+		return cacheprobe.StrategyFallback, err
+	}
+	if strategy != cacheprobe.StrategyFallback {
+		return strategy, nil
+	}
+	// GetStrategy returns Fallback both when results are missing/expired and
+	// when a fresh probe found the class unsupported. Honour the TTL of a fresh
+	// negative result: if the class was recently probed and found unusable, do
+	// not re-probe (which would create a PVC+pod) on every reconcile.
+	fresh, err := store.HasFreshResult(ctx, HelmCacheSharedStorageClassName)
+	if err != nil {
+		return cacheprobe.StrategyFallback, err
+	}
+	if fresh {
+		return cacheprobe.StrategyFallback, nil
+	}
+	// No valid cached result: probe ROX then RWX and persist.
+	prober := cacheprobe.NewProber(r.Client, ModelCacheInitNamespace, HelmCacheSharedStorageClassName, sharedFSProbeTTLSeconds)
+	strategy, results := prober.DetermineStrategy(ctx)
+	if err := store.Save(ctx, results); err != nil {
+		log.Error(err, "Failed to persist shared-FS probe results")
+	}
+	return strategy, nil
+}
+
+// doModelCacheSharedFS populates and exposes the model cache on a shared
+// filesystem storage class (nvcf-miniservice-sc), used when NVMesh is not present. The
+// cache is populated once (single-writer via the init lease/job, writing to the
+// shared backend), and each workload namespace gets a read-only PVC on the same
+// class that the existing webhook mounts via ModelCacheStatus.ROPVCName. The
+// reader access mode (ROX preferred, RWX fallback) is chosen by a CSI probe.
+//
+// Unlike the NVMesh path it does not create primary/secondary PVs or rewrite
+// CSI volume handles: cross-namespace sharing is a property of the shared class.
+func (r *Reconciler) doModelCacheSharedFS(ctx context.Context,
+	st nvcav1new.StorageRequest, stCopy *nvcav1new.StorageRequest,
+	icmsReq *nvcav2beta1.ICMSRequest,
+) (reconcile.Result, error) {
+	log := logf.FromContext(ctx)
+
+	if stCopy.Spec.ModelCache == nil {
+		return reconcile.Result{}, r.terminalErrorWithMetric(modelcachetypes.ReasonCacheSpecInvalid, "modelCache field is not set")
+	}
+	cacheHandle := stCopy.Spec.ModelCache.CacheHandle
+	if cacheHandle == "" {
+		return reconcile.Result{}, r.terminalErrorWithMetric(modelcachetypes.ReasonCacheSpecInvalid, "modelCache.cacheHandle field is not set")
+	}
+	if stCopy.Labels == nil {
+		stCopy.Labels = map[string]string{}
+	}
+	if stCopy.Labels[modelCacheHandleLabelKey] == "" {
+		stCopy.Labels[modelCacheHandleLabelKey] = cacheHandle
+	}
+
+	rwPVC, initJob, pullSecrets, err := r.findAndDecodeCacheArtifacts(icmsReq, st.Namespace)
+	if err != nil {
+		return reconcile.Result{}, r.terminalErrorWithMetricErr(modelcachetypes.ReasonCacheSpecInvalid, fmt.Errorf("find and decode artifacts: %w", err))
+	}
+	sharedSC := HelmCacheSharedStorageClassName
+	rwPVC.Spec.StorageClassName = &sharedSC
+
+	// Gate on the durable populated marker, mirroring the NVMesh/Samba
+	// getPrimaryPV gate. Shared storage shares data across namespaces natively
+	// so there is no primary PV, but consumers still need a restart-safe signal
+	// that the cache is populated; the in-memory init-status fan-out is lost on
+	// agent restart. The marker is a label on the retained writer RW PVC.
+	writerPVC, populated, err := r.sharedFSCachePopulated(ctx, rwPVC.Name)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	switch st.Status.Phase {
+	case nvcav1new.StorageUnknown, nvcav1new.StoragePending, nvcav1new.StorageInitRunning:
+		if !populated {
+			// Not yet populated: populate the cache on the shared backend via
+			// the single-writer init path. Populating the writer PVC does not
+			// need the reader access-mode probe.
+			return r.doInitModelCacheNVMesh(ctx, st, stCopy, rwPVC, initJob, pullSecrets, HelmCacheBackendSharedFS)
+		}
+		// Cache already populated (durable marker present): skip init and bind
+		// this namespace's reader below.
+		r.metrics.RecordModelCacheReuse(string(HelmCacheBackendSharedFS))
+		stCopy.Status.Phase = nvcav1new.StorageCreating
+	case nvcav1new.StorageFailed, nvcav1new.StorageRuntimeError:
+		log.V(1).Error(fmt.Errorf("storage request is failed"), "Ignoring failed shared-FS model cache")
+		return reconcile.Result{}, nil
+	case nvcav1new.StorageCreating, nvcav1new.StorageReady:
+		// Cache populated; ensure the per-namespace reader PVC below.
+	}
+
+	// Record last-referenced on the retained writer PVC so idle GC
+	// (reclaimIdleSharedFSModelCaches) can reclaim it once no function
+	// references the handle. Best effort.
+	if writerPVC != nil {
+		if err := r.touchCacheReferenced(ctx, writerPVC); err != nil {
+			log.V(1).Error(err, "Failed to update shared-FS writer PVC last-referenced", "pvc", writerPVC.Name)
+		}
+	}
+
+	// Reader RO PVC in the workload namespace on the shared class. With a
+	// shared-capable class all consumers see the same published cache data.
+	roPVCName := "ro-pvc-" + cacheHandle
+	roPVC := &corev1.PersistentVolumeClaim{}
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: roPVCName, Namespace: stCopy.Namespace}, roPVC); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return reconcile.Result{}, err
+		}
+		// The reader PVC does not exist yet: probe the shared class once to
+		// choose its access mode. The probe is intentionally scoped to reader
+		// creation; once the reader exists we never re-probe, so a transient
+		// probe failure after the TTL expires can never mark an already-healthy
+		// cache as failed.
+		strategy, err := r.resolveSharedFSStrategy(ctx)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		if strategy == cacheprobe.StrategyFallback {
+			return reconcile.Result{}, r.terminalErrorWithMetric("shared_fs_unusable",
+				fmt.Sprintf("%s supports neither ROX nor RWX; shared caching disabled", HelmCacheSharedStorageClassName))
+		}
+		accessMode := corev1.ReadWriteMany
+		if strategy == cacheprobe.StrategyROX {
+			accessMode = corev1.ReadOnlyMany
+		}
+		roPVC = &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        roPVCName,
+				Namespace:   stCopy.Namespace,
+				Labels:      types.GetLabelsForRequest(icmsReq, r.fff),
+				Annotations: types.GetAnnotationsForRequest(icmsReq),
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes:      []corev1.PersistentVolumeAccessMode{accessMode},
+				StorageClassName: &sharedSC,
+				Resources:        rwPVC.Spec.Resources,
+			},
+		}
+		maps.Copy(roPVC.Labels, getClusterWideResourceLabels(stCopy))
+		if err := r.setControlledObjectMeta(ctx, stCopy, roPVC); err != nil {
+			return reconcile.Result{}, err
+		}
+		if err := r.Client.Create(ctx, roPVC); err != nil {
+			return reconcile.Result{}, err
+		}
+		log.Info("Shared-FS reader RO PVC created", "pvc", roPVCName, "accessMode", accessMode)
+	}
+
+	switch r.getPVCState(roPVC) {
+	case pvcBound:
+		if stCopy.Status.Phase != nvcav1new.StorageReady || stCopy.Status.ModelCache == nil {
+			log.Info("Shared-FS reader RO PVC bound, storage is ready")
+			stCopy.Status.Phase = nvcav1new.StorageReady
+			stCopy.Status.ModelCache = &nvcav1new.ModelCacheStatus{ROPVCName: roPVC.Name}
+			r.metrics.RecordModelCacheResult(modelcachetypes.ResultSuccess, "", string(HelmCacheBackendSharedFS))
+		}
+	case pvcBindFailed:
+		log.Error(fmt.Errorf("pvc bind failed"), "Shared-FS reader RO PVC failed", "pvc", roPVC.Name)
+		stCopy.Status.Phase = nvcav1new.StorageFailed
+		r.metrics.RecordModelCacheResult(modelcachetypes.ResultFailure, modelcachetypes.ReasonPVCBindFailed, string(HelmCacheBackendSharedFS))
+	case pvcUnbound:
+		// PVC events will requeue the storage request.
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// doModelCacheSamba populates and exposes the model cache on an NVCA-managed
+// per-cacheHandle Samba server (backend 3, "Samba over NVMesh"). Each handle gets
+// its OWN Samba server + nvcf-sc data PVC (samba-<cacheHandle>, sized to the
+// request's cacheSize) exporting one SMB share; there is no shared/global data
+// PVC. The per-handle backing PVC is the durable reuse marker: if it already
+// exists the cache is reused, and a cachePopulatedLabelKey label on it (stamped
+// by the writer on success) signals readers may safely attach. A single-writer
+// init job populates the share; on success the writer (job/RW SMB PV/PVC/lease)
+// is torn down and the backing PVC is marked populated. Each workload namespace
+// then binds its own RO SMB PV/PVC to the share. It creates no StorageClass
+// (nvcf-miniservice-sc is the operator's branch-2 class) and needs no CSI probe (SMB is
+// RWX/ROX). Idle per-handle servers/PVCs are reclaimed by cleanupIdleModelCaches.
+func (r *Reconciler) doModelCacheSamba(ctx context.Context,
+	st nvcav1new.StorageRequest, stCopy *nvcav1new.StorageRequest,
+	icmsReq *nvcav2beta1.ICMSRequest,
+) (reconcile.Result, error) {
+	log := logf.FromContext(ctx)
+
+	if stCopy.Spec.ModelCache == nil {
+		return reconcile.Result{}, r.terminalErrorWithMetric(modelcachetypes.ReasonCacheSpecInvalid, "modelCache field is not set")
+	}
+	cacheHandle := stCopy.Spec.ModelCache.CacheHandle
+	if cacheHandle == "" {
+		return reconcile.Result{}, r.terminalErrorWithMetric(modelcachetypes.ReasonCacheSpecInvalid, "modelCache.cacheHandle field is not set")
+	}
+	if stCopy.Labels == nil {
+		stCopy.Labels = map[string]string{}
+	}
+	if stCopy.Labels[modelCacheHandleLabelKey] == "" {
+		stCopy.Labels[modelCacheHandleLabelKey] = cacheHandle
+	}
+
+	rwPVC, initJob, pullSecrets, err := r.findAndDecodeCacheArtifacts(icmsReq, st.Namespace)
+	if err != nil {
+		return reconcile.Result{}, r.terminalErrorWithMetricErr(modelcachetypes.ReasonCacheSpecInvalid, fmt.Errorf("find and decode artifacts: %w", err))
+	}
+	// cacheSize comes from the request payload (the translator sizes the cache
+	// PVC from CacheLaunchSpecification.CacheSize): the per-handle backing volume
+	// is sized to it, not a global guess.
+	capacity := rwPVC.Spec.Resources.Requests[corev1.ResourceStorage]
+
+	// Ensure the per-handle Samba server + nvcf-sc backing PVC (samba-<handle>,
+	// sized to cacheSize). Idempotent: an existing backing PVC is reused.
+	smbResources := corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList(r.cfg.Agent.SharedStorage.Server.ContainerResources.Limits),
+		Requests: corev1.ResourceList(r.cfg.Agent.SharedStorage.Server.ContainerResources.Requests),
+		Claims:   r.cfg.Agent.SharedStorage.Server.ContainerResources.Claims,
+	}
+	var ready bool
+	err = nvcaotel.InvokeWithSpan(ctx, modelCacheTracer, "nvca.modelcache.samba.ensure_infra",
+		func(ctx context.Context) error {
+			var e error
+			ready, e = EnsureSambaModelCacheInfra(ctx, r.Client, cacheHandle, r.cfg.Agent.SharedStorage.Server.Image, smbResources, capacity)
+			return e
+		},
+		oteltrace.WithAttributes(otelattr.String("nvcf.modelcache.handle", cacheHandle)),
+	)
+	if err != nil {
+		// This runs on EVERY reconcile of a Samba request (including ones whose
+		// cache is already Ready), so a transient API error (timeout, 429, 503)
+		// must requeue, never terminally fail the request. Only genuinely
+		// non-transient errors (misconfiguration, Forbidden, Invalid) are
+		// terminal.
+		if k8sutil.IsTransientK8sError(err) {
+			log.V(1).Info("Transient error ensuring Samba model cache infra, requeuing", "error", err.Error())
+			return reconcile.Result{Requeue: true}, nil
+		}
+		return reconcile.Result{}, r.terminalErrorWithMetricErr("samba_infra_failed", fmt.Errorf("ensure samba model cache infra: %w", err))
+	}
+	if !ready {
+		log.V(1).Info("Samba model cache server not ready, requeuing")
+		return reconcile.Result{RequeueAfter: defaultRequeueDelay}, nil
+	}
+
+	// Writer RW SMB PV bound to the per-handle Samba share root. Each handle has
+	// its own server/share, so no per-handle subdir (and no subPath) is needed.
+	// It is plumbing, not data: cleanupInitModelCache deletes it with the writer
+	// PVC (static PVs are never reclaimed by the PV controller).
+	emptySC := ""
+	rwPVName := sambaModelCacheWriterPVName(cacheHandle)
+	rwPVC.Spec.StorageClassName = &emptySC
+	rwPVC.Spec.VolumeName = rwPVName
+	if err := ensureCreated(ctx, r.Client,
+		newSambaModelCachePV(rwPVName, rwPVC.Name, ModelCacheInitNamespace, cacheHandle, false, capacity)); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// The per-handle backing PVC is the durable reuse marker. Its existence means
+	// the cache is being provisioned; its cachePopulatedLabelKey label (stamped by
+	// the writer on success) means readers may attach. This is restart-safe and
+	// cross-namespace: it does not rely on the init lease or in-memory fan-out.
+	backingPVCName := SambaModelCacheBackingPVCName(cacheHandle)
+	backingPVC := &corev1.PersistentVolumeClaim{}
+	if err := r.Client.Get(ctx, client.ObjectKey{Namespace: ModelCacheInitNamespace, Name: backingPVCName}, backingPVC); err != nil {
+		return reconcile.Result{}, err
+	}
+	populated := backingPVC.Labels[cachePopulatedLabelKey] == cachePopulatedLabelValue
+
+	switch st.Status.Phase {
+	case nvcav1new.StorageUnknown, nvcav1new.StoragePending, nvcav1new.StorageInitRunning:
+		if !populated {
+			// Not yet populated: single-writer populate via the init lease/job.
+			// On success reconcileInitModelCacheNVMesh marks the backing PVC
+			// populated and tears down the writer (backend-aware).
+			return r.doInitModelCacheNVMesh(ctx, st, stCopy, rwPVC, initJob, pullSecrets, HelmCacheBackendSamba)
+		}
+		// Cache populated: skip init and bind the per-namespace reader below.
+		r.metrics.RecordModelCacheReuse(string(HelmCacheBackendSamba))
+		stCopy.Status.Phase = nvcav1new.StorageCreating
+	case nvcav1new.StorageFailed, nvcav1new.StorageRuntimeError:
+		log.V(1).Error(fmt.Errorf("storage request is failed"), "Ignoring failed Samba model cache")
+		return reconcile.Result{}, nil
+	case nvcav1new.StorageCreating, nvcav1new.StorageReady:
+		if !populated {
+			return reconcile.Result{}, r.terminalErrorWithMetricErr(modelcachetypes.ReasonPVCSetupFailed,
+				fmt.Errorf("samba backing PVC %s not marked populated after init", backingPVCName))
+		}
+		// Cache populated; ensure the per-namespace reader PV/PVC below.
+	}
+
+	// Record last-referenced on the backing PVC so idle GC can reclaim the
+	// per-handle server/PVC once no function references the handle. Best effort.
+	if err := r.touchCacheReferenced(ctx, backingPVC); err != nil {
+		log.V(1).Error(err, "Failed to update Samba backing PVC last-referenced", "pvc", backingPVCName)
+	}
+
+	// Reader RO PV + PVC in the workload namespace, bound statically to the same
+	// per-handle Samba share, mounted read-only.
+	roPVCName := "ro-pvc-" + cacheHandle
+	roPVName := "samba-ro-pv-" + stCopy.Namespace + "-" + cacheHandle
+	roPVC := &corev1.PersistentVolumeClaim{}
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: roPVCName, Namespace: stCopy.Namespace}, roPVC); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return reconcile.Result{}, err
+		}
+		// Carry the cluster-wide resource labels so the per-request cleanup
+		// (doCleanupModelCacheNVMesh lists PVs by these labels) deletes this
+		// static PV when the StorageRequest goes away; the PV controller never
+		// reclaims a Released static PV on its own.
+		roPV := newSambaModelCachePV(roPVName, roPVCName, stCopy.Namespace, cacheHandle, true, capacity)
+		maps.Copy(roPV.Labels, getClusterWideResourceLabels(stCopy))
+		if err := ensureCreated(ctx, r.Client, roPV); err != nil {
+			return reconcile.Result{}, err
+		}
+		roPVC = newSambaModelCachePVC(roPVCName, stCopy.Namespace, roPVName, true, capacity)
+		roPVC.Labels = types.GetLabelsForRequest(icmsReq, r.fff)
+		roPVC.Annotations = types.GetAnnotationsForRequest(icmsReq)
+		maps.Copy(roPVC.Labels, getClusterWideResourceLabels(stCopy))
+		if err := r.setControlledObjectMeta(ctx, stCopy, roPVC); err != nil {
+			return reconcile.Result{}, err
+		}
+		if err := r.Client.Create(ctx, roPVC); err != nil {
+			return reconcile.Result{}, err
+		}
+		log.Info("Samba reader RO PVC created", "pvc", roPVCName)
+	}
+
+	switch r.getPVCState(roPVC) {
+	case pvcBound:
+		if stCopy.Status.Phase != nvcav1new.StorageReady || stCopy.Status.ModelCache == nil {
+			log.Info("Samba reader RO PVC bound, storage is ready")
+			stCopy.Status.Phase = nvcav1new.StorageReady
+			stCopy.Status.ModelCache = &nvcav1new.ModelCacheStatus{ROPVCName: roPVC.Name}
+			r.metrics.RecordModelCacheResult(modelcachetypes.ResultSuccess, "", string(HelmCacheBackendSamba))
+		}
+	case pvcBindFailed:
+		log.Error(fmt.Errorf("pvc bind failed"), "Samba reader RO PVC failed", "pvc", roPVC.Name)
+		stCopy.Status.Phase = nvcav1new.StorageFailed
+		r.metrics.RecordModelCacheResult(modelcachetypes.ResultFailure, modelcachetypes.ReasonPVCBindFailed, string(HelmCacheBackendSamba))
+	case pvcUnbound:
+		// PVC events will requeue the storage request.
+	}
+
+	return reconcile.Result{}, nil
 }
 
 var accessModesRO = []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany}
@@ -198,11 +615,12 @@ func (r *Reconciler) doModelCacheNVMesh(ctx context.Context, //nolint:gocyclo
 	switch st.Status.Phase {
 	case nvcav1new.StorageUnknown, nvcav1new.StoragePending, nvcav1new.StorageInitRunning:
 		if apierrors.IsNotFound(ppvErr) {
-			return r.doInitModelCacheNVMesh(ctx, st, stCopy, rwPVC, initJob, workerPullSecrets)
+			return r.doInitModelCacheNVMesh(ctx, st, stCopy, rwPVC, initJob, workerPullSecrets, HelmCacheBackendNVMesh)
 		} else if ppvErr != nil {
 			return reconcile.Result{}, ppvErr
 		}
 		// Fallthrough and finalize secondary storage objects since the primary PV exists.
+		r.metrics.RecordModelCacheReuse(string(HelmCacheBackendNVMesh))
 		stCopy.Status.Phase = nvcav1new.StorageCreating
 	case nvcav1new.StorageCreating, nvcav1new.StorageReady:
 		if ppvErr != nil {
@@ -216,14 +634,14 @@ func (r *Reconciler) doModelCacheNVMesh(ctx context.Context, //nolint:gocyclo
 		// Fallthrough and finalize secondary storage objects since there were no issues retrieving.
 	case nvcav1new.StorageFailed, nvcav1new.StorageRuntimeError:
 		log.V(1).Error(fmt.Errorf("storage request is failed"), "Ignoring failed storage request")
-		return reconcile.Result{}, r.doCleanupModelCacheNVMesh(ctx, stCopy)
+		return r.doCleanupModelCacheNVMesh(ctx, stCopy)
 	}
 
 	switch primaryPV.Status.Phase {
 	case corev1.VolumeFailed:
 		log.Info("Primary PV is failed", "pv", primaryPV.Name)
 		stCopy.Status.Phase = nvcav1new.StorageFailed
-		r.metrics.RecordModelCacheResult(modelcachetypes.ResultFailure, modelcachetypes.ReasonPVCSetupFailed)
+		r.metrics.RecordModelCacheResult(modelcachetypes.ResultFailure, modelcachetypes.ReasonPVCSetupFailed, string(HelmCacheBackendNVMesh))
 		return reconcile.Result{}, nil
 	case corev1.VolumePending:
 		log.V(1).Info("Primary PV is pending", "pv", primaryPV.Name)
@@ -342,12 +760,12 @@ func (r *Reconciler) doModelCacheNVMesh(ctx context.Context, //nolint:gocyclo
 				ROPVCName:    roPVC.Name,
 				VolumeHandle: secondaryPV.Spec.CSI.VolumeHandle,
 			}
-			r.metrics.RecordModelCacheResult(modelcachetypes.ResultSuccess, "")
+			r.metrics.RecordModelCacheResult(modelcachetypes.ResultSuccess, "", string(HelmCacheBackendNVMesh))
 		}
 	case pvcBindFailed:
 		log.Error(fmt.Errorf("pvc bind failed"), "RO PVC failed", "pvc", roPVC.Name)
 		stCopy.Status.Phase = nvcav1new.StorageFailed
-		r.metrics.RecordModelCacheResult(modelcachetypes.ResultFailure, modelcachetypes.ReasonPVCBindFailed)
+		r.metrics.RecordModelCacheResult(modelcachetypes.ResultFailure, modelcachetypes.ReasonPVCBindFailed, string(HelmCacheBackendNVMesh))
 	case pvcUnbound:
 		// PVC events will requeue the storage request.
 		//
@@ -398,6 +816,7 @@ func (r *Reconciler) doInitModelCacheNVMesh(ctx context.Context,
 	rwPVC *corev1.PersistentVolumeClaim,
 	initJob *batchv1.Job,
 	pullSecrets []*corev1.Secret,
+	backend HelmCacheBackend,
 ) (res reconcile.Result, err error) {
 	logf.IntoContext(ctx, logf.FromContext(ctx, "namespace", ModelCacheInitNamespace))
 
@@ -429,7 +848,7 @@ func (r *Reconciler) doInitModelCacheNVMesh(ctx context.Context,
 	r.initStatuses.Lock()
 	defer r.initStatuses.Unlock()
 
-	res, err = r.reconcileInitModelCacheNVMesh(ctx, st, stCopy, rwPVC, initJob, pullSecrets)
+	res, err = r.reconcileInitModelCacheNVMesh(ctx, st, stCopy, rwPVC, initJob, pullSecrets, backend)
 
 	// The lease holder updates the status for all non-holders (fan-out).
 	if existingStatus, ok := r.initStatuses.get(cacheHandle); !ok ||
@@ -453,6 +872,7 @@ func (r *Reconciler) reconcileInitModelCacheNVMesh(ctx context.Context,
 	rwPVC *corev1.PersistentVolumeClaim,
 	initJob *batchv1.Job,
 	pullSecrets []*corev1.Secret,
+	backend HelmCacheBackend,
 ) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
@@ -473,8 +893,11 @@ func (r *Reconciler) reconcileInitModelCacheNVMesh(ctx context.Context,
 			initJob.Spec.Template.Labels = map[string]string{}
 		}
 		initJob.Spec.Template.Labels[modelCacheHandleLabelKey] = stCopy.Spec.ModelCache.CacheHandle
-		// NVMesh client readiness scheduling.
-		SetNVMeshClientStatusSchedulingRequirement(&initJob.Spec.Template.Spec)
+		// NVMesh client readiness scheduling applies only to the NVMesh backend;
+		// the shared-FS backend (nvcf-miniservice-sc) has no NVMesh node requirement.
+		if backend == HelmCacheBackendNVMesh {
+			SetNVMeshClientStatusSchedulingRequirement(&initJob.Spec.Template.Spec)
+		}
 		objsToCreate = append(objsToCreate, initJob)
 		for _, obj := range objsToCreate {
 			obj.SetNamespace(ModelCacheInitNamespace)
@@ -534,17 +957,51 @@ func (r *Reconciler) reconcileInitModelCacheNVMesh(ctx context.Context,
 		}
 		switch r.getPVCState(rwPVC) {
 		case pvcBound:
-			log.Info("Cache init RW PVC bound, finalizing primary PV")
-
-			if err := r.finalizePrimaryPVOnSuccessfulInit(ctx, stCopy, rwPVC); err != nil {
-				log.Error(err, "Failed to finalize primary PV")
-				return reconcile.Result{}, err
+			switch backend {
+			case HelmCacheBackendNVMesh:
+				// NVMesh: retain the bound dynamic PV as the cross-namespace
+				// "primary" PV (it carries the data volume handle that secondary
+				// PVs copy) and tear down the writer job/RW PVC.
+				log.Info("Cache init RW PVC bound, finalizing primary PV")
+				if err := r.finalizePrimaryPVOnSuccessfulInit(ctx, stCopy, rwPVC); err != nil {
+					log.Error(err, "Failed to finalize primary PV")
+					return reconcile.Result{}, err
+				}
+				_ = r.cleanupInitModelCache(ctx, stCopy, false)
+			case HelmCacheBackendSamba:
+				// Samba: the cache data lives in the per-handle backing PVC
+				// (samba-<handle>), populated via the writer's SMB mount. Stamp
+				// the populated marker on that durable PVC and tear down the
+				// ephemeral writer (job/RW SMB PV/PVC/lease). The backing PVC and
+				// its label are the cross-namespace, restart-safe reuse marker.
+				if err := r.markSambaCachePopulated(ctx, stCopy.Spec.ModelCache.CacheHandle); err != nil {
+					log.Error(err, "Failed to mark Samba cache populated")
+					return reconcile.Result{}, err
+				}
+				_ = r.cleanupInitModelCache(ctx, stCopy, false)
+			default:
+				// Shared-FS: the cache data lives on the shared backend
+				// (nvcf-miniservice-sc). Keep the writer RW PVC/job as the persistent
+				// writer-side claim; readers mount the same backend RO. There is
+				// no primary PV, but stamp a durable "populated" marker on the
+				// retained RW PVC so any namespace, including after an agent
+				// restart (when the in-memory init-status fan-out is empty), can
+				// detect the cache is populated and skip init.
+				log.Info("Cache init RW PVC bound (shared-FS), marking cache populated")
+				if err := r.markCachePopulated(ctx, rwPVC); err != nil {
+					log.Error(err, "Failed to mark shared-FS cache populated")
+					return reconcile.Result{}, err
+				}
+				// Tear down the init job and lease but retain the writer PVC:
+				// without this, one completed Job and one Lease would accumulate
+				// per cache handle with no other cleanup path (idle GC only
+				// reclaims writer PVCs).
+				_ = r.cleanupInitModelCache(ctx, stCopy, true)
 			}
 
-			_ = r.cleanupInitModelCache(ctx, stCopy)
-
+			// The single-writer download completed: count one populate for the backend.
+			r.metrics.RecordModelCachePopulate(string(backend))
 			stCopy.Status.Phase = nvcav1new.StorageCreating
-			// Requeue to check if PV is finalized.
 			return reconcile.Result{Requeue: true}, nil
 		case pvcBindFailed:
 			// The caller's cleanup method will delete cache resources.
@@ -736,6 +1193,67 @@ func (r *Reconciler) finalizePrimaryPVOnSuccessfulInit(ctx context.Context,
 	}
 
 	return nil
+}
+
+// markCachePopulated stamps the durable populated marker (cachePopulatedLabelKey)
+// on a per-handle backing PVC (the Samba samba-<handle> PVC or the shared-FS
+// retained writer PVC). Patching the label is also a PVC update event, which
+// fans out to every StorageRequest with the same cache-handle label, waking
+// namespaces waiting on the populate.
+func (r *Reconciler) markCachePopulated(ctx context.Context, pvc *corev1.PersistentVolumeClaim) error {
+	old := pvc.DeepCopy()
+	if pvc.Labels == nil {
+		pvc.Labels = map[string]string{}
+	}
+	pvc.Labels[cachePopulatedLabelKey] = cachePopulatedLabelValue
+	if err := r.Client.Patch(ctx, pvc, client.MergeFrom(old)); err != nil {
+		return fmt.Errorf("mark cache populated: %w", err)
+	}
+	return nil
+}
+
+// markSambaCachePopulated stamps the populated marker on the per-handle Samba
+// backing PVC (samba-<cacheHandle>) once the writer has finished populating the
+// share over SMB.
+func (r *Reconciler) markSambaCachePopulated(ctx context.Context, cacheHandle string) error {
+	pvc := &corev1.PersistentVolumeClaim{}
+	key := client.ObjectKey{Namespace: ModelCacheInitNamespace, Name: SambaModelCacheBackingPVCName(cacheHandle)}
+	if err := r.Client.Get(ctx, key, pvc); err != nil {
+		return fmt.Errorf("get samba backing pvc: %w", err)
+	}
+	return r.markCachePopulated(ctx, pvc)
+}
+
+// touchCacheReferenced records the last-referenced time on a per-handle backing
+// PVC so cleanupIdleModelCaches can reclaim it (and, for Samba, the per-handle
+// server) once no function has referenced the handle for the idle period.
+func (r *Reconciler) touchCacheReferenced(ctx context.Context, pvc *corev1.PersistentVolumeClaim) error {
+	old := pvc.DeepCopy()
+	if pvc.Annotations == nil {
+		pvc.Annotations = map[string]string{}
+	}
+	pvc.Annotations[primaryPVLastReferencedAnnotationKey] = r.nowFunc().Format(primaryPVLastReferencedTimeFormat)
+	if err := r.Client.Patch(ctx, pvc, client.MergeFrom(old)); err != nil {
+		return fmt.Errorf("touch cache referenced: %w", err)
+	}
+	return nil
+}
+
+// sharedFSCachePopulated reports whether the retained shared-FS writer RW PVC
+// (rwPVCName, in the model-cache init namespace) carries the durable populated
+// marker, returning the PVC so callers can record last-referenced on it. A
+// missing PVC means the cache has not been populated yet and is not an error.
+// It is the shared-FS analogue of getPrimaryPV.
+func (r *Reconciler) sharedFSCachePopulated(ctx context.Context, rwPVCName string) (*corev1.PersistentVolumeClaim, bool, error) {
+	pvc := &corev1.PersistentVolumeClaim{}
+	key := client.ObjectKey{Namespace: ModelCacheInitNamespace, Name: rwPVCName}
+	if err := r.Client.Get(ctx, key, pvc); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return pvc, pvc.Labels[cachePopulatedLabelKey] == cachePopulatedLabelValue, nil
 }
 
 func newInitLease(st *nvcav1new.StorageRequest) *coordv1.Lease {
@@ -951,45 +1469,38 @@ func isInitJobPodProgressing(pod *corev1.Pod, k8sTimeConfig *k8sutil.TimeConfig)
 	return fmt.Sprintf("code bug: unreachable pod phase %s", ps.Phase), false
 }
 
-func (r *Reconciler) waitForVolumeDetach(ctx context.Context, volumeName string) error {
+// isVolumeDetached performs a SINGLE, non-blocking check of whether volumeName
+// is still attached read-write. The model-cache controller has one reconcile
+// worker; polling for detachment inside a reconcile (the previous behavior)
+// would block that worker for up to the detach timeout, starving every other
+// StorageRequest, including the terminating-namespace finalizer escape hatch.
+// Callers instead requeue when this returns false, so the worker is never held.
+func (r *Reconciler) isVolumeDetached(ctx context.Context, volumeName string) (bool, error) {
 	log := logf.FromContext(ctx).WithValues("pv", volumeName)
-	log.V(1).Info("Checking attachment status of volume")
 
-	interval := 1 * time.Second
-	if err := wait.PollUntilContextTimeout(ctx, interval, r.k8sTimeConfig.ModelCacheVolumeDetachmentTimeout, true,
-		func(ctx context.Context) (done bool, err error) {
-			vaList := &storagev1.VolumeAttachmentList{}
-			if err := r.Client.List(ctx, vaList); err != nil {
-				log.Error(err, "Failed to list volume attachments")
-				return false, err
-			}
-
-			for _, va := range vaList.Items {
-				if va.Spec.Source.PersistentVolumeName != nil && *va.Spec.Source.PersistentVolumeName == volumeName {
-					pv := &corev1.PersistentVolume{}
-					if err := r.Client.Get(ctx, client.ObjectKey{Name: volumeName}, pv); err != nil {
-						if apierrors.IsNotFound(err) {
-							log.V(1).Info("PV not found, skipping wait for detach")
-							return true, nil
-						}
-						return false, fmt.Errorf("failed to get PV %v to check volume attachment status: %w", volumeName, err)
-					}
-					if len(pv.Spec.AccessModes) == 1 && pv.Spec.AccessModes[0] == corev1.ReadOnlyMany {
-						// not attached in rwMode.
-						log.V(1).Info("PV not attached in RW mode")
-						return true, nil
-					}
-					log.V(1).Info("PV still attached, retrying after interval")
-					return false, nil
-				}
-			}
-			log.V(1).Info("PV not found in volume attachments, assuming detached")
-			return true, nil
-		},
-	); err == nil || !errors.Is(err, context.Canceled) {
-		return err
+	vaList := &storagev1.VolumeAttachmentList{}
+	if err := r.Client.List(ctx, vaList); err != nil {
+		return false, fmt.Errorf("list volume attachments: %w", err)
 	}
-	return fmt.Errorf("PV still attached after timeout")
+	for _, va := range vaList.Items {
+		if va.Spec.Source.PersistentVolumeName == nil || *va.Spec.Source.PersistentVolumeName != volumeName {
+			continue
+		}
+		pv := &corev1.PersistentVolume{}
+		if err := r.Client.Get(ctx, client.ObjectKey{Name: volumeName}, pv); err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, fmt.Errorf("get PV %v to check attachment status: %w", volumeName, err)
+		}
+		// A read-only attachment does not block deleting the writer PVC.
+		if len(pv.Spec.AccessModes) == 1 && pv.Spec.AccessModes[0] == corev1.ReadOnlyMany {
+			return true, nil
+		}
+		log.V(1).Info("PV still attached read-write")
+		return false, nil
+	}
+	return true, nil
 }
 
 // Cross-namespace NVMesh volumes (in NVMesh 3.2) are a required feature for this controller's

--- a/src/compute-plane-services/nvca/pkg/storage/modelcache.go
+++ b/src/compute-plane-services/nvca/pkg/storage/modelcache.go
@@ -193,8 +193,14 @@ func (r *Reconciler) doModelCacheRouted(ctx context.Context,
 		res, err = r.doModelCacheSharedFS(ctx, st, stCopy, icmsReq)
 	case string(HelmCacheBackendSamba):
 		res, err = r.doModelCacheSamba(ctx, st, stCopy, icmsReq)
-	default:
+	case "", string(HelmCacheBackendNVMesh):
+		// Empty preserves requests created before the Backend field existed.
 		res, err = r.doModelCacheNVMesh(ctx, st, stCopy, icmsReq)
+	default:
+		// A typo or a non-provisioning value (e.g. "ephemeral") must not fall
+		// through to NVMesh provisioning against an unavailable backend.
+		err = r.terminalErrorWithMetric(modelcachetypes.ReasonCacheSpecInvalid,
+			fmt.Sprintf("unsupported model cache backend %q", backend))
 	}
 	if isTerminal(err) {
 		stCopy.Status.Phase = nvcav1new.StorageFailed
@@ -470,19 +476,6 @@ func (r *Reconciler) doModelCacheSamba(ctx context.Context,
 		return reconcile.Result{RequeueAfter: defaultRequeueDelay}, nil
 	}
 
-	// Writer RW SMB PV bound to the per-handle Samba share root. Each handle has
-	// its own server/share, so no per-handle subdir (and no subPath) is needed.
-	// It is plumbing, not data: cleanupInitModelCache deletes it with the writer
-	// PVC (static PVs are never reclaimed by the PV controller).
-	emptySC := ""
-	rwPVName := sambaModelCacheWriterPVName(cacheHandle)
-	rwPVC.Spec.StorageClassName = &emptySC
-	rwPVC.Spec.VolumeName = rwPVName
-	if err := ensureCreated(ctx, r.Client,
-		newSambaModelCachePV(rwPVName, rwPVC.Name, ModelCacheInitNamespace, cacheHandle, false, capacity)); err != nil {
-		return reconcile.Result{}, err
-	}
-
 	// The per-handle backing PVC is the durable reuse marker. Its existence means
 	// the cache is being provisioned; its cachePopulatedLabelKey label (stamped by
 	// the writer on success) means readers may attach. This is restart-safe and
@@ -497,6 +490,21 @@ func (r *Reconciler) doModelCacheSamba(ctx context.Context,
 	switch st.Status.Phase {
 	case nvcav1new.StorageUnknown, nvcav1new.StoragePending, nvcav1new.StorageInitRunning:
 		if !populated {
+			// Writer RW SMB PV bound to the per-handle Samba share root. Each
+			// handle has its own server/share, so no per-handle subdir (and no
+			// subPath) is needed. It is plumbing, not data, and is created only
+			// while population is required: cleanupInitModelCache deletes it
+			// with the writer PVC after population (static PVs are never
+			// reclaimed by the PV controller), and recreating it afterwards
+			// would leave an orphaned Released static PV per handle.
+			emptySC := ""
+			rwPVName := sambaModelCacheWriterPVName(cacheHandle)
+			rwPVC.Spec.StorageClassName = &emptySC
+			rwPVC.Spec.VolumeName = rwPVName
+			if err := ensureCreated(ctx, r.Client,
+				newSambaModelCachePV(rwPVName, rwPVC.Name, ModelCacheInitNamespace, cacheHandle, false, capacity)); err != nil {
+				return reconcile.Result{}, err
+			}
 			// Not yet populated: single-writer populate via the init lease/job.
 			// On success reconcileInitModelCacheNVMesh marks the backing PVC
 			// populated and tears down the writer (backend-aware).
@@ -1228,11 +1236,21 @@ func (r *Reconciler) markSambaCachePopulated(ctx context.Context, cacheHandle st
 // PVC so cleanupIdleModelCaches can reclaim it (and, for Samba, the per-handle
 // server) once no function has referenced the handle for the idle period.
 func (r *Reconciler) touchCacheReferenced(ctx context.Context, pvc *corev1.PersistentVolumeClaim) error {
+	// Patching the watched PVC requeues every request sharing its handle, and
+	// each of those reconciles would patch it again. Skip the patch while the
+	// existing stamp is fresh (a quarter of the idle period keeps idle GC
+	// accurate enough) so steady state does not fan out into a requeue loop.
+	now := r.nowFunc()
+	if prev, err := time.Parse(primaryPVLastReferencedTimeFormat,
+		pvc.Annotations[primaryPVLastReferencedAnnotationKey]); err == nil &&
+		now.Sub(prev) < r.k8sTimeConfig.ModelCacheIdlePeriod/4 {
+		return nil
+	}
 	old := pvc.DeepCopy()
 	if pvc.Annotations == nil {
 		pvc.Annotations = map[string]string{}
 	}
-	pvc.Annotations[primaryPVLastReferencedAnnotationKey] = r.nowFunc().Format(primaryPVLastReferencedTimeFormat)
+	pvc.Annotations[primaryPVLastReferencedAnnotationKey] = now.Format(primaryPVLastReferencedTimeFormat)
 	if err := r.Client.Patch(ctx, pvc, client.MergeFrom(old)); err != nil {
 		return fmt.Errorf("touch cache referenced: %w", err)
 	}

--- a/src/compute-plane-services/nvca/pkg/storage/modelcache_cleanup.go
+++ b/src/compute-plane-services/nvca/pkg/storage/modelcache_cleanup.go
@@ -224,6 +224,7 @@ func (r *Reconciler) cleanupInitModelCache(ctx context.Context, st *nvcav1new.St
 
 	if !retainWriterPVC {
 		// Delete the RW PVC once all Pods are deleted.
+		writerVolumeSettled := true
 		pvcList := &corev1.PersistentVolumeClaimList{}
 		if err := r.Client.List(ctx, pvcList, listOpts...); err != nil {
 			log.Error(err, "RW PVC list failed, manual cleanup needed")
@@ -251,7 +252,9 @@ func (r *Reconciler) cleanupInitModelCache(ctx context.Context, st *nvcav1new.St
 						deletePVC = false
 					}
 				}
-				if deletePVC {
+				if !deletePVC {
+					writerVolumeSettled = false
+				} else {
 					log.V(1).Info("Deleting model cache init RW PVC", "pvc", pvc.Name)
 					if err := r.Client.Delete(ctx, &pvc); err != nil && !apierrors.IsNotFound(err) {
 						log.Error(err, "Init RW PVC delete failed, manual cleanup needed", "pvc", pvc.Name)
@@ -268,12 +271,16 @@ func (r *Reconciler) cleanupInitModelCache(ctx context.Context, st *nvcav1new.St
 		// The Samba writer binds a static plumbing SMB PV; delete it with the writer
 		// PVC. Static PVs have no provisioner, so a Released one leaks forever, and
 		// its stale claimRef would block a later writer PVC from re-binding.
-		// NotFound is the normal case for the other backends.
-		sambaWriterPV := &corev1.PersistentVolume{}
-		sambaWriterPV.Name = sambaModelCacheWriterPVName(st.Spec.ModelCache.CacheHandle)
-		if err := r.Client.Delete(ctx, sambaWriterPV); err != nil && !apierrors.IsNotFound(err) {
-			log.Error(err, "Samba writer PV delete failed, manual cleanup needed", "pv", sambaWriterPV.Name)
-			errs = append(errs, err)
+		// NotFound is the normal case for the other backends. While the writer
+		// volume is still attached the PVC is retained above, so retain the PV
+		// with it; the requeued cleanup deletes both after detachment.
+		if writerVolumeSettled {
+			sambaWriterPV := &corev1.PersistentVolume{}
+			sambaWriterPV.Name = sambaModelCacheWriterPVName(st.Spec.ModelCache.CacheHandle)
+			if err := r.Client.Delete(ctx, sambaWriterPV); err != nil && !apierrors.IsNotFound(err) {
+				log.Error(err, "Samba writer PV delete failed, manual cleanup needed", "pv", sambaWriterPV.Name)
+				errs = append(errs, err)
+			}
 		}
 	}
 

--- a/src/compute-plane-services/nvca/pkg/storage/modelcache_cleanup.go
+++ b/src/compute-plane-services/nvca/pkg/storage/modelcache_cleanup.go
@@ -35,9 +35,19 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	nvcav1new "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/v1"
 )
+
+// errVolumeStillAttached signals that a cache init writer volume has not yet
+// detached. Cleanup treats it as a requeue, not a failure, so the single
+// reconcile worker is never blocked polling for detachment.
+var errVolumeStillAttached = errors.New("model cache init writer volume still attached")
+
+// volumeDetachRequeueInterval is how soon cleanup retries after finding the
+// writer volume still attached.
+const volumeDetachRequeueInterval = 2 * time.Second
 
 var primaryPVSel labels.Selector
 
@@ -54,7 +64,7 @@ func init() {
 	}
 }
 
-func (r *Reconciler) doCleanupModelCacheNVMesh(ctx context.Context, st *nvcav1new.StorageRequest) error { //nolint
+func (r *Reconciler) doCleanupModelCacheNVMesh(ctx context.Context, st *nvcav1new.StorageRequest) (reconcile.Result, error) { //nolint
 	log := logf.FromContext(ctx)
 
 	log.Info("Cleaning model cache for storage request")
@@ -69,14 +79,14 @@ func (r *Reconciler) doCleanupModelCacheNVMesh(ctx context.Context, st *nvcav1ne
 	}
 
 	var errs []error
-	errs = append(errs, r.cleanupInitModelCache(ctx, st)...)
+	errs = append(errs, r.cleanupInitModelCache(ctx, st, false)...)
 
 	cwResourceLabels := getClusterWideResourceLabels(st)
 
 	pvList := &corev1.PersistentVolumeList{}
 	if err := r.Client.List(ctx, pvList, client.MatchingLabels(cwResourceLabels)); err != nil {
 		log.Error(err, "Failed to list PVs for storage request")
-		return errors.Join(append(errs, err)...)
+		return reconcile.Result{}, errors.Join(append(errs, err)...)
 	}
 
 	pvcList := &corev1.PersistentVolumeClaimList{}
@@ -85,7 +95,7 @@ func (r *Reconciler) doCleanupModelCacheNVMesh(ctx context.Context, st *nvcav1ne
 		client.InNamespace(st.Namespace),
 	); err != nil {
 		log.Error(err, "Failed to list PVCs for storage request")
-		return errors.Join(append(errs, err)...)
+		return reconcile.Result{}, errors.Join(append(errs, err)...)
 	}
 
 	// PVC's can be deleted before pods are, and will be finalized once the pod is deleted.
@@ -109,7 +119,31 @@ func (r *Reconciler) doCleanupModelCacheNVMesh(ctx context.Context, st *nvcav1ne
 		}
 	}
 
-	if len(errs) == 0 {
+	// A still-attaching writer volume is not a failure: requeue and retry without
+	// blocking the single reconcile worker (the previous in-reconcile poll could
+	// starve every other StorageRequest, including the terminating-namespace
+	// finalizer escape hatch). Separate that sentinel from real errors.
+	var realErrs []error
+	pendingDetach := false
+	for _, e := range errs {
+		if errors.Is(e, errVolumeStillAttached) {
+			pendingDetach = true
+			continue
+		}
+		realErrs = append(realErrs, e)
+	}
+
+	if len(realErrs) == 0 && pendingDetach {
+		meta.SetStatusCondition(&st.Status.Conditions, metav1.Condition{
+			Type:    ConditionTypeCleanupSuccessful,
+			Status:  metav1.ConditionFalse,
+			Reason:  ConditionReasonSomeObjectsPendingDeletion,
+			Message: "waiting for cache init volume to detach before deleting the writer PVC",
+		})
+		return reconcile.Result{RequeueAfter: volumeDetachRequeueInterval}, nil
+	}
+
+	if len(realErrs) == 0 {
 		meta.SetStatusCondition(&st.Status.Conditions, metav1.Condition{
 			Type:    ConditionTypeCleanupSuccessful,
 			Status:  metav1.ConditionTrue,
@@ -121,17 +155,22 @@ func (r *Reconciler) doCleanupModelCacheNVMesh(ctx context.Context, st *nvcav1ne
 			Type:    ConditionTypeCleanupSuccessful,
 			Status:  metav1.ConditionFalse,
 			Reason:  ConditionReasonSomeObjectsPendingDeletion,
-			Message: fmt.Sprintf("errors encountered while cleaning up: %+q", errs),
+			Message: fmt.Sprintf("errors encountered while cleaning up: %+q", realErrs),
 		})
 	}
 
-	return errors.Join(errs...)
+	return reconcile.Result{}, errors.Join(realErrs...)
 }
 
-func (r *Reconciler) cleanupInitModelCache(ctx context.Context, st *nvcav1new.StorageRequest) (errs []error) {
+// cleanupInitModelCache deletes the init objects (job, pods, lease, pull
+// secrets, writer PV/PVC) for the request's cache handle. retainWriterPVC
+// keeps the writer RW PVC and its volume: the shared-FS backend retains the
+// bound writer claim as the durable populated marker, but its init job and
+// lease still must not accumulate per cache handle.
+func (r *Reconciler) cleanupInitModelCache(ctx context.Context, st *nvcav1new.StorageRequest, retainWriterPVC bool) (errs []error) {
 	log := logf.FromContext(ctx)
 
-	log.V(1).Info("Cleaning up model cache init objects")
+	log.V(1).Info("Cleaning up model cache init objects", "retainWriterPVC", retainWriterPVC)
 
 	listOpts := []client.ListOption{
 		client.MatchingLabels(map[string]string{
@@ -183,34 +222,59 @@ func (r *Reconciler) cleanupInitModelCache(ctx context.Context, st *nvcav1new.St
 		}
 	}
 
-	// Delete the RW PVC once all Pods are deleted.
-	pvcList := &corev1.PersistentVolumeClaimList{}
-	if err := r.Client.List(ctx, pvcList, listOpts...); err != nil {
-		log.Error(err, "RW PVC list failed, manual cleanup needed")
-		errs = append(errs, err)
-	}
-	switch l := len(pvcList.Items); l {
-	case 0:
-	case 1:
-		pvc := pvcList.Items[0]
-		if pvc.DeletionTimestamp == nil {
-			if pvc.Spec.VolumeName != "" {
-				if err := r.waitForVolumeDetach(ctx, pvc.Spec.VolumeName); err != nil {
-					log.Error(err, "Failed during wait for PV detachment", "pv", pvc.Spec.VolumeName)
-					errs = append(errs, err)
+	if !retainWriterPVC {
+		// Delete the RW PVC once all Pods are deleted.
+		pvcList := &corev1.PersistentVolumeClaimList{}
+		if err := r.Client.List(ctx, pvcList, listOpts...); err != nil {
+			log.Error(err, "RW PVC list failed, manual cleanup needed")
+			errs = append(errs, err)
+		}
+		switch l := len(pvcList.Items); l {
+		case 0:
+		case 1:
+			pvc := pvcList.Items[0]
+			if pvc.DeletionTimestamp == nil {
+				// Delete the RW PVC only once its volume has detached, but NEVER block
+				// the single reconcile worker polling for it: a single-shot check that
+				// returns a requeue sentinel when still attached (see isVolumeDetached).
+				deletePVC := true
+				if pvc.Spec.VolumeName != "" {
+					detached, err := r.isVolumeDetached(ctx, pvc.Spec.VolumeName)
+					switch {
+					case err != nil:
+						log.Error(err, "Failed to check PV detachment", "pv", pvc.Spec.VolumeName)
+						errs = append(errs, err)
+						deletePVC = false
+					case !detached:
+						log.V(1).Info("Init RW PVC volume still attached, will requeue", "pv", pvc.Spec.VolumeName)
+						errs = append(errs, errVolumeStillAttached)
+						deletePVC = false
+					}
+				}
+				if deletePVC {
+					log.V(1).Info("Deleting model cache init RW PVC", "pvc", pvc.Name)
+					if err := r.Client.Delete(ctx, &pvc); err != nil && !apierrors.IsNotFound(err) {
+						log.Error(err, "Init RW PVC delete failed, manual cleanup needed", "pvc", pvc.Name)
+						errs = append(errs, err)
+					}
 				}
 			}
-
-			log.V(1).Info("Deleting model cache init RW PVC", "pvc", pvc.Name)
-			if err := r.Client.Delete(ctx, &pvc); err != nil && !apierrors.IsNotFound(err) {
-				log.Error(err, "Init RW PVC delete failed, manual cleanup needed", "pvc", pvc.Name)
-				errs = append(errs, err)
-			}
+		default:
+			// This should never happen, but log it in case there's a bug.
+			log.Error(fmt.Errorf("unexpected number of init RW PVCs"),
+				"Found more than one PVC to delete", "found", l)
 		}
-	default:
-		// This should never happen, but log it in case there's a bug.
-		log.Error(fmt.Errorf("unexpected number of init RW PVCs"),
-			"Found more than one PVC to delete", "found", l)
+
+		// The Samba writer binds a static plumbing SMB PV; delete it with the writer
+		// PVC. Static PVs have no provisioner, so a Released one leaks forever, and
+		// its stale claimRef would block a later writer PVC from re-binding.
+		// NotFound is the normal case for the other backends.
+		sambaWriterPV := &corev1.PersistentVolume{}
+		sambaWriterPV.Name = sambaModelCacheWriterPVName(st.Spec.ModelCache.CacheHandle)
+		if err := r.Client.Delete(ctx, sambaWriterPV); err != nil && !apierrors.IsNotFound(err) {
+			log.Error(err, "Samba writer PV delete failed, manual cleanup needed", "pv", sambaWriterPV.Name)
+			errs = append(errs, err)
+		}
 	}
 
 	// Finally delete the rest. Do not fail on these.
@@ -357,6 +421,8 @@ func (r *Reconciler) cleanupIdleModelCaches(ctx context.Context) error { //nolin
 			// so the primary volume be deleted.
 			if err := r.Client.Delete(ctx, pv); err != nil && !apierrors.IsNotFound(err) {
 				log.Error(err, "Failed to delete PV, manual cleanup needed")
+			} else {
+				r.metrics.RecordModelCacheReclaimed(string(HelmCacheBackendNVMesh))
 			}
 			// Second pass GC: delete now-deleted PV's.
 			if pv.Labels != nil {
@@ -365,7 +431,150 @@ func (r *Reconciler) cleanupIdleModelCaches(ctx context.Context) error { //nolin
 		}
 	}
 
+	// Refresh the NVMesh inventory gauge (primary PVs are NVMesh-only).
+	r.metrics.SetModelCacheBackendCount(string(HelmCacheBackendNVMesh), len(pvs.Items))
+
+	// Samba caches key reuse on a per-handle backing PVC, not an NVMesh primary
+	// PV, so they are reclaimed separately (and set the Samba gauge there).
+	if err := r.reclaimIdleSambaModelCaches(ctx, stList); err != nil {
+		log.Error(err, "Failed to reclaim idle Samba model caches")
+	}
+
+	// Shared-FS caches retain the writer PVC as the durable backing store; it
+	// has no primary PV, so it too is reclaimed by its own pass.
+	if err := r.reclaimIdleSharedFSModelCaches(ctx, stList); err != nil {
+		log.Error(err, "Failed to reclaim idle shared-FS model caches")
+	}
+
 	return nil
+}
+
+// reclaimIdleSharedFSModelCaches deletes retained shared-FS writer PVCs (the
+// durable per-handle backing claim on the shared class) for cacheHandles that
+// no active StorageRequest references and that have been idle past the
+// model-cache idle period. Samba backing PVCs also carry the populated label
+// but are reclaimed with their per-handle server by reclaimIdleSambaModelCaches.
+func (r *Reconciler) reclaimIdleSharedFSModelCaches(ctx context.Context, stList *nvcav1new.StorageRequestList) error {
+	log := logf.FromContext(ctx)
+
+	activeHandles := sets.New[string]()
+	for _, st := range stList.Items {
+		if st.DeletionTimestamp != nil || st.Spec.ModelCache == nil {
+			continue
+		}
+		if h := st.Spec.ModelCache.CacheHandle; h != "" {
+			activeHandles.Insert(h)
+		}
+	}
+
+	pvcs := &corev1.PersistentVolumeClaimList{}
+	if err := r.Client.List(ctx, pvcs,
+		client.InNamespace(ModelCacheInitNamespace),
+		client.MatchingLabels{cachePopulatedLabelKey: cachePopulatedLabelValue},
+	); err != nil {
+		return err
+	}
+
+	now := r.nowFunc()
+	count := 0
+	var errs []error
+	for i := range pvcs.Items {
+		pvc := &pvcs.Items[i]
+		if pvc.Labels[sambaModelCacheComponentLabelKey] == sambaModelCacheComponentLabelValue {
+			continue
+		}
+		handle := pvc.Labels[modelCacheHandleLabelKey]
+		if handle == "" {
+			continue
+		}
+		count++
+		if activeHandles.Has(handle) {
+			continue
+		}
+		// No last-referenced annotation yet means no consumer has attached since
+		// populate; treat as active rather than reclaiming a cache mid-rollout.
+		lastRefStr, ok := pvc.Annotations[primaryPVLastReferencedAnnotationKey]
+		if !ok {
+			continue
+		}
+		lastRef, err := time.Parse(primaryPVLastReferencedTimeFormat, lastRefStr)
+		if err != nil {
+			log.Error(err, "Failed to parse shared-FS writer PVC last-referenced time", "pvc", pvc.Name)
+			continue
+		}
+		if lastRef.Add(r.k8sTimeConfig.ModelCacheIdlePeriod).After(now) {
+			continue
+		}
+		log.Info("Reclaiming idle shared-FS model cache", "cacheHandle", handle, "pvc", pvc.Name)
+		if err := r.Client.Delete(ctx, pvc); err != nil && !apierrors.IsNotFound(err) {
+			errs = append(errs, err)
+			continue
+		}
+		r.metrics.RecordModelCacheReclaimed(string(HelmCacheBackendSharedFS))
+	}
+	r.metrics.SetModelCacheBackendCount(string(HelmCacheBackendSharedFS), count)
+	return errors.Join(errs...)
+}
+
+// reclaimIdleSambaModelCaches deletes the per-handle Samba server + backing PVC
+// for cacheHandles that no active StorageRequest references and that have been
+// idle past the model-cache idle period. Samba caches key reuse on the backing
+// PVC (samba-<handle>) rather than an NVMesh primary PV, so they are GC'd here
+// rather than by the primary-PV pass above.
+func (r *Reconciler) reclaimIdleSambaModelCaches(ctx context.Context, stList *nvcav1new.StorageRequestList) error {
+	log := logf.FromContext(ctx)
+
+	activeHandles := sets.New[string]()
+	for _, st := range stList.Items {
+		if st.DeletionTimestamp != nil || st.Spec.ModelCache == nil {
+			continue
+		}
+		if h := st.Spec.ModelCache.CacheHandle; h != "" {
+			activeHandles.Insert(h)
+		}
+	}
+
+	pvcs := &corev1.PersistentVolumeClaimList{}
+	if err := r.Client.List(ctx, pvcs,
+		client.InNamespace(ModelCacheInitNamespace),
+		client.MatchingLabels{sambaModelCacheComponentLabelKey: sambaModelCacheComponentLabelValue},
+	); err != nil {
+		return err
+	}
+	// Refresh the inventory gauge: how many Samba backing PVCs (= per-handle
+	// Samba servers) currently exist.
+	r.metrics.SetModelCacheBackendCount(string(HelmCacheBackendSamba), len(pvcs.Items))
+
+	now := r.nowFunc()
+	var errs []error
+	for i := range pvcs.Items {
+		pvc := &pvcs.Items[i]
+		handle := pvc.Annotations[sambaModelCacheHandleAnnotationKey]
+		if handle == "" || activeHandles.Has(handle) {
+			continue
+		}
+		// A backing PVC with no last-referenced annotation yet (writer still
+		// populating) is treated as active and not reclaimed.
+		lastRefStr, ok := pvc.Annotations[primaryPVLastReferencedAnnotationKey]
+		if !ok {
+			continue
+		}
+		lastRef, err := time.Parse(primaryPVLastReferencedTimeFormat, lastRefStr)
+		if err != nil {
+			log.Error(err, "Failed to parse Samba backing PVC last-referenced time", "pvc", pvc.Name)
+			continue
+		}
+		if lastRef.Add(r.k8sTimeConfig.ModelCacheIdlePeriod).After(now) {
+			continue
+		}
+		log.Info("Reclaiming idle Samba model cache", "cacheHandle", handle, "pvc", pvc.Name)
+		if err := DeleteSambaModelCacheInfra(ctx, r.Client, handle); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		r.metrics.RecordModelCacheReclaimed(string(HelmCacheBackendSamba))
+	}
+	return errors.Join(errs...)
 }
 
 func deleteStorageClassIfEncrypted(ctx context.Context, c client.Client, scName string) {

--- a/src/compute-plane-services/nvca/pkg/storage/modelcache_test.go
+++ b/src/compute-plane-services/nvca/pkg/storage/modelcache_test.go
@@ -19,8 +19,10 @@ package storage
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"maps"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,17 +31,22 @@ import (
 	nvcaconfig "github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/types/nvca/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	coordv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	nvcaenvtest "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/envtest"
 	modelcachetypes "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/metrics/modelcachetypes"
@@ -47,6 +54,7 @@ import (
 	nvcav1new "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/v1"
 	nvcav2beta1 "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/v2beta1"
 	featureflagmock "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/featureflag/mock"
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/storage/cacheprobe"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/types"
 )
 
@@ -64,6 +72,9 @@ func TestReconcile_ModelCache(t *testing.T) {
 		BaseContext:             func() context.Context { return ctx },
 		WebhookServer:           nvcaenvtest.NewFakeWebhookServer(),
 		Metrics:                 nvcaenvtest.NewFakeMetricsOptions(),
+		// Two model-cache envtests run in one process; the controller name
+		// "modelcache" is otherwise globally unique per controller-runtime.
+		Controller: ctrlconfig.Controller{SkipNameValidation: newBool(true)},
 	})
 	require.NoError(t, err)
 
@@ -89,46 +100,7 @@ func TestReconcile_ModelCache(t *testing.T) {
 	require.NoError(t, err)
 
 	cacheHandle := "abc123handle"
-	srSpec := nvcav2beta1.ICMSRequestSpec{
-		FunctionDetails: function.Details{
-			FunctionID:        "funcid-1",
-			FunctionVersionID: "funcverid-1",
-			FunctionType:      "DEFAULT",
-		},
-		Action:         common.FunctionCreationAction,
-		NCAId:          "ncaid-1",
-		RequestID:      "reqid1",
-		MessageBatchID: "mbatchid1",
-		CreationMsgInfo: nvcav2beta1.ICMSCreationMessageInfo{
-			CreationQueueMessageMetadata: common.CreationQueueMessageMetadata{
-				Action:            common.FunctionCreationAction,
-				RequestID:         "reqid1",
-				MessageBatchID:    "mbatchid1",
-				InstanceType:      "ON-PREM.GPU.L40",
-				InstanceTypeName:  "ON-PREM.GPU.L40_1x",
-				InstanceTypeValue: "ON-PREM.GPU.L40",
-				GPUType:           "L40",
-				RequestedGPUCount: 1,
-				InstanceCount:     1,
-				NCAID:             "ncaid-1",
-			},
-			FunctionLaunchSpecification: &function.LaunchSpecification{
-				CloudProvider:   "DGXCLOUD",
-				ICMSEnvironment: "prod",
-				GPUName:         "L40",
-				EnvironmentB64:  "QVRUQUNIRURfR1BVX0NPVU5UPSIxIgpCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUj1udmNyLmlvL3F0ZnB0MWgwYmlldS9udmNmLWNvcmUvYnlvby1vdGVsLWNvbGxlY3RvcjoxLjIuMwpDTE9VRF9QUk9WSURFUj1PTi1QUkVNCkVTU19BR0VOVF9DT05UQUlORVI9bnZjci5pby9udi1jZi9udmNmLWNvcmUvZXNzLWFnZW50OjEuMC4wCkZVTkNUSU9OX0lEPTVhM2Q0YTdlLTllZTMtNDc2Mi04ZDM3LWQzYjQwYTZmODRjNgpGVU5DVElPTl9OQU1FPW15LWZ1bmMKRlVOQ1RJT05fVkVSU0lPTl9JRD0yYzk0OGQ5Yi1kYjVkLTRmOTMtOGMyOS1mNWQ4YTVkODljYjkKR1BVX05BTUU9TDQwCkhFTE1fQ0hBUlRfSU5GRVJFTkNFX1NFUlZJQ0VfTkFNRT1teXNlcnZpY2UKQ09OVEFJTkVSX1JFR0lTVFJJRVNfQ1JFREVOVElBTFM9ZXlKck9ITlRaV055WlhSeklqcGJleUpoZFhSb2N5STZleUp1ZG1OeUxtbHZJanA3SW1GMWRHZ2lPaUpqTTFKdVRGZEdhVmw2UlhsTmVtOHlXbXBaZWs1SFVUUk9VekExVFhwR2JFeFVVWGhhYWxsMFdWUktiRmw1TURKT01razBUbnBWZDFwcVJYbE9NbFU5SW4xOWZWMTkKSU5GRVJFTkNFX0NPTlRBSU5FUl9FTlY9VzNzaWEyVjVJam9pU1U1R1JWSkZUa05GWDBWT1ZsOUxSVmtpTENKMllXeDFaU0k2SW1sdVptVnlaVzVqWlY5MllXeDFaU0o5WFE9PQpJTkZFUkVOQ0VfSEVBTFRIX0VORFBPSU5UPS92Mi9oZWFsdGgvcmVhZHkKSU5GRVJFTkNFX0hFQUxUSF9FWFBFQ1RFRF9SRVNQT05TRV9DT0RFPSIyMDAiCklORkVSRU5DRV9IRUFMVEhfUE9SVD0iNTAwNTEiCklORkVSRU5DRV9QT1JUPSI1MDA1MSIKSU5GRVJFTkNFX1BST1RPQ09MPUdSUEMKSU5GRVJFTkNFX1VSTD0vZ3JwYwpJTklUX0NPTlRBSU5FUj1udmNyLmlvL3F0ZnB0MWgwYmlldS9udmNmLWNvcmUvbnZjZl93b3JrZXJfaW5pdDowLjI0LjEwCk1BWF9SRVFVRVNUX0NPTkNVUlJFTkNZPSIxIgpOQ0FfSUQ9X2xJTFhCLTFOZk5tQm5RU2tfc3BxVldPdENBWFFtNTBVRU13ajNUUmd5bUpKMkF5dXdjZ3hxCk5WQ0ZfRlFETj1odHRwczovL3VzLXdlc3QtMi5hcGkubnZjZi5udmlkaWEuY29tCk5WQ0ZfRlFETl9HUlBDPWh0dHBzOi8vZ3JwYy5hcGkubnZjZi5udmlkaWEuY29tCk5WQ0ZfRlFETl9OQVRTPXRsczovL3VzLXdlc3QtMi5hd3MuY2xvdWQubmF0cy5udmNmLm52aWRpYS5jb206NDIyMgpOVkNGX1dPUktFUl9UT0tFTj10b2sKT1RFTF9DT05UQUlORVI9bnZjci5pby9xdGZwdDFoMGJpZXUvbnZjZi1jb3JlL29wZW50ZWxlbWV0cnktY29sbGVjdG9yOjAuNzQuMApPVEVMX0VYUE9SVEVSX09UTFBfRU5EUE9JTlQ9aHR0cHM6Ly9wcm9kLm90ZWwua2FpemVuLm52aWRpYS5jb206ODI4MgpTRUNSRVRTX0FTU0VSVElPTl9UT0tFTj1leUpoYkdjaU9pSlNVekkxTmlJc0luUjVjQ0k2SWtwWFZDSjkuZXlKemRXSWlPaUl4TWpNME5UWTNPRGt3SWl3aWJtRnRaU0k2SWtwdmFHNGdSRzlsSWl3aVlYTnpaWEowYVc5dUlqcDdJbk5sWTNKbGRGQmhkR2h6SWpwYkltRmpZMjkxYm5SekwxOXNTVXhZUWkweFRtWk9iVUp1VVZOclgzTndjVlpYVDNSRFFWaFJiVFV3VlVWTmQyb3pWRkpuZVcxS1NqSkJlWFYzWTJkNGNTOTBaV3hsYldWMGNua3ZObVpoT0RNMk5tVXROMkpoTWkwME1UUXpMV0UzTkRRdE56VXhOV1poWmpsaVpqY3lJaXdpWVdOamIzVnVkSE12WDJ4SlRGaENMVEZPWms1dFFtNVJVMnRmYzNCeFZsZFBkRU5CV0ZGdE5UQlZSVTEzYWpOVVVtZDViVXBLTWtGNWRYZGpaM2h4TDNSbGJHVnRaWFJ5ZVM4MlptRTRNelkyWlMwM1ltRXlMVFF4TkRNdFlUYzBOQzAzTlRFMVptRm1PV0ptT0RFaVhYMHNJbUZrYldsdUlqcDBjblZsTENKcFlYUWlPakUxTVRZeU16a3dNako5LlNwUVliRmUxbmZyUTVLc2hSbHk5U1VDMjZXX2oycFFoNkRNaW5zYnJzUUh2S2cxc2Uyb0gzVnpvaW5iTWJRel81TFhjZy1YTmt4NGNOSk4yQWp1d1VJems2RElVTElDSGVxdWpxLXhBYWdGUjhfejI1bzExZDAxekJTNU54RjlBQ2d0SWw2OWRoVEhrOHNLMmVRYjRBRkdDRmZmNjFqMGtYYWJJWUVTR0p4ZHY5UmtOZld0WVotRm1JYzl1RjRqWTU5elIxRUJkWGlsY2NjUjBSaUN2S0FsVFlvckU3VGotMDRLZ1RGbnZRYm1QMFRRR1FkNnhicWRBYVBSQnBYeUJHMDRxbUEyOTZUZnJBT1ZfMDJhSWR0akhhNVNqbXZ0UEFiVmVIVlY1QnhfWmQ4eVZteU4wZTdxZWduQU9xYzVOUDNrRjM4VzRuV2hURThWa05UWmpUUEEKU0lERUNBUl9SRUdJU1RSWV9DUkVERU5USUFMPWV5SmhkWFJvY3lJNmV5SnVkbU55TG1sdklqcDdJbUYxZEdnaU9pSktSemxvWkZoU2IyUkhPWEphVnpRMlltNWFhR05IYTNSak0xSnVURmRHYVZsNlJYbE5kejA5SW4xOWZRbz0KVFJBQ0lOR19BQ0NFU1NfVE9LRU49dHJhY2UtdG9rLTEKVVRJTFNfQ09OVEFJTkVSPW52Y3IuaW8vcXRmcHQxaDBiaWV1L252Y2YtY29yZS9udmNmX3dvcmtlcl91dGlsczoyLjIxLjQKSEVMTV9SRUdJU1RSSUVTX0NSRURFTlRJQUxTPWV5SnJPSE5UWldOeVpYUnpJanBiZXlKaGRYUm9jeUk2ZXlKb1pXeHRMbTVuWXk1dWRtbGthV0V1WTI5dElqcDdJbUYxZEdnaU9pSmpNMUp1VEZkR2FWbDZSWGxOZW04eVdtcFplazVIVVRST1V6QTFUWHBHYkV4VVVYaGFhbGwwV1ZSS2JGbDVNREpPTWtrMFRucFZkMXBxUlhsT01sVTlJbjE5ZlYxOQo=",
-				HelmChartLaunchSpecification: &common.HelmChartLaunchSpecification{
-					HelmChartURL: "https://helm.ngc.nvidia.com/myorg/myteam/charts/image-segmentation-1.0.3.tgz",
-					Values:       []byte(`{"foo":{"bar":"baz"}}`),
-				},
-				CacheLaunchSpecification: &common.CacheLaunchSpecification{
-					CacheArtifacts: true,
-					CacheHandle:    cacheHandle,
-					CacheSize:      262144000,
-				},
-			},
-		},
-	}
+	srSpec := newModelCacheICMSSpec(cacheHandle)
 
 	sts := []*nvcav1new.StorageRequest{}
 	for i := range 3 {
@@ -731,4 +703,672 @@ func TestMapPodIssuesToFailureReason(t *testing.T) {
 			assert.Equal(t, tt.expectedReason, result)
 		})
 	}
+}
+
+// newModelCacheLaunchEnvB64 builds the encoded launch env consumed by the
+// model cache envtests at runtime. The registry credentials and assertion
+// token are synthetic and assembled here instead of being committed as an
+// encoded blob, which secret scanners flag even for fake values.
+func newModelCacheLaunchEnvB64() string {
+	b64 := func(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
+	registryCreds := b64(`{"k8sSecrets":[{"auths":{"nvcr.io":{"auth":"` + b64("stg-user:fake-registry-password") + `"}}}]}`)
+	helmCreds := b64(`{"k8sSecrets":[{"auths":{"helm.ngc.nvidia.com":{"auth":"` + b64("stg-user:fake-registry-password") + `"}}}]}`)
+	sidecarCred := b64(`{"auths":{"nvcr.io":{"auth":"` + b64("$oauthtoken:fake-sidecar-token") + `"}}}`)
+
+	env := strings.Join([]string{
+		`ATTACHED_GPU_COUNT="1"`,
+		"BYOO_OTEL_COLLECTOR_CONTAINER=nvcr.io/qtfpt1h0bieu/nvcf-core/byoo-otel-collector:1.2.3",
+		"CLOUD_PROVIDER=ON-PREM",
+		"ESS_AGENT_CONTAINER=nvcr.io/nv-cf/nvcf-core/ess-agent:1.0.0",
+		"FUNCTION_ID=5a3d4a7e-9ee3-4762-8d37-d3b40a6f84c6",
+		"FUNCTION_NAME=my-func",
+		"FUNCTION_VERSION_ID=2c948d9b-db5d-4f93-8c29-f5d8a5d89cb9",
+		"GPU_NAME=L40",
+		"HELM_CHART_INFERENCE_SERVICE_NAME=myservice",
+		"CONTAINER_REGISTRIES_CREDENTIALS=" + registryCreds,
+		"INFERENCE_CONTAINER_ENV=" + b64(`[{"key":"INFERENCE_ENV_KEY","value":"inference_value"}]`),
+		"INFERENCE_HEALTH_ENDPOINT=/v2/health/ready",
+		`INFERENCE_HEALTH_EXPECTED_RESPONSE_CODE="200"`,
+		`INFERENCE_HEALTH_PORT="50051"`,
+		`INFERENCE_PORT="50051"`,
+		"INFERENCE_PROTOCOL=GRPC",
+		"INFERENCE_URL=/grpc",
+		"INIT_CONTAINER=nvcr.io/qtfpt1h0bieu/nvcf-core/nvcf_worker_init:0.24.10",
+		`MAX_REQUEST_CONCURRENCY="1"`,
+		"NCA_ID=_lILXB-1NfNmBnQSk_spqVWOtCAXQm50UEMwj3TRgymJJ2Ayuwcgxq",
+		"NVCF_FQDN=https://us-west-2.api.nvcf.nvidia.com",
+		"NVCF_FQDN_GRPC=https://grpc.api.nvcf.nvidia.com",
+		"NVCF_FQDN_NATS=tls://us-west-2.aws.cloud.nats.nvcf.nvidia.com:4222",
+		"NVCF_WORKER_TOKEN=tok",
+		"OTEL_CONTAINER=nvcr.io/qtfpt1h0bieu/nvcf-core/opentelemetry-collector:0.74.0",
+		"OTEL_EXPORTER_OTLP_ENDPOINT=https://prod.otel.kaizen.nvidia.com:8282",
+		"SECRETS_ASSERTION_TOKEN=fake-assertion-token",
+		"SIDECAR_REGISTRY_CREDENTIAL=" + sidecarCred,
+		"TRACING_ACCESS_TOKEN=trace-tok-1",
+		"UTILS_CONTAINER=nvcr.io/qtfpt1h0bieu/nvcf-core/nvcf_worker_utils:2.21.4",
+		"HELM_REGISTRIES_CREDENTIALS=" + helmCreds,
+	}, "\n")
+	return b64(env)
+}
+
+// newModelCacheICMSSpec returns the ICMS request spec used by the model cache
+// envtests (NVMesh and shared-FS). The EnvironmentB64 carries the encoded
+// launch env from which the writer job and cache PVC are decoded.
+func newModelCacheICMSSpec(cacheHandle string) nvcav2beta1.ICMSRequestSpec {
+	return nvcav2beta1.ICMSRequestSpec{
+		FunctionDetails: function.Details{
+			FunctionID:        "funcid-1",
+			FunctionVersionID: "funcverid-1",
+			FunctionType:      "DEFAULT",
+		},
+		Action:         common.FunctionCreationAction,
+		NCAId:          "ncaid-1",
+		RequestID:      "reqid1",
+		MessageBatchID: "mbatchid1",
+		CreationMsgInfo: nvcav2beta1.ICMSCreationMessageInfo{
+			CreationQueueMessageMetadata: common.CreationQueueMessageMetadata{
+				Action:            common.FunctionCreationAction,
+				RequestID:         "reqid1",
+				MessageBatchID:    "mbatchid1",
+				InstanceType:      "ON-PREM.GPU.L40",
+				InstanceTypeName:  "ON-PREM.GPU.L40_1x",
+				InstanceTypeValue: "ON-PREM.GPU.L40",
+				GPUType:           "L40",
+				RequestedGPUCount: 1,
+				InstanceCount:     1,
+				NCAID:             "ncaid-1",
+			},
+			FunctionLaunchSpecification: &function.LaunchSpecification{
+				CloudProvider:   "DGXCLOUD",
+				ICMSEnvironment: "prod",
+				GPUName:         "L40",
+				EnvironmentB64:  newModelCacheLaunchEnvB64(),
+				HelmChartLaunchSpecification: &common.HelmChartLaunchSpecification{
+					HelmChartURL: "https://helm.ngc.nvidia.com/myorg/myteam/charts/image-segmentation-1.0.3.tgz",
+					Values:       []byte(`{"foo":{"bar":"baz"}}`),
+				},
+				CacheLaunchSpecification: &common.CacheLaunchSpecification{
+					CacheArtifacts: true,
+					CacheHandle:    cacheHandle,
+					CacheSize:      262144000,
+				},
+			},
+		},
+	}
+}
+
+// TestReconcile_ModelCacheSharedFS drives the shared-FS (nvcf-miniservice-sc) populate
+// path: the cache is populated once via the single-writer init job (no NVMesh
+// primary/secondary PV), then a per-namespace read-only PVC on the shared class
+// is created and the request becomes Ready. The CSI probe is pre-seeded as ROX
+// so the path does not attempt a live probe under envtest.
+func TestReconcile_ModelCacheSharedFS(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	cfg, _, cleanup, err := nvcaenvtest.SetupEnvtest()
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	mgr, err := ctrl.NewManager(cfg, manager.Options{
+		Scheme:                  mgrScheme,
+		GracefulShutdownTimeout: new(time.Duration),
+		BaseContext:             func() context.Context { return ctx },
+		WebhookServer:           nvcaenvtest.NewFakeWebhookServer(),
+		Metrics:                 nvcaenvtest.NewFakeMetricsOptions(),
+		// Two model-cache envtests run in one process; the controller name
+		// "modelcache" is otherwise globally unique per controller-runtime.
+		Controller: ctrlconfig.Controller{SkipNameValidation: newBool(true)},
+	})
+	require.NoError(t, err)
+
+	defaultTimeConfig := (&k8sutil.TimeConfig{}).Complete()
+	err = BuildController(nvcaconfig.Config{}, nvcav1new.ModelCacheRequest, mgr, "my-cluster", "us-west-1", defaultTimeConfig, ControllerOptions{})
+	require.NoError(t, err)
+
+	mgrErrCh, err := nvcaenvtest.StartManager(ctx, mgr)
+	require.NoError(t, err)
+
+	cctx, ccancel := context.WithTimeout(context.Background(), 5*time.Second)
+	mgr.GetCache().WaitForCacheSync(cctx)
+	ccancel()
+
+	c := mgr.GetClient()
+
+	srNamespace := &corev1.Namespace{}
+	srNamespace.Name = types.DefaultICMSRequestNamespace
+	require.NoError(t, c.Create(ctx, srNamespace))
+	require.NoError(t, c.Create(ctx, NewModelCacheInitNamespace()))
+
+	// The shared class exists (operator- or Samba-provided) and its reader
+	// access mode is pre-resolved to ROX so resolveSharedFSStrategy does not
+	// run a live probe.
+	require.NoError(t, c.Create(ctx, &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: HelmCacheSharedStorageClassName},
+		Provisioner: SMBCSIDriverName,
+	}))
+	store := cacheprobe.NewStateStore(c, ModelCacheInitNamespace)
+	require.NoError(t, store.Save(ctx, map[string]cacheprobe.Result{
+		cacheprobe.ResultKey(HelmCacheSharedStorageClassName, cacheprobe.StrategyROX): {
+			State: cacheprobe.StateSupported,
+		},
+	}))
+
+	cacheHandle := "sharedfshandle"
+	workloadNS := &corev1.Namespace{}
+	workloadNS.Name = "sr-sharedfs"
+	require.NoError(t, c.Create(ctx, workloadNS))
+
+	sr := &nvcav2beta1.ICMSRequest{}
+	sr.Name, sr.Namespace = workloadNS.Name, srNamespace.Name
+	sr.Spec = newModelCacheICMSSpec(cacheHandle)
+	require.NoError(t, c.Create(ctx, sr))
+
+	st := &nvcav1new.StorageRequest{}
+	st.Name, st.Namespace = nvcav1new.ModelCacheRequest.Name(), workloadNS.Name
+	st.Spec.Type = nvcav1new.ModelCacheRequest
+	st.Spec.ICMSRequestName = sr.Name
+	st.Spec.ICMSRequestNamespace = srNamespace.Name
+	st.Spec.ModelCache = &nvcav1new.ModelCacheSpec{
+		CacheHandle: cacheHandle,
+		Backend:     string(HelmCacheBackendSharedFS),
+	}
+	require.NoError(t, c.Create(ctx, st))
+
+	// The writer job is created on the shared backend.
+	initJob := &batchv1.Job{}
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		err := c.Get(ctx, client.ObjectKey{Name: "writer-job-" + cacheHandle, Namespace: ModelCacheInitNamespace}, initJob)
+		assert.NoError(ct, err)
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// The writer RW PVC is on the shared class, not an NVMesh class.
+	rwPVC := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: "rw-pvc-" + cacheHandle, Namespace: ModelCacheInitNamespace}, rwPVC))
+	if assert.NotNil(t, rwPVC.Spec.StorageClassName) {
+		assert.Equal(t, HelmCacheSharedStorageClassName, *rwPVC.Spec.StorageClassName)
+	}
+
+	// Drive the writer job to "started" so the request moves to InitRunning.
+	initJobPod := &corev1.Pod{}
+	initJobPod.Name, initJobPod.Namespace = initJob.Spec.Template.Name+"-foobar", initJob.Namespace
+	initJobPod.Labels = make(map[string]string, len(initJob.Spec.Template.Labels))
+	maps.Copy(initJobPod.Labels, initJob.Spec.Template.Labels)
+	maps.Copy(initJobPod.Labels, initJob.Spec.Selector.MatchLabels)
+	initJobPod.Annotations = initJob.Spec.Template.Annotations
+	initJobPod.Spec = initJob.Spec.Template.Spec
+	require.NoError(t, c.Create(ctx, initJobPod))
+	initJobPod.Status = corev1.PodStatus{Phase: corev1.PodRunning}
+	require.NoError(t, c.Status().Update(ctx, initJobPod))
+
+	initJob.Status.StartTime = &metav1.Time{Time: time.Now().Add(-1 * time.Minute)}
+	require.NoError(t, c.Status().Update(ctx, initJob))
+
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		err := c.Get(ctx, client.ObjectKeyFromObject(st), st)
+		if assert.NoError(ct, err) {
+			assert.Equal(ct, nvcav1new.StorageInitRunning, st.Status.Phase)
+		}
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// Bind the writer RW PVC and complete the job: shared-FS keeps the writer
+	// claim (no primary PV finalize) and moves to Creating.
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(rwPVC), rwPVC))
+	rwPVC.Status.Phase = corev1.ClaimBound
+	require.NoError(t, c.Status().Update(ctx, rwPVC))
+
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(initJob), initJob))
+	initJob.Status.Succeeded++
+	initJob.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+	initJob.Status.Conditions = append(initJob.Status.Conditions,
+		batchv1.JobCondition{Type: batchv1.JobSuccessCriteriaMet, Status: corev1.ConditionTrue},
+		batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
+	)
+	require.NoError(t, c.Status().Update(ctx, initJob))
+
+	// A read-only reader PVC is created in the workload namespace on the shared
+	// class with the probed ROX access mode.
+	roPVC := &corev1.PersistentVolumeClaim{}
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		err := c.Get(ctx, client.ObjectKey{Name: "ro-pvc-" + cacheHandle, Namespace: workloadNS.Name}, roPVC)
+		assert.NoError(ct, err)
+	}, 5*time.Second, 50*time.Millisecond)
+	if assert.NotNil(t, roPVC.Spec.StorageClassName) {
+		assert.Equal(t, HelmCacheSharedStorageClassName, *roPVC.Spec.StorageClassName)
+	}
+	assert.Equal(t, []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany}, roPVC.Spec.AccessModes)
+
+	// Shared-FS does not create cross-namespace primary/secondary PVs.
+	secondaryPV := &corev1.PersistentVolume{}
+	err = c.Get(ctx, client.ObjectKey{Name: "secondary-pv-" + st.Name}, secondaryPV)
+	assert.True(t, apierrors.IsNotFound(err), "shared-FS must not create a secondary PV")
+
+	// Bind the reader PVC: the request becomes Ready and exposes the RO PVC.
+	roPVC.Status.Phase = corev1.ClaimBound
+	require.NoError(t, c.Status().Update(ctx, roPVC))
+
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		err := c.Get(ctx, client.ObjectKeyFromObject(st), st)
+		if assert.NoError(ct, err) {
+			assert.Equal(ct, nvcav1new.StorageReady, st.Status.Phase)
+			if assert.NotNil(ct, st.Status.ModelCache) {
+				assert.Equal(ct, "ro-pvc-"+cacheHandle, st.Status.ModelCache.ROPVCName)
+			}
+		}
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// After population the init job and lease are torn down (partial cleanup)
+	// while the writer PVC is retained as the durable populated marker.
+	lease := &coordv1.Lease{}
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		leaseErr := c.Get(ctx, client.ObjectKey{Name: buildInitLeaseName(cacheHandle), Namespace: ModelCacheInitNamespace}, lease)
+		assert.True(ct, apierrors.IsNotFound(leaseErr), "init lease must be deleted after shared-FS population")
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// envtest runs no GC controller, so a foreground-deleted Job lingers with a
+	// deletion timestamp; deletion having been initiated is the signal.
+	gotJob := &batchv1.Job{}
+	switch jobErr := c.Get(ctx, client.ObjectKeyFromObject(initJob), gotJob); {
+	case apierrors.IsNotFound(jobErr):
+	default:
+		require.NoError(t, jobErr)
+		assert.NotNil(t, gotJob.DeletionTimestamp, "init job deletion must be initiated after shared-FS population")
+	}
+
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(rwPVC), rwPVC))
+	assert.Nil(t, rwPVC.DeletionTimestamp, "writer PVC must be retained as the populated marker")
+
+	require.NoError(t, c.Delete(ctx, st))
+	cancel()
+	<-mgrErrCh
+}
+
+// TestReconcile_ModelCacheSamba drives the Samba (backend 3) path and asserts it
+// follows the NVMesh lifecycle, differing only in the backing store. The first
+// namespace populates the cache via the single-writer init job; on success the
+// static SMB RW PV is retained as the durable primary-PV marker and the writer
+// job/PVC/lease are torn down. A second namespace with the same handle then
+// binds its own RO reader purely from the marker, without re-running the writer
+// or touching the init lease, which is the cross-namespace / restart-safe
+// behavior the marker provides.
+func TestReconcile_ModelCacheSamba(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	cfg, _, cleanup, err := nvcaenvtest.SetupEnvtest()
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	mgr, err := ctrl.NewManager(cfg, manager.Options{
+		Scheme:                  mgrScheme,
+		GracefulShutdownTimeout: new(time.Duration),
+		BaseContext:             func() context.Context { return ctx },
+		WebhookServer:           nvcaenvtest.NewFakeWebhookServer(),
+		Metrics:                 nvcaenvtest.NewFakeMetricsOptions(),
+		Controller:              ctrlconfig.Controller{SkipNameValidation: newBool(true)},
+	})
+	require.NoError(t, err)
+
+	defaultTimeConfig := (&k8sutil.TimeConfig{}).Complete()
+	// The Samba path requires the server image to be configured; an empty image
+	// makes EnsureSambaModelCacheInfra return a terminal error.
+	nvcaCfg := nvcaconfig.Config{}
+	nvcaCfg.Agent.SharedStorage.Server.Image = "samba:test"
+	err = BuildController(nvcaCfg, nvcav1new.ModelCacheRequest, mgr, "my-cluster", "us-west-1", defaultTimeConfig, ControllerOptions{})
+	require.NoError(t, err)
+
+	mgrErrCh, err := nvcaenvtest.StartManager(ctx, mgr)
+	require.NoError(t, err)
+
+	cctx, ccancel := context.WithTimeout(context.Background(), 5*time.Second)
+	mgr.GetCache().WaitForCacheSync(cctx)
+	ccancel()
+
+	c := mgr.GetClient()
+
+	srNamespace := &corev1.Namespace{}
+	srNamespace.Name = types.DefaultICMSRequestNamespace
+	require.NoError(t, c.Create(ctx, srNamespace))
+	require.NoError(t, c.Create(ctx, NewModelCacheInitNamespace()))
+
+	cacheHandle := "sambahandle"
+
+	// newSambaSR creates the ICMSRequest + StorageRequest pair for a workload
+	// namespace, all wired to the shared cache handle on the Samba backend.
+	newSambaSR := func(nsName string) *nvcav1new.StorageRequest {
+		ns := &corev1.Namespace{}
+		ns.Name = nsName
+		require.NoError(t, c.Create(ctx, ns))
+		icms := &nvcav2beta1.ICMSRequest{}
+		icms.Name, icms.Namespace = nsName, srNamespace.Name
+		icms.Spec = newModelCacheICMSSpec(cacheHandle)
+		require.NoError(t, c.Create(ctx, icms))
+		st := &nvcav1new.StorageRequest{}
+		st.Name, st.Namespace = nvcav1new.ModelCacheRequest.Name(), nsName
+		st.Spec.Type = nvcav1new.ModelCacheRequest
+		st.Spec.ICMSRequestName = icms.Name
+		st.Spec.ICMSRequestNamespace = srNamespace.Name
+		st.Spec.ModelCache = &nvcav1new.ModelCacheSpec{
+			CacheHandle: cacheHandle,
+			Backend:     string(HelmCacheBackendSamba),
+		}
+		require.NoError(t, c.Create(ctx, st))
+		return st
+	}
+
+	st1 := newSambaSR("sr-samba-1")
+
+	// The per-handle Samba server Deployment (samba-<handle>) is bootstrapped
+	// idempotently. envtest has no deployment controller, so mark it Available to
+	// unblock the writer init.
+	dep := &appsv1.Deployment{}
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		err := c.Get(ctx, client.ObjectKey{Name: sambaModelCacheResourceName(cacheHandle), Namespace: ModelCacheInitNamespace}, dep)
+		assert.NoError(ct, err)
+	}, 5*time.Second, 50*time.Millisecond)
+	dep.Status.Replicas = 1
+	dep.Status.ReadyReplicas = 1
+	dep.Status.AvailableReplicas = 1
+	require.NoError(t, c.Status().Update(ctx, dep))
+
+	// The writer job and the STATIC SMB RW PV/PVC are created (no StorageClass).
+	initJob := &batchv1.Job{}
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		err := c.Get(ctx, client.ObjectKey{Name: "writer-job-" + cacheHandle, Namespace: ModelCacheInitNamespace}, initJob)
+		assert.NoError(ct, err)
+	}, 5*time.Second, 50*time.Millisecond)
+
+	rwPVC := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: "rw-pvc-" + cacheHandle, Namespace: ModelCacheInitNamespace}, rwPVC))
+	assert.Equal(t, "samba-rw-pv-"+cacheHandle, rwPVC.Spec.VolumeName)
+	if assert.NotNil(t, rwPVC.Spec.StorageClassName) {
+		assert.Equal(t, "", *rwPVC.Spec.StorageClassName, "Samba RW PVC must bind a static PV, not a StorageClass")
+	}
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: "samba-rw-pv-" + cacheHandle}, &corev1.PersistentVolume{}))
+
+	// Drive the writer pod to running so the request moves to InitRunning.
+	initJobPod := &corev1.Pod{}
+	initJobPod.Name, initJobPod.Namespace = initJob.Spec.Template.Name+"-foobar", initJob.Namespace
+	initJobPod.Labels = make(map[string]string, len(initJob.Spec.Template.Labels))
+	maps.Copy(initJobPod.Labels, initJob.Spec.Template.Labels)
+	maps.Copy(initJobPod.Labels, initJob.Spec.Selector.MatchLabels)
+	initJobPod.Annotations = initJob.Spec.Template.Annotations
+	initJobPod.Spec = initJob.Spec.Template.Spec
+	require.NoError(t, c.Create(ctx, initJobPod))
+	initJobPod.Status = corev1.PodStatus{Phase: corev1.PodRunning}
+	require.NoError(t, c.Status().Update(ctx, initJobPod))
+
+	initJob.Status.StartTime = &metav1.Time{Time: time.Now().Add(-1 * time.Minute)}
+	require.NoError(t, c.Status().Update(ctx, initJob))
+
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		err := c.Get(ctx, client.ObjectKeyFromObject(st1), st1)
+		if assert.NoError(ct, err) {
+			assert.Equal(ct, nvcav1new.StorageInitRunning, st1.Status.Phase)
+		}
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// Bind the RW PVC and complete the writer job.
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(rwPVC), rwPVC))
+	rwPVC.Status.Phase = corev1.ClaimBound
+	require.NoError(t, c.Status().Update(ctx, rwPVC))
+
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(initJob), initJob))
+	initJob.Status.Succeeded++
+	initJob.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+	initJob.Status.Conditions = append(initJob.Status.Conditions,
+		batchv1.JobCondition{Type: batchv1.JobSuccessCriteriaMet, Status: corev1.ConditionTrue},
+		batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
+	)
+	require.NoError(t, c.Status().Update(ctx, initJob))
+
+	// On success the per-handle backing PVC (samba-<handle>) is stamped with the
+	// durable populated marker. That label, not an NVMesh primary PV, is the
+	// cross-namespace / restart-safe reuse signal for the Samba backend.
+	backingPVC := &corev1.PersistentVolumeClaim{}
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		err := c.Get(ctx, client.ObjectKey{Name: SambaModelCacheBackingPVCName(cacheHandle), Namespace: ModelCacheInitNamespace}, backingPVC)
+		if assert.NoError(ct, err) {
+			assert.Equal(ct, cachePopulatedLabelValue, backingPVC.Labels[cachePopulatedLabelKey])
+		}
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// The writer's static plumbing PV is deleted with the writer teardown
+	// (static PVs are never reclaimed by the PV controller, so it must be
+	// removed explicitly). envtest has no PV-protection controller, so accept a
+	// pending deletion (deletionTimestamp set) as deleted.
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		writerPV := &corev1.PersistentVolume{}
+		err := c.Get(ctx, client.ObjectKey{Name: sambaModelCacheWriterPVName(cacheHandle)}, writerPV)
+		assert.True(ct, apierrors.IsNotFound(err) || writerPV.DeletionTimestamp != nil,
+			"writer plumbing PV must be deleted with the writer teardown")
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// First namespace: an RO reader PV/PVC is created against the per-handle share.
+	ro1 := &corev1.PersistentVolumeClaim{}
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		err := c.Get(ctx, client.ObjectKey{Name: "ro-pvc-" + cacheHandle, Namespace: st1.Namespace}, ro1)
+		assert.NoError(ct, err)
+	}, 5*time.Second, 50*time.Millisecond)
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: "samba-ro-pv-" + st1.Namespace + "-" + cacheHandle}, &corev1.PersistentVolume{}))
+	ro1.Status.Phase = corev1.ClaimBound
+	require.NoError(t, c.Status().Update(ctx, ro1))
+
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		err := c.Get(ctx, client.ObjectKeyFromObject(st1), st1)
+		if assert.NoError(ct, err) {
+			assert.Equal(ct, nvcav1new.StorageReady, st1.Status.Phase)
+		}
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// Second namespace, same handle: it must reach Ready purely from the durable
+	// backing-PVC populated marker. The init lease was deleted during the first
+	// namespace's writer teardown; if the second namespace re-ran init it would
+	// recreate the lease. Asserting the lease stays absent proves the marker path
+	// was taken.
+	st2 := newSambaSR("sr-samba-2")
+	ro2 := &corev1.PersistentVolumeClaim{}
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		err := c.Get(ctx, client.ObjectKey{Name: "ro-pvc-" + cacheHandle, Namespace: st2.Namespace}, ro2)
+		assert.NoError(ct, err)
+	}, 5*time.Second, 50*time.Millisecond)
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: "samba-ro-pv-" + st2.Namespace + "-" + cacheHandle}, &corev1.PersistentVolume{}))
+	ro2.Status.Phase = corev1.ClaimBound
+	require.NoError(t, c.Status().Update(ctx, ro2))
+
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		err := c.Get(ctx, client.ObjectKeyFromObject(st2), st2)
+		if assert.NoError(ct, err) {
+			assert.Equal(ct, nvcav1new.StorageReady, st2.Status.Phase)
+		}
+	}, 5*time.Second, 50*time.Millisecond)
+
+	lease := &coordv1.Lease{}
+	leaseErr := c.Get(ctx, client.ObjectKey{Name: buildInitLeaseName(cacheHandle), Namespace: ModelCacheInitNamespace}, lease)
+	assert.True(t, apierrors.IsNotFound(leaseErr),
+		"second namespace must consume the cache via the backing-PVC marker, not re-run the init lease")
+
+	// Deleting a consumer SR must run cleanup to completion and drop the
+	// storage-request finalizer (the workload namespaces are not terminating
+	// here, so this exercises the normal cleanup path, not the escape hatch).
+	// Deleting one consumer must NOT delete the shared per-handle backing PVC;
+	// it is reclaimed only when the cache goes idle (cleanupIdleModelCaches).
+	require.NoError(t, c.Delete(ctx, st1))
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		err := c.Get(ctx, client.ObjectKeyFromObject(st1), st1)
+		assert.True(ct, apierrors.IsNotFound(err), "st1 must be fully deleted (finalizer removed by cleanup)")
+	}, 10*time.Second, 100*time.Millisecond)
+
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: SambaModelCacheBackingPVCName(cacheHandle), Namespace: ModelCacheInitNamespace}, backingPVC),
+		"shared backing PVC must survive a single consumer's deletion")
+
+	require.NoError(t, c.Delete(ctx, st2))
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		err := c.Get(ctx, client.ObjectKeyFromObject(st2), st2)
+		assert.True(ct, apierrors.IsNotFound(err), "st2 must be fully deleted (finalizer removed by cleanup)")
+	}, 10*time.Second, 100*time.Millisecond)
+
+	cancel()
+	<-mgrErrCh
+}
+
+// TestDoModelCacheSharedFS_Validation covers the early terminal-validation
+// branches of the shared-FS path that run before any probe or client call.
+func TestDoModelCacheSharedFS_Validation(t *testing.T) {
+	tests := []struct {
+		name       string
+		modelCache *nvcav1new.ModelCacheSpec
+	}{
+		{name: "nil modelCache", modelCache: nil},
+		{name: "empty cacheHandle", modelCache: &nvcav1new.ModelCacheSpec{Backend: string(HelmCacheBackendSharedFS)}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{
+				Client:  fake.NewClientBuilder().WithScheme(mgrScheme).Build(),
+				metrics: newTestMetrics(),
+				fff:     &featureflagmock.Fetcher{},
+			}
+			st := nvcav1new.StorageRequest{}
+			stCopy := &nvcav1new.StorageRequest{Spec: nvcav1new.StorageRequestSpec{ModelCache: tt.modelCache}}
+			_, err := r.doModelCacheSharedFS(context.Background(), st, stCopy, &nvcav2beta1.ICMSRequest{})
+			require.Error(t, err)
+			assert.True(t, isTerminal(err), "validation failure must be terminal")
+		})
+	}
+}
+
+// TestDoCleanupModelCacheNVMesh_RequeuesWhileWriterVolumeAttached proves the
+// cleanup never blocks the single reconcile worker polling for volume detach:
+// while the writer volume is still attached read-write it requeues (does not
+// delete the writer PVC or mark cleanup successful), and once detached it
+// completes.
+func TestDoCleanupModelCacheNVMesh_RequeuesWhileWriterVolumeAttached(t *testing.T) {
+	ctx := context.Background()
+	handle := "attachhandle"
+	pvName := "pv-" + handle
+
+	rwPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rw-pvc-" + handle,
+			Namespace: ModelCacheInitNamespace,
+			Labels:    map[string]string{modelCacheHandleLabelKey: handle},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{VolumeName: pvName},
+	}
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: pvName},
+		Spec: corev1.PersistentVolumeSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+		},
+	}
+	va := &storagev1.VolumeAttachment{
+		ObjectMeta: metav1.ObjectMeta{Name: "va-1"},
+		Spec: storagev1.VolumeAttachmentSpec{
+			Attacher: "smb.csi.k8s.io",
+			NodeName: "node1",
+			Source:   storagev1.VolumeAttachmentSource{PersistentVolumeName: &pvName},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(mgrScheme).WithObjects(rwPVC, pv, va).Build()
+	r := &Reconciler{
+		Client:        c,
+		metrics:       newTestMetrics(),
+		fff:           &featureflagmock.Fetcher{},
+		nowFunc:       time.Now,
+		k8sTimeConfig: (&k8sutil.TimeConfig{}).Complete(),
+	}
+	st := &nvcav1new.StorageRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: nvcav1new.ModelCacheRequest.Name(), Namespace: "ns1"},
+		Spec: nvcav1new.StorageRequestSpec{
+			Type:       nvcav1new.ModelCacheRequest,
+			ModelCache: &nvcav1new.ModelCacheSpec{CacheHandle: handle},
+		},
+	}
+
+	// Still attached read-write: requeue, do not delete the writer PVC, do not
+	// mark cleanup successful.
+	res, err := r.doCleanupModelCacheNVMesh(ctx, st)
+	require.NoError(t, err)
+	assert.Equal(t, volumeDetachRequeueInterval, res.RequeueAfter, "must requeue (not block) while attached")
+	if cond := meta.FindStatusCondition(st.Status.Conditions, ConditionTypeCleanupSuccessful); assert.NotNil(t, cond) {
+		assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	}
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(rwPVC), &corev1.PersistentVolumeClaim{}),
+		"writer PVC must not be deleted while its volume is still attached")
+
+	// Detach: cleanup completes, writer PVC deleted, condition True.
+	require.NoError(t, c.Delete(ctx, va))
+	res, err = r.doCleanupModelCacheNVMesh(ctx, st)
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, res, "must not requeue once detached")
+	if cond := meta.FindStatusCondition(st.Status.Conditions, ConditionTypeCleanupSuccessful); assert.NotNil(t, cond) {
+		assert.Equal(t, metav1.ConditionTrue, cond.Status)
+	}
+	getErr := c.Get(ctx, client.ObjectKeyFromObject(rwPVC), &corev1.PersistentVolumeClaim{})
+	assert.True(t, apierrors.IsNotFound(getErr), "writer PVC must be deleted once detached")
+}
+
+// TestReclaimIdleSharedFSModelCaches proves the retained shared-FS writer PVC
+// (the durable backing claim) is reclaimed once no StorageRequest references
+// its handle and the idle period has passed, while active handles, recently
+// referenced handles, and Samba backing PVCs (reclaimed with their server by
+// the Samba pass) are left alone.
+func TestReclaimIdleSharedFSModelCaches(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	idle := (&k8sutil.TimeConfig{}).Complete().ModelCacheIdlePeriod
+
+	mkPVC := func(name, handle string, lastRef time.Time, sambaComponent bool) *corev1.PersistentVolumeClaim {
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ModelCacheInitNamespace,
+				Labels:    map[string]string{cachePopulatedLabelKey: cachePopulatedLabelValue},
+				Annotations: map[string]string{
+					primaryPVLastReferencedAnnotationKey: lastRef.Format(primaryPVLastReferencedTimeFormat),
+				},
+			},
+		}
+		if handle != "" {
+			pvc.Labels[modelCacheHandleLabelKey] = handle
+		}
+		if sambaComponent {
+			pvc.Labels[sambaModelCacheComponentLabelKey] = sambaModelCacheComponentLabelValue
+		}
+		return pvc
+	}
+
+	idlePVC := mkPVC("rw-pvc-idle", "idle-handle", now.Add(-2*idle), false)
+	activePVC := mkPVC("rw-pvc-active", "active-handle", now.Add(-2*idle), false)
+	recentPVC := mkPVC("rw-pvc-recent", "recent-handle", now.Add(-idle/2), false)
+	sambaPVC := mkPVC("samba-idle2", "", now.Add(-2*idle), true)
+
+	c := fake.NewClientBuilder().WithScheme(mgrScheme).
+		WithObjects(idlePVC, activePVC, recentPVC, sambaPVC).Build()
+	r := &Reconciler{
+		Client:        c,
+		metrics:       newTestMetrics(),
+		fff:           &featureflagmock.Fetcher{},
+		nowFunc:       func() time.Time { return now },
+		k8sTimeConfig: (&k8sutil.TimeConfig{}).Complete(),
+	}
+
+	stList := &nvcav1new.StorageRequestList{Items: []nvcav1new.StorageRequest{{
+		Spec: nvcav1new.StorageRequestSpec{
+			Type:       nvcav1new.ModelCacheRequest,
+			ModelCache: &nvcav1new.ModelCacheSpec{CacheHandle: "active-handle"},
+		},
+	}}}
+
+	require.NoError(t, r.reclaimIdleSharedFSModelCaches(ctx, stList))
+
+	err := c.Get(ctx, client.ObjectKeyFromObject(idlePVC), &corev1.PersistentVolumeClaim{})
+	assert.True(t, apierrors.IsNotFound(err), "idle unreferenced writer PVC must be reclaimed")
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(activePVC), &corev1.PersistentVolumeClaim{}),
+		"actively referenced handle must be kept")
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(recentPVC), &corev1.PersistentVolumeClaim{}),
+		"recently referenced handle must be kept")
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(sambaPVC), &corev1.PersistentVolumeClaim{}),
+		"samba backing PVCs are reclaimed by the samba pass, not here")
 }

--- a/src/compute-plane-services/nvca/pkg/storage/reconcile.go
+++ b/src/compute-plane-services/nvca/pkg/storage/reconcile.go
@@ -533,7 +533,7 @@ func (r *Reconciler) patchStorageRequest(ctx context.Context, oldObj, newObj *nv
 func (r *Reconciler) doCleanup(ctx context.Context, st *nvcav1new.StorageRequest) (res reconcile.Result, err error) {
 	switch st.Spec.Type {
 	case nvcav1new.ModelCacheRequest:
-		err = r.doCleanupModelCacheNVMesh(ctx, st)
+		res, err = r.doCleanupModelCacheNVMesh(ctx, st)
 		// Do not clean up primary PV. The periodic runner that invokes cleanupIdleModelCaches
 		// will handle those.
 	default:

--- a/src/compute-plane-services/nvca/pkg/storage/storagerequest.go
+++ b/src/compute-plane-services/nvca/pkg/storage/storagerequest.go
@@ -56,6 +56,16 @@ func NewModelCacheStorageRequest(req *nvcav2beta1.ICMSRequest, fff featureflag.F
 	st.Spec.ModelCache = &nvcav2beta1.ModelCacheSpec{
 		CacheHandle: cacheLaunchSpec.CacheHandle,
 	}
+	// Stamp the cache-handle label at creation. The model-cache controller's
+	// fan-out maps writer-job / PV(C) events back to the StorageRequest by
+	// listing on this label (getModelCacheFanOutEventHandlerMapFunc); the
+	// reconcile loop persists only status, so a label set during reconcile is
+	// not durable. Without it the SR never re-reconciles when the writer job
+	// completes, and the cache stays stuck in Pending (all backends).
+	if st.Labels == nil {
+		st.Labels = map[string]string{}
+	}
+	st.Labels[modelCacheHandleLabelKey] = cacheLaunchSpec.CacheHandle
 	if fff.IsFeatureFlagEnabled(featureflag.NVMeshEncryption) {
 		st.Spec.ModelCache.Encryption = &nvcav2beta1.ModelCacheEncryption{
 			Required: true,

--- a/src/compute-plane-services/nvca/pkg/storage/storagerequest_test.go
+++ b/src/compute-plane-services/nvca/pkg/storage/storagerequest_test.go
@@ -289,7 +289,14 @@ func TestNewModelCacheStorageRequest(t *testing.T) {
 			if tt.expError != "" {
 				assert.EqualError(t, err, tt.expError)
 			} else {
+				// The cache-handle label is stamped at creation so the
+				// controller fan-out can map writer-job/PV events back to the SR.
+				if tt.expected.Labels == nil {
+					tt.expected.Labels = map[string]string{}
+				}
+				tt.expected.Labels[modelCacheHandleLabelKey] = tt.expected.Spec.ModelCache.CacheHandle
 				assert.Equal(t, tt.expected, actual)
+				assert.Equal(t, actual.Spec.ModelCache.CacheHandle, actual.Labels[modelCacheHandleLabelKey])
 			}
 		})
 	}

--- a/src/compute-plane-services/nvca/pkg/storage/types.go
+++ b/src/compute-plane-services/nvca/pkg/storage/types.go
@@ -56,6 +56,16 @@ var (
 		nvcav1new.SchemeGroupVersion.Group,
 		nvcav1new.SharedStorageRequest)
 
+	// Ephemeral (per-pod emptyDir) model cache fallback (backend "ephemeral").
+	// When no shared cache backend is available, the reconciler sets this
+	// annotation (the init env travels in the miniservice metadata ConfigMap)
+	// so the helm storage webhook injects a model-cache-init init container
+	// that downloads the model into an emptyDir shared with the workload
+	// containers.
+	//nolint:gosec
+	WebhookEphemeralModelCacheInitImageAnnotationKey = fmt.Sprintf("%s/helm-ephemeral-model-cache-init-image",
+		nvcav1new.SchemeGroupVersion.Group)
+
 	storageRequestGVK        = nvcav1new.SchemeGroupVersion.WithKind("StorageRequest")
 	storageRequestV2Beta1GVK = nvcav2beta1.SchemeGroupVersion.WithKind("StorageRequest")
 )
@@ -84,6 +94,14 @@ const (
 
 	// SharedStorageEnabledLabel namespace label
 	SharedStorageEnabledLabel = "nvca.nvcf.nvidia.io/shared-storage-enabled"
+
+	// Ephemeral model cache fallback (per-pod emptyDir). Reuses the model
+	// cache volume name and mount paths (ModelCachePodVolumeName /
+	// ModelCachePod{Model,Resources}MountPath) so workload containers see the
+	// cache at the same paths regardless of backend.
+	EphemeralModelCacheInitContainerName     = "model-cache-init"
+	EphemeralModelCacheConfigDataVolumeName  = "config-data"
+	EphemeralModelCacheConfigSharedMountPath = "/config/shared"
 )
 
 func HasStorageAnnotation(annotations map[string]string) bool {

--- a/src/compute-plane-services/nvca/pkg/types/BUILD.bazel
+++ b/src/compute-plane-services/nvca/pkg/types/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "common_labels.go",
         "gpu.go",
         "miniservice_types.go",
+        "modelcache_types.go",
         "resource_types.go",
         "types.go",
     ],

--- a/src/compute-plane-services/nvca/pkg/types/miniservice_types.go
+++ b/src/compute-plane-services/nvca/pkg/types/miniservice_types.go
@@ -65,6 +65,11 @@ type MiniserviceMetadata struct {
 	ImagePullSecretNames          []string            `json:"imagePullSecretNames,omitempty"`
 	TerminationGracePeriodSeconds *int64              `json:"terminationGracePeriodSeconds,omitempty"`
 	SchedulerName                 string              `json:"schedulerName,omitempty"`
+
+	// ModelCacheInitEnv is the flattened launch environment (plus INSTANCE_ID)
+	// injected into the ephemeral model-cache-init container by the webhook.
+	// Set only when the ephemeral model-cache backend is selected.
+	ModelCacheInitEnv map[string]string `json:"modelCacheInitEnv,omitempty"`
 }
 
 // ToConfigMapData serializes m into ConfigMap-compatible flat string data.

--- a/src/compute-plane-services/nvca/pkg/types/modelcache_types.go
+++ b/src/compute-plane-services/nvca/pkg/types/modelcache_types.go
@@ -1,0 +1,51 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types //nolint:revive
+
+// HelmCacheBackend identifies the storage backend selected for the Helm model
+// cache. The backend is resolved from the CachingSupport gate plus the storage
+// classes available in the cluster (see pkg/storage SelectHelmCacheBackend).
+// It lives here so both pkg/storage and internal/metrics can share one set of
+// backend values without duplication.
+type HelmCacheBackend string
+
+const (
+	// HelmCacheBackendNone means caching is disabled (CachingSupport off).
+	HelmCacheBackendNone HelmCacheBackend = "none"
+	// HelmCacheBackendNVMesh uses NVMesh 3.x cross-namespace PV sharing.
+	HelmCacheBackendNVMesh HelmCacheBackend = "nvmesh"
+	// HelmCacheBackendSharedFS uses an operator-provided shared (RWX/ROX)
+	// storage class (nvcf-miniservice-sc): WEKA, EFS, CephFS, external NFS, etc.
+	HelmCacheBackendSharedFS HelmCacheBackend = "sharedfs"
+	// HelmCacheBackendSamba deploys a Samba server (on block storage) and
+	// caches via the shared-FS path.
+	HelmCacheBackendSamba HelmCacheBackend = "samba"
+	// HelmCacheBackendEphemeral is the per-pod emptyDir fallback when no
+	// shared cache backend is available.
+	HelmCacheBackendEphemeral HelmCacheBackend = "ephemeral"
+)
+
+// AllSelectableHelmCacheBackends is the set of backends that provision a
+// cache (HelmCacheBackendNone excluded), used to pre-initialize per-backend
+// metrics to zero.
+var AllSelectableHelmCacheBackends = []HelmCacheBackend{
+	HelmCacheBackendNVMesh,
+	HelmCacheBackendSharedFS,
+	HelmCacheBackendSamba,
+	HelmCacheBackendEphemeral,
+}

--- a/src/compute-plane-services/nvca/pkg/webhook/helm_storage_webhook.go
+++ b/src/compute-plane-services/nvca/pkg/webhook/helm_storage_webhook.go
@@ -20,6 +20,7 @@ package webhook
 import (
 	"context"
 	"errors"
+	"sort"
 
 	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/core"
 	appsv1 "k8s.io/api/apps/v1"
@@ -29,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	cmnnvcastorage "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/storage"
+	nvcatypes "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/types"
 )
 
 var (
@@ -48,7 +50,11 @@ func (v *helmStorageMutatingWebhook) Handle(_ context.Context, _ admission.Reque
 	return admission.Allowed("")
 }
 
-func (v *helmStorageMutatingWebhook) mutate(ctx context.Context, obj client.Object) (ok bool, warnings admission.Warnings, err error) {
+func (v *helmStorageMutatingWebhook) mutate(
+	ctx context.Context,
+	obj client.Object,
+	meta nvcatypes.MiniserviceMetadata,
+) (ok bool, warnings admission.Warnings, err error) {
 	log := core.GetLogger(ctx)
 
 	var mutations []podMutateFunc
@@ -117,10 +123,32 @@ func (v *helmStorageMutatingWebhook) mutate(ctx context.Context, obj client.Obje
 			false))
 	}
 
-	// Mutate if this is model cache pvc annotation exists
+	// Mutate if this is model cache pvc annotation exists.
+	//
+	// Drop any existing model-cache volume/mount first, then re-add, exactly like
+	// the shared-storage volumes above. The shared-storage path drops and re-adds
+	// its volumes on every admission; if model-data were only idempotently
+	// appended, the shared-storage re-add would land AFTER the sticky model-data
+	// volume on re-admission, reordering volumes relative to the originally
+	// admitted pod. The API server rejects volume reordering on an existing pod,
+	// so when a controller re-submits the pod via UPDATE (e.g. the KAI scheduler's
+	// pod-grouper) the update is rejected and the pod never schedules. Dropping
+	// and re-adding makes the post-admission volume/mount order deterministic and
+	// identical across CREATE and UPDATE.
 	if pvcName, ok := annotations[cmnnvcastorage.WebhookModelCachePVCNameAnnotationKey]; ok {
+		mutations = append(mutations, getModelCacheDropReservedFunc())
 		mutations = append(mutations, getModelCachePVCVolumeAppendFunc(pvcName))
 		mutations = append(mutations, getModelCachePVCVolumeMountAppendFunc())
+	}
+
+	// Inject the ephemeral (emptyDir) model cache init container when the
+	// reconciler selected the ephemeral backend (no shared cache available).
+	// The image annotation and the metadata env are set together by the
+	// reconciler; the init container downloads the model into an emptyDir
+	// shared with the workload containers.
+	initImage := annotations[cmnnvcastorage.WebhookEphemeralModelCacheInitImageAnnotationKey]
+	if initImage != "" && len(meta.ModelCacheInitEnv) > 0 {
+		mutations = append(mutations, getEphemeralModelCacheInitAppendFunc(initImage, meta.ModelCacheInitEnv))
 	}
 
 	var errs []error
@@ -147,6 +175,41 @@ func (v *helmStorageMutatingWebhook) mutate(ctx context.Context, obj client.Obje
 	}
 
 	return len(mutations) > 0, warnings, errors.Join(errs...)
+}
+
+// getModelCacheDropReservedFunc removes the model-cache volume and its mounts
+// from the PodSpec so the subsequent append re-adds them in a deterministic
+// position on every admission. It matches the model-cache volume by name only
+// (and its mounts by name), so it never touches shared-storage or workload
+// volumes.
+func getModelCacheDropReservedFunc() podMutateFunc {
+	return func(_ context.Context, ps *corev1.PodSpec) bool {
+		mod := false
+		volumes := make([]corev1.Volume, 0, len(ps.Volumes))
+		for _, v := range ps.Volumes {
+			if v.Name == cmnnvcastorage.ModelCachePodVolumeName {
+				mod = true
+				continue
+			}
+			volumes = append(volumes, v)
+		}
+		ps.Volumes = volumes
+
+		for _, containers := range [][]corev1.Container{ps.InitContainers, ps.Containers} {
+			for i := range containers {
+				mounts := make([]corev1.VolumeMount, 0, len(containers[i].VolumeMounts))
+				for _, m := range containers[i].VolumeMounts {
+					if m.Name == cmnnvcastorage.ModelCachePodVolumeName {
+						mod = true
+						continue
+					}
+					mounts = append(mounts, m)
+				}
+				containers[i].VolumeMounts = mounts
+			}
+		}
+		return mod
+	}
 }
 
 func getModelCachePVCVolumeAppendFunc(pvcName string) podMutateFunc {
@@ -190,6 +253,98 @@ func getModelCachePVCVolumeMountAppendFunc() podMutateFunc {
 		}
 		return mod
 	}
+}
+
+// getEphemeralModelCacheInitAppendFunc injects a model-cache-init init
+// container that downloads the model into an emptyDir shared with the workload
+// containers. Used as the per-pod fallback (backend "ephemeral") when no shared
+// model-cache backend is available. Workload containers see the cache at the
+// same mount paths as the shared-PVC path, so the workload is backend-agnostic.
+// envSet comes from the miniservice metadata ConfigMap and is injected as
+// explicit env vars, sorted by name for deterministic admission output.
+func getEphemeralModelCacheInitAppendFunc(initImage string, envSet map[string]string) podMutateFunc {
+	return func(_ context.Context, ps *corev1.PodSpec) bool {
+		if len(ps.Containers) == 0 {
+			return false
+		}
+		// Mount the shared model-data emptyDir into the workload containers.
+		mod := addVolumeMount(ps.Containers, cmnnvcastorage.ModelCachePodVolumeName,
+			cmnnvcastorage.ModelCachePodModelMountPath, false)
+		if addVolumeMount(ps.Containers, cmnnvcastorage.ModelCachePodVolumeName,
+			cmnnvcastorage.ModelCachePodResourcesMountPath, false) {
+			mod = true
+		}
+
+		// Add the emptyDir volumes the init and workload containers share.
+		for _, volName := range []string{
+			cmnnvcastorage.ModelCachePodVolumeName,
+			cmnnvcastorage.EphemeralModelCacheConfigDataVolumeName,
+		} {
+			if !hasVolumeNamed(ps.Volumes, volName) {
+				ps.Volumes = append(ps.Volumes, corev1.Volume{
+					Name:         volName,
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+				})
+				mod = true
+			}
+		}
+
+		// Add the init container once.
+		if hasContainerNamed(ps.InitContainers, cmnnvcastorage.EphemeralModelCacheInitContainerName) {
+			return mod
+		}
+		envKeys := make([]string, 0, len(envSet))
+		for k := range envSet {
+			envKeys = append(envKeys, k)
+		}
+		sort.Strings(envKeys)
+		env := make([]corev1.EnvVar, 0, len(envKeys))
+		for _, k := range envKeys {
+			env = append(env, corev1.EnvVar{Name: k, Value: envSet[k]})
+		}
+		ps.InitContainers = append(ps.InitContainers, corev1.Container{
+			Name:            cmnnvcastorage.EphemeralModelCacheInitContainerName,
+			Image:           initImage,
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			SecurityContext: &corev1.SecurityContext{
+				Capabilities: &corev1.Capabilities{Drop: []corev1.Capability{"NET_RAW"}},
+			},
+			Env: env,
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      cmnnvcastorage.EphemeralModelCacheConfigDataVolumeName,
+					MountPath: cmnnvcastorage.EphemeralModelCacheConfigSharedMountPath,
+				},
+				{
+					Name:      cmnnvcastorage.ModelCachePodVolumeName,
+					MountPath: cmnnvcastorage.ModelCachePodModelMountPath,
+				},
+				{
+					Name:      cmnnvcastorage.ModelCachePodVolumeName,
+					MountPath: cmnnvcastorage.ModelCachePodResourcesMountPath,
+				},
+			},
+		})
+		return true
+	}
+}
+
+func hasVolumeNamed(volumes []corev1.Volume, name string) bool {
+	for _, v := range volumes {
+		if v.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasContainerNamed(containers []corev1.Container, name string) bool {
+	for _, c := range containers {
+		if c.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 func getSharedVolumeDropAllReservedFunc(

--- a/src/compute-plane-services/nvca/pkg/webhook/helm_storage_webhook_test.go
+++ b/src/compute-plane-services/nvca/pkg/webhook/helm_storage_webhook_test.go
@@ -18,12 +18,15 @@ limitations under the License.
 package webhook
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 
 	cmnnvcastorage "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/storage"
+	nvcatypes "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/types"
 )
 
 func TestGetModelCachePVCAppend(t *testing.T) {
@@ -279,4 +282,120 @@ func TestGetModelCachePVCAppend(t *testing.T) {
 			assert.Equal(t, tt.expMod, gotMod)
 		})
 	}
+}
+
+func TestGetEphemeralModelCacheInitAppendFunc(t *testing.T) {
+	ps := corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "workload"}},
+	}
+	envSet := map[string]string{"MODEL_URL": "https://models.example/m1", "API_KEY": "k"}
+	mod := getEphemeralModelCacheInitAppendFunc("init-image:1", envSet)(t.Context(), &ps)
+	assert.True(t, mod)
+
+	if assert.Len(t, ps.InitContainers, 1) {
+		ic := ps.InitContainers[0]
+		assert.Equal(t, cmnnvcastorage.EphemeralModelCacheInitContainerName, ic.Name)
+		assert.Equal(t, "init-image:1", ic.Image)
+		// Env is injected explicitly (from the miniservice metadata ConfigMap),
+		// sorted by name for deterministic admission output.
+		assert.Equal(t, []corev1.EnvVar{
+			{Name: "API_KEY", Value: "k"},
+			{Name: "MODEL_URL", Value: "https://models.example/m1"},
+		}, ic.Env)
+		assert.Len(t, ic.VolumeMounts, 3)
+	}
+
+	assert.True(t, hasVolumeNamed(ps.Volumes, cmnnvcastorage.ModelCachePodVolumeName))
+	assert.True(t, hasVolumeNamed(ps.Volumes, cmnnvcastorage.EphemeralModelCacheConfigDataVolumeName))
+	for _, v := range ps.Volumes {
+		assert.NotNilf(t, v.VolumeSource.EmptyDir, "volume %s should be emptyDir", v.Name)
+	}
+	assert.Len(t, ps.Containers[0].VolumeMounts, 2)
+
+	// Idempotent: a second pass does not duplicate the container, volumes, or mounts.
+	getEphemeralModelCacheInitAppendFunc("init-image:1", envSet)(t.Context(), &ps)
+	assert.Len(t, ps.InitContainers, 1)
+	assert.Len(t, ps.Volumes, 2)
+	assert.Len(t, ps.Containers[0].VolumeMounts, 2)
+}
+
+// TestMutate_EphemeralModelCacheInitTrigger verifies the ephemeral init
+// container is injected only when both the image annotation (from pod
+// annotations) and the init env (from the miniservice metadata ConfigMap)
+// are present.
+func TestMutate_EphemeralModelCacheInitTrigger(t *testing.T) {
+	ctx := context.Background()
+	v := &helmStorageMutatingWebhook{}
+	pod := &corev1.Pod{}
+	pod.Annotations = map[string]string{
+		cmnnvcastorage.WebhookEphemeralModelCacheInitImageAnnotationKey: "init-image:1",
+	}
+	pod.Spec.Containers = []corev1.Container{{Name: "workload"}}
+
+	// Without metadata env: no injection.
+	_, _, err := v.mutate(ctx, pod, nvcatypes.MiniserviceMetadata{})
+	require.NoError(t, err)
+	assert.Empty(t, pod.Spec.InitContainers)
+
+	// With metadata env: init container injected with the env.
+	meta := nvcatypes.MiniserviceMetadata{ModelCacheInitEnv: map[string]string{"MODEL_URL": "u"}}
+	_, _, err = v.mutate(ctx, pod, meta)
+	require.NoError(t, err)
+	if assert.Len(t, pod.Spec.InitContainers, 1) {
+		assert.Equal(t, "init-image:1", pod.Spec.InitContainers[0].Image)
+		assert.Equal(t, []corev1.EnvVar{{Name: "MODEL_URL", Value: "u"}}, pod.Spec.InitContainers[0].Env)
+	}
+}
+
+// TestMutate_StableVolumeOrderAcrossReadmission guards against the model-cache
+// volume reordering that blocked KAI scheduling: the shared-storage volumes are
+// dropped and re-added on every admission, so the model-cache volume/mount must
+// also be dropped and re-added to keep a deterministic order. Otherwise a
+// controller that re-submits the already-mutated pod via UPDATE (e.g. the KAI
+// scheduler's pod-grouper) produces a reordered spec, which the API server
+// rejects as an immutable-field change, leaving the pod unschedulable.
+func TestMutate_StableVolumeOrderAcrossReadmission(t *testing.T) {
+	ctx := context.Background()
+	v := &helmStorageMutatingWebhook{}
+
+	pod := &corev1.Pod{}
+	pod.Annotations = map[string]string{
+		cmnnvcastorage.HelmWebhookSharedStorageKNSReadWritePVCNameAnnotationKey:     "nvcf-kns-data-rw",
+		cmnnvcastorage.HelmWebhookSharedStorageSecretsReadWritePVCNameAnnotationKey: "nvcf-secrets-data-rw",
+		cmnnvcastorage.WebhookModelCachePVCNameAnnotationKey:                        "ro-pvc-cache",
+	}
+	pod.Spec.InitContainers = []corev1.Container{{Name: "init"}}
+	pod.Spec.Containers = []corev1.Container{{Name: "utils"}}
+
+	volNames := func(vs []corev1.Volume) []string {
+		out := make([]string, len(vs))
+		for i, x := range vs {
+			out[i] = x.Name
+		}
+		return out
+	}
+	mountSig := func(ms []corev1.VolumeMount) []string {
+		out := make([]string, len(ms))
+		for i, m := range ms {
+			out[i] = m.Name + ":" + m.MountPath
+		}
+		return out
+	}
+
+	// First admission (CREATE).
+	_, _, err := v.mutate(ctx, pod, nvcatypes.MiniserviceMetadata{})
+	require.NoError(t, err)
+	wantVols := volNames(pod.Spec.Volumes)
+	wantMounts := mountSig(pod.Spec.Containers[0].VolumeMounts)
+	wantInitMounts := mountSig(pod.Spec.InitContainers[0].VolumeMounts)
+	// Sanity: all three injected volumes are present.
+	assert.Contains(t, wantVols, cmnnvcastorage.ModelCachePodVolumeName)
+
+	// Second admission (simulates KAI's pod-grouper re-submitting the pod). The
+	// order must be byte-for-byte identical, or the UPDATE is rejected.
+	_, _, err = v.mutate(ctx, pod, nvcatypes.MiniserviceMetadata{})
+	require.NoError(t, err)
+	assert.Equal(t, wantVols, volNames(pod.Spec.Volumes), "volume order must be stable across re-admission")
+	assert.Equal(t, wantMounts, mountSig(pod.Spec.Containers[0].VolumeMounts), "container mount order must be stable")
+	assert.Equal(t, wantInitMounts, mountSig(pod.Spec.InitContainers[0].VolumeMounts), "init mount order must be stable")
 }

--- a/src/compute-plane-services/nvca/pkg/webhook/miniservice_mutating_webhook.go
+++ b/src/compute-plane-services/nvca/pkg/webhook/miniservice_mutating_webhook.go
@@ -234,7 +234,7 @@ func (w *miniserviceMutatingWebhook) Handle(ctx context.Context, req admission.R
 	if pod, ok := obj.(*corev1.Pod); ok && pod.Name == translatecommon.UtilsPodName {
 		if isCreate {
 			// Shared storage mutation does not need metadata.
-			if _, _, err := w.sharedStorageMutator.mutate(ctx, obj); err != nil {
+			if _, _, err := w.sharedStorageMutator.mutate(ctx, obj, nvcatypes.MiniserviceMetadata{}); err != nil {
 				return admission.Errored(http.StatusInternalServerError,
 					fmt.Errorf("mutate shared storage on utils pod: %w", err))
 			}
@@ -334,7 +334,7 @@ func (w *miniserviceMutatingWebhook) mutate(ctx context.Context, obj client.Obje
 				w.mutateNVLinkDRA(obj.GetNamespace(), t)
 			}
 
-			if _, _, err := w.sharedStorageMutator.mutate(ctx, obj); err != nil {
+			if _, _, err := w.sharedStorageMutator.mutate(ctx, obj, meta); err != nil {
 				return fmt.Errorf("mutate shared storage: %w", err)
 			}
 		}


### PR DESCRIPTION
## TL;DR

Remove the HelmCachingSupport feature flag and make Helm MiniService model caching work on any cluster topology: gate all caching on CachingSupport and select the cache storage backend from the cluster's storage classes (SelectHelmCacheBackend), instead of assuming NVMesh 3.x.

1. nvcf-sc-30 present: NVMesh 3.x, existing cross-namespace NVMesh path.
2. else nvcf-miniservice-sc present: operator-provided shared storage, shared-FS populate path (single-writer populate on the shared class, per-namespace read-only reader PVC mounted by the existing webhook). Reader access mode (ROX preferred, RWX fallback) chosen by a CSI capability probe with a TTL-cached result.
3. else HelmSharedStorage enabled: NVCA deploys a Samba server on durable block storage (nvcf-sc) and publishes the nvcf-miniservice-sc SMB CSI StorageClass; the next reconcile resolves to shared-FS.
4. else: per-pod ephemeral emptyDir cache injected by the helm storage webhook.

## Additional Details

This folds the full backend selection into NVCA (no new operator, no new CRDs); it extends NVCA's existing model-cache machinery (control namespace, single-writer lease, writer job, RW/RO PVCs, GC, mutating webhook). The design is documented in docs/dev/sdd-central-model-cache-service.md.

This supersedes the pre-migration internal merge request for the same change and folds in the review feedback from that review:

- The shared-FS populate path now tears down the init job and lease after population while retaining the writer PVC as the durable populated marker, so one completed Job and one Lease no longer accumulate per cache handle.
- The shared cache StorageClass is named nvcf-miniservice-sc (helm -> miniservice rename).
- The ephemeral backend's init env travels in the existing miniservice metadata ConfigMap instead of a dedicated per-instance ConfigMap; the webhook injects it as explicit env vars.
- The CSI capability probe deletes its PV explicitly, so Retain-reclaim storage classes do not accumulate Released PVs.
- The HelmCacheBackend type lives in pkg/types and metrics use the same constants instead of duplicating the backend strings.

At runtime, when the Samba backend is selected NVCA creates a credentials Secret, a durable nvcf-sc data PVC, a Samba Deployment and Service, and the nvcf-miniservice-sc StorageClass in the model cache control namespace (nvca-modelcache-init).

## For the Reviewer

Suggested focus: pkg/storage/cachebackend.go (backend selection), pkg/storage/modelcache.go (per-backend populate paths and the shared-FS partial cleanup), pkg/storage/cacheprobe/ (CSI access-mode probe), internal/miniservice/reconcile.go plus pkg/webhook/helm_storage_webhook.go (ephemeral fallback via miniservice metadata).

## For QA

- go build ./... and go test on the ported tree: pkg/storage, pkg/storage/cacheprobe, pkg/webhook, internal/miniservice, internal/metrics, pkg/types all pass (envtest-backed reconcile tests included: NVMesh, shared-FS, Samba, ephemeral).
- make test and make lint pass on the source branch.
- Backend selection and populate lifecycles are covered by unit and envtest coverage per backend; the shared-FS test asserts the init job and lease are cleaned up and the writer PVC is retained.
- QA on a cluster without NVMesh is recommended before release (shared-FS via an operator-provided class, Samba bootstrap, and ephemeral fallback).

## Issues

Closes #226

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ModelCacheSpec.backend` to select a model-cache storage backend (defaults to `nvmesh`; invalid values fail validation).
  * Implemented backend-aware model-cache initialization, including Samba and per-pod ephemeral fallback.
  * Added durable, reusable cache population markers across namespaces and restarts.

* **Bug Fixes / Improvements**
  * Improved workload volume/mount injection stability across admissions.
  * Made writer-PVC cleanup non-blocking when volumes are still attached.

* **Observability**
  * Extended model-cache metrics with a `backend` label and added new backend-specific counters/gauges.

* **Documentation / Tests**
  * Added design documentation for centralized model-cache behavior and backend lifecycle; updated and expanded unit/integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->