### PR TITLE
chore: migrate nvsnap and nvcf-unbound golangci-lint configs to v2

### DIFF
--- a/src/compute-plane-services/nvcf-unbound/.golangci.yml
+++ b/src/compute-plane-services/nvcf-unbound/.golangci.yml
@@ -1,10 +1,28 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+version: "2"
 linters:
   enable:
     - goheader
-
-linters-settings:
-  goheader:
-    template-path: goheader.tmpl
+  settings:
+    goheader:
+      template-path: goheader.tmpl
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/src/compute-plane-services/nvsnap/.golangci.yml
+++ b/src/compute-plane-services/nvsnap/.golangci.yml
@@ -2,115 +2,111 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # NVSNAP golangci-lint configuration
+version: "2"
 run:
-  timeout: 5m
   modules-download-mode: readonly
-
 linters:
   enable:
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - unused
-    - gofmt
-    - goimports
+    - bodyclose
+    - copyloopvar
+    - errorlint
+    - gocritic
+    - gosec
     - misspell
+    - nakedret
+    - noctx
+    - prealloc
+    - revive
     - unconvert
     - unparam
-    - nakedret
-    - prealloc
-    - copyloopvar
-    - gocritic
-    - revive
-    - bodyclose
-    - noctx
-    - gosec
-    - errorlint
-
-linters-settings:
-  goimports:
-    local-prefixes: github.com/NVIDIA/nvcf/src/compute-plane-services/nvsnap
-
-  govet:
-    enable:
-      - shadow
-  
-  revive:
+  settings:
+    errorlint:
+      errorf: true
+      asserts: true
+      comparison: true
+    gocritic:
+      disabled-checks:
+        - hugeParam # We pass large structs by value intentionally in some cases
+      enabled-tags:
+        - diagnostic
+        - style
+        - performance
+    gosec:
+      excludes:
+        - G104 # Audit errors not checked - we handle this case by case
+        - G304 # Potential file inclusion - necessary for our use case
+        # Permissive dir/file perms are intentional: restored pods run as a
+        # different uid (distroless 65532) than the capturing agent, so the
+        # cache/checkpoint/blob trees these rules flag MUST stay world-readable
+        # for cross-uid restore to work. Tightening them breaks restore.
+        - G301 # dir perms (MkdirAll 0755) — see above
+        - G302 # file perms on chmod — see above
+        - G306 # WriteFile perms (0644) — see above
+    govet:
+      enable:
+        - shadow
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: exported
+        - name: increment-decrement
+        - name: var-naming
+        - name: var-declaration
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: indent-error-flow
+        - name: errorf
+  exclusions:
+    generated: lax
     rules:
-      - name: blank-imports
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: dot-imports
-      - name: error-return
-      - name: error-strings
-      - name: error-naming
-      - name: exported
-      - name: increment-decrement
-      - name: var-naming
-      - name: var-declaration
-      - name: package-comments
-      - name: range
-      - name: receiver-naming
-      - name: time-naming
-      - name: unexported-return
-      - name: indent-error-flow
-      - name: errorf
-  
-  gosec:
-    excludes:
-      - G104 # Audit errors not checked - we handle this case by case
-      - G304 # Potential file inclusion - necessary for our use case
-      # Permissive dir/file perms are intentional: restored pods run as a
-      # different uid (distroless 65532) than the capturing agent, so the
-      # cache/checkpoint/blob trees these rules flag MUST stay world-readable
-      # for cross-uid restore to work. Tightening them breaks restore.
-      - G301 # dir perms (MkdirAll 0755) — see above
-      - G302 # file perms on chmod — see above
-      - G306 # WriteFile perms (0644) — see above
-
-  errorlint:
-    errorf: true
-    asserts: true
-    comparison: true
-
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - style
-      - performance
-    disabled-checks:
-      - hugeParam # We pass large structs by value intentionally in some cases
-
+      # Test files can have longer functions
+      - linters:
+          - funlen
+        path: _test\.go
+      # Allow dot imports in tests
+      - linters:
+          - revive
+        path: _test\.go
+        text: dot-imports
+      # Generated files
+      - linters:
+          - all
+        path: zz_generated
+      # API types have many fields
+      - linters:
+          - revive
+        path: pkg/apis/
+        text: 'exported:'
+    paths:
+      # Third-party vendored code (npm package that happens to ship a .go file).
+      - ui/node_modules
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude-use-default: false
   max-issues-per-linter: 0
   max-same-issues: 0
-
-  # Third-party vendored code (npm package that happens to ship a .go file).
-  exclude-dirs:
-    - ui/node_modules
-
-  exclude-rules:
-    # Test files can have longer functions
-    - path: _test\.go
-      linters:
-        - funlen
-    
-    # Allow dot imports in tests
-    - path: _test\.go
-      linters:
-        - revive
-      text: "dot-imports"
-    
-    # Generated files
-    - path: zz_generated
-      linters:
-        - all
-    
-    # API types have many fields
-    - path: pkg/apis/
-      linters:
-        - revive
-      text: "exported:"
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/NVIDIA/nvcf/src/compute-plane-services/nvsnap
+  exclusions:
+    generated: lax
+    paths:
+      - ui/node_modules
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
## TL;DR
nvsnap and nvcf-unbound .golangci.yml were still v1 schema, so golangci-lint v2 failed to load them. Migrated both with the official migrate tool and restored stripped comments. golangci-lint config verify passes for both.

## Issues
NO-REF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated code-quality checks across compute services.
  - Improved handling of generated code, examples, third-party files, and test-specific patterns.
  - Standardized formatting and linting rules for more consistent validation.
  - Refined security, style, and correctness checks while preserving service behavior.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->