### PR TITLE
chore(nvca): fix Deprecated doc comment formatting

### DIFF
--- a/src/compute-plane-services/nvca/internal/metrics/metrics.go
+++ b/src/compute-plane-services/nvca/internal/metrics/metrics.go
@@ -1063,6 +1063,7 @@ func (m *Metrics) RecordMiniServiceFailure(ncaID, reason string) {
 }
 
 // SetMiniServiceReadyStatus sets the ready status gauge for a MiniService.
+//
 // Deprecated: use RecordMiniServicePhaseTransition and RecordMiniServiceFailure instead.
 func (m *Metrics) SetMiniServiceReadyStatus(ncaID string, value float64) {
 	if m == nil {


### PR DESCRIPTION
## TL;DR
Add the blank comment line gocritic (deprecatedComment) requires before the Deprecated: notice on SetMiniServiceReadyStatus. One-line change, no behavior affected.

## Issues
NO-REF
