### PR TITLE
fix(ci): support CodeQL comments on fork PRs

### DIFF
--- a/.github/workflows/codeql-comment.yml
+++ b/.github/workflows/codeql-comment.yml
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The pull_request CodeQL workflow cannot comment on fork PRs because GitHub
+# gives those runs a read-only token. This companion workflow runs only after
+# CodeQL completes, downloads its SARIF artifacts, and posts the comment from
+# the base repository context without checking out or executing fork code.
+
+name: "CodeQL: Comment"
+
+on:
+  workflow_run:
+    workflows: ["codeql"]
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.full_name || github.repository }}-${{ github.event.workflow_run.head_branch || github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name != github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Download CodeQL results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: codeql-pr-results-*
+          path: codeql-results
+          merge-multiple: true
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post or update CodeQL results comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          EVENT_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          set -euo pipefail
+
+          PR_NUMBER="$EVENT_PR_NUMBER"
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            PR_NUMBER=$(gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/pull_requests" \
+              --jq 'map(select(.state == "open")) | .[0].number // empty')
+          fi
+
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::warning::Could not resolve a pull request for CodeQL run ${RUN_ID}"
+            exit 0
+          fi
+
+          mapfile -d '' SARIF_FILES < <(find codeql-results -type f -name '*.sarif' -print0)
+          if [ "${#SARIF_FILES[@]}" -eq 0 ]; then
+            echo "::error::No SARIF files were downloaded for CodeQL run ${RUN_ID}"
+            exit 1
+          fi
+
+          RESULTS_FILE=$(mktemp)
+          BODY_FILE=$(mktemp)
+          COMMENTS_FILE=$(mktemp)
+          trap 'rm -f "$RESULTS_FILE" "$BODY_FILE" "$COMMENTS_FILE"' EXIT
+
+          jq -s '[.[].runs[]?.results[]?]' "${SARIF_FILES[@]}" > "$RESULTS_FILE"
+
+          TOTAL_ISSUES=$(jq 'length' "$RESULTS_FILE")
+          ERRORS=$(jq '[.[] | select(.level == "error")] | length' "$RESULTS_FILE")
+          WARNINGS=$(jq '[.[] | select(.level == "warning")] | length' "$RESULTS_FILE")
+          NOTES=$(jq '[.[] | select(.level == "note")] | length' "$RESULTS_FILE")
+
+          {
+            echo '<!-- dsx-codeql-scan -->'
+            echo '## CodeQL Analysis'
+            echo
+            if [ "$TOTAL_ISSUES" -eq 0 ]; then
+              echo 'No security issues found.'
+            else
+              echo "Found **${TOTAL_ISSUES}** issue(s)."
+              echo
+              echo "- Errors: ${ERRORS}"
+              echo "- Warnings: ${WARNINGS}"
+              echo "- Notes: ${NOTES}"
+              echo
+              echo '<details>'
+              echo '<summary>Top issues</summary>'
+              echo
+              jq -r '
+                .[0:5][] |
+                "- **\(.ruleId // "unknown")**: " +
+                "\(.message.text // "No description") " +
+                "(`\(.locations[0].physicalLocation.artifactLocation.uri // "unknown"):" +
+                "\(.locations[0].physicalLocation.region.startLine // "?")`)"
+              ' "$RESULTS_FILE"
+              echo
+              echo '</details>'
+            fi
+            echo
+            echo "[View the CodeQL workflow run](${RUN_URL})"
+            echo
+            echo "<sub>Commit: ${HEAD_SHA:0:7}</sub>"
+          } > "$BODY_FILE"
+
+          gh api --paginate --slurp \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            > "$COMMENTS_FILE"
+
+          COMMENT_ID=$(jq -r '
+            [.[][] |
+              select(.user.login == "github-actions[bot]") |
+              select(.body | contains("<!-- dsx-codeql-scan -->"))] |
+            first | .id // empty
+          ' "$COMMENTS_FILE")
+
+          if [ -n "$COMMENT_ID" ]; then
+            jq -n --rawfile body "$BODY_FILE" '{body: $body}' |
+              gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" \
+                --method PATCH \
+                --input -
+          else
+            jq -n --rawfile body "$BODY_FILE" '{body: $body}' |
+              gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+                --method POST \
+                --input -
+          fi

--- a/.github/workflows/codeql-comment.yml
+++ b/.github/workflows/codeql-comment.yml
@@ -131,22 +131,14 @@ jobs:
             WARNINGS=$(jq -s '[.[].runs[]?.results[]? | select(.level == "warning")] | length' "${SARIF_FILES[@]}")
             NOTES=$(jq -s '[.[].runs[]?.results[]? | select(.level == "note")] | length' "${SARIF_FILES[@]}")
 
-            # SARIF artifacts from fork runs are untrusted. Encode and truncate
-            # displayed fields before adding up to five findings to the comment.
+            # Match the shared action's same-repository comment format.
             TOP_ISSUES=$(jq -rs '
-              def safe($limit):
-                tostring
-                | gsub("[\\r\\n\\t]+"; " ")
-                | .[0:$limit]
-                | explode
-                | map("&#\(.);")
-                | join("");
               [.[].runs[]?.results[]?
                 | select(.level == "error" or .level == "warning")][0:5][]
-              | "- **\((.ruleId // "unknown") | safe(100))**: "
-                + "\((.message.text // "No description") | safe(300)) "
-                + "(\((.locations[0].physicalLocation.artifactLocation.uri // "unknown") | safe(200)):"
-                + "\((.locations[0].physicalLocation.region.startLine // "?") | safe(20)))"
+              | "- **\(.ruleId // "unknown")**: "
+                + "\(.message.text // "No description") "
+                + "(\(.locations[0].physicalLocation.artifactLocation.uri // "unknown"):"
+                + "\(.locations[0].physicalLocation.region.startLine // "?"))"
             ' "${SARIF_FILES[@]}")
 
             REPORT="${COMMENT_MARKER}

--- a/.github/workflows/codeql-comment.yml
+++ b/.github/workflows/codeql-comment.yml
@@ -30,12 +30,8 @@ permissions:
   actions: read
   pull-requests: write
 
-concurrency:
-  group: codeql-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
-  cancel-in-progress: true
-
 jobs:
-  comment:
+  resolve-pr:
     # Same-repository PRs are commented on directly by the CodeQL workflow.
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
@@ -43,6 +39,55 @@ jobs:
       github.event.workflow_run.head_repository.full_name != github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    outputs:
+      pr_number: ${{ steps.validate.outputs.pr_number }}
+    steps:
+      - name: Download fork PR metadata
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: codeql-pr-metadata
+          path: codeql-pr-metadata
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate pull request metadata
+        id: validate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          PR_NUMBER=$(tr -d '[:space:]' < codeql-pr-metadata/pr-number)
+          if ! [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::Invalid pull request number in CodeQL metadata artifact"
+            exit 1
+          fi
+
+          PR_DATA=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")
+          if ! jq -e \
+            --arg head_repository "$HEAD_REPOSITORY" \
+            --arg head_branch "$HEAD_BRANCH" \
+            --arg head_sha "$HEAD_SHA" \
+            '.state == "open" and
+             .head.repo.full_name == $head_repository and
+             .head.ref == $head_branch and
+             .head.sha == $head_sha' <<< "$PR_DATA" > /dev/null; then
+            echo "::error::Pull request ${PR_NUMBER} does not match the CodeQL workflow run"
+            exit 1
+          fi
+
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+  comment:
+    needs: resolve-pr
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: codeql-comment-pr-${{ needs.resolve-pr.outputs.pr_number }}
+      cancel-in-progress: true
     steps:
       - name: Download CodeQL results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -56,26 +101,11 @@ jobs:
       - name: Post or update CodeQL results comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR_NUMBER: ${{ needs.resolve-pr.outputs.pr_number }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: |
           set -euo pipefail
-
-          # workflow_run.pull_requests can be empty for fork runs. Resolve the PR
-          # from trusted event metadata instead of fork-controlled artifacts.
-          HEAD_OWNER=${HEAD_REPOSITORY%%/*}
-          PR_NUMBER=$(gh api --method GET \
-            "repos/${GITHUB_REPOSITORY}/pulls" \
-            -f state=open \
-            -f head="${HEAD_OWNER}:${HEAD_BRANCH}" |
-            jq -r --arg sha "$HEAD_SHA" \
-              '[.[] | select(.head.sha == $sha)][0].number // empty')
-          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
-            echo "::warning::Could not resolve a pull request for CodeQL run ${RUN_URL}"
-            exit 0
-          fi
 
           mapfile -d '' SARIF_FILES < <(find codeql-results -type f -name '*.sarif' -print0)
           if [ "${#SARIF_FILES[@]}" -eq 0 ]; then

--- a/.github/workflows/codeql-comment.yml
+++ b/.github/workflows/codeql-comment.yml
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The pull_request CodeQL workflow cannot comment on fork PRs because GitHub
-# gives those runs a read-only token. This companion workflow runs only after
-# CodeQL completes, downloads its SARIF artifacts, and posts the comment from
-# the base repository context without checking out or executing fork code.
+# Fork pull requests receive a read-only GITHUB_TOKEN, so the CodeQL scan can
+# upload results but cannot post its summary comment. This workflow runs after
+# a successful fork scan in the base repository context, where it can create or
+# update that comment from the uploaded SARIF artifacts. Same-repository pull
+# requests comment directly from codeql.yml and do not need this workflow.
 
 name: "CodeQL: Comment"
 
@@ -30,11 +31,12 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.full_name || github.repository }}-${{ github.event.workflow_run.head_branch || github.event.workflow_run.id }}
+  group: codeql-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 jobs:
   comment:
+    # Same-repository PRs are commented on directly by the CodeQL workflow.
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&
@@ -54,94 +56,101 @@ jobs:
       - name: Post or update CodeQL results comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
-          EVENT_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
         run: |
           set -euo pipefail
 
-          PR_NUMBER="$EVENT_PR_NUMBER"
+          # workflow_run.pull_requests can be empty for fork runs. Resolve the PR
+          # from trusted event metadata instead of fork-controlled artifacts.
+          HEAD_OWNER=${HEAD_REPOSITORY%%/*}
+          PR_NUMBER=$(gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/pulls" \
+            -f state=open \
+            -f head="${HEAD_OWNER}:${HEAD_BRANCH}" |
+            jq -r --arg sha "$HEAD_SHA" \
+              '[.[] | select(.head.sha == $sha)][0].number // empty')
           if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
-            PR_NUMBER=$(gh api \
-              "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/pull_requests" \
-              --jq 'map(select(.state == "open")) | .[0].number // empty')
-          fi
-
-          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
-            echo "::warning::Could not resolve a pull request for CodeQL run ${RUN_ID}"
+            echo "::warning::Could not resolve a pull request for CodeQL run ${RUN_URL}"
             exit 0
           fi
 
           mapfile -d '' SARIF_FILES < <(find codeql-results -type f -name '*.sarif' -print0)
           if [ "${#SARIF_FILES[@]}" -eq 0 ]; then
-            echo "::error::No SARIF files were downloaded for CodeQL run ${RUN_ID}"
+            echo "::error::No SARIF files were downloaded from ${RUN_URL}"
             exit 1
           fi
 
-          RESULTS_FILE=$(mktemp)
-          BODY_FILE=$(mktemp)
-          COMMENTS_FILE=$(mktemp)
-          trap 'rm -f "$RESULTS_FILE" "$BODY_FILE" "$COMMENTS_FILE"' EXIT
+          COMMENT_MARKER="<!-- dsx-codeql-scan -->"
+          TOTAL_ISSUES=$(jq -s '[.[].runs[]?.results[]?] | length' "${SARIF_FILES[@]}")
+          SHORT_SHA=${HEAD_SHA:0:7}
+          FOOTER="🔗 [View full details in Security tab](https://github.com/${GITHUB_REPOSITORY}/security/code-scanning)"
 
-          jq -s '[.[].runs[]?.results[]?]' "${SARIF_FILES[@]}" > "$RESULTS_FILE"
+          if [ "$TOTAL_ISSUES" -eq 0 ]; then
+            REPORT="${COMMENT_MARKER}
+          ## 🛡️ CodeQL Analysis
+          ✅ No security issues found!
 
-          TOTAL_ISSUES=$(jq 'length' "$RESULTS_FILE")
-          ERRORS=$(jq '[.[] | select(.level == "error")] | length' "$RESULTS_FILE")
-          WARNINGS=$(jq '[.[] | select(.level == "warning")] | length' "$RESULTS_FILE")
-          NOTES=$(jq '[.[] | select(.level == "note")] | length' "$RESULTS_FILE")
+          $FOOTER
 
-          {
-            echo '<!-- dsx-codeql-scan -->'
-            echo '## CodeQL Analysis'
-            echo
-            if [ "$TOTAL_ISSUES" -eq 0 ]; then
-              echo 'No security issues found.'
-            else
-              echo "Found **${TOTAL_ISSUES}** issue(s)."
-              echo
-              echo "- Errors: ${ERRORS}"
-              echo "- Warnings: ${WARNINGS}"
-              echo "- Notes: ${NOTES}"
-              echo
-              echo '<details>'
-              echo '<summary>Top issues</summary>'
-              echo
-              jq -r '
-                .[0:5][] |
-                "- **\(.ruleId // "unknown")**: " +
-                "\(.message.text // "No description") " +
-                "(`\(.locations[0].physicalLocation.artifactLocation.uri // "unknown"):" +
-                "\(.locations[0].physicalLocation.region.startLine // "?")`)"
-              ' "$RESULTS_FILE"
-              echo
-              echo '</details>'
-            fi
-            echo
-            echo "[View the CodeQL workflow run](${RUN_URL})"
-            echo
-            echo "<sub>Commit: ${HEAD_SHA:0:7}</sub>"
-          } > "$BODY_FILE"
+          <sub>🕐 Last updated: $(date -u '+%Y-%m-%d %H:%M:%S UTC') | Commit: ${SHORT_SHA}</sub>"
+          else
+            ERRORS=$(jq -s '[.[].runs[]?.results[]? | select(.level == "error")] | length' "${SARIF_FILES[@]}")
+            WARNINGS=$(jq -s '[.[].runs[]?.results[]? | select(.level == "warning")] | length' "${SARIF_FILES[@]}")
+            NOTES=$(jq -s '[.[].runs[]?.results[]? | select(.level == "note")] | length' "${SARIF_FILES[@]}")
 
-          gh api --paginate --slurp \
+            # SARIF artifacts from fork runs are untrusted. Encode and truncate
+            # displayed fields before adding up to five findings to the comment.
+            TOP_ISSUES=$(jq -rs '
+              def safe($limit):
+                tostring
+                | gsub("[\\r\\n\\t]+"; " ")
+                | .[0:$limit]
+                | explode
+                | map("&#\(.);")
+                | join("");
+              [.[].runs[]?.results[]?
+                | select(.level == "error" or .level == "warning")][0:5][]
+              | "- **\((.ruleId // "unknown") | safe(100))**: "
+                + "\((.message.text // "No description") | safe(300)) "
+                + "(\((.locations[0].physicalLocation.artifactLocation.uri // "unknown") | safe(200)):"
+                + "\((.locations[0].physicalLocation.region.startLine // "?") | safe(20)))"
+            ' "${SARIF_FILES[@]}")
+
+            REPORT="${COMMENT_MARKER}
+          ## 🛡️ CodeQL Analysis
+          🚨 Found **${TOTAL_ISSUES}** issue(s)
+
+          **Severity Breakdown:**
+          - 🔴 Errors: ${ERRORS}
+          - 🟡 Warnings: ${WARNINGS}
+          - 🔵 Notes: ${NOTES}
+
+          <details>
+          <summary>📋 Top Issues</summary>
+
+          ${TOP_ISSUES}
+
+          </details>
+
+          $FOOTER
+
+          <sub>🕐 Last updated: $(date -u '+%Y-%m-%d %H:%M:%S UTC') | Commit: ${SHORT_SHA}</sub>"
+          fi
+
+          COMMENT_ID=$(gh api --paginate \
             "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-            > "$COMMENTS_FILE"
-
-          COMMENT_ID=$(jq -r '
-            [.[][] |
-              select(.user.login == "github-actions[bot]") |
-              select(.body | contains("<!-- dsx-codeql-scan -->"))] |
-            first | .id // empty
-          ' "$COMMENTS_FILE")
+            --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("<!-- dsx-codeql-scan -->")) | .id' |
+            sed -n '1p')
 
           if [ -n "$COMMENT_ID" ]; then
-            jq -n --rawfile body "$BODY_FILE" '{body: $body}' |
-              gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" \
-                --method PATCH \
-                --input -
+            gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" \
+              --method PATCH \
+              -f body="$REPORT"
           else
-            jq -n --rawfile body "$BODY_FILE" '{body: $body}' |
-              gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-                --method POST \
-                --input -
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              --method POST \
+              -f body="$REPORT"
           fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -80,6 +80,23 @@ jobs:
         with:
           # The companion workflow parses this artifact as untrusted data only.
           name: codeql-pr-results-${{ matrix.language }}
-          path: results/*.sarif
+          path: results/${{ matrix.language }}.sarif
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Prepare fork PR metadata
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && matrix.language == 'go' }}
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/codeql-pr-metadata"
+          printf '%s\n' "$PR_NUMBER" > "${RUNNER_TEMP}/codeql-pr-metadata/pr-number"
+
+      - name: Upload fork PR metadata
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && matrix.language == 'go' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: codeql-pr-metadata
+          path: ${{ runner.temp }}/codeql-pr-metadata/pr-number
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,7 +67,17 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           upload-sarif: true
-          post-pr-comment: true
+          # Fork pull requests receive a read-only token and cannot post comments.
+          post-pr-comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
           # Non-blocking during rollout: findings surface in the Security tab and
           # as a PR comment, but do not gate merges yet. Tighten once triaged.
           fail-on-findings: false
+
+      - name: Upload CodeQL results for fork PR comment
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: codeql-pr-results-${{ matrix.language }}
+          path: results/*.sarif
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,7 +67,8 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           upload-sarif: true
-          # Fork pull requests receive a read-only token and cannot post comments.
+          # Same-repository PRs can comment here. Fork PRs have a read-only token
+          # and are handled by the companion codeql-comment.yml workflow.
           post-pr-comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
           # Non-blocking during rollout: findings surface in the Security tab and
           # as a PR comment, but do not gate merges yet. Tighten once triaged.
@@ -77,6 +78,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          # The companion workflow parses this artifact as untrusted data only.
           name: codeql-pr-results-${{ matrix.language }}
           path: results/*.sarif
           if-no-files-found: error


### PR DESCRIPTION
## TL;DR

CodeQL scans on fork pull requests complete successfully, but posting the summary comment fails because fork workflows receive a read-only `GITHUB_TOKEN`. This change keeps fork PR workflows read-only and uses a separate workflow_run workflow with permission to post the CodeQL summary.

## Additional Details

The NVCF CodeQL workflow invokes a reusable composite action from `NVIDIA/dsx-github-actions` to initialize CodeQL, run analysis, upload SARIF, optionally post a PR comment, and enforce the configured quality gate. Fork pull requests receive a read-only `GITHUB_TOKEN`, so analysis and SARIF upload succeed, but the action fails when it attempts to post its PR comment:

```text
GraphQL: Resource not accessible by integration (addComment)
```

For example, in the [NVIDIA/nvcf#233 CodeQL workflow run](https://github.com/NVIDIA/nvcf/actions/runs/29572137450), both the Rust and Go jobs completed analysis and found their SARIF files, then failed at the PR comment step with this error.

This change separates fork scanning from commenting:

- Same-repository pull requests continue to use `post-pr-comment` in the `NVIDIA/dsx-github-actions` CodeQL composite action.
- Fork pull requests upload the Go and Rust SARIF files as one-day workflow artifacts.
- A companion `workflow_run` workflow runs in the base repository context, downloads both artifacts, aggregates their results, and creates or updates one CodeQL comment.
- The fork comment follows the existing [CodeQL composite action comment format](https://github.com/NVIDIA/dsx-github-actions/blob/9a9ce3a7770a8b53d2726afa920be3276bc3ddd7/.github/actions/codeql-scan/action.yml#L153-L185).

## Issues

NO-REF

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated CodeQL scan summary comments on pull requests, including severity counts and a short “Top Issues” list.
  * Scan comments are now kept up to date by creating or updating an existing comment marker.
  * Improved support for fork-based pull requests by uploading scan results and using PR metadata to publish summaries only when applicable.
* **Chores**
  * Added a dedicated follow-up workflow that generates and posts the CodeQL report after the scan completes.
  * Updated the CodeQL workflow to conditionally enable PR commenting and to upload fork-specific artifacts only when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->