### PR TITLE
feat(openbao-migrations): support optional JWT issuer override

### DIFF
--- a/migrations/openbao/addons/nvcf-ui/setup_nvcf-ui.sh
+++ b/migrations/openbao/addons/nvcf-ui/setup_nvcf-ui.sh
@@ -43,7 +43,7 @@ sis_policy_base="services-${sis_account}"
 SCOPES="attributes_listing,cluster-management,clusters_listing,cluster_listing,gpu_listing,instance_types,regions_listing"
 
 # Issuer: http://api.sis.svc.cluster.local
-jwt_secret_role=$(generate_jwt_secret_role "${sis_namespace}" "${sis_service}" "${SERVICE_ACCOUNT_NAME}" "${SCOPES}")
+jwt_secret_role=$(generate_jwt_secret_role "${sis_namespace}" "${sis_service}" "${SERVICE_ACCOUNT_NAME}" "${SCOPES}" "${JWT_ISSUER_OVERRIDE:-}")
 create_secret_jwt_role "${sis_secret_base}/jwt" "${SERVICE_ACCOUNT_NAME}" "${jwt_secret_role}"
 
 policy=$(generate_acl_policy "${sis_secret_base}/jwt/sign/${SERVICE_ACCOUNT_NAME}" "create,update,read")

--- a/migrations/openbao/job.yaml
+++ b/migrations/openbao/job.yaml
@@ -46,6 +46,10 @@ spec:
               value: ""
             - name: ADMIN_CLIENT_ID
               value: "ncp"
+            # Optional: overrides the derived in-cluster issuer stamped into the
+            # generated JWT secret roles. Empty keeps the default per-service issuer.
+            - name: JWT_ISSUER_OVERRIDE
+              value: ""
           volumeMounts:
             - name: openbao-secrets-root-token
               mountPath: "/secrets/root_token"

--- a/migrations/openbao/migrations/09_setup_nvcf-api.sh
+++ b/migrations/openbao/migrations/09_setup_nvcf-api.sh
@@ -113,7 +113,7 @@ SCOPES="spot-request,cluster_listing,instance_types,cluster-management"
 # Create JWT Secret Role for NVCF JWT Signer
 #-------------------------------------------
 # Issuer: http://api.sis.svc.cluster.local
-jwt_secret_role=$(generate_jwt_secret_role "${SIS_API_SERVICE_ACCOUNT_NAMESPACE}" "${SIS_API_SERVICE_NAME}" "${SERVICE_ACCOUNT_NAME}" "${SCOPES}")
+jwt_secret_role=$(generate_jwt_secret_role "${SIS_API_SERVICE_ACCOUNT_NAMESPACE}" "${SIS_API_SERVICE_NAME}" "${SERVICE_ACCOUNT_NAME}" "${SCOPES}" "${JWT_ISSUER_OVERRIDE:-}")
 create_secret_jwt_role "${SIS_API_SECRET_BASE_PATH}/jwt" "${SERVICE_ACCOUNT_NAME}" "${jwt_secret_role}"
 
 #-------------------------------------------

--- a/migrations/openbao/migrations/14_setup_nvca.sh
+++ b/migrations/openbao/migrations/14_setup_nvca.sh
@@ -51,7 +51,7 @@ SCOPES="nvca-cluster,instance_request_update"
 # Create JWT Secret Role for SIS JWT Signer
 #-------------------------------------------
 # Issuer: http://api.sis.svc.cluster.local
-jwt_secret_role=$(generate_jwt_secret_role "${SIS_API_SERVICE_ACCOUNT_NAMESPACE}" "${SIS_API_SERVICE_NAME}" "${SERVICE_ACCOUNT_NAME}" "${SCOPES}")
+jwt_secret_role=$(generate_jwt_secret_role "${SIS_API_SERVICE_ACCOUNT_NAMESPACE}" "${SIS_API_SERVICE_NAME}" "${SERVICE_ACCOUNT_NAME}" "${SCOPES}" "${JWT_ISSUER_OVERRIDE:-}")
 create_secret_jwt_role "${SIS_API_SECRET_BASE_PATH}/jwt" "${SERVICE_ACCOUNT_NAME}" "${jwt_secret_role}"
 
 

--- a/migrations/openbao/migrations/15_setup_nvca-operator.sh
+++ b/migrations/openbao/migrations/15_setup_nvca-operator.sh
@@ -51,7 +51,7 @@ SCOPES="cluster-management"
 # Create JWT Secret Role for SIS JWT Signer
 #-------------------------------------------
 # Issuer: http://api.sis.svc.cluster.local
-jwt_secret_role=$(generate_jwt_secret_role "${SIS_API_SERVICE_ACCOUNT_NAMESPACE}" "${SIS_API_SERVICE_NAME}" "${SERVICE_ACCOUNT_NAME}" "${SCOPES}")
+jwt_secret_role=$(generate_jwt_secret_role "${SIS_API_SERVICE_ACCOUNT_NAMESPACE}" "${SIS_API_SERVICE_NAME}" "${SERVICE_ACCOUNT_NAME}" "${SCOPES}" "${JWT_ISSUER_OVERRIDE:-}")
 create_secret_jwt_role "${SIS_API_SECRET_BASE_PATH}/jwt" "${SERVICE_ACCOUNT_NAME}" "${jwt_secret_role}"
 
 

--- a/migrations/openbao/migrations/20_setup_nvct.sh
+++ b/migrations/openbao/migrations/20_setup_nvct.sh
@@ -126,7 +126,7 @@ SCOPES="spot-request,cluster_listing,instance_types,cluster-management"
 # Create JWT Secret Role for NVCF JWT Signer
 #-------------------------------------------
 # Issuer: http://api.sis.svc.cluster.local
-jwt_secret_role=$(generate_jwt_secret_role "${SIS_API_SERVICE_ACCOUNT_NAMESPACE}" "${SIS_API_SERVICE_NAME}" "${SERVICE_ACCOUNT_NAME}" "${SCOPES}")
+jwt_secret_role=$(generate_jwt_secret_role "${SIS_API_SERVICE_ACCOUNT_NAMESPACE}" "${SIS_API_SERVICE_NAME}" "${SERVICE_ACCOUNT_NAME}" "${SCOPES}" "${JWT_ISSUER_OVERRIDE:-}")
 create_secret_jwt_role "${SIS_API_SECRET_BASE_PATH}/jwt" "${SERVICE_ACCOUNT_NAME}" "${jwt_secret_role}"
 
 #-------------------------------------------

--- a/migrations/openbao/migrations/utils/functions.sh
+++ b/migrations/openbao/migrations/utils/functions.sh
@@ -469,27 +469,33 @@ EOF
 # @param target_service_account_namespace The namespace of the target service account
 # @param client_service_name The name of the client service
 # @param scopes The scopes to be added to the JWT secret role
+# @param issuer_override Optional. When non-empty, overrides the derived
+#        "http://<target_service_name>.<target_service_account_namespace>.svc.cluster.local"
+#        issuer. Leave empty to preserve the default in-cluster issuer.
 #
 function generate_jwt_secret_role() {
   local target_service_account_namespace=$1
   local target_service_name=$2
   local client_service_name=$3
   local scopes=$4
+  local issuer_override=${5:-""}
 
   local quoted_scopes=$(sed 's/\([^,]*\)/"\1"/g' <<< "$scopes")
-  local issuer="http://${target_service_name}.${target_service_account_namespace}.svc.cluster.local"
 
-  local role_json=$(cat <<EOF
-{
-  "issuer":"${issuer}",
-  "claims":{
-    "azp":"${client_service_name}",
-    "aud":["${client_service_name}","s:${target_service_name}"],
-    "scopes":[${quoted_scopes}],
-    "sub":"${client_service_name}"
-  }
-}
-EOF
-)
+  local issuer="http://${target_service_name}.${target_service_account_namespace}.svc.cluster.local"
+  if [[ -n "${issuer_override}" ]]; then
+    issuer="${issuer_override}"
+  fi
+
+  # Build the role JSON with jq so every string value is escaped correctly.
+  # Delegating to --arg handles quotes, backslashes, and control characters,
+  # which manual interpolation into a heredoc cannot do safely.
+  local role_json
+  role_json=$(jq -n \
+    --arg issuer     "${issuer}" \
+    --arg client     "${client_service_name}" \
+    --arg target     "${target_service_name}" \
+    --argjson scopes "[${quoted_scopes}]" \
+    '{issuer: $issuer, claims: {azp: $client, aud: [$client, ("s:" + $target)], scopes: $scopes, sub: $client}}')
   echo "$role_json"
 }


### PR DESCRIPTION
Closes #246 

## Summary
Adds an optional `JWT_ISSUER_OVERRIDE` to the OpenBao migrations so the JWT `iss`
claim stamped into the generated secret roles can be overridden, and hardens the
role-JSON construction by building it with `jq`.

## What changed
- `migrations/utils/functions.sh` — `generate_jwt_secret_role` accepts an optional
  issuer-override argument; when non-empty it replaces the derived
  `http://<service>.<namespace>.svc.cluster.local` issuer. The role JSON is now built
  with `jq -n --arg/--argjson` instead of a heredoc, so every string value is escaped
  correctly (quotes, backslashes, control characters).
- `09_setup_nvcf-api.sh`, `14_setup_nvca.sh`, `15_setup_nvca-operator.sh`,
  `20_setup_nvct.sh`, `addons/nvcf-ui/setup_nvcf-ui.sh` — pass through
  `${JWT_ISSUER_OVERRIDE:-}` for the relevant signer role.
- `job.yaml` — expose `JWT_ISSUER_OVERRIDE` (empty by default) as an example env var.

## Why
Lets the migrations run with a custom issuer where the default in-cluster issuer isn't
appropriate, without forking the scripts. The `jq`-based construction also removes a
class of JSON-escaping bugs from shell interpolation.

## Backward compatibility
`JWT_ISSUER_OVERRIDE` defaults to empty; when unset, the derived per-service issuer and
the exact role-JSON shape are unchanged, so existing deployments are unaffected.

## Testing
- `bash -n` on all modified scripts.
- Verified the `jq`-built role JSON is byte-equivalent to the previous heredoc output for
  the default (no-override) case, and that a set override is reflected in the minted
  token's `iss` claim.