### PR TITLE
feat(llm-api-gateway): add function ID metric labels

### DIFF
--- a/docs/user/llm-gateway.md
+++ b/docs/user/llm-gateway.md
@@ -194,6 +194,47 @@ For Responses API follow-up calls, `previous_response_id` does not override the 
 
 Sticky routing only affects backend selection when the LLM request router is configured with a cache-affinity-aware routing method for the target model. Clients should only use `x-multi-turn-session-id`. The gateway derives and forwards the internal `x-cache-affinity-key`; clients should not send that header.
 
+## Metrics
+
+LLM API Gateway request metrics include a `function_id` label. The value is the
+function ID extracted from the request routing key. Requests without a routing
+key, such as health checks, use `function_id="none"`.
+
+| Metric | Type | Labels | Description |
+| --- | --- | --- | --- |
+| `llm_api_gateway_http_requests_total` | Counter | `method`, `route`, `status`, `function_id` | Inbound HTTP requests. |
+| `llm_api_gateway_http_request_duration_seconds` | Histogram | `method`, `route`, `status`, `function_id` | Inbound HTTP request latency. |
+| `llm_api_gateway_http_active_requests` | Up-down counter | `method`, `route`, `function_id` | In-flight inbound HTTP requests. |
+| `llm_api_gateway_upstream_requests_total` | Counter | `upstream`, `result`, `status`, `function_id` | Requests sent to an upstream provider. |
+| `llm_api_gateway_upstream_request_duration_seconds` | Histogram | `upstream`, `result`, `status`, `function_id` | Upstream provider request latency. |
+| `llm_api_gateway_llm_tokens_total` | Counter | `endpoint`, `token_type`, `stream`, `function_id` | Token counts reported by upstream providers. |
+| `llm_api_gateway_provider_time_seconds` | Histogram | `endpoint`, `phase`, `stream`, `function_id` | Provider-reported timing phases. |
+| `llm_api_gateway_stream_first_token_seconds` | Histogram | `endpoint`, `function_id` | Time from stream request start to the first token. |
+| `llm_api_gateway_stream_duration_seconds` | Histogram | `endpoint`, `status`, `function_id` | Total stream duration. |
+
+Infrastructure metrics for authentication, rate limit synchronization, pub/sub,
+and the distributed cache do not include `function_id` because they are not
+associated with a single routed function.
+
+Use the label to calculate request rate by function:
+
+```promql
+sum by (function_id) (
+  rate(llm_api_gateway_http_requests_total[5m])
+)
+```
+
+Use the histogram label to calculate p95 request latency by function:
+
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le, function_id) (
+    rate(llm_api_gateway_http_request_duration_seconds_bucket[5m])
+  )
+)
+```
+
 ## Operational Notes
 
 - The LLM invocation route is served by the `llm.invocation.<domain>` hostname.

--- a/src/invocation-plane-services/llm-api-gateway/README.md
+++ b/src/invocation-plane-services/llm-api-gateway/README.md
@@ -155,6 +155,36 @@ Useful overrides:
 - `OTEL_TRACES_EXPORTER=otlp|stdout|none` to enable trace export
 - `OTEL_METRICS_EXPORTER=otlp|none` to enable metric export
 
+## Metrics
+
+Request-facing metrics include a `function_id` label. The value comes from the
+request routing key. Requests without a function, such as health checks, use
+`function_id="none"`.
+
+The label is present on HTTP request, upstream request, token usage, provider
+time, first-token time, and stream duration metrics. Infrastructure metrics for
+authentication, pub/sub, rate-limit synchronization, and Olric remain
+function-independent.
+
+Example request-rate query:
+
+```promql
+sum by (function_id) (
+  rate(llm_api_gateway_http_requests_total[5m])
+)
+```
+
+Example p95 request-latency query:
+
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le, function_id) (
+    rate(llm_api_gateway_http_request_duration_seconds_bucket[5m])
+  )
+)
+```
+
 ## Tooling and Tasks
 
 Common tasks:

--- a/src/invocation-plane-services/llm-api-gateway/api/chat_handler.go
+++ b/src/invocation-plane-services/llm-api-gateway/api/chat_handler.go
@@ -101,7 +101,13 @@ func (h *OpenAIChatHandlers) handleChatCompletionRequest(
 
 	if usageHasTokenCounts(&response.Usage) {
 		finalUsage = &response.Usage
-		h.handlers.observability.recordLLMUsage(c.UserContext(), endpointLabel(c), finalUsage, false)
+		h.handlers.observability.recordLLMUsage(
+			c.UserContext(),
+			endpointLabel(c),
+			requestFunctionID(c),
+			finalUsage,
+			false,
+		)
 	}
 	if responseModel != "" {
 		response.Model = responseModel
@@ -155,6 +161,7 @@ func (h *OpenAIChatHandlers) streamChatCompletionWithSender(
 		finalizeCtx,
 		c.UserContext(),
 		endpointLabel(c),
+		requestFunctionID(c),
 		request,
 		responseModel,
 		stream,
@@ -235,6 +242,7 @@ func (h *OpenAIChatHandlers) wrapStreamForFinalization(
 	finalizeCtx context.Context,
 	streamCtx context.Context,
 	endpoint string,
+	functionID string,
 	request *provider.NormalizedRequest,
 	responseModel string,
 	stream <-chan provider.StreamEvent,
@@ -258,6 +266,7 @@ func (h *OpenAIChatHandlers) wrapStreamForFinalization(
 			ctx:                context.WithoutCancel(ctx),
 			finalizeCtx:        finalizeCtx,
 			endpoint:           endpoint,
+			functionID:         functionID,
 			metrics:            h.handlers.observability,
 			request:            request,
 			firstTokenRecorded: &firstTokenRecorded,
@@ -272,6 +281,7 @@ func (h *OpenAIChatHandlers) wrapStreamForFinalization(
 				time.Since(streamStart).Seconds(),
 				attribute.String("endpoint", endpoint),
 				attribute.String("status", streamStatus),
+				telemetry.FunctionIDAttribute(functionID),
 			)
 		}()
 
@@ -292,6 +302,7 @@ type streamObservation struct {
 	ctx                context.Context
 	finalizeCtx        context.Context
 	endpoint           string
+	functionID         string
 	metrics            observabilityMetrics
 	request            *provider.NormalizedRequest
 	firstTokenRecorded *bool
@@ -302,8 +313,24 @@ type streamObservation struct {
 
 func (h *OpenAIChatHandlers) observeStreamEvent(obs streamObservation, event provider.StreamEvent) (string, bool) {
 	streamStatus, hasStatus := streamEventStatus(event.Err, obs.span)
-	recordFirstTokenIfNeeded(obs.ctx, obs.endpoint, obs.metrics, event.Chunk, obs.firstTokenRecorded, obs.streamStart)
-	h.finalizeStreamUsageIfNeeded(obs.ctx, obs.finalizeCtx, obs.endpoint, obs.request, event.Chunk, obs.state)
+	recordFirstTokenIfNeeded(
+		obs.ctx,
+		obs.endpoint,
+		obs.functionID,
+		obs.metrics,
+		event.Chunk,
+		obs.firstTokenRecorded,
+		obs.streamStart,
+	)
+	h.finalizeStreamUsageIfNeeded(
+		obs.ctx,
+		obs.finalizeCtx,
+		obs.endpoint,
+		obs.functionID,
+		obs.request,
+		event.Chunk,
+		obs.state,
+	)
 	return streamStatus, hasStatus
 }
 
@@ -328,6 +355,7 @@ func streamEventStatus(err error, span trace.Span) (string, bool) {
 func recordFirstTokenIfNeeded(
 	ctx context.Context,
 	endpoint string,
+	functionID string,
 	metrics observabilityMetrics,
 	chunk *models.ChatCompletionChunk,
 	firstTokenRecorded *bool,
@@ -342,6 +370,7 @@ func recordFirstTokenIfNeeded(
 		metrics.streamFirstToken,
 		time.Since(streamStart).Seconds(),
 		attribute.String("endpoint", endpoint),
+		telemetry.FunctionIDAttribute(functionID),
 	)
 }
 
@@ -349,6 +378,7 @@ func (h *OpenAIChatHandlers) finalizeStreamUsageIfNeeded(
 	ctx context.Context,
 	finalizeCtx context.Context,
 	endpoint string,
+	functionID string,
 	request *provider.NormalizedRequest,
 	chunk *models.ChatCompletionChunk,
 	state *streamFinalizationState,
@@ -356,7 +386,7 @@ func (h *OpenAIChatHandlers) finalizeStreamUsageIfNeeded(
 	if chunk == nil || !usageHasTokenCounts(chunk.Usage) || !state.MarkFinalized() {
 		return
 	}
-	h.handlers.observability.recordLLMUsage(ctx, endpoint, chunk.Usage, true)
+	h.handlers.observability.recordLLMUsage(ctx, endpoint, functionID, chunk.Usage, true)
 	h.handlers.finalizeTokenConsumption(finalizeCtx, request, chunk.Usage)
 }
 

--- a/src/invocation-plane-services/llm-api-gateway/api/chat_handler.go
+++ b/src/invocation-plane-services/llm-api-gateway/api/chat_handler.go
@@ -258,6 +258,9 @@ func (h *OpenAIChatHandlers) wrapStreamForFinalization(
 		ctx, span := telemetry.Tracer().Start(streamCtx, "llm-api-gateway.stream")
 		defer span.End()
 		span.SetAttributes(attribute.String("endpoint", endpoint))
+		if functionID != "" {
+			span.SetAttributes(attribute.String("nvcf.function.id", functionID))
+		}
 
 		streamStart := time.Now()
 		firstTokenRecorded := false

--- a/src/invocation-plane-services/llm-api-gateway/api/middleware.go
+++ b/src/invocation-plane-services/llm-api-gateway/api/middleware.go
@@ -92,6 +92,7 @@ func NewContextMiddleware(cfg *config.Config) echo.MiddlewareFunc {
 			metricAttrs := []attribute.KeyValue{
 				attribute.String("method", gc.Request().Method),
 				attribute.String("route", routePath),
+				telemetry.FunctionIDAttribute(routingKey),
 			}
 			telemetry.AddUpDownWithContext(ctx, activeRequests, 1, metricAttrs...)
 			defer telemetry.AddUpDownWithContext(context.WithoutCancel(ctx), activeRequests, -1, metricAttrs...)

--- a/src/invocation-plane-services/llm-api-gateway/api/middleware.go
+++ b/src/invocation-plane-services/llm-api-gateway/api/middleware.go
@@ -81,6 +81,9 @@ func NewContextMiddleware(cfg *config.Config) echo.MiddlewareFunc {
 				attribute.String("url.path", routePath),
 				attribute.String("gateway.routing_key", routingKey),
 			)
+			if routingKey != "" {
+				span.SetAttributes(attribute.String("nvcf.function.id", routingKey))
+			}
 
 			logger := requestLogger(requestID, routingKey, targetRegion, gc.Request().Method, routePath)
 

--- a/src/invocation-plane-services/llm-api-gateway/api/middleware_telemetry_test.go
+++ b/src/invocation-plane-services/llm-api-gateway/api/middleware_telemetry_test.go
@@ -97,6 +97,7 @@ func TestNewContextMiddlewareRecordsTraceParentAndStatus(t *testing.T) {
 	assertHasAttribute(t, attrs, "http.response.status_code", int64(http.StatusAccepted))
 	assertHasAttribute(t, attrs, "url.path", "/v1/chat/completions")
 	assertHasAttribute(t, attrs, "http.request.method", http.MethodPost)
+	assertHasAttribute(t, attrs, "nvcf.function.id", "fn-chat")
 }
 
 func TestNewContextMiddlewareRecordsServiceScopedHTTPMetrics(t *testing.T) {
@@ -146,6 +147,20 @@ func TestNewContextMiddlewareRecordsServiceScopedHTTPMetrics(t *testing.T) {
 }
 
 func TestRequestMetricsIncludeFunctionID(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	t.Cleanup(func() {
+		_ = tracerProvider.Shutdown(context.Background())
+	})
+
+	oldTracer := telemetry.Tracer
+	telemetry.Tracer = sync.OnceValue(func() trace.Tracer {
+		return tracerProvider.Tracer("test")
+	})
+	t.Cleanup(func() {
+		telemetry.Tracer = oldTracer
+	})
+
 	reader := sdkmetric.NewManualReader()
 	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	oldMeterProvider := otel.GetMeterProvider()
@@ -215,6 +230,18 @@ func TestRequestMetricsIncludeFunctionID(t *testing.T) {
 		&streamFinalizationState{},
 	)
 	for range wrapped {
+	}
+
+	streamSpanFound := false
+	for _, span := range spanRecorder.Ended() {
+		if span.Name() != "llm-api-gateway.stream" {
+			continue
+		}
+		assertHasAttribute(t, span.Attributes(), "nvcf.function.id", "fn-metrics")
+		streamSpanFound = true
+	}
+	if !streamSpanFound {
+		t.Fatal("missing llm-api-gateway.stream span")
 	}
 
 	metrics := collectMetrics(t, reader)

--- a/src/invocation-plane-services/llm-api-gateway/api/middleware_telemetry_test.go
+++ b/src/invocation-plane-services/llm-api-gateway/api/middleware_telemetry_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	echo "github.com/labstack/echo/v4"
 	"go.opentelemetry.io/otel"
@@ -36,6 +37,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/NVIDIA/nvcf/src/invocation-plane-services/llm-gateway/config"
+	"github.com/NVIDIA/nvcf/src/invocation-plane-services/llm-gateway/models"
+	"github.com/NVIDIA/nvcf/src/invocation-plane-services/llm-gateway/provider"
 	"github.com/NVIDIA/nvcf/src/invocation-plane-services/llm-gateway/telemetry"
 )
 
@@ -124,19 +127,110 @@ func TestNewContextMiddlewareRecordsServiceScopedHTTPMetrics(t *testing.T) {
 
 	metrics := collectMetrics(t, reader)
 	assertMetricHasAttributes(t, metrics, "llm_api_gateway_http_requests_total", map[string]string{
-		"method": http.MethodGet,
-		"route":  "/healthz",
-		"status": "202",
+		"method":      http.MethodGet,
+		"route":       "/healthz",
+		"status":      "202",
+		"function_id": "none",
 	})
 	assertMetricHasAttributes(t, metrics, "llm_api_gateway_http_request_duration_seconds", map[string]string{
-		"method": http.MethodGet,
-		"route":  "/healthz",
-		"status": "202",
+		"method":      http.MethodGet,
+		"route":       "/healthz",
+		"status":      "202",
+		"function_id": "none",
 	})
 	assertMetricHasAttributes(t, metrics, "llm_api_gateway_http_active_requests", map[string]string{
-		"method": http.MethodGet,
-		"route":  "/healthz",
+		"method":      http.MethodGet,
+		"route":       "/healthz",
+		"function_id": "none",
 	})
+}
+
+func TestRequestMetricsIncludeFunctionID(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	oldMeterProvider := otel.GetMeterProvider()
+	otel.SetMeterProvider(meterProvider)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(oldMeterProvider)
+		_ = meterProvider.Shutdown(context.Background())
+	})
+
+	e := echo.New()
+	e.Use(NewContextMiddleware(config.Default()))
+	e.POST("/v1/chat/completions", func(ec echo.Context) error {
+		return ec.NoContent(http.StatusOK)
+	})
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/chat/completions",
+		strings.NewReader(`{"model":"fn-metrics/provider/model"}`),
+	)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	observability := newObservabilityMetrics()
+	observability.recordLLMUsage(
+		context.Background(),
+		"/v1/chat/completions",
+		"fn-metrics",
+		&models.ChatCompletionUsage{
+			PromptTokens:     2,
+			PromptTime:       0.02,
+			CompletionTokens: 3,
+			CompletionTime:   0.03,
+			TotalTokens:      5,
+			TotalTime:        0.05,
+		},
+		false,
+	)
+
+	content := "first token"
+	firstTokenRecorded := false
+	recordFirstTokenIfNeeded(
+		context.Background(),
+		"/v1/chat/completions",
+		"fn-metrics",
+		observability,
+		&models.ChatCompletionChunk{
+			Choices: []models.ChatCompletionChunkChoice{{
+				Delta: models.ChatCompletionChunkDelta{Content: &content},
+			}},
+		},
+		&firstTokenRecorded,
+		time.Now().Add(-time.Millisecond),
+	)
+
+	events := make(chan provider.StreamEvent)
+	close(events)
+	handlers := &OpenAIChatHandlers{handlers: &Handlers{observability: observability}}
+	wrapped := handlers.wrapStreamForFinalization(
+		context.Background(),
+		context.Background(),
+		"/v1/chat/completions",
+		"fn-metrics",
+		nil,
+		"",
+		events,
+		&streamFinalizationState{},
+	)
+	for range wrapped {
+	}
+
+	metrics := collectMetrics(t, reader)
+	for _, name := range []string{
+		"llm_api_gateway_http_requests_total",
+		"llm_api_gateway_http_request_duration_seconds",
+		"llm_api_gateway_http_active_requests",
+		"llm_api_gateway_llm_tokens_total",
+		"llm_api_gateway_provider_time_seconds",
+		"llm_api_gateway_stream_first_token_seconds",
+		"llm_api_gateway_stream_duration_seconds",
+	} {
+		assertMetricHasAttributes(t, metrics, name, map[string]string{
+			"function_id": "fn-metrics",
+		})
+	}
 }
 
 func assertHasAttribute(t *testing.T, attrs []attribute.KeyValue, key string, want any) {

--- a/src/invocation-plane-services/llm-api-gateway/api/observability.go
+++ b/src/invocation-plane-services/llm-api-gateway/api/observability.go
@@ -33,6 +33,7 @@ func endpointLabel(c *GatewayContext) string {
 func (m observabilityMetrics) recordLLMUsage(
 	ctx context.Context,
 	endpoint string,
+	functionID string,
 	usage *models.ChatCompletionUsage,
 	stream bool,
 ) {
@@ -52,6 +53,7 @@ func (m observabilityMetrics) recordLLMUsage(
 			attribute.String("endpoint", endpoint),
 			attribute.String("token_type", tokenType),
 			attribute.String("stream", streamValue),
+			telemetry.FunctionIDAttribute(functionID),
 		)
 	}
 	addTokens("prompt", usage.PromptTokens)
@@ -69,6 +71,7 @@ func (m observabilityMetrics) recordLLMUsage(
 			attribute.String("endpoint", endpoint),
 			attribute.String("phase", phase),
 			attribute.String("stream", streamValue),
+			telemetry.FunctionIDAttribute(functionID),
 		)
 	}
 	if usage.QueueTime != nil {
@@ -77,6 +80,13 @@ func (m observabilityMetrics) recordLLMUsage(
 	recordProviderTime("prompt", usage.PromptTime)
 	recordProviderTime("completion", usage.CompletionTime)
 	recordProviderTime("total", usage.TotalTime)
+}
+
+func requestFunctionID(c *GatewayContext) string {
+	if c == nil || c.RequestContext() == nil {
+		return ""
+	}
+	return c.RequestContext().RoutingKey
 }
 
 func boolLabel(value bool) string {

--- a/src/invocation-plane-services/llm-api-gateway/api/responses_handler.go
+++ b/src/invocation-plane-services/llm-api-gateway/api/responses_handler.go
@@ -20,7 +20,6 @@ package api
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -305,7 +304,7 @@ func (h *ResponsesHandlers) relayNativeResponsesStream(
 	setMultiTurnSessionResponseHeader(c)
 	c.Response().WriteHeader(resp.StatusCode)
 	if resp.Body == nil {
-		h.finalizeNativeResponsesUsage(c.UserContext(), request, nil, true)
+		h.finalizeNativeResponsesUsage(c, request, nil, true)
 		return nil
 	}
 	defer resp.Body.Close()
@@ -316,9 +315,9 @@ func (h *ResponsesHandlers) relayNativeResponsesStream(
 		c.Response().Writer,
 	)
 	if terminalResponse != nil {
-		h.recordNativeResponsesProviderTime(c.UserContext(), start, true)
+		h.recordNativeResponsesProviderTime(c, start, true)
 	}
-	h.finalizeNativeResponsesUsage(c.UserContext(), request, terminalResponse, true)
+	h.finalizeNativeResponsesUsage(c, request, terminalResponse, true)
 	return err
 }
 
@@ -328,7 +327,7 @@ func (h *ResponsesHandlers) aggregateNativeResponsesStream(
 	resp *provider.ProxyResponse,
 ) error {
 	if resp.Body == nil {
-		h.finalizeNativeResponsesUsage(c.UserContext(), request, nil, false)
+		h.finalizeNativeResponsesUsage(c, request, nil, false)
 		return echo.NewHTTPError(http.StatusBadGateway, "responses proxy returned no body")
 	}
 	defer resp.Body.Close()
@@ -338,26 +337,26 @@ func (h *ResponsesHandlers) aggregateNativeResponsesStream(
 		setMultiTurnSessionResponseHeader(c)
 		c.Response().WriteHeader(resp.StatusCode)
 		_, err := io.Copy(c.Response().Writer, resp.Body)
-		h.finalizeNativeResponsesUsage(c.UserContext(), request, nil, false)
+		h.finalizeNativeResponsesUsage(c, request, nil, false)
 		return err
 	}
 
 	start := time.Now()
 	terminalResponse, err := consumeNativeResponsesSSE(resp.Body, nil)
 	if err != nil {
-		h.finalizeNativeResponsesUsage(c.UserContext(), request, nil, false)
+		h.finalizeNativeResponsesUsage(c, request, nil, false)
 		return err
 	}
 	if terminalResponse == nil {
-		h.finalizeNativeResponsesUsage(c.UserContext(), request, nil, false)
+		h.finalizeNativeResponsesUsage(c, request, nil, false)
 		return echo.NewHTTPError(
 			http.StatusBadGateway,
 			"responses proxy stream ended without a terminal response event",
 		)
 	}
 
-	h.recordNativeResponsesProviderTime(c.UserContext(), start, false)
-	h.finalizeNativeResponsesUsage(c.UserContext(), request, terminalResponse, false)
+	h.recordNativeResponsesProviderTime(c, start, false)
+	h.finalizeNativeResponsesUsage(c, request, terminalResponse, false)
 	setMultiTurnSessionResponseHeader(c)
 	return c.JSON(http.StatusOK, terminalResponse)
 }
@@ -464,23 +463,31 @@ func parseNativeResponsesSSEBlock(block []byte) *openairesponses.Response {
 }
 
 func (h *ResponsesHandlers) finalizeNativeResponsesUsage(
-	ctx context.Context,
+	c *GatewayContext,
 	request *provider.NormalizedRequest,
 	response *openairesponses.Response,
 	stream bool,
 ) {
+	ctx := c.UserContext()
 	usage := chatUsageFromResponses(response)
 	if usageHasTokenCounts(usage) {
-		h.handlers.observability.recordLLMUsage(ctx, responsesEndpointPath, usage, stream)
+		h.handlers.observability.recordLLMUsage(
+			ctx,
+			responsesEndpointPath,
+			requestFunctionID(c),
+			usage,
+			stream,
+		)
 	}
 	h.handlers.finalizeTokenConsumption(ctx, request, usage)
 }
 
 func (h *ResponsesHandlers) recordNativeResponsesProviderTime(
-	ctx context.Context,
+	c *GatewayContext,
 	start time.Time,
 	stream bool,
 ) {
+	ctx := c.UserContext()
 	telemetry.RecordWithContext(
 		ctx,
 		h.handlers.observability.providerTime,
@@ -488,6 +495,7 @@ func (h *ResponsesHandlers) recordNativeResponsesProviderTime(
 		attribute.String("endpoint", responsesEndpointPath),
 		attribute.String("phase", "total"),
 		attribute.String("stream", boolLabel(stream)),
+		telemetry.FunctionIDAttribute(requestFunctionID(c)),
 	)
 }
 

--- a/src/invocation-plane-services/llm-api-gateway/provider/BUILD.bazel
+++ b/src/invocation-plane-services/llm-api-gateway/provider/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
         "//requestctx",
         "@com_github_stretchr_testify//require",
         "@io_opentelemetry_go_otel//:otel",
+        "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel//propagation",
         "@io_opentelemetry_go_otel_sdk//trace",
         "@io_opentelemetry_go_otel_sdk_metric//:metric",

--- a/src/invocation-plane-services/llm-api-gateway/provider/BUILD.bazel
+++ b/src/invocation-plane-services/llm-api-gateway/provider/BUILD.bazel
@@ -60,5 +60,7 @@ go_test(
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel//propagation",
         "@io_opentelemetry_go_otel_sdk//trace",
+        "@io_opentelemetry_go_otel_sdk_metric//:metric",
+        "@io_opentelemetry_go_otel_sdk_metric//metricdata",
     ],
 )

--- a/src/invocation-plane-services/llm-api-gateway/provider/stargate.go
+++ b/src/invocation-plane-services/llm-api-gateway/provider/stargate.go
@@ -215,11 +215,15 @@ func (p *StargateProvider) recordUpstreamRequest(
 		status = strconv.Itoa(statusCode)
 	}
 
+	routingKey := ""
+	if reqCtx != nil {
+		routingKey = reqCtx.RoutingKey
+	}
 	attrs := []attribute.KeyValue{
 		attribute.String("upstream", upstreamName),
 		attribute.String("result", result),
 		attribute.String("status", status),
-		telemetry.FunctionIDAttribute(reqCtx.RoutingKey),
+		telemetry.FunctionIDAttribute(routingKey),
 	}
 	telemetry.AddWithContext(ctx, p.upstreamRequestsTotal, 1, attrs...)
 	telemetry.RecordWithContext(ctx, p.upstreamRequestDuration, time.Since(start).Seconds(), attrs...)

--- a/src/invocation-plane-services/llm-api-gateway/provider/stargate.go
+++ b/src/invocation-plane-services/llm-api-gateway/provider/stargate.go
@@ -219,6 +219,7 @@ func (p *StargateProvider) recordUpstreamRequest(
 		attribute.String("upstream", upstreamName),
 		attribute.String("result", result),
 		attribute.String("status", status),
+		telemetry.FunctionIDAttribute(reqCtx.RoutingKey),
 	}
 	telemetry.AddWithContext(ctx, p.upstreamRequestsTotal, 1, attrs...)
 	telemetry.RecordWithContext(ctx, p.upstreamRequestDuration, time.Since(start).Seconds(), attrs...)

--- a/src/invocation-plane-services/llm-api-gateway/provider/stargate_test.go
+++ b/src/invocation-plane-services/llm-api-gateway/provider/stargate_test.go
@@ -67,23 +67,44 @@ func TestStargateProviderMetricsIncludeFunctionID(t *testing.T) {
 		http.StatusOK,
 		nil,
 	)
+	p.recordUpstreamRequest(
+		context.Background(),
+		nil,
+		time.Now().Add(-time.Millisecond),
+		http.StatusOK,
+		nil,
+	)
 
 	var resourceMetrics metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(context.Background(), &resourceMetrics))
-	want := map[string]bool{
-		"llm_api_gateway_upstream_requests_total":           false,
-		"llm_api_gateway_upstream_request_duration_seconds": false,
+	want := map[string]map[string]bool{
+		"llm_api_gateway_upstream_requests_total": {
+			"fn-upstream": false,
+			"none":        false,
+		},
+		"llm_api_gateway_upstream_request_duration_seconds": {
+			"fn-upstream": false,
+			"none":        false,
+		},
 	}
 	for _, scope := range resourceMetrics.ScopeMetrics {
 		for _, metric := range scope.Metrics {
-			if _, ok := want[metric.Name]; ok && metricHasFunctionID(metric.Data, "fn-upstream") {
-				want[metric.Name] = true
+			functionIDs, ok := want[metric.Name]
+			if !ok {
+				continue
+			}
+			for functionID := range functionIDs {
+				if metricHasFunctionID(metric.Data, functionID) {
+					functionIDs[functionID] = true
+				}
 			}
 		}
 	}
-	for name, found := range want {
-		if !found {
-			t.Fatalf("metric %q missing function_id=fn-upstream", name)
+	for name, functionIDs := range want {
+		for functionID, found := range functionIDs {
+			if !found {
+				t.Fatalf("metric %q missing function_id=%s", name, functionID)
+			}
 		}
 	}
 }

--- a/src/invocation-plane-services/llm-api-gateway/provider/stargate_test.go
+++ b/src/invocation-plane-services/llm-api-gateway/provider/stargate_test.go
@@ -32,7 +32,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
 	"github.com/NVIDIA/nvcf/src/invocation-plane-services/llm-gateway/config"
@@ -40,7 +43,72 @@ import (
 	"github.com/NVIDIA/nvcf/src/invocation-plane-services/llm-gateway/internal/servicetier"
 	"github.com/NVIDIA/nvcf/src/invocation-plane-services/llm-gateway/models"
 	"github.com/NVIDIA/nvcf/src/invocation-plane-services/llm-gateway/requestctx"
+	"github.com/NVIDIA/nvcf/src/invocation-plane-services/llm-gateway/telemetry"
 )
+
+func TestStargateProviderMetricsIncludeFunctionID(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	oldMeterProvider := otel.GetMeterProvider()
+	otel.SetMeterProvider(meterProvider)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(oldMeterProvider)
+		_ = meterProvider.Shutdown(context.Background())
+	})
+
+	p := &StargateProvider{
+		upstreamRequestsTotal:   telemetry.UpstreamRequestsTotal(),
+		upstreamRequestDuration: telemetry.UpstreamRequestDuration(),
+	}
+	p.recordUpstreamRequest(
+		context.Background(),
+		&requestctx.RequestContext{RoutingKey: "fn-upstream"},
+		time.Now().Add(-time.Millisecond),
+		http.StatusOK,
+		nil,
+	)
+
+	var resourceMetrics metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &resourceMetrics))
+	want := map[string]bool{
+		"llm_api_gateway_upstream_requests_total":           false,
+		"llm_api_gateway_upstream_request_duration_seconds": false,
+	}
+	for _, scope := range resourceMetrics.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if _, ok := want[metric.Name]; ok && metricHasFunctionID(metric.Data, "fn-upstream") {
+				want[metric.Name] = true
+			}
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Fatalf("metric %q missing function_id=fn-upstream", name)
+		}
+	}
+}
+
+func metricHasFunctionID(data metricdata.Aggregation, want string) bool {
+	hasFunctionID := func(attrs attribute.Set) bool {
+		value, ok := attrs.Value(attribute.Key("function_id"))
+		return ok && value.AsString() == want
+	}
+	switch typed := data.(type) {
+	case metricdata.Sum[int64]:
+		for _, point := range typed.DataPoints {
+			if hasFunctionID(point.Attributes) {
+				return true
+			}
+		}
+	case metricdata.Histogram[float64]:
+		for _, point := range typed.DataPoints {
+			if hasFunctionID(point.Attributes) {
+				return true
+			}
+		}
+	}
+	return false
+}
 
 func TestStargateProviderCompleteForwardsChatPayloadAndRoutingHeaders(t *testing.T) {
 	t.Parallel()

--- a/src/invocation-plane-services/llm-api-gateway/telemetry/metrics.go
+++ b/src/invocation-plane-services/llm-api-gateway/telemetry/metrics.go
@@ -30,13 +30,21 @@ import (
 )
 
 const (
-	metricPrefix = "llm_api_gateway_"
+	metricPrefix           = "llm_api_gateway_"
+	missingFunctionIDLabel = "none"
 
 	dropReasonSameCluster      = "same_cluster"
 	dropReasonOldMessage       = "old_message"
 	dropReasonRemoteApplyOff   = "remote_apply_disabled"
 	synchronizerDropOldMessage = "old_message"
 )
+
+func FunctionIDAttribute(functionID string) attribute.KeyValue {
+	if functionID == "" {
+		functionID = missingFunctionIDLabel
+	}
+	return attribute.String("function_id", functionID)
+}
 
 var DurationBuckets = []float64{
 	0.005,

--- a/src/invocation-plane-services/llm-api-gateway/telemetry/metrics_test.go
+++ b/src/invocation-plane-services/llm-api-gateway/telemetry/metrics_test.go
@@ -111,6 +111,29 @@ func TestMetricsDefinitionsUseServiceScopedNames(t *testing.T) {
 	}
 }
 
+func TestFunctionIDAttribute(t *testing.T) {
+	tests := []struct {
+		name       string
+		functionID string
+		want       string
+	}{
+		{name: "function", functionID: "fn-123", want: "fn-123"},
+		{name: "missing", want: "none"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			attr := FunctionIDAttribute(test.functionID)
+			if got := string(attr.Key); got != "function_id" {
+				t.Fatalf("attribute key = %q, want function_id", got)
+			}
+			if got := attr.Value.AsString(); got != test.want {
+				t.Fatalf("attribute value = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestInitStartsPrometheusMetricsServer(t *testing.T) {
 	port := freePort(t)
 


### PR DESCRIPTION
## TL;DR

- Adds `function_id` to request-facing LLM gateway metrics so operators can break down traffic, latency, and token use by function.
- Uses `none` for unrouted endpoints and keeps infrastructure metrics function-independent.

## Additional Details

- Labels HTTP, upstream, token, provider-time, first-token, and stream-duration series.
- Includes `function_id` on latency histograms.
- Adds regression coverage and PromQL examples.
- Documents the updated metric names, label sets, and per-function PromQL queries on the public LLM Gateway page.

## For the Reviewer

- Review metric attribute propagation in the API middleware, stream handlers, and Stargate provider.
- Review the metrics reference in `docs/user/llm-gateway.md`.

## For QA

- `go test ./...`
- `bazel test //... --flaky_test_attempts=3` (11 of 11 tests passed)
- `./tools/ci/check-docs` (0 errors; one advisory version-sync warning)
- QA needed: No.

## Issues

NVCF-11079

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover this change.
- [x] The documentation is up to date.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `function_id` labeling across LLM Gateway metrics, including HTTP request counts/latency/active requests, upstream request results, token usage, provider timing, first-token timing, and streaming duration.
  - Requests without a routing/function selection (e.g., health checks) are labeled `function_id="none"`.
  - Gateway traces now include the `nvcf.function.id` attribute when a routing key is present.

- **Documentation**
  - Updated Metrics documentation with the new label behavior, supported metric categories, and PromQL examples (per-function request rate and p95 latency), noting function-independent infrastructure metrics.

- **Tests**
  - Added/updated metric validation to ensure `function_id` is present on emitted datapoints for both Gateway and upstream provider metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->