### PR TITLE
docs(user): fix broken links in observability page

### DIFF
--- a/docs/user/observability.md
+++ b/docs/user/observability.md
@@ -8,12 +8,12 @@ Common operator questions and where to look on this page or in linked references
 
 | Question | Where to look |
 |----------|---------------|
-| How do I see application-level NVCF stats (number of functions, queue depth, request latency)? | [State Metrics Service metrics](./state-metrics). The page documents per-function instance count, queue depth, and request latency, plus other function-level signals. |
-| How do I debug a single request end-to-end? | Combine the per-hop signals: enable tracing per [Tracing Configuration](#tracing-configuration), correlate with the [Metrics Overview](./metrics-overview) for each service in the request path, and tail the matching service logs. A consolidated hop-by-hop walkthrough is in development. |
-| Where are per-service metrics? | [Metrics Overview](./metrics-overview). |
-| Where are gRPC proxy metrics? | [gRPC Proxy metrics](./metrics/grpc-proxy/metrics). The page documents client connection counts, NATS pipe health, gRPC worker session-attach latency, and HTTP RED metrics. |
+| How do I see application-level NVCF stats (number of functions, queue depth, request latency)? | [State Metrics Service metrics](./metrics/state-metrics/metrics.md). The page documents per-function instance count, queue depth, and request latency, plus other function-level signals. |
+| How do I debug a single request end-to-end? | Combine the per-hop signals: enable tracing per [Tracing Configuration](#tracing-configuration), correlate with the [Metrics Overview](./metrics/metrics-index.md) for each service in the request path, and tail the matching service logs. A consolidated hop-by-hop walkthrough is in development. |
+| Where are per-service metrics? | [Metrics Overview](./metrics/metrics-index.md). |
+| Where are gRPC proxy metrics? | [gRPC Proxy metrics](./metrics/grpc-proxy/metrics.md). The page documents client connection counts, NATS pipe health, gRPC worker session-attach latency, and HTTP RED metrics. |
 | How do I add custom spans or metrics in a Kit application? | Use the OpenTelemetry API directly, the OmniTrace helper, the Carbonite static metrics API, or the `omni::observability::IMeter` interface. Refer to the Omniverse Kit and Carbonite documentation for details. |
-| Where are reference dashboards? | [Example dashboards](./example-dashboards) and the [Dashboards](#dashboards) section below. |
+| Where are reference dashboards? | [Example dashboards](./example-dashboards.md) and the [Dashboards](#dashboards) section below. |
 
 ## Overview
 
@@ -176,7 +176,7 @@ Or configure Prometheus scrape targets manually in your prometheus.yml.
 The State Metrics Service exposes per-function signals you can query in
 Prometheus. The following PromQL examples cover the three most common
 operator questions. Metric names and labels are sourced from
-[State Metrics Service metrics](./metrics/state-metrics/metrics).
+[State Metrics Service metrics](./metrics/state-metrics/metrics.md).
 
 Number of registered functions:
 


### PR DESCRIPTION
Fixes broken links in docs/user/observability.md. They pointed to old paths; the real pages live under docs/user/metrics/.

Tested: verified each link target exists, ran ./tools/ci/check-docs (0 errors).

Refs: NO-REF