### PR TITLE
docs(ngc-managed): fix broken links in cluster-management docs

### DIFF
--- a/docs/ngc-managed/cluster-management/kai-scheduler.md
+++ b/docs/ngc-managed/cluster-management/kai-scheduler.md
@@ -1,7 +1,7 @@
 # KAI Scheduler Integration Guide
 
 [KAI Scheduler](https://github.com/kai-scheduler/KAI-Scheduler) is an open source Kubernetes Native scheduler for AI workloads at large scale.
-To use the KAI Scheduler for NVCF Workloads the following configuration should be applied post the installation of the KAI Scheduler in the cluster and the [Optimized AI Workload Scheduling](nvca-feature-flags) enabled on the
+To use the KAI Scheduler for NVCF Workloads the following configuration should be applied post the installation of the KAI Scheduler in the cluster and the [Optimized AI Workload Scheduling](./configuration.md#managing-feature-flags) enabled on the
 cluster. NVCF Workloads deployed will be automatically BinPacked upon this cluster configuration changes.
 
 **KAI Scheduler Installation**

--- a/docs/ngc-managed/cluster-management/reference.md
+++ b/docs/ngc-managed/cluster-management/reference.md
@@ -201,6 +201,6 @@ Only used when `ngcConfig.clusterSource: "helm-managed"`.
 
 ## Related Documentation
 
-- [NVCA Configuration](nvca-configuration) — how to use these values to configure specific features (caching, network policies, manual instance config, etc.)
-- [Helm-Managed Clusters](helm-managed-config) — switching to and from helm-managed mode
-- [Agent config merging](nvca-agent-config) — using `agentConfig.mergeConfig` for runtime config overrides
+- [NVCA Configuration](./configuration.md), how to use these values to configure specific features (caching, network policies, manual instance config, etc.)
+- [Helm-Managed Clusters](./helm-managed.md), switching to and from helm-managed mode
+- [Agent Config Merging](./configuration.md#agent-config-merging), using `agentConfig.mergeConfig` for runtime config overrides


### PR DESCRIPTION
Related Documentation links in reference.md and kai-scheduler.md used slugs that match no real file. Pointed them at the real configuration.md and helm-managed.md files/sections.

Tested: verified each target exists, ran ./tools/ci/check-docs (0 errors).

Refs: NO-REF