### PR TITLE
docs(agents): remove references to skills that were never created

### DIFF
--- a/ai-tooling/dev/skills/nvcf-explore-stack/SKILL.md
+++ b/ai-tooling/dev/skills/nvcf-explore-stack/SKILL.md
@@ -104,7 +104,7 @@ Assume the user is onboarding to the stack. Be concise. Always include the chart
 After exploring, suggest the next skill when applicable:
 
 - `nvcf-self-managed-installation` for installing, upgrading, or tearing down the stack
-- `nvcf-self-hosted-local-dev` for k3d / local cluster work
+- `docs/dev/local-development.md` for k3d / local cluster work
 - `nvcf-self-managed-cli` for `nvcf-cli` usage against an installed stack
 - `docs/AGENTS.md` and `fern/versions/main.yml` for routing the user to a published docs page
 - `tools/ci/check-doc-version-sync` for keeping the documentation manifest in sync with the docs version catalog

--- a/src/compute-plane-services/byoo-otel-collector/AGENTS.md
+++ b/src/compute-plane-services/byoo-otel-collector/AGENTS.md
@@ -31,10 +31,6 @@ otelconfig validation. Do not add a subtree `.gitlab-ci.yml`.
 
 ## Collector Version Updates
 
-Agents that can read Cursor project skills should load
-`.cursor/skills/update-otel-collector-version/SKILL.md` before changing
-collector versions.
-
 Use the script instead of editing version strings by hand:
 
 ```bash
@@ -45,8 +41,7 @@ Use the script instead of editing version strings by hand:
 
 The script updates version references in `otel-collector-build.yaml`,
 `AGENTS.md`, `README.md`, `Makefile`, `Dockerfile`,
-`Dockerfile.nvcf-otel-collector`, `scripts/regenerate-otelcol.sh`,
-`../../../ai-tooling/dev/skills/update-otel-collector-version/SKILL.md`, and
+`Dockerfile.nvcf-otel-collector`, `scripts/regenerate-otelcol.sh`, and
 `VERSION`. It also updates `.gitlab-ci.yml` when that file exists. Run it from
 the BYOO collector root. You can pass versions with or without the `v` prefix
 (for example, `v0.153.0` or `0.153.0`). Pass the optional `v1.x.y` provider

--- a/src/compute-plane-services/byoo-otel-collector/scripts/update-collector-version.sh
+++ b/src/compute-plane-services/byoo-otel-collector/scripts/update-collector-version.sh
@@ -25,8 +25,7 @@
 #
 # Updates: otel-collector-build.yaml, AGENTS.md, README.md, Makefile, Dockerfile,
 #          Dockerfile.nvcf-otel-collector, .gitlab-ci.yml,
-#          scripts/regenerate-otelcol.sh,
-#          ../../../ai-tooling/dev/skills/update-otel-collector-version/SKILL.md, VERSION
+#          scripts/regenerate-otelcol.sh, VERSION
 # Run from the BYOO collector root.
 
 set -euo pipefail
@@ -159,7 +158,6 @@ V_FORM_FILES=(
 	Dockerfile.nvcf-otel-collector
 	.gitlab-ci.yml
 	scripts/regenerate-otelcol.sh
-	../../../ai-tooling/dev/skills/update-otel-collector-version/SKILL.md
 )
 
 PLAIN_FORM_FILES=(
@@ -167,7 +165,6 @@ PLAIN_FORM_FILES=(
 	README.md
 	.gitlab-ci.yml
 	Dockerfile.nvcf-otel-collector
-	../../../ai-tooling/dev/skills/update-otel-collector-version/SKILL.md
 )
 
 # Replace vX.Y.Z (builder/gomod form)

--- a/tools/ncp-local-cluster/AGENTS.md
+++ b/tools/ncp-local-cluster/AGENTS.md
@@ -20,8 +20,8 @@ make test-multicluster-make
 ```
 
 Cluster lifecycle targets require local tools such as `k3d`, `kubectl`, `helm`, and Docker.
-For detailed local k3d workflow and cleanup safety, use
-`.cursor/skills/nvcf-self-hosted-local-dev/SKILL.md` from the repo root.
+For detailed local k3d workflow and cleanup safety, see
+`docs/dev/local-development.md` from the repo root.
 
 ## Ownership
 


### PR DESCRIPTION
Three files referenced two skills, update-otel-collector-version and nvcf-self-hosted-local-dev, that were never created. Removed the dead references and pointed at existing docs instead.

Tested: version-bump script already guards each file with an existence check, so no behavior change. bash -n passes, no remaining references anywhere in the repo.

Refs: NO-REF