### PR TITLE
chore(ess-agent): fix two comment typos

### DIFF
--- a/src/compute-plane-services/ess-agent/config/mapstructure.go
+++ b/src/compute-plane-services/ess-agent/config/mapstructure.go
@@ -61,7 +61,7 @@ func StringToWaitDurationHookFunc() mapstructure.DecodeHookFunc {
 
 // ConsulStringToStructFunc checks if the value set for the key should actually
 // be a struct and sets the appropriate value in the struct. This is for
-// backwards-compatability with older versions of Consul Template.
+// backwards-compatibility with older versions of Consul Template.
 func ConsulStringToStructFunc() mapstructure.DecodeHookFunc {
 	return func(
 		f reflect.Type,

--- a/src/compute-plane-services/ess-agent/dependency/vault_agent_token_test.go
+++ b/src/compute-plane-services/ess-agent/dependency/vault_agent_token_test.go
@@ -50,7 +50,7 @@ func TestVaultAgentTokenQuery_Fetch(t *testing.T) {
 }
 
 func TestVaultAgentTokenQuery_Fetch_missingFile(t *testing.T) {
-	// Use a non-existant token file path.
+	// Use a non-existent token file path.
 	d, err := NewVaultAgentTokenQuery("/tmp/invalid-file")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Fixed two comment typos in ess-agent: compatability -> compatibility, non-existant -> non-existent. Comment-only, no logic change.

Tested: go build and go vet pass, go test ./config/... passes.

Refs: NO-REF