### PR TITLE
fix(llm-request-router): pass --backend-connectivity=reverse with reverse tunnel

### DIFF
--- a/deploy/helm/llm-request-router/llm-request-router/templates/deployment.yaml
+++ b/deploy/helm/llm-request-router/llm-request-router/templates/deployment.yaml
@@ -94,6 +94,7 @@ spec:
             - --quic-request-timeout-ms={{ .Values.llmRequestRouter.transport.quicRequestTimeoutMs }}
             - --metrics-port={{ .Values.llmRequestRouter.service.metricsPort }}
             {{- if .Values.llmRequestRouter.transport.reverseTunnelListenAddr }}
+            - --backend-connectivity=reverse
             - --reverse-tunnel-listen-addr={{ .Values.llmRequestRouter.transport.reverseTunnelListenAddr }}
             {{- end }}
             {{- if and .Values.llmRequestRouter.transport.reverseTunnelListenAddr (gt $replicaCount 1) }}


### PR DESCRIPTION
## Why
Stargate 0.3.2 added a `--backend-connectivity` gate that rejects `--reverse-tunnel-listen-addr` unless `--backend-connectivity=reverse` is set. The chart always passes the reverse-tunnel listen address (default `0.0.0.0:50072`) but never set the connectivity mode, so the router crash-looped on startup with `--reverse-tunnel-listen-addr requires --backend-connectivity=reverse`. QA hit this on chart 1.6.5 (stargate image 0.3.2); it blocks the entire self-hosted stack deploy whenever the LLM addon is enabled.

## What changed
Emit `--backend-connectivity=reverse` inside the same reverse-tunnel guard so the two flags always render together. When no reverse-tunnel address is set, neither flag is emitted and the binary default (direct) stays valid.

## Testing
`helm template` renders both flags together in the expected order.

## References
NVBUG-6469041

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved router backend connectivity by enabling reverse connectivity mode at startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->