### PR TITLE
fix(self-managed-stack): bump llm-request-router pin to 1.6.6

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -155,7 +155,7 @@ releases:
 
   - name: llm-request-router
     chart: nvcf/helm-nvcf-llm-request-router
-    version: 1.6.3
+    version: 1.6.6
     namespace: nvcf
     condition: addons.llm.enabled
     values:


### PR DESCRIPTION
## Why
The self-managed stack pinned llm-request-router chart 1.6.3 (stargate image 0.3.0). The 0.3.2 image adds a `--backend-connectivity` gate; chart 1.6.5 took the 0.3.2 image without passing the flag and crash-loops the router. Chart 1.6.6 (NVIDIA/nvcf#248) passes `--backend-connectivity=reverse`.

## What changed
Bump the llm-request-router pin 1.6.3 -> 1.6.6 in the self-managed core helmfile, picking up the stargate 0.3.2 image and the crashloop fix together. Keeps main-line (0.7.0) from regressing into the same crashloop when it moves onto the 0.3.2 image.

## References
NVBUG-6469041
Chart fix: NVIDIA/nvcf#248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the LLM request router to a newer chart version, bringing the deployment to version 1.6.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->