### PR TITLE
fix(docs): add explicit kube context step before control-plane helmfile sync

### DIFF
--- a/docs/user/helmfile-installation.md
+++ b/docs/user/helmfile-installation.md
@@ -701,6 +701,16 @@ printf '%s' "${ACCESS_KEY_ID}:${SECRET_ACCESS_KEY}" | base64 | tr -d '\n'
 
 </Tabs>
 
+Set kubectl to the control-plane cluster context before proceeding. Steps 4
+and 5 run kubectl and helmfile commands that target the current context. In a
+multi-cluster setup, verify the context is the control-plane cluster to avoid
+installing to the wrong cluster.
+
+```bash
+kubectl config use-context <control-plane-context>
+kubectl config current-context
+```
+
 ### Step 4. Configure image pull secrets (conditional)
 
 <Note>
@@ -758,14 +768,8 @@ This replaces any need for a separate admission controller or policy engine to i
 
 ### Step 5. Deploy the NVCF control plane components
 
-Set kubectl to the control-plane cluster context before deploying. In a
-multi-cluster setup, a bare `helmfile sync` targets whatever context is
-currently active, so verify the context is correct before proceeding.
-
-```bash
-kubectl config use-context <control-plane-context>
-kubectl config current-context
-```
+Confirm your kubectl context is still set to the control-plane cluster (see
+above).
 
 <Info>
 Ensure your local environment is authenticated to the container registry where

--- a/docs/user/helmfile-installation.md
+++ b/docs/user/helmfile-installation.md
@@ -758,7 +758,14 @@ This replaces any need for a separate admission controller or policy engine to i
 
 ### Step 5. Deploy the NVCF control plane components
 
-Set kubectl context to your cluster.
+Set kubectl to the control-plane cluster context before deploying. In a
+multi-cluster setup, a bare `helmfile sync` targets whatever context is
+currently active, so verify the context is correct before proceeding.
+
+```bash
+kubectl config use-context <control-plane-context>
+kubectl config current-context
+```
 
 <Info>
 Ensure your local environment is authenticated to the container registry where

--- a/docs/v0.6.0/helmfile-installation.md
+++ b/docs/v0.6.0/helmfile-installation.md
@@ -701,6 +701,16 @@ printf '%s' "${ACCESS_KEY_ID}:${SECRET_ACCESS_KEY}" | base64 | tr -d '\n'
 
 </Tabs>
 
+Set kubectl to the control-plane cluster context before proceeding. Steps 4
+and 5 run kubectl and helmfile commands that target the current context. In a
+multi-cluster setup, verify the context is the control-plane cluster to avoid
+installing to the wrong cluster.
+
+```bash
+kubectl config use-context <control-plane-context>
+kubectl config current-context
+```
+
 ### Step 4. Configure image pull secrets (conditional)
 
 <Note>
@@ -758,14 +768,8 @@ This replaces any need for a separate admission controller or policy engine to i
 
 ### Step 5. Deploy the NVCF control plane components
 
-Set kubectl to the control-plane cluster context before deploying. In a
-multi-cluster setup, a bare `helmfile sync` targets whatever context is
-currently active, so verify the context is correct before proceeding.
-
-```bash
-kubectl config use-context <control-plane-context>
-kubectl config current-context
-```
+Confirm your kubectl context is still set to the control-plane cluster (see
+above).
 
 <Info>
 Ensure your local environment is authenticated to the container registry where

--- a/docs/v0.6.0/helmfile-installation.md
+++ b/docs/v0.6.0/helmfile-installation.md
@@ -758,7 +758,14 @@ This replaces any need for a separate admission controller or policy engine to i
 
 ### Step 5. Deploy the NVCF control plane components
 
-Set kubectl context to your cluster.
+Set kubectl to the control-plane cluster context before deploying. In a
+multi-cluster setup, a bare `helmfile sync` targets whatever context is
+currently active, so verify the context is correct before proceeding.
+
+```bash
+kubectl config use-context <control-plane-context>
+kubectl config current-context
+```
 
 <Info>
 Ensure your local environment is authenticated to the container registry where


### PR DESCRIPTION
## TL;DR

- Step 5 of the Helmfile installation guide says "set kubectl context to your cluster" with no concrete command or control-plane specificity. In a multi-cluster setup, `helmfile sync` silently targets the wrong cluster.
- Adds an explicit `kubectl config use-context` command and a context verification step.

## Additional Details

- Applied to both `docs/user/helmfile-installation.md` (top-of-tree) and `docs/v0.6.0/helmfile-installation.md` (frozen v0.6.0 release docs).
- Steps 7 and 8 (compute-plane) already use explicit `--kubeconfig` flags and are not affected.

## For the Reviewer

@sbaum -- please confirm we want this in both doc streams.

## For QA

Docs-only change. No QA needed.

## Issues

Fixes #251

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how to select the control-plane Kubernetes cluster before deployment.
  * Added commands to switch and verify the active `kubectl` context.
  * Included reminders to confirm the current `kubectl` context before running Helmfile deployment steps, with added guidance for multi-cluster environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->