### PR TITLE
ci: use buildless (build-mode none) for Go CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,10 +48,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Go is a traced language and does not support build-mode none, so it
-          # autobuilds. Rust has no autobuilder and uses buildless extraction.
+          # Both languages use buildless extraction. Go autobuild compiled and
+          # downloaded deps for every module in this umbrella, which was slow;
+          # CodeQL 2.16+ supports build-mode none for Go, so extract from source.
           - language: go
-            build-mode: autobuild
+            build-mode: none
           - language: rust
             build-mode: none
     steps:


### PR DESCRIPTION
## Why
CodeQL runs were dominated by the Go `autobuild` step. In this umbrella,
autobuild compiles and downloads module dependencies for every Go module under
`src/`, which is slow and fragile. The workflow comment claimed Go does not
support `build-mode: none`, but CodeQL added buildless Go extraction in 2.16
(the `codeql-action` v3 here supports it). Rust already uses buildless.

## What changed
- `.github/workflows/codeql.yml`: Go matrix entry `build-mode: autobuild` ->
  `build-mode: none`; updated the stale comment.

Buildless extraction reads source without compiling, so no Go build and no
dependency download. Trade-off is slightly lower precision on generated /
build-constrained code; acceptable here since the scan is non-blocking
(`fail-on-findings: false`) during rollout.

## Testing
Config-only change. The next CodeQL run on this PR exercises the Go buildless
path end to end; compare its duration to the autobuild baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved security analysis workflow efficiency by enabling buildless extraction for Go projects.
  * Reduced unnecessary build and dependency download time during code scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->