### PR TITLE
ci: per-language CodeQL - Go scans on main and weekly, buildless languages on PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,6 +40,11 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Decide which languages to analyze. On a PR, only the language(s) whose files
+  # changed run (a Rust-only PR skips the ~25 min Go autobuild, and vice versa).
+  # Pushes to main and the weekly schedule scan both. Emits a dynamic matrix so
+  # no job-level `if` referencing `matrix` is needed (that context is not allowed
+  # in a job `if`). Uses the GitHub API, not a third-party action (org allowlist).
   detect:
     name: Detect changed languages
     runs-on: ubuntu-latest
@@ -47,8 +52,8 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      go: ${{ steps.f.outputs.go }}
-      rust: ${{ steps.f.outputs.rust }}
+      matrix: ${{ steps.f.outputs.matrix }}
+      any: ${{ steps.f.outputs.any }}
     steps:
       - name: Detect changed languages
         id: f
@@ -64,33 +69,29 @@ jobs:
           fi
           go=false; rust=false
           if [ "${{ github.event_name }}" != "pull_request" ]; then go=true; rust=true; fi
-          printf '%s\n' "$files" | grep -qE '(\.go|/go\.mod|/go\.sum)$'         && go=true   || true
-          printf '%s\n' "$files" | grep -qE '(\.rs|/Cargo\.toml|/Cargo\.lock)$' && rust=true || true
+          if printf '%s\n' "$files" | grep -qE '(\.go|/go\.mod|/go\.sum)$';         then go=true;   fi
+          if printf '%s\n' "$files" | grep -qE '(\.rs|/Cargo\.toml|/Cargo\.lock)$'; then rust=true; fi
           # A change to the scan config itself re-scans both languages.
-          printf '%s\n' "$files" | grep -qE '\.github/workflows/codeql\.yml$'    && { go=true; rust=true; } || true
-          echo "go=$go"     >> "$GITHUB_OUTPUT"
-          echo "rust=$rust" >> "$GITHUB_OUTPUT"
+          if printf '%s\n' "$files" | grep -qE '\.github/workflows/codeql\.yml$';    then go=true; rust=true; fi
+          inc=""
+          if [ "$go" = true ];   then inc="${inc}{\"language\":\"go\",\"build-mode\":\"autobuild\"},"; fi
+          if [ "$rust" = true ]; then inc="${inc}{\"language\":\"rust\",\"build-mode\":\"none\"},"; fi
+          inc="${inc%,}"
+          echo "matrix={\"include\":[${inc}]}" >> "$GITHUB_OUTPUT"
+          if [ -n "$inc" ]; then echo "any=true" >> "$GITHUB_OUTPUT"; else echo "any=false" >> "$GITHUB_OUTPUT"; fi
           echo "changed-languages: go=$go rust=$rust"
 
   analyze:
     name: CodeQL (${{ matrix.language }})
     needs: detect
-    # On a PR, only run the language(s) that actually changed: a Rust-only PR
-    # skips the expensive Go autobuild, and a Go-only PR skips Rust. Pushes to
-    # main and the weekly schedule always run both for a complete baseline.
-    if: github.event_name != 'pull_request' || needs.detect.outputs[matrix.language] == 'true'
+    if: needs.detect.outputs.any == 'true'
     runs-on: ubuntu-latest
     strategy:
       # Keep one language's failure from cancelling the others.
       fail-fast: false
-      matrix:
-        include:
-          # Go is a traced language and does not support build-mode none, so it
-          # autobuilds. Rust has no autobuilder and uses buildless extraction.
-          - language: go
-            build-mode: autobuild
-          - language: rust
-            build-mode: none
+      # Only the languages detect selected. Go must autobuild (CodeQL 2.26
+      # confirmed Go does not support build-mode none); Rust uses buildless.
+      matrix: ${{ fromJSON(needs.detect.outputs.matrix) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,8 +40,45 @@ permissions:
   pull-requests: write
 
 jobs:
+  detect:
+    name: Detect changed languages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      go: ${{ steps.f.outputs.go }}
+      rust: ${{ steps.f.outputs.rust }}
+    steps:
+      - name: Detect changed languages
+        id: f
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            files="$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --jq '.[].filename' || true)"
+          else
+            files=""
+          fi
+          go=false; rust=false
+          if [ "${{ github.event_name }}" != "pull_request" ]; then go=true; rust=true; fi
+          printf '%s\n' "$files" | grep -qE '(\.go|/go\.mod|/go\.sum)$'         && go=true   || true
+          printf '%s\n' "$files" | grep -qE '(\.rs|/Cargo\.toml|/Cargo\.lock)$' && rust=true || true
+          # A change to the scan config itself re-scans both languages.
+          printf '%s\n' "$files" | grep -qE '\.github/workflows/codeql\.yml$'    && { go=true; rust=true; } || true
+          echo "go=$go"     >> "$GITHUB_OUTPUT"
+          echo "rust=$rust" >> "$GITHUB_OUTPUT"
+          echo "changed-languages: go=$go rust=$rust"
+
   analyze:
     name: CodeQL (${{ matrix.language }})
+    needs: detect
+    # On a PR, only run the language(s) that actually changed: a Rust-only PR
+    # skips the expensive Go autobuild, and a Go-only PR skips Rust. Pushes to
+    # main and the weekly schedule always run both for a complete baseline.
+    if: github.event_name != 'pull_request' || needs.detect.outputs[matrix.language] == 'true'
     runs-on: ubuntu-latest
     strategy:
       # Keep one language's failure from cancelling the others.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,11 +40,14 @@ permissions:
   pull-requests: write
 
 jobs:
-  # Decide which languages to analyze. On a PR, only the language(s) whose files
-  # changed run (a Rust-only PR skips the ~25 min Go autobuild, and vice versa).
-  # Pushes to main and the weekly schedule scan both. Emits a dynamic matrix so
-  # no job-level `if` referencing `matrix` is needed (that context is not allowed
-  # in a job `if`). Uses the GitHub API, not a third-party action (org allowlist).
+  # Decide which languages to analyze. PR policy: only buildless languages scan
+  # pre-merge (today Rust; Java joins as build-mode none when it lands). Go is
+  # excluded on PRs: its traced autobuild compiles the whole umbrella (~20+ min)
+  # for advisory-only feedback (fail-on-findings is false). Go coverage comes
+  # from every push to main and the weekly schedule, which scan everything.
+  # Emits a dynamic matrix so no job-level `if` referencing `matrix` is needed
+  # (that context is not allowed in a job `if`). Uses the GitHub API, not a
+  # third-party action (org allowlist).
   detect:
     name: Detect changed languages
     runs-on: ubuntu-latest
@@ -68,18 +71,21 @@ jobs:
             files=""
           fi
           go=false; rust=false
-          if [ "${{ github.event_name }}" != "pull_request" ]; then go=true; rust=true; fi
-          if printf '%s\n' "$files" | grep -qE '(\.go|/go\.mod|/go\.sum)$';         then go=true;   fi
-          if printf '%s\n' "$files" | grep -qE '(\.rs|/Cargo\.toml|/Cargo\.lock)$'; then rust=true; fi
-          # A change to the scan config itself re-scans both languages.
-          if printf '%s\n' "$files" | grep -qE '\.github/workflows/codeql\.yml$';    then go=true; rust=true; fi
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # Pushes to main and the weekly schedule scan everything, Go included.
+            go=true; rust=true
+          else
+            if printf '%s\n' "$files" | grep -qE '(\.rs|/Cargo\.toml|/Cargo\.lock)$'; then rust=true; fi
+            # A change to the scan config itself re-scans the PR-time languages.
+            if printf '%s\n' "$files" | grep -qE '\.github/workflows/codeql\.yml$';    then rust=true; fi
+          fi
           inc=""
           if [ "$go" = true ];   then inc="${inc}{\"language\":\"go\",\"build-mode\":\"autobuild\"},"; fi
           if [ "$rust" = true ]; then inc="${inc}{\"language\":\"rust\",\"build-mode\":\"none\"},"; fi
           inc="${inc%,}"
           echo "matrix={\"include\":[${inc}]}" >> "$GITHUB_OUTPUT"
           if [ -n "$inc" ]; then echo "any=true" >> "$GITHUB_OUTPUT"; else echo "any=false" >> "$GITHUB_OUTPUT"; fi
-          echo "changed-languages: go=$go rust=$rust"
+          echo "selected languages: go=$go rust=$rust"
 
   analyze:
     name: CodeQL (${{ matrix.language }})

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,7 +7,6 @@ on:
     # migrations, and other non-code PRs skip the scan (the Go autobuild is
     # expensive). The weekly schedule still does a full unconditional scan.
     paths:
-      - "src/**"
       - "**/*.go"
       - "**/*.rs"
       - "**/go.mod"
@@ -18,7 +17,6 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - "src/**"
       - "**/*.go"
       - "**/*.rs"
       - "**/go.mod"
@@ -65,19 +63,23 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            files="$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --jq '.[].filename' || true)"
-          else
-            files=""
-          fi
           go=false; rust=false
+          files=""
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             # Pushes to main and the weekly schedule scan everything, Go included.
             go=true; rust=true
           else
-            if printf '%s\n' "$files" | grep -qE '(\.rs|/Cargo\.toml|/Cargo\.lock)$'; then rust=true; fi
+            # Never silently skip: if the changed-file lookup fails, scan both
+            # languages instead of treating an empty result as "no code changed".
+            if ! files="$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --jq '.[].filename')"; then
+              echo "::warning::changed-file lookup failed; scanning all languages"
+              go=true; rust=true; files=""
+            fi
+            # gh api filenames are repo-relative with no leading slash, so anchor
+            # manifests with (^|/) to match root and nested files alike.
+            if printf '%s\n' "$files" | grep -qE '\.rs$|(^|/)Cargo\.(toml|lock)$'; then rust=true; fi
             # A change to the scan config itself re-scans the PR-time languages.
-            if printf '%s\n' "$files" | grep -qE '\.github/workflows/codeql\.yml$';    then rust=true; fi
+            if printf '%s\n' "$files" | grep -qE '(^|/)\.github/workflows/codeql\.yml$'; then rust=true; fi
           fi
           inc=""
           if [ "$go" = true ];   then inc="${inc}{\"language\":\"go\",\"build-mode\":\"autobuild\"},"; fi


### PR DESCRIPTION
## Why
The Go CodeQL job autobuilds the entire umbrella (~21 min per run). Go is the
only language in the stack whose analysis requires a traced build: CodeQL's
`build-mode: none` is supported for C/C++, C#, Java, and Rust, but not Go (the
CLI rejects it, and #253 proved that live). The scan is also advisory on PRs
(`fail-on-findings: false`), so every Go-touching PR paid 21 minutes for
non-blocking feedback.

## What changed
`.github/workflows/codeql.yml` gains a `detect` job (GitHub API file listing,
no third-party action per the org allowlist) that emits a dynamic analyze
matrix:

- Pull requests: only buildless languages scan. Today that is Rust (~2.5 min),
  and only when the PR touches Rust files or this workflow. Go never scans on
  PRs. Java joins as `build-mode: none` when it lands in the mirror.
- Pushes to main and the weekly schedule: unconditional full scan of all
  languages, Go included. The Security-tab baseline is unchanged; Go detection
  moves from pre-merge to at-merge.

The matrix is emitted as JSON by `detect` (a job-level `if` cannot reference
the `matrix` context, which caused this branch's earlier startup failure - now
also guarded repo-wide by the actionlint gate in #255).

## Testing
- Detect logic simulated locally for all cases: Go-only PR scans nothing,
  Rust-touching PR scans rust only, codeql.yml PR scans rust only, push and
  schedule scan both.
- Workflow passes the #255 actionlint gate (expressions + shellcheck) locally.
- This PR's own run is the live proof: `detect` selected rust only, and the
  checks list shows CodeQL (rust) with no 21-minute Go leg.

## References
NO-REF (CI efficiency change; no associated issue).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CodeQL scanning so pull requests analyze only affected supported languages.
  * Ensured security analysis still runs for workflow changes and when changed-file detection is unavailable.
  * Preserved full Go and Rust analysis for direct updates to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->