### PR TITLE
ci: lint GitHub workflows with actionlint

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Lint the GitHub Actions workflows themselves. These workflows live only on
+# the GitHub mirror (the GitLab umbrella is frozen), so nothing else validates
+# them before they run; a bad expression or context reference otherwise
+# surfaces as a live startup_failure. actionlint checks workflow YAML,
+# expression syntax and context availability, and runs shellcheck over run:
+# blocks. The binary is downloaded directly with a pinned version and sha256
+# (no third-party action, per the org actions allowlist).
+name: actionlint
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+
+concurrency:
+  group: actionlint-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: Lint workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Download actionlint (pinned, checksum-verified)
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+          ACTIONLINT_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+        run: |
+          set -euo pipefail
+          cd "${RUNNER_TEMP}"
+          curl -sSL --retry 3 -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum -c -
+          tar xzf actionlint.tar.gz actionlint
+
+      - name: Run actionlint
+        env:
+          # Gate on shellcheck warnings and errors; info/style-level notes
+          # (e.g. SC2016 on the intentionally literal '$oauthtoken' helm
+          # username) are not worth failing CI over.
+          SHELLCHECK_OPTS: "--severity=warning"
+        run: |
+          set -euo pipefail
+          "${RUNNER_TEMP}/actionlint" -color


### PR DESCRIPTION
## Why
Workflow files live only on the GitHub mirror ,
so nothing validates them before they run. A bad expression or context
reference surfaces as a live `startup_failure` - exactly what happened this
week with a `matrix` reference in a job-level `if` in `codeql.yml`. Of the last
100 runs, the failures cluster in workflow-config and policy gates, and this
closes the workflow-config class.

## What changed
`.github/workflows/actionlint.yml`: on any PR or main push that touches
`.github/workflows/**`, run actionlint 1.7.12 over all workflows:
- workflow YAML structure, expression syntax, and context availability
  (verified locally that it catches this week's `matrix`-in-`if` startup
  failure with a precise error)
- shellcheck over `run:` blocks at `--severity=warning` (info/style notes such
  as SC2016 on the intentionally literal `'$oauthtoken'` helm username do not
  fail CI)
- binary downloaded with a pinned version and sha256 verification; no
  third-party action, per the org actions allowlist
- path-filtered, so PRs that do not touch workflows pay nothing

## Testing
Verified locally with actionlint 1.7.12 + shellcheck 0.10.0:
- all 16 existing workflows pass at the chosen severity floor
- the new workflow passes its own lint
- a reproduction of this week's broken `codeql.yml` is rejected with
  `context "matrix" is not allowed here`

This PR touches `.github/workflows/**`, so the gate runs on this PR itself.

## References
NO-REF (CI hardening; no associated issue).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation for GitHub Actions workflow files.
  * Workflow checks run on relevant pushes and pull requests, helping identify configuration issues before changes are merged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->