### PR TITLE
docs(byoo-otel-collector): remove dead deployment doc reference

### DIFF
--- a/src/compute-plane-services/byoo-otel-collector/AGENTS.md
+++ b/src/compute-plane-services/byoo-otel-collector/AGENTS.md
@@ -74,4 +74,3 @@ The root generated release config must keep `release.version_file: VERSION` and 
 - `README.md`
 - `generator/doc/README.md`
 - `validator/README.md`
-- `docs/Deployment.md`


### PR DESCRIPTION
Removed docs/Deployment.md from the References section in byoo-otel-collector/AGENTS.md. That file does not exist in this subtree.

Tested: grep confirms no remaining references anywhere in the repo.

Refs: NO-REF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the BYO OpenTelemetry Collector documentation references by removing an outdated deployment guide link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->