### PR TITLE
chore(agents): add missing root hook fanout symlinks

### DIFF
--- a/.claude/hooks/validate-skill-fanout.py
+++ b/.claude/hooks/validate-skill-fanout.py
@@ -1,0 +1,1 @@
+../../ai-tooling/dev/hooks/validate-skill-fanout.py

--- a/.codex/hooks/validate-skill-fanout.py
+++ b/.codex/hooks/validate-skill-fanout.py
@@ -1,0 +1,1 @@
+../../ai-tooling/dev/hooks/validate-skill-fanout.py

--- a/.cursor/hooks/validate-skill-fanout.py
+++ b/.cursor/hooks/validate-skill-fanout.py
@@ -1,0 +1,1 @@
+../../ai-tooling/dev/hooks/validate-skill-fanout.py


### PR DESCRIPTION
AGENTS.md documents .cursor/hooks/, .codex/hooks/, and .claude/hooks/ as symlink fanouts to ai-tooling/dev/hooks/, mirroring the skills fanout, but none of the three existed. The repo's own validate-skill-fanout.py hook was reporting all three missing.

Added the three symlinks. Tool-specific config wiring (hooks.json, config.toml, settings.json) is out of scope for this PR.

Tested: ran ai-tooling/dev/hooks/validate-skill-fanout.py, it now returns {} with no problems.

Refs: NO-REF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized validation checks across supported development environments.
  * Consolidated shared validation behavior to improve consistency and reduce configuration differences.
  * No changes to application functionality or the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->