### PR TITLE
docs(agents): note .gitlab-ci.yml is internal in root AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,7 +210,9 @@ manually before finishing.
 ## GitLab CI for native subprojects
 
 The umbrella parent pipeline (`.gitlab-ci.yml`) is not where native service
-build, test, helm-lint, or release validation jobs go.
+build, test, helm-lint, or release validation jobs go. `.gitlab-ci.yml` and
+`tools/ci/generated-release-jobs.yml` are internal GitLab CI config not
+present in this public snapshot.
 
 | Job kind | Where to declare it |
 |---|---|


### PR DESCRIPTION
The GitLab CI for native subprojects section references .gitlab-ci.yml and tools/ci/generated-release-jobs.yml without noting they are internal config not present in this public snapshot, unlike tools/ci/subproject-validations.yaml which already got that note in #213. Added the same disclaimer here.

Refs: NO-REF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified where native subproject CI jobs are defined.
  * Documented that certain CI configuration files are internal and excluded from public snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->