### PR TITLE
docs(v0.6.0): fix broken links in observability snapshot page

### DIFF
--- a/docs/v0.6.0/observability.md
+++ b/docs/v0.6.0/observability.md
@@ -8,12 +8,12 @@ Common operator questions and where to look on this page or in linked references
 
 | Question | Where to look |
 |----------|---------------|
-| How do I see application-level NVCF stats (number of functions, queue depth, request latency)? | [State Metrics Service metrics](./state-metrics). The page documents per-function instance count, queue depth, and request latency, plus other function-level signals. |
-| How do I debug a single request end-to-end? | Combine the per-hop signals: enable tracing per [Tracing Configuration](#tracing-configuration), correlate with the [Metrics Overview](./metrics-overview) for each service in the request path, and tail the matching service logs. A consolidated hop-by-hop walkthrough is in development. |
-| Where are per-service metrics? | [Metrics Overview](./metrics-overview). |
-| Where are gRPC proxy metrics? | [gRPC Proxy metrics](./metrics/grpc-proxy/metrics). The page documents client connection counts, NATS pipe health, gRPC worker session-attach latency, and HTTP RED metrics. |
+| How do I see application-level NVCF stats (number of functions, queue depth, request latency)? | [State Metrics Service metrics](./metrics/state-metrics/metrics.md). The page documents per-function instance count, queue depth, and request latency, plus other function-level signals. |
+| How do I debug a single request end-to-end? | Combine the per-hop signals: enable tracing per [Tracing Configuration](#tracing-configuration), correlate with the [Metrics Overview](./metrics/metrics-index.md) for each service in the request path, and tail the matching service logs. A consolidated hop-by-hop walkthrough is in development. |
+| Where are per-service metrics? | [Metrics Overview](./metrics/metrics-index.md). |
+| Where are gRPC proxy metrics? | [gRPC Proxy metrics](./metrics/grpc-proxy/metrics.md). The page documents client connection counts, NATS pipe health, gRPC worker session-attach latency, and HTTP RED metrics. |
 | How do I add custom spans or metrics in a Kit application? | Use the OpenTelemetry API directly, the OmniTrace helper, the Carbonite static metrics API, or the `omni::observability::IMeter` interface. Refer to the Omniverse Kit and Carbonite documentation for details. |
-| Where are reference dashboards? | [Example dashboards](./example-dashboards) and the [Dashboards](#dashboards) section below. |
+| Where are reference dashboards? | [Example dashboards](./example-dashboards.md) and the [Dashboards](#dashboards) section below. |
 
 ## Overview
 
@@ -176,7 +176,7 @@ Or configure Prometheus scrape targets manually in your prometheus.yml.
 The State Metrics Service exposes per-function signals you can query in
 Prometheus. The following PromQL examples cover the three most common
 operator questions. Metric names and labels are sourced from
-[State Metrics Service metrics](./metrics/state-metrics/metrics).
+[State Metrics Service metrics](./metrics/state-metrics/metrics.md).
 
 Number of registered functions:
 


### PR DESCRIPTION
docs/v0.6.0/observability.md carries the same broken links docs/user/observability.md had before #240: they pointed to old paths, the real pages live under metrics/. This is a frozen version snapshot, normally left alone per docs/AGENTS.md, but fixed here at explicit request since #240 does not touch it.

Tested: verified each new link target exists on disk.

Refs: NO-REF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated observability documentation links to match the latest Markdown file paths.
  * Corrected references for application statistics, service metrics, gRPC proxy metrics, example dashboards, and State Metrics Service metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->