### PR TITLE
chore(ess-agent): fix duplicate word in configuration doc

### DIFF
--- a/src/compute-plane-services/ess-agent/docs/configuration.md
+++ b/src/compute-plane-services/ess-agent/docs/configuration.md
@@ -195,7 +195,7 @@ err_on_failed_lookup = true
 # This is the quiescence timers; it defines the minimum and maximum amount of
 # time to wait for the cluster to reach a consistent state before rendering a
 # template. This is useful to enable in systems that have a lot of flapping,
-# because it will reduce the the number of times a template is rendered.
+# because it will reduce the number of times a template is rendered.
 wait {
   min = "5s"
   max = "10s"


### PR DESCRIPTION
"reduce the the number" had a repeated word in the quiescence timers section.

Refs: NO-REF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a wording error in the quiescence timers documentation for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->