### PR TITLE
feat(container-cache): NVCFSRE-7831 expose configurable maxUnavailable in DaemonSet

### DIFF
--- a/deploy/helm/container-cache/deploy/Chart.yaml
+++ b/deploy/helm/container-cache/deploy/Chart.yaml
@@ -16,5 +16,5 @@ apiVersion: v2
 name: nvcf-container-cache
 description: NVCF Container Cache Helm Chart for Kubernetes
 type: application
-version: 0.25.20
+version: 0.25.21
 appVersion: "1.2.1"

--- a/deploy/helm/container-cache/deploy/templates/daemonset.yaml
+++ b/deploy/helm/container-cache/deploy/templates/daemonset.yaml
@@ -21,6 +21,10 @@ metadata:
     app: {{ $.Release.Name }}
     {{ include "nvcf-container-cache.labels" . | nindent 4 }}
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: {{ $.Values.updateStrategy.rollingUpdate.maxUnavailable | default 1 }}
   selector:
     matchLabels:
       name: configure-containerd

--- a/deploy/helm/container-cache/deploy/values.yaml
+++ b/deploy/helm/container-cache/deploy/values.yaml
@@ -173,3 +173,7 @@ crio:
 # Monitoring configuration.
 monitoring:
   enabled: false
+
+updateStrategy:
+  rollingUpdate:
+    maxUnavailable: 1


### PR DESCRIPTION
## Summary

Expose `updateStrategy.rollingUpdate.maxUnavailable` as a configurable Helm values key in the container-cache DaemonSet template. The default remains `1` (current behavior). This allows sbom-templates to override the value to `"10%"` so rollouts scale proportionally with cluster size instead of updating one pod at a time on 100+ node clusters.

Only the DaemonSet is modified. The StatefulSet is not in scope.

### Changes
- `deploy/helm/container-cache/deploy/templates/daemonset.yaml`: add `updateStrategy` block before `selector:`
- `deploy/helm/container-cache/deploy/values.yaml`: add `updateStrategy.rollingUpdate.maxUnavailable: 1`
- `deploy/helm/container-cache/deploy/Chart.yaml`: bump 0.25.20 → 0.25.21

## Tracker

NVCFSRE-7831

Closes NVCFSRE-7831