### PR TITLE
feat(go-lib/version): add Handler and HandlerFor http.Handler

### DIFF
--- a/src/libraries/go/lib/pkg/version/BUILD.bazel
+++ b/src/libraries/go/lib/pkg/version/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "version",
     srcs = [
+        "handler.go",
         "http.go",
         "version.go",
     ],
@@ -28,6 +29,7 @@ go_library(
 go_test(
     name = "version_test",
     srcs = [
+        "handler_test.go",
         "http_test.go",
         "version_test.go",
     ],

--- a/src/libraries/go/lib/pkg/version/BUILD.bazel
+++ b/src/libraries/go/lib/pkg/version/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
     ],
     importpath = "github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/version",
     visibility = ["//visibility:public"],
+    deps = ["@org_uber_go_zap//:zap"],
 )
 
 go_test(

--- a/src/libraries/go/lib/pkg/version/handler.go
+++ b/src/libraries/go/lib/pkg/version/handler.go
@@ -23,26 +23,27 @@ import (
 	"runtime/debug"
 )
 
-// Info holds the resolved build version metadata returned by the /version endpoint.
+// Info holds the resolved build metadata returned by the GET /info endpoint.
 type Info struct {
+	Service string `json:"service"`
 	Version string `json:"version"`
 	Commit  string `json:"commit"`
 }
 
-// Handler returns an http.Handler that serves build version info as JSON.
-// Version and Commit are resolved from the package-level ldflags vars
-// (Version, GitHash), with buildinfo used as a fallback for Commit
+// Handler returns an http.Handler that serves build info as JSON.
+// Service, Version, and Commit are resolved from the package-level ldflags vars
+// (Service, Version, GitHash), with buildinfo used as a fallback for Commit
 // when GitHash is empty.
 func Handler() http.Handler {
-	return HandlerFor(Version, GitHash)
+	return HandlerFor(Service, Version, GitHash)
 }
 
-// HandlerFor returns an http.Handler using the provided version and commit
-// values, falling back to buildinfo for commit when commit is empty.
+// HandlerFor returns an http.Handler using the provided service, version, and
+// commit values, falling back to buildinfo for commit when commit is empty.
 // Use this for services that maintain their own ldflags vars rather than
 // pointing directly at this package.
-func HandlerFor(ver, commit string) http.Handler {
-	info := resolve(ver, commit)
+func HandlerFor(service, ver, commit string) http.Handler {
+	info := resolve(service, ver, commit)
 	body, _ := json.Marshal(info)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -50,11 +51,14 @@ func HandlerFor(ver, commit string) http.Handler {
 	})
 }
 
-// resolve builds an Info by combining the given ver/commit,
+// resolve builds an Info by combining the given service/ver/commit,
 // falling back to runtime buildinfo for commit when empty.
-func resolve(ver, commit string) Info {
+func resolve(service, ver, commit string) Info {
 	if commit == "" {
 		commit = commitFromBuildInfo()
+	}
+	if service == "" {
+		service = "unknown"
 	}
 	if ver == "" {
 		ver = "unknown"
@@ -62,7 +66,7 @@ func resolve(ver, commit string) Info {
 	if commit == "" {
 		commit = "unknown"
 	}
-	return Info{Version: ver, Commit: commit}
+	return Info{Service: service, Version: ver, Commit: commit}
 }
 
 // commitFromBuildInfo reads the VCS revision from Go's embedded build info

--- a/src/libraries/go/lib/pkg/version/handler.go
+++ b/src/libraries/go/lib/pkg/version/handler.go
@@ -1,0 +1,81 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"encoding/json"
+	"net/http"
+	"runtime/debug"
+)
+
+// Info holds the resolved build version metadata returned by the /version endpoint.
+type Info struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+}
+
+// Handler returns an http.Handler that serves build version info as JSON.
+// Version and Commit are resolved from the package-level ldflags vars
+// (Version, GitHash), with buildinfo used as a fallback for Commit
+// when GitHash is empty.
+func Handler() http.Handler {
+	return HandlerFor(Version, GitHash)
+}
+
+// HandlerFor returns an http.Handler using the provided version and commit
+// values, falling back to buildinfo for commit when commit is empty.
+// Use this for services that maintain their own ldflags vars rather than
+// pointing directly at this package.
+func HandlerFor(ver, commit string) http.Handler {
+	info := resolve(ver, commit)
+	body, _ := json.Marshal(info)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	})
+}
+
+// resolve builds an Info by combining the given ver/commit,
+// falling back to runtime buildinfo for commit when empty.
+func resolve(ver, commit string) Info {
+	if commit == "" {
+		commit = commitFromBuildInfo()
+	}
+	if ver == "" {
+		ver = "unknown"
+	}
+	if commit == "" {
+		commit = "unknown"
+	}
+	return Info{Version: ver, Commit: commit}
+}
+
+// commitFromBuildInfo reads the VCS revision from Go's embedded build info
+// (available when built inside a git repository without -buildvcs=false).
+func commitFromBuildInfo() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	for _, s := range info.Settings {
+		if s.Key == "vcs.revision" {
+			return s.Value
+		}
+	}
+	return ""
+}

--- a/src/libraries/go/lib/pkg/version/handler.go
+++ b/src/libraries/go/lib/pkg/version/handler.go
@@ -46,6 +46,11 @@ func HandlerFor(service, ver, commit string) http.Handler {
 	info := resolve(service, ver, commit)
 	body, _ := json.Marshal(info)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(body)
 	})

--- a/src/libraries/go/lib/pkg/version/handler.go
+++ b/src/libraries/go/lib/pkg/version/handler.go
@@ -58,7 +58,7 @@ func HandlerFor(service, ver, commit string) http.Handler {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		if _, err := w.Write(body); err != nil {
-			zap.L().Error("failed to write build info response", zap.Error(err))
+			zap.L().Debug("failed to write build info response", zap.String("path", r.URL.Path), zap.Error(err))
 		}
 	})
 }

--- a/src/libraries/go/lib/pkg/version/handler.go
+++ b/src/libraries/go/lib/pkg/version/handler.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"runtime/debug"
+
+	"go.uber.org/zap"
 )
 
 // Info holds the resolved build metadata returned by the GET /info endpoint.
@@ -44,7 +46,10 @@ func Handler() http.Handler {
 // pointing directly at this package.
 func HandlerFor(service, ver, commit string) http.Handler {
 	info := resolve(service, ver, commit)
-	body, _ := json.Marshal(info)
+	body, err := json.Marshal(info)
+	if err != nil {
+		zap.L().Error("failed to marshal build info", zap.Error(err))
+	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			w.Header().Set("Allow", http.MethodGet)
@@ -52,7 +57,9 @@ func HandlerFor(service, ver, commit string) http.Handler {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(body)
+		if _, err := w.Write(body); err != nil {
+			zap.L().Error("failed to write build info response", zap.Error(err))
+		}
 	})
 }
 

--- a/src/libraries/go/lib/pkg/version/handler_test.go
+++ b/src/libraries/go/lib/pkg/version/handler_test.go
@@ -1,0 +1,105 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandlerFor(t *testing.T) {
+	tests := []struct {
+		name        string
+		ver         string
+		commit      string
+		wantVersion string
+		wantCommit  string
+	}{
+		{
+			name:        "both set",
+			ver:         "1.2.3",
+			commit:      "abc1234",
+			wantVersion: "1.2.3",
+			wantCommit:  "abc1234",
+		},
+		{
+			name:        "empty version falls back to unknown",
+			ver:         "",
+			commit:      "abc1234",
+			wantVersion: "unknown",
+			wantCommit:  "abc1234",
+		},
+		{
+			name:    "empty commit falls back to buildinfo or unknown",
+			ver:     "1.2.3",
+			commit:  "",
+			wantVersion: "1.2.3",
+			// commit will be whatever buildinfo provides in the test binary,
+			// or "unknown" -- just assert it is non-empty string
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/version", nil)
+			HandlerFor(tc.ver, tc.commit).ServeHTTP(w, r)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+			var got Info
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+
+			if tc.wantVersion != "" {
+				assert.Equal(t, tc.wantVersion, got.Version)
+			}
+			if tc.wantCommit != "" {
+				assert.Equal(t, tc.wantCommit, got.Commit)
+			}
+			assert.NotEmpty(t, got.Commit)
+		})
+	}
+}
+
+func TestHandler(t *testing.T) {
+	t.Cleanup(func() {
+		Version = ""
+		GitHash = ""
+	})
+
+	Version = "2.0.0"
+	GitHash = "deadbeef"
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/version", nil)
+	Handler().ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	var got Info
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, "2.0.0", got.Version)
+	assert.Equal(t, "deadbeef", got.Commit)
+}

--- a/src/libraries/go/lib/pkg/version/handler_test.go
+++ b/src/libraries/go/lib/pkg/version/handler_test.go
@@ -30,29 +30,46 @@ import (
 func TestHandlerFor(t *testing.T) {
 	tests := []struct {
 		name        string
+		service     string
 		ver         string
 		commit      string
+		wantService string
 		wantVersion string
 		wantCommit  string
 	}{
 		{
-			name:        "both set",
+			name:        "all set",
+			service:     "nvcf-my-service",
 			ver:         "1.2.3",
 			commit:      "abc1234",
+			wantService: "nvcf-my-service",
+			wantVersion: "1.2.3",
+			wantCommit:  "abc1234",
+		},
+		{
+			name:        "empty service falls back to unknown",
+			service:     "",
+			ver:         "1.2.3",
+			commit:      "abc1234",
+			wantService: "unknown",
 			wantVersion: "1.2.3",
 			wantCommit:  "abc1234",
 		},
 		{
 			name:        "empty version falls back to unknown",
+			service:     "nvcf-my-service",
 			ver:         "",
 			commit:      "abc1234",
+			wantService: "nvcf-my-service",
 			wantVersion: "unknown",
 			wantCommit:  "abc1234",
 		},
 		{
-			name:    "empty commit falls back to buildinfo or unknown",
-			ver:     "1.2.3",
-			commit:  "",
+			name:        "empty commit falls back to buildinfo or unknown",
+			service:     "nvcf-my-service",
+			ver:         "1.2.3",
+			commit:      "",
+			wantService: "nvcf-my-service",
 			wantVersion: "1.2.3",
 			// commit will be whatever buildinfo provides in the test binary,
 			// or "unknown" -- just assert it is non-empty string
@@ -62,8 +79,8 @@ func TestHandlerFor(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			r := httptest.NewRequest(http.MethodGet, "/version", nil)
-			HandlerFor(tc.ver, tc.commit).ServeHTTP(w, r)
+			r := httptest.NewRequest(http.MethodGet, "/info", nil)
+			HandlerFor(tc.service, tc.ver, tc.commit).ServeHTTP(w, r)
 
 			assert.Equal(t, http.StatusOK, w.Code)
 			assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
@@ -71,6 +88,9 @@ func TestHandlerFor(t *testing.T) {
 			var got Info
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
 
+			if tc.wantService != "" {
+				assert.Equal(t, tc.wantService, got.Service)
+			}
 			if tc.wantVersion != "" {
 				assert.Equal(t, tc.wantVersion, got.Version)
 			}
@@ -84,15 +104,17 @@ func TestHandlerFor(t *testing.T) {
 
 func TestHandler(t *testing.T) {
 	t.Cleanup(func() {
+		Service = ""
 		Version = ""
 		GitHash = ""
 	})
 
+	Service = "nvcf-my-service"
 	Version = "2.0.0"
 	GitHash = "deadbeef"
 
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest(http.MethodGet, "/version", nil)
+	r := httptest.NewRequest(http.MethodGet, "/info", nil)
 	Handler().ServeHTTP(w, r)
 
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -100,6 +122,7 @@ func TestHandler(t *testing.T) {
 
 	var got Info
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, "nvcf-my-service", got.Service)
 	assert.Equal(t, "2.0.0", got.Version)
 	assert.Equal(t, "deadbeef", got.Commit)
 }

--- a/src/libraries/go/lib/pkg/version/handler_test.go
+++ b/src/libraries/go/lib/pkg/version/handler_test.go
@@ -41,38 +41,38 @@ func TestHandlerFor(t *testing.T) {
 			name:        "all set",
 			service:     "nvcf-my-service",
 			ver:         "1.2.3",
-			commit:      "abc1234",
+			commit:      "abc1234def5678901234567890123456789012ab",
 			wantService: "nvcf-my-service",
 			wantVersion: "1.2.3",
-			wantCommit:  "abc1234",
+			wantCommit:  "abc1234def5678901234567890123456789012ab",
 		},
 		{
 			name:        "empty service falls back to unknown",
 			service:     "",
 			ver:         "1.2.3",
-			commit:      "abc1234",
+			commit:      "abc1234def5678901234567890123456789012ab",
 			wantService: "unknown",
 			wantVersion: "1.2.3",
-			wantCommit:  "abc1234",
+			wantCommit:  "abc1234def5678901234567890123456789012ab",
 		},
 		{
 			name:        "empty version falls back to unknown",
 			service:     "nvcf-my-service",
 			ver:         "",
-			commit:      "abc1234",
+			commit:      "abc1234def5678901234567890123456789012ab",
 			wantService: "nvcf-my-service",
 			wantVersion: "unknown",
-			wantCommit:  "abc1234",
+			wantCommit:  "abc1234def5678901234567890123456789012ab",
 		},
 		{
-			name:        "empty commit falls back to buildinfo or unknown",
-			service:     "nvcf-my-service",
-			ver:         "1.2.3",
-			commit:      "",
-			wantService: "nvcf-my-service",
-			wantVersion: "1.2.3",
+			name:    "empty commit falls back to buildinfo or unknown",
+			service: "nvcf-my-service",
+			ver:     "1.2.3",
+			commit:  "",
 			// commit will be whatever buildinfo provides in the test binary,
 			// or "unknown" -- just assert it is non-empty string
+			wantService: "nvcf-my-service",
+			wantVersion: "1.2.3",
 		},
 	}
 
@@ -111,7 +111,7 @@ func TestHandler(t *testing.T) {
 
 	Service = "nvcf-my-service"
 	Version = "2.0.0"
-	GitHash = "deadbeef"
+	GitHash = "deadbeef1234567890abcdef1234567890abcdef"
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/info", nil)
@@ -124,5 +124,5 @@ func TestHandler(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
 	assert.Equal(t, "nvcf-my-service", got.Service)
 	assert.Equal(t, "2.0.0", got.Version)
-	assert.Equal(t, "deadbeef", got.Commit)
+	assert.Equal(t, "deadbeef1234567890abcdef1234567890abcdef", got.Commit)
 }

--- a/src/libraries/go/lib/pkg/version/handler_test.go
+++ b/src/libraries/go/lib/pkg/version/handler_test.go
@@ -126,3 +126,17 @@ func TestHandler(t *testing.T) {
 	assert.Equal(t, "2.0.0", got.Version)
 	assert.Equal(t, "deadbeef1234567890abcdef1234567890abcdef", got.Commit)
 }
+
+func TestHandlerForRejectsNonGET(t *testing.T) {
+	h := HandlerFor("nvcf-my-service", "1.2.3", "abc1234def5678901234567890123456789012ab")
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		t.Run(method, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(method, "/info", nil)
+			h.ServeHTTP(w, r)
+
+			assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+			assert.Empty(t, w.Body.String())
+		})
+	}
+}

--- a/src/libraries/go/lib/pkg/version/handler_test.go
+++ b/src/libraries/go/lib/pkg/version/handler_test.go
@@ -103,10 +103,11 @@ func TestHandlerFor(t *testing.T) {
 }
 
 func TestHandler(t *testing.T) {
+	oldService, oldVersion, oldGitHash := Service, Version, GitHash
 	t.Cleanup(func() {
-		Service = ""
-		Version = ""
-		GitHash = ""
+		Service = oldService
+		Version = oldVersion
+		GitHash = oldGitHash
 	})
 
 	Service = "nvcf-my-service"

--- a/src/libraries/go/lib/pkg/version/handler_test.go
+++ b/src/libraries/go/lib/pkg/version/handler_test.go
@@ -137,6 +137,7 @@ func TestHandlerForRejectsNonGET(t *testing.T) {
 			h.ServeHTTP(w, r)
 
 			assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+			assert.Equal(t, http.MethodGet, w.Header().Get("Allow"))
 			assert.Empty(t, w.Body.String())
 		})
 	}

--- a/src/libraries/go/lib/pkg/version/version.go
+++ b/src/libraries/go/lib/pkg/version/version.go
@@ -21,6 +21,7 @@ import "strings"
 
 // Following variables are set by CI during compilation.
 var (
+	Service string
 	Version string
 	GitHash string
 	// Dirty is set to "true" if current git working directory has


### PR DESCRIPTION
## TL;DR

Adds `Handler()` and `HandlerFor()` to `go-lib/pkg/version`, a shared HTTP handler that serves build metadata as JSON at `GET /info`. Each service registers one line to expose the endpoint. Service name, version, and commit are injected via Bazel `x_defs` at build time.

## Additional Details

`Handler()` reads the `Service`, `Version`, and `GitHash` package vars injected at link time via `x_defs` (set to a hardcoded service name, `{STABLE_VERSION}`, and `{STABLE_GIT_COMMIT_FULL}` from `tools/workspace_status.sh` when building with `--stamp`). `HandlerFor()` accepts explicit `(service, ver, commit)` values and falls back to Go runtime build info for commit when the value is empty, so `go build` locally returns a real commit SHA. Empty service or version fall back to `"unknown"`. Any non-GET method returns `405 Method Not Allowed`.

Response schema: `{"service":"nvcf-my-service","version":"v1.2.3","commit":"16769d1988ff11c19071966db971de23b173f289"}`

This is a prerequisite for the follow-on PR that wires `nvcfversion.Handler()` into each Go control plane service.

## For the Reviewer

- `handler.go` and `handler_test.go` are new files. `BUILD.bazel` adds them to the existing `go_library` and `go_test` targets.
- `version.go` is updated to add a `Service` package var alongside the existing `Version`, `GitHash`, and `Dirty` vars.

## For QA

`go test ./pkg/version/...` passes. No service changes in this PR.

## Issues

Relates to #315

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a build-info HTTP endpoint that returns JSON including `service`, `version`, and `commit`.
  * Supports configuring service/version/commit values, using `"unknown"` when inputs are missing.
  * Automatically extracts the commit from embedded build metadata when no commit is provided, and returns `application/json` for successful GET requests.
  * Non-GET requests are rejected with `405 Method Not Allowed` (including an `Allow: GET` header).

* **Tests**
  * Added coverage to verify non-GET requests are rejected with `405 Method Not Allowed`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
