### PR TITLE
ci(codeql): enable Java (java-kotlin) analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,7 @@ on:
       - "src/**"
       - "**/*.go"
       - "**/*.rs"
+      - "**/*.java"
       - "**/go.mod"
       - "**/go.sum"
       - "**/Cargo.toml"
@@ -21,6 +22,7 @@ on:
       - "src/**"
       - "**/*.go"
       - "**/*.rs"
+      - "**/*.java"
       - "**/go.mod"
       - "**/go.sum"
       - "**/Cargo.toml"
@@ -53,6 +55,10 @@ jobs:
           - language: go
             build-mode: autobuild
           - language: rust
+            build-mode: none
+          # Java (CodeQL id java-kotlin) supports buildless extraction, so it
+          # runs build-mode none like rust: no Bazel/Maven build on PRs.
+          - language: java-kotlin
             build-mode: none
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Why

The monorepo already contains Java source (`examples/java-spring-boot-service`) and gains more with the incoming nv-boot-parent import, but CodeQL only scanned Go and Rust. Java should get the same security coverage.

## What changed

- Add `java-kotlin` to the CodeQL matrix with `build-mode: none`. Java supports buildless (source-only) extraction, so it scans on PRs like Rust, with no Bazel/Maven build required.
- Trigger the workflow on `**/*.java` changes in addition to Go/Rust paths.

## Customer Release Notes

Not customer visible. CI security scanning.

## Plan Summary

Not applicable.

## Usage

Not applicable. Runs automatically on push/PR touching Java (and the weekly full scan).

## Testing

`.github/workflows/codeql.yml` parses as valid YAML. CodeQL `java-kotlin` + `build-mode: none` is the standard buildless Java configuration; findings surface in the Security tab and as PR comments, non-blocking during rollout (`fail-on-findings: false`), same as Go/Rust.

## Notes

Buildless keeps Java analysis cheap and avoids the autobuild complexity that makes Go expensive. If deeper analysis is later wanted, it can move to a built mode once the root Bazel Java integration lands.

## References

NO-REF

## Related Merge Requests/Pull Requests

None

## Dependencies

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded security analysis coverage to include Java source changes.
  * Added buildless analysis support for Java and Kotlin code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->