### PR TITLE
fix(function-autoscaler): use OTLP gRPC tracing exporter

### DIFF
--- a/src/control-plane-services/function-autoscaler/Cargo.lock
+++ b/src/control-plane-services/function-autoscaler/Cargo.lock
@@ -131,6 +131,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,11 +177,38 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -169,7 +218,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -180,10 +229,30 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1563,6 +1632,12 @@ dependencies = [
 
 [[package]]
 name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -1871,20 +1946,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-http"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8863faf2910030d139fb48715ad5ff2f35029fc5f244f6d5f689ddcf4d26253"
-dependencies = [
- "async-trait",
- "bytes",
- "http",
- "opentelemetry",
- "reqwest",
- "tracing",
-]
-
-[[package]]
 name = "opentelemetry-otlp"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,12 +1955,12 @@ dependencies = [
  "futures-core",
  "http",
  "opentelemetry",
- "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
  "thiserror 2.0.18",
+ "tokio",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -2469,9 +2530,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
@@ -2493,7 +2552,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -2527,7 +2586,7 @@ dependencies = [
  "async-trait",
  "getrandom 0.2.17",
  "http",
- "matchit",
+ "matchit 0.8.4",
  "opentelemetry",
  "reqwest",
  "reqwest-middleware",
@@ -2576,7 +2635,7 @@ version = "1.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
+ "axum 0.8.9",
  "axum-server",
  "backon",
  "base64 0.22.1",
@@ -2615,6 +2674,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+ "tonic 0.12.3",
  "tonic 0.13.1",
  "tonic-build",
  "tracing",
@@ -2678,6 +2738,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3376,19 +3445,31 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
+ "async-stream",
  "async-trait",
+ "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-pemfile",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-rustls",
  "tokio-stream",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3398,7 +3479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
  "async-trait",
- "axum",
+ "axum 0.8.9",
  "base64 0.22.1",
  "bytes",
  "h2",
@@ -3416,7 +3497,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3434,6 +3515,26 @@ dependencies = [
  "prost-types",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3468,7 +3569,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -3823,6 +3924,24 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/src/control-plane-services/function-autoscaler/crates/server/Cargo.toml
+++ b/src/control-plane-services/function-autoscaler/crates/server/Cargo.toml
@@ -36,7 +36,7 @@ chrono = { version = "0.4", features = ["serde"] }
 scylla = { version = "1.2.0", features = ["chrono-04", "openssl-010", "unstable-cloud"] }
 config = { version = "0.14", features = ["yaml"] }
 opentelemetry = "0.28"
-opentelemetry-otlp = { version = "0.28", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
+opentelemetry-otlp = { version = "0.28", default-features = false, features = ["trace", "grpc-tonic", "tls-webpki-roots"] }
 opentelemetry_sdk = "0.28"
 tracing-opentelemetry = "0.29"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -73,6 +73,7 @@ rand = "0.9.2"
 tokio-util = "0.7.16"
 moka = { version = "0.12", features = ["future", "sync"] }
 tonic = { version = "0.13", features = ["tls-native-roots", "tls-ring"] }
+tonic-otel = { package = "tonic", version = "0.12.3", default-features = false, features = ["tls", "tls-webpki-roots"] }
 prost = "0.13"
 prost-types = "0.13"
 

--- a/src/control-plane-services/function-autoscaler/crates/server/src/tracing_init.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/tracing_init.rs
@@ -21,9 +21,11 @@ use crate::settings::{OtelResourceSettings, TracingSettings};
 use opentelemetry::trace::TracerProvider;
 use opentelemetry::KeyValue;
 use opentelemetry_otlp::WithExportConfig;
-use opentelemetry_otlp::WithHttpConfig;
+use opentelemetry_otlp::WithTonicConfig;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use opentelemetry_sdk::Resource;
+use tonic_otel::metadata::{Ascii, MetadataKey, MetadataMap, MetadataValue};
+use tonic_otel::transport::ClientTlsConfig;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 /// Initialize tracing and return a guard that flushes on drop.
@@ -48,15 +50,31 @@ pub fn initialize_tracing(
 
     let resource = Resource::builder().with_attributes(resource_kvs).build();
 
-    let endpoint = build_otlp_http_endpoint(tracing_settings);
+    let endpoint = build_otlp_grpc_endpoint(tracing_settings);
 
     let mut exporter_builder = opentelemetry_otlp::SpanExporter::builder()
-        .with_http()
+        .with_tonic()
         .with_endpoint(&endpoint)
         .with_timeout(std::time::Duration::from_secs(10));
 
+    if endpoint.starts_with("https://") {
+        exporter_builder =
+            exporter_builder.with_tls_config(ClientTlsConfig::new().with_enabled_roots());
+    }
+
     if let Some(headers) = &tracing_settings.headers {
-        exporter_builder = exporter_builder.with_headers(headers.clone());
+        let mut metadata = MetadataMap::new();
+
+        for (key, value) in headers {
+            if let (Ok(key), Ok(value)) = (
+                key.parse::<MetadataKey<Ascii>>(),
+                value.parse::<MetadataValue<Ascii>>(),
+            ) {
+                metadata.insert(key, value);
+            }
+        }
+
+        exporter_builder = exporter_builder.with_metadata(metadata);
     }
 
     let exporter = exporter_builder.build().expect("OTLP span exporter build");
@@ -84,7 +102,7 @@ pub fn initialize_tracing(
     }
 }
 
-fn build_otlp_http_endpoint(tracing_settings: &TracingSettings) -> String {
+fn build_otlp_grpc_endpoint(tracing_settings: &TracingSettings) -> String {
     match tracing_settings.endpoint_ip.as_deref() {
         Some(host) => {
             let mut endpoint = normalize_endpoint_host(host);
@@ -92,12 +110,12 @@ fn build_otlp_http_endpoint(tracing_settings: &TracingSettings) -> String {
                 endpoint = format!(
                     "{}:{}",
                     endpoint,
-                    tracing_settings.endpoint_port.unwrap_or(4318)
+                    tracing_settings.endpoint_port.unwrap_or(4317)
                 );
             }
-            format!("{endpoint}/v1/traces")
+            endpoint
         }
-        _ => "http://127.0.0.1:4318/v1/traces".to_string(),
+        _ => "http://127.0.0.1:4317".to_string(),
     }
 }
 
@@ -129,7 +147,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn build_otlp_http_endpoint_preserves_https_scheme() {
+    fn build_otlp_grpc_endpoint_preserves_https_scheme() {
         let settings = TracingSettings {
             endpoint_ip: Some("https://otel.example.com".to_string()),
             endpoint_port: Some(8282),
@@ -137,27 +155,24 @@ mod tests {
         };
 
         assert_eq!(
-            build_otlp_http_endpoint(&settings),
-            "https://otel.example.com:8282/v1/traces"
+            build_otlp_grpc_endpoint(&settings),
+            "https://otel.example.com:8282"
         );
     }
 
     #[test]
-    fn build_otlp_http_endpoint_defaults_bare_hosts_to_http() {
+    fn build_otlp_grpc_endpoint_defaults_bare_hosts_to_http() {
         let settings = TracingSettings {
             endpoint_ip: Some("localhost".to_string()),
-            endpoint_port: Some(4318),
+            endpoint_port: Some(4317),
             ..Default::default()
         };
 
-        assert_eq!(
-            build_otlp_http_endpoint(&settings),
-            "http://localhost:4318/v1/traces"
-        );
+        assert_eq!(build_otlp_grpc_endpoint(&settings), "http://localhost:4317");
     }
 
     #[test]
-    fn build_otlp_http_endpoint_preserves_embedded_port_with_configured_port() {
+    fn build_otlp_grpc_endpoint_preserves_embedded_port_with_configured_port() {
         let settings = TracingSettings {
             endpoint_ip: Some("https://otel.example.com:8282".to_string()),
             endpoint_port: Some(8282),
@@ -165,13 +180,13 @@ mod tests {
         };
 
         assert_eq!(
-            build_otlp_http_endpoint(&settings),
-            "https://otel.example.com:8282/v1/traces"
+            build_otlp_grpc_endpoint(&settings),
+            "https://otel.example.com:8282"
         );
     }
 
     #[test]
-    fn build_otlp_http_endpoint_preserves_embedded_port_without_configured_port() {
+    fn build_otlp_grpc_endpoint_preserves_embedded_port_without_configured_port() {
         let settings = TracingSettings {
             endpoint_ip: Some("https://otel.example.com:8282".to_string()),
             endpoint_port: None,
@@ -179,19 +194,16 @@ mod tests {
         };
 
         assert_eq!(
-            build_otlp_http_endpoint(&settings),
-            "https://otel.example.com:8282/v1/traces"
+            build_otlp_grpc_endpoint(&settings),
+            "https://otel.example.com:8282"
         );
     }
 
     #[test]
-    fn build_otlp_http_endpoint_uses_local_default_without_host() {
+    fn build_otlp_grpc_endpoint_uses_local_default_without_host() {
         let settings = TracingSettings::default();
 
-        assert_eq!(
-            build_otlp_http_endpoint(&settings),
-            "http://127.0.0.1:4318/v1/traces"
-        );
+        assert_eq!(build_otlp_grpc_endpoint(&settings), "http://127.0.0.1:4317");
     }
 }
 


### PR DESCRIPTION
**TL;DR**
Switches function autoscaler tracing from OTLP/HTTP to OTLP/gRPC so it works with the documented collector endpoint behavior.

**Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)**
Uses the tonic OTLP exporter instead of the HTTP/protobuf exporter.
Stops appending `/v1/traces`, since gRPC collector endpoints do not use the HTTP trace path.
Enables TLS roots for `https://` collector endpoints.
Preserves the existing access token header by converting tracing headers into tonic metadata.
Keeps the existing autoscaler OTel 0.28 stack and adds a renamed tonic 0.12 dependency only for exporter-compatible TLS/metadata types.

**For the Reviewer**
Start with `tracing_init.rs` for the exporter setup and endpoint construction.
The key behavior change is that configured `https://...:8282` endpoints now go out as OTLP/gRPC with TLS instead of OTLP/HTTP to `:8282/v1/traces`.

**For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)**
`cargo test -p rs-autoscaler tracing_init`

Result: 5 passed, 0 failed.

**Issues**
NO-REF

**Checklist**
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nvcf/CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated telemetry export to use gRPC instead of HTTP.
  * Added secure TLS support for encrypted telemetry connections.
  * Improved endpoint handling, including automatic default ports and support for custom ports.
  * Updated telemetry header processing for gRPC-compatible metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->