### PR TITLE
fix(worker): populate metering nspect_id from NVCF_NSPECT_ID env

### DIFF
--- a/src/compute-plane-services/worker-init/internal/workerinit/initializer.go
+++ b/src/compute-plane-services/worker-init/internal/workerinit/initializer.go
@@ -143,6 +143,7 @@ func NewInitializer(config configs.InitConfig) (Initializer, error) {
 		Backend:                backend,
 		NcaId:                  config.NcaId,
 		BillingNcaId:           billingNcaId,
+		NspectId:               metering.NspectIdFromEnv(),
 		InstanceId:             config.InstanceId,
 		InstanceType:           config.InstanceType,
 		ICMSEnvironment:        config.ICMSEnvironment,

--- a/src/compute-plane-services/worker-init/internal/workerinit/initializer_test.go
+++ b/src/compute-plane-services/worker-init/internal/workerinit/initializer_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/worker-init/configs"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/worker-init/internal/downloader"
+	"github.com/NVIDIA/nvcf/src/libraries/go/worker/metering"
 	"github.com/NVIDIA/nvcf/src/libraries/go/worker/types"
 )
 
@@ -76,6 +77,21 @@ func TestNewInitializerSelectsNvctAndAppliesOverrides(t *testing.T) {
 	require.Equal(t, "stage", nvct.config.ICMSEnvironment, "ICMSEnvironment is filled from SpotEnvironment")
 	require.Equal(t, "GFN", nvct.meteringConfg.Backend, "NGN is normalized to GFN in metering")
 	require.Equal(t, "nca-1", nvct.meteringConfg.BillingNcaId, "BillingNcaId defaults to NcaId")
+}
+
+func TestNewInitializerPropagatesNspectId(t *testing.T) {
+	// NspectId is sourced from the NVCF_NSPECT_ID env var and must propagate
+	// into the metering config so NVCF_Infrastructure init events carry nspect_id.
+	t.Setenv(metering.EnvNspectId, "NSPECT-INIT-1234")
+	c := validConfig()
+	c.NvcfWorkerToken = "tok"
+
+	init, err := NewInitializer(c)
+	require.NoError(t, err)
+
+	nvcf, ok := init.(*NvcfInitializer)
+	require.True(t, ok)
+	require.Equal(t, "NSPECT-INIT-1234", nvcf.meteringConfg.NspectId)
 }
 
 func TestNewInitializerInvalidOTELEndpoint(t *testing.T) {

--- a/src/compute-plane-services/worker-task/internal/worker/worker.go
+++ b/src/compute-plane-services/worker-task/internal/worker/worker.go
@@ -125,6 +125,7 @@ func NewNVCTWorker(ctx context.Context, zapLogger *logs.ZapLogger, config config
 		Backend:                config.CloudProvider,
 		NcaId:                  config.NcaId,
 		BillingNcaId:           billingNcaId,
+		NspectId:               metering.NspectIdFromEnv(),
 		InstanceId:             config.InstanceId,
 		InstanceType:           config.InstanceType,
 		ICMSEnvironment:        config.ICMSEnvironment,

--- a/src/compute-plane-services/worker-task/internal/worker/worker_newnvctworker_test.go
+++ b/src/compute-plane-services/worker-task/internal/worker/worker_newnvctworker_test.go
@@ -64,6 +64,15 @@ func build(t *testing.T, mutate func(c *configs.Config)) (*NVCTWorker, error) {
 	return NewNVCTWorker(context.Background(), testLogger(), cfg)
 }
 
+func TestNewNVCTWorker_NspectIdFromEnv(t *testing.T) {
+	// NspectId is sourced from the NVCF_NSPECT_ID env var and must propagate
+	// into the metering config so NVCT_Infrastructure events carry nspect_id.
+	t.Setenv(metering.EnvNspectId, "NSPECT-TASK-1234")
+	w, err := build(t, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "NSPECT-TASK-1234", w.meteringConfig.NspectId)
+}
+
 func TestNewNVCTWorker_ValidBaseline(t *testing.T) {
 	w, err := build(t, nil)
 	require.NoError(t, err)

--- a/src/compute-plane-services/worker-utils/worker/newworker_test.go
+++ b/src/compute-plane-services/worker-utils/worker/newworker_test.go
@@ -190,6 +190,14 @@ func TestNewNVCFWorker_Normalization(t *testing.T) {
 		assert.Equal(t, "GFN", w.meteringConfig.Backend)
 	})
 
+	t.Run("nspect id is populated from environment for metering events", func(t *testing.T) {
+		t.Setenv(metering.EnvNspectId, "NSPECT-TEST-1234")
+		cfg := baseValidConfig(t)
+		w, err := NewNVCFWorker(context.Background(), newTestLogger(t), cfg)
+		require.NoError(t, err)
+		assert.Equal(t, "NSPECT-TEST-1234", w.meteringConfig.NspectId)
+	})
+
 	t.Run("inference ready timeout defaults when zero", func(t *testing.T) {
 		cfg := baseValidConfig(t)
 		cfg.InferenceReadyTimeout = 0

--- a/src/compute-plane-services/worker-utils/worker/worker.go
+++ b/src/compute-plane-services/worker-utils/worker/worker.go
@@ -231,6 +231,7 @@ func NewNVCFWorker(ctx context.Context, zapLogger *logs.ZapLogger, config Config
 		Backend:                config.CloudProvider,
 		NcaId:                  config.NcaId,
 		BillingNcaId:           billingNcaId,
+		NspectId:               metering.NspectIdFromEnv(),
 		FunctionId:             config.FunctionId,
 		FunctionVersionId:      config.FunctionVersionId,
 		InstanceId:             config.InstanceId,


### PR DESCRIPTION
## Summary

NVCF worker metering events (`NVCF_Invocation` and `NVCF_Infrastructure`) were being emitted with an empty `data.nspect_id`, causing the downstream metering ingestion pipeline to reject them for failing mandatory-field schema validation.

During the open-source split, `nspect_id` was moved to the `NVCF_NSPECT_ID` env var, but the worker only consumed it for the `NVCF-NSPECTID` inference header and never populated `metering.Config.NspectId` (serialized in `metering.go` and `infra.go`). This wires `metering.NspectIdFromEnv()` into the metering config so the events carry the `nspect_id` again.

## Changes

- Set `NspectId: metering.NspectIdFromEnv()` in the three `metering.Config` constructors:
  - `src/compute-plane-services/worker-utils/worker/worker.go` (function worker — emits both affected event types)
  - `src/compute-plane-services/worker-init/internal/workerinit/initializer.go` (init-phase infra events)
  - `src/compute-plane-services/worker-task/internal/worker/worker.go` (task infra events)
- Added a unit test asserting `NVCF_NSPECT_ID` flows into `meteringConfig.NspectId`.

## Testing

- `gofmt` clean.
- New test `TestNewNVCFWorker_Normalization/"nspect id is populated from environment for metering events"`.
- Existing metering tests already assert `nspect_id` serialization from `Config.NspectId`.

## Issues

NO-REF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metering configuration now captures the spectral identifier provided through the environment across worker initialization and creation paths.

* **Tests**
  * Added coverage confirming the environment-provided spectral identifier is correctly propagated into worker metering configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->