### PR TITLE
fix(openbao-migrations): sleep between health check retries

### DIFF
--- a/migrations/openbao/entrypoint.sh
+++ b/migrations/openbao/entrypoint.sh
@@ -63,6 +63,7 @@ while [ $retry_count -lt $MAX_RETRIES ]; do
   else
     log_info "OpenBao service not responsive. Retrying in $RETRY_DELAY seconds..."
     retry_count=$((retry_count + 1))
+    sleep "$RETRY_DELAY"
   fi
 done
 
@@ -93,7 +94,7 @@ initialize_mount_lists
 # exits non-zero whenever any required task fails. The previous behavior
 # (warn-and-continue, exit 0 regardless) let misconfigured deployments
 # green the Helm hook Job while leaving OpenBao in a half-configured
-# state — surfacing later as a downstream service-cert outage instead of
+# state, surfacing later as a downstream service-cert outage instead of
 # a blocked deployment.
 #
 # Addons enter the accumulator only when they're explicitly enabled
@@ -184,7 +185,7 @@ if [ "${#FAILED_MIGRATIONS[@]}" -gt 0 ]; then
     log_error "  - $m"
   done
   if [ "${MIGRATIONS_ALLOW_FAILURES:-false}" = "true" ]; then
-    log_warn "MIGRATIONS_ALLOW_FAILURES=true; exiting 0 despite ${#FAILED_MIGRATIONS[@]} failure(s) — investigate before next deploy"
+    log_warn "MIGRATIONS_ALLOW_FAILURES=true; exiting 0 despite ${#FAILED_MIGRATIONS[@]} failure(s); investigate before next deploy"
   else
     log_error "Exiting non-zero. Set MIGRATIONS_ALLOW_FAILURES=true only as an emergency rollback override"
     exit 1


### PR DESCRIPTION
## TL;DR
The OpenBao health check loop logged "Retrying in 5 seconds" but never slept, so all 5 attempts ran within milliseconds and slow startups failed the migration Job. Adds the missing sleep. bash -n passes; entrypoint script with no test harness.

## Issues
Closes #293


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added an explicit wait between OpenBao `/v1/sys/health` retry attempts to improve retry pacing.
  * Updated migration warning text formatting for the “failures allowed” scenario, while keeping the same outcomes and exit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->