### PR TITLE
fix(nvcf-unbound): nest format param under params in PodMonitor

### DIFF
--- a/deploy/helm/nvcf-unbound/templates/podmonitor.yaml
+++ b/deploy/helm/nvcf-unbound/templates/podmonitor.yaml
@@ -34,8 +34,8 @@ spec:
     scheme: http
   - interval: 15s
     params:
-    format:
-      - prometheus
+      format:
+        - prometheus
     path: /metrics
     port: logger-metrics
     scheme: http


### PR DESCRIPTION
## TL;DR
In the logger-metrics endpoint, format: sat at the same indent level as params:, so the CRD schema pruned it and the format=prometheus scrape parameter was never sent. Nested it under params, matching the container-cache chart. helm lint and helm template verified.

## Issues
Closes #295


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Prometheus metrics configuration to ensure monitoring endpoints are interpreted properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->