### PR TITLE
fix(examples): exit non-zero on count_tasks.sh error paths

### DIFF
--- a/examples/load-tests/tasks/count_tasks.sh
+++ b/examples/load-tests/tasks/count_tasks.sh
@@ -13,22 +13,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set -e
+set -euo pipefail
 
 # take in one command argument for the org id
-ORG_ID=$1
+ORG_ID=${1:-}
 
 # check to see if the org id is provided
 if [ -z "$ORG_ID" ]; then
     echo "org id is required"
-    exit
+    exit 1
 fi
 
 # check to see if the ngc cli is installed
 if ! command -v ngc &> /dev/null
 then
     echo "ngc cli could not be found - please install it from https://org.ngc.nvidia.com/setup/installers/cli"
-    exit
+    exit 1
 fi
 
 # get the number of tasks in the org in json format


### PR DESCRIPTION
## TL;DR
Both error paths used a bare exit, so the script returned 0 when the org id was missing or ngc was absent. Now exit 1, matching clear_all_tasks.sh, plus set -euo pipefail and ORG_ID=${1:-} per the examples shell style. Both failure paths verified to exit 1; example script with no test harness.

## Issues
Closes #297
