### PR TITLE
fix(invocation-plane): guard bearer credentials Close with sync.Once

### DIFF
--- a/src/invocation-plane-services/grpc-proxy/proxy/credentials/bearer.go
+++ b/src/invocation-plane-services/grpc-proxy/proxy/credentials/bearer.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sync"
 	"sync/atomic"
 
 	"github.com/fsnotify/fsnotify"
@@ -35,6 +36,7 @@ type BearerTokenCredentials struct {
 	secretsPath  string
 	tokenKey     string
 	watcherDone  chan struct{}
+	closeOnce    sync.Once
 }
 
 // NewBearerTokenCredentials creates a new BearerTokenCredentials that reads the token
@@ -84,7 +86,9 @@ func (c *BearerTokenCredentials) updateToken(token string) {
 
 // Close stops the file watcher
 func (c *BearerTokenCredentials) Close() error {
-	close(c.watcherDone)
+	c.closeOnce.Do(func() {
+		close(c.watcherDone)
+	})
 	return nil
 }
 

--- a/src/invocation-plane-services/grpc-proxy/proxy/credentials/bearer_test.go
+++ b/src/invocation-plane-services/grpc-proxy/proxy/credentials/bearer_test.go
@@ -90,6 +90,21 @@ func TestNewBearerTokenCredentialsError(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestCloseTwice(t *testing.T) {
+	dir := t.TempDir()
+	secretsPath := filepath.Join(dir, "test-secrets.json")
+	tokenKey := "test_api_token"
+
+	err := writeSecretsFile(secretsPath, tokenKey, "token-value")
+	require.NoError(t, err)
+
+	creds, err := NewBearerTokenCredentials(secretsPath, tokenKey, true)
+	require.NoError(t, err)
+
+	assert.NoError(t, creds.Close())
+	assert.NoError(t, creds.Close())
+}
+
 func writeSecretsFile(path, tokenKey, tokenValue string) error {
 	secrets := map[string]any{
 		tokenKey: tokenValue,

--- a/src/invocation-plane-services/ratelimiter/credentials/bearer.go
+++ b/src/invocation-plane-services/ratelimiter/credentials/bearer.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sync"
 	"sync/atomic"
 
 	"github.com/fsnotify/fsnotify"
@@ -36,6 +37,7 @@ type BearerTokenCredentials struct {
 	secretsPath  string
 	tokenKey     string
 	watcherDone  chan struct{}
+	closeOnce    sync.Once
 }
 
 // NewBearerTokenCredentials creates a new BearerTokenCredentials that reads the token
@@ -85,7 +87,9 @@ func (c *BearerTokenCredentials) updateToken(token string) {
 
 // Close stops the file watcher
 func (c *BearerTokenCredentials) Close() error {
-	close(c.watcherDone)
+	c.closeOnce.Do(func() {
+		close(c.watcherDone)
+	})
 	return nil
 }
 

--- a/src/invocation-plane-services/ratelimiter/credentials/bearer_test.go
+++ b/src/invocation-plane-services/ratelimiter/credentials/bearer_test.go
@@ -91,6 +91,21 @@ func TestNewBearerTokenCredentialsError(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestCloseTwice(t *testing.T) {
+	dir := t.TempDir()
+	secretsPath := filepath.Join(dir, "test-secrets.json")
+	tokenKey := "test_api_token"
+
+	err := writeSecretsFile(secretsPath, tokenKey, "token-value")
+	require.NoError(t, err)
+
+	creds, err := NewBearerTokenCredentials(secretsPath, tokenKey, true)
+	require.NoError(t, err)
+
+	assert.NoError(t, creds.Close())
+	assert.NoError(t, creds.Close())
+}
+
 func writeSecretsFile(path, tokenKey, tokenValue string) error {
 	secrets := map[string]any{
 		tokenKey: tokenValue,


### PR DESCRIPTION
## TL;DR
BearerTokenCredentials.Close closed watcherDone unconditionally, so a second Close panicked with close of closed channel. Added a sync.Once guard to both the grpc-proxy and ratelimiter copies plus a TestCloseTwice in each package. go build and go test pass; the new tests panic without the fix.

## Issues
Closes #301


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shutdown handling for bearer-token credentials.
  - Repeated cleanup calls no longer cause errors or application panics.

- **Tests**
  - Added coverage confirming credentials can be closed multiple times safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->