### PR TITLE
chore(nvsnap): add missing test-checkpoint make target

### DIFF
--- a/src/compute-plane-services/nvsnap/Makefile
+++ b/src/compute-plane-services/nvsnap/Makefile
@@ -103,6 +103,10 @@ test-coverage:
 test-server:
 	go test -v ./internal/server
 
+# Run checkpoint unit tests only
+test-checkpoint:
+	go test -v ./internal/checkpointstore
+
 # Download dependencies
 deps:
 	go mod download


### PR DESCRIPTION
## TL;DR
.PHONY and the help text advertised test-checkpoint but the recipe did not exist, so make test-checkpoint failed. Added the target running the internal/checkpointstore tests, mirroring test-server. The package is linux-only, consistent with the rest of the Makefile.

## Issues
Closes #304


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a dedicated command for running verbose checkpoint-related tests.
  * Existing test commands remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->