### PR TITLE
feat(self-managed): wire function-autoscaler release into  self-managed stack

### DIFF
--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -266,6 +266,14 @@ stateMetrics:
   serviceMonitor:
     enabled: false
 
+# Function Autoscaler workload (stage 03). Disabled by default; requires the
+# stage-01 Cassandra/OpenBao migrations and the observability stack's VictoriaMetrics.
+functionAutoscaler:
+  enabled: false
+  chartVersion: "0.0.0" # Pin to the published helm-nvcf-function-autoscaler version.
+  cassandraContactPoints: "" # e.g. cassandra.cassandra-system.svc.cluster.local
+  timeseriesDbUrl: "" # e.g. http://vmsingle.monitoring.svc:8428
+
 rateLimiter:
   enabled: true
   replicaCount: 1

--- a/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
@@ -40,3 +40,26 @@ releases:
       - template: service
     # When enabled, this service will export realtime function information that can be
     # scraped by a Prometheus ServiceMonitor
+
+  # --- Function Autoscaler workload ---
+  # Deploys the function-autoscaler (chart nvcf/helm-nvcf-function-autoscaler),
+  # disabled by default. SECRETS_PATH and CONFIG come from the chart defaults;
+  # only the in-cluster endpoints are set here. Ordered after state-metrics and
+  # depends on the stage-01 Cassandra and OpenBao migrations and a reachable
+  # VictoriaMetrics from the observability stack.
+  - name: function-autoscaler
+    version: "{{ .Values.functionAutoscaler.chartVersion }}" # Pin to the published helm-nvcf-function-autoscaler version.
+    namespace: nvcf
+    condition: functionAutoscaler.enabled
+    needs:
+      - nvcf/state-metrics
+    inherit:
+      - template: service
+    values:
+      - functionautoscaler:
+          image:
+            registry: "{{ .Values.global.image.registry }}"
+            repository: "{{ .Values.global.image.repository }}/nvcf-autoscaler-service"
+          env:
+            CASSANDRA__CONTACT_POINTS: "{{ .Values.functionAutoscaler.cassandraContactPoints }}"
+            TIMESERIES_DB__TIMESERIES_DB_URL: "{{ .Values.functionAutoscaler.timeseriesDbUrl }}"


### PR DESCRIPTION
## Summary
Adds the function-autoscaler workload release to the self-managed stack's stage-03
helmfile, so functionAutoscaler.enabled deploys the autoscaler alongside state-metrics.
Last-mile of the self-hosted autoscaler epic; builds on the merged chart (#205) and
startup-health fix (#220).

## Changes
- environments/base.yaml: new `functionAutoscaler` toggle (default off) + chartVersion +
  in-cluster Cassandra/VM endpoints.
- helmfile.d/03-observability.yaml.gotmpl: the `function-autoscaler` release — gated on
  functionAutoscaler.enabled, needs: [nvcf/state-metrics], inherits the service template,
  sets functionautoscaler.env (CASSANDRA__CONTACT_POINTS, TIMESERIES_DB__TIMESERIES_DB_URL).
  SECRETS_PATH + CONFIG come from chart defaults (#205).

## Draft — TODO before ready
- [ ] Pin the published helm-nvcf-function-autoscaler chart version (currently 0.0.0 placeholder)
- [ ] Confirm the published autoscaler image repo
- [ ] Set the real per-env endpoints (validated on k3d: cassandra.cassandra-system.svc…, vmsingle.monitoring.svc:8428)
- [ ] Full `helmfile sync` on k3d once the chart publishes

## Test plan
- `helmfile list`: release ENABLED=true when functionAutoscaler.enabled=true, filtered when false.
- Validated end-to-end on k3d (autoscaler v1.18.5 + obs stack): injection, nvcf_ metrics in VM,
  autoscaler 2/2 running its dry-run scaling loop.

## For the Reviewer
<!--mention reviewers you wish to review this MR-->
<!--call out specific files that should be looked at closely-->
<!--anything you need answered pertaining to this review-->

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
<!--list steps you took to verify this change-->
<!--Is QA Needed?-->

## Issues
<!--
Required: add a valid NVIDIA/nvcf issue reference below.
Accepted: "Closes #123", "Fixes #123", "Resolves NVIDIA/nvcf#123",
"Relates to #123", or last-resort "NO-REF".
Do not use Jira/private tracker keys, private bug IDs, private URLs, title-only
refs, other-repo refs, or commented-out template examples. If context is
private, create a generic public issue without private details.
-->


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
