### PR TITLE
fix(stargate): document reverse listener requires backend-connectivity=reverse

### DIFF
--- a/src/libraries/rust/stargate/README.md
+++ b/src/libraries/rust/stargate/README.md
@@ -18,7 +18,9 @@ Two backend connectivity configurations are first-class:
 
 Set the same `--backend-connectivity=direct|reverse` topology on Stargate and
 pylon. The [local quickstart](docs/getting-started/local-quickstart.md) uses the
-Edge/direct path.
+Edge/direct path. On Stargate, a reverse listener
+(`--reverse-tunnel-listen-addr`) requires `--backend-connectivity=reverse`; the
+mismatched combination is rejected at startup.
 
 Pylon model membership is either an explicit repeatable `--model-name` set or,
 when that flag is omitted, a continuously discovered Dynamo `GET /v1/models`


### PR DESCRIPTION
## Why
Stargate rejects `--reverse-tunnel-listen-addr` without `--backend-connectivity=reverse` at startup (verified locally). The README topology guidance did not note this. This also serves as the release trigger to cut the stargate 0.5.x line and publish the current stargate/pylon images, which already carry the archived standalone repo v0.5.0 pylon work.

## What changed
One-line README clarification next to the backend-connectivity topology guidance. Docs-only, no code change.

## Testing
Docs-only.

## Issues
NO-REF