### PR TITLE
fix(nv-boot): make notice_check_test work in the monorepo layout

### DIFF
--- a/src/libraries/java/nv-boot-parent/tools/bazel/BUILD.bazel
+++ b/src/libraries/java/nv-boot-parent/tools/bazel/BUILD.bazel
@@ -32,7 +32,10 @@ sh_test(
         ":generate_notice.py",
         ":notice_metadata.json",
         "//:MODULE.bazel",
-        "//:NOTICE",
+        # nv-boot-parent's own NOTICE (its Java closure), not the aggregate root
+        # NOTICE which also covers the Go/Rust subtrees and can never match a
+        # Java-only regeneration.
+        "//src/libraries/java/nv-boot-parent:NOTICE",
         "//:maven_install.json",
         ":notice_roots.json",
     ],

--- a/src/libraries/java/nv-boot-parent/tools/bazel/notice_check_test.sh
+++ b/src/libraries/java/nv-boot-parent/tools/bazel/notice_check_test.sh
@@ -46,8 +46,12 @@ find_workspace() {
 }
 
 workspace="$(find_workspace)"
+# nv-boot-parent is a subtree of the monorepo, not the workspace root, so its
+# notice tooling and its own NOTICE live under this prefix rather than at the
+# repo root. The Maven lock, however, is the single root maven_install.json.
+nvboot="${workspace}/src/libraries/java/nv-boot-parent"
 
-PYTHONPATH="${workspace}/tools/bazel" python3 - <<'PY'
+PYTHONPATH="${nvboot}/tools/bazel" python3 - <<'PY'
 import pathlib
 import tempfile
 import zipfile
@@ -96,9 +100,9 @@ with tempfile.TemporaryDirectory() as directory:
         raise AssertionError("Runtime NOTICE accepted a stale lockfile version")
 PY
 
-exec python3 "${workspace}/tools/bazel/generate_notice.py" \
+exec python3 "${nvboot}/tools/bazel/generate_notice.py" \
     --maven-install "${workspace}/maven_install.json" \
-    --metadata "${workspace}/tools/bazel/notice_metadata.json" \
-    --notice "${workspace}/NOTICE" \
-    --root-manifest "${workspace}/tools/bazel/notice_roots.json" \
+    --metadata "${nvboot}/tools/bazel/notice_metadata.json" \
+    --notice "${nvboot}/NOTICE" \
+    --root-manifest "${nvboot}/tools/bazel/notice_roots.json" \
     --check


### PR DESCRIPTION
## Why
The #269 merge turned main red once #311 enabled root tests: `//src/libraries/java/nv-boot-parent/tools/bazel:notice_check_test` failed with `No module named 'generate_notice'`. It was written for nv-boot-parent as a standalone workspace root, so it resolved its helper/metadata at `${workspace}/tools/bazel/...` and checked `${workspace}/NOTICE` — but in the monorepo the workspace root is the repo root (files live under `src/libraries/java/nv-boot-parent/...`), and `${workspace}/NOTICE` is the aggregate root NOTICE (Go+Rust+Java) that a Java-only regeneration can never match.

## What changed (proper fix, not a quarantine)
- `notice_check_test.sh`: resolve `generate_notice.py`, metadata, and roots under the `src/libraries/java/nv-boot-parent` prefix, and check nv-boot-parent's **own** NOTICE. The Maven lock stays the single root `//:maven_install.json`.
- `tools/bazel/BUILD.bazel`: swap the `//:NOTICE` data dep for `//src/libraries/java/nv-boot-parent:NOTICE`.

The test now validates nv-boot-parent's NOTICE (its Java closure) against the root lock, which is what it was designed to do. No quarantine.

## Testing
Script passes `bash -n`; the root row runs the test (no longer skipped). Green root here confirms the NOTICE is fresh and the test passes.

## Issues
Closes #323

## References
Broke via #269 after #311 enabled root tests.

## Dependencies
None