### PR TITLE
ci: tolerate CRLF line endings in pr-issue-check

### DIFF
--- a/ci/check-pr-issue.sh
+++ b/ci/check-pr-issue.sh
@@ -36,6 +36,10 @@ if repo.lower() != "nvidia/nvcf":
     sys.exit(1)
 
 body = os.environ.get("PR_BODY", "")
+# GitHub stores PR bodies with CRLF line endings (web UI and bot edits), so
+# normalize to LF before matching; the ## Issues heading regex expects a bare
+# newline and would otherwise fail to find the section on a CRLF body.
+body = body.replace("\r\n", "\n").replace("\r", "\n")
 visible = re.sub(r"<!--.*?(?:-->|$)", "", body, flags=re.S)
 
 section_match = re.search(


### PR DESCRIPTION
## TL;DR
Fixes a false negative in the `pr-issue-check` gate: a PR with a valid `## Issues` reference fails when its body uses CRLF line endings. The section detector required a bare LF after the `## Issues` heading, but GitHub stores PR bodies with CRLF (web UI edits and bot edits such as automated summaries), so the `\r` made the regex miss the section and report it missing. The fix normalizes the body to LF before matching.

## Additional Details
- Only newline handling changes. The reference, `NO-REF`, disallowed-tracker, and disallowed-URL checks are untouched.
- Observed symptom: a correct `Closes #NNN` still fails with `PR body is missing a visible ## Issues section` after a bot rewrites the description with CRLF.

## For the Reviewer
- One-line normalization of the body before the `## Issues` regex in `ci/check-pr-issue.sh`.

## For QA
- Ran `ci/check-pr-issue.sh` against CRLF and LF bodies: CRLF with `Closes #NNN` now passes and LF still passes, while the negative cases (no `## Issues` section, section with no reference, `NO-REF`, and a disallowed Jira key) all still behave as before.

## Issues
NO-REF

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request issue-section detection for content using Windows-style line endings.
  * Ensured line-ending variations are handled consistently during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->