### PR TITLE
ci(docs): replace lychee with fern broken-links config

### DIFF
--- a/.github/workflows/fern-docs-ci.yml
+++ b/.github/workflows/fern-docs-ci.yml
@@ -63,9 +63,3 @@ jobs:
 
       - name: Fern check
         run: fern check
-
-      - name: Check links
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
-        with:
-          args: --offline --no-progress 'docs/**/*.md'
-          fail: true

--- a/docs/user/cluster-management/index.md
+++ b/docs/user/cluster-management/index.md
@@ -29,7 +29,7 @@ After installing NVCA on a cluster:
 
     - If your cloud provider does not support the NVIDIA GPU Operator, [Manual Instance Configuration](./configuration.md) is possible, but not recommended due to lack of maintainability.
     - To get the most out of clusters with multi-node NVLink ([MNNVL](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/dra-cds.html#dra-docs-compute-domains)) GPUs like [GB200](https://www.nvidia.com/en-us/data-center/gb200-nvl72/), the [NVIDIA GPU DRA driver](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/dra-intro-install.html) must be installed. See the [nvlink-optimized-clusters](./configuration.md) for details.
-    - For development or testing environments without physical GPUs, install the [fake-gpu-operator](../fake-gpu-operator.md) instead.
+    - For development or testing environments without physical GPUs, install the [fake-gpu-operator](../fake-gpu-operator) instead.
 
 - Registering the cluster requires `kubectl` and `helm` installed.
 

--- a/docs/user/cluster-management/self-managed.md
+++ b/docs/user/cluster-management/self-managed.md
@@ -29,7 +29,7 @@ Before installing the NVCA Operator, ensure the following prerequisites are met:
 
 - The [control plane](../helmfile-installation.md) is installed and all core services are running.
 
-- The [NVIDIA GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html) is installed on the GPU cluster. The GPU Operator manages the NVIDIA drivers, device plugin, and GPU feature discovery required for workload scheduling. For development or testing environments without physical GPUs, see [fake-gpu-operator](../fake-gpu-operator.md).
+- The [NVIDIA GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html) is installed on the GPU cluster. The GPU Operator manages the NVIDIA drivers, device plugin, and GPU feature discovery required for workload scheduling. For development or testing environments without physical GPUs, see [fake-gpu-operator](../fake-gpu-operator).
 
 - (Optional) The [KAI Scheduler](./kai-scheduler.md) can be installed on the GPU cluster for optimized AI workload scheduling and bin-packing of GPU resources. It is required only when you enable the `KAIScheduler` feature flag. See [NVCA Configuration](./configuration.md).
 

--- a/docs/user/infrastructure-sizing.md
+++ b/docs/user/infrastructure-sizing.md
@@ -7,8 +7,8 @@ types and storage classes are AWS examples. For another cloud service provider
 storage classes that provide at least the listed vCPU, memory, storage, zone
 spread, and GPU compatibility characteristics. Actual requirements depend on
 workload characteristics, function count, and request concurrency. Use the
-[self-managed-grpc-load-test](./grpc-load-testing.md) and
-[self-managed-http-load-test](./http-load-testing.md) guides to validate
+[self-managed-grpc-load-test](../g-rpc-load-testing) and
+[self-managed-http-load-test](../http-load-testing) guides to validate
 throughput and tune your control plane accordingly.
 
 </Info>
@@ -56,7 +56,7 @@ For local development of the stack or functions, CI pipelines, or quick demos,
 you can run the entire NVCF stack on a single machine using k3d. This setup
 uses a single Cassandra replica, fake GPUs, and ephemeral `local-path` storage.
 
-See [local-development](./local-development.md) for full step-by-step instructions.
+See [local-development](../local-development) for full step-by-step instructions.
 
 ### Staging / Demo
 
@@ -80,7 +80,7 @@ Use this tier for:
 
 <Tip>
 You can also run the full stack on your laptop using Kind or k3d. See
-[local-development](./local-development.md) for instructions.
+[local-development](../local-development) for instructions.
 
 </Tip>
 
@@ -153,7 +153,7 @@ GPU requirements:
 - Physical GPU hardware on worker nodes
 
 For development and testing environments without GPUs, install the fake GPU
-operator to simulate GPU resources. See [fake-gpu-operator](./fake-gpu-operator.md) for
+operator to simulate GPU resources. See [fake-gpu-operator](../fake-gpu-operator) for
 instructions.
 
 ## Storage Recommendations
@@ -180,8 +180,8 @@ The default control-plane resource sizing shipped with the helmfile stack is
 designed to handle approximately 100 concurrent users. If you need higher
 throughput:
 
-1. Benchmark your deployment using the [self-managed-grpc-load-test](./grpc-load-testing.md)
-   or [self-managed-http-load-test](./http-load-testing.md) guide. Start with
+1. Benchmark your deployment using the [self-managed-grpc-load-test](../g-rpc-load-testing)
+   or [self-managed-http-load-test](../http-load-testing) guide. Start with
    `--vus 100` and increase gradually.
 2. Scale node pools independently. Cassandra, OpenBao, and control-plane
    pools can each be scaled without affecting the others.
@@ -191,7 +191,7 @@ throughput:
 
 <Note>
 - [Quickstart](./quickstart.md): One-click fresh installation walkthrough
-- [self-managed-grpc-load-test](./grpc-load-testing.md): Validate control-plane throughput
-- [self-managed-http-load-test](./http-load-testing.md): Validate HTTP invocation throughput
+- [self-managed-grpc-load-test](../g-rpc-load-testing): Validate control-plane throughput
+- [self-managed-http-load-test](../http-load-testing): Validate HTTP invocation throughput
 
 </Note>

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -9,7 +9,7 @@ For a full list of required artifacts, see [self-hosted-artifact-manifest](./man
 ![Self-hosted component overview](images/nvcf-high-level-stack.svg)
 
 <Tip>
-Want to try NVCF locally first? See [Local Development](./local-development.md) to create a k3d cluster, then use the [Quickstart](./quickstart.md) local k3d flow.
+Want to try NVCF locally first? See [Local Development](../local-development) to create a k3d cluster, then use the [Quickstart](./quickstart.md) local k3d flow.
 
 </Tip>
 
@@ -75,7 +75,7 @@ See [NVIDIA GPU Operator documentation](https://docs.nvidia.com/datacenter/cloud
 Fake GPU Operator for development and testing:
 
 For environments without actual GPU hardware, install the fake GPU operator to simulate
-GPU resources. See [fake-gpu-operator](./fake-gpu-operator.md) for full instructions.
+GPU resources. See [fake-gpu-operator](../fake-gpu-operator) for full instructions.
 </Note>
 
 #### SMB CSI Driver

--- a/docs/user/quickstart.md
+++ b/docs/user/quickstart.md
@@ -346,7 +346,7 @@ Common local k3d issues:
 
 ## See Also
 
-- [Local Development](./local-development.md) for local k3d variants and cleanup commands.
+- [Local Development](../local-development) for local k3d variants and cleanup commands.
 - [Helmfile Installation](./helmfile-installation.md) for remote or manual control-plane installs.
 - [Self-Managed Clusters](./cluster-management/self-managed.md) for registering GPU clusters outside the local quickstart.
 - `src/clis/nvcf-cli/examples/` in this repository for sample CLI input files.

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -36,6 +36,10 @@ versions:
   path: versions/v0.5.yml
   slug: "v0.5"
 
+check:
+  rules:
+    broken-links: warn
+
 redirects:
   - source: "/nvcf/index.html"
     destination: "/nvcf/"

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -38,7 +38,7 @@ versions:
 
 check:
   rules:
-    broken-links: warn
+    broken-links: error
 
 redirects:
   - source: "/nvcf/index.html"


### PR DESCRIPTION
## TL;DR

Replace the lychee link-check step in Fern docs CI with fern's native \`check.rules.broken-links: error\` setting in \`docs.yml\`, and fix the 14 nav-tree link errors that would otherwise block CI.

## Additional Details

Fern's checker validates links against the navigation tree, not just the filesystem. The lychee \`--offline\` check only caught missing files; fern also catches nav-context resolution errors -- links that exist on disk but resolve to the wrong section in the published docs.

The deprecated \`--broken-links\` CLI flag and \`fern docs broken-links\` subcommand both point to this config-based approach as the intended path.

The 14 nav-tree errors were all relative link resolution issues where Fern interprets \`./target.md\` relative to the page's slug rather than the filesystem directory. Fixes applied to quickstart.md, infrastructure-sizing.md, installation.md, cluster-management/index.md, and cluster-management/self-managed.md. Note: Fern slugifies "gRPC" as \`g-rpc\`, so links to grpc-load-testing.md use slug \`g-rpc-load-testing\`.

\`fern check\` passes with 0 errors after this change.

## For the Reviewer

8 files changed: \`fern/docs.yml\` (warn → error), \`fern-docs-ci.yml\` (lychee step removed), and 6 \`docs/user/\` files with corrected nav-tree link paths.

## For QA

\`fern check\` -- 0 errors, 13 warnings (unrelated redirect warnings, tracked in #351).

## Issues

Fixes #330

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links for cluster management, infrastructure sizing, installation, and quickstart guides.
  * Corrected references to local development and fake GPU operator documentation.
* **Bug Fixes**
  * Broken documentation links are now treated as errors during validation.
  * Improved link validation coverage across the documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->