### PR TITLE
fix(docs): fix broken links from GitLab-to-GitHub migration

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -85,13 +85,13 @@ NVCF supports four workload types on the compute plane:
 
 Each component ships an `AGENTS.md` with detailed internals, data flows, and API contracts:
 
-- [`src/compute-plane-services/nvca/AGENTS.md`](../../src/compute-plane-services/nvca/AGENTS.md)
-- [`src/compute-plane-services/ess-agent/AGENTS.md`](../../src/compute-plane-services/ess-agent/AGENTS.md)
-- [`src/compute-plane-services/byoo-otel-collector/AGENTS.md`](../../src/compute-plane-services/byoo-otel-collector/AGENTS.md)
-- [`src/invocation-plane-services/http-invocation/AGENTS.md`](../../src/invocation-plane-services/http-invocation/AGENTS.md)
-- [`src/invocation-plane-services/grpc-proxy/AGENTS.md`](../../src/invocation-plane-services/grpc-proxy/AGENTS.md)
-- [`src/invocation-plane-services/llm-api-gateway/AGENTS.md`](../../src/invocation-plane-services/llm-api-gateway/AGENTS.md)
-- [`src/invocation-plane-services/ratelimiter/AGENTS.md`](../../src/invocation-plane-services/ratelimiter/AGENTS.md)
-- [`src/control-plane-services/nats-auth-callout/AGENTS.md`](../../src/control-plane-services/nats-auth-callout/AGENTS.md)
-- [`src/control-plane-services/function-autoscaler/AGENTS.md`](../../src/control-plane-services/function-autoscaler/AGENTS.md)
-- [`examples/AGENTS.md`](../../examples/AGENTS.md)
+- [src/compute-plane-services/nvca/AGENTS.md](https://github.com/NVIDIA/nvcf/blob/main/src/compute-plane-services/nvca/AGENTS.md)
+- [src/compute-plane-services/ess-agent/AGENTS.md](https://github.com/NVIDIA/nvcf/blob/main/src/compute-plane-services/ess-agent/AGENTS.md)
+- [src/compute-plane-services/byoo-otel-collector/AGENTS.md](https://github.com/NVIDIA/nvcf/blob/main/src/compute-plane-services/byoo-otel-collector/AGENTS.md)
+- [src/invocation-plane-services/http-invocation/AGENTS.md](https://github.com/NVIDIA/nvcf/blob/main/src/invocation-plane-services/http-invocation/AGENTS.md)
+- [src/invocation-plane-services/grpc-proxy/AGENTS.md](https://github.com/NVIDIA/nvcf/blob/main/src/invocation-plane-services/grpc-proxy/AGENTS.md)
+- [src/invocation-plane-services/llm-api-gateway/AGENTS.md](https://github.com/NVIDIA/nvcf/blob/main/src/invocation-plane-services/llm-api-gateway/AGENTS.md)
+- [src/invocation-plane-services/ratelimiter/AGENTS.md](https://github.com/NVIDIA/nvcf/blob/main/src/invocation-plane-services/ratelimiter/AGENTS.md)
+- [src/control-plane-services/nats-auth-callout/AGENTS.md](https://github.com/NVIDIA/nvcf/blob/main/src/control-plane-services/nats-auth-callout/AGENTS.md)
+- [src/control-plane-services/function-autoscaler/AGENTS.md](https://github.com/NVIDIA/nvcf/blob/main/src/control-plane-services/function-autoscaler/AGENTS.md)
+- [examples/AGENTS.md](https://github.com/NVIDIA/nvcf/blob/main/examples/AGENTS.md)

--- a/docs/dev/grpc-load-testing.md
+++ b/docs/dev/grpc-load-testing.md
@@ -37,12 +37,12 @@ The `grpc_echo_sample` from the same repository shares the
 </Note>
 
 The source, build instructions, and registry push examples are in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/function_samples/load_tester_supreme)
+[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
 repository. Build and push the image to whichever container registry your
 cluster has credentials for:
 
 ```bash
-git clone https://github.com/NVIDIA/nv-cloud-function-helpers.git
+git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
 cd nv-cloud-function-helpers/examples/function_samples/load_tester_supreme
 
 # Build
@@ -115,7 +115,7 @@ The CLI saves the function and version IDs automatically. Run
 ## Clone the load test scripts
 
 ```bash
-git clone https://github.com/NVIDIA/nv-cloud-function-helpers.git
+git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
 cd nv-cloud-function-helpers/examples/load-tests
 ```
 

--- a/docs/dev/grpc-load-testing.md
+++ b/docs/dev/grpc-load-testing.md
@@ -37,13 +37,13 @@ The `grpc_echo_sample` from the same repository shares the
 </Note>
 
 The source, build instructions, and registry push examples are in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
+[NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
 repository. Build and push the image to whichever container registry your
 cluster has credentials for:
 
 ```bash
-git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
-cd nv-cloud-function-helpers/examples/function_samples/load_tester_supreme
+git clone https://github.com/NVIDIA/nvcf.git
+cd nvcf/examples/function-samples/load-tester-supreme
 
 # Build
 docker build --platform linux/amd64 -t load_tester_supreme .
@@ -115,8 +115,8 @@ The CLI saves the function and version IDs automatically. Run
 ## Clone the load test scripts
 
 ```bash
-git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
-cd nv-cloud-function-helpers/examples/load-tests
+git clone https://github.com/NVIDIA/nvcf.git
+cd nvcf/examples/load-tests
 ```
 
 ## Install k6

--- a/docs/dev/http-load-testing.md
+++ b/docs/dev/http-load-testing.md
@@ -29,13 +29,13 @@ for high-throughput benchmarking and includes:
 - Built-in OpenTelemetry tracing
 
 The source, build instructions, and registry push examples are in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
+[NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
 repository. Build and push the image to whichever container registry your
 cluster has credentials for:
 
 ```bash
-git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
-cd nv-cloud-function-helpers/examples/function_samples/load_tester_supreme
+git clone https://github.com/NVIDIA/nvcf.git
+cd nvcf/examples/function-samples/load-tester-supreme
 
 # Build
 docker build --platform linux/amd64 -t load_tester_supreme .
@@ -100,8 +100,8 @@ k3d, Docker Desktop) it is typically `localhost` or `127.0.0.1`.
 ## Clone the load test scripts
 
 ```bash
-git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
-cd nv-cloud-function-helpers/examples/load-tests
+git clone https://github.com/NVIDIA/nvcf.git
+cd nvcf/examples/load-tests
 ```
 
 ## Install k6

--- a/docs/dev/http-load-testing.md
+++ b/docs/dev/http-load-testing.md
@@ -29,12 +29,12 @@ for high-throughput benchmarking and includes:
 - Built-in OpenTelemetry tracing
 
 The source, build instructions, and registry push examples are in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/function_samples/load_tester_supreme)
+[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
 repository. Build and push the image to whichever container registry your
 cluster has credentials for:
 
 ```bash
-git clone https://github.com/NVIDIA/nv-cloud-function-helpers.git
+git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
 cd nv-cloud-function-helpers/examples/function_samples/load_tester_supreme
 
 # Build
@@ -100,7 +100,7 @@ k3d, Docker Desktop) it is typically `localhost` or `127.0.0.1`.
 ## Clone the load test scripts
 
 ```bash
-git clone https://github.com/NVIDIA/nv-cloud-function-helpers.git
+git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
 cd nv-cloud-function-helpers/examples/load-tests
 ```
 

--- a/docs/dev/http-soak-testing.md
+++ b/docs/dev/http-soak-testing.md
@@ -32,13 +32,13 @@ for high-throughput benchmarking and includes:
 - Built-in OpenTelemetry tracing
 
 The source, build instructions, and registry push examples are in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
+[NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
 repository. Build and push the image to whichever container registry your
 cluster has credentials for:
 
 ```bash
-git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
-cd nv-cloud-function-helpers/examples/function_samples/load_tester_supreme
+git clone https://github.com/NVIDIA/nvcf.git
+cd nvcf/examples/function-samples/load-tester-supreme
 
 # Build (multi-arch)
 docker buildx build --platform linux/amd64,linux/arm64 -t load_tester_supreme .
@@ -162,7 +162,7 @@ you want a steady, predictable load.
 
 <Note>
 The latest version of this script is maintained in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples)
+[NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples)
 repository.
 
 </Note>

--- a/docs/dev/http-soak-testing.md
+++ b/docs/dev/http-soak-testing.md
@@ -32,12 +32,12 @@ for high-throughput benchmarking and includes:
 - Built-in OpenTelemetry tracing
 
 The source, build instructions, and registry push examples are in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/function_samples/load_tester_supreme)
+[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
 repository. Build and push the image to whichever container registry your
 cluster has credentials for:
 
 ```bash
-git clone https://github.com/NVIDIA/nv-cloud-function-helpers.git
+git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
 cd nv-cloud-function-helpers/examples/function_samples/load_tester_supreme
 
 # Build (multi-arch)
@@ -162,7 +162,7 @@ you want a steady, predictable load.
 
 <Note>
 The latest version of this script is maintained in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nv-cloud-function-helpers)
+[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples)
 repository.
 
 </Note>

--- a/docs/ngc-managed/cluster-management/monitoring.md
+++ b/docs/ngc-managed/cluster-management/monitoring.md
@@ -21,7 +21,7 @@ The cluster agent and operator emit Prometheus-style metrics. The following metr
 | nvca_cluster_group | The NVCA cluster group |
 | nvca_version | The NVCA version |
 
-Cluster maintainers can scrape the available metrics. See a full example of how to do this with an OpenTelemetry Collector in the cluster [here](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/cluster_monitoring_sample).
+Cluster maintainers can scrape the available metrics. See a full example of how to do this with an OpenTelemetry Collector in the cluster [here](https://github.com/NVIDIA/nvcf/tree/main/examples/cluster-monitoring-sample).
 
 Use the following examples of a PodMonitor for NVCA Operator and ServiceMonitor for NVCA for reference:
 

--- a/docs/ngc-managed/cluster-management/monitoring.md
+++ b/docs/ngc-managed/cluster-management/monitoring.md
@@ -21,7 +21,7 @@ The cluster agent and operator emit Prometheus-style metrics. The following metr
 | nvca_cluster_group | The NVCA cluster group |
 | nvca_version | The NVCA version |
 
-Cluster maintainers can scrape the available metrics. See a full example of how to do this with an OpenTelemetry Collector in the cluster [here](https://github.com/NVIDIA/nvcf/tree/main/examples/cluster-monitoring-sample).
+Cluster maintainers can scrape the available metrics. See a full example of how to do this with an OpenTelemetry Collector in the cluster [cluster monitoring example](https://github.com/NVIDIA/nvcf/tree/main/examples/cluster-monitoring-sample).
 
 Use the following examples of a PodMonitor for NVCA Operator and ServiceMonitor for NVCA for reference:
 

--- a/docs/user/cli.md
+++ b/docs/user/cli.md
@@ -344,7 +344,7 @@ Or use the `--debug` flag or `NVCF_DEBUG=true` environment variable per-command.
 ```
 
 <Note>
-For immediate testing, you can use `load_tester_supreme` from `nvcf-onprem` (see [self-hosted-artifact-manifest](./manifest.md)), which supports the `{"message": "hello world"}` request body above. For more function samples, see the [nv-cloud-function-helpers](https://github.com/NVIDIA/nv-cloud-function-helpers) repository and [function-creation](./function-creation.md) for function creation documentation.
+For immediate testing, you can use `load_tester_supreme` from `nvcf-onprem` (see [self-hosted-artifact-manifest](./manifest.md)), which supports the `{"message": "hello world"}` request body above. For more function samples, see the [nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples) repository and [function-creation](./function-creation.md) for function creation documentation.
 
 </Note>
 

--- a/docs/user/cli.md
+++ b/docs/user/cli.md
@@ -344,7 +344,7 @@ Or use the `--debug` flag or `NVCF_DEBUG=true` environment variable per-command.
 ```
 
 <Note>
-For immediate testing, you can use `load_tester_supreme` from `nvcf-onprem` (see [self-hosted-artifact-manifest](./manifest.md)), which supports the `{"message": "hello world"}` request body above. For more function samples, see the [nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples) repository and [function-creation](./function-creation.md) for function creation documentation.
+For immediate testing, you can use `load_tester_supreme` from `nvcf-onprem` (see [self-hosted-artifact-manifest](./manifest.md)), which supports the `{"message": "hello world"}` request body above. For more function samples, see the [NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples) repository and [function-creation](./function-creation.md) for function creation documentation.
 
 </Note>
 

--- a/docs/user/cluster-management/monitoring.md
+++ b/docs/user/cluster-management/monitoring.md
@@ -21,7 +21,7 @@ The cluster agent and operator emit Prometheus-style metrics. The following metr
 | nvca_cluster_group | The NVCA cluster group           |
 | nvca_version       | The NVCA version                 |
 
-Cluster maintainers can scrape the available metrics. See a full example of how to do this with an OpenTelemetry Collector in the cluster [here](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/cluster_monitoring_sample).
+Cluster maintainers can scrape the available metrics. See a full example of how to do this with an OpenTelemetry Collector in the cluster [here](https://github.com/NVIDIA/nvcf/tree/main/examples/cluster-monitoring-sample).
 
 Use the following examples of a PodMonitor for NVCA Operator and ServiceMonitor for NVCA for reference:
 

--- a/docs/user/cluster-management/monitoring.md
+++ b/docs/user/cluster-management/monitoring.md
@@ -21,7 +21,7 @@ The cluster agent and operator emit Prometheus-style metrics. The following metr
 | nvca_cluster_group | The NVCA cluster group           |
 | nvca_version       | The NVCA version                 |
 
-Cluster maintainers can scrape the available metrics. See a full example of how to do this with an OpenTelemetry Collector in the cluster [here](https://github.com/NVIDIA/nvcf/tree/main/examples/cluster-monitoring-sample).
+Cluster maintainers can scrape the available metrics. See a full example of how to do this with an OpenTelemetry Collector in the cluster [cluster monitoring example](https://github.com/NVIDIA/nvcf/tree/main/examples/cluster-monitoring-sample).
 
 Use the following examples of a PodMonitor for NVCA Operator and ServiceMonitor for NVCA for reference:
 

--- a/docs/user/container-functions.md
+++ b/docs/user/container-functions.md
@@ -43,7 +43,7 @@ Cloud Functions also expects the following directories in the container to remai
 
 ## Composing a FastAPI Container
 
-It's possible to use any container with Cloud Functions as long as it implements a server with the above endpoints. The below is an example of a FastAPI-based container compatible with Cloud Functions. Clone the [FastAPI echo example](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/function_samples/fastapi_echo_sample).
+It's possible to use any container with Cloud Functions as long as it implements a server with the above endpoints. The below is an example of a FastAPI-based container compatible with Cloud Functions. Clone the [FastAPI echo example](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/fastapi-echo-sample).
 
 ### Create the "requirements.txt" File
 
@@ -289,7 +289,7 @@ Create the function via the NVCF API. In this example, we defined the inference 
 
 ### Additional Examples
 
-See more examples of containers that are Cloud Functions compatible [in the function samples directory](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/function_samples/).
+See more examples of containers that are Cloud Functions compatible [in the function samples directory](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/).
 
 ## Creating gRPC-based Functions
 
@@ -300,7 +300,7 @@ Cloud Functions supports function invocation via gRPC. During function creation,
 - The function container must implement a gRPC port, endpoint and health check. The health check is expected to be served by the gRPC inference port, there is no need to define a separate health endpoint path.
 
   - See [gRPC health checking](https://grpc.io/docs/guides/health-checking/).
-  - See an [example container](https://github.com/NVIDIA/nv-cloud-function-helpers/blob/main/examples/function_samples/grpc_echo_sample/grpc_echo_server.py) with a gRPC server that is Cloud Functions compatible.
+  - See an [example container](https://github.com/NVIDIA/nvcf/blob/main/examples/function-samples/grpc-echo-sample/grpc_echo_server.py) with a gRPC server that is Cloud Functions compatible.
 
 ### gRPC Function Creation via API
 

--- a/docs/user/container-functions.md
+++ b/docs/user/container-functions.md
@@ -4,9 +4,9 @@ Container-based functions require building and pushing a Cloud Functions compati
 
 ## Resources
 
-- Example containers can be found [in the examples repository](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples).
+- Example containers can be found [in the examples directory](https://github.com/NVIDIA/nvcf/tree/main/examples).
 
-- The repository also contains [helper functions](https://github.com/NVIDIA/nv-cloud-function-helpers/blob/main/helper_library/nv_cloud_function_helpers/nvcf_container/helpers.py) that are useful when authoring your container, including:
+- The repository also contains [helper functions](https://github.com/NVIDIA/nvcf/blob/main/src/libraries/python/nv-cloud-function-helpers/nv_cloud_function_helpers/nvcf_container/helpers.py) that are useful when authoring your container, including:
 
   - Helpers that parse Cloud Functions-specific parameters on invocation
   - Helpers that can be used to instrument your container with Cloud Functions compatible logs

--- a/docs/user/function-creation.md
+++ b/docs/user/function-creation.md
@@ -48,7 +48,7 @@ For LLM functions, see [LLM Gateway](./llm-gateway.md#function-configuration) fo
 
 The following is a reference of available variables via the headers of the invocation message (auto-populated by Cloud Functions), accessible within the container.
 
-For examples of how to extract and use some of these variables, see [NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples).
+For examples of how to extract and use some of these variables, see [NVCF Container Helper Functions](https://github.com/NVIDIA/nvcf/tree/main/src/libraries/python/nv-cloud-function-helpers).
 
 | Name                         | Description                                             |
 | ---------------------------- | ------------------------------------------------------- |

--- a/docs/user/function-creation.md
+++ b/docs/user/function-creation.md
@@ -48,7 +48,7 @@ For LLM functions, see [LLM Gateway](./llm-gateway.md#function-configuration) fo
 
 The following is a reference of available variables via the headers of the invocation message (auto-populated by Cloud Functions), accessible within the container.
 
-For examples of how to extract and use some of these variables, see [NVCF Container Helper Functions](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main).
+For examples of how to extract and use some of these variables, see [NVCF Container Helper Functions](https://github.com/NVIDIA/nvcf/tree/main/examples).
 
 | Name                         | Description                                             |
 | ---------------------------- | ------------------------------------------------------- |

--- a/docs/user/function-creation.md
+++ b/docs/user/function-creation.md
@@ -48,7 +48,7 @@ For LLM functions, see [LLM Gateway](./llm-gateway.md#function-configuration) fo
 
 The following is a reference of available variables via the headers of the invocation message (auto-populated by Cloud Functions), accessible within the container.
 
-For examples of how to extract and use some of these variables, see [NVCF Container Helper Functions](https://github.com/NVIDIA/nvcf/tree/main/examples).
+For examples of how to extract and use some of these variables, see [NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples).
 
 | Name                         | Description                                             |
 | ---------------------------- | ------------------------------------------------------- |

--- a/docs/user/helm-functions.md
+++ b/docs/user/helm-functions.md
@@ -41,7 +41,7 @@ All Pod specs in your helm chart will be updated with pull secrets at runtime, s
 
 **Example Creation via API**
 
-Please see our [sample helm chart used](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/function_samples/helmchart_samples/inference_test_sample) in this example for reference.
+Please see our [sample helm chart used](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/helmchart-samples/inference-test-sample) in this example for reference.
 
 Below is an example function creation API call creating a helm-based function:
 
@@ -72,7 +72,7 @@ For gRPC-based functions, set `"inferenceURL" : "/gRPC"`. This signals to Cloud 
 To create a multi-node helm deployment, you need to use the following format for the `instanceType`:
 `<CSP>.GPU.<GPU_NAME>_<number of gpus per node>x[.x<number of nodes>]`. For example, `DGXC.GPU.L40S_1x` is a single L40S instance while `ON-PREM.GPU.B200_8x.x2` is two full nodes of 8-way B200.
 
-A sample helm chart for a multi-node deployment can be found [in the multi-node helm example](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/function_samples/helmchart_samples/multi_node_helm_function_test/).
+A sample helm chart for a multi-node deployment can be found [in the multi-node helm example](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/helmchart-samples/multi-node-helm-function-test/).
 
 ## Limitations
 

--- a/docs/user/helmfile-installation.md
+++ b/docs/user/helmfile-installation.md
@@ -191,7 +191,7 @@ Environment configuration files define how NVCF is deployed in your specific env
 Set `HELMFILE_ENV` to your environment name and copy the base configuration.
 The filename must match `HELMFILE_ENV` because Helmfile uses it to select the
 environment file. The template below shows the values to configure for Amazon
-EKS ([cp-env-eks-example.yaml](samples/configs/cp-env-eks-example.yaml)).
+EKS ([cp-env-eks-example.yaml](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/user/samples/configs/cp-env-eks-example.yaml)).
 
 ```bash
 cd path/to/nvcf-self-managed-stack
@@ -586,7 +586,7 @@ These credentials will then be used for function deployments. Note that if the r
 Copy the secrets template using the same `HELMFILE_ENV` value from Step 2. The
 filename must match `HELMFILE_ENV` because Helmfile loads the corresponding
 secrets file. The example below shows the required structure
-([example-secrets.yaml](samples/configs/cp-example-secrets.yaml)). You must
+([example-secrets.yaml](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/user/samples/configs/cp-example-secrets.yaml)). You must
 replace all instances of `REPLACE_WITH_BASE64_DOCKER_CREDENTIAL` with your
 actual base64-encoded registry credentials.
 
@@ -731,7 +731,7 @@ registry.
 If your `image` registry is private and your cluster nodes do not have built-in credential helpers, you must create Kubernetes `docker-registry` secrets in each NVCF namespace and configure the helmfile to reference them.
 
 1. Create the pull secret in each NVCF namespace
-   ([create-nvcr-pull-secrets.sh](samples/scripts/create-nvcr-pull-secrets.sh)):
+   ([create-nvcr-pull-secrets.sh](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/user/samples/scripts/create-nvcr-pull-secrets.sh)):
 
 ```bash
 export NGC_API_KEY="<your-ngc-api-key>"

--- a/docs/user/observability.md
+++ b/docs/user/observability.md
@@ -295,7 +295,7 @@ Dashboards are provided in native Grafana JSON format for [file-provisioning](ht
 Load dashboards into Grafana by placing them in `/etc/grafana/provisioning/dashboards/` on startup.
 
 Published dashboards will be available in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nv-cloud-function-helpers) public GitHub repository.
+[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples) public GitHub repository.
 
 ## Troubleshooting
 

--- a/docs/user/observability.md
+++ b/docs/user/observability.md
@@ -295,7 +295,7 @@ Dashboards are provided in native Grafana JSON format for [file-provisioning](ht
 Load dashboards into Grafana by placing them in `/etc/grafana/provisioning/dashboards/` on startup.
 
 Published dashboards will be available in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples) public GitHub repository.
+[NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples) public GitHub repository.
 
 ## Troubleshooting
 

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -1090,7 +1090,7 @@ echo "=============================================="
 
 ```
 
-[force-cleanup-nvcf.sh](samples/scripts/force-cleanup-nvcf.sh)
+[force-cleanup-nvcf.sh](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/user/samples/scripts/force-cleanup-nvcf.sh)
 
 **Usage:**
 

--- a/docs/v0.5/cli.md
+++ b/docs/v0.5/cli.md
@@ -274,7 +274,7 @@ Or use the `--debug` flag or `NVCF_DEBUG=true` environment variable per-command.
 ```
 
 <Note>
-For immediate testing, you can use `load_tester_supreme` from `nvcf-onprem` (see [self-hosted-artifact-manifest](./manifest.md)), which supports the `{"message": "hello world"}` request body above. For more function samples, see the [nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples) repository and [function-creation](./function-creation.md) for function creation documentation.
+For immediate testing, you can use `load_tester_supreme` from `nvcf-onprem` (see [self-hosted-artifact-manifest](./manifest.md)), which supports the `{"message": "hello world"}` request body above. For more function samples, see the [NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples) repository and [function-creation](./function-creation.md) for function creation documentation.
 
 </Note>
 

--- a/docs/v0.5/cli.md
+++ b/docs/v0.5/cli.md
@@ -274,7 +274,7 @@ Or use the `--debug` flag or `NVCF_DEBUG=true` environment variable per-command.
 ```
 
 <Note>
-For immediate testing, you can use `load_tester_supreme` from `nvcf-onprem` (see [self-hosted-artifact-manifest](./manifest.md)), which supports the `{"message": "hello world"}` request body above. For more function samples, see the [nv-cloud-function-helpers](https://github.com/NVIDIA/nv-cloud-function-helpers) repository and [function-creation](./function-creation.md) for function creation documentation.
+For immediate testing, you can use `load_tester_supreme` from `nvcf-onprem` (see [self-hosted-artifact-manifest](./manifest.md)), which supports the `{"message": "hello world"}` request body above. For more function samples, see the [nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples) repository and [function-creation](./function-creation.md) for function creation documentation.
 
 </Note>
 

--- a/docs/v0.5/cluster-management/monitoring.md
+++ b/docs/v0.5/cluster-management/monitoring.md
@@ -21,7 +21,7 @@ The cluster agent and operator emit Prometheus-style metrics. The following metr
 | nvca_cluster_group | The NVCA cluster group           |
 | nvca_version       | The NVCA version                 |
 
-Cluster maintainers can scrape the available metrics. See a full example of how to do this with an OpenTelemetry Collector in the cluster [here](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/cluster_monitoring_sample).
+Cluster maintainers can scrape the available metrics. See a full example of how to do this with an OpenTelemetry Collector in the cluster [here](https://github.com/NVIDIA/nvcf/tree/main/examples/cluster-monitoring-sample).
 
 Use the following examples of a PodMonitor for NVCA Operator and ServiceMonitor for NVCA for reference:
 

--- a/docs/v0.5/cluster-management/monitoring.md
+++ b/docs/v0.5/cluster-management/monitoring.md
@@ -21,7 +21,7 @@ The cluster agent and operator emit Prometheus-style metrics. The following metr
 | nvca_cluster_group | The NVCA cluster group           |
 | nvca_version       | The NVCA version                 |
 
-Cluster maintainers can scrape the available metrics. See a full example of how to do this with an OpenTelemetry Collector in the cluster [here](https://github.com/NVIDIA/nvcf/tree/main/examples/cluster-monitoring-sample).
+Cluster maintainers can scrape the available metrics. See a full example of how to do this with an OpenTelemetry Collector in the cluster [cluster monitoring example](https://github.com/NVIDIA/nvcf/tree/main/examples/cluster-monitoring-sample).
 
 Use the following examples of a PodMonitor for NVCA Operator and ServiceMonitor for NVCA for reference:
 

--- a/docs/v0.5/container-functions.md
+++ b/docs/v0.5/container-functions.md
@@ -43,7 +43,7 @@ Cloud Functions also expects the following directories in the container to remai
 
 ## Composing a FastAPI Container
 
-It's possible to use any container with Cloud Functions as long as it implements a server with the above endpoints. The below is an example of a FastAPI-based container compatible with Cloud Functions. Clone the [FastAPI echo example](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/function_samples/fastapi_echo_sample).
+It's possible to use any container with Cloud Functions as long as it implements a server with the above endpoints. The below is an example of a FastAPI-based container compatible with Cloud Functions. Clone the [FastAPI echo example](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/fastapi-echo-sample).
 
 ### Create the "requirements.txt" File
 
@@ -289,7 +289,7 @@ Create the function via the NVCF API. In this example, we defined the inference 
 
 ### Additional Examples
 
-See more examples of containers that are Cloud Functions compatible [in the function samples directory](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/function_samples/).
+See more examples of containers that are Cloud Functions compatible [in the function samples directory](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/).
 
 ## Creating gRPC-based Functions
 
@@ -300,7 +300,7 @@ Cloud Functions supports function invocation via gRPC. During function creation,
 - The function container must implement a gRPC port, endpoint and health check. The health check is expected to be served by the gRPC inference port, there is no need to define a separate health endpoint path.
 
   - See [gRPC health checking](https://grpc.io/docs/guides/health-checking/).
-  - See an [example container](https://github.com/NVIDIA/nv-cloud-function-helpers/blob/main/examples/function_samples/grpc_echo_sample/grpc_echo_server.py) with a gRPC server that is Cloud Functions compatible.
+  - See an [example container](https://github.com/NVIDIA/nvcf/blob/main/examples/function-samples/grpc-echo-sample/grpc_echo_server.py) with a gRPC server that is Cloud Functions compatible.
 
 ### gRPC Function Creation via API
 

--- a/docs/v0.5/container-functions.md
+++ b/docs/v0.5/container-functions.md
@@ -4,9 +4,9 @@ Container-based functions require building and pushing a Cloud Functions compati
 
 ## Resources
 
-- Example containers can be found [in the examples repository](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples).
+- Example containers can be found [in the examples directory](https://github.com/NVIDIA/nvcf/tree/main/examples).
 
-- The repository also contains [helper functions](https://github.com/NVIDIA/nv-cloud-function-helpers/blob/main/helper_library/nv_cloud_function_helpers/nvcf_container/helpers.py) that are useful when authoring your container, including:
+- The repository also contains [helper functions](https://github.com/NVIDIA/nvcf/blob/main/src/libraries/python/nv-cloud-function-helpers/nv_cloud_function_helpers/nvcf_container/helpers.py) that are useful when authoring your container, including:
 
   - Helpers that parse Cloud Functions-specific parameters on invocation
   - Helpers that can be used to instrument your container with Cloud Functions compatible logs
@@ -321,4 +321,4 @@ When creating the gRPC function, set the `inferenceUrl` field to `/grpc`:
 
 ### gRPC Function Invocation
 
-gRPC function invocation uses the same `Authorization: Bearer $NVCF_TOKEN` header as HTTP invocation, passed as gRPC metadata. See the [gRPC invocation examples](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples) for details on how to authenticate and invoke your gRPC function.
+gRPC function invocation uses the same `Authorization: Bearer $NVCF_TOKEN` header as HTTP invocation, passed as gRPC metadata. See the [gRPC invocation examples](https://github.com/NVIDIA/nvcf/tree/main/examples) for details on how to authenticate and invoke your gRPC function.

--- a/docs/v0.5/function-creation.md
+++ b/docs/v0.5/function-creation.md
@@ -35,7 +35,7 @@ Additionally, Cloud Functions supports [Low Latency Streaming (LLS) functions](.
 
 The following is a reference of available variables via the headers of the invocation message (auto-populated by Cloud Functions), accessible within the container.
 
-For examples of how to extract and use some of these variables, see [NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples).
+For examples of how to extract and use some of these variables, see [NVCF Container Helper Functions](https://github.com/NVIDIA/nvcf/tree/main/src/libraries/python/nv-cloud-function-helpers).
 
 | Name                         | Description                                             |
 | ---------------------------- | ------------------------------------------------------- |

--- a/docs/v0.5/function-creation.md
+++ b/docs/v0.5/function-creation.md
@@ -35,7 +35,7 @@ Additionally, Cloud Functions supports [Low Latency Streaming (LLS) functions](.
 
 The following is a reference of available variables via the headers of the invocation message (auto-populated by Cloud Functions), accessible within the container.
 
-For examples of how to extract and use some of these variables, see [NVCF Container Helper Functions](https://github.com/NVIDIA/nvcf/tree/main/examples).
+For examples of how to extract and use some of these variables, see [NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples).
 
 | Name                         | Description                                             |
 | ---------------------------- | ------------------------------------------------------- |

--- a/docs/v0.5/function-creation.md
+++ b/docs/v0.5/function-creation.md
@@ -35,7 +35,7 @@ Additionally, Cloud Functions supports [Low Latency Streaming (LLS) functions](.
 
 The following is a reference of available variables via the headers of the invocation message (auto-populated by Cloud Functions), accessible within the container.
 
-For examples of how to extract and use some of these variables, see [NVCF Container Helper Functions](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main).
+For examples of how to extract and use some of these variables, see [NVCF Container Helper Functions](https://github.com/NVIDIA/nvcf/tree/main/examples).
 
 | Name                         | Description                                             |
 | ---------------------------- | ------------------------------------------------------- |

--- a/docs/v0.5/grpc-load-testing.md
+++ b/docs/v0.5/grpc-load-testing.md
@@ -37,13 +37,13 @@ The `grpc_echo_sample` from the same repository shares the
 </Note>
 
 The source, build instructions, and registry push examples are in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
+[NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
 repository. Build and push the image to whichever container registry your
 cluster has credentials for:
 
 ```bash
-git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
-cd nv-cloud-function-helpers/examples/function_samples/load_tester_supreme
+git clone https://github.com/NVIDIA/nvcf.git
+cd nvcf/examples/function-samples/load-tester-supreme
 
 # Build
 docker build --platform linux/amd64 -t load_tester_supreme .
@@ -111,8 +111,8 @@ The CLI saves the function and version IDs automatically. Run
 ## Clone the load test scripts
 
 ```bash
-git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
-cd nv-cloud-function-helpers/examples/load-tests
+git clone https://github.com/NVIDIA/nvcf.git
+cd nvcf/examples/load-tests
 ```
 
 ## Install k6

--- a/docs/v0.5/grpc-load-testing.md
+++ b/docs/v0.5/grpc-load-testing.md
@@ -37,12 +37,12 @@ The `grpc_echo_sample` from the same repository shares the
 </Note>
 
 The source, build instructions, and registry push examples are in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/function_samples/load_tester_supreme)
+[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
 repository. Build and push the image to whichever container registry your
 cluster has credentials for:
 
 ```bash
-git clone https://github.com/NVIDIA/nv-cloud-function-helpers.git
+git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
 cd nv-cloud-function-helpers/examples/function_samples/load_tester_supreme
 
 # Build
@@ -111,7 +111,7 @@ The CLI saves the function and version IDs automatically. Run
 ## Clone the load test scripts
 
 ```bash
-git clone https://github.com/NVIDIA/nv-cloud-function-helpers.git
+git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
 cd nv-cloud-function-helpers/examples/load-tests
 ```
 

--- a/docs/v0.5/helm-functions.md
+++ b/docs/v0.5/helm-functions.md
@@ -41,7 +41,7 @@ All Pod specs in your helm chart will be updated with pull secrets at runtime, s
 
 **Example Creation via API**
 
-Please see our [sample helm chart used](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/function_samples/helmchart_samples/inference_test_sample) in this example for reference.
+Please see our [sample helm chart used](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/helmchart-samples/inference-test-sample) in this example for reference.
 
 Below is an example function creation API call creating a helm-based function:
 
@@ -72,7 +72,7 @@ For gRPC-based functions, set `"inferenceURL" : "/gRPC"`. This signals to Cloud 
 To create a multi-node helm deployment, you need to use the following format for the `instanceType`:
 `<CSP>.GPU.<GPU_NAME>_<number of gpus per node>x[.x<number of nodes>]`. For example, `DGXC.GPU.L40S_1x` is a single L40S instance while `ON-PREM.GPU.B200_8x.x2` is two full nodes of 8-way B200.
 
-A sample helm chart for a multi-node deployment can be found [in the multi-node helm example](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/function_samples/helmchart_samples/multi_node_helm_function_test/).
+A sample helm chart for a multi-node deployment can be found [in the multi-node helm example](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/helmchart-samples/multi-node-helm-function-test/).
 
 ## Limitations
 

--- a/docs/v0.5/helmfile-installation.md
+++ b/docs/v0.5/helmfile-installation.md
@@ -259,7 +259,7 @@ The Gateway you created here will be used by the `nvcf-gateway-routes` chart to 
 
 Environment configuration files define how NVCF is deployed in your specific environment. They are YAML files that provide values to the Helm charts.
 
-Create your environment file from the template below ([cp-env-eks-example.yaml](samples/configs/cp-env-eks-example.yaml)).
+Create your environment file from the template below ([cp-env-eks-example.yaml](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/v0.5/samples/configs/cp-env-eks-example.yaml)).
 
 ```bash
 cd path/to/nvcf-self-managed-stack
@@ -606,7 +606,7 @@ Secrets configuration contains any sensitive data required for NVCF operation. T
 
 These credentials will then be used for function deployments. Note that if the registry credentials are not correct you can always update them using the steps in [third-party-registries-self-hosted](./third-party-registries.md).
 
-Create your secrets file from the template below ([example-secrets.yaml](samples/configs/cp-example-secrets.yaml)). You must replace all instances of `REPLACE_WITH_BASE64_DOCKER_CREDENTIAL` with your actual base64-encoded registry credentials.
+Create your secrets file from the template below ([example-secrets.yaml](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/v0.5/samples/configs/cp-example-secrets.yaml)). You must replace all instances of `REPLACE_WITH_BASE64_DOCKER_CREDENTIAL` with your actual base64-encoded registry credentials.
 
 ```bash
 cd path/to/nvcf-self-managed-stack
@@ -727,7 +727,7 @@ The secrets file you configured in Step 3 handles **API bootstrap registry crede
 
 If your `image` registry is private and your cluster nodes do not have built-in credential helpers, you must create Kubernetes `docker-registry` secrets in each NVCF namespace and configure the helmfile to reference them.
 
-**1. Create the pull secret** in each NVCF namespace ([create-nvcr-pull-secrets.sh](samples/scripts/create-nvcr-pull-secrets.sh)):
+**1. Create the pull secret** in each NVCF namespace ([create-nvcr-pull-secrets.sh](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/v0.5/samples/scripts/create-nvcr-pull-secrets.sh)):
 
 ```bash
 export NGC_API_KEY="<your-ngc-api-key>"

--- a/docs/v0.5/http-soak-testing.md
+++ b/docs/v0.5/http-soak-testing.md
@@ -32,13 +32,13 @@ for high-throughput benchmarking and includes:
 - Built-in OpenTelemetry tracing
 
 The source, build instructions, and registry push examples are in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
+[NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
 repository. Build and push the image to whichever container registry your
 cluster has credentials for:
 
 ```bash
-git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
-cd nv-cloud-function-helpers/examples/function_samples/load_tester_supreme
+git clone https://github.com/NVIDIA/nvcf.git
+cd nvcf/examples/function-samples/load-tester-supreme
 
 # Build (multi-arch)
 docker buildx build --platform linux/amd64,linux/arm64 -t load_tester_supreme .
@@ -163,7 +163,7 @@ you want a steady, predictable load.
 
 <Note>
 The latest version of this script is maintained in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples)
+[NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples)
 repository.
 
 </Note>

--- a/docs/v0.5/http-soak-testing.md
+++ b/docs/v0.5/http-soak-testing.md
@@ -32,12 +32,12 @@ for high-throughput benchmarking and includes:
 - Built-in OpenTelemetry tracing
 
 The source, build instructions, and registry push examples are in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/function_samples/load_tester_supreme)
+[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
 repository. Build and push the image to whichever container registry your
 cluster has credentials for:
 
 ```bash
-git clone https://github.com/NVIDIA/nv-cloud-function-helpers.git
+git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
 cd nv-cloud-function-helpers/examples/function_samples/load_tester_supreme
 
 # Build (multi-arch)
@@ -163,7 +163,7 @@ you want a steady, predictable load.
 
 <Note>
 The latest version of this script is maintained in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nv-cloud-function-helpers)
+[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples)
 repository.
 
 </Note>

--- a/docs/v0.5/local-development.md
+++ b/docs/v0.5/local-development.md
@@ -24,7 +24,7 @@ for details on mirroring artifacts to other registries.
 
 <Tip>
 A ready-to-use k3d configuration and setup script is available in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/self_hosted_local_development)
+[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples)
 repository. Clone it and run `./setup.sh` to create the cluster with all prerequisites,
 then skip to [Deploy the NVCF Stack].
 
@@ -160,7 +160,7 @@ k3d handles LoadBalancer services automatically via its built-in `klipper-lb`.
 ## Step 2 (Environment file)
 
 Create a local development environment file from the template below
-([local-dev-env.yaml](samples/configs/local-dev-env.yaml)).
+([local-dev-env.yaml](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/v0.5/samples/configs/local-dev-env.yaml)).
 Save it as `environments/<name>.yaml` (e.g., `environments/my-local.yaml`) in your
 `nvcf-self-managed-stack` directory.
 

--- a/docs/v0.5/local-development.md
+++ b/docs/v0.5/local-development.md
@@ -23,10 +23,10 @@ and adjust the pull secret configuration accordingly. See [self-hosted-image-mir
 for details on mirroring artifacts to other registries.
 
 <Tip>
-A ready-to-use k3d configuration and setup script is available in the
-[NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples)
-repository. Clone it and run `./setup.sh` to create the cluster with all prerequisites,
-then skip to [Deploy the NVCF Stack].
+A ready-to-use k3d configuration and Makefile is available in
+[tools/ncp-local-cluster](https://github.com/NVIDIA/nvcf/tree/main/tools/ncp-local-cluster)
+in the NVCF repository. Clone the repo, then run `make` from that directory to create
+the cluster with all prerequisites, then skip to [Deploy the NVCF Stack].
 
 </Tip>
 

--- a/docs/v0.5/local-development.md
+++ b/docs/v0.5/local-development.md
@@ -24,7 +24,7 @@ for details on mirroring artifacts to other registries.
 
 <Tip>
 A ready-to-use k3d configuration and setup script is available in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples)
+[NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples)
 repository. Clone it and run `./setup.sh` to create the cluster with all prerequisites,
 then skip to [Deploy the NVCF Stack].
 

--- a/docs/v0.5/observability.md
+++ b/docs/v0.5/observability.md
@@ -234,7 +234,7 @@ Dashboards are provided in native Grafana JSON format for [file-provisioning](ht
 Load dashboards into Grafana by placing them in `/etc/grafana/provisioning/dashboards/` on startup.
 
 Published dashboards will be available in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples) public GitHub repository.
+[NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples) public GitHub repository.
 
 ## Troubleshooting
 

--- a/docs/v0.5/observability.md
+++ b/docs/v0.5/observability.md
@@ -234,7 +234,7 @@ Dashboards are provided in native Grafana JSON format for [file-provisioning](ht
 Load dashboards into Grafana by placing them in `/etc/grafana/provisioning/dashboards/` on startup.
 
 Published dashboards will be available in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nv-cloud-function-helpers) public GitHub repository.
+[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples) public GitHub repository.
 
 ## Troubleshooting
 

--- a/docs/v0.5/standalone-core-services.md
+++ b/docs/v0.5/standalone-core-services.md
@@ -28,7 +28,7 @@ API Keys provides authentication token management for all NVCF API interactions.
 
 ### Configuration
 
-Create `api-keys-values.yaml` ([download template](samples/configs/standalone/api-keys-values.yaml)):
+Create `api-keys-values.yaml` ([download template](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/v0.5/samples/configs/standalone/api-keys-values.yaml)):
 
 <Accordion title="api-keys-values.yaml">
 ```yaml title="api-keys-values.yaml"
@@ -80,7 +80,7 @@ The Spot Instance Service (SIS) handles cluster registration and GPU resource ma
 
 ### Configuration
 
-Create `sis-values.yaml` ([download template](samples/configs/standalone/sis-values.yaml)):
+Create `sis-values.yaml` ([download template](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/v0.5/samples/configs/standalone/sis-values.yaml)):
 
 <Accordion title="sis-values.yaml">
 ```yaml title="sis-values.yaml"
@@ -130,7 +130,7 @@ The ESS (Enterprise Secrets Service) API distributes secrets to NVCF services vi
 
 ### Configuration
 
-Create `ess-api-values.yaml` ([download template](samples/configs/standalone/ess-api-values.yaml)):
+Create `ess-api-values.yaml` ([download template](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/v0.5/samples/configs/standalone/ess-api-values.yaml)):
 
 <Accordion title="ess-api-values.yaml">
 ```yaml title="ess-api-values.yaml"
@@ -184,7 +184,7 @@ communicates with ESS during initialization.
 
 ### Configuration
 
-Create `nvcf-api-values.yaml` ([download template](samples/configs/standalone/nvcf-api-values.yaml)):
+Create `nvcf-api-values.yaml` ([download template](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/v0.5/samples/configs/standalone/nvcf-api-values.yaml)):
 
 <Accordion title="nvcf-api-values.yaml">
 ```yaml title="nvcf-api-values.yaml"
@@ -324,7 +324,7 @@ The Invocation Service handles function invocation requests and routes them to w
 
 ### Configuration
 
-Create `invocation-service-values.yaml` ([download template](samples/configs/standalone/invocation-service-values.yaml)):
+Create `invocation-service-values.yaml` ([download template](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/v0.5/samples/configs/standalone/invocation-service-values.yaml)):
 
 <Accordion title="invocation-service-values.yaml">
 ```yaml title="invocation-service-values.yaml"
@@ -374,7 +374,7 @@ The gRPC Proxy enables streaming workloads over gRPC connections.
 
 ### Configuration
 
-Create `grpc-proxy-values.yaml` ([download template](samples/configs/standalone/grpc-proxy-values.yaml)):
+Create `grpc-proxy-values.yaml` ([download template](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/v0.5/samples/configs/standalone/grpc-proxy-values.yaml)):
 
 <Accordion title="grpc-proxy-values.yaml">
 ```yaml title="grpc-proxy-values.yaml"
@@ -424,7 +424,7 @@ The Notary Service handles request signing and validation for secure inter-servi
 
 ### Configuration
 
-Create `notary-service-values.yaml` ([download template](samples/configs/standalone/notary-service-values.yaml)):
+Create `notary-service-values.yaml` ([download template](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/v0.5/samples/configs/standalone/notary-service-values.yaml)):
 
 <Accordion title="notary-service-values.yaml">
 ```yaml title="notary-service-values.yaml"
@@ -475,7 +475,7 @@ installed in the `nvcf` namespace with the `helm-reval` chart.
 
 ### Configuration
 
-Create `reval-values.yaml` ([download template](samples/configs/standalone/reval-values.yaml)):
+Create `reval-values.yaml` ([download template](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/v0.5/samples/configs/standalone/reval-values.yaml)):
 
 <Accordion title="reval-values.yaml">
 ```yaml title="reval-values.yaml"
@@ -528,7 +528,7 @@ requiring pre-existing credentials. It is used for initial setup and emergency a
 
 ### Configuration
 
-Create `admin-issuer-proxy-values.yaml` ([download template](samples/configs/standalone/admin-issuer-proxy-values.yaml)):
+Create `admin-issuer-proxy-values.yaml` ([download template](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/v0.5/samples/configs/standalone/admin-issuer-proxy-values.yaml)):
 
 <Accordion title="admin-issuer-proxy-values.yaml">
 ```yaml title="admin-issuer-proxy-values.yaml"

--- a/docs/v0.5/standalone-gateway.md
+++ b/docs/v0.5/standalone-gateway.md
@@ -139,7 +139,7 @@ to NVCF services through the Gateway.
 
 ### Configuration
 
-Create `gateway-routes-values.yaml` ([download template](samples/configs/standalone/gateway-routes-values.yaml)):
+Create `gateway-routes-values.yaml` ([download template](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/v0.5/samples/configs/standalone/gateway-routes-values.yaml)):
 
 <Accordion title="gateway-routes-values.yaml">
 ```yaml title="gateway-routes-values.yaml"

--- a/docs/v0.5/standalone-infrastructure.md
+++ b/docs/v0.5/standalone-infrastructure.md
@@ -23,7 +23,7 @@ components.
 
 ### Configuration
 
-Create `nats-values.yaml` with your registry settings ([download template](samples/configs/standalone/nats-values.yaml)):
+Create `nats-values.yaml` with your registry settings ([download template](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/v0.5/samples/configs/standalone/nats-values.yaml)):
 
 <Accordion title="nats-values.yaml">
 </Accordion>
@@ -135,7 +135,7 @@ communicates with NATS during initialization.
 
 ### Configuration
 
-Create `openbao-values.yaml` with your registry and secret settings ([download template](samples/configs/standalone/openbao-values.yaml)):
+Create `openbao-values.yaml` with your registry and secret settings ([download template](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/v0.5/samples/configs/standalone/openbao-values.yaml)):
 
 <Accordion title="openbao-values.yaml">
 </Accordion>
@@ -358,7 +358,7 @@ deployment state, and other operational data.
 
 ### Configuration
 
-Create `cassandra-values.yaml` with your registry and storage settings ([download template](samples/configs/standalone/cassandra-values.yaml)):
+Create `cassandra-values.yaml` with your registry and storage settings ([download template](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/v0.5/samples/configs/standalone/cassandra-values.yaml)):
 
 <Accordion title="cassandra-values.yaml">
 </Accordion>

--- a/docs/v0.5/troubleshooting.md
+++ b/docs/v0.5/troubleshooting.md
@@ -855,7 +855,7 @@ echo "=============================================="
 
 ```
 
-[force-cleanup-nvcf.sh](samples/scripts/force-cleanup-nvcf.sh)
+[force-cleanup-nvcf.sh](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/v0.5/samples/scripts/force-cleanup-nvcf.sh)
 
 **Usage:**
 

--- a/docs/v0.6.0/cli.md
+++ b/docs/v0.6.0/cli.md
@@ -337,7 +337,7 @@ Or use the `--debug` flag or `NVCF_DEBUG=true` environment variable per-command.
 ```
 
 <Note>
-For immediate testing, you can use `load_tester_supreme` from `nvcf-onprem` (see [self-hosted-artifact-manifest](./manifest.md)), which supports the `{"message": "hello world"}` request body above. For more function samples, see the [nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples) repository and [function-creation](./function-creation.md) for function creation documentation.
+For immediate testing, you can use `load_tester_supreme` from `nvcf-onprem` (see [self-hosted-artifact-manifest](./manifest.md)), which supports the `{"message": "hello world"}` request body above. For more function samples, see the [NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples) repository and [function-creation](./function-creation.md) for function creation documentation.
 
 </Note>
 

--- a/docs/v0.6.0/cli.md
+++ b/docs/v0.6.0/cli.md
@@ -337,7 +337,7 @@ Or use the `--debug` flag or `NVCF_DEBUG=true` environment variable per-command.
 ```
 
 <Note>
-For immediate testing, you can use `load_tester_supreme` from `nvcf-onprem` (see [self-hosted-artifact-manifest](./manifest.md)), which supports the `{"message": "hello world"}` request body above. For more function samples, see the [nv-cloud-function-helpers](https://github.com/NVIDIA/nv-cloud-function-helpers) repository and [function-creation](./function-creation.md) for function creation documentation.
+For immediate testing, you can use `load_tester_supreme` from `nvcf-onprem` (see [self-hosted-artifact-manifest](./manifest.md)), which supports the `{"message": "hello world"}` request body above. For more function samples, see the [nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples) repository and [function-creation](./function-creation.md) for function creation documentation.
 
 </Note>
 

--- a/docs/v0.6.0/cluster-management/monitoring.md
+++ b/docs/v0.6.0/cluster-management/monitoring.md
@@ -21,7 +21,7 @@ The cluster agent and operator emit Prometheus-style metrics. The following metr
 | nvca_cluster_group | The NVCA cluster group           |
 | nvca_version       | The NVCA version                 |
 
-Cluster maintainers can scrape the available metrics. See a full example of how to do this with an OpenTelemetry Collector in the cluster [here](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/cluster_monitoring_sample).
+Cluster maintainers can scrape the available metrics. See a full example of how to do this with an OpenTelemetry Collector in the cluster [here](https://github.com/NVIDIA/nvcf/tree/main/examples/cluster-monitoring-sample).
 
 Use the following examples of a PodMonitor for NVCA Operator and ServiceMonitor for NVCA for reference:
 

--- a/docs/v0.6.0/cluster-management/monitoring.md
+++ b/docs/v0.6.0/cluster-management/monitoring.md
@@ -21,7 +21,7 @@ The cluster agent and operator emit Prometheus-style metrics. The following metr
 | nvca_cluster_group | The NVCA cluster group           |
 | nvca_version       | The NVCA version                 |
 
-Cluster maintainers can scrape the available metrics. See a full example of how to do this with an OpenTelemetry Collector in the cluster [here](https://github.com/NVIDIA/nvcf/tree/main/examples/cluster-monitoring-sample).
+Cluster maintainers can scrape the available metrics. See a full example of how to do this with an OpenTelemetry Collector in the cluster [cluster monitoring example](https://github.com/NVIDIA/nvcf/tree/main/examples/cluster-monitoring-sample).
 
 Use the following examples of a PodMonitor for NVCA Operator and ServiceMonitor for NVCA for reference:
 

--- a/docs/v0.6.0/container-functions.md
+++ b/docs/v0.6.0/container-functions.md
@@ -43,7 +43,7 @@ Cloud Functions also expects the following directories in the container to remai
 
 ## Composing a FastAPI Container
 
-It's possible to use any container with Cloud Functions as long as it implements a server with the above endpoints. The below is an example of a FastAPI-based container compatible with Cloud Functions. Clone the [FastAPI echo example](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/function_samples/fastapi_echo_sample).
+It's possible to use any container with Cloud Functions as long as it implements a server with the above endpoints. The below is an example of a FastAPI-based container compatible with Cloud Functions. Clone the [FastAPI echo example](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/fastapi-echo-sample).
 
 ### Create the "requirements.txt" File
 
@@ -289,7 +289,7 @@ Create the function via the NVCF API. In this example, we defined the inference 
 
 ### Additional Examples
 
-See more examples of containers that are Cloud Functions compatible [in the function samples directory](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/function_samples/).
+See more examples of containers that are Cloud Functions compatible [in the function samples directory](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/).
 
 ## Creating gRPC-based Functions
 
@@ -300,7 +300,7 @@ Cloud Functions supports function invocation via gRPC. During function creation,
 - The function container must implement a gRPC port, endpoint and health check. The health check is expected to be served by the gRPC inference port, there is no need to define a separate health endpoint path.
 
   - See [gRPC health checking](https://grpc.io/docs/guides/health-checking/).
-  - See an [example container](https://github.com/NVIDIA/nv-cloud-function-helpers/blob/main/examples/function_samples/grpc_echo_sample/grpc_echo_server.py) with a gRPC server that is Cloud Functions compatible.
+  - See an [example container](https://github.com/NVIDIA/nvcf/blob/main/examples/function-samples/grpc-echo-sample/grpc_echo_server.py) with a gRPC server that is Cloud Functions compatible.
 
 ### gRPC Function Creation via API
 

--- a/docs/v0.6.0/container-functions.md
+++ b/docs/v0.6.0/container-functions.md
@@ -4,9 +4,9 @@ Container-based functions require building and pushing a Cloud Functions compati
 
 ## Resources
 
-- Example containers can be found [in the examples repository](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples).
+- Example containers can be found [in the examples directory](https://github.com/NVIDIA/nvcf/tree/main/examples).
 
-- The repository also contains [helper functions](https://github.com/NVIDIA/nv-cloud-function-helpers/blob/main/helper_library/nv_cloud_function_helpers/nvcf_container/helpers.py) that are useful when authoring your container, including:
+- The repository also contains [helper functions](https://github.com/NVIDIA/nvcf/blob/main/src/libraries/python/nv-cloud-function-helpers/nv_cloud_function_helpers/nvcf_container/helpers.py) that are useful when authoring your container, including:
 
   - Helpers that parse Cloud Functions-specific parameters on invocation
   - Helpers that can be used to instrument your container with Cloud Functions compatible logs

--- a/docs/v0.6.0/function-creation.md
+++ b/docs/v0.6.0/function-creation.md
@@ -48,7 +48,7 @@ For LLM functions, see [LLM Gateway](./llm-gateway.md#function-configuration) fo
 
 The following is a reference of available variables via the headers of the invocation message (auto-populated by Cloud Functions), accessible within the container.
 
-For examples of how to extract and use some of these variables, see [NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples).
+For examples of how to extract and use some of these variables, see [NVCF Container Helper Functions](https://github.com/NVIDIA/nvcf/tree/main/src/libraries/python/nv-cloud-function-helpers).
 
 | Name                         | Description                                             |
 | ---------------------------- | ------------------------------------------------------- |

--- a/docs/v0.6.0/function-creation.md
+++ b/docs/v0.6.0/function-creation.md
@@ -48,7 +48,7 @@ For LLM functions, see [LLM Gateway](./llm-gateway.md#function-configuration) fo
 
 The following is a reference of available variables via the headers of the invocation message (auto-populated by Cloud Functions), accessible within the container.
 
-For examples of how to extract and use some of these variables, see [NVCF Container Helper Functions](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main).
+For examples of how to extract and use some of these variables, see [NVCF Container Helper Functions](https://github.com/NVIDIA/nvcf/tree/main/examples).
 
 | Name                         | Description                                             |
 | ---------------------------- | ------------------------------------------------------- |

--- a/docs/v0.6.0/function-creation.md
+++ b/docs/v0.6.0/function-creation.md
@@ -48,7 +48,7 @@ For LLM functions, see [LLM Gateway](./llm-gateway.md#function-configuration) fo
 
 The following is a reference of available variables via the headers of the invocation message (auto-populated by Cloud Functions), accessible within the container.
 
-For examples of how to extract and use some of these variables, see [NVCF Container Helper Functions](https://github.com/NVIDIA/nvcf/tree/main/examples).
+For examples of how to extract and use some of these variables, see [NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples).
 
 | Name                         | Description                                             |
 | ---------------------------- | ------------------------------------------------------- |

--- a/docs/v0.6.0/grpc-load-testing.md
+++ b/docs/v0.6.0/grpc-load-testing.md
@@ -37,12 +37,12 @@ The `grpc_echo_sample` from the same repository shares the
 </Note>
 
 The source, build instructions, and registry push examples are in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/function_samples/load_tester_supreme)
+[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
 repository. Build and push the image to whichever container registry your
 cluster has credentials for:
 
 ```bash
-git clone https://github.com/NVIDIA/nv-cloud-function-helpers.git
+git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
 cd nv-cloud-function-helpers/examples/function_samples/load_tester_supreme
 
 # Build
@@ -115,7 +115,7 @@ The CLI saves the function and version IDs automatically. Run
 ## Clone the load test scripts
 
 ```bash
-git clone https://github.com/NVIDIA/nv-cloud-function-helpers.git
+git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
 cd nv-cloud-function-helpers/examples/load-tests
 ```
 

--- a/docs/v0.6.0/grpc-load-testing.md
+++ b/docs/v0.6.0/grpc-load-testing.md
@@ -37,13 +37,13 @@ The `grpc_echo_sample` from the same repository shares the
 </Note>
 
 The source, build instructions, and registry push examples are in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
+[NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
 repository. Build and push the image to whichever container registry your
 cluster has credentials for:
 
 ```bash
-git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
-cd nv-cloud-function-helpers/examples/function_samples/load_tester_supreme
+git clone https://github.com/NVIDIA/nvcf.git
+cd nvcf/examples/function-samples/load-tester-supreme
 
 # Build
 docker build --platform linux/amd64 -t load_tester_supreme .
@@ -115,8 +115,8 @@ The CLI saves the function and version IDs automatically. Run
 ## Clone the load test scripts
 
 ```bash
-git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
-cd nv-cloud-function-helpers/examples/load-tests
+git clone https://github.com/NVIDIA/nvcf.git
+cd nvcf/examples/load-tests
 ```
 
 ## Install k6

--- a/docs/v0.6.0/helm-functions.md
+++ b/docs/v0.6.0/helm-functions.md
@@ -41,7 +41,7 @@ All Pod specs in your helm chart will be updated with pull secrets at runtime, s
 
 **Example Creation via API**
 
-Please see our [sample helm chart used](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/function_samples/helmchart_samples/inference_test_sample) in this example for reference.
+Please see our [sample helm chart used](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/helmchart-samples/inference-test-sample) in this example for reference.
 
 Below is an example function creation API call creating a helm-based function:
 
@@ -72,7 +72,7 @@ For gRPC-based functions, set `"inferenceURL" : "/gRPC"`. This signals to Cloud 
 To create a multi-node helm deployment, you need to use the following format for the `instanceType`:
 `<CSP>.GPU.<GPU_NAME>_<number of gpus per node>x[.x<number of nodes>]`. For example, `DGXC.GPU.L40S_1x` is a single L40S instance while `ON-PREM.GPU.B200_8x.x2` is two full nodes of 8-way B200.
 
-A sample helm chart for a multi-node deployment can be found [in the multi-node helm example](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/function_samples/helmchart_samples/multi_node_helm_function_test/).
+A sample helm chart for a multi-node deployment can be found [in the multi-node helm example](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/helmchart-samples/multi-node-helm-function-test/).
 
 ## Limitations
 

--- a/docs/v0.6.0/helmfile-installation.md
+++ b/docs/v0.6.0/helmfile-installation.md
@@ -191,7 +191,7 @@ Environment configuration files define how NVCF is deployed in your specific env
 Set `HELMFILE_ENV` to your environment name and copy the base configuration.
 The filename must match `HELMFILE_ENV` because Helmfile uses it to select the
 environment file. The template below shows the values to configure for Amazon
-EKS ([cp-env-eks-example.yaml](samples/configs/cp-env-eks-example.yaml)).
+EKS ([cp-env-eks-example.yaml](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/v0.6.0/samples/configs/cp-env-eks-example.yaml)).
 
 ```bash
 cd path/to/nvcf-self-managed-stack
@@ -586,7 +586,7 @@ These credentials will then be used for function deployments. Note that if the r
 Copy the secrets template using the same `HELMFILE_ENV` value from Step 2. The
 filename must match `HELMFILE_ENV` because Helmfile loads the corresponding
 secrets file. The example below shows the required structure
-([example-secrets.yaml](samples/configs/cp-example-secrets.yaml)). You must
+([example-secrets.yaml](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/v0.6.0/samples/configs/cp-example-secrets.yaml)). You must
 replace all instances of `REPLACE_WITH_BASE64_DOCKER_CREDENTIAL` with your
 actual base64-encoded registry credentials.
 
@@ -731,7 +731,7 @@ registry.
 If your `image` registry is private and your cluster nodes do not have built-in credential helpers, you must create Kubernetes `docker-registry` secrets in each NVCF namespace and configure the helmfile to reference them.
 
 1. Create the pull secret in each NVCF namespace
-   ([create-nvcr-pull-secrets.sh](samples/scripts/create-nvcr-pull-secrets.sh)):
+   ([create-nvcr-pull-secrets.sh](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/v0.6.0/samples/scripts/create-nvcr-pull-secrets.sh)):
 
 ```bash
 export NGC_API_KEY="<your-ngc-api-key>"

--- a/docs/v0.6.0/http-load-testing.md
+++ b/docs/v0.6.0/http-load-testing.md
@@ -29,13 +29,13 @@ for high-throughput benchmarking and includes:
 - Built-in OpenTelemetry tracing
 
 The source, build instructions, and registry push examples are in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
+[NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
 repository. Build and push the image to whichever container registry your
 cluster has credentials for:
 
 ```bash
-git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
-cd nv-cloud-function-helpers/examples/function_samples/load_tester_supreme
+git clone https://github.com/NVIDIA/nvcf.git
+cd nvcf/examples/function-samples/load-tester-supreme
 
 # Build
 docker build --platform linux/amd64 -t load_tester_supreme .
@@ -100,8 +100,8 @@ k3d, Docker Desktop) it is typically `localhost` or `127.0.0.1`.
 ## Clone the load test scripts
 
 ```bash
-git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
-cd nv-cloud-function-helpers/examples/load-tests
+git clone https://github.com/NVIDIA/nvcf.git
+cd nvcf/examples/load-tests
 ```
 
 ## Install k6

--- a/docs/v0.6.0/http-load-testing.md
+++ b/docs/v0.6.0/http-load-testing.md
@@ -29,12 +29,12 @@ for high-throughput benchmarking and includes:
 - Built-in OpenTelemetry tracing
 
 The source, build instructions, and registry push examples are in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/function_samples/load_tester_supreme)
+[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
 repository. Build and push the image to whichever container registry your
 cluster has credentials for:
 
 ```bash
-git clone https://github.com/NVIDIA/nv-cloud-function-helpers.git
+git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
 cd nv-cloud-function-helpers/examples/function_samples/load_tester_supreme
 
 # Build
@@ -100,7 +100,7 @@ k3d, Docker Desktop) it is typically `localhost` or `127.0.0.1`.
 ## Clone the load test scripts
 
 ```bash
-git clone https://github.com/NVIDIA/nv-cloud-function-helpers.git
+git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
 cd nv-cloud-function-helpers/examples/load-tests
 ```
 

--- a/docs/v0.6.0/http-soak-testing.md
+++ b/docs/v0.6.0/http-soak-testing.md
@@ -32,13 +32,13 @@ for high-throughput benchmarking and includes:
 - Built-in OpenTelemetry tracing
 
 The source, build instructions, and registry push examples are in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
+[NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
 repository. Build and push the image to whichever container registry your
 cluster has credentials for:
 
 ```bash
-git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
-cd nv-cloud-function-helpers/examples/function_samples/load_tester_supreme
+git clone https://github.com/NVIDIA/nvcf.git
+cd nvcf/examples/function-samples/load-tester-supreme
 
 # Build (multi-arch)
 docker buildx build --platform linux/amd64,linux/arm64 -t load_tester_supreme .
@@ -159,7 +159,7 @@ you want a steady, predictable load.
 
 <Note>
 The latest version of this script is maintained in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples)
+[NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples)
 repository.
 
 </Note>

--- a/docs/v0.6.0/http-soak-testing.md
+++ b/docs/v0.6.0/http-soak-testing.md
@@ -32,12 +32,12 @@ for high-throughput benchmarking and includes:
 - Built-in OpenTelemetry tracing
 
 The source, build instructions, and registry push examples are in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nv-cloud-function-helpers/tree/main/examples/function_samples/load_tester_supreme)
+[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples/function-samples/load-tester-supreme)
 repository. Build and push the image to whichever container registry your
 cluster has credentials for:
 
 ```bash
-git clone https://github.com/NVIDIA/nv-cloud-function-helpers.git
+git clone https://github.com/NVIDIA/nvcf/tree/main/examples.git
 cd nv-cloud-function-helpers/examples/function_samples/load_tester_supreme
 
 # Build (multi-arch)
@@ -159,7 +159,7 @@ you want a steady, predictable load.
 
 <Note>
 The latest version of this script is maintained in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nv-cloud-function-helpers)
+[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples)
 repository.
 
 </Note>

--- a/docs/v0.6.0/observability.md
+++ b/docs/v0.6.0/observability.md
@@ -295,7 +295,7 @@ Dashboards are provided in native Grafana JSON format for [file-provisioning](ht
 Load dashboards into Grafana by placing them in `/etc/grafana/provisioning/dashboards/` on startup.
 
 Published dashboards will be available in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nv-cloud-function-helpers) public GitHub repository.
+[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples) public GitHub repository.
 
 ## Troubleshooting
 

--- a/docs/v0.6.0/observability.md
+++ b/docs/v0.6.0/observability.md
@@ -295,7 +295,7 @@ Dashboards are provided in native Grafana JSON format for [file-provisioning](ht
 Load dashboards into Grafana by placing them in `/etc/grafana/provisioning/dashboards/` on startup.
 
 Published dashboards will be available in the
-[nv-cloud-function-helpers](https://github.com/NVIDIA/nvcf/tree/main/examples) public GitHub repository.
+[NVCF examples](https://github.com/NVIDIA/nvcf/tree/main/examples) public GitHub repository.
 
 ## Troubleshooting
 

--- a/docs/v0.6.0/troubleshooting.md
+++ b/docs/v0.6.0/troubleshooting.md
@@ -1050,7 +1050,7 @@ echo "=============================================="
 
 ```
 
-[force-cleanup-nvcf.sh](samples/scripts/force-cleanup-nvcf.sh)
+[force-cleanup-nvcf.sh](https://raw.githubusercontent.com/NVIDIA/nvcf/main/docs/v0.6.0/samples/scripts/force-cleanup-nvcf.sh)
 
 **Usage:**
 


### PR DESCRIPTION
## TL;DR

Fix 36 of the 58 broken URLs identified in NVBug 6482070, covering three categories of migration artifacts in the docs source.

## Additional Details

Production scan of docs.nvidia.com found 58 unique broken URLs (75 rows counting duplicates across pages). This PR addresses the three categories where the fix lives in the docs source:

**Category 1 -- AGENTS.md relative paths (10 URLs, 1 file)**
`docs/dev/architecture.md` links to per-component AGENTS.md files as relative filesystem paths (`../../src/.../AGENTS.md`). Fern resolves these as `docs.nvidia.com/src/...` which returns 404. Changed to absolute `github.com/NVIDIA/nvcf/blob/main/...` URLs.

**Category 2 -- Sample file download links (17 URLs, 10 files)**
Helmfile installation, standalone, local-dev, and troubleshooting docs link to sample configs and scripts as relative paths (`samples/configs/...`, `samples/scripts/...`). Fern cannot serve non-markdown files, so these become dead `docs.nvidia.com/.../samples/...` URLs. Changed to `raw.githubusercontent.com` URLs pointing to the files in the repo.

**Category 3 -- Archived nv-cloud-function-helpers repo (9 URLs, 28 files)**
`NVIDIA/nv-cloud-function-helpers` is archived. Content migrated to `NVIDIA/nvcf/examples/` with path renames (underscores to hyphens, e.g. `function_samples/` to `function-samples/`). Updated all links with corrected paths.

Remaining 22 broken URLs (Omniverse dead links and old slugs already fixed at source) are not addressed here.

## For the Reviewer

38 files changed, all in `docs/`. Changes are mechanical link replacements -- no content changes. Verified with `lychee --offline` (0 errors after changes).

## For QA

`lychee --offline --no-progress 'docs/**/*.md'` -- 0 errors.

## Issues

Fixes #335

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated example, script, template, monitoring, observability, and load-testing links across current and versioned guides to use new canonical locations.
  * Switched load-testing and container-function references from the older repository to NVCF examples paths.
  * Replaced several relative/local links with direct `raw.githubusercontent.com` URLs and refreshed architecture references to use stable, absolute GitHub URLs with consistent markdown formatting.
  * Updated CLI and quick-start sample references accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->