### PR TITLE
fix(ci): push images with --config=release (opt)

### DIFF
--- a/.github/workflows/image-push-manual.yml
+++ b/.github/workflows/image-push-manual.yml
@@ -145,7 +145,8 @@ jobs:
             mkdir -p ci-ghcr
             printf 'load("@rules_oci//oci:defs.bzl", "oci_push")\n\noci_push(\n    name = "push",\n    image = "%s",\n    repository = "%s",\n    remote_tags = ["%s", "latest-dispatch"],\n)\n' \
               "$tgt" "$dest" "$TAG" > ci-ghcr/BUILD.bazel
-            bazel run --remote_cache= --disk_cache="${BAZEL_DISK_CACHE}" //ci-ghcr:push
+            # --config=release (-c opt): default fastbuild makes zig cc emit UBSan traps in C deps (jemalloc) that SIGTRAP at startup on arm64 (nvbug 6451362).
+            bazel run --config=release --remote_cache= --disk_cache="${BAZEL_DISK_CACHE}" //ci-ghcr:push
             rm -rf ci-ghcr
           done
           echo "Done: pushed ${#indexes[@]} image(s) under ${REGISTRY}/ at tag ${TAG}"


### PR DESCRIPTION
The manual image-push workflow runs bazel in the default `fastbuild` mode, so the zig cross toolchain compiles C deps with UBSan trap-on-undefined-behavior. `nvcf-invocation-service` (the only jemalloc global-allocator service) SIGTRAPs at startup on arm64 — jemalloc `realloc`, reached via glibc `getdelim`/`pthread_getattr_np` in Rust's main-thread stack-guard init, trips a UBSan trap → exit 133 CrashLoopBackOff. amd64 uses host gcc (no such traps), so only the arm64 image variant hit it; it surfaced on QA arm64 deployments (Graviton, arm64 k3d).

Add `--config=release` (`-c opt`) to the push so images are optimized, stripped, and free of UBSan traps. Root and all subtree `.bazelrc` define `build:release`.

Verified locally: an opt/release build of the service has 0 `brk #0x55xx` traps and starts cleanly, vs 130169 traps + exit 133 in the shipped fastbuild image.

Closes NVBUG-6451362

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multi-architecture image publishing to use release-mode builds.
  * Improved arm64 image startup reliability by avoiding build configurations that could trigger runtime traps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->