### PR TITLE
fix(oci): force -c opt on the http-invocation multi-arch image

### DIFF
--- a/src/invocation-plane-services/http-invocation/rules/oci/transition.bzl
+++ b/src/invocation-plane-services/http-invocation/rules/oci/transition.bzl
@@ -5,14 +5,18 @@
 
 def _multiarch_transition(settings, attr):
     return [
-        {"//command_line_option:platforms": str(platform)}
+        {
+            "//command_line_option:platforms": str(platform),
+            # Pin opt: fastbuild's zig arm64 UBSan traps SIGTRAP jemalloc at startup (nvbug 6451362).
+            "//command_line_option:compilation_mode": "opt",
+        }
         for platform in attr.platforms
     ]
 
 multiarch_transition = transition(
     implementation = _multiarch_transition,
     inputs = [],
-    outputs = ["//command_line_option:platforms"],
+    outputs = ["//command_line_option:platforms", "//command_line_option:compilation_mode"],
 )
 
 def _multi_arch_impl(ctx):


### PR DESCRIPTION
The `multi_arch` transition (`rules/oci/transition.bzl`) set only the target platform, so the shipped `image_index` inherited the `.bazelrc` default `compilation_mode=fastbuild`. Under the zig arm64 cross toolchain, fastbuild compiles C deps with UBSan trap-on-undefined-behavior; jemalloc (this service's `#[global_allocator]`) trips one at startup on arm64 — jemalloc `realloc` via glibc `getdelim`/`pthread_getattr_np` in Rust's stack-guard init → SIGTRAP, exit 133 CrashLoopBackOff. amd64 (host gcc) is unaffected.

Add `//command_line_option:compilation_mode=opt` to the transition so the pushed multi-arch image is always built `-c opt` (trap-free), regardless of the CI compilation flag. Dev `bazel build //...:server` and tests stay fastbuild. Only affects the shipped multi-arch `_index`; local single-arch `docker load` stays fastbuild.

Verified locally: an opt build of the service has 0 `brk #0x55xx` traps and starts clean, vs 130169 traps + exit 133 in the shipped fastbuild image. Complements the nvcf-internal build-flag fix (`--config=release`) as the durable, pipeline-agnostic guarantee.

Closes NVBUG-6451362