### PR TITLE
fix(http-invocation): correct "coveraged" typo in README

### DIFF
--- a/src/invocation-plane-services/http-invocation/README.md
+++ b/src/invocation-plane-services/http-invocation/README.md
@@ -266,7 +266,7 @@ Install the Coverage Gutters extension.  From Vscode:
 1. Ctl-Shift-p
 1. Type then select, `Coverage gutters: watch`
 
-From the code editor, see that coveraged lines have green sidebars, otherwise red.
+From the code editor, see that covered lines have green sidebars, otherwise red.
 To see entire lines highlighted in green and red:
 1. Right click the extension and select settings
 1. In the settings pane, select `Show line coverage`


### PR DESCRIPTION
Corrects a typo (`coveraged` → `covered`) in the README coverage section.

Purpose: cut a patch release so a fresh `nvcf-invocation-service` image builds through the release backend — now compiling with `--config=release` (opt) — for arm64 SIGTRAP verification (nvbug 6451362).

Related to NVBUG-6451362