### PR TITLE
fix(nvca): inject BYOO env vars into Helm utils collector

### DIFF
--- a/src/compute-plane-services/nvca/internal/miniservice/reconcile.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/reconcile.go
@@ -739,7 +739,11 @@ func (r *Reconciler) doInstall(ctx context.Context,
 		}
 		// Apply BYOO telemetry annotations to workload objects for Helm-rendered pods
 		metaInput.EnvVars = append(metaInput.EnvVars, byooEnvs...)
-		metaInput.OTelCollectorEnvVars = append(metaInput.OTelCollectorEnvVars, r.cfg.Agent.BYOOOTelCollectorEnvVars()...)
+		collectorEnvs := r.cfg.Agent.BYOOOTelCollectorEnvVars()
+		metaInput.OTelCollectorEnvVars = append(metaInput.OTelCollectorEnvVars, collectorEnvs...)
+		// The webhook special-cases Helm utils pods and skips metadata-carried collector
+		// env injection, so inject the envs directly into the BYOO collector sidecar.
+		k8sutil.AddBYOOEnvVarsToPodSpec(&utilsPod.Spec, collectorEnvs)
 	}
 
 	// Task-specific mutators.

--- a/src/compute-plane-services/nvca/internal/miniservice/reconcile_test.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/reconcile_test.go
@@ -256,7 +256,7 @@ func TestReconcile_Function(t *testing.T) {
 	r.cfg.Agent.SharedStorage.Server.Image = "smb:latest"
 	exporterBatchMaxSizeBytes := int64(1000000)
 	r.cfg.Agent.BYOOLogChunking = nvcaconfig.BYOOLogChunkingConfig{
-		MaxBodyBytes:              983040,
+		MaxBodyBytes:              262144,
 		DryRun:                    true,
 		ExporterBatchMaxSizeBytes: &exporterBatchMaxSizeBytes,
 	}
@@ -659,6 +659,21 @@ rules:
 			assert.Len(t, c.Resources.Requests, 2)
 		}
 	}
+	var byooCollector *corev1.Container
+	for i := range utilsPod.Spec.Containers {
+		if utilsPod.Spec.Containers[i].Name == common.ByooOTelCollectorPodNameBase {
+			byooCollector = &utilsPod.Spec.Containers[i]
+			break
+		}
+	}
+	require.NotNil(t, byooCollector, "utils pod should include BYOO collector sidecar")
+	byooCollectorEnv := map[string]string{}
+	for _, env := range byooCollector.Env {
+		byooCollectorEnv[env.Name] = env.Value
+	}
+	assert.Equal(t, "262144", byooCollectorEnv[nvcaconfig.BYOOLogChunkMaxBodyBytesEnv])
+	assert.Equal(t, "true", byooCollectorEnv[nvcaconfig.BYOOLogChunkDryRunEnv])
+	assert.Equal(t, "1000000", byooCollectorEnv[nvcaconfig.BYOOLogExporterBatchMaxSizeBytesEnv])
 	assert.Contains(t, utilsPod.Spec.Tolerations, configuredToleration)
 	assert.Equal(t, mergeMaps(translatedLabels, map[string]string{
 		common.BYOOMetricsEgressTargetLabelKey: common.BYOOMetricsEgressTargetLabelValue,
@@ -818,7 +833,7 @@ rules:
 	for _, env := range msMeta.OTelCollectorEnvVars {
 		otelCollectorEnv[env.Name] = env.Value
 	}
-	assert.Equal(t, "983040", otelCollectorEnv[nvcaconfig.BYOOLogChunkMaxBodyBytesEnv])
+	assert.Equal(t, "262144", otelCollectorEnv[nvcaconfig.BYOOLogChunkMaxBodyBytesEnv])
 	assert.Equal(t, "true", otelCollectorEnv[nvcaconfig.BYOOLogChunkDryRunEnv])
 	assert.Equal(t, "1000000", otelCollectorEnv[nvcaconfig.BYOOLogExporterBatchMaxSizeBytesEnv])
 	assert.Equal(t, "true", otelCollectorEnv[nvcaconfig.BYOOMetricSubsetEnabledEnv])


### PR DESCRIPTION
## TL;DR

Inject BYOO OTel collector environment variables directly into the collector sidecar on Helm-generated `utils` pods.

The webhook special-cases `utils` pods and skips the normal metadata-based environment injection. Consequently, log-chunking settings were present in MiniService metadata but absent from the collector, causing oversized logs to be exported without chunking.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

- Preserve metadata-based collector configuration for workload pods.
- Apply `BYOOOTelCollectorEnvVars()` directly to the generated Helm `utils` pod using `AddBYOOEnvVarsToPodSpec`.
- The helper targets only the `byoo-otel-collector` sidecar.
- Using `BYOOOTelCollectorEnvVars()` keeps this compatible with additional collector settings introduced by #194.
- Add regression coverage confirming the collector receives:
  - `BYOO_LOG_CHUNK_MAX_BODY_BYTES=262144`
  - `BYOO_LOG_CHUNK_DRY_RUN=true`
  - `BYOO_LOG_EXPORTER_BATCH_MAX_SIZE_BYTES=1000000`
- End-to-end staging validation is not included in this PR.

Related: #194

## For the Reviewer

Please review:

- `src/compute-plane-services/nvca/internal/miniservice/reconcile.go`
  - Confirm direct injection into the generated `utils` pod is the appropriate scope.
  - Confirm the metadata path should remain for workload pods.
- `src/compute-plane-services/nvca/internal/miniservice/reconcile_test.go`
  - Confirm the regression assertions cover the expected collector settings.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

Local verification:

`GOWORK=off go test ./internal/miniservice/ -run 'TestReconcile_Function$' -count=1 -ldflags '-X github.com/NVIDIA/k8s-dra-driver-gpu/internal/info.version=v25.8.0'`

Result: passed.

QA is recommended in staging:

1. Deploy a Helm-based function with BYOO logs enabled.
2. Inspect the `byoo-otel-collector` container on the generated `utils` pod.
3. Verify the expected `BYOO_LOG_*` environment variables are present.
4. Emit an oversized log record.
5. Verify it is exported as chunked records and no HTTP 413 is reported.

## Issues

NO-REF

## Checklist

- [X] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BYOO telemetry setup by applying collector environment settings directly to the utility pod.
  * Ensured BYOO log chunking and OpenTelemetry collector settings are consistently applied and reflected in deployment metadata.
* **Tests**
  * Added coverage validating collector sidecar environment variables and updated log chunking expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->