### PR TITLE
fix(icms-translate): mount config-data volume in LLM worker sidecars

### DIFF
--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
@@ -161,6 +161,13 @@ func newLLMRouterClientContainer(
 				Name:      "llm",
 				MountPath: llmDirMountPath,
 			},
+			// config-data backs SHARED_CONFIG_DIR, shared with the credential
+			// manager. Mount it so the nvcf client does not fail creating
+			// ConfigDirPath at startup.
+			{
+				Name:      "config-data",
+				MountPath: ConfigDirPath,
+			},
 		},
 	}
 
@@ -225,6 +232,12 @@ func newLLMCredentialManagerContainer(allEnvSet map[string]string, _ TranslateCo
 			{
 				Name:      "llm",
 				MountPath: llmDirMountPath,
+			},
+			// config-data backs SHARED_CONFIG_DIR. The credential manager
+			// creates and caches the worker token here, so it must be mounted.
+			{
+				Name:      "config-data",
+				MountPath: ConfigDirPath,
 			},
 		},
 	}

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/llm_test.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/llm_test.go
@@ -272,9 +272,11 @@ func TestNewLLMRouterClientContainer(t *testing.T) {
 			instanceID: "inst-vol",
 			isHelm:     false,
 			validate: func(t *testing.T, c corev1.Container) {
-				require.Len(t, c.VolumeMounts, 1)
+				require.Len(t, c.VolumeMounts, 2)
 				assert.Equal(t, "llm", c.VolumeMounts[0].Name)
 				assert.Equal(t, "/var/run/llm", c.VolumeMounts[0].MountPath)
+				assert.Equal(t, "config-data", c.VolumeMounts[1].Name)
+				assert.Equal(t, ConfigDirPath, c.VolumeMounts[1].MountPath)
 			},
 		},
 		{
@@ -394,9 +396,11 @@ func TestNewLLMCredentialManagerContainer(t *testing.T) {
 			allEnvSet: map[string]string{},
 			tcfg:      TranslateConfig{},
 			validate: func(t *testing.T, c corev1.Container) {
-				require.Len(t, c.VolumeMounts, 1)
+				require.Len(t, c.VolumeMounts, 2)
 				assert.Equal(t, "llm", c.VolumeMounts[0].Name)
 				assert.Equal(t, "/var/run/llm", c.VolumeMounts[0].MountPath)
+				assert.Equal(t, "config-data", c.VolumeMounts[1].Name)
+				assert.Equal(t, ConfigDirPath, c.VolumeMounts[1].MountPath)
 			},
 		},
 	}

--- a/src/libraries/go/lib/testdata/icms-translate/function/container/llm/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/container/llm/exp.yaml
@@ -279,6 +279,8 @@ spec:
     volumeMounts:
     - mountPath: /var/run/llm
       name: llm
+    - mountPath: /config/shared
+      name: config-data
   - env:
     - name: FUNCTION_ID
       value: 5a3d4a7e-9ee3-4762-8d37-d3b40a6f84c6
@@ -343,6 +345,8 @@ spec:
     volumeMounts:
     - mountPath: /var/run/llm
       name: llm
+    - mountPath: /config/shared
+      name: config-data
   imagePullSecrets:
   - name: workload-sr-887518b9-0ae0-4481-a273-56c86638bd71-regcred-0
   - name: worker-sr-887518b9-0ae0-4481-a273-56c86638bd71-regcred-0

--- a/src/libraries/go/lib/testdata/icms-translate/function/helmchart/llm/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/helmchart/llm/exp.yaml
@@ -247,6 +247,8 @@ spec:
     volumeMounts:
     - mountPath: /var/run/llm
       name: llm
+    - mountPath: /config/shared
+      name: config-data
   - env:
     - name: FUNCTION_ID
       value: 5a3d4a7e-9ee3-4762-8d37-d3b40a6f84c6
@@ -311,6 +313,8 @@ spec:
     volumeMounts:
     - mountPath: /var/run/llm
       name: llm
+    - mountPath: /config/shared
+      name: config-data
   imagePullSecrets:
   - name: worker-sr-887518b9-0ae0-4481-a273-56c86638bd71-regcred-0
   initContainers:


### PR DESCRIPTION
## TL;DR
LLM function worker pods crash-loop because the two LLM sidecars never mount the
shared config volume. Both `llm-worker` and `llm-credential-manager` are
configured with `SHARED_CONFIG_DIR=/config/shared` but only mount the `llm`
emptyDir. The credential manager fails at startup creating that directory
(`mkdir /config: permission denied`) and exits, and the router client then fails
because the worker token the credential manager should write is never produced.
This mounts the existing `config-data` volume at `/config/shared` on both
sidecars, matching the `init` and `utils` containers.

## Issues
Fixes #347




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LLM service startup by ensuring required configuration and worker token data can be created and cached reliably.
  * Added the required shared configuration storage to both LLM-related containers.

* **Tests**
  * Updated validation to confirm the shared configuration storage is mounted correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->