### PR TITLE
chore(deps): bump vendored nvcf go lib to f5e2792f

### DIFF
--- a/src/compute-plane-services/nvca/go.mod
+++ b/src/compute-plane-services/nvca/go.mod
@@ -5,7 +5,7 @@ go 1.25.10
 require (
 	github.com/NVIDIA/KAI-scheduler v0.12.6
 	github.com/NVIDIA/k8s-dra-driver-gpu v0.0.0-20251017125642-cfe35ffd3d2c
-	github.com/NVIDIA/nvcf/src/libraries/go/lib v0.0.0-20260601212822-4e2f12a33aba
+	github.com/NVIDIA/nvcf/src/libraries/go/lib v0.0.0-20260722095202-f5e2792f5630
 	github.com/aws/aws-sdk-go v1.55.5
 	github.com/bombsimon/logrusr/v4 v4.1.0
 	github.com/evanphx/json-patch/v5 v5.9.11

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/core/kubeconfigurator.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/core/kubeconfigurator.go
@@ -113,7 +113,7 @@ type TokenFetcher interface {
 // TokenKubeConfigurator implements KubeConfigurator by building
 // rest.Config use the bear token retrieved from a tokenFetcher. It
 // checks token update at given `Interval`, and only sends new
-// kubeconfig down to the channel if cached token get's changed.
+// kubeconfig down to the channel if cached token gets changed.
 type TokenKubeConfigurator struct {
 	masterURL string
 	fetcher   TokenFetcher

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
@@ -161,6 +161,13 @@ func newLLMRouterClientContainer(
 				Name:      "llm",
 				MountPath: llmDirMountPath,
 			},
+			// config-data backs SHARED_CONFIG_DIR, shared with the credential
+			// manager. Mount it so the nvcf client does not fail creating
+			// ConfigDirPath at startup.
+			{
+				Name:      "config-data",
+				MountPath: ConfigDirPath,
+			},
 		},
 	}
 
@@ -225,6 +232,12 @@ func newLLMCredentialManagerContainer(allEnvSet map[string]string, _ TranslateCo
 			{
 				Name:      "llm",
 				MountPath: llmDirMountPath,
+			},
+			// config-data backs SHARED_CONFIG_DIR. The credential manager
+			// creates and caches the worker token here, so it must be mounted.
+			{
+				Name:      "config-data",
+				MountPath: ConfigDirPath,
 			},
 		},
 	}

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/nvkit/errors/errors.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/nvkit/errors/errors.go
@@ -35,7 +35,7 @@ import (
 var (
 	ErrBadConfig                 = fmt.Errorf("bad config")
 	ErrInvalidConfig             = fmt.Errorf("invalid config")
-	ErrUninitializedConfig       = fmt.Errorf("unintialized config")
+	ErrUninitializedConfig       = fmt.Errorf("uninitialized config")
 	ErrBadCerts                  = fmt.Errorf("bad certs")
 	ErrCertAndKeyRequired        = fmt.Errorf("missing cert or key file when tls is enabled")
 	ErrCertOrKeyFileMissing      = fmt.Errorf("either both tls cert path and tls key path should be provided or none")

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/oauth/jwtcache.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/oauth/jwtcache.go
@@ -48,7 +48,7 @@ type tokenVerifier interface {
 }
 
 type JWTCache struct {
-	// Followings are immutable configurations.
+	// Following are immutable configurations.
 
 	fetcher tokenFetcher
 	// nowFunc returns current time, inject as dependency for testing.
@@ -56,7 +56,7 @@ type JWTCache struct {
 	expiryMargin time.Duration
 	jwtVerifier  tokenVerifier
 
-	// sync.Mutex protects followings mutable states
+	// sync.Mutex protects following mutable states
 	sync.Mutex
 	token  string
 	expiry *time.Time

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/types/nvca/config/types.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/types/nvca/config/types.go
@@ -343,7 +343,7 @@ type AgentConfig struct {
 	FunctionDeploymentStagesProdOAuthTokenURL              string `yaml:",omitempty"`
 	FunctionDeploymentStagesProdOAuthPublicKeysetEndpoint  string `yaml:",omitempty"`
 
-	// NVCA Operater version
+	// NVCA Operator version
 	OperatorVersion string `yaml:",omitempty"`
 	// Kubernetes version override
 	KubernetesVersionOverride string `yaml:",omitempty"`

--- a/src/compute-plane-services/nvca/vendor/modules.txt
+++ b/src/compute-plane-services/nvca/vendor/modules.txt
@@ -32,7 +32,7 @@ github.com/NVIDIA/k8s-dra-driver-gpu/pkg/nvidia.com/informers/externalversions/i
 github.com/NVIDIA/k8s-dra-driver-gpu/pkg/nvidia.com/informers/externalversions/resource
 github.com/NVIDIA/k8s-dra-driver-gpu/pkg/nvidia.com/informers/externalversions/resource/v1beta1
 github.com/NVIDIA/k8s-dra-driver-gpu/pkg/nvidia.com/listers/resource/v1beta1
-# github.com/NVIDIA/nvcf/src/libraries/go/lib v0.0.0-20260601212822-4e2f12a33aba => ../../libraries/go/lib
+# github.com/NVIDIA/nvcf/src/libraries/go/lib v0.0.0-20260722095202-f5e2792f5630 => ../../libraries/go/lib
 ## explicit; go 1.25.0
 github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/auth
 github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/core


### PR DESCRIPTION
## TL;DR
Bump the vendored internal shared library `github.com/NVIDIA/nvcf/src/libraries/go/lib` from the 2026-06-01 pin
(4e2f12a33aba) to current monorepo HEAD (2026-07-22, f5e2792f5630), rolling nvca's vendored copy forward. The one behavioral change it carries is the icms-translate fix that mounts the config-data volume (`SHARED_CONFIG_DIR`) into LLM worker sidecars so the nvcf client credential manager can create and cache the worker token at `ConfigDirPath` instead of failing at startup (#348). 


## Issues
Closes #347

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal library version to incorporate the latest available changes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->