### PR TITLE
feat(self-managed): add function-autoscaler release

### DIFF
--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -266,6 +266,14 @@ stateMetrics:
   serviceMonitor:
     enabled: false
 
+# Function Autoscaler workload (stage 03). Disabled by default; requires the
+# stage-01 Cassandra/OpenBao migrations and the observability stack's VictoriaMetrics.
+functionAutoscaler:
+  enabled: false
+  chartVersion: "0.0.0" # Pin to the published helm-nvcf-function-autoscaler version.
+  cassandraContactPoints: "" # e.g. cassandra.cassandra-system.svc.cluster.local
+  timeseriesDbUrl: "" # e.g. http://vmsingle.monitoring.svc:8428
+
 rateLimiter:
   enabled: true
   replicaCount: 1

--- a/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
@@ -40,3 +40,26 @@ releases:
       - template: service
     # When enabled, this service will export realtime function information that can be
     # scraped by a Prometheus ServiceMonitor
+
+  # --- Function Autoscaler workload ---
+  # Deploys the function-autoscaler (chart nvcf/helm-nvcf-function-autoscaler),
+  # disabled by default. SECRETS_PATH and CONFIG come from the chart defaults;
+  # only the in-cluster endpoints are set here. Ordered after state-metrics and
+  # depends on the stage-01 Cassandra and OpenBao migrations and a reachable
+  # VictoriaMetrics from the observability stack.
+  - name: function-autoscaler
+    version: "{{ .Values.functionAutoscaler.chartVersion }}" # Pin to the published helm-nvcf-function-autoscaler version.
+    namespace: nvcf
+    condition: functionAutoscaler.enabled
+    needs:
+      - nvcf/state-metrics
+    inherit:
+      - template: service
+    values:
+      - functionautoscaler:
+          image:
+            registry: "{{ .Values.global.image.registry }}"
+            repository: "{{ .Values.global.image.repository }}/nvcf-autoscaler-service"
+          env:
+            CASSANDRA__CONTACT_POINTS: "{{ .Values.functionAutoscaler.cassandraContactPoints }}"
+            TIMESERIES_DB__TIMESERIES_DB_URL: "{{ .Values.functionAutoscaler.timeseriesDbUrl }}"


### PR DESCRIPTION
## TL;DR

Wire the function-autoscaler workload into the self-managed stack's stage-03
observability helmfile, gated behind a new `functionAutoscaler` toggle that is
disabled by default.

## Additional Details

- Adds a `function-autoscaler` release to
  `deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl`,
  conditioned on `functionAutoscaler.enabled` and ordered after `state-metrics`.
- Adds the `functionAutoscaler` values block to `environments/base.yaml`
  (disabled by default; empty endpoints; chart-version placeholder).
- The release inherits the shared `service` template. `SECRETS_PATH` and
  `CONFIG` come from the chart defaults; only the in-cluster endpoints
  (Cassandra contact points and VictoriaMetrics URL) are environment-specific.
- Depends on the stage-01 Cassandra and OpenBao migrations and a reachable
  VictoriaMetrics from the observability stack.

**Draft** until the function-autoscaler chart is published: `chartVersion` is a
`0.0.0` placeholder that must be pinned to the published
`helm-nvcf-function-autoscaler` version before this can merge.

## For the Reviewer

- Two files: the `base.yaml` values block and the `03-observability` release.
- Note the release is inert by default (`condition: functionAutoscaler.enabled`,
  which is `false` in base), so this is safe to land ahead of enabling any env.

## For QA

Validated with `helmfile list` against the stage-03 helmfile:

- Default (toggle off): `function-autoscaler` renders `ENABLED=false` (not actioned).
- `--state-values-set functionAutoscaler.enabled=true`: renders `ENABLED=true`,
  namespace `nvcf`, chart `nvcf/helm-nvcf-function-autoscaler`, ordered after
  `state-metrics`.

## Issues

Closes #352

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
