### PR TITLE
chore: refine codeowners routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,59 @@
 # CODEOWNERS for the NVCF monorepo.
+# Order matters: the last matching pattern wins.
+# Some subgroup teams may be created after this file lands; keep the intended
+# ownership routing here.
+
+# Default fallback for paths not otherwise matched.
 * @NVIDIA/nvcf-dev
 
 # This CODEOWNERS file.
 /.github/CODEOWNERS @NVIDIA/nvcf-admin
+
+# CI, automation, and developer tooling.
+/.github/workflows/ @NVIDIA/nvcf-ci-dev
+/ci/ @NVIDIA/nvcf-ci-dev
+/tools/ @NVIDIA/nvcf-ci-dev
+
+# Documentation.
+/docs/ @NVIDIA/nvcf-docs-dev
+
+# Infrastructure foundations.
+/deploy/helm/cassandra/ @NVIDIA/nvcf-infra-dev
+/deploy/helm/nats/ @NVIDIA/nvcf-infra-dev
+/deploy/helm/openbao/ @NVIDIA/nvcf-infra-dev
+/infra/cassandra/ @NVIDIA/nvcf-infra-dev
+/migrations/cassandra/ @NVIDIA/nvcf-infra-dev
+/migrations/openbao/ @NVIDIA/nvcf-infra-dev
+
+# Control-plane services and charts.
+# Includes the NVCF API, rate limiter, invocation service, gRPC proxy, event
+# ledger, deployment stages, NVCT API, vanity gateway, autoscaler, Helm ReVal,
+# LLM gateway, LLM request router, SIS, and Stargate.
+/src/control-plane-services/ @NVIDIA/nvcf-control-plane-dev
+/src/invocation-plane-services/ @NVIDIA/nvcf-control-plane-dev
+/src/libraries/rust/stargate/ @NVIDIA/nvcf-control-plane-dev
+/deploy/helm/admin-token-issuer-proxy/ @NVIDIA/nvcf-control-plane-dev
+/deploy/helm/api-keys-colocated/ @NVIDIA/nvcf-control-plane-dev
+/deploy/helm/function-autoscaler/ @NVIDIA/nvcf-control-plane-dev
+/deploy/helm/gateway-routes/ @NVIDIA/nvcf-control-plane-dev
+/deploy/helm/grpc-proxy/ @NVIDIA/nvcf-control-plane-dev
+/deploy/helm/helm-reval/ @NVIDIA/nvcf-control-plane-dev
+/deploy/helm/http-invocation/ @NVIDIA/nvcf-control-plane-dev
+/deploy/helm/llm-api-gateway/ @NVIDIA/nvcf-control-plane-dev
+/deploy/helm/llm-request-router/ @NVIDIA/nvcf-control-plane-dev
+/deploy/helm/nats-auth-callout/ @NVIDIA/nvcf-control-plane-dev
+/deploy/helm/ratelimiter/ @NVIDIA/nvcf-control-plane-dev
+/migrations/cassandra/keyspaces/api_keys_api/ @NVIDIA/nvcf-control-plane-dev
+/migrations/cassandra/keyspaces/ess_api/ @NVIDIA/nvcf-control-plane-dev
+/migrations/cassandra/keyspaces/event_ledger/ @NVIDIA/nvcf-control-plane-dev
+/migrations/cassandra/keyspaces/nvcf_api/ @NVIDIA/nvcf-control-plane-dev
+/migrations/cassandra/keyspaces/sis_api/ @NVIDIA/nvcf-control-plane-dev
+
+# Compute-plane services and charts.
+# Includes NVCA, BYOO, Dynamo operator integration, and future Nsight operator
+# integration.
+/src/compute-plane-services/ @NVIDIA/nvcf-compute-plane-dev
+/deploy/helm/container-cache/ @NVIDIA/nvcf-compute-plane-dev
+/deploy/helm/nvca-operator/ @NVIDIA/nvcf-compute-plane-dev
+/deploy/helm/nvcf-unbound/ @NVIDIA/nvcf-compute-plane-dev
+/deploy/stacks/nvcf-compute-plane/ @NVIDIA/nvcf-compute-plane-dev


### PR DESCRIPTION
## TL;DR
Add back team-based CODEOWNERS routing for major NVCF ownership areas while retaining @NVIDIA/nvcf-dev as the fallback and @NVIDIA/nvcf-admin ownership of .github/CODEOWNERS.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
- Routes control-plane and invocation-plane service paths to @NVIDIA/nvcf-control-plane-dev, including former invocation, SIS, and Stargate ownership.
- Routes compute-plane paths and NVCA-related charts/stack ownership to @NVIDIA/nvcf-compute-plane-dev.
- Routes Cassandra, NATS, and OpenBao infrastructure paths to @NVIDIA/nvcf-infra-dev.
- Routes GitHub workflows, ci, and tools paths to @NVIDIA/nvcf-ci-dev.
- Routes docs/ to @NVIDIA/nvcf-docs-dev.
- Some subgroup teams may be created after this file lands; the CODEOWNERS entries capture the intended routing.

## For the Reviewer
Please review the .github/CODEOWNERS grouping and rule ordering.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
Validation:
- git diff --check
- local CODEOWNERS path existence check

Is QA Needed? No, CODEOWNERS-only metadata change.

## Issues
Closes #364

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated repository ownership rules with detailed, path-specific coverage across workflows, documentation, infrastructure, and service components.
  - Added guidance on match-order precedence to clarify how ownership is determined.
  - Retained existing default fallback behavior and preserved current ownership for the CODEOWNERS file.
  - No end-user-facing functionality or behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->