### PR TITLE
ci(function-autoscaler): add Helm chart release metadata

### DIFF
--- a/tools/ci/github-release-subprojects.json
+++ b/tools/ci/github-release-subprojects.json
@@ -115,6 +115,11 @@
       "legacy_tag_prefix": "nvcf-function-autoscaler-v"
     },
     {
+      "id": "function-autoscaler-helm",
+      "path": "deploy/helm/function-autoscaler",
+      "service_name": "helm-nvcf-function-autoscaler"
+    },
+    {
       "id": "nats-auth-callout",
       "path": "src/control-plane-services/nats-auth-callout",
       "service_name": "nvcf-nats-auth-callout-service",


### PR DESCRIPTION
## Summary

- register the function autoscaler Helm chart with GitHub release automation
- produce path-scoped chart tags under `deploy/helm/function-autoscaler/v*`
- establish `helm-nvcf-function-autoscaler` as the release artifact identity

## Test plan

- `python3 -m json.tool tools/ci/github-release-subprojects.json`
- `python3 tools/ci/test-github-release.py`
- verified the release helper resolves version `1.0.0` to `deploy/helm/function-autoscaler/v1.0.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Helm release configuration for the Function Autoscaler subproject.
  * Enabled automated release handling for the Function Autoscaler Helm service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->