### PR TITLE
fix(cassandra): fully-qualify the Dockerfile base images

### DIFF
--- a/infra/cassandra/Dockerfile
+++ b/infra/cassandra/Dockerfile
@@ -4,7 +4,7 @@
 # yq is used by the chart's conf initContainer to deep-merge cassandra.yaml
 # overrides onto the image default. Fetch it in a native build stage (no
 # emulation) and verify it against a pinned checksum.
-FROM --platform=$BUILDPLATFORM alpine:3.21 AS yq-downloader
+FROM --platform=$BUILDPLATFORM docker.io/library/alpine:3.21 AS yq-downloader
 ARG TARGETARCH
 ARG YQ_VERSION=v4.44.3
 ARG YQ_LINUX_AMD64_SHA256=a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7
@@ -19,7 +19,7 @@ RUN apk add --no-cache curl && \
     printf '%s  /tmp/yq\n' "${YQ_SHA256}" | sha256sum -c - && \
     chmod +x /tmp/yq
 
-FROM cassandra:5.0.8
+FROM docker.io/library/cassandra:5.0.8
 
 # Metrics exporter agent. The OSS snapshot does not redistribute the jar;
 # only files/.gitkeep ships, so the default here points at that placeholder


### PR DESCRIPTION
## Why
buildah on the CI builder enforces short-name resolution and can't prompt without a TTY, so `FROM cassandra:5.0.8` fails with `short-name resolution enforced but cannot prompt without a TTY`. (`alpine` only worked via a built-in short-name alias.) Surfaced by the nvcf-internal cassandra release build.

## What changed
Fully-qualify both bases to `docker.io/library/*` (`cassandra:5.0.8`, `alpine:3.21`), matching the fully-qualified base the standalone nvcf-cassandra Dockerfile always used. No behavior change - same images.

## Testing
The nvcf-internal cassandra build reached this exact line (clone, exporter-jar injection, and the yq stage all succeeded) and failed only on the short-name; this resolves it.

## References
Cassandra dockerfile release (nvcf-internal !82).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image references to use fully qualified registry paths.
  * No changes to runtime configuration or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->