### PR TITLE
fix(self-managed): consume remediated OpenBao chart

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
@@ -47,7 +47,7 @@ releases:
     <<: *dependency
 
   - name: openbao-server # this name MUST not change
-    version: 0.30.23
+    version: 0.30.25
     condition: openbao.enabled # From defaults.yaml or env overrides
     namespace: vault-system
     <<: *dependency # Inherits base values from the dependency template


### PR DESCRIPTION
## TL;DR

Update the self-managed stack OpenBao dependency from chart `0.30.23` to `0.30.25` so deployments consume the remediated OpenBao image set.

## Additional Details

The OpenBao chart defaults in this repository already use:

- `nvcf-openbao:2.5.5-nv-1.3.1`
- `nvcf-openbao-migrations:0.16.2`

The downstream stack pin remained on chart `0.30.23`, which selects the previous `2.5.4-nv-1.3.0` image set. This change moves the stack to the existing `0.30.25` chart release.

The chart retains the `OnDelete` StatefulSet strategy. Existing installations must follow the controlled pod-rotation procedure documented in #380 after upgrading.

## For the Reviewer

Review the OpenBao release entry in `deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl`. No release ordering or dependency changes are included.

## For QA

- `git diff --check`
- Confirmed `deploy/helm/openbao/v0.30.25` exists and contains the remediated chart defaults.
- No cluster QA was run for this one-line stack pin. The change does not alter Kubernetes resource shapes.

## Issues

Relates to #379

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] Existing chart and stack validation cover this version-only change.
- [x] Documentation is handled in #380.

## Dependencies

- `deploy/helm/openbao/v0.30.25`
- Documentation PR #380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the OpenBao server deployment chart to version 0.30.25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->