### PR TITLE
fix(tracing-versions): stamp service versions for tracing

### DIFF
--- a/.github/workflows/image-push-manual.yml
+++ b/.github/workflows/image-push-manual.yml
@@ -121,6 +121,7 @@ jobs:
         env:
           SVC_PATH: ${{ github.event.inputs.service_path }}
           TAG: ${{ steps.meta.outputs.tag }}
+          NVCF_VERSION: ${{ steps.meta.outputs.tag }}
           REGISTRY: ${{ secrets.NCP_DEV_REGISTRY }}
         run: |
           set -euo pipefail
@@ -145,7 +146,7 @@ jobs:
             mkdir -p ci-ghcr
             printf 'load("@rules_oci//oci:defs.bzl", "oci_push")\n\noci_push(\n    name = "push",\n    image = "%s",\n    repository = "%s",\n    remote_tags = ["%s", "latest-dispatch"],\n)\n' \
               "$tgt" "$dest" "$TAG" > ci-ghcr/BUILD.bazel
-            bazel run --remote_cache= --disk_cache="${BAZEL_DISK_CACHE}" //ci-ghcr:push
+            bazel run --stamp --remote_cache= --disk_cache="${BAZEL_DISK_CACHE}" //ci-ghcr:push
             rm -rf ci-ghcr
           done
           echo "Done: pushed ${#indexes[@]} image(s) under ${REGISTRY}/ at tag ${TAG}"

--- a/src/control-plane-services/function-autoscaler/tools/workspace_status.sh
+++ b/src/control-plane-services/function-autoscaler/tools/workspace_status.sh
@@ -24,11 +24,28 @@ if [ "$COMMIT" != "unknown" ] && [ -n "$(git status --porcelain 2>/dev/null)" ];
 fi
 
 # CI overrides for VERSION (from git tag or MR sha) and BUILD_USER.
-# When unset, fall back to the values the legacy nvcf-cli Makefile computed.
+# When unset, use only tags that belong to this service. `git describe
+# --exact-match` is unsafe in the monorepo because a commit can also have
+# stack/chart tags such as deploy/stacks/nvcf-compute-plane/v...
+TAG_PREFIX="src/control-plane-services/function-autoscaler/v"
+LEGACY_TAG_PREFIX="nvcf-function-autoscaler-v"
+
+version_from_exact_tag() {
+    local prefix tag
+    for prefix in "$@"; do
+        tag=$(git tag --points-at HEAD --list "${prefix}*" 2>/dev/null | sort -V | tail -n1 || true)
+        if [ -n "${tag}" ]; then
+            printf '%s\n' "${tag#"${prefix}"}"
+            return 0
+        fi
+    done
+    return 1
+}
+
 if [ -n "${NVCF_VERSION:-}" ]; then
     VERSION="${NVCF_VERSION}"
-elif TAG=$(git describe --tags --exact-match HEAD 2>/dev/null); then
-    VERSION="${TAG}"
+elif VERSION=$(version_from_exact_tag "${TAG_PREFIX}" "${LEGACY_TAG_PREFIX}"); then
+    :
 else
     VERSION="mr-${COMMIT}"
 fi

--- a/src/invocation-plane-services/http-invocation/tools/workspace_status.sh
+++ b/src/invocation-plane-services/http-invocation/tools/workspace_status.sh
@@ -24,11 +24,28 @@ if [ "$COMMIT" != "unknown" ] && [ -n "$(git status --porcelain 2>/dev/null)" ];
 fi
 
 # CI overrides for VERSION (from git tag or MR sha) and BUILD_USER.
-# When unset, fall back to the values the legacy nvcf-cli Makefile computed.
+# When unset, use only tags that belong to this service. `git describe
+# --exact-match` is unsafe in the monorepo because a commit can also have
+# stack/chart tags such as deploy/stacks/nvcf-compute-plane/v...
+TAG_PREFIX="src/invocation-plane-services/http-invocation/v"
+LEGACY_TAG_PREFIX="nvcf-invocation-service-v"
+
+version_from_exact_tag() {
+    local prefix tag
+    for prefix in "$@"; do
+        tag=$(git tag --points-at HEAD --list "${prefix}*" 2>/dev/null | sort -V | tail -n1 || true)
+        if [ -n "${tag}" ]; then
+            printf '%s\n' "${tag#"${prefix}"}"
+            return 0
+        fi
+    done
+    return 1
+}
+
 if [ -n "${NVCF_VERSION:-}" ]; then
     VERSION="${NVCF_VERSION}"
-elif TAG=$(git describe --tags --exact-match HEAD 2>/dev/null); then
-    VERSION="${TAG}"
+elif VERSION=$(version_from_exact_tag "${TAG_PREFIX}" "${LEGACY_TAG_PREFIX}"); then
+    :
 else
     VERSION="mr-${COMMIT}"
 fi


### PR DESCRIPTION
## TL;DR
Stamp the real release version into the HTTP invocation and function autoscaler Bazel image builds so tracing reports the service-specific version instead of stale package defaults or unrelated monorepo tags.

## Additional Details
- Pass `NVCF_VERSION` from the manual image push workflow and run the Bazel image push with `--stamp`.
- Update both service `workspace_status.sh` scripts to prefer `NVCF_VERSION`.
- Fall back only to tags that belong to the specific service, avoiding unrelated stack/chart tags on the same commit.

## For the Reviewer
Please look closely at:
- `.github/workflows/image-push-manual.yml`
- `src/invocation-plane-services/http-invocation/tools/workspace_status.sh`
- `src/control-plane-services/function-autoscaler/tools/workspace_status.sh`

## For QA
Verified with:
- `bash -n src/control-plane-services/function-autoscaler/tools/workspace_status.sh`
- `bash -n src/invocation-plane-services/http-invocation/tools/workspace_status.sh`
- `git diff --check origin/main...HEAD`

QA needed: no separate QA pass expected; this is build/stamping behavior.

## Issues
NO-REF

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service version detection for builds using exact Git tags.
  * Added support for both current and legacy service tag formats.
  * Ensured manually built and pushed images receive the computed snapshot version.
  * Preserved fallback versioning when no matching tag is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->