### PR TITLE
docs(self-managed): remove Vanity Gateway references from v0.6.0 docs

### DIFF
--- a/docs/v0.6.0/csp-end-to-end-example-installation.md
+++ b/docs/v0.6.0/csp-end-to-end-example-installation.md
@@ -268,9 +268,6 @@ addons:
       enabled: false               # OpenBao-issued QUIC TLS for the request router. Optional.
       allowedDomains: ""           # Required only when llm.pki.enabled: comma-separated DNS suffixes.
       dnsNames: []                 # Required only when llm.pki.enabled: SANs on the issued certificate.
-  vanityGateway:
-    enabled: false                 # Vanity and OpenAI-compatible invocation routes. Optional.
-    replicaCount: 2                # Vanity gateway replicas (applied only when enabled).
 
 stateMetrics:
   enabled: false                   # State-metrics exporter. Optional.
@@ -304,9 +301,6 @@ ingress:
         routeAnnotations: {}       # Optional annotations for the invocation route.
       llmInvocation:
         routeAnnotations: {}       # Optional annotations for the LLM invocation route.
-      vanityGateway:
-        hostnames: []              # Override vanity hostnames. Default is vanity.<domain>.
-        routeAnnotations: {}       # Optional annotations for the vanity route.
       grpc:
         routeAnnotations: {}       # Optional annotations for the gRPC route.
       nats:

--- a/docs/v0.6.0/gateway-routing.md
+++ b/docs/v0.6.0/gateway-routing.md
@@ -365,7 +365,6 @@ When you deploy the control plane via helmfile, the `nvcf-gateway-routes` chart 
 
 - `HTTPRoutes` for API Keys, NVCF API, and Invocation services
 - Optional LLM invocation HTTPRoute when the `llmInvocation` route is enabled
-- Optional Vanity Gateway HTTPRoute only when the stack package includes the addon and the `vanityGateway` route is enabled
 - `TCPRoute` for gRPC
 - Optional `TCPRoute` for split or multi-cluster gRPC invocation when the
   `grpcWorker` route is enabled
@@ -382,7 +381,6 @@ These routes attach to the Gateway you prepared in [Gateway quickstart](./gatewa
 | NVCF API | `api.<domain>` | 80 | Function management (create, deploy, delete) |
 | Invocation | `invocation.<domain>`, `*.invocation.<domain>` | 80 | Function invocation (wildcard for dynamic routing) |
 | LLM Invocation | `llm.invocation.<domain>` | 80 | OpenAI-compatible LLM invocation routes such as `/v1/chat/completions`, `/v1/responses`, and `/v1/embeddings` |
-| Vanity Gateway | `vanity.<domain>` | 80 | Optional vanity host/path routing to `vanity-gateway.nvcf:8080`, only in stack packages that include the addon |
 | gRPC | N/A (TCP routing, no hostname matching) | 10081 | gRPC function invocations |
 | gRPC worker callback | N/A (TCP routing, no hostname matching) | 10086 | HTTP/1 CONNECT callback from workers to grpc-proxy when the beta `grpcWorker` route is enabled |
 | NATS | N/A (TCP routing, no hostname matching) | 4222 | NVCA messaging when the NATS route is enabled |
@@ -403,31 +401,6 @@ For local and multi-cluster invocation-path diagrams, see
 [Generic HTTP Function Invocation](./generic-http-function-invocation.md),
 [gRPC Function Invocation](./grpc-function-invocation.md), and
 [LLM Gateway](./llm-gateway.md).
-
-### Vanity Gateway (Optional)
-
-Vanity Gateway is disabled by default. It is available only in stack packages
-that include the Vanity Gateway addon. If your extracted stack package does not
-contain a `vanity-gateway` release and `vanityGateway` route values, skip this
-section until you use a stack package that includes them.
-
-Enable it only when you need a customer-facing hostname or mapping layer in
-front of the standard NVCF service routes. In Helmfile-based stack packages that
-include the addon, set:
-
-```yaml
-addons:
-  vanityGateway:
-    enabled: true
-    mappingConfig: {}
-```
-
-By default, the route host is `vanity.<domain>` and the backend is
-`vanity-gateway.nvcf:8080`. Use `addons.vanityGateway.mappingConfig` for the
-host and path mappings required by your deployment. If you need custom vanity
-hostnames instead of `vanity.<domain>`, configure the route hostname overrides
-supported by your stack package, then create matching DNS records for those
-hosts.
 
 ### How Routing Works
 
@@ -469,11 +442,7 @@ kubectl get httproute -A -o jsonpath='{range .items[*]}{.metadata.name}: {.spec.
 # api-keys: api-keys.a1b2c3d4.us-west-2.elb.amazonaws.com
 # nvcf-api: api.a1b2c3d4.us-west-2.elb.amazonaws.com
 # invocation-service: *.invocation.a1b2c3d4.us-west-2.elb.amazonaws.com invocation.a1b2c3d4.us-west-2.elb.amazonaws.com
-# vanity-gateway: vanity.a1b2c3d4.us-west-2.elb.amazonaws.com  # only when enabled and present in the stack package
 ```
-
-If Vanity Gateway is disabled or your stack package does not include the addon,
-the `vanity-gateway` HTTPRoute is not expected.
 
 ### Verify TCPRoutes
 
@@ -497,9 +466,6 @@ kubectl get svc -n envoy-gateway-system -l gateway.envoyproxy.io/owning-gateway-
 # Test HTTP endpoints with Host header
 curl -H "Host: api-keys.$GATEWAY_ADDR" http://$GATEWAY_ADDR/health
 curl -H "Host: api.$GATEWAY_ADDR" http://$GATEWAY_ADDR/health
-
-# Optional Vanity Gateway route, only if the addon is present and enabled
-curl -H "Host: vanity.$GATEWAY_ADDR" http://$GATEWAY_ADDR/health
 
 # Test gRPC endpoint (requires grpcurl)
 grpcurl -plaintext $GATEWAY_ADDR:10081 grpc.health.v1.Health/Check

--- a/docs/v0.6.0/helmfile-installation.md
+++ b/docs/v0.6.0/helmfile-installation.md
@@ -1004,52 +1004,9 @@ If dependencies are corrupted or you prefer a clean slate, follow the complete
 [Uninstalling](#uninstalling) steps, fix your configuration, then redeploy from
 Step 1.
 
-#### Enabling Vanity Gateway
-
-Vanity Gateway is optional and disabled by default. It is available only in
-stack packages that include the Vanity Gateway addon. If your extracted stack
-package does not contain a `vanity-gateway` release and `vanityGateway` route
-values, skip this section until you use a stack package that includes them.
-
-Enable it only when you need a customer-facing hostname or path mapping layer in
-front of the standard NVCF service routes.
-
-In stack packages that include the addon, set the value shape in your
-environment file:
-
-```yaml
-addons:
-  vanityGateway:
-    enabled: true
-    mappingConfig: {}
-```
-
-By default, the route host is `vanity.<domain>` and the backend is
-`vanity-gateway.nvcf:8080`. Put deployment-specific host and path mappings under
-`addons.vanityGateway.mappingConfig`. If your deployment needs custom vanity
-hosts, use the route hostname overrides supported by your stack package and
-create matching DNS records.
-
-After confirming your stack package includes the `vanity-gateway` release,
-preview and apply the service plus gateway routes:
-
-```bash
-HELMFILE_ENV=<environment-name> helmfile --selector name=vanity-gateway template
-HELMFILE_ENV=<environment-name> helmfile --selector name=vanity-gateway sync
-HELMFILE_ENV=<environment-name> helmfile --selector release-group=ingress sync
-```
-
-Verify only when the addon is present and enabled:
-
-```bash
-kubectl get deploy,svc -n nvcf -l app.kubernetes.io/name=vanity-gateway
-kubectl get httproute -A | grep -i vanity
-curl -H "Host: vanity.<domain>" "http://<gateway-address>/health"
-```
-
 #### Recovering from Gateway Address Changes
 
-If your Gateway or its underlying load balancer was deleted and recreated (e.g., due to a TCPRoute misconfiguration or infrastructure change), the external address will change. Services that depend on the `domain` value -- including Gateway API routes, SIS cluster registration, API hostname resolution, and the optional Vanity Gateway route -- will break until the new address is propagated.
+If your Gateway or its underlying load balancer was deleted and recreated (e.g., due to a TCPRoute misconfiguration or infrastructure change), the external address will change. Services that depend on the `domain` value -- including Gateway API routes, SIS cluster registration, and API hostname resolution -- will break until the new address is propagated.
 
 1. Get the new Gateway address:
 

--- a/docs/v0.6.0/image-mirroring.md
+++ b/docs/v0.6.0/image-mirroring.md
@@ -122,7 +122,7 @@ helm repo update
 helm pull nvcf/helm-nvca-operator --version 1.12.7
 
 # Prerelease charts require --devel when searching
-helm search repo nvcf/helm-nvcf-vanity-gateway --versions --devel
+helm search repo nvcf/helm-nvcf-<chart-name> --versions --devel
 ```
 
 **Other Repository-based Helm Charts (Non-OCI)**

--- a/docs/v0.6.0/images/nvcf-http-invocation-path.svg
+++ b/docs/v0.6.0/images/nvcf-http-invocation-path.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1280" height="460" viewBox="0 0 1280 460" role="img" aria-labelledby="title desc">
   <title id="title">NVCF HTTP invocation path</title>
-  <desc id="desc">Client traffic flows through an optional Vanity or custom edge, the public HTTP invocation endpoint, Invocation Service, NATS and worker request path, the worker sidecar, and the customer HTTP function.</desc>
+  <desc id="desc">Client traffic flows through an optional custom edge, the public HTTP invocation endpoint, Invocation Service, NATS and worker request path, the worker sidecar, and the customer HTTP function.</desc>
   <defs>
     <style>
       :root {
@@ -61,8 +61,8 @@
   <text class="small" x="110" y="218" text-anchor="middle">HTTP request</text>
 
   <rect class="optional" x="220" y="155" width="168" height="88" rx="8" />
-  <text class="label" x="304" y="185" text-anchor="middle">Optional Vanity</text>
-  <text class="small" x="304" y="211" text-anchor="middle">or custom edge</text>
+  <text class="label" x="304" y="185" text-anchor="middle">Optional custom</text>
+  <text class="small" x="304" y="211" text-anchor="middle">edge</text>
   <text class="small" x="304" y="232" text-anchor="middle">front door</text>
 
   <rect class="panel-muted" x="428" y="155" width="196" height="88" rx="8" />

--- a/docs/v0.6.0/images/nvcf-http-invocation-path.svg
+++ b/docs/v0.6.0/images/nvcf-http-invocation-path.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1280" height="460" viewBox="0 0 1280 460" role="img" aria-labelledby="title desc">
   <title id="title">NVCF HTTP invocation path</title>
-  <desc id="desc">Client traffic flows through an optional custom edge, the public HTTP invocation endpoint, Invocation Service, NATS and worker request path, the worker sidecar, and the customer HTTP function.</desc>
+  <desc id="desc">Client traffic flows through the public HTTP invocation endpoint, Invocation Service, NATS and worker request path, the worker sidecar, and the customer HTTP function.</desc>
   <defs>
     <style>
       :root {
@@ -38,7 +38,6 @@
       .bg { fill: var(--svg-bg); }
       .panel { fill: var(--svg-panel); stroke: var(--svg-border); stroke-width: 2; }
       .panel-muted { fill: var(--svg-panel-muted); stroke: var(--svg-border); stroke-width: 2; }
-      .optional { fill: var(--svg-panel); stroke: var(--svg-amber); stroke-width: 2; stroke-dasharray: 8 6; }
       .service { fill: var(--svg-panel); stroke: var(--nvidia-green); stroke-width: 3; }
       .compute { fill: var(--svg-panel-muted); stroke: var(--svg-blue); stroke-width: 2; }
       .title { fill: var(--svg-text); font: 700 26px Arial, sans-serif; }
@@ -59,11 +58,6 @@
   <rect class="panel" x="40" y="155" width="140" height="88" rx="8" />
   <text class="label" x="110" y="192" text-anchor="middle">Client</text>
   <text class="small" x="110" y="218" text-anchor="middle">HTTP request</text>
-
-  <rect class="optional" x="220" y="155" width="168" height="88" rx="8" />
-  <text class="label" x="304" y="185" text-anchor="middle">Optional custom</text>
-  <text class="small" x="304" y="211" text-anchor="middle">edge</text>
-  <text class="small" x="304" y="232" text-anchor="middle">front door</text>
 
   <rect class="panel-muted" x="428" y="155" width="196" height="88" rx="8" />
   <text class="label" x="526" y="185" text-anchor="middle">Public HTTP</text>
@@ -89,8 +83,7 @@
   <text class="label" x="1116" y="373" text-anchor="middle">Function</text>
   <text class="small" x="1116" y="398" text-anchor="middle">container endpoint</text>
 
-  <line class="line" x1="180" y1="199" x2="220" y2="199" />
-  <line class="line" x1="388" y1="199" x2="428" y2="199" />
+  <line class="line" x1="180" y1="199" x2="428" y2="199" />
   <line class="line" x1="624" y1="199" x2="664" y2="199" />
   <line class="line" x1="870" y1="199" x2="920" y2="199" />
   <path class="line" d="M 1009 243 L 1009 280 L 849 280 L 849 320" />

--- a/docs/v0.6.0/images/nvcf-llm-invocation-path.svg
+++ b/docs/v0.6.0/images/nvcf-llm-invocation-path.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1280" height="460" viewBox="0 0 1280 460" role="img" aria-labelledby="title desc">
   <title id="title">NVCF LLM invocation path</title>
-  <desc id="desc">Client traffic flows through an optional Vanity or custom edge, the public LLM/HTTP invocation endpoint, LLM API Gateway, LLM Request Router, the LLM worker sidecar, and the customer inference container.</desc>
+  <desc id="desc">Client traffic flows through an optional custom edge, the public LLM/HTTP invocation endpoint, LLM API Gateway, LLM Request Router, the LLM worker sidecar, and the customer inference container.</desc>
   <defs>
     <style>
       :root {
@@ -71,8 +71,8 @@
   <text class="small" x="110" y="218" text-anchor="middle">OpenAI API</text>
 
   <rect class="optional" x="220" y="155" width="168" height="88" rx="8" />
-  <text class="label" x="304" y="185" text-anchor="middle">Optional Vanity</text>
-  <text class="small" x="304" y="211" text-anchor="middle">or custom edge</text>
+  <text class="label" x="304" y="185" text-anchor="middle">Optional custom</text>
+  <text class="small" x="304" y="211" text-anchor="middle">edge</text>
   <text class="small" x="304" y="232" text-anchor="middle">front door</text>
 
   <rect class="panel-muted" x="428" y="155" width="188" height="88" rx="8" />

--- a/docs/v0.6.0/images/nvcf-llm-invocation-path.svg
+++ b/docs/v0.6.0/images/nvcf-llm-invocation-path.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1280" height="460" viewBox="0 0 1280 460" role="img" aria-labelledby="title desc">
   <title id="title">NVCF LLM invocation path</title>
-  <desc id="desc">Client traffic flows through an optional custom edge, the public LLM/HTTP invocation endpoint, LLM API Gateway, LLM Request Router, the LLM worker sidecar, and the customer inference container.</desc>
+  <desc id="desc">Client traffic flows through the public LLM/HTTP invocation endpoint, LLM API Gateway, LLM Request Router, the LLM worker sidecar, and the customer inference container.</desc>
   <defs>
     <style>
       :root {
@@ -38,7 +38,6 @@
       .bg { fill: var(--svg-bg); }
       .panel { fill: var(--svg-panel); stroke: var(--svg-border); stroke-width: 2; }
       .panel-muted { fill: var(--svg-panel-muted); stroke: var(--svg-border); stroke-width: 2; }
-      .optional { fill: var(--svg-panel); stroke: var(--svg-amber); stroke-width: 2; stroke-dasharray: 8 6; }
       .service { fill: var(--svg-panel); stroke: var(--nvidia-green); stroke-width: 3; }
       .compute { fill: var(--svg-panel-muted); stroke: var(--svg-blue); stroke-width: 2; }
       .title { fill: var(--svg-text); font: 700 26px Arial, sans-serif; }
@@ -70,11 +69,6 @@
   <text class="label" x="110" y="192" text-anchor="middle">Client</text>
   <text class="small" x="110" y="218" text-anchor="middle">OpenAI API</text>
 
-  <rect class="optional" x="220" y="155" width="168" height="88" rx="8" />
-  <text class="label" x="304" y="185" text-anchor="middle">Optional custom</text>
-  <text class="small" x="304" y="211" text-anchor="middle">edge</text>
-  <text class="small" x="304" y="232" text-anchor="middle">front door</text>
-
   <rect class="panel-muted" x="428" y="155" width="188" height="88" rx="8" />
   <text class="label" x="522" y="185" text-anchor="middle">Public LLM/HTTP</text>
   <text class="small" x="522" y="211" text-anchor="middle">invocation endpoint</text>
@@ -103,8 +97,7 @@
   <text class="label" x="604" y="351" text-anchor="middle">NVCF API</text>
   <text class="small" x="604" y="377" text-anchor="middle">LLM auth policy</text>
 
-  <line class="line" x1="180" y1="199" x2="220" y2="199" />
-  <line class="line" x1="388" y1="199" x2="428" y2="199" />
+  <line class="line" x1="180" y1="199" x2="428" y2="199" />
   <line class="line" x1="616" y1="199" x2="656" y2="199" />
   <line class="line" x1="852" y1="199" x2="900" y2="199" />
   <path class="line" d="M 995 243 L 995 280 L 847 280 L 847 320" />

--- a/docs/v0.6.0/installation.md
+++ b/docs/v0.6.0/installation.md
@@ -1,6 +1,6 @@
 # Deployment
 
-Self-hosted NVCF installation includes the core components required for NVCF inference. Optional components such as caching and low latency streaming support are also available. Vanity Gateway routing is available only in stack packages that include the Vanity Gateway addon.
+Self-hosted NVCF installation includes the core components required for NVCF inference. Optional components such as caching and low latency streaming support are also available.
 
 For a local k3d fresh install, start with the [Quickstart](./quickstart.md). The quickstart uses `nvcf-cli self-hosted up` to install the control plane, register the local k3d cluster, install NVCA, and run basic health checks.
 
@@ -48,7 +48,7 @@ Every installation path follows the same high-level sequence:
 
 6. Install Low Latency Streaming if needed for streaming workloads. See [LLS Installation](./lls-installation.md).
 
-7. Install optional enhancements, such as caches, low latency streaming, or Vanity Gateway routing when your stack package includes that addon. See [Optional Enhancements](./optional-enhancements.md).
+7. Install optional enhancements, such as caches or low latency streaming. See [Optional Enhancements](./optional-enhancements.md).
 
 ## Kubernetes Cluster Requirements
 

--- a/docs/v0.6.0/manifest.md
+++ b/docs/v0.6.0/manifest.md
@@ -88,7 +88,6 @@ The following tables list the complete artifact inventory.
 | `helm-nvcf-rate-limiter` | `1.0.3` | Optional | Deploys request rate limiting for supported invocation paths. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-rate-limiter:1.0.3` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/ratelimiter) |
 | `helm-nvcf-sis` | `1.18.3` | Required | Deploys the Spot Instance Service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-sis:1.18.3` |  |
 | `helm-nvcf-state-metrics` | `1.0.1` | Optional | Deploys NVCF state metrics for observability. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-state-metrics:1.0.1` |  |
-| `helm-nvcf-vanity-gateway` | `0.1.0-nvcf-10204.1` | Optional | Deploys the optional vanity hostname gateway. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-vanity-gateway:0.1.0-nvcf-10204.1` |  |
 | `helm-reval` | `1.3.8` | Required | Deploys the function revalidation service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-reval:1.3.8` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/helm-reval) |
 | `nvcf-example-dashboards` | `1.6.0` | Optional | Deploys example Grafana dashboards for NVCF telemetry. | `https://helm.ngc.nvidia.com/nvidia/nvcf/nvcf-example-dashboards:1.6.0` |  |
 | `nvcf-gateway-routes` | `1.14.0` | Optional | Deploys Gateway API routes for the reference architecture. | `https://helm.ngc.nvidia.com/nvidia/nvcf/nvcf-gateway-routes:1.14.0` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/gateway-routes) |

--- a/docs/v0.6.0/optional-enhancements.md
+++ b/docs/v0.6.0/optional-enhancements.md
@@ -17,21 +17,6 @@ installation and configuration guide.
 - [container-cache](./cluster-management/container-cache.md) - Accelerates container image pulls by caching layers locally
 - [gxcache](./cluster-management/gxcache.md) - Shader caching for simulation and rendering workloads
 
-## Vanity Gateway
-
-Vanity Gateway is an optional HTTP gateway service for deployments that need
-customer-facing hostnames or path mappings in front of the standard NVCF API and
-invocation routes. It is available only in stack packages that include the
-Vanity Gateway addon. Older packages do not contain the `vanity-gateway` release
-or route values.
-
-When the addon is present and enabled, it is deployed as the `vanity-gateway`
-service and exposed through the Gateway API route `vanity.<domain>` by default.
-Enable it only when you need a vanity routing layer. Standard API, API Keys,
-invocation, LLM invocation, and gRPC routes do not require it. See
-[Gateway Routing](./gateway-routing.md#vanity-gateway-optional) for routing and
-verification details.
-
 ## Physical Simulation Caches
 
 For an overview refer to [self-hosted-caches](./caches.md)


### PR DESCRIPTION
## TL;DR
Removes all Vanity Gateway references from the frozen `docs/v0.6.0/` tree. The
addon is no longer surfaced in the v0.6.0 documentation, so the routing
section, install steps, manifest row, value blocks, and invocation-path
diagram labels that mention it are dropped to avoid pointing users at an
option this release set no longer documents.

## Additional Details
Scope is documentation-only, limited to `docs/v0.6.0/`:
- `optional-enhancements.md`: removed the `## Vanity Gateway` section.
- `installation.md`: removed the Vanity note in the intro and step 7.
- `gateway-routing.md`: removed the route bullet, the routing-table row, the
  `Vanity Gateway (Optional)` section, and the verify/curl examples plus the
  disabled-route note.
- `helmfile-installation.md`: removed the `Enabling Vanity Gateway` section and
  the Vanity mention in the gateway-address recovery note.
- `csp-end-to-end-example-installation.md`: removed the `addons.vanityGateway`
  and `routes.vanityGateway` value blocks.
- `manifest.md`: removed the `helm-nvcf-vanity-gateway` artifact row.
- `image-mirroring.md`: replaced the vanity-gateway prerelease search example
  with a generic `<chart-name>` placeholder.
- `images/nvcf-http-invocation-path.svg` and
  `images/nvcf-llm-invocation-path.svg`: relabeled the "Optional Vanity" box to
  "Optional custom edge" and updated the `desc` accessibility text.

Verified no remaining `vanity` matches and no dangling anchor links to the
removed sections.

## For the Reviewer
`docs/v0.6.0/` is a frozen versioned tree; this edit was made on explicit
request. `manifest.md` is a generated-style table, but v0.6.0 is a snapshot
that is not regenerated, so the row was edited directly. Flag if you would
prefer it driven from the version catalog instead.

## For QA
Docs-only change. No QA needed. Optional: `rg -n vanity docs/v0.6.0` returns no
matches; render Fern docs locally to confirm the diagrams and pages read
cleanly.

## Issues
Relates to #386


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed outdated Vanity Gateway installation, routing, configuration, and artifact references.
  - Updated installation guidance to clarify available optional enhancements.
  - Added documentation for Physical Simulation Caches, including supported cache services and deployment guidance.
  - Generalized prerelease chart search instructions.
  - Updated gateway address recovery guidance to reflect current dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->