### PR TITLE
fix(helmfile): support HTTP Helm repo in addition to OCI registry

### DIFF
--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -9,8 +9,16 @@ global:
   # =============================================================================
   # Helm Chart Sources Configuration
   # =============================================================================
-  # Configure the OCI registry where NVCF Helm charts are stored.
-  # This must point to a registry containing the NVCF chart packages.
+  # Option A — HTTP Helm repository (e.g. NGC public catalog):
+  #   sources:
+  #     url: "https://helm.ngc.nvidia.com/nvidia/nvcf"
+  #     username: "$oauthtoken"
+  #     password: "YOUR_NGC_API_KEY"
+  #
+  # Option B — OCI registry (e.g. ECR or a private NGC org after mirroring):
+  #   sources:
+  #     registry: "nvcr.io"           # or <account>.dkr.ecr.<region>.amazonaws.com
+  #     repository: "YOUR_ORG/YOUR_TEAM"
   # =============================================================================
   helm:
     sources:

--- a/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
@@ -8,8 +8,18 @@ environments:
 
 repositories:
   - name: nvcf
+{{- if dig "global" "helm" "sources" "url" "" .Values }}
+    url: {{ .Values.global.helm.sources.url | quote }}
+    {{- if dig "global" "helm" "sources" "username" "" .Values }}
+    username: {{ dig "global" "helm" "sources" "username" "" .Values | quote }}
+    {{- end }}
+    {{- if dig "global" "helm" "sources" "password" "" .Values }}
+    password: {{ dig "global" "helm" "sources" "password" "" .Values | quote }}
+    {{- end }}
+{{- else }}
     url: {{ .Values.global.helm.sources.registry }}/{{ .Values.global.helm.sources.repository }}
     oci: true
+{{- end }}
 
 helmDefaults:
   createNamespace: true

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -8,8 +8,19 @@ environments:
 
 repositories:
   - name: nvcf
+{{- if dig "global" "helm" "sources" "url" "" .Values }}
+    url: {{ .Values.global.helm.sources.url | quote }}
+    {{- if dig "global" "helm" "sources" "username" "" .Values }}
+    username: {{ dig "global" "helm" "sources" "username" "" .Values | quote }}
+    {{- end }}
+    {{- if dig "global" "helm" "sources" "password" "" .Values }}
+    password: {{ dig "global" "helm" "sources" "password" "" .Values | quote }}
+    {{- end }}
+{{- else }}
     url: {{ .Values.global.helm.sources.registry }}/{{ .Values.global.helm.sources.repository }}
     oci: true
+{{- end }}
+
 
 helmDefaults:
   createNamespace: true

--- a/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
@@ -8,8 +8,18 @@ environments:
 
 repositories:
   - name: nvcf
+{{- if dig "global" "helm" "sources" "url" "" .Values }}
+    url: {{ .Values.global.helm.sources.url | quote }}
+    {{- if dig "global" "helm" "sources" "username" "" .Values }}
+    username: {{ dig "global" "helm" "sources" "username" "" .Values | quote }}
+    {{- end }}
+    {{- if dig "global" "helm" "sources" "password" "" .Values }}
+    password: {{ dig "global" "helm" "sources" "password" "" .Values | quote }}
+    {{- end }}
+{{- else }}
     url: {{ .Values.global.helm.sources.registry }}/{{ .Values.global.helm.sources.repository }}
     oci: true
+{{- end }}
 
 helmDefaults:
   createNamespace: true


### PR DESCRIPTION
## Why

The Artifact Manifest documents all NVCF Helm charts distributed via HTTP at
`https://helm.ngc.nvidia.com/nvidia/nvcf/`. The helmfile templates
(`01-dependencies.yaml.gotmpl` and `02-core.yaml.gotmpl`) previously hard-coded
`oci: true`, requiring operators to mirror every chart into a private OCI
registry before deploying. This made the HTTP distribution path unusable from
Helmfile directly.

The docs worked around this by documenting a chart-mirroring step, but the
correct fix is to make Helmfile support HTTP chart sources natively so that
the public NGC catalog can be used without mirroring.

## What changed

- `helmfile.d/01-dependencies.yaml.gotmpl`: Added a conditional block to the `repositories` stanza. When `global.helm.sources.url` is set, Helmfile configures an HTTP Helm repository with optional `username`/`password`. When `url` is absent, the existing OCI path (`registry`/`repository` with `oci: true`) is used unchanged.
- `helmfile.d/02-core.yaml.gotmpl`: Same change as `01-dependencies`.
- `environments/base.yaml`: Updated the `helm.sources` comment block to document both Option A (HTTP, `url`/`username`/`password`) and Option B (OCI, `registry`/`repository`).

## Customer Release Notes

Helmfile now supports pulling NVCF Helm charts directly from the NGC public HTTP catalog (`https://helm.ngc.nvidia.com/nvidia/nvcf/`) via `global.helm.sources.url`. OCI registry mirroring is no longer required for operators who can reach the NGC catalog directly.

## Plan Summary

Not applicable.

## Usage

Option A (HTTP, NGC public catalog):

```yaml
global:
  helm:
    sources:
      url: "https://helm.ngc.nvidia.com/nvidia/nvcf"
      username: "$oauthtoken"
      password: "YOUR_NGC_API_KEY"
```

Option B (OCI, existing behavior):

```yaml
global:
  helm:
    sources:
      registry: "nvcr.io"
      repository: "YOUR_ORG/YOUR_TEAM"
```

## Testing

Validated template rendering logic. Backward compatibility with the OCI path is preserved because the `url` key is absent in the default `base.yaml`.

## Notes

The `dig` helper is used to safely test for the presence of `url` so that environments without `url` set continue to use the OCI path without errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring Helm chart sources in either standard HTTP Helm repositories or OCI registries.
  - HTTP chart sources can now include optional authentication credentials.
  - Existing OCI registry configurations remain supported as a fallback when no HTTP URL is provided.

- **Documentation**
  - Expanded Helm chart source configuration guidance with examples for both HTTP and OCI approaches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->