### PR TITLE
fix(self-managed): bump invocation-service chart pin 1.5.5 -> 1.5.6

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -71,7 +71,7 @@ releases:
       - template: service
 
   - name: invocation-service
-    version: 1.5.5
+    version: 1.5.6
     namespace: nvcf
     inherit:
       - template: service


### PR DESCRIPTION
Bumps the self-managed stack's invocation-service chart pin `1.5.5` → `1.5.6`.

Chart 1.5.6 bakes invocation image **0.8.8** — the arm64 SIGTRAP fix (fastbuild zig UBSan traps in jemalloc). Chart 1.5.5 shipped the crashing 0.8.5. Chart 1.5.6 is published to ncp-dev (verified: `appVersion 0.8.8`, `values.image.tag 0.8.8`) via the `deploy/helm/http-invocation/v1.5.6` release.

Related to NVBUG-6451362

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the self-managed deployment configuration to use the latest Invocation Service chart version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->