### PR TITLE
docs(nvca): touch README for review routing

### DIFF
--- a/src/compute-plane-services/nvca/README.md
+++ b/src/compute-plane-services/nvca/README.md
@@ -1,5 +1,7 @@
 # NVIDIA Cloud Functions Agent (NVCA)
 
+<!-- Review-routing touchpoint for compute-plane-owned NVCA docs. -->
+
 NVCA is a Kubernetes agent that manages NVCF Bring-Your-Own-Compute (BYOC) Kubernetes clusters. This repository also contains the **NVCA Operator**, which automates the deployment and lifecycle management of NVCA.
 
 ## Overview


### PR DESCRIPTION
## TL;DR

- Adds a source-only comment in the NVCA README.
- Exercises `/src/compute-plane-services/` CODEOWNERS routing to `@NVIDIA/nvcf-compute-plane-dev`.

## For the Reviewer

- Confirm the PR requests the compute-plane owner set.

## For QA

- `git diff --check`
- No runtime tests run; this is a README comment-only test change.
- QA needed: no.

## Issues

NO-REF

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved NVCA README formatting by properly closing a shell-code example.
  * Added documentation metadata to support review routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->