### PR TITLE
ci(bazel): bump bazel-ci image to 0.13.0

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -309,7 +309,7 @@ jobs:
       # Bazelisk then selects the root .bazelversion release. Update this tag
       # only after the corresponding internal image has been published and
       # mirrored.
-      image: ghcr.io/nvidia/nvcf/bazel-ci:0.12.0
+      image: ghcr.io/nvidia/nvcf/bazel-ci:0.13.0
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bumps the GHA bazel matrix container image `ghcr.io/nvidia/nvcf/bazel-ci` from 0.12.0 to 0.13.0.

0.13.0 prewarms the hermetic rules_go Go SDKs (1.25.0 / 1.25.1 / 1.25.6 / 1.25.10 / 1.25.11) into the image's Bazel repo cache, so cold GHA jobs stop re-downloading them. Built in nvcf/bazel-ci-templates and mirrored to ghcr; this PR's own matrix run validates 0.13.0 across every subtree before merge.

Co-authored-by: Balaji Ganesan <bganesan@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the automated build and validation environment to use a newer Bazel CI image for improved compatibility and reliability.
  * No changes were made to application functionality or user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->