### PR TITLE
fix(worker-init): package ESS config in image

### DIFF
--- a/src/compute-plane-services/worker-init/.bazelrc
+++ b/src/compute-plane-services/worker-init/.bazelrc
@@ -22,6 +22,7 @@ common --enable_bzlmod
 build --incompatible_strict_action_env
 common --enable_platform_specific_config
 common --incompatible_enable_proto_toolchain_resolution
+common --@com_google_protobuf//bazel/toolchains:allow_nonstandard_protoc
 
 test --test_output=errors
 test --test_env=HOME=/tmp

--- a/src/compute-plane-services/worker-init/MODULE.bazel
+++ b/src/compute-plane-services/worker-init/MODULE.bazel
@@ -72,7 +72,6 @@ go_deps.gazelle_override(
     directives = ["gazelle:proto disable_global"],
     path = "github.com/NVIDIA/nvcf/src/libraries/go/lib",
 )
-
 go_deps.gazelle_override(
     build_file_generation = "clean",
     directives = ["gazelle:proto disable_global"],
@@ -98,20 +97,29 @@ use_repo(
     "com_github_samber_lo",
     "com_github_spf13_cobra",
     "com_github_spf13_pflag",
+    "com_github_stretchr_testify",
     "com_github_testcontainers_testcontainers_go",
     "com_github_testcontainers_testcontainers_go_modules_localstack",
     "io_opentelemetry_go_otel",
     "io_opentelemetry_go_otel_trace",
+    "org_golang_google_grpc",
+    "org_golang_google_protobuf",
     "org_golang_x_sync",
     "org_uber_go_zap",
 )
 
 # ============================================================================
-# Prebuilt protoc. Bazel 9 ships with protobuf >= 33.4 which bundles
-# prebuilt protoc binaries. toolchains_protoc is archived and no longer
-# needed. Just enable the flag to use prebuilt protoc instead of
-# compiling from source.
+# Prebuilt protoc toolchain. Keep this aligned with the umbrella module so
+# standalone worker-init image tests do not compile protoc from source.
 # ============================================================================
+bazel_dep(name = "toolchains_protoc", version = "0.6.1")
+bazel_dep(name = "protobuf", version = "33.4", repo_name = "com_google_protobuf")
+
+protoc = use_extension("@toolchains_protoc//protoc:extensions.bzl", "protoc")
+protoc.toolchain(
+    google_protobuf = "com_google_protobuf",
+    version = "v33.0",
+)
 
 # ============================================================================
 # C++ cross-compilation (multi-arch container builds).

--- a/src/compute-plane-services/worker-init/MODULE.bazel.lock
+++ b/src/compute-plane-services/worker-init/MODULE.bazel.lock
@@ -1,5 +1,5 @@
 {
-  "lockFileVersion": 26,
+  "lockFileVersion": 28,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
@@ -224,6 +224,8 @@
     "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.2/source.json": "5fba48bbe0ba48761f9e9f75f92876cafb5d07c0ce059cc7a8027416de94a05b",
     "https://bcr.bazel.build/modules/tar.bzl/0.2.1/MODULE.bazel": "52d1c00a80a8cc67acbd01649e83d8dd6a9dc426a6c0b754a04fe8c219c76468",
     "https://bcr.bazel.build/modules/tar.bzl/0.2.1/source.json": "600ac6ff61744667a439e7b814ae59c1f29632c3984fccf8000c64c9db8d7bb6",
+    "https://bcr.bazel.build/modules/toolchains_protoc/0.6.1/MODULE.bazel": "377cbb438118f413c3361a1dd363da8a42077018473fcdc71a19c203aaf94b17",
+    "https://bcr.bazel.build/modules/toolchains_protoc/0.6.1/source.json": "b14b0b38c8309691bee7a0ab46113678b8675e04e8999294c58e68b036b8dbff",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/yq.bzl/0.1.1/MODULE.bazel": "9039681f9bcb8958ee2c87ffc74bdafba9f4369096a2b5634b88abc0eaefa072",
     "https://bcr.bazel.build/modules/yq.bzl/0.1.1/source.json": "2d2bad780a9f2b9195a4a370314d2c17ae95eaa745cefc2e12fbc49759b15aa3",
@@ -237,7 +239,7 @@
   "moduleExtensions": {
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "Ga4z8lQy1YQ5rAMy+dOl0dqcCEBnYNCXku8x3YQmDZI=",
+        "bzlTransitiveDigest": "+Kp6j204mBZ3mxlIDDR0gBoP45BZ4jYRhRAcB8sU0qc=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedInputs": [
           "REPO_MAPPING:rules_kotlin+,bazel_tools bazel_tools"
@@ -294,8 +296,8 @@
     },
     "@@rules_oci+//oci:extensions.bzl%oci": {
       "general": {
-        "bzlTransitiveDigest": "qGzrjxshR+J4OqW/IYdHPjWbclbeUFswL6msJ9ALGOg=",
-        "usagesDigest": "T10tMQ8VqxNvO6gegj0A6gWUHLdgZAKsdQW6hAYjlJA=",
+        "bzlTransitiveDigest": "pt4oC5w4SZXivjOVNAFM5W2NyEaU5cCGwrSOmM0x9wQ=",
+        "usagesDigest": "3rI6ePVZWxlU+BLWSwsiOiw1KcukikjMM96tsOWXQk8=",
         "recordedInputs": [
           "REPO_MAPPING:aspect_bazel_lib+,bazel_tools bazel_tools",
           "REPO_MAPPING:bazel_features+,bazel_tools bazel_tools",
@@ -307,13 +309,11 @@
           "distroless_go_linux_amd64": {
             "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_pull",
             "attributes": {
-              "www_authenticate_challenges": {
-                "urm.nvidia.com": "Bearer realm=\"https://urm.nvidia.com/artifactory/api/docker/null/v2/token\",service=\"urm.nvidia.com\",scope=\"repository:{repository}:pull\""
-              },
+              "www_authenticate_challenges": {},
               "scheme": "https",
-              "registry": "urm.nvidia.com",
-              "repository": "sw-gpu-ucs-hardened-docker/distroless/go",
-              "identifier": "sha256:d8dce9196ddb44921bc018cc240992850e7b7a46e76cc982555f8c80763507b6",
+              "registry": "nvcr.io",
+              "repository": "nvidia/distroless/go",
+              "identifier": "sha256:2ae1c3f90de1735fefb2a951977b7e78aa1c691f345d58c87b0d6bb7eff4f4d5",
               "platform": "linux/amd64",
               "target_name": "distroless_go_linux_amd64",
               "bazel_tags": []
@@ -322,13 +322,11 @@
           "distroless_go_linux_arm64_v8": {
             "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_pull",
             "attributes": {
-              "www_authenticate_challenges": {
-                "urm.nvidia.com": "Bearer realm=\"https://urm.nvidia.com/artifactory/api/docker/null/v2/token\",service=\"urm.nvidia.com\",scope=\"repository:{repository}:pull\""
-              },
+              "www_authenticate_challenges": {},
               "scheme": "https",
-              "registry": "urm.nvidia.com",
-              "repository": "sw-gpu-ucs-hardened-docker/distroless/go",
-              "identifier": "sha256:d8dce9196ddb44921bc018cc240992850e7b7a46e76cc982555f8c80763507b6",
+              "registry": "nvcr.io",
+              "repository": "nvidia/distroless/go",
+              "identifier": "sha256:2ae1c3f90de1735fefb2a951977b7e78aa1c691f345d58c87b0d6bb7eff4f4d5",
               "platform": "linux/arm64/v8",
               "target_name": "distroless_go_linux_arm64_v8",
               "bazel_tags": []
@@ -338,13 +336,11 @@
             "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_alias",
             "attributes": {
               "target_name": "distroless_go",
-              "www_authenticate_challenges": {
-                "urm.nvidia.com": "Bearer realm=\"https://urm.nvidia.com/artifactory/api/docker/null/v2/token\",service=\"urm.nvidia.com\",scope=\"repository:{repository}:pull\""
-              },
+              "www_authenticate_challenges": {},
               "scheme": "https",
-              "registry": "urm.nvidia.com",
-              "repository": "sw-gpu-ucs-hardened-docker/distroless/go",
-              "identifier": "sha256:d8dce9196ddb44921bc018cc240992850e7b7a46e76cc982555f8c80763507b6",
+              "registry": "nvcr.io",
+              "repository": "nvidia/distroless/go",
+              "identifier": "sha256:2ae1c3f90de1735fefb2a951977b7e78aa1c691f345d58c87b0d6bb7eff4f4d5",
               "platforms": {
                 "@@platforms//cpu:x86_64": "@distroless_go_linux_amd64",
                 "@@platforms//cpu:arm64": "@distroless_go_linux_arm64_v8"
@@ -481,7 +477,7 @@
     },
     "@@rules_python+//python/extensions:config.bzl%config": {
       "general": {
-        "bzlTransitiveDigest": "iibnRYgg8LpcfmH7EAnVwYePC3jsVaJ6Id8XxUjSZps=",
+        "bzlTransitiveDigest": "dzD8Q2YmrP3fz8saWLHPmlwPLO91ImtTmP/c9JKTStM=",
         "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
         "recordedInputs": [
           "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
@@ -843,5 +839,6 @@
         ]
       }
     }
-  }
+  },
+  "factsVersions": {}
 }

--- a/src/compute-plane-services/worker-init/cmd/BUILD.bazel
+++ b/src/compute-plane-services/worker-init/cmd/BUILD.bazel
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//rules/oci:defs.bzl", "go_oci_image")
 
 go_library(
@@ -46,6 +46,15 @@ go_oci_image(
     name = "image",
     base = "@distroless_go",
     binary = ":worker-init",
+    # SetupEssAgent reads these files when a function uses secrets.
+    extra_layers = ["//pkg/ess:ess_config_layer"],
     tags = ["nvcf-worker-init"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "image_ess_config_test",
+    srcs = ["image_ess_config_test.go"],
+    args = ["-image_tar=$(location :image.tar)"],
+    data = [":image.tar"],
 )

--- a/src/compute-plane-services/worker-init/cmd/image_ess_config_test.go
+++ b/src/compute-plane-services/worker-init/cmd/image_ess_config_test.go
@@ -1,0 +1,144 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"archive/tar"
+	"bufio"
+	"compress/gzip"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var imageTar = flag.String("image_tar", "", "path to the worker-init image tarball")
+
+func TestImageContainsESSConfig(t *testing.T) {
+	if *imageTar == "" {
+		t.Fatal("-image_tar is required")
+	}
+
+	imagePath := resolveRunfile(*imageTar)
+	file, err := os.Open(imagePath)
+	if err != nil {
+		t.Fatalf("open image tarball %q: %v", imagePath, err)
+	}
+	defer file.Close()
+
+	required := []string{
+		"etc/ess/config.hcl",
+		"etc/ess/secrets.tmpl",
+		"etc/ess/accounts-secrets.tmpl",
+	}
+	found := make(map[string]bool, len(required))
+
+	image := tar.NewReader(file)
+	for {
+		header, err := image.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("read image tarball: %v", err)
+		}
+		if !header.FileInfo().Mode().IsRegular() {
+			continue
+		}
+
+		// Docker image tarballs contain metadata and layer archives. Non-tar
+		// entries are expected and ignored.
+		if err := scanLayer(io.LimitReader(image, header.Size), found); err != nil {
+			continue
+		}
+		if containsAll(found, required) {
+			return
+		}
+	}
+
+	var missing []string
+	for _, path := range required {
+		if !found[path] {
+			missing = append(missing, "/"+path)
+		}
+	}
+	t.Fatalf("worker-init image is missing required ESS files: %s", strings.Join(missing, ", "))
+}
+
+func resolveRunfile(path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	if _, err := os.Stat(path); err == nil {
+		return path
+	}
+
+	runfilesDir := os.Getenv("TEST_SRCDIR")
+	workspace := os.Getenv("TEST_WORKSPACE")
+	if runfilesDir != "" && workspace != "" {
+		return filepath.Join(runfilesDir, workspace, path)
+	}
+	return path
+}
+
+func scanLayer(reader io.Reader, found map[string]bool) error {
+	buffered := bufio.NewReader(reader)
+	layerReader := io.Reader(buffered)
+
+	magic, err := buffered.Peek(2)
+	if err != nil {
+		return err
+	}
+	if magic[0] == 0x1f && magic[1] == 0x8b {
+		compressed, err := gzip.NewReader(buffered)
+		if err != nil {
+			return err
+		}
+		defer compressed.Close()
+		layerReader = compressed
+	}
+
+	layer := tar.NewReader(layerReader)
+	for {
+		header, err := layer.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read layer: %w", err)
+		}
+		if !header.FileInfo().Mode().IsRegular() {
+			continue
+		}
+
+		path := strings.TrimPrefix(strings.TrimPrefix(header.Name, "./"), "/")
+		found[path] = true
+	}
+}
+
+func containsAll(found map[string]bool, required []string) bool {
+	for _, path := range required {
+		if !found[path] {
+			return false
+		}
+	}
+	return true
+}

--- a/src/compute-plane-services/worker-init/pkg/ess/BUILD.bazel
+++ b/src/compute-plane-services/worker-init/pkg/ess/BUILD.bazel
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 go_library(
     name = "ess",
@@ -37,4 +39,20 @@ go_test(
     deps = [
         "@com_github_hashicorp_hcl_v2//hclsimple",
     ],
+)
+
+# Raw ESS configuration consumed by SetupEssAgent from /etc/ess.
+pkg_files(
+    name = "ess_config_files",
+    srcs = glob(["configs/*"]),
+    prefix = "/etc/ess",
+    strip_prefix = strip_prefix.from_pkg("configs"),
+    visibility = ["//visibility:private"],
+)
+
+pkg_tar(
+    name = "ess_config_layer",
+    srcs = [":ess_config_files"],
+    extension = "tar.gz",
+    visibility = ["//cmd:__pkg__"],
 )

--- a/src/compute-plane-services/worker-init/rules/oci/private/go.bzl
+++ b/src/compute-plane-services/worker-init/rules/oci/private/go.bzl
@@ -19,7 +19,7 @@ load("@rules_pkg//pkg:mappings.bzl", "strip_prefix")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//rules/oci/private:common.bzl", "DEFAULT_BASE", "create_oci_image")
 
-def _go_oci_image_impl(name, visibility, binary, base, entrypoint, registry, tags):
+def _go_oci_image_impl(name, visibility, binary, base, entrypoint, registry, tags, extra_layers):
     layer_name = name + "_layer"
 
     # Place the binary at /<basename> in the layer tarball. Without
@@ -46,7 +46,7 @@ def _go_oci_image_impl(name, visibility, binary, base, entrypoint, registry, tag
 
     create_oci_image(
         name = name,
-        tars = [layer_name],
+        tars = [layer_name] + list(extra_layers),
         base = base,
         entrypoint = entry,
         visibility = visibility,
@@ -66,6 +66,10 @@ go_oci_image = macro(
         "base": attr.label(
             doc = "Base OCI image.",
             default = DEFAULT_BASE,
+            configurable = False,
+        ),
+        "extra_layers": attr.label_list(
+            doc = "Additional pkg_tar layers to stack on top of the binary layer.",
             configurable = False,
         ),
         "entrypoint": attr.string_list(


### PR DESCRIPTION
Restore secret-bearing deployments by layering the required ESS configuration into the worker-init image and guarding its contents with a Go regression test.

Refs #406

## TL;DR
The released `worker-init` image shipped only the binary and omitted the ESS files under `/etc/ess`. Secret-bearing function deployments then failed during ESS setup. This change packages `config.hcl`, `secrets.tmpl`, and `accounts-secrets.tmpl` into the image and adds a Go regression test that fails if any of those files are missing.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
- Parent epic: #404
- Phase 1 of the ordered repair tracked by #406
- Source configs already lived in `pkg/ess/configs/`; the Bazel OCI image build did not include them
- `go_oci_image` now accepts `extra_layers`, and `cmd:image` stacks an ESS config layer at `/etc/ess`
- Standalone worker-init Bazel/protoc wiring was aligned so the image-content test can build reliably
- Chart/stack consumption remains out of scope and begins in #408 after a fixed worker-init image is published

## For the Reviewer
Please focus on:
- `src/compute-plane-services/worker-init/pkg/ess/BUILD.bazel`
- `src/compute-plane-services/worker-init/cmd/BUILD.bazel`
- `src/compute-plane-services/worker-init/cmd/image_ess_config_test.go`
- `src/compute-plane-services/worker-init/rules/oci/private/go.bzl`

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
Verified locally from `src/compute-plane-services/worker-init`:

```bash
bazel test //cmd:image_ess_config_test //pkg/ess:ess_test --test_output=errors
```

Both tests passed. Image-content coverage confirms:
- `/etc/ess/config.hcl`
- `/etc/ess/secrets.tmpl`
- `/etc/ess/accounts-secrets.tmpl`

QA Needed? No for this packaging fix beyond the automated image-content test. End-to-end secret-bearing deployment validation is covered by later phases (#407, #405).

## Issues
Relates to #406
Relates to #404

NO-REF

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worker-init container images now include ESS configuration files under `/etc/ess`.
  * Added support for layering additional packaged files into OCI images.

* **Bug Fixes**
  * Improved build configuration for consistent Protobuf toolchain usage and Go dependency resolution.

* **Tests**
  * Added validation to confirm required ESS configuration and secret template files are present in the container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->