### PR TITLE
fix(cassandra): render migration replica count

### DIFF
--- a/docs/user/release-notes/0.6.0-to-0.6.1-upgrade.md
+++ b/docs/user/release-notes/0.6.0-to-0.6.1-upgrade.md
@@ -232,6 +232,7 @@ succeed:
    Apply the Cassandra release and wait for its migration job:
 
    ```bash
+   set -euo pipefail
    make install HELMFILE_ENV="$HELMFILE_ENV" HELMFILE_SELECTOR=name=cassandra
    kubectl -n cassandra-system wait \
      --for=condition=complete job/cassandra-migrations --timeout=10m
@@ -241,8 +242,7 @@ succeed:
    The logs must end with `All Cassandra migrations completed successfully`.
    Do not continue if the job failed or timed out.
 
-6. Confirm that every application keyspace created by the migration job
-   includes both datacenters:
+6. Inventory application keyspace replication after the migration job:
 
    ```sql
    SELECT keyspace_name, replication
@@ -260,6 +260,9 @@ succeed:
      '<new-datacenter>': <rf>
    };
    ```
+
+   Run the `system_schema.keyspaces` query again. Confirm that every application
+   keyspace lists both datacenters before continuing.
 
    If a newly created keyspace already contains data, rebuild that keyspace on
    each new-datacenter node before continuing:

--- a/docs/user/release-notes/0.6.0-to-0.6.1-upgrade.md
+++ b/docs/user/release-notes/0.6.0-to-0.6.1-upgrade.md
@@ -90,6 +90,23 @@ kubectl -n cassandra-system exec cassandra-0 -c cassandra -- \
   cqlsh -u <user> -p <password> -e "DESCRIBE KEYSPACES;"
 ```
 
+Check the existing schema migration state:
+
+```sql
+SELECT table_name
+FROM system_schema.tables
+WHERE keyspace_name = 'schema_migrations';
+```
+
+For each table returned, run:
+
+```sql
+SELECT version, dirty FROM schema_migrations.<table-name>;
+```
+
+Every migration record must have `dirty` set to `false`. If any record is
+dirty, reconcile that partial migration before starting this upgrade.
+
 <Warning>
 Take a backup before migrating. On every node, run
 `nodetool flush` and then `nodetool snapshot`, and copy the snapshots off-node.
@@ -161,15 +178,13 @@ succeed:
    Cassandra nodes with the same cluster name as the existing cluster, a
    distinct datacenter name, seeds that reach the existing datacenter, and
    `auto_bootstrap: false` so the new nodes join without streaming during
-   bootstrap. Do not run the schema-initialization or migration jobs against the
-   new datacenter: the schema already exists in the cluster and the new nodes
-   receive it through gossip. Disable them in the new datacenter's values with
+   bootstrap. Do not run the schema-initialization or migration jobs yet. The
+   schema already exists in the cluster, and the new nodes receive it through
+   gossip. Disable both jobs in the new datacenter's values with
    `cassandra.hooks.initializeCluster.enabled: false` and
-   `cassandra.hooks.migrations.enabled: false`. This matters because the
-   migrations include destructive `ALTER` statements and the new datacenter is
-   not yet in every keyspace's replication (that happens in step 3): running the
-   migration job there can re-apply those statements from an earlier tracked
-   version and race the existing schema.
+   `cassandra.hooks.migrations.enabled: false`. Keep them disabled until the new
+   datacenter is included in the application and migration-state keyspaces in
+   step 3.
 
 2. Confirm both datacenters are visible and healthy from a node in either
    datacenter:
@@ -181,8 +196,10 @@ succeed:
    Every node should report `UN`. The new datacenter nodes appear with no or
    minimal load until the rebuild in step 4.
 
-3. Extend replication for every application keyspace, and for `system_auth`,
-   `system_distributed`, and `system_traces`, to include the new datacenter.
+3. Extend replication for every application keyspace, `schema_migrations`,
+   `system_auth`, `system_distributed`, and `system_traces` to include the new
+   datacenter. Replicating `schema_migrations` preserves the version and dirty
+   state that the 0.6.1 migration job uses to apply only pending migrations.
    For each keyspace:
 
    ```sql
@@ -200,11 +217,77 @@ succeed:
      nodetool rebuild -- <old-datacenter>
    ```
 
-5. Move clients to the new datacenter. Point application traffic at the new
+5. Run the pending 0.6.1 schema migrations before moving clients. Keep cluster
+   initialization disabled and enable only the migration hook:
+
+   ```yaml
+   cassandra:
+     hooks:
+       initializeCluster:
+         enabled: false
+       migrations:
+         enabled: true
+   ```
+
+   Apply the Cassandra release and wait for its migration job:
+
+   ```bash
+   make install HELMFILE_ENV="$HELMFILE_ENV" HELMFILE_SELECTOR=name=cassandra
+   kubectl -n cassandra-system wait \
+     --for=condition=complete job/cassandra-migrations --timeout=10m
+   kubectl -n cassandra-system logs job/cassandra-migrations
+   ```
+
+   The logs must end with `All Cassandra migrations completed successfully`.
+   Do not continue if the job failed or timed out.
+
+6. Confirm that every application keyspace created by the migration job
+   includes both datacenters:
+
+   ```sql
+   SELECT keyspace_name, replication
+   FROM system_schema.keyspaces;
+   ```
+
+   The 0.6.1 migrations add the `event_ledger` keyspace. Update its replication,
+   and repeat this operation for any other application keyspace that does not
+   list both datacenters:
+
+   ```sql
+   ALTER KEYSPACE event_ledger WITH replication = {
+     'class': 'NetworkTopologyStrategy',
+     '<old-datacenter>': <rf>,
+     '<new-datacenter>': <rf>
+   };
+   ```
+
+   If a newly created keyspace already contains data, rebuild that keyspace on
+   each new-datacenter node before continuing:
+
+   ```bash
+   kubectl -n cassandra-system exec <new-dc-pod> -c cassandra -- \
+     nodetool rebuild -ks <keyspace> -- <old-datacenter>
+   ```
+
+7. Confirm the migration state is clean:
+
+   ```sql
+   SELECT version, dirty FROM schema_migrations.api_keys_api;
+   SELECT version, dirty FROM schema_migrations.ess_api;
+   SELECT version, dirty FROM schema_migrations.event_ledger;
+   SELECT version, dirty FROM schema_migrations.nvcf_api;
+   SELECT version, dirty FROM schema_migrations.sis_api;
+   ```
+
+   Each query must return one record with `dirty` set to `false`. This confirms
+   that the cluster can receive later schema migrations. Do not move clients or
+   remove the old datacenter while a migration is missing or dirty.
+
+8. Move clients to the new datacenter. Point application traffic at the new
    datacenter using `LOCAL_QUORUM` against the new datacenter name, and confirm
    reads and writes succeed there.
 
-6. Remove the old datacenter from replication, then decommission it. Alter every
+9. Remove the old datacenter from replication, then decommission it. Alter every
    keyspace again to drop the old datacenter from the replication map, then
    decommission the old-datacenter nodes and remove the old stack.
 
@@ -307,3 +390,7 @@ kubectl get pods -A | grep -vE 'Running|Completed|READY'
 
 This command should print nothing. Any output is a pod that is not yet
 `Running` or `Completed`.
+
+Finally, query each table in the `schema_migrations` keyspace as described in
+the pre-migration check. Every record must have `dirty` set to `false` before
+you consider the upgrade complete.

--- a/migrations/cassandra/README.md
+++ b/migrations/cassandra/README.md
@@ -62,10 +62,11 @@ The container reads the following environment variables:
 | `CASSANDRA_USER` | Cassandra superuser used to apply DDL |
 | `CASSANDRA_PASSWORD` | Cassandra superuser password |
 | `SERVICE_ROLE_PASSWORD` | Substituted into the per-keyspace login role passwords (`02_init_roles.up.sql`) |
+| `REPLICA_COUNT` | Replication factor for service keyspaces (defaults to `3`) |
 
 For each keyspace under `keyspaces/`, the container:
 
-1. Pre-processes any `*.up.sql` and `*.cql` files via `envsubst` so that `${SERVICE_ROLE_PASSWORD}` is substituted (other environment variables are intentionally not substituted).
+1. Pre-processes any `*.up.sql` and `*.cql` files via `envsubst` so that `${SERVICE_ROLE_PASSWORD}` and `${REPLICA_COUNT}` are substituted (other environment variables are intentionally not substituted).
 2. Runs `migrate up` with the `cassandra://` driver, using the keyspace name as the migrations table name.
 
 A failure in any keyspace's migration set stops the run.
@@ -93,9 +94,9 @@ cqlsh -u "$CASSANDRA_USER" -p "$CASSANDRA_PASSWORD" "$CASSANDRA_HOSTS" \
 
 The migration may have applied some statements before the failure. Decide whether to roll the schema back to `<N-1>` or roll it forward to `<N>`:
 
-- **Re-apply migration `<N>` from `<N-1>`** (recommended when the migration is fully idempotent). Most bundled migrations use `CREATE TABLE IF NOT EXISTS`, `CREATE TYPE IF NOT EXISTS`, and similar idempotent forms; if the failing file is fully idempotent, fix the root cause of the failure (network, capacity, malformed CQL) and re-running migration `<N>` will be safe. Plan to `force <N-1>` in step 3.
-- **Roll back manually** to `<N-1>`. If the migration is not idempotent, drop any tables / types / columns the partial run created so the schema matches the post-`<N-1>` state, then `force <N-1>` in step 3.
-- **Roll forward manually** to `<N>`. Run the remaining CQL statements from `<N>` by hand so the schema matches the post-`<N>` state, then `force <N>` in step 3.
+- Re-apply migration `<N>` from `<N-1>` (recommended when the migration is fully idempotent). Most bundled migrations use `CREATE TABLE IF NOT EXISTS`, `CREATE TYPE IF NOT EXISTS`, and similar idempotent forms; if the failing file is fully idempotent, fix the root cause of the failure (network, capacity, malformed CQL) and re-running migration `<N>` will be safe. Plan to `force <N-1>` in step 3.
+- Roll back manually to `<N-1>`. If the migration is not idempotent, drop any tables / types / columns the partial run created so the schema matches the post-`<N-1>` state, then `force <N-1>` in step 3.
+- Roll forward manually to `<N>`. Run the remaining CQL statements from `<N>` by hand so the schema matches the post-`<N>` state, then `force <N>` in step 3.
 
 #### 3. Clear the dirty flag and re-run
 
@@ -149,7 +150,7 @@ NN_description.up.sql
 
 For a brand-new keyspace, the conventional sequence is:
 
-1. `01_init_keyspace.up.sql` - creates the keyspace with `NetworkTopologyStrategy` (uses `{{ $replicaCount }}` template variable, substituted upstream).
+1. `01_init_keyspace.up.sql` - creates the keyspace with `NetworkTopologyStrategy` and substitutes `${REPLICA_COUNT}` before migration.
 2. `02_init_roles.up.sql` - creates the application role and grants, with the login password supplied by `${SERVICE_ROLE_PASSWORD}`.
 3. `03_init_tables.up.sql` - the canonical schema (UDTs, tables, indexes) for the keyspace.
 

--- a/migrations/cassandra/README.md
+++ b/migrations/cassandra/README.md
@@ -66,7 +66,7 @@ The container reads the following environment variables:
 
 For each keyspace under `keyspaces/`, the container:
 
-1. Pre-processes any `*.up.sql` and `*.cql` files via `envsubst` so that `${SERVICE_ROLE_PASSWORD}` and `${REPLICA_COUNT}` are substituted (other environment variables are intentionally not substituted).
+1. Pre-processes any `*.sql` and `*.cql` files via `envsubst` so that `${SERVICE_ROLE_PASSWORD}` and `${REPLICA_COUNT}` are substituted (other environment variables are intentionally not substituted).
 2. Runs `migrate up` with the `cassandra://` driver, using the keyspace name as the migrations table name.
 
 A failure in any keyspace's migration set stops the run.

--- a/migrations/cassandra/execute_sqls.sh
+++ b/migrations/cassandra/execute_sqls.sh
@@ -15,18 +15,6 @@
 # limitations under the License.
 
 
-timeout=120
-interval=5
-while [ $timeout -gt 0 ]; do
-  if nc -z -w 1 ${CASSANDRA_HOSTS} 9042; then
-    echo "Cassandra hosts are up"
-    break
-  fi
-  echo "Waiting for Cassandra hosts to be available..."
-  sleep $interval
-  timeout=$((timeout - interval))
-done
-
 # Verify the superuser and the cqlsh listener is available
 max_retries=10 # 10 * 1s = 10s
 attempt=1
@@ -43,11 +31,14 @@ echo "Cassandra cqlsh superuser is available"
 
 #
 # Pre-process SQL files with environment variable substitution
-# This allows configurable values like SERVICE_ROLE_PASSWORD
+# This allows configurable values like SERVICE_ROLE_PASSWORD and REPLICA_COUNT
 #
 # SECURITY: Only explicitly listed variables are substituted to prevent
 # unintended substitution of other environment variables
-ENVSUBST_VARS='$SERVICE_ROLE_PASSWORD'
+REPLICA_COUNT=${REPLICA_COUNT:-3}
+export REPLICA_COUNT
+# shellcheck disable=SC2016
+ENVSUBST_VARS='$SERVICE_ROLE_PASSWORD $REPLICA_COUNT'
 
 TEMP_KEYSPACES="/tmp/keyspaces"
 echo "Pre-processing SQL files with environment variable substitution..."

--- a/migrations/cassandra/execute_sqls.sh
+++ b/migrations/cassandra/execute_sqls.sh
@@ -14,6 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+REPLICA_COUNT=${REPLICA_COUNT:-3}
+case "$REPLICA_COUNT" in
+  ''|*[!0-9]*|0)
+    echo "REPLICA_COUNT must be an integer from 1 to 2147483647" >&2
+    exit 1
+    ;;
+esac
+if [ "${#REPLICA_COUNT}" -gt 10 ] || [ "$REPLICA_COUNT" -gt 2147483647 ]; then
+  echo "REPLICA_COUNT must be an integer from 1 to 2147483647" >&2
+  exit 1
+fi
+export REPLICA_COUNT
 
 # Verify the superuser and the cqlsh listener is available
 max_retries=10 # 10 * 1s = 10s
@@ -35,8 +47,6 @@ echo "Cassandra cqlsh superuser is available"
 #
 # SECURITY: Only explicitly listed variables are substituted to prevent
 # unintended substitution of other environment variables
-REPLICA_COUNT=${REPLICA_COUNT:-3}
-export REPLICA_COUNT
 # shellcheck disable=SC2016
 ENVSUBST_VARS='$SERVICE_ROLE_PASSWORD $REPLICA_COUNT'
 

--- a/migrations/cassandra/execute_sqls.sh
+++ b/migrations/cassandra/execute_sqls.sh
@@ -16,13 +16,13 @@
 
 REPLICA_COUNT=${REPLICA_COUNT:-3}
 case "$REPLICA_COUNT" in
-  ''|*[!0-9]*|0)
-    echo "REPLICA_COUNT must be an integer from 1 to 2147483647" >&2
+  ''|*[!0-9]*|0*)
+    echo "ERROR: REPLICA_COUNT must be an integer from 1 to 2147483647, got: $REPLICA_COUNT" >&2
     exit 1
     ;;
 esac
 if [ "${#REPLICA_COUNT}" -gt 10 ] || [ "$REPLICA_COUNT" -gt 2147483647 ]; then
-  echo "REPLICA_COUNT must be an integer from 1 to 2147483647" >&2
+  echo "ERROR: REPLICA_COUNT must be an integer from 1 to 2147483647, got: $REPLICA_COUNT" >&2
   exit 1
 fi
 export REPLICA_COUNT

--- a/migrations/cassandra/keyspaces/README.md
+++ b/migrations/cassandra/keyspaces/README.md
@@ -9,7 +9,7 @@ Migrations are applied in filename order and follow the naming convention:
 NN_description.up.sql
 ```
 
-The schemas in this directory follow a **clean-slate** model — there are no delta
+The schemas in this directory follow a clean-slate model. There are no delta
 `ALTER TABLE` migrations. Each `03_init_tables.up.sql` represents the complete,
 canonical schema for its keyspace at the pinned upstream service version. When the
 upstream schema changes, `03_init_tables.up.sql` is updated in place and the
@@ -29,7 +29,7 @@ pinned version reference is bumped accordingly.
 | `nvct_api`        | [nvct_api/03_init_tables.up.sql](nvct_api/03_init_tables.up.sql)               | `v1.5.2`       | `a0247478` |
 | `sis_api`         | [sis_api/03_init_tables.up.sql](sis_api/03_init_tables.up.sql)                 | `v1.531.2`     | `8a492a2e` |
 
-> **Note — `sis_api`:** The upstream SoT is under active clarification. The schema
+> Note: The upstream source of truth for `sis_api` is under active clarification. The schema
 > was sourced from `nvcf/nvcf-spot/spot@v1.517.0`. A competing source
 > (`kaizen-data/helenus/schemas/gfn-core/spot`) was identified during analysis but
 > has not been confirmed as authoritative. Review before the next schema update.
@@ -40,9 +40,9 @@ pinned version reference is bumped accordingly.
 
 | File                      | Purpose                                                                                                                                                                                                            |
 |---------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `01_init_keyspace.up.sql` | Creates the keyspace with `NetworkTopologyStrategy` replication. Uses `{{ $replicaCount }}` template variable.                                                                                                     |
+| `01_init_keyspace.up.sql` | Creates the keyspace with `NetworkTopologyStrategy` replication. Uses `${REPLICA_COUNT}`, which the entrypoint substitutes before migration.                                                                    |
 | `02_init_roles.up.sql`    | Creates the application role, grants privileges, and sets the service login password via `${SERVICE_ROLE_PASSWORD}`.                                                                                               |
-| `03_init_tables.up.sql`   | Complete canonical schema — all UDTs, tables, and indexes at the pinned upstream version.                                                                                                                          |
+| `03_init_tables.up.sql`   | Complete canonical schema with all UDTs, tables, and indexes at the pinned upstream version.                                                                                                                       |
 | `04_*`, `05_*`, `06_*`    | Incremental deltas for rolling upgrades. These add tables/columns that are not in `03_init_tables.up.sql` at the version that was applied on existing clusters. `ess_api/04_*` is a data seed (deployment-specific values). `sis_api/04_*`-`06_*` and `nvcf_api/04_*`-`05_*` are DDL deltas. |
 
 ---
@@ -51,7 +51,7 @@ pinned version reference is bumped accordingly.
 
 ### Clean-Slate Model
 
-This repo does **not** use incremental `ALTER TABLE` migrations for fresh
+This repo does not use incremental `ALTER TABLE` migrations for fresh
 installations. The `03_init_tables.up.sql` file always reflects the full desired
 schema. This avoids the complexity of replaying a long chain of deltas on new
 clusters.
@@ -61,8 +61,8 @@ clusters.
 We are consumers/specializations of upstream services. When updating schemas from
 upstream:
 
-- **DDL (table/type definitions)** — follow the upstream SoT exactly.
-- **Data seeds and configuration values** — use **our** values (service endpoints,
+- DDL (table/type definitions): follow the upstream source of truth exactly.
+- Data seeds and configuration values: use our values (service endpoints,
   client IDs, etc.), not the upstream's local dev defaults. The upstream's seed
   files (e.g. `ncp.cql` in ess-api-service) are for their own test environments
   and are not authoritative for our deployment.
@@ -84,5 +84,5 @@ upstream:
    - Dropped tables or columns
    - Any data/config values that must use our deployment's values
 4. Update `03_init_tables.up.sql` in place.
-5. Update the **Schema Sources** table in this README with the new version and
+5. Update the Schema Sources table in this README with the new version and
    commit SHA.

--- a/migrations/cassandra/keyspaces/api_keys_api/01_init_keyspace.up.sql
+++ b/migrations/cassandra/keyspaces/api_keys_api/01_init_keyspace.up.sql
@@ -1,2 +1,1 @@
-{{ $replicaCount := envOrDefault "REPLICA_COUNT" "3" }}
-CREATE KEYSPACE IF NOT EXISTS api_keys_api WITH replication = {'class': 'NetworkTopologyStrategy', 'ncp': '{{ $replicaCount }}' }  AND durable_writes = true;
+CREATE KEYSPACE IF NOT EXISTS api_keys_api WITH replication = {'class': 'NetworkTopologyStrategy', 'ncp': '${REPLICA_COUNT}' }  AND durable_writes = true;

--- a/migrations/cassandra/keyspaces/ess_api/01_init_keyspace.up.sql
+++ b/migrations/cassandra/keyspaces/ess_api/01_init_keyspace.up.sql
@@ -1,2 +1,1 @@
-{{ $replicaCount := envOrDefault "REPLICA_COUNT" "3" }}
-CREATE KEYSPACE IF NOT EXISTS ess_api WITH replication = {'class': 'NetworkTopologyStrategy', 'ncp': '{{ $replicaCount }}' }  AND durable_writes = true;
+CREATE KEYSPACE IF NOT EXISTS ess_api WITH replication = {'class': 'NetworkTopologyStrategy', 'ncp': '${REPLICA_COUNT}' }  AND durable_writes = true;

--- a/migrations/cassandra/keyspaces/event_ledger/01_init_keyspace.up.sql
+++ b/migrations/cassandra/keyspaces/event_ledger/01_init_keyspace.up.sql
@@ -1,2 +1,1 @@
-{{ $replicaCount := envOrDefault "REPLICA_COUNT" "3" }}
-CREATE KEYSPACE IF NOT EXISTS event_ledger WITH replication = {'class': 'NetworkTopologyStrategy', 'ncp': '{{ $replicaCount }}' }  AND durable_writes = true;
+CREATE KEYSPACE IF NOT EXISTS event_ledger WITH replication = {'class': 'NetworkTopologyStrategy', 'ncp': '${REPLICA_COUNT}' }  AND durable_writes = true;

--- a/migrations/cassandra/keyspaces/nvcf_api/01_init_keyspace.up.sql
+++ b/migrations/cassandra/keyspaces/nvcf_api/01_init_keyspace.up.sql
@@ -1,2 +1,1 @@
-{{ $replicaCount := envOrDefault "REPLICA_COUNT" "3" }}
-CREATE KEYSPACE IF NOT EXISTS nvcf_api WITH replication = {'class': 'NetworkTopologyStrategy', 'ncp': '{{ $replicaCount }}' }  AND durable_writes = true;
+CREATE KEYSPACE IF NOT EXISTS nvcf_api WITH replication = {'class': 'NetworkTopologyStrategy', 'ncp': '${REPLICA_COUNT}' }  AND durable_writes = true;

--- a/migrations/cassandra/keyspaces/sis_api/01_init_keyspace.up.sql
+++ b/migrations/cassandra/keyspaces/sis_api/01_init_keyspace.up.sql
@@ -1,2 +1,1 @@
-{{ $replicaCount := envOrDefault "REPLICA_COUNT" "3" }}
-CREATE KEYSPACE IF NOT EXISTS sis_api WITH replication = {'class': 'NetworkTopologyStrategy', 'ncp': '{{ $replicaCount }}' }  AND durable_writes = true;
+CREATE KEYSPACE IF NOT EXISTS sis_api WITH replication = {'class': 'NetworkTopologyStrategy', 'ncp': '${REPLICA_COUNT}' }  AND durable_writes = true;

--- a/migrations/cassandra/tests/test-execute-sqls.sh
+++ b/migrations/cassandra/tests/test-execute-sqls.sh
@@ -31,6 +31,21 @@ if ! grep -F -q 'REPLICA_COUNT=${REPLICA_COUNT:-3}' "${script}"; then
   fail "execute_sqls.sh does not preserve the default replica count"
 fi
 
+# shellcheck disable=SC2016
+replica_count_validation=$(
+  sed -n '/^REPLICA_COUNT=${REPLICA_COUNT:-3}$/,/^export REPLICA_COUNT$/p' "${script}"
+)
+for replica_count in 1 3 2147483647; do
+  if ! REPLICA_COUNT="${replica_count}" sh -c "${replica_count_validation}"; then
+    fail "execute_sqls.sh rejects valid replica count ${replica_count}"
+  fi
+done
+for replica_count in 0 -1 invalid 2147483648 99999999999; do
+  if REPLICA_COUNT="${replica_count}" sh -c "${replica_count_validation}" 2>/dev/null; then
+    fail "execute_sqls.sh accepts invalid replica count ${replica_count}"
+  fi
+done
+
 for migration in "${keyspaces}"/*/01_init_keyspace.up.sql; do
   rendered=$(
     REPLICA_COUNT=2 SERVICE_ROLE_PASSWORD=test-password \
@@ -46,7 +61,7 @@ for migration in "${keyspaces}"/*/01_init_keyspace.up.sql; do
   fi
 done
 
-if grep -q 'nc -z' "${script}"; then
+if grep -Eq '(^|[[:space:]])nc([[:space:]]|$)' "${script}"; then
   fail "execute_sqls.sh depends on netcat even though the image does not install it"
 fi
 

--- a/migrations/cassandra/tests/test-execute-sqls.sh
+++ b/migrations/cassandra/tests/test-execute-sqls.sh
@@ -40,7 +40,7 @@ for replica_count in 1 3 2147483647; do
     fail "execute_sqls.sh rejects valid replica count ${replica_count}"
   fi
 done
-for replica_count in 0 -1 invalid 2147483648 99999999999; do
+for replica_count in 0 01 -1 invalid 2147483648 99999999999; do
   if REPLICA_COUNT="${replica_count}" sh -c "${replica_count_validation}" 2>/dev/null; then
     fail "execute_sqls.sh accepts invalid replica count ${replica_count}"
   fi

--- a/migrations/cassandra/tests/test-execute-sqls.sh
+++ b/migrations/cassandra/tests/test-execute-sqls.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -u
+
+test_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+subtree_dir=$(CDPATH='' cd -- "${test_dir}/.." && pwd)
+script="${subtree_dir}/execute_sqls.sh"
+keyspaces="${subtree_dir}/keyspaces"
+status=0
+
+fail()
+{
+  printf 'FAIL: %s\n' "$1" >&2
+  status=1
+}
+
+if grep -R -n -F 'envOrDefault "REPLICA_COUNT"' "${keyspaces}"; then
+  fail "keyspace migrations contain templates unsupported by stock golang-migrate"
+fi
+
+envsubst_vars=$(sed -n "s/^ENVSUBST_VARS='\\(.*\\)'$/\\1/p" "${script}")
+# shellcheck disable=SC2016
+if [ "${envsubst_vars}" != '$SERVICE_ROLE_PASSWORD $REPLICA_COUNT' ]; then
+  fail "execute_sqls.sh does not allow REPLICA_COUNT substitution"
+fi
+
+# shellcheck disable=SC2016
+if ! grep -F -q 'REPLICA_COUNT=${REPLICA_COUNT:-3}' "${script}"; then
+  fail "execute_sqls.sh does not preserve the default replica count"
+fi
+
+for migration in "${keyspaces}"/*/01_init_keyspace.up.sql; do
+  rendered=$(
+    REPLICA_COUNT=2 SERVICE_ROLE_PASSWORD=test-password \
+      envsubst "${envsubst_vars}" < "${migration}"
+  )
+
+  if printf '%s\n' "${rendered}" | grep -q '{{'; then
+    fail "${migration} leaves a Go template in rendered CQL"
+  fi
+
+  if ! printf '%s\n' "${rendered}" | grep -F -q "'ncp': '2'"; then
+    fail "${migration} does not substitute REPLICA_COUNT"
+  fi
+done
+
+if grep -q 'nc -z' "${script}"; then
+  fail "execute_sqls.sh depends on netcat even though the image does not install it"
+fi
+
+if ! grep -q '^until cqlsh ' "${script}"; then
+  fail "execute_sqls.sh must retain the Cassandra authentication readiness check"
+fi
+
+exit "${status}"


### PR DESCRIPTION
## Why

TLDR: We migrate to CVE free Cassandra in 0.6.1 patch - the migrations as they're written are incompatible with that.

The stock `golang-migrate` CLI does not process the previous `envOrDefault`
templates. Fresh Cassandra schema initialization therefore sent unsupported Go
templates to Cassandra and left migration version 1 dirty.

The 0.6.0 to 0.6.1 datacenter-expansion guide also disabled the migration hook
without a later step to run pending migrations. Following that sequence could
leave the upgraded cluster behind the 0.6.1 schema and unable to receive later
schema migrations safely.

## What changed

- Substitute `${REPLICA_COUNT}` alongside `${SERVICE_ROLE_PASSWORD}` before
  invoking stock `golang-migrate`.
- Preserve the existing default replica count of `3`.
- Remove the `nc` probe because netcat is not installed, while retaining the
  authenticated `cqlsh` readiness check.
- Add a shell regression test that renders every initial keyspace migration and
  rejects unsupported templates or unavailable netcat usage.
- Correct the datacenter-expansion guide to replicate `schema_migrations`, run
  pending 0.6.1 migrations before cutover, normalize replication for newly
  created keyspaces, and require every migration record to be clean.

## Customer Release Notes

Fixed fresh Cassandra schema initialization with the stock migration image and
corrected the 0.6.0 to 0.6.1 datacenter migration procedure so the upgraded
cluster remains ready for later schema updates.

## Plan Summary

Not applicable.

## Usage

Publish the migration fix as a new patch image tag and update consumers to that
tag. Existing 0.6.0 installations using datacenter expansion must follow the
updated guide and complete the migration-state checks before client cutover.

## Testing

The following checks pass:

```sh
sh migrations/cassandra/tests/test-execute-sqls.sh
sh -n migrations/cassandra/execute_sqls.sh migrations/cassandra/tests/test-execute-sqls.sh
shellcheck migrations/cassandra/tests/test-execute-sqls.sh
shellcheck -e SC2231,SC2006,SC2086,SC2181 migrations/cassandra/execute_sqls.sh
./tools/ci/check-docs
git diff --check
```

The docs check passes with an advisory warning because `imports.yaml` is absent
from the public snapshot.

QA is needed when publishing the patch image: run it against a fresh Cassandra
instance using the release image. The two-datacenter procedure should also be
validated in a non-production environment before production use.

## Notes

No existing installations require migration-state recovery. The documentation
change prevents operators from leaving a datacenter-expansion upgrade in a
partial migration state.

## Issues

Closes #413

## References

None.

## Related Pull Requests

None.

## Dependencies

No dependencies changed. No license review or NOTICE update is required.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `REPLICA_COUNT` support for Cassandra keyspace migrations and documentation, defaulting to `3`.
* **Bug Fixes**
  * Improved Cassandra migration execution by relying on `cqlsh`-based listener readiness instead of network polling.
  * Strengthened upgrade checks to verify `schema_migrations` entries remain non-dirty before proceeding.
* **Documentation**
  * Updated Cassandra migration and keyspace README guidance to reflect `REPLICA_COUNT` behavior and clarified recovery/authoring instructions.
  * Expanded the 0.6.0→0.6.1 upgrade guide with additional migration-state and datacenter expansion validation steps.
* **Tests**
  * Added automated coverage for `REPLICA_COUNT` substitution, validation, and correct migration rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->