### PR TITLE
fix(self-managed): bump API chart pin to 1.23.9

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -56,7 +56,7 @@ releases:
       - template: service
 
   - name: api
-    version: 1.23.8
+    version: 1.23.9
     namespace: nvcf
     inherit:
       - template: service


### PR DESCRIPTION
## TL;DR
Bump the self-managed stack API chart pin from `1.23.8` to `1.23.9` to consume worker-init `1.0.9`, which restores ESS configuration packaging for secret-bearing function deployments.

## Additional Details
- Parent epic: #404
- Phase 4 of the ordered repair tracked by #405
- API chart `1.23.9` includes `nvcf-worker-init-oss:1.0.9` from Phase 2
- Only the API chart version is changed; no unrelated chart or image updates are included

## For the Reviewer
Please focus on:
- `deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl`

## For QA
Verified the chart pin change is limited to the API release entry.
End-to-end secret-bearing deployment validation remains the Phase 4 follow-up after this stack pin lands.

## Issues
Relates to #405
Relates to #404

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the API release to version 1.23.9.
  * Preserved the existing namespace and deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->