### PR TITLE
ci(bazel): restore change-aware matrix scheduling

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -4,11 +4,12 @@
 # Bazel build + test on the public NVIDIA/nvcf mirror.
 #
 # The detect job computes dependency-aware subtree selection, including shared
-# Java triggers and framework-to-service reverse dependencies. Current policy
-# deliberately forces the full matrix on every PR and push for regression
-# safety; the change-aware result remains implemented and locally validated so
-# that policy can be restored later by removing the documented run_all=true
-# override. workflow_dispatch and unsafe/unknown diffs also use the full matrix.
+# Java triggers and framework-to-service reverse dependencies. A change is
+# scheduled only for the subtrees it touches: each subtree is an isolated Bazel
+# module, so a change under one service cannot break another. workflow_dispatch,
+# a change to this workflow, and unsafe/unknown diffs (unreadable or rewritten
+# history, a new branch) fall back to the full matrix so an untrustworthy
+# changeset is never under-tested.
 #
 # Matrix entries reference subtrees that have their Bazel scaffold
 # mirrored to GitHub (each subtree's upstream .oss-allowlist controls
@@ -170,13 +171,17 @@ jobs:
               fi
               ;;
           esac
-          # Policy: run the full test matrix on every PR and push so no subtree's
-          # tests are skipped because an unrelated path changed (regression safety
-          # over queue latency; the remote cache keeps unaffected targets to cache
-          # hits). The change-aware detection above and the reverse-dependency
-          # edges below are retained but inert while this is set; delete the next
-          # line to restore change-aware scheduling.
-          run_all=true
+          # Change-aware scheduling. Each subtree is an isolated Bazel module, so
+          # a change under src/<service> only affects that service's own //...
+          # build+test and can never break another module. Select only the
+          # subtrees a change actually touches (path prefix), plus the
+          # reverse-dependency edges below (shared Java config -> every Java row;
+          # a Java framework -> every Java service) and ROOT_GLOBS -> root row. A
+          # docs-only or helm-only change touches no subtree and runs nothing.
+          # The full-matrix fallbacks stay in the case above (workflow_dispatch,
+          # an unreadable or rewritten diff, a new branch) so an untrustworthy
+          # changeset is never under-tested.
+          #
           # A change to this workflow itself revalidates everything.
           if printf '%s\n' "$changed" | grep -q '^\.github/workflows/bazel\.yml$'; then
             run_all=true
@@ -197,9 +202,8 @@ jobs:
 
           # Root-owned Java dependencies and reusable Java rules/tools affect
           # every root-scoped Java component even though the changed path is
-          # outside that component's subtree. Keep these explicit edges correct
-          # while run_all=true; they become active automatically if change-aware
-          # scheduling is restored.
+          # outside that component's subtree, so a change to any of them schedules
+          # every Java row (edge applied below).
           JAVA_SHARED_GLOBS=(
             MODULE.bazel
             MODULE.bazel.lock


### PR DESCRIPTION
## Why
Since #343 merged, every PR rebuilds and tests every service, including docs-only changes like #423. #343 (commit f286e51b) added a blanket `run_all=true` override on top of the change-aware scheduler that had been working since commit 126c56bb (`feat(ci): change-aware GHA bazel matrix`). The override was a safety net while debugging cloud-tasks test output during that import, and is no longer needed.

Each subtree is an isolated Bazel module, so a change under one service builds and tests only that service's `//...` and cannot break another module. Forcing the full matrix on unrelated changes just burns queue time (and pays a cold rebuild on the `bazel-docker` lanes, which only warm on main pushes).

## What changed
Remove the unconditional `run_all=true` override in the `detect` job, restoring change-aware scheduling. Everything else is intentionally unchanged:
- Reverse-dependency edges: a Java framework change (nv-boot-parent) still fans out to every Java service (cloud-tasks); shared Java/root infra still schedules every Java row; `ROOT_GLOBS` still select the root row.
- Full-matrix fallbacks stay: `workflow_dispatch`, a change to this workflow itself, and unreadable/rewritten/new-branch diffs.
- A docs-only or helm-only change selects zero rows; the `bazel-verification` gate passes on `any=false`.

## Customer Release Notes
Not customer visible (CI-only).

## Testing
Traced the `detect` selection logic against representative changesets:
- grpc-proxy source change -> only the grpc-proxy row.
- nv-boot-parent change -> nv-boot-parent plus every java-service (cloud-tasks) rebuilt and tested in its docker-host lane.
- docs-only change (as in #423) -> zero rows; verification gate exits 0 on `any=false`.

YAML validated with a parser; the unconditional `run_all=true` assignment is removed while the conditional fallbacks remain.

## References
Override introduced in #343 (f286e51b). Change-aware scheduling originally landed in 126c56bb.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bazel build and test workflows now run only the affected modules and their dependent Java targets by default.
  * Full workflow coverage remains available for manual runs, workflow changes, and changes that cannot be safely analyzed.
  * Improved workflow guidance clarifies how root-level Java dependency or configuration changes are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->