### PR TITLE
fix(worker-llm-credentials): write worker-token 0644 so pylon can read it

### DIFF
--- a/src/compute-plane-services/worker-llm-credentials/internal/worker/worker.go
+++ b/src/compute-plane-services/worker-llm-credentials/internal/worker/worker.go
@@ -98,7 +98,17 @@ func (w *Worker) Run(ctx context.Context) error {
 				}
 			}
 			tmp := w.config.WorkerTokenPath + ".tmp"
-			if err := os.WriteFile(tmp, []byte(t.Token), 0600); err != nil {
+			// 0644 so the pylon sidecar (a different non-root UID) can read the
+			// token from the shared emptyDir; only these two infra sidecars
+			// mount it, not the customer workload container.
+			//nolint:gosec // G306: intentionally readable by the pylon sidecar
+			if err := os.WriteFile(tmp, []byte(t.Token), 0644); err != nil {
+				return err
+			}
+			// WriteFile honors umask and skips the mode when tmp already exists;
+			// chmod guarantees 0644 so the sidecar can read it.
+			//nolint:gosec // G302: intentionally readable by the pylon sidecar
+			if err := os.Chmod(tmp, 0644); err != nil {
 				return err
 			}
 			return os.Rename(tmp, w.config.WorkerTokenPath)

--- a/src/compute-plane-services/worker-llm-credentials/internal/worker/worker_coverage_test.go
+++ b/src/compute-plane-services/worker-llm-credentials/internal/worker/worker_coverage_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
@@ -134,6 +135,11 @@ func TestNew_DefaultsSharedConfigDir(t *testing.T) {
 // subdirectory that does not yet exist, so os.Stat returns ErrNotExist and the
 // callback must create the directory tree before writing the token.
 func TestRun_CreatesMissingTokenDir(t *testing.T) {
+	// A restrictive umask must not strip the token's read bits: Run chmods the
+	// file after writing so the pylon sidecar can always read it.
+	oldUmask := syscall.Umask(0o077)
+	defer syscall.Umask(oldUmask)
+
 	addr := startMockNVCFServer(t)
 	tmpDir := t.TempDir()
 	// Nested, non-existent subdirectory of the temp dir.
@@ -197,6 +203,16 @@ func TestRun_CreatesMissingTokenDir(t *testing.T) {
 	}
 	if string(content) != testWorkerToken {
 		t.Fatalf("expected token %q, got %q", testWorkerToken, string(content))
+	}
+
+	// The token must be readable by the pylon sidecar, which runs as a
+	// different UID on the shared emptyDir.
+	tokenInfo, err := os.Stat(workerTokenPath)
+	if err != nil {
+		t.Fatalf("token file not found: %v", err)
+	}
+	if got := tokenInfo.Mode().Perm(); got != 0644 {
+		t.Fatalf("expected token file mode 0644, got %o", got)
 	}
 }
 


### PR DESCRIPTION
## Why
Managed LLM workers never register with the request router, so gateway invokes return `no_eligible_candidates`. The credential-manager writes `/var/run/llm/worker-token` as 0600 (owner root), but pylon (`llm-router-client`) reads it via `--auth-token-file` while running as a different non-root UID (`nvs`) on the shared emptyDir, so it gets EACCES and never authenticates its registration.

## What changed
Write the worker-token 0644 so the pylon sidecar can read it. The `llm` emptyDir is mounted only by the two infra sidecars (`llm-router-client` + `llm-credential-manager`), not the customer workload container, so this does not expose the token to customer code.

Security note: this makes a router-auth token world-readable within the pod (gosec G306, suppressed with a reason). The alternative is a matched `runAsUser` + 0600 rendered by icms-translate (#409); this PR is the simpler, credential-manager-local fix. Pick one.

## Customer Release Notes
LLM function workers now register with the request router in managed deployments; OpenAI-compatible invocations no longer fail with no_eligible_candidates due to the worker-token permission mismatch.

## Testing
`go test ./internal/worker/` (`TestRun_CreatesMissingTokenDir` now asserts the token file is written 0644).

## References
Closes #410

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated refreshed worker token persistence to use `0644` permissions so required supporting processes can read the shared token file.
  * Ensured the token contents remain unchanged while applying the expected permission bits.

* **Tests**
  * Strengthened the token-file test to set a restrictive umask and verify the token directory is created and the file permissions are exactly `0644`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->