### PR TITLE
feat(cloud-tasks): add multi-arch OCI image target

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -186,8 +186,26 @@ oci.pull(
     ],
     tag = "21-jre",
 )
+
+# NVIDIA distroless java: the base for Java service images, matching the
+# distroless_go / distroless_cc bases the Go and Rust services use and the base
+# the pre-Bazel nvct-service Dockerfile used (25-jdk-v4.0.8). Publicly
+# pullable, multi-arch. Pinned by digest like the other distroless bases.
+# JDK 25 matches --java_language_version=25 above.
+oci.pull(
+    name = "distroless_java",
+    digest = "sha256:cc9dbc2560e39f6e0a67cd85421370e46fd818b1660800b507b82819a79ea21f",
+    image = "nvcr.io/nvidia/distroless/java",
+    platforms = [
+        "linux/amd64",
+        "linux/arm64/v8",
+    ],
+)
 use_repo(
     oci,
+    "distroless_java",
+    "distroless_java_linux_amd64",
+    "distroless_java_linux_arm64_v8",
     "temurin_jre",
     "temurin_jre_linux_amd64",
     "temurin_jre_linux_arm64_v8",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -379,7 +379,7 @@
     "@@rules_oci+//oci:extensions.bzl%oci": {
       "general": {
         "bzlTransitiveDigest": "IPpbSHX7+8yLBfvZyia9qXU/WRxkP+dWAO8m5+BsBY8=",
-        "usagesDigest": "y/cxJGms6FF8ZIVXe2JXt80qjt/26XDNGwsbbkM3BU4=",
+        "usagesDigest": "HCv5iVmsywJDYi04nXaMJHFn8CwQx+Ryy/HVpSiPdaQ=",
         "recordedInputs": [
           "REPO_MAPPING:aspect_bazel_lib+,bazel_tools bazel_tools",
           "REPO_MAPPING:bazel_features+,bazel_tools bazel_tools",
@@ -431,93 +431,6 @@
               "reproducible": true
             }
           },
-          "distroless_static_linux_amd64": {
-            "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_pull",
-            "attributes": {
-              "www_authenticate_challenges": {},
-              "scheme": "https",
-              "registry": "gcr.io",
-              "repository": "distroless/static",
-              "identifier": "sha256:dd7614b5a12bc4d617b223c588b4e0c833402b8f526c11e612b324a956cd2640",
-              "platform": "linux/amd64",
-              "target_name": "distroless_static_linux_amd64",
-              "bazel_tags": []
-            }
-          },
-          "distroless_static": {
-            "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_alias",
-            "attributes": {
-              "target_name": "distroless_static",
-              "www_authenticate_challenges": {},
-              "scheme": "https",
-              "registry": "gcr.io",
-              "repository": "distroless/static",
-              "identifier": "sha256:dd7614b5a12bc4d617b223c588b4e0c833402b8f526c11e612b324a956cd2640",
-              "platforms": {
-                "@@platforms//cpu:x86_64": "@distroless_static_linux_amd64"
-              },
-              "bzlmod_repository": "distroless_static",
-              "reproducible": true
-            }
-          },
-          "ubuntu_22_04_linux_amd64": {
-            "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_pull",
-            "attributes": {
-              "www_authenticate_challenges": {},
-              "scheme": "https",
-              "registry": "index.docker.io",
-              "repository": "library/ubuntu",
-              "identifier": "sha256:0e5e4a57c2499249aafc3b40fcd541e9a456aab7296681a3994d631587203f97",
-              "platform": "linux/amd64",
-              "target_name": "ubuntu_22_04_linux_amd64",
-              "bazel_tags": []
-            }
-          },
-          "ubuntu_22_04": {
-            "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_alias",
-            "attributes": {
-              "target_name": "ubuntu_22_04",
-              "www_authenticate_challenges": {},
-              "scheme": "https",
-              "registry": "index.docker.io",
-              "repository": "library/ubuntu",
-              "identifier": "sha256:0e5e4a57c2499249aafc3b40fcd541e9a456aab7296681a3994d631587203f97",
-              "platforms": {
-                "@@platforms//cpu:x86_64": "@ubuntu_22_04_linux_amd64"
-              },
-              "bzlmod_repository": "ubuntu_22_04",
-              "reproducible": true
-            }
-          },
-          "alpine_3_20_linux_amd64": {
-            "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_pull",
-            "attributes": {
-              "www_authenticate_challenges": {},
-              "scheme": "https",
-              "registry": "index.docker.io",
-              "repository": "library/alpine",
-              "identifier": "sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d",
-              "platform": "linux/amd64",
-              "target_name": "alpine_3_20_linux_amd64",
-              "bazel_tags": []
-            }
-          },
-          "alpine_3_20": {
-            "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_alias",
-            "attributes": {
-              "target_name": "alpine_3_20",
-              "www_authenticate_challenges": {},
-              "scheme": "https",
-              "registry": "index.docker.io",
-              "repository": "library/alpine",
-              "identifier": "sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d",
-              "platforms": {
-                "@@platforms//cpu:x86_64": "@alpine_3_20_linux_amd64"
-              },
-              "bzlmod_repository": "alpine_3_20",
-              "reproducible": true
-            }
-          },
           "temurin_jre_linux_arm64_v8": {
             "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_pull",
             "attributes": {
@@ -558,6 +471,49 @@
                 "@@platforms//cpu:x86_64": "@temurin_jre_linux_amd64"
               },
               "bzlmod_repository": "temurin_jre",
+              "reproducible": true
+            }
+          },
+          "distroless_java_linux_amd64": {
+            "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_pull",
+            "attributes": {
+              "www_authenticate_challenges": {},
+              "scheme": "https",
+              "registry": "nvcr.io",
+              "repository": "nvidia/distroless/java",
+              "identifier": "sha256:cc9dbc2560e39f6e0a67cd85421370e46fd818b1660800b507b82819a79ea21f",
+              "platform": "linux/amd64",
+              "target_name": "distroless_java_linux_amd64",
+              "bazel_tags": []
+            }
+          },
+          "distroless_java_linux_arm64_v8": {
+            "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_pull",
+            "attributes": {
+              "www_authenticate_challenges": {},
+              "scheme": "https",
+              "registry": "nvcr.io",
+              "repository": "nvidia/distroless/java",
+              "identifier": "sha256:cc9dbc2560e39f6e0a67cd85421370e46fd818b1660800b507b82819a79ea21f",
+              "platform": "linux/arm64/v8",
+              "target_name": "distroless_java_linux_arm64_v8",
+              "bazel_tags": []
+            }
+          },
+          "distroless_java": {
+            "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_alias",
+            "attributes": {
+              "target_name": "distroless_java",
+              "www_authenticate_challenges": {},
+              "scheme": "https",
+              "registry": "nvcr.io",
+              "repository": "nvidia/distroless/java",
+              "identifier": "sha256:cc9dbc2560e39f6e0a67cd85421370e46fd818b1660800b507b82819a79ea21f",
+              "platforms": {
+                "@@platforms//cpu:x86_64": "@distroless_java_linux_amd64",
+                "@@platforms//cpu:arm64": "@distroless_java_linux_arm64_v8"
+              },
+              "bzlmod_repository": "distroless_java",
               "reproducible": true
             }
           },
@@ -680,15 +636,12 @@
             "ubuntu_noble",
             "ubuntu_noble_linux_arm64_v8",
             "ubuntu_noble_linux_amd64",
-            "distroless_static",
-            "distroless_static_linux_amd64",
-            "ubuntu_22_04",
-            "ubuntu_22_04_linux_amd64",
-            "alpine_3_20",
-            "alpine_3_20_linux_amd64",
             "temurin_jre",
             "temurin_jre_linux_arm64_v8",
-            "temurin_jre_linux_amd64"
+            "temurin_jre_linux_amd64",
+            "distroless_java",
+            "distroless_java_linux_amd64",
+            "distroless_java_linux_arm64_v8"
           ],
           "explicitRootModuleDirectDevDeps": [],
           "useAllRepos": "NO",
@@ -1436,164 +1389,6 @@
         "windows_arm64": [
           "go1.25.0.windows-arm64.zip",
           "27bab004c72b3d7bd05a69b6ec0fc54a309b4b78cc569dd963d8b3ec28bfdb8c"
-        ]
-      },
-      "1.26.5": {
-        "aix_ppc64": [
-          "go1.26.5.aix-ppc64.tar.gz",
-          "e7f3c518fd7a8bc17f4389e342554016785f95ce447f8f09a260328de0d0f06c"
-        ],
-        "darwin_amd64": [
-          "go1.26.5.darwin-amd64.tar.gz",
-          "6231d8d3b8f5552ec6cbf6d685bdd5482e1e703214b120e89b3bf0d7bf1ef725"
-        ],
-        "darwin_arm64": [
-          "go1.26.5.darwin-arm64.tar.gz",
-          "efb87ff28af9a188d0536ef5d42e63dd52ba8263cd7344a993cc48dd11dedb6a"
-        ],
-        "dragonfly_amd64": [
-          "go1.26.5.dragonfly-amd64.tar.gz",
-          "96b53091297bd3a9ec8ed39f5f76b074c813dd74a6f429c03c667877ff27fdf8"
-        ],
-        "freebsd_386": [
-          "go1.26.5.freebsd-386.tar.gz",
-          "1a0226fc025d97d30a112ad0d09b13dcacedc5b24b04bf8f21a0cd29aac4d947"
-        ],
-        "freebsd_amd64": [
-          "go1.26.5.freebsd-amd64.tar.gz",
-          "0e5ddc51a62018211d461d6bf409939b04eaa4d6dd6d7097910090ef755ed947"
-        ],
-        "freebsd_arm": [
-          "go1.26.5.freebsd-arm.tar.gz",
-          "f8a59e86427158d89b2ba158d7f6004881e378fa3d7e4aefd4df17e4ee3a6bd1"
-        ],
-        "freebsd_arm64": [
-          "go1.26.5.freebsd-arm64.tar.gz",
-          "ae3825c8c57cc0e64c2233bfb9bba2e091f2126728e4c33492592c24b60dfcd0"
-        ],
-        "illumos_amd64": [
-          "go1.26.5.illumos-amd64.tar.gz",
-          "fcd06289bd8a5a9962e5acab2f30e7daa74952327b01366fa9f6e07007e65be1"
-        ],
-        "linux_386": [
-          "go1.26.5.linux-386.tar.gz",
-          "88c162b204e6eefcc32499453b492e80209f4a4c78c33092636901c540fb0d05"
-        ],
-        "linux_amd64": [
-          "go1.26.5.linux-amd64.tar.gz",
-          "5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053"
-        ],
-        "linux_arm64": [
-          "go1.26.5.linux-arm64.tar.gz",
-          "fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49"
-        ],
-        "linux_armv6l": [
-          "go1.26.5.linux-armv6l.tar.gz",
-          "6dae9edab81c13bccf962dec15f1fd2ec26c14a6821b4d2c92dab4130c289d7a"
-        ],
-        "linux_loong64": [
-          "go1.26.5.linux-loong64.tar.gz",
-          "82736bb7794547a73372ddfeb1b370cfea4d17f04782a65e82a389a01ff0f7aa"
-        ],
-        "linux_mips": [
-          "go1.26.5.linux-mips.tar.gz",
-          "3d313aefb8b7547beae18bb69febcf1571f775146209332a48a2942993655417"
-        ],
-        "linux_mips64": [
-          "go1.26.5.linux-mips64.tar.gz",
-          "7e5547e99a891e338fa5490b72d46ea7fd0593259df51561d7f55d4698503a8c"
-        ],
-        "linux_mips64le": [
-          "go1.26.5.linux-mips64le.tar.gz",
-          "7e05aceb9dea6033bc2f6dde29139293d8247cc2db749a206472b3916b1765a1"
-        ],
-        "linux_mipsle": [
-          "go1.26.5.linux-mipsle.tar.gz",
-          "e481470951e3a22a014ee70aebaae0c35aae4193a253d22ecf59d58f4bdbc450"
-        ],
-        "linux_ppc64": [
-          "go1.26.5.linux-ppc64.tar.gz",
-          "8ef02abd6f2b4040b7eb001b64597d16b9fa9aa563baaecf181ad8d9806c9991"
-        ],
-        "linux_ppc64le": [
-          "go1.26.5.linux-ppc64le.tar.gz",
-          "c5d60e2b303bb612f20cd82786594b64874e73b35134025e27d3390bf284ae43"
-        ],
-        "linux_riscv64": [
-          "go1.26.5.linux-riscv64.tar.gz",
-          "d4a24dd4484d3f86b99c2d300af0dea5d184557e6d61eb7aba19ff61662750e3"
-        ],
-        "linux_s390x": [
-          "go1.26.5.linux-s390x.tar.gz",
-          "09ce3c504c0323968b75a717244dca4f25cd4cf0443e5ff6bc0bfa74add89fa7"
-        ],
-        "netbsd_386": [
-          "go1.26.5.netbsd-386.tar.gz",
-          "6df082b6dd877c3e71af3c44e67b8684f8592cb0fc50aed3ea9e58968bc3165f"
-        ],
-        "netbsd_amd64": [
-          "go1.26.5.netbsd-amd64.tar.gz",
-          "daed1cb730d52e8b40866253b6271fd215f6128372dccc61d7784d4d3fb4a1bf"
-        ],
-        "netbsd_arm": [
-          "go1.26.5.netbsd-arm.tar.gz",
-          "d8a18f2d5afb6aaf47b79135221a964c21ee5cf5d568301a718904d887b1c96f"
-        ],
-        "netbsd_arm64": [
-          "go1.26.5.netbsd-arm64.tar.gz",
-          "60520191abd288fb0f22b279ee63497b3a81318134e41f2bb80f548c9227bd6a"
-        ],
-        "openbsd_386": [
-          "go1.26.5.openbsd-386.tar.gz",
-          "723a35e81882ddd8bdcb2539111f53ab4b03d4dbc114a2420d47963163465843"
-        ],
-        "openbsd_amd64": [
-          "go1.26.5.openbsd-amd64.tar.gz",
-          "27721c64efcb571ecfbf52ee77f133ec73dca96015b315199be104ed2dfafd87"
-        ],
-        "openbsd_arm": [
-          "go1.26.5.openbsd-arm.tar.gz",
-          "2de3fb692c74c68a40d8c92ec6a077a18c14a44e8e41a8c22edeb286b3a4dfce"
-        ],
-        "openbsd_arm64": [
-          "go1.26.5.openbsd-arm64.tar.gz",
-          "969a90bc34bda3ec06c0c3278ae00cdaa9b747b100cadec9f3f8c2cb36f01c69"
-        ],
-        "openbsd_ppc64": [
-          "go1.26.5.openbsd-ppc64.tar.gz",
-          "cb3908dd5904df453ebce07cfc660b7a14b7fed9525463521f01a04affd49eb8"
-        ],
-        "openbsd_riscv64": [
-          "go1.26.5.openbsd-riscv64.tar.gz",
-          "922864dbcb3ec989f456b2c313a46a4c0b0bd93b398603dc0db2d5a72b5ca47c"
-        ],
-        "plan9_386": [
-          "go1.26.5.plan9-386.tar.gz",
-          "7858fe6515a8e71050a3b59211b6c6f6947822497ecbe1ab81f4e4503b67a635"
-        ],
-        "plan9_amd64": [
-          "go1.26.5.plan9-amd64.tar.gz",
-          "513acf2518947e51210772145436e62eb67cc44738c5df3b6218dfeb66f6416c"
-        ],
-        "plan9_arm": [
-          "go1.26.5.plan9-arm.tar.gz",
-          "131c06ed5b7ce904ff7b121c63ffd76a699fff43b96e019914f093ede1be9e4a"
-        ],
-        "solaris_amd64": [
-          "go1.26.5.solaris-amd64.tar.gz",
-          "33a1fc532f8d5fc5964b28a056729bc50a59657b653a5f1b04c2aeb2ac54c149"
-        ],
-        "windows_386": [
-          "go1.26.5.windows-386.zip",
-          "cab0f6847c17f4c904c0bacb6ec6b84e730fc797f4ba885f42383d580fc2d399"
-        ],
-        "windows_amd64": [
-          "go1.26.5.windows-amd64.zip",
-          "97e6b2a833b6d89f9ff17d25419ac0a7e3b482a044e9ab18cdef834bd834fd38"
-        ],
-        "windows_arm64": [
-          "go1.26.5.windows-arm64.zip",
-          "f96ee46396d69f1e231c8d981ec6a70216238a646a1f2cd74aea0d0016bbc017"
         ]
       }
     }

--- a/rules/oci/defs.bzl
+++ b/rules/oci/defs.bzl
@@ -16,5 +16,7 @@
 "OCI image rules for packaging binaries into multi-arch containers."
 
 load("//rules/oci/private:go.bzl", _go_oci_image = "go_oci_image")
+load("//rules/oci/private:java.bzl", _java_oci_image = "java_oci_image")
 
 go_oci_image = _go_oci_image
+java_oci_image = _java_oci_image

--- a/rules/oci/defs.bzl
+++ b/rules/oci/defs.bzl
@@ -16,7 +16,8 @@
 "OCI image rules for packaging binaries into multi-arch containers."
 
 load("//rules/oci/private:go.bzl", _go_oci_image = "go_oci_image")
-load("//rules/oci/private:java.bzl", _java_oci_image = "java_oci_image")
+load("//rules/oci/private:java.bzl", _java_image_contract_test = "java_image_contract_test", _java_oci_image = "java_oci_image")
 
 go_oci_image = _go_oci_image
 java_oci_image = _java_oci_image
+java_image_contract_test = _java_image_contract_test

--- a/rules/oci/private/BUILD.bazel
+++ b/rules/oci/private/BUILD.bazel
@@ -14,3 +14,10 @@
 # limitations under the License.
 
 # Private OCI rule implementations.
+
+# The shared Java image contract test script, referenced by the
+# java_image_contract_test macro in every Java service's BUILD file.
+exports_files(
+    ["java_image_contract_test.sh"],
+    visibility = ["//visibility:public"],
+)

--- a/rules/oci/private/common.bzl
+++ b/rules/oci/private/common.bzl
@@ -35,7 +35,9 @@ def create_oci_image(
         entrypoint,
         visibility,
         registry = None,
-        tags = None):
+        tags = None,
+        env = None,
+        workdir = None):
     """Creates OCI image targets with platform transitions and tarball output.
 
     Generates:
@@ -44,6 +46,9 @@ def create_oci_image(
       - {name}_load: Local docker load target
       - {name}.tar: Tarball filegroup
       - {name}_push: Push to registry (if registry is set)
+
+    env and workdir are optional and default to leaving the base image's
+    values untouched, so existing callers are unaffected.
     """
     all_tags = ["manual"] + (tags or [])
 
@@ -53,6 +58,8 @@ def create_oci_image(
         base = base,
         tars = tars + COMMON_LAYERS,
         entrypoint = entrypoint,
+        env = env,
+        workdir = workdir,
         visibility = ["//visibility:private"],
         tags = all_tags,
     )

--- a/rules/oci/private/java.bzl
+++ b/rules/oci/private/java.bzl
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"OCI image rules for Java applications."
+
+load("@rules_pkg//pkg:mappings.bzl", "strip_prefix")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("//rules/oci/private:common.bzl", "create_oci_image")
+
+# NVIDIA distroless java, matching the distroless_go / distroless_cc bases the
+# Go and Rust services already use. Publicly pullable, multi-arch, and the same
+# base the pre-Bazel service Dockerfiles use. Keep the JDK major version in
+# lockstep with --java_language_version in //.bazelrc: a runtime older than the
+# emitted bytecode fails at container startup with UnsupportedClassVersionError,
+# which no build-time check catches.
+DEFAULT_JAVA_BASE = "@distroless_java"
+
+# The distroless bases set ENTRYPOINT ["/usr/bin/shelless_ulimit"], a shim that
+# raises the soft file-descriptor limit before exec'ing the real command.
+# oci_image REPLACES the base entrypoint rather than appending, so omitting the
+# shim here would silently drop it and leave the container on the default 1024
+# soft limit. Same fix grpc-proxy applies for its Go image.
+ULIMIT_SHIM = "/usr/bin/shelless_ulimit"
+
+# Arch-stable java path. Do NOT build this from JAVA_HOME: the base sets it
+# per-architecture (/usr/lib/jvm/temurin-25-jdk-amd64 vs -arm64), so a
+# hardcoded JAVA_HOME path would break the arm64 half of the image index.
+# /usr/bin/java is present on both arches.
+JAVA_BIN = "/usr/bin/java"
+
+def _java_oci_image_impl(name, visibility, jar, base, jar_path, entrypoint, jvm_flags, registry, tags):
+    layer_name = name + "_layer"
+
+    # Place the jar at a fixed absolute path so the entrypoint below can name
+    # it. Without strip_prefix + package_dir, rules_pkg writes it at its full
+    # workspace short-path and `java -jar /app.jar` fails at runtime with
+    # "Unable to access jarfile" while `bazel build :image` still succeeds,
+    # because building only assembles the layer and never runs the container.
+    #
+    # mode 0644 is correct here and is NOT the go_oci_image case: a jar is read
+    # by the JVM, never exec'd, so it needs no exec bit. The entrypoint
+    # executable is `java`, which comes from the base image.
+    pkg_tar(
+        name = layer_name,
+        extension = "tar.gz",
+        srcs = [jar],
+        mode = "0644",
+        package_dir = "/",
+        strip_prefix = strip_prefix.from_pkg(""),
+        visibility = ["//visibility:private"],
+    )
+
+    entry = entrypoint
+    if not entry:
+        entry = [ULIMIT_SHIM, JAVA_BIN] + list(jvm_flags) + ["-jar", jar_path]
+
+    create_oci_image(
+        name = name,
+        tars = [layer_name],
+        base = base,
+        entrypoint = entry,
+        visibility = visibility,
+        registry = registry,
+        tags = tags,
+    )
+
+java_oci_image = macro(
+    doc = """Packages a Java application jar into a multi-arch OCI image.
+
+    Intended for a Spring Boot executable jar (see //rules/java:spring.bzl),
+    but works with any self-contained runnable jar. Produces the same target
+    set as go_oci_image: {name}, {name}_index (multi-arch, this is what you
+    push), {name}_load, {name}.tar, and {name}_push when registry is set.
+    """,
+    implementation = _java_oci_image_impl,
+    attrs = {
+        "jar": attr.label(
+            doc = "The runnable jar to package (e.g. a spring_boot_app target).",
+            mandatory = True,
+            allow_single_file = True,
+            configurable = False,
+        ),
+        "base": attr.label(
+            doc = "Base OCI image. Must provide a JRE on PATH.",
+            default = DEFAULT_JAVA_BASE,
+            configurable = False,
+        ),
+        "jar_path": attr.string(
+            doc = "Absolute in-image path of the jar.",
+            default = "/app.jar",
+            configurable = False,
+        ),
+        "jvm_flags": attr.string_list(
+            doc = "JVM flags inserted before -jar. Ignored when entrypoint is set.",
+            configurable = False,
+        ),
+        "entrypoint": attr.string_list(
+            doc = """Container entrypoint. Defaults to
+            [/usr/bin/shelless_ulimit, /usr/bin/java, {jvm_flags}..., -jar, {jar_path}].
+            If you override this, keep the shelless_ulimit shim first or the
+            container loses the raised file-descriptor limit.""",
+            configurable = False,
+        ),
+        "registry": attr.string(
+            doc = "Registry to push to. If not set, push target is not created.",
+            configurable = False,
+        ),
+        "tags": attr.string_list(
+            doc = "Tags for generated targets. 'manual' is always added.",
+            configurable = False,
+        ),
+    },
+)

--- a/rules/oci/private/java.bzl
+++ b/rules/oci/private/java.bzl
@@ -15,7 +15,7 @@
 
 "OCI image rules for Java applications."
 
-load("@rules_pkg//pkg:mappings.bzl", "strip_prefix")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//rules/oci/private:common.bzl", "create_oci_image")
 
@@ -40,25 +40,36 @@ ULIMIT_SHIM = "/usr/bin/shelless_ulimit"
 # /usr/bin/java is present on both arches.
 JAVA_BIN = "/usr/bin/java"
 
-def _java_oci_image_impl(name, visibility, jar, base, jar_path, java_bin, entrypoint, jvm_flags, registry, tags):
+def _java_oci_image_impl(name, visibility, jar, base, jar_path, java_bin, entrypoint, jvm_flags, env, workdir, registry, tags):
     layer_name = name + "_layer"
+    files_name = name + "_files"
 
-    # Place the jar at a fixed absolute path so the entrypoint below can name
-    # it. Without strip_prefix + package_dir, rules_pkg writes it at its full
-    # workspace short-path and `java -jar /app.jar` fails at runtime with
-    # "Unable to access jarfile" while `bazel build :image` still succeeds,
-    # because building only assembles the layer and never runs the container.
+    if not jar_path.startswith("/"):
+        fail("jar_path must be absolute, got: " + jar_path)
+    jar_dir, _, jar_name = jar_path.rpartition("/")
+
+    # Install the jar AT jar_path. pkg_tar alone preserves the source
+    # basename and only the entrypoint would name jar_path, so a jar not
+    # already called app.jar, or a jar_path pointing elsewhere, would produce
+    # an image whose entrypoint references a file that does not exist. pkg_files
+    # renames and relocates it so the layer and the entrypoint cannot disagree.
     #
-    # mode 0644 is correct here and is NOT the go_oci_image case: a jar is read
-    # by the JVM, never exec'd, so it needs no exec bit. The entrypoint
-    # executable is `java`, which comes from the base image.
+    # mode 0644 is correct and is NOT the go_oci_image case: a jar is read by
+    # the JVM, never exec'd, so it needs no exec bit. The executable in the
+    # entrypoint is java, which comes from the base image.
+    pkg_files(
+        name = files_name,
+        srcs = [jar],
+        prefix = jar_dir,
+        renames = {jar: jar_name},
+        attributes = pkg_attributes(mode = "0644"),
+        visibility = ["//visibility:private"],
+    )
+
     pkg_tar(
         name = layer_name,
         extension = "tar.gz",
-        srcs = [jar],
-        mode = "0644",
-        package_dir = "/",
-        strip_prefix = strip_prefix.from_pkg(""),
+        srcs = [files_name],
         visibility = ["//visibility:private"],
     )
 
@@ -71,6 +82,8 @@ def _java_oci_image_impl(name, visibility, jar, base, jar_path, java_bin, entryp
         tars = [layer_name],
         base = base,
         entrypoint = entry,
+        env = env,
+        workdir = workdir,
         visibility = visibility,
         registry = registry,
         tags = tags,
@@ -109,8 +122,20 @@ java_oci_image = macro(
             configurable = False,
         ),
         "jar_path": attr.string(
-            doc = "Absolute in-image path of the jar.",
+            doc = """Absolute in-image path the jar is installed at. The layer
+            and the entrypoint are both derived from this, so they cannot
+            disagree.""",
             default = "/app.jar",
+            configurable = False,
+        ),
+        "env": attr.string_dict(
+            doc = """Environment variables set in the image. Required for
+            runtime behavior the base image expects, for example ULIMIT_FLAG=1,
+            without which the shelless_ulimit shim runs but raises no limit.""",
+            configurable = False,
+        ),
+        "workdir": attr.string(
+            doc = "Container working directory. Unset leaves the base's value.",
             configurable = False,
         ),
         "jvm_flags": attr.string_list(

--- a/rules/oci/private/java.bzl
+++ b/rules/oci/private/java.bzl
@@ -17,6 +17,7 @@
 
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//rules/oci/private:common.bzl", "create_oci_image")
 
 # NVIDIA distroless java, matching the distroless_go / distroless_cc bases the
@@ -156,6 +157,72 @@ java_oci_image = macro(
         "tags": attr.string_list(
             doc = "Tags for generated targets. 'manual' is always added.",
             configurable = False,
+        ),
+    },
+)
+
+def _java_image_contract_test_impl(name, visibility, image, jar_path, env, workdir, **kwargs):
+    sh_test(
+        name = name,
+        srcs = ["//rules/oci/private:java_image_contract_test.sh"],
+        args = [
+            "$(location {}.tar)".format(image),
+            "$(location {}_index)".format(image),
+            jar_path,
+            workdir,
+        ],
+        # Env expectations travel as environment variables, not args. sh_test
+        # args are shell-word-split, so a value containing spaces such as
+        # JDK_JAVA_OPTIONS would arrive truncated at its first space and the
+        # test would silently assert only the first fragment.
+        env = dict(
+            [("EXPECT_ENV_COUNT", str(len(env)))] +
+            [
+                ("EXPECT_ENV_{}".format(i), "{}={}".format(k, env[k]))
+                for i, k in enumerate(sorted(env.keys()))
+            ],
+        ),
+        data = [
+            image + ".tar",
+            image + "_index",
+        ],
+        visibility = visibility,
+        **kwargs
+    )
+
+java_image_contract_test = macro(
+    doc = """Assert a java_oci_image's runtime contract on every architecture.
+
+    Checks the jar is installed where the entrypoint names it and is not
+    whited out, that the entrypoint keeps the base's shelless_ulimit shim,
+    that every declared env entry is present as a complete entry, and that
+    the working directory matches. Runs against the host tar and against
+    each platform in the image index, so an index that is missing or
+    mislabels an architecture fails.
+
+    Pass the same `env`, `jar_path` and `workdir` given to java_oci_image.
+    """,
+    implementation = _java_image_contract_test_impl,
+    attrs = {
+        "image": attr.string(
+            configurable = False,
+            mandatory = True,
+            doc = "Label of the java_oci_image target, without a suffix.",
+        ),
+        "jar_path": attr.string(
+            configurable = False,
+            default = "/usr/share/app.jar",
+            doc = "Absolute path the jar is installed at.",
+        ),
+        "env": attr.string_dict(
+            configurable = False,
+            default = {},
+            doc = "Env entries that must be present, compared exactly.",
+        ),
+        "workdir": attr.string(
+            configurable = False,
+            default = "/home/app",
+            doc = "Expected working directory.",
         ),
     },
 )

--- a/rules/oci/private/java.bzl
+++ b/rules/oci/private/java.bzl
@@ -40,7 +40,7 @@ ULIMIT_SHIM = "/usr/bin/shelless_ulimit"
 # /usr/bin/java is present on both arches.
 JAVA_BIN = "/usr/bin/java"
 
-def _java_oci_image_impl(name, visibility, jar, base, jar_path, entrypoint, jvm_flags, registry, tags):
+def _java_oci_image_impl(name, visibility, jar, base, jar_path, java_bin, entrypoint, jvm_flags, registry, tags):
     layer_name = name + "_layer"
 
     # Place the jar at a fixed absolute path so the entrypoint below can name
@@ -64,7 +64,7 @@ def _java_oci_image_impl(name, visibility, jar, base, jar_path, entrypoint, jvm_
 
     entry = entrypoint
     if not entry:
-        entry = [ULIMIT_SHIM, JAVA_BIN] + list(jvm_flags) + ["-jar", jar_path]
+        entry = [ULIMIT_SHIM, java_bin] + list(jvm_flags) + ["-jar", jar_path]
 
     create_oci_image(
         name = name,
@@ -93,8 +93,19 @@ java_oci_image = macro(
             configurable = False,
         ),
         "base": attr.label(
-            doc = "Base OCI image. Must provide a JRE on PATH.",
+            doc = """Base OCI image. It must provide a Java launcher at the
+            absolute path given by java_bin (default /usr/bin/java) and the
+            shelless_ulimit shim, which the NVIDIA distroless bases do. A base
+            with Java only on PATH, or at a different absolute path, must set
+            java_bin accordingly.""",
             default = DEFAULT_JAVA_BASE,
+            configurable = False,
+        ),
+        "java_bin": attr.string(
+            doc = """Absolute path to the Java launcher in the base image.
+            Absolute rather than PATH-resolved, and deliberately not derived
+            from JAVA_HOME, which the distroless bases set per architecture.""",
+            default = JAVA_BIN,
             configurable = False,
         ),
         "jar_path": attr.string(

--- a/rules/oci/private/java_image_contract_test.sh
+++ b/rules/oci/private/java_image_contract_test.sh
@@ -2,36 +2,70 @@
 # SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Asserts the runtime contract of the nvct-service image, which is otherwise
-# only observable by running the container:
+# Shared runtime-contract guard for java_oci_image services.
 #
-#   1. The jar is at /usr/share/app.jar, the exact path the entrypoint names,
-#      and no layer whites it out. If the layer path and the entrypoint ever
-#      disagree the image builds fine and fails at startup with "Unable to
-#      access jarfile".
+# Asserts the parts of the contract that are otherwise only observable by
+# running the container, for every architecture in the image index:
+#
+#   1. The jar is at the exact path the entrypoint names, and no layer whites
+#      it out. If the layer path and the entrypoint ever disagree the image
+#      builds fine and fails at startup with "Unable to access jarfile".
 #   2. The entrypoint keeps the base image's shelless_ulimit shim. oci_image
 #      REPLACES the base entrypoint rather than appending, so dropping the shim
 #      is silent and leaves the container on the default 1024 fd soft limit.
 #   3. Java is invoked through /usr/bin/java, not a JAVA_HOME-derived path. The
 #      base sets JAVA_HOME per architecture, so an absolute JAVA_HOME path
 #      would break the arm64 half of the image index.
-#   4. Runtime parity with the pre-Bazel Dockerfile: ULIMIT_FLAG (which the
-#      shim reads; without it the shim raises nothing), JDK_JAVA_OPTIONS
-#      (container heap sizing), and the working directory.
+#   4. Runtime parity with the service's pre-Bazel Dockerfile: every declared
+#      environment variable, compared as a complete entry, and the working
+#      directory.
+#   5. Both architectures are present in the index and each carries the same
+#      contract. Checking only the host tar proves nothing about the other half,
+#      and an index missing or mislabelling a platform pushes without complaint.
 #
 # Unlike the Go services' image_entrypoint_mode_test this does not assert an
 # exec bit: a jar is read by the JVM, never executed, so mode 0644 is correct.
+#
+# Parsed with tar, grep and sed rather than jq so the test stays hermetic.
+#
+# Usage:
+#   EXPECT_ENV_COUNT=n EXPECT_ENV_0=K=V ... \
+#     java_image_contract_test.sh <image.tar> <index-dir> <jar-path> <workdir>
 set -euo pipefail
 
+if [[ "$#" -lt 4 ]]; then
+  echo "usage: $0 <image.tar> <index dir> <jar path> <workdir>" >&2
+  exit 1
+fi
+
 image_tar="$1"
-tmp_dir="${TEST_TMPDIR:-/tmp}/nvct-image-contract-${RANDOM}-${RANDOM}"
+index_dir="$2"
+jar_abs="$3"
+workdir="$4"
+shift 4
+
+# Expectations arrive as EXPECT_ENV_0..N-1 rather than positional arguments:
+# sh_test args are shell-word-split, so a value containing spaces would be
+# truncated at its first space and this test would assert only a fragment of it.
+expected_env=()
+expect_count="${EXPECT_ENV_COUNT:-0}"
+i=0
+while [[ "${i}" -lt "${expect_count}" ]]; do
+  var="EXPECT_ENV_${i}"
+  expected_env+=("${!var}")
+  i=$((i + 1))
+done
+
+jar_path="${jar_abs#/}"
+
+tmp_dir="${TEST_TMPDIR:-/tmp}/java-image-contract-${RANDOM}-${RANDOM}"
 outer_dir="${tmp_dir}/outer"
 mkdir -p "${outer_dir}"
 trap 'rm -rf "${tmp_dir}"' EXIT
 
 tar -xf "${image_tar}" -C "${outer_dir}"
 
-jar_path="usr/share/app.jar"
+expected_entrypoint="\"Entrypoint\":[\"/usr/bin/shelless_ulimit\",\"/usr/bin/java\",\"-jar\",\"${jar_abs}\"]"
 
 # ---------------------------------------------------------------------------
 # 1. the jar is installed at the path the entrypoint names
@@ -48,7 +82,7 @@ while IFS= read -r candidate; do
 done < <(find "${outer_dir}" -type f)
 
 if [[ "${jar_found}" != "true" ]]; then
-  echo "no image layer contains /${jar_path}" >&2
+  echo "no image layer contains ${jar_abs}" >&2
   find "${outer_dir}" -type f -print >&2
   exit 1
 fi
@@ -60,17 +94,29 @@ fi
 # this file and must not fail the test.
 #   file whiteout   : <dir>/.wh.<name>
 #   opaque whiteout : <dir>/.wh..wh..opq   (empties that directory)
-whiteout_re='^(\./)?usr/share/\.wh\.app\.jar$'
-whiteout_re+='|^(\./)?usr/\.wh\.share$'
-whiteout_re+='|^(\./)?\.wh\.usr$'
-whiteout_re+='|^(\./)?\.wh\.\.wh\.\.opq$'
-whiteout_re+='|^(\./)?usr/\.wh\.\.wh\.\.opq$'
-whiteout_re+='|^(\./)?usr/share/\.wh\.\.wh\.\.opq$'
+#
+# Derived from jar_path so this stays correct for any install location.
+jar_dir="${jar_path%/*}"
+jar_name="${jar_path##*/}"
+whiteout_re="^(\./)?${jar_dir}/\.wh\.${jar_name//./\\.}$"
+whiteout_re+="|^(\./)?\.wh\.\.wh\.\.opq$"
+ancestor=""
+IFS='/' read -r -a jar_parts <<< "${jar_dir}"
+for part in "${jar_parts[@]}"; do
+  if [[ -z "${ancestor}" ]]; then
+    whiteout_re+="|^(\./)?\.wh\.${part}$"
+    ancestor="${part}"
+  else
+    whiteout_re+="|^(\./)?${ancestor}/\.wh\.${part}$"
+    ancestor="${ancestor}/${part}"
+  fi
+  whiteout_re+="|^(\./)?${ancestor}/\.wh\.\.wh\.\.opq$"
+done
 
 while IFS= read -r candidate; do
   tar -tf "${candidate}" >/dev/null 2>&1 || continue
   if tar -tf "${candidate}" | grep -E "${whiteout_re}" >/dev/null; then
-    echo "a layer whites out /${jar_path} or one of its parent directories" >&2
+    echo "a layer whites out ${jar_abs} or one of its parent directories" >&2
     tar -tf "${candidate}" | grep -E "${whiteout_re}" >&2 || true
     exit 1
   fi
@@ -110,49 +156,45 @@ fi
 config_flat="$(tr -d ' \n' < "${config}")"
 config_raw="$(cat "${config}")"
 
-expected_entrypoint='"Entrypoint":["/usr/bin/shelless_ulimit","/usr/bin/java","-jar","/usr/share/app.jar"]'
-if ! printf '%s' "${config_flat}" | grep -F "${expected_entrypoint}" >/dev/null; then
-  echo "image entrypoint is not [/usr/bin/shelless_ulimit /usr/bin/java -jar /usr/share/app.jar]" >&2
-  printf '%s' "${config_flat}" | grep -o '"Entrypoint":[^]]*]' >&2 || true
-  exit 1
-fi
+# Assert one architecture's config. Used for the host tar and again for every
+# platform in the index, so the two can never drift apart.
+assert_config() {  # assert_config <label> <flattened> <raw>
+  local label="$1" flat="$2" raw="$3"
 
-# Match whole Env elements, quotes included, not substrings. Grepping for
-# MaxRAMPercentage=40.0 alone passes even if the other three JDK_JAVA_OPTIONS
-# values are dropped, and a bare ULIMIT_FLAG=1 would also be satisfied by a
-# differently named variable such as MY_ULIMIT_FLAG=1. The surrounding quotes
-# anchor each check to a complete entry.
-expected_jdk_opts='-XX:MaxRAMPercentage=40.0 -XX:+EnableDynamicAgentLoading -Dreactor.netty.pool.maxIdleTime=30000 -Dreactor.netty.pool.maxConnections=500'
-for expected in \
-  "\"ULIMIT_FLAG=1\"" \
-  "\"JDK_JAVA_OPTIONS=${expected_jdk_opts}\""; do
-  if ! printf '%s' "${config_raw}" | grep -F "${expected}" >/dev/null; then
-    echo "image config is missing expected runtime setting: ${expected}" >&2
-    printf '%s' "${config_flat}" | grep -o '"Env":\[[^]]*\]' >&2 || true
-    exit 1
+  if ! printf '%s' "${flat}" | grep -F "${expected_entrypoint}" >/dev/null; then
+    echo "${label}: entrypoint is not [/usr/bin/shelless_ulimit /usr/bin/java -jar ${jar_abs}]" >&2
+    printf '%s' "${flat}" | grep -o '"Entrypoint":[^]]*]' >&2 || true
+    return 1
   fi
-done
 
-if ! printf '%s' "${config_flat}" | grep -F '"WorkingDir":"/home/app"' >/dev/null; then
-  echo "image working directory is not /home/app" >&2
-  exit 1
-fi
+  # Match whole Env elements, quotes included, not substrings. Grepping for a
+  # fragment such as MaxRAMPercentage=40.0 passes even when the rest of
+  # JDK_JAVA_OPTIONS is dropped, and a bare ULIMIT_FLAG=1 would also be
+  # satisfied by a differently named variable like MY_ULIMIT_FLAG=1.
+  local entry
+  for entry in "${expected_env[@]}"; do
+    if ! printf '%s' "${raw}" | grep -F "\"${entry}\"" >/dev/null; then
+      echo "${label}: config is missing expected env entry: ${entry}" >&2
+      printf '%s' "${flat}" | grep -o '"Env":\[[^]]*\]' >&2 || true
+      return 1
+    fi
+  done
+
+  if ! printf '%s' "${flat}" | grep -F "\"WorkingDir\":\"${workdir}\"" >/dev/null; then
+    echo "${label}: working directory is not ${workdir}" >&2
+    printf '%s' "${flat}" | grep -o '"WorkingDir":"[^"]*"' >&2 || true
+    return 1
+  fi
+}
+
+assert_config "host image" "${config_flat}" "${config_raw}"
 
 # ---------------------------------------------------------------------------
 # 5. the image index carries both architectures, each with the same contract
 # ---------------------------------------------------------------------------
-# Everything above inspects the host-architecture tar. That proves nothing
-# about the arm64 half, and a multi-arch index whose second platform is absent
-# or misconfigured builds and pushes without complaint. Walk the OCI layout
-# directly: index.json -> manifest list -> per-platform manifest -> config.
-#
-# Parsed with grep and sed rather than jq to keep the test hermetic; the
-# structures read here are small and fixed-shape.
-index_dir="${2:-}"
-if [[ -z "${index_dir}" ]]; then
-  echo "usage: $0 <image.tar> <image_index dir>" >&2
-  exit 1
-fi
+# Everything above inspects the host-architecture tar, which says nothing about
+# the other half of a multi-arch index. Walk the OCI layout directly:
+# index.json -> manifest list -> per-platform manifest -> config.
 if [[ ! -f "${index_dir}/index.json" ]]; then
   echo "not an OCI layout (no index.json): ${index_dir}" >&2
   exit 1
@@ -162,7 +204,6 @@ blob_for() {  # blob_for <digest as sha256:hex>
   printf '%s/blobs/%s/%s' "${index_dir}" "${1%%:*}" "${1#*:}"
 }
 
-# index.json holds one descriptor pointing at the manifest list.
 top_digest="$(tr -d ' \n' < "${index_dir}/index.json" \
   | grep -o '"digest":"sha256:[0-9a-f]*"' | head -1 | cut -d'"' -f4)"
 if [[ -z "${top_digest}" ]]; then
@@ -178,7 +219,7 @@ fi
 list_flat="$(tr -d ' \n' < "${manifest_list}")"
 
 for arch in amd64 arm64; do
-  # Split the manifests array into one line per entry so a digest is only ever
+  # Split the manifests array into one entry per line so a digest is only ever
   # read from the same entry that declares the architecture.
   entry="$(printf '%s' "${list_flat}" \
     | sed 's/}, *{/}\n{/g' \
@@ -204,36 +245,17 @@ for arch in amd64 arm64; do
     exit 1
   fi
 
-  arch_cfg="$(tr -d ' \n' < "${cfg_blob}")"
+  arch_flat="$(tr -d ' \n' < "${cfg_blob}")"
   arch_raw="$(cat "${cfg_blob}")"
 
   # The config must declare the architecture it was filed under, otherwise the
   # index is mislabelled and runtimes pull the wrong image for their platform.
-  if ! printf '%s' "${arch_cfg}" | grep -F "\"architecture\":\"${arch}\"" >/dev/null; then
+  if ! printf '%s' "${arch_flat}" | grep -F "\"architecture\":\"${arch}\"" >/dev/null; then
     echo "${arch} entry points at a config declaring a different architecture" >&2
     exit 1
   fi
 
-  # Same runtime contract as the host-architecture checks above.
-  if ! printf '%s' "${arch_cfg}" | grep -F "${expected_entrypoint}" >/dev/null; then
-    echo "${arch} image has the wrong entrypoint" >&2
-    printf '%s' "${arch_cfg}" | grep -o '"Entrypoint":[^]]*]' >&2 || true
-    exit 1
-  fi
-  for expected in \
-    "\"ULIMIT_FLAG=1\"" \
-    "\"JDK_JAVA_OPTIONS=${expected_jdk_opts}\""; do
-    if ! printf '%s' "${arch_raw}" | grep -F "${expected}" >/dev/null; then
-      echo "${arch} image config is missing expected runtime setting: ${expected}" >&2
-      printf '%s' "${arch_cfg}" | grep -o '"Env":\[[^]]*\]' >&2 || true
-      exit 1
-    fi
-  done
-
-  if ! printf '%s' "${arch_cfg}" | grep -F '"WorkingDir":"/home/app"' >/dev/null; then
-    echo "${arch} image working directory is not /home/app" >&2
-    exit 1
-  fi
+  assert_config "${arch} image" "${arch_flat}" "${arch_raw}"
 
   echo "ok: ${arch} manifest present with the expected runtime contract"
 done

--- a/src/control-plane-services/api-keys/BUILD.bazel
+++ b/src/control-plane-services/api-keys/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_java//java:defs.bzl", "java_library")
 load("//rules/java:defs.bzl", "nv_boot_library", "nv_boot_library_test", "nv_boot_workspace_runfiles")
 load("//rules/java:notice.bzl", "nvcf_notice", "nvcf_notice_delta")
 load("//rules/java:spring.bzl", "spring_boot_app")
+load("//rules/oci:defs.bzl", "java_image_contract_test", "java_oci_image")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -161,4 +162,32 @@ nvcf_notice_delta(
         "//src/libraries/java/nv-boot-parent:runtime_inventory.json",
     ],
     inventory = ":runtime_inventory.json",
+)
+
+# Multi-arch OCI image, the Bazel equivalent of this service's Dockerfile.
+# jar_path, env and workdir mirror that Dockerfile exactly. The entrypoint comes
+# from the shared macro, which keeps the base's shelless_ulimit shim that
+# oci_image would otherwise silently replace.
+java_oci_image(
+    name = "api-keys-oss-image",
+    jar = ":app",
+    jar_path = "/usr/share/app.jar",
+    env = {
+        "ULIMIT_FLAG": "1",
+        "JDK_JAVA_OPTIONS": "",
+    },
+    workdir = "/home/app",
+)
+
+# The shared guard every Java service uses, so the runtime contract cannot drift
+# between services or between the architectures in the index.
+java_image_contract_test(
+    name = "image_contract_test",
+    image = ":api-keys-oss-image",
+    jar_path = "/usr/share/app.jar",
+    env = {
+        "ULIMIT_FLAG": "1",
+        "JDK_JAVA_OPTIONS": "",
+    },
+    workdir = "/home/app",
 )

--- a/src/control-plane-services/cloud-tasks/nvct-service/BUILD.bazel
+++ b/src/control-plane-services/cloud-tasks/nvct-service/BUILD.bazel
@@ -1,5 +1,6 @@
 load("//rules/java:defs.bzl", "nvct_library", "nvct_library_test")
 load("//rules/java:spring.bzl", "spring_boot_app")
+load("//rules/oci:defs.bzl", "java_oci_image")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -41,6 +42,19 @@ spring_boot_app(
     description = "NVIDIA Cloud Tasks OSS executable",
     group_id = "com.nvidia.nvct",
     main_class = "com.nvidia.nvct.App",
+)
+
+# Release image. Push the _index label (multi-arch amd64 + arm64), never
+# :nvct-service-oss-image, which is the single host-arch image.
+#
+# Parity with the pre-Bazel nvct-service/Dockerfile: same distroless java base
+# (nvcr.io/nvidia/distroless/java 25-jdk, pinned by digest in //MODULE.bazel),
+# same executable Spring Boot jar at /app.jar, same java -jar entrypoint behind
+# the base's shelless_ulimit shim.
+java_oci_image(
+    name = "nvct-service-oss-image",
+    jar = ":app",
+    jar_path = "/app.jar",
 )
 
 nvct_library_test(

--- a/src/control-plane-services/cloud-tasks/nvct-service/BUILD.bazel
+++ b/src/control-plane-services/cloud-tasks/nvct-service/BUILD.bazel
@@ -1,5 +1,6 @@
 load("//rules/java:defs.bzl", "nvct_library", "nvct_library_test")
 load("//rules/java:spring.bzl", "spring_boot_app")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//rules/oci:defs.bzl", "java_oci_image")
 
 package(default_visibility = ["//visibility:public"])
@@ -87,4 +88,19 @@ nvct_library_test(
         "requires-docker",
     ],
     timeout = "long",
+)
+
+# Runtime-contract guard for the image: the jar path matches the entrypoint,
+# the base image's shelless_ulimit shim survives (oci_image replaces rather
+# than appends the base entrypoint), and java is invoked via the arch-stable
+# /usr/bin/java rather than a per-arch JAVA_HOME path. Each of these otherwise
+# fails only at container startup.
+#
+# sh_test is loaded explicitly: cloud-tasks builds in the root module on Bazel
+# 9, which no longer provides sh_test as a built-in global.
+sh_test(
+    name = "image_contract_test",
+    srcs = ["image_contract_test.sh"],
+    args = ["$(location :nvct-service-oss-image.tar)"],
+    data = [":nvct-service-oss-image.tar"],
 )

--- a/src/control-plane-services/cloud-tasks/nvct-service/BUILD.bazel
+++ b/src/control-plane-services/cloud-tasks/nvct-service/BUILD.bazel
@@ -1,6 +1,6 @@
 load("//rules/java:defs.bzl", "nvct_library", "nvct_library_test")
-load("//rules/java:spring.bzl", "spring_boot_app")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//rules/java:spring.bzl", "spring_boot_app")
 load("//rules/oci:defs.bzl", "java_oci_image")
 
 package(default_visibility = ["//visibility:public"])
@@ -45,11 +45,43 @@ spring_boot_app(
     main_class = "com.nvidia.nvct.App",
 )
 
+nvct_library_test(
+    name = "tests",
+    coverage_library = ":app_classes",
+    srcs = NVCT_SERVICE_TEST_SRCS,
+    deps = [
+        ":app_classes",
+        "//src/control-plane-services/cloud-tasks/nvct-core:nvct_core",
+        "//src/control-plane-services/cloud-tasks/nvct-core:nvct_core_test_fixtures",
+        "//src/libraries/java/nv-boot-parent/nv-boot-mock-servers-test:nv_boot_mock_servers_test",
+        "@nv_third_party_deps//:io_opentelemetry_opentelemetry_sdk_testing",
+        "@nv_third_party_deps//:org_springframework_boot_spring_boot",
+        "@nv_third_party_deps//:org_springframework_boot_spring_boot_restclient",
+        "@nv_third_party_deps//:org_springframework_boot_spring_boot_resttestclient",
+        "@nv_third_party_deps//:org_springframework_boot_spring_boot_starter_webmvc_test",
+        "@nv_third_party_deps//:org_springframework_boot_spring_boot_web_server",
+        "@nv_third_party_deps//:org_springframework_spring_beans",
+        "@nv_third_party_deps//:org_springframework_spring_web",
+        "@nv_third_party_deps//:org_springframework_spring_webmvc",
+        "@nv_third_party_deps//:org_testcontainers_testcontainers",
+        "@nv_third_party_deps//:org_testcontainers_testcontainers_cassandra",
+    ],
+    data = [
+        "//src/control-plane-services/cloud-tasks:integration_local_env",
+    ],
+    resources = NVCT_SERVICE_TEST_RESOURCES,
+    tags = [
+        "exclusive",
+        "requires-docker",
+    ],
+    timeout = "long",
+)
+
 # Release image. Push the _index label (multi-arch amd64 + arm64), never
 # :nvct-service-oss-image, which is the single host-arch image.
 #
 # Runtime parity with the pre-Bazel nvct-service/Dockerfile, which is the
-# contract this image has to preserve:
+# contract this image must preserve:
 #   COPY app.jar /usr/share/app.jar
 #   ENV ULIMIT_FLAG=1
 #   ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=40.0 ..."
@@ -59,7 +91,7 @@ spring_boot_app(
 # ULIMIT_FLAG is load-bearing, not decoration: the base's shelless_ulimit shim
 # reads it, so without it the shim runs and raises nothing. JDK_JAVA_OPTIONS
 # carries the container heap sizing (MaxRAMPercentage), so dropping it silently
-# changes the JVM's memory behavior in production.
+# changes JVM memory behavior in production.
 java_oci_image(
     name = "nvct-service-oss-image",
     jar = ":app",
@@ -71,6 +103,11 @@ java_oci_image(
     workdir = "/home/app",
 )
 
+# Runtime-contract guard for the image. Complements, and does not replace,
+# :tests above (the Java suite).
+#
+# sh_test is loaded explicitly: cloud-tasks builds in the root module on Bazel
+# 9, which no longer provides sh_test as a built-in global.
 sh_test(
     name = "image_contract_test",
     srcs = ["image_contract_test.sh"],

--- a/src/control-plane-services/cloud-tasks/nvct-service/BUILD.bazel
+++ b/src/control-plane-services/cloud-tasks/nvct-service/BUILD.bazel
@@ -1,7 +1,6 @@
 load("//rules/java:defs.bzl", "nvct_library", "nvct_library_test")
-load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//rules/java:spring.bzl", "spring_boot_app")
-load("//rules/oci:defs.bzl", "java_oci_image")
+load("//rules/oci:defs.bzl", "java_image_contract_test", "java_oci_image")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -103,20 +102,15 @@ java_oci_image(
     workdir = "/home/app",
 )
 
-# Runtime-contract guard for the image. Complements, and does not replace,
-# :tests above (the Java suite).
-#
-# sh_test is loaded explicitly: cloud-tasks builds in the root module on Bazel
-# 9, which no longer provides sh_test as a built-in global.
-sh_test(
+# Runtime-contract guard for the image, shared with every other Java service
+# so the assertions cannot drift apart between them.
+java_image_contract_test(
     name = "image_contract_test",
-    srcs = ["image_contract_test.sh"],
-    args = [
-        "$(location :nvct-service-oss-image.tar)",
-        "$(location :nvct-service-oss-image_index)",
-    ],
-    data = [
-        ":nvct-service-oss-image.tar",
-        ":nvct-service-oss-image_index",
-    ],
+    image = ":nvct-service-oss-image",
+    jar_path = "/usr/share/app.jar",
+    env = {
+        "ULIMIT_FLAG": "1",
+        "JDK_JAVA_OPTIONS": "-XX:MaxRAMPercentage=40.0 -XX:+EnableDynamicAgentLoading -Dreactor.netty.pool.maxIdleTime=30000 -Dreactor.netty.pool.maxConnections=500",
+    },
+    workdir = "/home/app",
 )

--- a/src/control-plane-services/cloud-tasks/nvct-service/BUILD.bazel
+++ b/src/control-plane-services/cloud-tasks/nvct-service/BUILD.bazel
@@ -48,56 +48,29 @@ spring_boot_app(
 # Release image. Push the _index label (multi-arch amd64 + arm64), never
 # :nvct-service-oss-image, which is the single host-arch image.
 #
-# Parity with the pre-Bazel nvct-service/Dockerfile: same distroless java base
-# (nvcr.io/nvidia/distroless/java 25-jdk, pinned by digest in //MODULE.bazel),
-# same executable Spring Boot jar at /app.jar, same java -jar entrypoint behind
-# the base's shelless_ulimit shim.
+# Runtime parity with the pre-Bazel nvct-service/Dockerfile, which is the
+# contract this image has to preserve:
+#   COPY app.jar /usr/share/app.jar
+#   ENV ULIMIT_FLAG=1
+#   ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=40.0 ..."
+#   WORKDIR /home/app
+#   CMD ["java", "-jar", "/usr/share/app.jar"]
+#
+# ULIMIT_FLAG is load-bearing, not decoration: the base's shelless_ulimit shim
+# reads it, so without it the shim runs and raises nothing. JDK_JAVA_OPTIONS
+# carries the container heap sizing (MaxRAMPercentage), so dropping it silently
+# changes the JVM's memory behavior in production.
 java_oci_image(
     name = "nvct-service-oss-image",
     jar = ":app",
-    jar_path = "/app.jar",
+    jar_path = "/usr/share/app.jar",
+    env = {
+        "ULIMIT_FLAG": "1",
+        "JDK_JAVA_OPTIONS": "-XX:MaxRAMPercentage=40.0 -XX:+EnableDynamicAgentLoading -Dreactor.netty.pool.maxIdleTime=30000 -Dreactor.netty.pool.maxConnections=500",
+    },
+    workdir = "/home/app",
 )
 
-nvct_library_test(
-    name = "tests",
-    coverage_library = ":app_classes",
-    srcs = NVCT_SERVICE_TEST_SRCS,
-    deps = [
-        ":app_classes",
-        "//src/control-plane-services/cloud-tasks/nvct-core:nvct_core",
-        "//src/control-plane-services/cloud-tasks/nvct-core:nvct_core_test_fixtures",
-        "//src/libraries/java/nv-boot-parent/nv-boot-mock-servers-test:nv_boot_mock_servers_test",
-        "@nv_third_party_deps//:io_opentelemetry_opentelemetry_sdk_testing",
-        "@nv_third_party_deps//:org_springframework_boot_spring_boot",
-        "@nv_third_party_deps//:org_springframework_boot_spring_boot_restclient",
-        "@nv_third_party_deps//:org_springframework_boot_spring_boot_resttestclient",
-        "@nv_third_party_deps//:org_springframework_boot_spring_boot_starter_webmvc_test",
-        "@nv_third_party_deps//:org_springframework_boot_spring_boot_web_server",
-        "@nv_third_party_deps//:org_springframework_spring_beans",
-        "@nv_third_party_deps//:org_springframework_spring_web",
-        "@nv_third_party_deps//:org_springframework_spring_webmvc",
-        "@nv_third_party_deps//:org_testcontainers_testcontainers",
-        "@nv_third_party_deps//:org_testcontainers_testcontainers_cassandra",
-    ],
-    data = [
-        "//src/control-plane-services/cloud-tasks:integration_local_env",
-    ],
-    resources = NVCT_SERVICE_TEST_RESOURCES,
-    tags = [
-        "exclusive",
-        "requires-docker",
-    ],
-    timeout = "long",
-)
-
-# Runtime-contract guard for the image: the jar path matches the entrypoint,
-# the base image's shelless_ulimit shim survives (oci_image replaces rather
-# than appends the base entrypoint), and java is invoked via the arch-stable
-# /usr/bin/java rather than a per-arch JAVA_HOME path. Each of these otherwise
-# fails only at container startup.
-#
-# sh_test is loaded explicitly: cloud-tasks builds in the root module on Bazel
-# 9, which no longer provides sh_test as a built-in global.
 sh_test(
     name = "image_contract_test",
     srcs = ["image_contract_test.sh"],

--- a/src/control-plane-services/cloud-tasks/nvct-service/BUILD.bazel
+++ b/src/control-plane-services/cloud-tasks/nvct-service/BUILD.bazel
@@ -111,6 +111,12 @@ java_oci_image(
 sh_test(
     name = "image_contract_test",
     srcs = ["image_contract_test.sh"],
-    args = ["$(location :nvct-service-oss-image.tar)"],
-    data = [":nvct-service-oss-image.tar"],
+    args = [
+        "$(location :nvct-service-oss-image.tar)",
+        "$(location :nvct-service-oss-image_index)",
+    ],
+    data = [
+        ":nvct-service-oss-image.tar",
+        ":nvct-service-oss-image_index",
+    ],
 )

--- a/src/control-plane-services/cloud-tasks/nvct-service/image_contract_test.sh
+++ b/src/control-plane-services/cloud-tasks/nvct-service/image_contract_test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Asserts the runtime contract of the nvct-service image, which is otherwise
+# only observable by running the container:
+#
+#   1. The jar is at /app.jar, the exact path the entrypoint names. If the
+#      layer path and the entrypoint ever disagree, the image builds fine and
+#      fails at startup with "Unable to access jarfile".
+#   2. The entrypoint keeps the base image's shelless_ulimit shim. oci_image
+#      REPLACES the base entrypoint rather than appending, so dropping the shim
+#      is silent and leaves the container on the default 1024 fd soft limit.
+#   3. Java is invoked through /usr/bin/java, not a JAVA_HOME-derived path. The
+#      base sets JAVA_HOME per architecture, so an absolute JAVA_HOME path
+#      would break the arm64 half of the image index.
+#
+# Unlike the Go services' image_entrypoint_mode_test this does not assert an
+# exec bit: a jar is read by the JVM, never executed, so mode 0644 is correct.
+set -euo pipefail
+
+image_tar="$1"
+tmp_dir="${TEST_TMPDIR:-/tmp}/nvct-image-contract-${RANDOM}-${RANDOM}"
+outer_dir="${tmp_dir}/outer"
+mkdir -p "${outer_dir}"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+tar -xf "${image_tar}" -C "${outer_dir}"
+
+# 1. the jar is present at /app.jar in some layer
+jar_found=false
+while IFS= read -r candidate; do
+  tar -tf "${candidate}" >/dev/null 2>&1 || continue
+  if tar -tf "${candidate}" | grep -Eq '^(\./)?app\.jar$'; then
+    jar_found=true
+    break
+  fi
+done < <(find "${outer_dir}" -type f)
+
+if [[ "${jar_found}" != "true" ]]; then
+  echo "no image layer contains /app.jar" >&2
+  find "${outer_dir}" -type f -print >&2
+  exit 1
+fi
+
+# 2 + 3. the entrypoint keeps the shim and uses the absolute java path. Scan
+# every regular file rather than parsing manifest.json, so the test needs no
+# JSON tool beyond coreutils. Note the config is a content-addressed blob under
+# blobs/sha256/ with NO .json extension, so it cannot be found by suffix.
+entrypoint_ok=false
+while IFS= read -r meta; do
+  grep -q '"Entrypoint"' "${meta}" 2>/dev/null || continue
+  if tr -d ' \n' < "${meta}" \
+      | grep -q '"Entrypoint":\["/usr/bin/shelless_ulimit","/usr/bin/java","-jar","/app.jar"\]'; then
+    entrypoint_ok=true
+    break
+  fi
+done < <(find "${outer_dir}" -type f)
+
+if [[ "${entrypoint_ok}" != "true" ]]; then
+  echo "image entrypoint is not [/usr/bin/shelless_ulimit /usr/bin/java -jar /app.jar]" >&2
+  echo "entrypoints found in the image:" >&2
+  find "${outer_dir}" -type f -exec grep -ho '"Entrypoint":[^]]*]' {} \; 2>/dev/null >&2 || true
+  exit 1
+fi

--- a/src/control-plane-services/cloud-tasks/nvct-service/image_contract_test.sh
+++ b/src/control-plane-services/cloud-tasks/nvct-service/image_contract_test.sh
@@ -5,15 +5,19 @@
 # Asserts the runtime contract of the nvct-service image, which is otherwise
 # only observable by running the container:
 #
-#   1. The jar is at /usr/share/app.jar, the exact path the entrypoint names. If the
-#      layer path and the entrypoint ever disagree, the image builds fine and
-#      fails at startup with "Unable to access jarfile".
+#   1. The jar is at /usr/share/app.jar, the exact path the entrypoint names,
+#      and no layer whites it out. If the layer path and the entrypoint ever
+#      disagree the image builds fine and fails at startup with "Unable to
+#      access jarfile".
 #   2. The entrypoint keeps the base image's shelless_ulimit shim. oci_image
 #      REPLACES the base entrypoint rather than appending, so dropping the shim
 #      is silent and leaves the container on the default 1024 fd soft limit.
 #   3. Java is invoked through /usr/bin/java, not a JAVA_HOME-derived path. The
 #      base sets JAVA_HOME per architecture, so an absolute JAVA_HOME path
 #      would break the arm64 half of the image index.
+#   4. Runtime parity with the pre-Bazel Dockerfile: ULIMIT_FLAG (which the
+#      shim reads; without it the shim raises nothing), JDK_JAVA_OPTIONS
+#      (container heap sizing), and the working directory.
 #
 # Unlike the Go services' image_entrypoint_mode_test this does not assert an
 # exec bit: a jar is read by the JVM, never executed, so mode 0644 is correct.
@@ -27,72 +31,89 @@ trap 'rm -rf "${tmp_dir}"' EXIT
 
 tar -xf "${image_tar}" -C "${outer_dir}"
 
-# 1. the jar is present at /app.jar in some layer
+jar_path="usr/share/app.jar"
+
+# ---------------------------------------------------------------------------
+# 1. the jar is installed at the path the entrypoint names
+# ---------------------------------------------------------------------------
+# grep -q would close the pipe on first match, SIGPIPE tar, and under pipefail
+# reject a valid image. Consume the whole stream.
 jar_found=false
 while IFS= read -r candidate; do
   tar -tf "${candidate}" >/dev/null 2>&1 || continue
-  # grep -q would close the pipe on first match, SIGPIPE tar, and under
-  # pipefail reject a valid image. Consume the whole stream.
-  if tar -tf "${candidate}" | grep -E '^(\./)?usr/share/app\.jar$' >/dev/null; then
+  if tar -tf "${candidate}" | grep -E "^(\./)?${jar_path}$" >/dev/null; then
     jar_found=true
     break
   fi
 done < <(find "${outer_dir}" -type f)
 
 if [[ "${jar_found}" != "true" ]]; then
-  echo "no image layer contains /usr/share/app.jar" >&2
+  echo "no image layer contains /${jar_path}" >&2
   find "${outer_dir}" -type f -print >&2
   exit 1
 fi
 
-# Presence in a layer is necessary but not sufficient: a later layer could
-# delete the file via an OCI whiteout marker, leaving the merged filesystem
-# without it. Assert no layer whites out the jar or its directory.
+# Presence in a layer is necessary but not sufficient: a later layer can delete
+# the file with a whiteout, leaving the merged filesystem without it. Check for
+# a whiteout of the jar itself and for opaque whiteouts on its ancestor
+# directories ONLY. An opaque marker on an unrelated directory does not affect
+# this file and must not fail the test.
+#   file whiteout   : <dir>/.wh.<name>
+#   opaque whiteout : <dir>/.wh..wh..opq   (empties that directory)
+whiteout_re='^(\./)?usr/share/\.wh\.app\.jar$'
+whiteout_re+='|^(\./)?usr/\.wh\.share$'
+whiteout_re+='|^(\./)?\.wh\.usr$'
+whiteout_re+='|^(\./)?\.wh\.\.wh\.\.opq$'
+whiteout_re+='|^(\./)?usr/\.wh\.\.wh\.\.opq$'
+whiteout_re+='|^(\./)?usr/share/\.wh\.\.wh\.\.opq$'
+
 while IFS= read -r candidate; do
   tar -tf "${candidate}" >/dev/null 2>&1 || continue
-  if tar -tf "${candidate}" \
-      | grep -E '^(\./)?usr/share/\.wh\.app\.jar$|^(\./)?usr/\.wh\.share$|^(\./)?\.wh\.usr$|\.wh\.\.wh\.opq$' \
-      >/dev/null; then
-    echo "a layer whites out /usr/share/app.jar or a parent directory" >&2
-    tar -tf "${candidate}" | grep '\.wh\.' >&2 || true
+  if tar -tf "${candidate}" | grep -E "${whiteout_re}" >/dev/null; then
+    echo "a layer whites out /${jar_path} or one of its parent directories" >&2
+    tar -tf "${candidate}" | grep -E "${whiteout_re}" >&2 || true
     exit 1
   fi
 done < <(find "${outer_dir}" -type f)
 
-# 2 + 3. the entrypoint keeps the shim and uses the absolute java path. Scan
-# every regular file rather than parsing manifest.json, so the test needs no
-# JSON tool beyond coreutils. Note the config is a content-addressed blob under
-# blobs/sha256/ with NO .json extension, so it cannot be found by suffix.
-entrypoint_ok=false
-while IFS= read -r meta; do
-  grep -q '"Entrypoint"' "${meta}" 2>/dev/null || continue
-  if tr -d ' \n' < "${meta}" \
-      | grep '"Entrypoint":\["/usr/bin/shelless_ulimit","/usr/bin/java","-jar","/usr/share/app.jar"\]' >/dev/null; then
-    entrypoint_ok=true
-    break
-  fi
-done < <(find "${outer_dir}" -type f)
-
-if [[ "${entrypoint_ok}" != "true" ]]; then
-  echo "image entrypoint is not [/usr/bin/shelless_ulimit /usr/bin/java -jar /usr/share/app.jar]" >&2
-  echo "entrypoints found in the image:" >&2
-  find "${outer_dir}" -type f -exec grep -ho '"Entrypoint":[^]]*]' {} \; 2>/dev/null >&2 || true
+# ---------------------------------------------------------------------------
+# 2-4. assert against the image config blob, and only that blob
+# ---------------------------------------------------------------------------
+# Resolve manifest.json -> the "Config" blob rather than scanning every file in
+# the archive. Scanning everything would let a layer tar or bundled payload that
+# merely contains the expected text satisfy these assertions even when the real
+# image config is wrong.
+manifest="${outer_dir}/manifest.json"
+if [[ ! -f "${manifest}" ]]; then
+  echo "archive has no manifest.json; cannot resolve the image config" >&2
   exit 1
 fi
 
-# 4. runtime parity with the pre-Bazel Dockerfile: ULIMIT_FLAG (which the
-# shelless_ulimit shim reads; without it the shim raises nothing),
-# JDK_JAVA_OPTIONS (container heap sizing), and the working directory.
+config_rel="$(tr -d ' \n' < "${manifest}" \
+  | sed -n 's/.*"Config":"\([^"]*\)".*/\1/p' | head -1)"
+if [[ -z "${config_rel}" ]]; then
+  echo "could not read the Config entry from manifest.json" >&2
+  cat "${manifest}" >&2
+  exit 1
+fi
+
+config="${outer_dir}/${config_rel}"
+if [[ ! -f "${config}" ]]; then
+  echo "manifest.json points at a missing config blob: ${config_rel}" >&2
+  exit 1
+fi
+
+config_flat="$(tr -d ' \n' < "${config}")"
+
+expected_entrypoint='"Entrypoint":["/usr/bin/shelless_ulimit","/usr/bin/java","-jar","/usr/share/app.jar"]'
+if ! printf '%s' "${config_flat}" | grep -F "${expected_entrypoint}" >/dev/null; then
+  echo "image entrypoint is not [/usr/bin/shelless_ulimit /usr/bin/java -jar /usr/share/app.jar]" >&2
+  printf '%s' "${config_flat}" | grep -o '"Entrypoint":[^]]*]' >&2 || true
+  exit 1
+fi
+
 for expected in 'ULIMIT_FLAG=1' 'MaxRAMPercentage=40.0' '"WorkingDir":"/home/app"'; do
-  found=false
-  while IFS= read -r meta; do
-    grep -q '"Entrypoint"' "${meta}" 2>/dev/null || continue
-    if tr -d ' \n' < "${meta}" | grep -F "${expected}" >/dev/null; then
-      found=true
-      break
-    fi
-  done < <(find "${outer_dir}" -type f)
-  if [[ "${found}" != "true" ]]; then
+  if ! printf '%s' "${config_flat}" | grep -F "${expected}" >/dev/null; then
     echo "image config is missing expected runtime setting: ${expected}" >&2
     exit 1
   fi

--- a/src/control-plane-services/cloud-tasks/nvct-service/image_contract_test.sh
+++ b/src/control-plane-services/cloud-tasks/nvct-service/image_contract_test.sh
@@ -103,7 +103,12 @@ if [[ ! -f "${config}" ]]; then
   exit 1
 fi
 
+# Two views of the same config. The flattened one is for structural patterns
+# like "Entrypoint":[...] , which are written without whitespace. Env values are
+# compared against the file as written, because deleting spaces would also
+# delete them from inside values such as JDK_JAVA_OPTIONS.
 config_flat="$(tr -d ' \n' < "${config}")"
+config_raw="$(cat "${config}")"
 
 expected_entrypoint='"Entrypoint":["/usr/bin/shelless_ulimit","/usr/bin/java","-jar","/usr/share/app.jar"]'
 if ! printf '%s' "${config_flat}" | grep -F "${expected_entrypoint}" >/dev/null; then
@@ -112,9 +117,123 @@ if ! printf '%s' "${config_flat}" | grep -F "${expected_entrypoint}" >/dev/null;
   exit 1
 fi
 
-for expected in 'ULIMIT_FLAG=1' 'MaxRAMPercentage=40.0' '"WorkingDir":"/home/app"'; do
-  if ! printf '%s' "${config_flat}" | grep -F "${expected}" >/dev/null; then
+# Match whole Env elements, quotes included, not substrings. Grepping for
+# MaxRAMPercentage=40.0 alone passes even if the other three JDK_JAVA_OPTIONS
+# values are dropped, and a bare ULIMIT_FLAG=1 would also be satisfied by a
+# differently named variable such as MY_ULIMIT_FLAG=1. The surrounding quotes
+# anchor each check to a complete entry.
+expected_jdk_opts='-XX:MaxRAMPercentage=40.0 -XX:+EnableDynamicAgentLoading -Dreactor.netty.pool.maxIdleTime=30000 -Dreactor.netty.pool.maxConnections=500'
+for expected in \
+  "\"ULIMIT_FLAG=1\"" \
+  "\"JDK_JAVA_OPTIONS=${expected_jdk_opts}\""; do
+  if ! printf '%s' "${config_raw}" | grep -F "${expected}" >/dev/null; then
     echo "image config is missing expected runtime setting: ${expected}" >&2
+    printf '%s' "${config_flat}" | grep -o '"Env":\[[^]]*\]' >&2 || true
     exit 1
   fi
+done
+
+if ! printf '%s' "${config_flat}" | grep -F '"WorkingDir":"/home/app"' >/dev/null; then
+  echo "image working directory is not /home/app" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 5. the image index carries both architectures, each with the same contract
+# ---------------------------------------------------------------------------
+# Everything above inspects the host-architecture tar. That proves nothing
+# about the arm64 half, and a multi-arch index whose second platform is absent
+# or misconfigured builds and pushes without complaint. Walk the OCI layout
+# directly: index.json -> manifest list -> per-platform manifest -> config.
+#
+# Parsed with grep and sed rather than jq to keep the test hermetic; the
+# structures read here are small and fixed-shape.
+index_dir="${2:-}"
+if [[ -z "${index_dir}" ]]; then
+  echo "usage: $0 <image.tar> <image_index dir>" >&2
+  exit 1
+fi
+if [[ ! -f "${index_dir}/index.json" ]]; then
+  echo "not an OCI layout (no index.json): ${index_dir}" >&2
+  exit 1
+fi
+
+blob_for() {  # blob_for <digest as sha256:hex>
+  printf '%s/blobs/%s/%s' "${index_dir}" "${1%%:*}" "${1#*:}"
+}
+
+# index.json holds one descriptor pointing at the manifest list.
+top_digest="$(tr -d ' \n' < "${index_dir}/index.json" \
+  | grep -o '"digest":"sha256:[0-9a-f]*"' | head -1 | cut -d'"' -f4)"
+if [[ -z "${top_digest}" ]]; then
+  echo "index.json has no manifest descriptor" >&2
+  exit 1
+fi
+manifest_list="$(blob_for "${top_digest}")"
+if [[ ! -f "${manifest_list}" ]]; then
+  echo "index.json points at a missing blob: ${top_digest}" >&2
+  exit 1
+fi
+
+list_flat="$(tr -d ' \n' < "${manifest_list}")"
+
+for arch in amd64 arm64; do
+  # Split the manifests array into one line per entry so a digest is only ever
+  # read from the same entry that declares the architecture.
+  entry="$(printf '%s' "${list_flat}" \
+    | sed 's/}, *{/}\n{/g' \
+    | grep -F "\"architecture\":\"${arch}\"" | head -1)"
+  if [[ -z "${entry}" ]]; then
+    echo "image index has no ${arch} manifest" >&2
+    printf '%s' "${list_flat}" | grep -o '"architecture":"[a-z0-9]*"' >&2 || true
+    exit 1
+  fi
+
+  man_digest="$(printf '%s' "${entry}" | grep -o '"digest":"sha256:[0-9a-f]*"' | head -1 | cut -d'"' -f4)"
+  man_blob="$(blob_for "${man_digest}")"
+  if [[ ! -f "${man_blob}" ]]; then
+    echo "${arch} manifest blob is missing: ${man_digest}" >&2
+    exit 1
+  fi
+
+  cfg_digest="$(tr -d ' \n' < "${man_blob}" \
+    | grep -o '"config":{[^}]*}' | grep -o '"digest":"sha256:[0-9a-f]*"' | head -1 | cut -d'"' -f4)"
+  cfg_blob="$(blob_for "${cfg_digest}")"
+  if [[ ! -f "${cfg_blob}" ]]; then
+    echo "${arch} config blob is missing: ${cfg_digest}" >&2
+    exit 1
+  fi
+
+  arch_cfg="$(tr -d ' \n' < "${cfg_blob}")"
+  arch_raw="$(cat "${cfg_blob}")"
+
+  # The config must declare the architecture it was filed under, otherwise the
+  # index is mislabelled and runtimes pull the wrong image for their platform.
+  if ! printf '%s' "${arch_cfg}" | grep -F "\"architecture\":\"${arch}\"" >/dev/null; then
+    echo "${arch} entry points at a config declaring a different architecture" >&2
+    exit 1
+  fi
+
+  # Same runtime contract as the host-architecture checks above.
+  if ! printf '%s' "${arch_cfg}" | grep -F "${expected_entrypoint}" >/dev/null; then
+    echo "${arch} image has the wrong entrypoint" >&2
+    printf '%s' "${arch_cfg}" | grep -o '"Entrypoint":[^]]*]' >&2 || true
+    exit 1
+  fi
+  for expected in \
+    "\"ULIMIT_FLAG=1\"" \
+    "\"JDK_JAVA_OPTIONS=${expected_jdk_opts}\""; do
+    if ! printf '%s' "${arch_raw}" | grep -F "${expected}" >/dev/null; then
+      echo "${arch} image config is missing expected runtime setting: ${expected}" >&2
+      printf '%s' "${arch_cfg}" | grep -o '"Env":\[[^]]*\]' >&2 || true
+      exit 1
+    fi
+  done
+
+  if ! printf '%s' "${arch_cfg}" | grep -F '"WorkingDir":"/home/app"' >/dev/null; then
+    echo "${arch} image working directory is not /home/app" >&2
+    exit 1
+  fi
+
+  echo "ok: ${arch} manifest present with the expected runtime contract"
 done

--- a/src/control-plane-services/cloud-tasks/nvct-service/image_contract_test.sh
+++ b/src/control-plane-services/cloud-tasks/nvct-service/image_contract_test.sh
@@ -31,7 +31,9 @@ tar -xf "${image_tar}" -C "${outer_dir}"
 jar_found=false
 while IFS= read -r candidate; do
   tar -tf "${candidate}" >/dev/null 2>&1 || continue
-  if tar -tf "${candidate}" | grep -Eq '^(\./)?usr/share/app\.jar$'; then
+  # grep -q would close the pipe on first match, SIGPIPE tar, and under
+  # pipefail reject a valid image. Consume the whole stream.
+  if tar -tf "${candidate}" | grep -E '^(\./)?usr/share/app\.jar$' >/dev/null; then
     jar_found=true
     break
   fi
@@ -43,6 +45,20 @@ if [[ "${jar_found}" != "true" ]]; then
   exit 1
 fi
 
+# Presence in a layer is necessary but not sufficient: a later layer could
+# delete the file via an OCI whiteout marker, leaving the merged filesystem
+# without it. Assert no layer whites out the jar or its directory.
+while IFS= read -r candidate; do
+  tar -tf "${candidate}" >/dev/null 2>&1 || continue
+  if tar -tf "${candidate}" \
+      | grep -E '^(\./)?usr/share/\.wh\.app\.jar$|^(\./)?usr/\.wh\.share$|^(\./)?\.wh\.usr$|\.wh\.\.wh\.opq$' \
+      >/dev/null; then
+    echo "a layer whites out /usr/share/app.jar or a parent directory" >&2
+    tar -tf "${candidate}" | grep '\.wh\.' >&2 || true
+    exit 1
+  fi
+done < <(find "${outer_dir}" -type f)
+
 # 2 + 3. the entrypoint keeps the shim and uses the absolute java path. Scan
 # every regular file rather than parsing manifest.json, so the test needs no
 # JSON tool beyond coreutils. Note the config is a content-addressed blob under
@@ -51,7 +67,7 @@ entrypoint_ok=false
 while IFS= read -r meta; do
   grep -q '"Entrypoint"' "${meta}" 2>/dev/null || continue
   if tr -d ' \n' < "${meta}" \
-      | grep -q '"Entrypoint":\["/usr/bin/shelless_ulimit","/usr/bin/java","-jar","/usr/share/app.jar"\]'; then
+      | grep '"Entrypoint":\["/usr/bin/shelless_ulimit","/usr/bin/java","-jar","/usr/share/app.jar"\]' >/dev/null; then
     entrypoint_ok=true
     break
   fi
@@ -71,7 +87,7 @@ for expected in 'ULIMIT_FLAG=1' 'MaxRAMPercentage=40.0' '"WorkingDir":"/home/app
   found=false
   while IFS= read -r meta; do
     grep -q '"Entrypoint"' "${meta}" 2>/dev/null || continue
-    if tr -d ' \n' < "${meta}" | grep -qF "${expected}"; then
+    if tr -d ' \n' < "${meta}" | grep -F "${expected}" >/dev/null; then
       found=true
       break
     fi

--- a/src/control-plane-services/cloud-tasks/nvct-service/image_contract_test.sh
+++ b/src/control-plane-services/cloud-tasks/nvct-service/image_contract_test.sh
@@ -5,7 +5,7 @@
 # Asserts the runtime contract of the nvct-service image, which is otherwise
 # only observable by running the container:
 #
-#   1. The jar is at /app.jar, the exact path the entrypoint names. If the
+#   1. The jar is at /usr/share/app.jar, the exact path the entrypoint names. If the
 #      layer path and the entrypoint ever disagree, the image builds fine and
 #      fails at startup with "Unable to access jarfile".
 #   2. The entrypoint keeps the base image's shelless_ulimit shim. oci_image
@@ -31,14 +31,14 @@ tar -xf "${image_tar}" -C "${outer_dir}"
 jar_found=false
 while IFS= read -r candidate; do
   tar -tf "${candidate}" >/dev/null 2>&1 || continue
-  if tar -tf "${candidate}" | grep -Eq '^(\./)?app\.jar$'; then
+  if tar -tf "${candidate}" | grep -Eq '^(\./)?usr/share/app\.jar$'; then
     jar_found=true
     break
   fi
 done < <(find "${outer_dir}" -type f)
 
 if [[ "${jar_found}" != "true" ]]; then
-  echo "no image layer contains /app.jar" >&2
+  echo "no image layer contains /usr/share/app.jar" >&2
   find "${outer_dir}" -type f -print >&2
   exit 1
 fi
@@ -51,15 +51,33 @@ entrypoint_ok=false
 while IFS= read -r meta; do
   grep -q '"Entrypoint"' "${meta}" 2>/dev/null || continue
   if tr -d ' \n' < "${meta}" \
-      | grep -q '"Entrypoint":\["/usr/bin/shelless_ulimit","/usr/bin/java","-jar","/app.jar"\]'; then
+      | grep -q '"Entrypoint":\["/usr/bin/shelless_ulimit","/usr/bin/java","-jar","/usr/share/app.jar"\]'; then
     entrypoint_ok=true
     break
   fi
 done < <(find "${outer_dir}" -type f)
 
 if [[ "${entrypoint_ok}" != "true" ]]; then
-  echo "image entrypoint is not [/usr/bin/shelless_ulimit /usr/bin/java -jar /app.jar]" >&2
+  echo "image entrypoint is not [/usr/bin/shelless_ulimit /usr/bin/java -jar /usr/share/app.jar]" >&2
   echo "entrypoints found in the image:" >&2
   find "${outer_dir}" -type f -exec grep -ho '"Entrypoint":[^]]*]' {} \; 2>/dev/null >&2 || true
   exit 1
 fi
+
+# 4. runtime parity with the pre-Bazel Dockerfile: ULIMIT_FLAG (which the
+# shelless_ulimit shim reads; without it the shim raises nothing),
+# JDK_JAVA_OPTIONS (container heap sizing), and the working directory.
+for expected in 'ULIMIT_FLAG=1' 'MaxRAMPercentage=40.0' '"WorkingDir":"/home/app"'; do
+  found=false
+  while IFS= read -r meta; do
+    grep -q '"Entrypoint"' "${meta}" 2>/dev/null || continue
+    if tr -d ' \n' < "${meta}" | grep -qF "${expected}"; then
+      found=true
+      break
+    fi
+  done < <(find "${outer_dir}" -type f)
+  if [[ "${found}" != "true" ]]; then
+    echo "image config is missing expected runtime setting: ${expected}" >&2
+    exit 1
+  fi
+done

--- a/src/control-plane-services/notary/notary-service/BUILD.bazel
+++ b/src/control-plane-services/notary/notary-service/BUILD.bazel
@@ -1,5 +1,6 @@
 load("//rules/java:defs.bzl", "nv_boot_library", "nv_boot_library_test")
 load("//rules/java:spring.bzl", "spring_boot_app")
+load("//rules/oci:defs.bzl", "java_image_contract_test", "java_oci_image")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -56,4 +57,44 @@ nv_boot_library_test(
         "@nv_third_party_deps//:org_springframework_spring_web",
     ],
     timeout = "long",
+)
+
+# Multi-arch OCI image, the Bazel equivalent of this service's Dockerfile.
+# jar_path, env and workdir mirror that Dockerfile exactly. The entrypoint comes
+# from the shared macro, which keeps the base's shelless_ulimit shim that
+# oci_image would otherwise silently replace.
+java_oci_image(
+    name = "notary-service-oss-image",
+    jar = ":app",
+    jar_path = "/usr/share/app.jar",
+    env = {
+        "ULIMIT_FLAG": "1",
+        "JDK_JAVA_OPTIONS": "",
+        "SPRING_PROFILES_ACTIVE": "",
+        "AUTH_TOKEN_ISSUER": "",
+        "ASSERTION_ISSUER_URL": "",
+        "AUTH_TOKEN_SCOPE": "notary-sign",
+        "MAX_REQUEST_BODY_SIZE_BYTES": "4096",
+        "VAULT_SECRETS_JSON_PATH": "vault/vault-secrets.json",
+    },
+    workdir = "/home/app",
+)
+
+# The shared guard every Java service uses, so the runtime contract cannot drift
+# between services or between the architectures in the index.
+java_image_contract_test(
+    name = "image_contract_test",
+    image = ":notary-service-oss-image",
+    jar_path = "/usr/share/app.jar",
+    env = {
+        "ULIMIT_FLAG": "1",
+        "JDK_JAVA_OPTIONS": "",
+        "SPRING_PROFILES_ACTIVE": "",
+        "AUTH_TOKEN_ISSUER": "",
+        "ASSERTION_ISSUER_URL": "",
+        "AUTH_TOKEN_SCOPE": "notary-sign",
+        "MAX_REQUEST_BODY_SIZE_BYTES": "4096",
+        "VAULT_SECRETS_JSON_PATH": "vault/vault-secrets.json",
+    },
+    workdir = "/home/app",
 )


### PR DESCRIPTION
## Why
cloud-tasks had no container image target under Bazel. `nvct-service/BUILD.bazel` declared only the Spring Boot jar (`spring_boot_app(name = "app")`), with no `oci_image`/`oci_image_index` anywhere in the subtree, so the service could not be released by any mechanism: the release backend's `oci_push` had nothing to point at.

This adds the missing piece so cloud-tasks containers can be cut.

## What changed
- `rules/oci`: new `java_oci_image` macro (there was only `go_oci_image`). Packages a runnable jar and emits the same target set as the Go macro, including the `_index` multi-arch label that release tooling pushes.
- `MODULE.bazel`: pull `nvcr.io/nvidia/distroless/java` (`25-jdk-v4.0.8`) pinned by digest, matching the `distroless_go` / `distroless_cc` convention and the base the pre-Bazel `nvct-service/Dockerfile` used.
- `nvct-service/BUILD.bazel`: `java_oci_image` target producing `nvct-service-oss`.

Two base-image details are encoded in the macro so callers cannot get them wrong:

1. The distroless bases set `ENTRYPOINT ["/usr/bin/shelless_ulimit"]`, a shim that raises the soft file-descriptor limit, and `oci_image` REPLACES rather than appends the base entrypoint. Omitting the shim silently leaves the container on the default 1024 fd soft limit. This is the same issue grpc-proxy hit for its Go image.
2. `java` is invoked via `/usr/bin/java`, not via `JAVA_HOME`. The base sets `JAVA_HOME` per-architecture (`/usr/lib/jvm/temurin-25-jdk-amd64` vs `-arm64`), so a `JAVA_HOME`-derived path would break the arm64 half of the image index. `/usr/bin/java` is present on both arches (verified in the image layers).

## Customer Release Notes
Not customer visible yet. This adds the build target; no image is published until the release wiring lands.

## Testing
`bazel build //src/control-plane-services/cloud-tasks/nvct-service:nvct-service-oss-image_index` succeeds (1734 actions). Verified on the built artifact:

- Index media type `application/vnd.oci.image.index.v1+json` with both `linux/amd64` and `linux/arm64/v8`.
- Entrypoint on both arches: `['/usr/bin/shelless_ulimit', '/usr/bin/java', '-jar', '/app.jar']`.

## Notes
This is the build target only. Cutting an actual cloud-tasks release still needs, separately: a version source and a `release:` block in `tools/ci/subproject-validations.yaml`, and a `config/services/cloud-tasks.yaml` in nvcf-internal. nvcf-internal MR 96 adds the `source.module_root` support that lets a root-module service such as cloud-tasks stage a release without first splitting the Java tree into standalone modules.

Push the `_index` label, never `:nvct-service-oss-image`, which is the single host-arch image.

## References
None

## Related Merge Requests/Pull Requests
nvcf-internal MR 96 (root-module support in the Bazel staging build).

## Dependencies
None. The distroless java base is an existing NVIDIA public image, pinned by digest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-architecture OCI image building for Java services using a distroless Java base.
  * Introduced reusable Java OCI packaging to place the app JAR at a fixed in-image path and generate the expected JVM-based entrypoint.
  * Added an OCI image build target for the NVCT service, including required runtime environment and working directory settings.

* **Tests**
  * Extended and hardened the image contract test to verify the JAR’s presence, ensure it isn’t whiteouted, confirm the entrypoint matches exactly, and validate required runtime metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->