### PR TITLE
fix(worker-llm-credentials): add subtree .bazelrc so the release image builds

### DIFF
--- a/src/compute-plane-services/worker-llm-credentials/.bazelrc
+++ b/src/compute-plane-services/worker-llm-credentials/.bazelrc
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ============================================================================
+# Bazel configuration for nvcf-worker-llm-credentials.
+#
+# The release image is built from the isolated subtree snapshot, so the
+# release config (and pure-Go, workspace stamping) must live here rather than
+# only in the umbrella .bazelrc. See BAZEL.md for the shared wiring.
+# ============================================================================
+
+build --compilation_mode=fastbuild
+common --enable_bzlmod
+build --incompatible_strict_action_env
+common --enable_platform_specific_config
+
+test --test_output=errors
+test --test_env=HOME=/tmp
+test --test_env=XDG_CACHE_HOME=/tmp/.cache
+
+startup --host_jvm_args=-Xmx2g
+
+# ---- Go ----
+# Pure Go (no cgo) to match the distroless_go static base image.
+build --@rules_go//go/config:pure
+
+# ---- Workspace status (build stamping) ----
+# Feeds tools/workspace_status.sh keys (STABLE_VERSION, STABLE_OCI_TAG, ...)
+# into the stamped OCI tags emitted by the go_oci_image push target.
+build --workspace_status_command=tools/workspace_status.sh
+
+# ---- CI profile ----
+build:ci --jobs=16
+
+# ---- Debug / release profiles ----
+build:debug --compilation_mode=dbg
+build:debug -s
+build:release --compilation_mode=opt
+build:release --strip=always


### PR DESCRIPTION
## Why
The worker-llm-credentials release image build (nvcf-internal) fails:
```
[bazel-release-build] building nvcf-worker-llm-credentials-oss with //cmd:image_index
ERROR: Config value 'release' is not defined in any .rc file
```
The release image is built from an isolated subtree snapshot cloned at the subtree tag, which does not carry the umbrella `.bazelrc` (where `build:release` and `--@rules_go//go/config:pure` live). Every other releasable subtree (nvca, worker-init, worker-utils, image-credential-helper, ...) ships its own `.bazelrc`; worker-llm-credentials was the only one missing it. The full-mono bazel CI passes because it uses the root `.bazelrc`, so this only surfaces at release build time. It was exposed by the first `fix:` to cut a release for this subtree.

## What changed
Add `src/compute-plane-services/worker-llm-credentials/.bazelrc`, mirroring the sibling Go services: bzlmod, pure Go (for the `distroless_go` static base), workspace stamping (`tools/workspace_status.sh`), and the `release`/`debug`/`ci` config profiles. Proto-toolchain lines are omitted since this service declares no protobuf module and has no proto targets.

## Customer Release Notes
Not customer visible.

## Testing
Flags reference only native Bazel and `rules_go` (declared in this subtree's MODULE.bazel), and `tools/workspace_status.sh` exists. The isolated release-snapshot build cannot be reproduced locally (subtree dep resolution needs the CI proxy); the nvcf-internal release build validates it. A new release tag will pick up this file plus the already-merged worker-token change.

## References
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added standardized Bazel build and test configuration.
  * Introduced CI, debug, and release build profiles.
  * Improved build reproducibility, caching, environment handling, and release binary optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->