### PR TITLE
fix(self-managed): bump sis, nvcf-api, and nvct-api chart pins

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -50,13 +50,13 @@ releases:
       - template: service
 
   - name: sis
-    version: 1.18.3
+    version: 2.0.0
     namespace: sis
     inherit:
       - template: service
 
   - name: api
-    version: 1.23.9
+    version: 1.23.10
     namespace: nvcf
     inherit:
       - template: service
@@ -65,7 +65,7 @@ releases:
       - ess/ess-api
                       
   - name: nvct-api
-    version: 1.4.3
+    version: 1.4.4
     namespace: nvcf
     inherit:
       - template: service


### PR DESCRIPTION
## TL;DR
Bump three self-managed core stack chart pins to consume the latest released
charts: sis 1.18.3 -> 2.0.0, nvcf-api 1.23.9 -> 1.23.10, and nvct-api 1.4.3 -> 1.4.4.

## Additional Details
Chart version pins in `deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl`
control which published chart each core NVCF service release deploys. This
change advances the sis, api, and nvct-api releases to their newest chart
versions. No other stack values or ordering change.

Background per chart:

- sis 1.18.3 -> 2.0.0: major bump. The chart now ships hot-reloadable remote
  config for the service (config delivered through a namespace ConfigMap with
  RBAC and a service-account token reshape) and moves to the OSS service image
  with the ncp profile in self-hosted, plus a NATS reconnect fix. This is a
  breaking chart release, see Notes.
- api 1.23.9 -> 1.23.10: patch bump that pulls in the newer OSS service image.
- nvct-api 1.4.3 -> 1.4.4: patch bump that pulls in the newer OSS service image.

## For the Reviewer
Single-file change; the diff is three version-line edits. 

## For QA
Not run yet. Recommend a `helmfile template`/`diff` against the self-managed
stack to confirm the pinned charts resolve, plus a deploy smoke on a test
cluster.

## Notes
sis 2.0.0 is a breaking chart release. Two items to verify against the
self-managed stack values before deploy:

- Volume keys renamed: `sis.volumes` -> `sis.extraVolumes` and
  `sis.volumeMounts` -> `sis.extraVolumeMounts`. The token volume and mount are
  now chart-owned; the chart fails rendering if the old keys are still set.
- Remote config grants the service account `list`/`watch` on the namespace
  ConfigMap collection. Clusters that block broad namespace reads need a policy
  exception, or set `sis.remoteConfig.enabled: false` to opt out (hot reload
  then unavailable).

## Issues
<!-- Replace with a valid NVIDIA/nvcf issue reference before creating the PR. -->
Relates to #ISSUE

## Checklist
- [X] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [X] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated core service chart versions.
  * Includes the latest releases for SIS, API, and NVCT API services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->