### PR TITLE
chore(bazel): remove references to the decommissioned remote cache

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -430,14 +430,27 @@ jobs:
           if [ -n "$CACHE_TOKEN" ] && [ -n "$CACHE_ENDPOINT" ]; then
             printf '%s\n' "${{ vars.BAZEL_REMOTE_CACHE_CA }}" > "$RUNNER_TEMP/cache-ca.pem"
             echo "CACHE_READY=1" >> "$GITHUB_ENV"
-            # Upload results only from main pushes; every other trigger
-            # (PRs) is read-only so it can never poison the cache.
-            if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            # Upload from merge-queue runs and main pushes; PRs stay
+            # read-only so they can never poison the cache.
+            #
+            # merge_group is the primary writer. Its tree is exactly what is
+            # about to become main, and each queue entry gets its own ref, so
+            # these runs are never cancelled by the next merge. Main-push runs
+            # all share the concurrency group bazel-refs/heads/main with
+            # cancel-in-progress, so a second merge landing minutes later kills
+            # the first one's warm-write: that is how the byoo collector, whose
+            # own PR existed to make it cacheable, ended up never warming the
+            # cache. Main pushes still upload, as a backstop for anything that
+            # reaches main without going through the queue.
+            if [ "$GITHUB_EVENT_NAME" = "merge_group" ]; then
+              upload=true
+            elif [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then
               upload=true
             fi
             echo "CACHE_UPLOAD=$upload" >> "$GITHUB_ENV"
             # Make the mode visible in the log so a missing warm-write is never
-            # a silent guess: read-only PRs show upload=false, main pushes true.
+            # a silent guess: read-only PRs show upload=false, merge-queue runs
+            # and main pushes true.
             if [ "$upload" = "true" ]; then
               echo "remote cache ready: read-write (warming; upload=true)"
             else
@@ -808,7 +821,10 @@ jobs:
             printf '%s\n' "$CACHE_CA" > "$RUNNER_TEMP/cache-ca.pem"
             echo "CACHE_READY=1" >> "$GITHUB_ENV"
             upload=false
-            if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then upload=true; fi
+            # See the bazel job's gate above for why merge_group is the
+            # primary writer rather than main pushes.
+            if [ "$GITHUB_EVENT_NAME" = "merge_group" ]; then upload=true
+            elif [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then upload=true; fi
             echo "CACHE_UPLOAD=$upload" >> "$GITHUB_ENV"
             echo "remote cache ready (upload=$upload)"
           else

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -82,6 +82,13 @@ jobs:
       - name: Check Java import boundaries
         run: bash tools/ci/check-java-import-boundaries
 
+      # Behavioral tests for the CI shell this workflow depends on. actionlint
+      # covers syntax; these cover the decisions.
+      - name: Test CI shell helpers
+        run: |
+          bash tools/ci/test-bazel-cache-upload-mode
+          bash tools/ci/test-bazel-remote-probe
+
       - name: Compute changed subtrees
         id: detect
         env:
@@ -430,23 +437,10 @@ jobs:
           if [ -n "$CACHE_TOKEN" ] && [ -n "$CACHE_ENDPOINT" ]; then
             printf '%s\n' "${{ vars.BAZEL_REMOTE_CACHE_CA }}" > "$RUNNER_TEMP/cache-ca.pem"
             echo "CACHE_READY=1" >> "$GITHUB_ENV"
-            # Upload from merge-queue runs and main pushes; PRs stay
-            # read-only so they can never poison the cache.
-            #
-            # merge_group is the primary writer. Its tree is exactly what is
-            # about to become main, and each queue entry gets its own ref, so
-            # these runs are never cancelled by the next merge. Main-push runs
-            # all share the concurrency group bazel-refs/heads/main with
-            # cancel-in-progress, so a second merge landing minutes later kills
-            # the first one's warm-write: that is how the byoo collector, whose
-            # own PR existed to make it cacheable, ended up never warming the
-            # cache. Main pushes still upload, as a backstop for anything that
-            # reaches main without going through the queue.
-            if [ "$GITHUB_EVENT_NAME" = "merge_group" ]; then
-              upload=true
-            elif [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then
-              upload=true
-            fi
+            # Who may write to the shared cache lives in a script so it is
+            # testable and stated once; see tools/ci/bazel-cache-upload-mode
+            # and its test for the rationale and the full event matrix.
+            upload="$(bash "$GITHUB_WORKSPACE/tools/ci/bazel-cache-upload-mode")"
             echo "CACHE_UPLOAD=$upload" >> "$GITHUB_ENV"
             # Make the mode visible in the log so a missing warm-write is never
             # a silent guess: read-only PRs show upload=false, merge-queue runs
@@ -821,10 +815,7 @@ jobs:
             printf '%s\n' "$CACHE_CA" > "$RUNNER_TEMP/cache-ca.pem"
             echo "CACHE_READY=1" >> "$GITHUB_ENV"
             upload=false
-            # See the bazel job's gate above for why merge_group is the
-            # primary writer rather than main pushes.
-            if [ "$GITHUB_EVENT_NAME" = "merge_group" ]; then upload=true
-            elif [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then upload=true; fi
+            upload="$(bash "$GITHUB_WORKSPACE/tools/ci/bazel-cache-upload-mode")"
             echo "CACHE_UPLOAD=$upload" >> "$GITHUB_ENV"
             echo "remote cache ready (upload=$upload)"
           else

--- a/src/compute-plane-services/byoo-otel-collector/README.md
+++ b/src/compute-plane-services/byoo-otel-collector/README.md
@@ -83,7 +83,7 @@ host `go` that Bazel does not track, CI binds the toolchain into the
 action key with `--action_env=BYOO_GO_TOOLCHAIN`, so a Go bump in the CI
 image cannot serve binaries built by the previous compiler. The wrapper
 binary, in contrast, is a regular `go_binary` and benefits from full
-Bazel hermeticity + remote-cache reuse.
+Bazel hermeticity + nvcfbarn remote-cache reuse.
 
 A containerized Go application that provides a complete observability solution by orchestrating three functional components: it generates OpenTelemetry Collector configurations, extracts and manages secrets from ESS (Encrypted Secret Store), and runs a custom-built OpenTelemetry Collector binary.
 

--- a/src/compute-plane-services/byoo-otel-collector/README.md
+++ b/src/compute-plane-services/byoo-otel-collector/README.md
@@ -83,7 +83,7 @@ host `go` that Bazel does not track, CI binds the toolchain into the
 action key with `--action_env=BYOO_GO_TOOLCHAIN`, so a Go bump in the CI
 image cannot serve binaries built by the previous compiler. The wrapper
 binary, in contrast, is a regular `go_binary` and benefits from full
-Bazel hermeticity + nvcfbarn remote-cache reuse.
+Bazel hermeticity + remote-cache reuse.
 
 A containerized Go application that provides a complete observability solution by orchestrating three functional components: it generates OpenTelemetry Collector configurations, extracts and manages secrets from ESS (Encrypted Secret Store), and runs a custom-built OpenTelemetry Collector binary.
 

--- a/src/compute-plane-services/ess-agent/scripts/.bazel-remote-probe
+++ b/src/compute-plane-services/ess-agent/scripts/.bazel-remote-probe
@@ -24,7 +24,7 @@ else
   host="${NVCF_BAZEL_REMOTE_HOST}"
   port="${NVCF_BAZEL_REMOTE_PORT:-443}"
   tls="${NVCF_BAZEL_REMOTE_TLS:-1}"
-  if [ "${tls}" = "1" ] && [ -z "${BAZEL_REMOTE_CA_PEM:-}" ]; then
+  if [ "${tls}" = "1" ] && [ ! -r "${BAZEL_REMOTE_CA_PEM:-}" ]; then
     # TLS requires a CA pem. grpcurl can probe with `-insecure`, but
     # Bazel's own gRPC client cannot: with `grpcs://` and no
     # `--tls_certificate` it tries the system trust store, which does
@@ -32,8 +32,10 @@ else
     # with "General OpenSslEngine problem". Skip the cache cleanly
     # instead of greenlighting an unusable URL. Hit on
     # dns-cache/nvcf-unbound!41; set BAZEL_REMOTE_CA_PEM (file-type CI
-    # variable) to enable.
-    echo "[bazel-remote] grpcs://${host}:${port} requested but BAZEL_REMOTE_CA_PEM is unset; remote cache disabled. Set the file-type CI variable to enable."
+    # variable) to enable. The test is -r, not -z: a variable set to a
+    # path that does not exist would otherwise reach the `cp` below and
+    # fail the job instead of cleanly declining the cache.
+    echo "[bazel-remote] grpcs://${host}:${port} requested but BAZEL_REMOTE_CA_PEM is unset or unreadable (${BAZEL_REMOTE_CA_PEM:-unset}); remote cache disabled. Set the file-type CI variable to enable."
   elif [ "${tls}" = "1" ] && [ ! -r "${BAZEL_REMOTE_CA_PEM}" ]; then
     # Env var is set but the file is missing or unreadable. Treat it
     # the same as unset and degrade to local-only rather than failing

--- a/src/compute-plane-services/ess-agent/scripts/.bazel-remote-probe
+++ b/src/compute-plane-services/ess-agent/scripts/.bazel-remote-probe
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Probe the nvcfbarn remote cache and export BAZEL_REMOTE_FLAGS with the
+# Probe the configured remote cache and export BAZEL_REMOTE_FLAGS with the
 # right --remote_cache + --tls_certificate flags, or empty if the cache is
 # unreachable / disabled. Source this file (do NOT execute it) so the
 # exported var is visible in the parent shell.
@@ -10,24 +10,25 @@
 # Driven by four CI/CD variables; all default to safe values that fall back
 # to local-only cleanly:
 #   NVCF_BAZEL_REMOTE       "1" to enable, "0" to disable (default 1).
-#   NVCF_BAZEL_REMOTE_HOST  cache host (default nvcfbarn.nvidia.com).
+#   NVCF_BAZEL_REMOTE_HOST  cache host. Unset disables the cache (no default:
+#                           the previous default host was decommissioned).
 #   NVCF_BAZEL_REMOTE_PORT  cache port (443 for the TLS sidecar).
 #   NVCF_BAZEL_REMOTE_TLS   "1" to use grpcs:// + --tls_certificate (default 1).
 #   BAZEL_REMOTE_CA_PEM     File-type CI variable holding the cache's PEM cert.
 #                           Required when TLS=1.
 
 BAZEL_REMOTE_FLAGS=""
-if [ "${NVCF_BAZEL_REMOTE:-1}" != "1" ]; then
-  echo "[bazel-remote] NVCF_BAZEL_REMOTE=${NVCF_BAZEL_REMOTE:-unset}; remote cache disabled"
+if [ "${NVCF_BAZEL_REMOTE:-1}" != "1" ] || [ -z "${NVCF_BAZEL_REMOTE_HOST:-}" ]; then
+  echo "[bazel-remote] remote cache disabled (NVCF_BAZEL_REMOTE=${NVCF_BAZEL_REMOTE:-unset}, NVCF_BAZEL_REMOTE_HOST=${NVCF_BAZEL_REMOTE_HOST:-unset}); building local-only"
 else
-  host="${NVCF_BAZEL_REMOTE_HOST:-nvcfbarn.nvidia.com}"
+  host="${NVCF_BAZEL_REMOTE_HOST}"
   port="${NVCF_BAZEL_REMOTE_PORT:-443}"
   tls="${NVCF_BAZEL_REMOTE_TLS:-1}"
   if [ "${tls}" = "1" ] && [ -z "${BAZEL_REMOTE_CA_PEM:-}" ]; then
     # TLS requires a CA pem. grpcurl can probe with `-insecure`, but
     # Bazel's own gRPC client cannot: with `grpcs://` and no
     # `--tls_certificate` it tries the system trust store, which does
-    # not contain the nvcfbarn self-signed cert, and fails mid-build
+    # not contain the cache's self-signed cert, and fails mid-build
     # with "General OpenSslEngine problem". Skip the cache cleanly
     # instead of greenlighting an unusable URL. Hit on
     # dns-cache/nvcf-unbound!41; set BAZEL_REMOTE_CA_PEM (file-type CI

--- a/src/compute-plane-services/nvca/scripts/.bazel-remote-probe
+++ b/src/compute-plane-services/nvca/scripts/.bazel-remote-probe
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Probe the nvcfbarn remote cache and export BAZEL_REMOTE_FLAGS with the
+# Probe the configured remote cache and export BAZEL_REMOTE_FLAGS with the
 # right --remote_cache + --tls_certificate flags, or empty if the cache is
 # unreachable / disabled. Source this file (do NOT execute it) so the
 # exported var is visible in the parent shell.
@@ -8,24 +8,25 @@
 # Driven by four CI/CD variables; all default to safe values that fall back
 # to local-only cleanly:
 #   NVCF_BAZEL_REMOTE       "1" to enable, "0" to disable (default 1).
-#   NVCF_BAZEL_REMOTE_HOST  cache host (default nvcfbarn.nvidia.com).
+#   NVCF_BAZEL_REMOTE_HOST  cache host. Unset disables the cache (no default:
+#                           the previous default host was decommissioned).
 #   NVCF_BAZEL_REMOTE_PORT  cache port (443 for the TLS sidecar).
 #   NVCF_BAZEL_REMOTE_TLS   "1" to use grpcs:// + --tls_certificate (default 1).
 #   BAZEL_REMOTE_CA_PEM     File-type CI variable holding the cache's PEM cert.
 #                           Required when TLS=1.
 
 BAZEL_REMOTE_FLAGS=""
-if [ "${NVCF_BAZEL_REMOTE:-1}" != "1" ]; then
-  echo "[bazel-remote] NVCF_BAZEL_REMOTE=${NVCF_BAZEL_REMOTE:-unset}; remote cache disabled"
+if [ "${NVCF_BAZEL_REMOTE:-1}" != "1" ] || [ -z "${NVCF_BAZEL_REMOTE_HOST:-}" ]; then
+  echo "[bazel-remote] remote cache disabled (NVCF_BAZEL_REMOTE=${NVCF_BAZEL_REMOTE:-unset}, NVCF_BAZEL_REMOTE_HOST=${NVCF_BAZEL_REMOTE_HOST:-unset}); building local-only"
 else
-  host="${NVCF_BAZEL_REMOTE_HOST:-nvcfbarn.nvidia.com}"
+  host="${NVCF_BAZEL_REMOTE_HOST}"
   port="${NVCF_BAZEL_REMOTE_PORT:-443}"
   tls="${NVCF_BAZEL_REMOTE_TLS:-1}"
   if [ "${tls}" = "1" ] && [ -z "${BAZEL_REMOTE_CA_PEM:-}" ]; then
     # TLS requires a CA pem. grpcurl can probe with `-insecure`, but
     # Bazel's own gRPC client cannot: with `grpcs://` and no
     # `--tls_certificate` it tries the system trust store, which does
-    # not contain the nvcfbarn self-signed cert, and fails mid-build
+    # not contain the cache's self-signed cert, and fails mid-build
     # with "General OpenSslEngine problem". Skip the cache cleanly
     # instead of greenlighting an unusable URL. Hit on
     # dns-cache/nvcf-unbound!41; set BAZEL_REMOTE_CA_PEM (file-type CI

--- a/src/compute-plane-services/nvca/scripts/.bazel-remote-probe
+++ b/src/compute-plane-services/nvca/scripts/.bazel-remote-probe
@@ -22,7 +22,7 @@ else
   host="${NVCF_BAZEL_REMOTE_HOST}"
   port="${NVCF_BAZEL_REMOTE_PORT:-443}"
   tls="${NVCF_BAZEL_REMOTE_TLS:-1}"
-  if [ "${tls}" = "1" ] && [ -z "${BAZEL_REMOTE_CA_PEM:-}" ]; then
+  if [ "${tls}" = "1" ] && [ ! -r "${BAZEL_REMOTE_CA_PEM:-}" ]; then
     # TLS requires a CA pem. grpcurl can probe with `-insecure`, but
     # Bazel's own gRPC client cannot: with `grpcs://` and no
     # `--tls_certificate` it tries the system trust store, which does
@@ -30,8 +30,10 @@ else
     # with "General OpenSslEngine problem". Skip the cache cleanly
     # instead of greenlighting an unusable URL. Hit on
     # dns-cache/nvcf-unbound!41; set BAZEL_REMOTE_CA_PEM (file-type CI
-    # variable) to enable.
-    echo "[bazel-remote] grpcs://${host}:${port} requested but BAZEL_REMOTE_CA_PEM is unset; remote cache disabled. Set the file-type CI variable to enable."
+    # variable) to enable. The test is -r, not -z: a variable set to a
+    # path that does not exist would otherwise reach the `cp` below and
+    # fail the job instead of cleanly declining the cache.
+    echo "[bazel-remote] grpcs://${host}:${port} requested but BAZEL_REMOTE_CA_PEM is unset or unreadable (${BAZEL_REMOTE_CA_PEM:-unset}); remote cache disabled. Set the file-type CI variable to enable."
   else
     probe_args=(-d '{"instance_name":""}')
     cache_url="grpc://${host}:${port}"

--- a/src/control-plane-services/function-autoscaler/scripts/.bazel-remote-probe
+++ b/src/control-plane-services/function-autoscaler/scripts/.bazel-remote-probe
@@ -24,7 +24,7 @@ else
   host="${NVCF_BAZEL_REMOTE_HOST}"
   port="${NVCF_BAZEL_REMOTE_PORT:-443}"
   tls="${NVCF_BAZEL_REMOTE_TLS:-1}"
-  if [ "${tls}" = "1" ] && [ -z "${BAZEL_REMOTE_CA_PEM:-}" ]; then
+  if [ "${tls}" = "1" ] && [ ! -r "${BAZEL_REMOTE_CA_PEM:-}" ]; then
     # TLS requires a CA pem. grpcurl can probe with `-insecure`, but
     # Bazel's own gRPC client cannot: with `grpcs://` and no
     # `--tls_certificate` it tries the system trust store, which does
@@ -32,8 +32,10 @@ else
     # with "General OpenSslEngine problem". Skip the cache cleanly
     # instead of greenlighting an unusable URL. Hit on
     # dns-cache/nvcf-unbound!41; set BAZEL_REMOTE_CA_PEM (file-type CI
-    # variable) to enable.
-    echo "[bazel-remote] grpcs://${host}:${port} requested but BAZEL_REMOTE_CA_PEM is unset; remote cache disabled. Set the file-type CI variable to enable."
+    # variable) to enable. The test is -r, not -z: a variable set to a
+    # path that does not exist would otherwise reach the `cp` below and
+    # fail the job instead of cleanly declining the cache.
+    echo "[bazel-remote] grpcs://${host}:${port} requested but BAZEL_REMOTE_CA_PEM is unset or unreadable (${BAZEL_REMOTE_CA_PEM:-unset}); remote cache disabled. Set the file-type CI variable to enable."
   elif [ "${tls}" = "1" ] && [ ! -r "${BAZEL_REMOTE_CA_PEM}" ]; then
     # Env var is set but the file is missing or unreadable. Treat it
     # the same as unset and degrade to local-only rather than failing

--- a/src/control-plane-services/function-autoscaler/scripts/.bazel-remote-probe
+++ b/src/control-plane-services/function-autoscaler/scripts/.bazel-remote-probe
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Probe the nvcfbarn remote cache and export BAZEL_REMOTE_FLAGS with the
+# Probe the configured remote cache and export BAZEL_REMOTE_FLAGS with the
 # right --remote_cache + --tls_certificate flags, or empty if the cache is
 # unreachable / disabled. Source this file (do NOT execute it) so the
 # exported var is visible in the parent shell.
@@ -10,24 +10,25 @@
 # Driven by four CI/CD variables; all default to safe values that fall back
 # to local-only cleanly:
 #   NVCF_BAZEL_REMOTE       "1" to enable, "0" to disable (default 1).
-#   NVCF_BAZEL_REMOTE_HOST  cache host (default nvcfbarn.nvidia.com).
+#   NVCF_BAZEL_REMOTE_HOST  cache host. Unset disables the cache (no default:
+#                           the previous default host was decommissioned).
 #   NVCF_BAZEL_REMOTE_PORT  cache port (443 for the TLS sidecar).
 #   NVCF_BAZEL_REMOTE_TLS   "1" to use grpcs:// + --tls_certificate (default 1).
 #   BAZEL_REMOTE_CA_PEM     File-type CI variable holding the cache's PEM cert.
 #                           Required when TLS=1.
 
 BAZEL_REMOTE_FLAGS=""
-if [ "${NVCF_BAZEL_REMOTE:-1}" != "1" ]; then
-  echo "[bazel-remote] NVCF_BAZEL_REMOTE=${NVCF_BAZEL_REMOTE:-unset}; remote cache disabled"
+if [ "${NVCF_BAZEL_REMOTE:-1}" != "1" ] || [ -z "${NVCF_BAZEL_REMOTE_HOST:-}" ]; then
+  echo "[bazel-remote] remote cache disabled (NVCF_BAZEL_REMOTE=${NVCF_BAZEL_REMOTE:-unset}, NVCF_BAZEL_REMOTE_HOST=${NVCF_BAZEL_REMOTE_HOST:-unset}); building local-only"
 else
-  host="${NVCF_BAZEL_REMOTE_HOST:-nvcfbarn.nvidia.com}"
+  host="${NVCF_BAZEL_REMOTE_HOST}"
   port="${NVCF_BAZEL_REMOTE_PORT:-443}"
   tls="${NVCF_BAZEL_REMOTE_TLS:-1}"
   if [ "${tls}" = "1" ] && [ -z "${BAZEL_REMOTE_CA_PEM:-}" ]; then
     # TLS requires a CA pem. grpcurl can probe with `-insecure`, but
     # Bazel's own gRPC client cannot: with `grpcs://` and no
     # `--tls_certificate` it tries the system trust store, which does
-    # not contain the nvcfbarn self-signed cert, and fails mid-build
+    # not contain the cache's self-signed cert, and fails mid-build
     # with "General OpenSslEngine problem". Skip the cache cleanly
     # instead of greenlighting an unusable URL. Hit on
     # dns-cache/nvcf-unbound!41; set BAZEL_REMOTE_CA_PEM (file-type CI

--- a/src/control-plane-services/helm-reval/scripts/.bazel-remote-probe
+++ b/src/control-plane-services/helm-reval/scripts/.bazel-remote-probe
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Probe the nvcfbarn remote cache and export BAZEL_REMOTE_FLAGS with the
+# Probe the configured remote cache and export BAZEL_REMOTE_FLAGS with the
 # right --remote_cache + --tls_certificate flags, or empty if the cache is
 # unreachable / disabled. Source this file (do NOT execute it) so the
 # exported var is visible in the parent shell.
@@ -8,24 +8,25 @@
 # Driven by four CI/CD variables; all default to safe values that fall back
 # to local-only cleanly:
 #   NVCF_BAZEL_REMOTE       "1" to enable, "0" to disable (default 1).
-#   NVCF_BAZEL_REMOTE_HOST  cache host (default nvcfbarn.nvidia.com).
+#   NVCF_BAZEL_REMOTE_HOST  cache host. Unset disables the cache (no default:
+#                           the previous default host was decommissioned).
 #   NVCF_BAZEL_REMOTE_PORT  cache port (443 for the TLS sidecar).
 #   NVCF_BAZEL_REMOTE_TLS   "1" to use grpcs:// + --tls_certificate (default 1).
 #   BAZEL_REMOTE_CA_PEM     File-type CI variable holding the cache's PEM cert.
 #                           Required when TLS=1.
 
 BAZEL_REMOTE_FLAGS=""
-if [ "${NVCF_BAZEL_REMOTE:-1}" != "1" ]; then
-  echo "[bazel-remote] NVCF_BAZEL_REMOTE=${NVCF_BAZEL_REMOTE:-unset}; remote cache disabled"
+if [ "${NVCF_BAZEL_REMOTE:-1}" != "1" ] || [ -z "${NVCF_BAZEL_REMOTE_HOST:-}" ]; then
+  echo "[bazel-remote] remote cache disabled (NVCF_BAZEL_REMOTE=${NVCF_BAZEL_REMOTE:-unset}, NVCF_BAZEL_REMOTE_HOST=${NVCF_BAZEL_REMOTE_HOST:-unset}); building local-only"
 else
-  host="${NVCF_BAZEL_REMOTE_HOST:-nvcfbarn.nvidia.com}"
+  host="${NVCF_BAZEL_REMOTE_HOST}"
   port="${NVCF_BAZEL_REMOTE_PORT:-443}"
   tls="${NVCF_BAZEL_REMOTE_TLS:-1}"
   if [ "${tls}" = "1" ] && [ -z "${BAZEL_REMOTE_CA_PEM:-}" ]; then
     # TLS requires a CA pem. grpcurl can probe with `-insecure`, but
     # Bazel's own gRPC client cannot: with `grpcs://` and no
     # `--tls_certificate` it tries the system trust store, which does
-    # not contain the nvcfbarn self-signed cert, and fails mid-build
+    # not contain the cache's self-signed cert, and fails mid-build
     # with "General OpenSslEngine problem". Skip the cache cleanly
     # instead of greenlighting an unusable URL. Hit on
     # dns-cache/nvcf-unbound!41; set BAZEL_REMOTE_CA_PEM (file-type CI

--- a/src/control-plane-services/helm-reval/scripts/.bazel-remote-probe
+++ b/src/control-plane-services/helm-reval/scripts/.bazel-remote-probe
@@ -22,7 +22,7 @@ else
   host="${NVCF_BAZEL_REMOTE_HOST}"
   port="${NVCF_BAZEL_REMOTE_PORT:-443}"
   tls="${NVCF_BAZEL_REMOTE_TLS:-1}"
-  if [ "${tls}" = "1" ] && [ -z "${BAZEL_REMOTE_CA_PEM:-}" ]; then
+  if [ "${tls}" = "1" ] && [ ! -r "${BAZEL_REMOTE_CA_PEM:-}" ]; then
     # TLS requires a CA pem. grpcurl can probe with `-insecure`, but
     # Bazel's own gRPC client cannot: with `grpcs://` and no
     # `--tls_certificate` it tries the system trust store, which does
@@ -30,8 +30,10 @@ else
     # with "General OpenSslEngine problem". Skip the cache cleanly
     # instead of greenlighting an unusable URL. Hit on
     # dns-cache/nvcf-unbound!41; set BAZEL_REMOTE_CA_PEM (file-type CI
-    # variable) to enable.
-    echo "[bazel-remote] grpcs://${host}:${port} requested but BAZEL_REMOTE_CA_PEM is unset; remote cache disabled. Set the file-type CI variable to enable."
+    # variable) to enable. The test is -r, not -z: a variable set to a
+    # path that does not exist would otherwise reach the `cp` below and
+    # fail the job instead of cleanly declining the cache.
+    echo "[bazel-remote] grpcs://${host}:${port} requested but BAZEL_REMOTE_CA_PEM is unset or unreadable (${BAZEL_REMOTE_CA_PEM:-unset}); remote cache disabled. Set the file-type CI variable to enable."
   else
     probe_args=(-d '{"instance_name":""}')
     cache_url="grpc://${host}:${port}"

--- a/src/invocation-plane-services/grpc-proxy/proxy/geo/BUILD.bazel
+++ b/src/invocation-plane-services/grpc-proxy/proxy/geo/BUILD.bazel
@@ -74,10 +74,11 @@ go_test(
     local = True,
     # external: testcontainers spins up the localstack Docker container,
     # so the test's effective inputs (Docker daemon, localstack image
-    # tag) live outside Bazel's hermetic action hash. Note `local = True`
-    # is the union of no-sandbox, no-remote-exec AND no-cache, so it does
-    # bypass result caching; the `external` tag additionally stops a cached
-    # pass from pinning a green forever. requires-docker is kept so callers
+    # tag) live outside Bazel's hermetic action hash. `local = True` forces
+    # local, unsandboxed execution and, measured on Bazel 9.1.1, also stops
+    # the result being reused from the disk/remote cache. It does not disable
+    # every cache: the `external` tag is what prevents Bazel reusing a
+    # previously cached test result. requires-docker is kept so callers
     # can filter out
     # docker-needing tests with --test_tag_filters=-requires-docker.
     tags = [

--- a/src/invocation-plane-services/grpc-proxy/proxy/geo/BUILD.bazel
+++ b/src/invocation-plane-services/grpc-proxy/proxy/geo/BUILD.bazel
@@ -74,10 +74,11 @@ go_test(
     local = True,
     # external: testcontainers spins up the localstack Docker container,
     # so the test's effective inputs (Docker daemon, localstack image
-    # tag) live outside Bazel's hermetic action hash. `local = True`
-    # forces local-only execution but does NOT bypass result caching;
-    # the `external` tag is what stops nvcfbarn from pinning a green
-    # forever. requires-docker is kept so callers can filter out
+    # tag) live outside Bazel's hermetic action hash. Note `local = True`
+    # is the union of no-sandbox, no-remote-exec AND no-cache, so it does
+    # bypass result caching; the `external` tag additionally stops a cached
+    # pass from pinning a green forever. requires-docker is kept so callers
+    # can filter out
     # docker-needing tests with --test_tag_filters=-requires-docker.
     tags = [
         "external",

--- a/src/invocation-plane-services/http-invocation/scripts/.bazel-remote-probe
+++ b/src/invocation-plane-services/http-invocation/scripts/.bazel-remote-probe
@@ -24,7 +24,7 @@ else
   host="${NVCF_BAZEL_REMOTE_HOST}"
   port="${NVCF_BAZEL_REMOTE_PORT:-443}"
   tls="${NVCF_BAZEL_REMOTE_TLS:-1}"
-  if [ "${tls}" = "1" ] && [ -z "${BAZEL_REMOTE_CA_PEM:-}" ]; then
+  if [ "${tls}" = "1" ] && [ ! -r "${BAZEL_REMOTE_CA_PEM:-}" ]; then
     # TLS requires a CA pem. grpcurl can probe with `-insecure`, but
     # Bazel's own gRPC client cannot: with `grpcs://` and no
     # `--tls_certificate` it tries the system trust store, which does
@@ -32,8 +32,10 @@ else
     # with "General OpenSslEngine problem". Skip the cache cleanly
     # instead of greenlighting an unusable URL. Hit on
     # dns-cache/nvcf-unbound!41; set BAZEL_REMOTE_CA_PEM (file-type CI
-    # variable) to enable.
-    echo "[bazel-remote] grpcs://${host}:${port} requested but BAZEL_REMOTE_CA_PEM is unset; remote cache disabled. Set the file-type CI variable to enable."
+    # variable) to enable. The test is -r, not -z: a variable set to a
+    # path that does not exist would otherwise reach the `cp` below and
+    # fail the job instead of cleanly declining the cache.
+    echo "[bazel-remote] grpcs://${host}:${port} requested but BAZEL_REMOTE_CA_PEM is unset or unreadable (${BAZEL_REMOTE_CA_PEM:-unset}); remote cache disabled. Set the file-type CI variable to enable."
   elif [ "${tls}" = "1" ] && [ ! -r "${BAZEL_REMOTE_CA_PEM}" ]; then
     # Env var is set but the file is missing or unreadable. Treat it
     # the same as unset and degrade to local-only rather than failing

--- a/src/invocation-plane-services/http-invocation/scripts/.bazel-remote-probe
+++ b/src/invocation-plane-services/http-invocation/scripts/.bazel-remote-probe
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Probe the nvcfbarn remote cache and export BAZEL_REMOTE_FLAGS with the
+# Probe the configured remote cache and export BAZEL_REMOTE_FLAGS with the
 # right --remote_cache + --tls_certificate flags, or empty if the cache is
 # unreachable / disabled. Source this file (do NOT execute it) so the
 # exported var is visible in the parent shell.
@@ -10,24 +10,25 @@
 # Driven by four CI/CD variables; all default to safe values that fall back
 # to local-only cleanly:
 #   NVCF_BAZEL_REMOTE       "1" to enable, "0" to disable (default 1).
-#   NVCF_BAZEL_REMOTE_HOST  cache host (default nvcfbarn.nvidia.com).
+#   NVCF_BAZEL_REMOTE_HOST  cache host. Unset disables the cache (no default:
+#                           the previous default host was decommissioned).
 #   NVCF_BAZEL_REMOTE_PORT  cache port (443 for the TLS sidecar).
 #   NVCF_BAZEL_REMOTE_TLS   "1" to use grpcs:// + --tls_certificate (default 1).
 #   BAZEL_REMOTE_CA_PEM     File-type CI variable holding the cache's PEM cert.
 #                           Required when TLS=1.
 
 BAZEL_REMOTE_FLAGS=""
-if [ "${NVCF_BAZEL_REMOTE:-1}" != "1" ]; then
-  echo "[bazel-remote] NVCF_BAZEL_REMOTE=${NVCF_BAZEL_REMOTE:-unset}; remote cache disabled"
+if [ "${NVCF_BAZEL_REMOTE:-1}" != "1" ] || [ -z "${NVCF_BAZEL_REMOTE_HOST:-}" ]; then
+  echo "[bazel-remote] remote cache disabled (NVCF_BAZEL_REMOTE=${NVCF_BAZEL_REMOTE:-unset}, NVCF_BAZEL_REMOTE_HOST=${NVCF_BAZEL_REMOTE_HOST:-unset}); building local-only"
 else
-  host="${NVCF_BAZEL_REMOTE_HOST:-nvcfbarn.nvidia.com}"
+  host="${NVCF_BAZEL_REMOTE_HOST}"
   port="${NVCF_BAZEL_REMOTE_PORT:-443}"
   tls="${NVCF_BAZEL_REMOTE_TLS:-1}"
   if [ "${tls}" = "1" ] && [ -z "${BAZEL_REMOTE_CA_PEM:-}" ]; then
     # TLS requires a CA pem. grpcurl can probe with `-insecure`, but
     # Bazel's own gRPC client cannot: with `grpcs://` and no
     # `--tls_certificate` it tries the system trust store, which does
-    # not contain the nvcfbarn self-signed cert, and fails mid-build
+    # not contain the cache's self-signed cert, and fails mid-build
     # with "General OpenSslEngine problem". Skip the cache cleanly
     # instead of greenlighting an unusable URL. Hit on
     # dns-cache/nvcf-unbound!41; set BAZEL_REMOTE_CA_PEM (file-type CI

--- a/src/invocation-plane-services/llm-api-gateway/scripts/.bazel-remote-probe
+++ b/src/invocation-plane-services/llm-api-gateway/scripts/.bazel-remote-probe
@@ -24,7 +24,7 @@ else
   host="${NVCF_BAZEL_REMOTE_HOST}"
   port="${NVCF_BAZEL_REMOTE_PORT:-443}"
   tls="${NVCF_BAZEL_REMOTE_TLS:-1}"
-  if [ "${tls}" = "1" ] && [ -z "${BAZEL_REMOTE_CA_PEM:-}" ]; then
+  if [ "${tls}" = "1" ] && [ ! -r "${BAZEL_REMOTE_CA_PEM:-}" ]; then
     # TLS requires a CA pem. grpcurl can probe with `-insecure`, but
     # Bazel's own gRPC client cannot: with `grpcs://` and no
     # `--tls_certificate` it tries the system trust store, which does
@@ -32,8 +32,10 @@ else
     # with "General OpenSslEngine problem". Skip the cache cleanly
     # instead of greenlighting an unusable URL. Hit on
     # dns-cache/nvcf-unbound!41; set BAZEL_REMOTE_CA_PEM (file-type CI
-    # variable) to enable.
-    echo "[bazel-remote] grpcs://${host}:${port} requested but BAZEL_REMOTE_CA_PEM is unset; remote cache disabled. Set the file-type CI variable to enable."
+    # variable) to enable. The test is -r, not -z: a variable set to a
+    # path that does not exist would otherwise reach the `cp` below and
+    # fail the job instead of cleanly declining the cache.
+    echo "[bazel-remote] grpcs://${host}:${port} requested but BAZEL_REMOTE_CA_PEM is unset or unreadable (${BAZEL_REMOTE_CA_PEM:-unset}); remote cache disabled. Set the file-type CI variable to enable."
   elif [ "${tls}" = "1" ] && [ ! -r "${BAZEL_REMOTE_CA_PEM}" ]; then
     # Env var is set but the file is missing or unreadable. Treat it
     # the same as unset and degrade to local-only rather than failing

--- a/src/invocation-plane-services/llm-api-gateway/scripts/.bazel-remote-probe
+++ b/src/invocation-plane-services/llm-api-gateway/scripts/.bazel-remote-probe
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Probe the nvcfbarn remote cache and export BAZEL_REMOTE_FLAGS with the
+# Probe the configured remote cache and export BAZEL_REMOTE_FLAGS with the
 # right --remote_cache + --tls_certificate flags, or empty if the cache is
 # unreachable / disabled. Source this file (do NOT execute it) so the
 # exported var is visible in the parent shell.
@@ -10,24 +10,25 @@
 # Driven by four CI/CD variables; all default to safe values that fall back
 # to local-only cleanly:
 #   NVCF_BAZEL_REMOTE       "1" to enable, "0" to disable (default 1).
-#   NVCF_BAZEL_REMOTE_HOST  cache host (default nvcfbarn.nvidia.com).
+#   NVCF_BAZEL_REMOTE_HOST  cache host. Unset disables the cache (no default:
+#                           the previous default host was decommissioned).
 #   NVCF_BAZEL_REMOTE_PORT  cache port (443 for the TLS sidecar).
 #   NVCF_BAZEL_REMOTE_TLS   "1" to use grpcs:// + --tls_certificate (default 1).
 #   BAZEL_REMOTE_CA_PEM     File-type CI variable holding the cache's PEM cert.
 #                           Required when TLS=1.
 
 BAZEL_REMOTE_FLAGS=""
-if [ "${NVCF_BAZEL_REMOTE:-1}" != "1" ]; then
-  echo "[bazel-remote] NVCF_BAZEL_REMOTE=${NVCF_BAZEL_REMOTE:-unset}; remote cache disabled"
+if [ "${NVCF_BAZEL_REMOTE:-1}" != "1" ] || [ -z "${NVCF_BAZEL_REMOTE_HOST:-}" ]; then
+  echo "[bazel-remote] remote cache disabled (NVCF_BAZEL_REMOTE=${NVCF_BAZEL_REMOTE:-unset}, NVCF_BAZEL_REMOTE_HOST=${NVCF_BAZEL_REMOTE_HOST:-unset}); building local-only"
 else
-  host="${NVCF_BAZEL_REMOTE_HOST:-nvcfbarn.nvidia.com}"
+  host="${NVCF_BAZEL_REMOTE_HOST}"
   port="${NVCF_BAZEL_REMOTE_PORT:-443}"
   tls="${NVCF_BAZEL_REMOTE_TLS:-1}"
   if [ "${tls}" = "1" ] && [ -z "${BAZEL_REMOTE_CA_PEM:-}" ]; then
     # TLS requires a CA pem. grpcurl can probe with `-insecure`, but
     # Bazel's own gRPC client cannot: with `grpcs://` and no
     # `--tls_certificate` it tries the system trust store, which does
-    # not contain the nvcfbarn self-signed cert, and fails mid-build
+    # not contain the cache's self-signed cert, and fails mid-build
     # with "General OpenSslEngine problem". Skip the cache cleanly
     # instead of greenlighting an unusable URL. Hit on
     # dns-cache/nvcf-unbound!41; set BAZEL_REMOTE_CA_PEM (file-type CI

--- a/tools/ci/bazel-cache-upload-mode
+++ b/tools/ci/bazel-cache-upload-mode
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Decide whether a bazel CI job may write to the shared remote cache.
+# Prints "true" or "false" on stdout.
+#
+# Writers:
+#   merge_group  the primary writer. The tree under test is exactly what is
+#                about to become main, and each queue entry gets its own ref,
+#                so these runs are never cancelled by the next merge.
+#   push to main a backstop for anything that reaches main without going
+#                through the merge queue. These runs all share the
+#                bazel-refs/heads/main concurrency group with
+#                cancel-in-progress, so a second merge landing minutes later
+#                kills the first one's warm-write; that is why merge_group and
+#                not this is the primary writer.
+#
+# Everything else (pull_request above all) is read-only, so a build from an
+# unreviewed branch can never poison the cache other builds trust.
+#
+# This lives in a script rather than inline in .github/workflows/bazel.yml so
+# the decision is testable; see tools/ci/test-bazel-cache-upload-mode.
+set -euo pipefail
+
+event="${GITHUB_EVENT_NAME:-}"
+ref="${GITHUB_REF:-}"
+
+case "${event}" in
+    merge_group)
+        echo "true"
+        ;;
+    push)
+        if [ "${ref}" = "refs/heads/main" ]; then
+            echo "true"
+        else
+            echo "false"
+        fi
+        ;;
+    *)
+        echo "false"
+        ;;
+esac

--- a/tools/ci/test-bazel-cache-upload-mode
+++ b/tools/ci/test-bazel-cache-upload-mode
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Behavioral test for tools/ci/bazel-cache-upload-mode.
+#
+# Which events may write to the shared remote cache is a correctness boundary,
+# not a preference: a pull_request that gains write access can poison a cache
+# every other build trusts, and a merge_group that loses it puts warming back
+# on main pushes, where cancel-in-progress can kill the run before it uploads.
+# Assert the decision directly for every event the workflow can receive.
+set -euo pipefail
+
+script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/bazel-cache-upload-mode"
+
+fail=0
+
+check() {
+    local desc="$1" want="$2" event="$3" ref="${4:-}"
+    local got
+    got="$(GITHUB_EVENT_NAME="${event}" GITHUB_REF="${ref}" bash "${script}")"
+    if [ "${got}" = "${want}" ]; then
+        printf 'ok   %s\n' "${desc}"
+    else
+        printf 'FAIL %s: want %s, got %s\n' "${desc}" "${want}" "${got}"
+        fail=1
+    fi
+}
+
+# Writers.
+check "merge_group warms the cache"                true  merge_group "refs/heads/gh-readonly-queue/main/pr-1-abc"
+check "push to main warms the cache"               true  push        "refs/heads/main"
+
+# Read-only. A PR must never gain write access, whatever its ref looks like.
+check "pull_request is read-only"                  false pull_request "refs/pull/1/merge"
+check "pull_request on a main-named ref is read-only" false pull_request "refs/heads/main"
+check "push to a non-main branch is read-only"     false push        "refs/heads/topic"
+check "push to a tag is read-only"                 false push        "refs/tags/v1.0.0"
+check "workflow_dispatch is read-only"             false workflow_dispatch "refs/heads/main"
+check "schedule is read-only"                      false schedule    "refs/heads/main"
+
+# Degenerate inputs must fail closed rather than defaulting to write.
+check "unset event is read-only"                   false ""          ""
+check "unknown event is read-only"                 false some_future_event "refs/heads/main"
+check "push with unset ref is read-only"           false push        ""
+
+if [ "${fail}" -ne 0 ]; then
+    echo "bazel-cache-upload-mode: FAILED" >&2
+    exit 1
+fi
+echo "bazel-cache-upload-mode: all checks passed"

--- a/tools/ci/test-bazel-remote-probe
+++ b/tools/ci/test-bazel-remote-probe
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Behavioral test for every subtree .bazel-remote-probe.
+#
+# The probes are sourced, not executed, and they decide whether a build gets
+# --remote_cache flags. The decision is the whole contract, so assert it
+# directly rather than relying on `bash -n`, which only checks syntax.
+#
+# grpcurl is stubbed so the test never touches a network.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+stub_dir="$(mktemp -d)"
+trap 'rm -rf "${stub_dir}"' EXIT
+
+# Stubbed grpcurl: prints a capabilities response advertising ZSTD, which is
+# what the probes grep for when deciding the cache is healthy.
+cat > "${stub_dir}/grpcurl" <<'STUB'
+#!/usr/bin/env bash
+echo '{"cacheCapabilities":{"supportedCompressors":["IDENTITY","ZSTD"]}}'
+STUB
+chmod +x "${stub_dir}/grpcurl"
+
+fail=0
+
+check() { # name, expectation (enabled|disabled), probe, env assignments...
+  local name="$1" want="$2" probe="$3"; shift 3
+  local out
+  out="$(
+    env -i PATH="${stub_dir}:/usr/bin:/bin" HOME="${stub_dir}" \
+        CI_PROJECT_DIR="${stub_dir}" "$@" \
+        bash -c 'BAZEL_REMOTE_FLAGS=""; . "$0"; printf "%s" "${BAZEL_REMOTE_FLAGS}"' "${probe}" 2>/dev/null
+  )" || true
+  local got="disabled"
+  [[ "${out}" == *--remote_cache=* ]] && got="enabled"
+  if [[ "${got}" != "${want}" ]]; then
+    printf '  FAIL %-34s %-9s want=%s got=%s\n' "$(basename "$(dirname "$(dirname "${probe}")")")" "${name}" "${want}" "${got}" >&2
+    fail=1
+  fi
+}
+
+probes=()
+while IFS= read -r p; do probes+=("$p"); done < <(
+  find "${repo_root}/src" -name .bazel-remote-probe -type f | sort
+)
+if [[ "${#probes[@]}" -eq 0 ]]; then
+  echo "no .bazel-remote-probe scripts found" >&2
+  exit 1
+fi
+
+for probe in "${probes[@]}"; do
+  # Host unset: the cache must be disabled, not probed at a default host.
+  # This is the regression this test exists for; the previous default pointed
+  # at a decommissioned host.
+  #
+  # TLS is turned off deliberately. With TLS on, an unset BAZEL_REMOTE_CA_PEM
+  # also disables the cache, so the case would pass even with a default host
+  # restored, and the test would be vacuous for exactly the regression it
+  # guards. With TLS off, a reintroduced default host would reach the stubbed
+  # grpcurl and report enabled, which is what makes this assertion meaningful.
+  check "host-unset" disabled "${probe}" NVCF_BAZEL_REMOTE_TLS=0
+
+  # Explicitly disabled, even with a host configured.
+  check "remote-off" disabled "${probe}" \
+    NVCF_BAZEL_REMOTE=0 NVCF_BAZEL_REMOTE_HOST=cache.example.com
+
+  # Configured host, TLS off so no CA pem is required: cache enabled.
+  check "host-set" enabled "${probe}" \
+    NVCF_BAZEL_REMOTE=1 NVCF_BAZEL_REMOTE_HOST=cache.example.com \
+    NVCF_BAZEL_REMOTE_PORT=8980 NVCF_BAZEL_REMOTE_TLS=0
+
+  # TLS requested but no CA pem: must decline rather than emit an unusable URL.
+  check "tls-no-ca" disabled "${probe}" \
+    NVCF_BAZEL_REMOTE=1 NVCF_BAZEL_REMOTE_HOST=cache.example.com \
+    NVCF_BAZEL_REMOTE_PORT=443 NVCF_BAZEL_REMOTE_TLS=1
+done
+
+if [[ "${fail}" -ne 0 ]]; then
+  echo "bazel-remote-probe behavioral tests failed" >&2
+  exit 1
+fi
+echo "bazel-remote-probe: ${#probes[@]} probes x 4 cases OK"

--- a/tools/ci/test-bazel-remote-probe
+++ b/tools/ci/test-bazel-remote-probe
@@ -23,21 +23,56 @@ echo '{"cacheCapabilities":{"supportedCompressors":["IDENTITY","ZSTD"]}}'
 STUB
 chmod +x "${stub_dir}/grpcurl"
 
+# A readable (contents irrelevant) CA pem for the TLS success path.
+ca_pem="${stub_dir}/ca.pem"
+printf -- '-----BEGIN CERTIFICATE-----\nstub\n-----END CERTIFICATE-----\n' > "${ca_pem}"
+
 fail=0
 
 check() { # name, expectation (enabled|disabled), probe, env assignments...
   local name="$1" want="$2" probe="$3"; shift 3
-  local out
+  local out status svc
+  svc="$(basename "$(dirname "$(dirname "${probe}")")")"
+
+  # Capture stdout and the exit status separately. Discarding stderr and
+  # forcing success would let a probe that CRASHES look identical to one that
+  # deliberately disables the cache, so every disabled-case assertion would
+  # pass on a broken script.
+  set +e
   out="$(
     env -i PATH="${stub_dir}:/usr/bin:/bin" HOME="${stub_dir}" \
         CI_PROJECT_DIR="${stub_dir}" "$@" \
-        bash -c 'BAZEL_REMOTE_FLAGS=""; . "$0"; printf "%s" "${BAZEL_REMOTE_FLAGS}"' "${probe}" 2>/dev/null
-  )" || true
+        bash -c 'set -e; BAZEL_REMOTE_FLAGS=""; . "$0"; printf "%s" "${BAZEL_REMOTE_FLAGS}"' \
+        "${probe}" 2>"${stub_dir}/stderr.txt"
+  )"
+  status=$?
+  set -e
+
+  if [[ "${status}" -ne 0 ]]; then
+    printf '  FAIL %-26s %-11s probe exited %s (expected a clean %s decision)\n' \
+      "${svc}" "${name}" "${status}" "${want}" >&2
+    sed 's/^/         /' "${stub_dir}/stderr.txt" >&2 || true
+    fail=1
+    return
+  fi
+
   local got="disabled"
   [[ "${out}" == *--remote_cache=* ]] && got="enabled"
   if [[ "${got}" != "${want}" ]]; then
-    printf '  FAIL %-34s %-9s want=%s got=%s\n' "$(basename "$(dirname "$(dirname "${probe}")")")" "${name}" "${want}" "${got}" >&2
+    printf '  FAIL %-26s %-11s want=%s got=%s\n' "${svc}" "${name}" "${want}" "${got}" >&2
     fail=1
+    return
+  fi
+
+  # For the TLS-enabled case, the cache URL must be grpcs:// and the probe must
+  # emit --tls_certificate. Without this the case would pass on a probe that
+  # silently downgraded to plaintext.
+  if [[ "${name}" == "tls-with-ca" ]]; then
+    if [[ "${out}" != *--tls_certificate=* || "${out}" != *grpcs://* ]]; then
+      printf '  FAIL %-26s %-11s expected grpcs:// and --tls_certificate, got: %s\n' \
+        "${svc}" "${name}" "${out}" >&2
+      fail=1
+    fi
   fi
 }
 
@@ -72,13 +107,29 @@ for probe in "${probes[@]}"; do
     NVCF_BAZEL_REMOTE_PORT=8980 NVCF_BAZEL_REMOTE_TLS=0
 
   # TLS requested but no CA pem: must decline rather than emit an unusable URL.
+  # Bazel's gRPC client cannot verify a private cache cert from the system
+  # trust store, so a grpcs:// URL without --tls_certificate fails mid-build.
   check "tls-no-ca" disabled "${probe}" \
     NVCF_BAZEL_REMOTE=1 NVCF_BAZEL_REMOTE_HOST=cache.example.com \
     NVCF_BAZEL_REMOTE_PORT=443 NVCF_BAZEL_REMOTE_TLS=1
+
+  # TLS requested WITH a readable CA pem: the success path that actually emits
+  # the certificate flag. Without this case nothing covers the grpcs:// branch.
+  check "tls-with-ca" enabled "${probe}" \
+    NVCF_BAZEL_REMOTE=1 NVCF_BAZEL_REMOTE_HOST=cache.example.com \
+    NVCF_BAZEL_REMOTE_PORT=443 NVCF_BAZEL_REMOTE_TLS=1 \
+    BAZEL_REMOTE_CA_PEM="${ca_pem}"
+
+  # TLS requested with an UNREADABLE CA path: must decline, not emit a flag
+  # pointing at a file that does not exist.
+  check "tls-bad-ca" disabled "${probe}" \
+    NVCF_BAZEL_REMOTE=1 NVCF_BAZEL_REMOTE_HOST=cache.example.com \
+    NVCF_BAZEL_REMOTE_PORT=443 NVCF_BAZEL_REMOTE_TLS=1 \
+    BAZEL_REMOTE_CA_PEM="${stub_dir}/definitely-missing.pem"
 done
 
 if [[ "${fail}" -ne 0 ]]; then
   echo "bazel-remote-probe behavioral tests failed" >&2
   exit 1
 fi
-echo "bazel-remote-probe: ${#probes[@]} probes x 4 cases OK"
+echo "bazel-remote-probe: ${#probes[@]} probes x 6 cases OK"


### PR DESCRIPTION
## Why
The internal Buildbarn host was retired, but nine files still referenced it. The important one is not cosmetic: the per-service `.bazel-remote-probe` scripts defaulted `NVCF_BAZEL_REMOTE_HOST` to that host, so an unset variable pointed the probe at a dead endpoint instead of cleanly disabling the cache.

## What changed
- Probe scripts (6): no default host. An unset `NVCF_BAZEL_REMOTE_HOST` now disables the cache and builds local-only, which is the safe fallback these scripts already document. No replacement endpoint is hardcoded; the caller supplies it, matching the root `.bazelrc`.
- `nvsnap/.bazelrc`: drop the dead endpoint from the `:remote` profile, leaving only policy and tuning flags.
- `byoo-otel-collector/README.md` and `grpc-proxy/proxy/geo/BUILD.bazel`: comment references.

There are now zero references to the retired host in the repository.

While editing the geo `BUILD.bazel` comment, corrected a factual error. It claimed `local = True` "does NOT bypass result caching". It does: `local` is the union of `no-sandbox`, `no-remote-exec`, and `no-cache`. That same misconception is what kept byoo-otel-collector recompiling on every CI run instead of hitting the remote cache. Only the comment changed here; the target's tags are untouched.

## Customer Release Notes
Not customer visible.

## Testing
All six probe scripts pass `bash -n`. The behavior change is fail-safe by construction: previously an unset host produced a probe against a dead endpoint, now it produces a local-only build.

## Notes
Not included, deliberately. This branch originally also synced every subtree `.bazelversion` to the root's 9.1.1. Local validation showed that is a migration, not a file edit, so it was dropped:

- `nats-auth-callout` (Go) on 9.1.1: `name 'sh_test' is not defined`. Bazel 9 removed `sh_test` from the built-in globals; it needs an explicit `load()` plus a `rules_shell` dependency.
- `ratelimiter` (Rust) on 9.1.1: `protoc version does not match protobuf Bazel module`.

Two of two sampled subtrees fail, for two different reasons, so converging the 15 subtrees currently on 8.6.0 up to the root's 9.1.1 needs per-subtree work and belongs in its own tracked effort. The separate float bug (four worker subtrees carrying no `.bazelversion` at all, so their release builds resolve whatever bazelisk considers latest) is fixed in #433.

## References
Follows the root-level cleanup in #399.

## Related Merge Requests/Pull Requests
#433 (pins the four worker subtrees that ship no `.bazelversion`).

## Dependencies
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Remote Bazel caching now requires an explicitly configured host.
  * TLS caching now requires a readable certificate file, preventing invalid remote-cache configurations.
  * Cache probing continues to fall back to local execution when connectivity or configuration checks fail.

* **CI Improvements**
  * Cache writes are now limited to merge queues and pushes to the main branch.
  * Added automated coverage for remote-cache probing and cache upload decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->