### PR TITLE
feat(self-managed): bump nvcf-ui charts

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -201,7 +201,7 @@ releases:
 
   - name: nvcf-ui
     chart: nvcf/helm-nvcf-ui
-    version: 1.1.1
+    version: 1.1.2
     namespace: nvcf-ui
     condition: addons.nvcfUi.enabled
     values:

--- a/docs/user/manifest.md
+++ b/docs/user/manifest.md
@@ -128,7 +128,7 @@ The following tables list the complete artifact inventory.
 | `helm-nvcf-rate-limiter` | `1.0.3` | Optional | Deploys request rate limiting for supported invocation paths. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-rate-limiter:1.0.3` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/ratelimiter) |
 | `helm-nvcf-sis` | `1.18.3` | Required | Deploys the Spot Instance Service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-sis:1.18.3` |  |
 | `helm-nvcf-state-metrics` | `1.0.1` | Optional | Deploys NVCF state metrics for observability. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-state-metrics:1.0.1` |  |
-| `helm-nvcf-ui` | `1.1.1` | Optional | Deploys the optional NVCF UI admin panel. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-ui:1.1.1` |  |
+| `helm-nvcf-ui` | `1.1.2` | Optional | Deploys the optional NVCF UI admin panel. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-ui:1.1.2` |  |
 | `helm-nvcf-vanity-gateway` | `0.1.0-nvcf-10204.1` | Optional | Deploys the optional vanity hostname gateway. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-vanity-gateway:0.1.0-nvcf-10204.1` |  |
 | `helm-reval` | `1.3.8` | Required | Deploys the function revalidation service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-reval:1.3.8` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/helm-reval) |
 | `nvcf-example-dashboards` | `1.6.0` | Optional | Deploys example Grafana dashboards for NVCF telemetry. | `https://helm.ngc.nvidia.com/nvidia/nvcf/nvcf-example-dashboards:1.6.0` |  |


### PR DESCRIPTION
## TL;DR
Bumping nvcf-ui to latest chart with service-account templating fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the self-managed deployment to use the latest **nvcf-ui** Helm chart version (**1.1.2**).
  * Includes maintenance and compatibility updates shipped with chart version **1.1.2**.
* **Documentation**
  * Refreshed the published control plane manifest entry for the **helm-nvcf-ui** artifact to reflect version **1.1.2** and its OCI reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->