### PR TITLE
fix(worker): avoid shared err race in multipart upload

### DIFF
--- a/src/compute-plane-services/worker-utils/worker/large.go
+++ b/src/compute-plane-services/worker-utils/worker/large.go
@@ -231,6 +231,33 @@ func recordUploadStats(uploadStart time.Time, meteringEvent *metering.EventDetai
 	metrics.LargeResponseTimeCounter.Add(uploadTimeSeconds)
 }
 
+// s3PartUploader is the subset of the S3 client used to upload a single part.
+// It lets tests drive uploadPart without a real S3 endpoint.
+type s3PartUploader interface {
+	UploadPart(ctx context.Context, params *s3.UploadPartInput, optFns ...func(*s3.Options)) (*s3.UploadPartOutput, error)
+}
+
+// uploadPart uploads one multipart part with retries and returns the completed
+// part. The error and result are local to this call, so concurrent part uploads
+// cannot clobber each other. A previous version shared a single function-scope
+// err across all upload goroutines, which raced and could dereference a nil
+// result when one part failed while another succeeded.
+func uploadPart(ctx context.Context, client s3PartUploader, partInput *s3.UploadPartInput) (types.CompletedPart, error) {
+	var uploadResult *s3.UploadPartOutput
+	if _, _, err := lo.AttemptWithDelay(3, 100*time.Millisecond, func(index int, duration time.Duration) error {
+		var err error
+		uploadResult, err = client.UploadPart(ctx, partInput)
+		return err
+	}); err != nil {
+		return types.CompletedPart{}, err
+	}
+
+	return types.CompletedPart{
+		ETag:       uploadResult.ETag,
+		PartNumber: partInput.PartNumber,
+	}, nil
+}
+
 func (w *NVCFWorker) multipartUpload(ctx context.Context, work *pb.WorkerInvokeFunctionRequest, body io.Reader, meteringEvent *metering.EventDetails) error {
 	// need regional client because the request id info is only in the originating region
 	nvcfClient, err := w.nvcfClient.GetRegionalNvcfClient(work.DirectResponseUrl)
@@ -293,21 +320,13 @@ func (w *NVCFWorker) multipartUpload(ctx context.Context, work *pb.WorkerInvokeF
 					UploadId:   resp.UploadId,
 				}
 
-				var uploadResult *s3.UploadPartOutput
-				_, _, err = lo.AttemptWithDelay(3, 100*time.Millisecond, func(index int, duration time.Duration) error {
-					var err error
-					uploadResult, err = client.UploadPart(ctx, partInput)
-					return err
-				})
+				part, err := uploadPart(ctx, client, partInput)
 				if err != nil {
 					return err
 				}
 
 				completedPartsLock.Lock()
-				completedParts = append(completedParts, types.CompletedPart{
-					ETag:       uploadResult.ETag,
-					PartNumber: &partNumber,
-				})
+				completedParts = append(completedParts, part)
 				completedPartsLock.Unlock()
 				return nil
 			})

--- a/src/compute-plane-services/worker-utils/worker/large_helpers_test.go
+++ b/src/compute-plane-services/worker-utils/worker/large_helpers_test.go
@@ -20,11 +20,16 @@ limitations under the License.
 package worker
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -60,4 +65,66 @@ func TestRecordUploadStats(t *testing.T) {
 	recordUploadStats(time.Now().Add(-1*time.Second), meteringEvent, 250)
 	// Stats accumulate onto the metering event's inference size.
 	assert.Equal(t, int64(350), meteringEvent.InferenceSize)
+}
+
+// fakePartUploader fails the part whose number equals failPart and succeeds for
+// every other part, returning a per-part ETag.
+type fakePartUploader struct {
+	failPart int32
+	err      error
+}
+
+func (f *fakePartUploader) UploadPart(_ context.Context, params *s3.UploadPartInput, _ ...func(*s3.Options)) (*s3.UploadPartOutput, error) {
+	if f.err != nil && params.PartNumber != nil && *params.PartNumber == f.failPart {
+		return nil, f.err
+	}
+	return &s3.UploadPartOutput{ETag: aws.String(fmt.Sprintf("etag-%d", aws.ToInt32(params.PartNumber)))}, nil
+}
+
+func TestUploadPart(t *testing.T) {
+	t.Run("success returns the completed part", func(t *testing.T) {
+		pn := int32(3)
+		part, err := uploadPart(context.Background(), &fakePartUploader{}, &s3.UploadPartInput{PartNumber: &pn})
+		require.NoError(t, err)
+		assert.Equal(t, "etag-3", aws.ToString(part.ETag))
+		assert.Equal(t, int32(3), aws.ToInt32(part.PartNumber))
+	})
+
+	t.Run("failure returns the error without a nil dereference", func(t *testing.T) {
+		wantErr := errors.New("upload failed")
+		pn := int32(1)
+		part, err := uploadPart(context.Background(), &fakePartUploader{failPart: 1, err: wantErr}, &s3.UploadPartInput{PartNumber: &pn})
+		assert.ErrorIs(t, err, wantErr)
+		assert.Zero(t, part)
+	})
+
+	// Run under -race. One part fails while the rest succeed concurrently; each
+	// call must report only its own outcome. The previous shared function-scope
+	// err raced here and could make a successful part inherit the failure (or
+	// dereference a nil result).
+	t.Run("concurrent parts do not clobber each other", func(t *testing.T) {
+		const parts = 16
+		const failPart = int32(7)
+		up := &fakePartUploader{failPart: failPart, err: errors.New("part failed")}
+
+		results := make([]error, parts)
+		var wg sync.WaitGroup
+		for i := int32(0); i < parts; i++ {
+			wg.Add(1)
+			go func(pn int32) {
+				defer wg.Done()
+				_, err := uploadPart(context.Background(), up, &s3.UploadPartInput{PartNumber: &pn})
+				results[pn] = err
+			}(i)
+		}
+		wg.Wait()
+
+		for i := int32(0); i < parts; i++ {
+			if i == failPart {
+				assert.Error(t, results[i], "the failing part must report its own error")
+			} else {
+				assert.NoError(t, results[i], "a successful part must not inherit another part's error")
+			}
+		}
+	})
 }


### PR DESCRIPTION
## TL;DR
In `multipartUpload`, every part-upload goroutine wrote the shared function-scope
`err` instead of a goroutine-local one. Concurrent parts raced on `err`
(`go test -race` flags it), and a failing part whose `err` was overwritten to nil
by a peer could skip its error return and dereference a nil upload result,
panicking the worker on the large-response upload path. Extract the per-part
upload into `uploadPart`, keeping the error and result local to each call.

## Issues
Closes #442

## Testing
`go test ./worker/ -race` passes. Added `TestUploadPart` covering success,
failure (returns the error with no nil dereference), and a concurrent run where
one part fails and must not clobber the others. Verified the pre-fix shared-`err`
pattern reports a data race under `-race`. No QA needed.

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multipart upload reliability by centralizing per-part retry behavior and standardizing returned completion data.
  * Ensured that failures in one part during concurrent multipart uploads don’t contaminate results from other parts.
* **Tests**
  * Added unit tests covering successful part uploads, correct error propagation with no partial results on failure, and concurrent multipart scenarios to verify error isolation per part.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->