### PR TITLE
docs(contributing): document direct GitHub merges

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,11 +43,8 @@ For all development, push your changes to a branch in your own fork of nvcf and 
 
 ### Current GitHub workflow
 
-This repository is being actively improved to support a more GitHub-native contribution flow. During this transition, commits are still pushed from our GitLab-based internal workflow, and GitHub pull requests cannot be merged directly.
-
-We do accept external contributions through GitHub pull requests. When a contribution is ready to land, the NVCF team will carry it through the current internal workflow and preserve attribution by co-authoring the resulting commit with the original contributor and the bot that pushes the commit.
-
-Thank you for working with us during this transition while we make the project easier to contribute to directly on GitHub.
+NVCF accepts external contributions through GitHub pull requests. Accepted
+contributions can be merged directly in this repository.
 
 ### Step 1: Set Up Your Environment
 


### PR DESCRIPTION
## TL;DR

Update the contribution workflow to state that accepted GitHub pull requests
can be merged directly in this repository. The existing text still describes
the retired GitLab handoff process.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

- Remove the obsolete transition notice and co-author handoff description.
- Preserve the existing section heading and anchor.
- Match the direct GitHub merge process confirmed by a maintainer:
  https://github.com/NVIDIA/nvcf/pull/4#issuecomment-4994604049

## For the Reviewer

Please review the wording in `CONTRIBUTING.md` under
`Current GitHub workflow`.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

- `git diff --check`: passed.
- `fern check --warnings`: passed with 0 errors. The unauthenticated redirect
  check was skipped and reported as 1 warning.
- QA needed: no. This is a documentation-only change.

## Issues

Closes #458

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines to clarify that external contributions are submitted through GitHub pull requests.
  * Clarified that accepted contributions are merged directly into the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->