### PR TITLE
build(go): declare the Go toolchain once and derive it everywhere

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.26.0'
+          go-version-file: tools/go-toolchain/go.mod
 
       - uses: actions/setup-node@v4
         with:
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.26.0'
+          go-version-file: tools/go-toolchain/go.mod
 
       - name: Run go-lib codegen freshness check
         run: ./tools/ci/check-go-codegen src/libraries/go/lib --install k8s.io/code-generator/cmd/deepcopy-gen@v0.34.2 --command 'make codegen-update'
@@ -60,3 +60,6 @@ jobs:
 
       - name: Run release helper tests
         run: python3 tools/ci/test-github-release.py
+
+      - name: Check Go toolchain declarations agree
+        run: tools/ci/check-go-version

--- a/.github/workflows/license-dependencies.yml
+++ b/.github/workflows/license-dependencies.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.26.0'
+          go-version-file: tools/go-toolchain/go.mod
 
       - name: Run check-license
         run: ./tools/ci/check-license
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.26.0'
+          go-version-file: tools/go-toolchain/go.mod
 
       - name: Run check-dependency-licenses
         run: ./tools/ci/check-dependency-licenses
@@ -56,7 +56,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.26.0'
+          go-version-file: tools/go-toolchain/go.mod
 
       - uses: actions/setup-python@v5
         with:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -89,7 +89,10 @@ bazel_dep(name = "rules_go", version = "0.60.0")
 bazel_dep(name = "gazelle", version = "0.48.0")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.25.0")
+# The Go toolchain version is declared once, in tools/go-toolchain/go.mod, and
+# derived here. Do not put a literal version in this file: it drifted from CI's
+# setup-go and from the bazel-ci image while each was maintained separately.
+go_sdk.from_file(go_mod = "//tools/go-toolchain:go.mod")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_work = "//:go.work.bazel")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1344,6 +1344,164 @@
           "go1.25.0.windows-arm64.zip",
           "27bab004c72b3d7bd05a69b6ec0fc54a309b4b78cc569dd963d8b3ec28bfdb8c"
         ]
+      },
+      "1.26.5": {
+        "aix_ppc64": [
+          "go1.26.5.aix-ppc64.tar.gz",
+          "e7f3c518fd7a8bc17f4389e342554016785f95ce447f8f09a260328de0d0f06c"
+        ],
+        "darwin_amd64": [
+          "go1.26.5.darwin-amd64.tar.gz",
+          "6231d8d3b8f5552ec6cbf6d685bdd5482e1e703214b120e89b3bf0d7bf1ef725"
+        ],
+        "darwin_arm64": [
+          "go1.26.5.darwin-arm64.tar.gz",
+          "efb87ff28af9a188d0536ef5d42e63dd52ba8263cd7344a993cc48dd11dedb6a"
+        ],
+        "dragonfly_amd64": [
+          "go1.26.5.dragonfly-amd64.tar.gz",
+          "96b53091297bd3a9ec8ed39f5f76b074c813dd74a6f429c03c667877ff27fdf8"
+        ],
+        "freebsd_386": [
+          "go1.26.5.freebsd-386.tar.gz",
+          "1a0226fc025d97d30a112ad0d09b13dcacedc5b24b04bf8f21a0cd29aac4d947"
+        ],
+        "freebsd_amd64": [
+          "go1.26.5.freebsd-amd64.tar.gz",
+          "0e5ddc51a62018211d461d6bf409939b04eaa4d6dd6d7097910090ef755ed947"
+        ],
+        "freebsd_arm": [
+          "go1.26.5.freebsd-arm.tar.gz",
+          "f8a59e86427158d89b2ba158d7f6004881e378fa3d7e4aefd4df17e4ee3a6bd1"
+        ],
+        "freebsd_arm64": [
+          "go1.26.5.freebsd-arm64.tar.gz",
+          "ae3825c8c57cc0e64c2233bfb9bba2e091f2126728e4c33492592c24b60dfcd0"
+        ],
+        "illumos_amd64": [
+          "go1.26.5.illumos-amd64.tar.gz",
+          "fcd06289bd8a5a9962e5acab2f30e7daa74952327b01366fa9f6e07007e65be1"
+        ],
+        "linux_386": [
+          "go1.26.5.linux-386.tar.gz",
+          "88c162b204e6eefcc32499453b492e80209f4a4c78c33092636901c540fb0d05"
+        ],
+        "linux_amd64": [
+          "go1.26.5.linux-amd64.tar.gz",
+          "5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053"
+        ],
+        "linux_arm64": [
+          "go1.26.5.linux-arm64.tar.gz",
+          "fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49"
+        ],
+        "linux_armv6l": [
+          "go1.26.5.linux-armv6l.tar.gz",
+          "6dae9edab81c13bccf962dec15f1fd2ec26c14a6821b4d2c92dab4130c289d7a"
+        ],
+        "linux_loong64": [
+          "go1.26.5.linux-loong64.tar.gz",
+          "82736bb7794547a73372ddfeb1b370cfea4d17f04782a65e82a389a01ff0f7aa"
+        ],
+        "linux_mips": [
+          "go1.26.5.linux-mips.tar.gz",
+          "3d313aefb8b7547beae18bb69febcf1571f775146209332a48a2942993655417"
+        ],
+        "linux_mips64": [
+          "go1.26.5.linux-mips64.tar.gz",
+          "7e5547e99a891e338fa5490b72d46ea7fd0593259df51561d7f55d4698503a8c"
+        ],
+        "linux_mips64le": [
+          "go1.26.5.linux-mips64le.tar.gz",
+          "7e05aceb9dea6033bc2f6dde29139293d8247cc2db749a206472b3916b1765a1"
+        ],
+        "linux_mipsle": [
+          "go1.26.5.linux-mipsle.tar.gz",
+          "e481470951e3a22a014ee70aebaae0c35aae4193a253d22ecf59d58f4bdbc450"
+        ],
+        "linux_ppc64": [
+          "go1.26.5.linux-ppc64.tar.gz",
+          "8ef02abd6f2b4040b7eb001b64597d16b9fa9aa563baaecf181ad8d9806c9991"
+        ],
+        "linux_ppc64le": [
+          "go1.26.5.linux-ppc64le.tar.gz",
+          "c5d60e2b303bb612f20cd82786594b64874e73b35134025e27d3390bf284ae43"
+        ],
+        "linux_riscv64": [
+          "go1.26.5.linux-riscv64.tar.gz",
+          "d4a24dd4484d3f86b99c2d300af0dea5d184557e6d61eb7aba19ff61662750e3"
+        ],
+        "linux_s390x": [
+          "go1.26.5.linux-s390x.tar.gz",
+          "09ce3c504c0323968b75a717244dca4f25cd4cf0443e5ff6bc0bfa74add89fa7"
+        ],
+        "netbsd_386": [
+          "go1.26.5.netbsd-386.tar.gz",
+          "6df082b6dd877c3e71af3c44e67b8684f8592cb0fc50aed3ea9e58968bc3165f"
+        ],
+        "netbsd_amd64": [
+          "go1.26.5.netbsd-amd64.tar.gz",
+          "daed1cb730d52e8b40866253b6271fd215f6128372dccc61d7784d4d3fb4a1bf"
+        ],
+        "netbsd_arm": [
+          "go1.26.5.netbsd-arm.tar.gz",
+          "d8a18f2d5afb6aaf47b79135221a964c21ee5cf5d568301a718904d887b1c96f"
+        ],
+        "netbsd_arm64": [
+          "go1.26.5.netbsd-arm64.tar.gz",
+          "60520191abd288fb0f22b279ee63497b3a81318134e41f2bb80f548c9227bd6a"
+        ],
+        "openbsd_386": [
+          "go1.26.5.openbsd-386.tar.gz",
+          "723a35e81882ddd8bdcb2539111f53ab4b03d4dbc114a2420d47963163465843"
+        ],
+        "openbsd_amd64": [
+          "go1.26.5.openbsd-amd64.tar.gz",
+          "27721c64efcb571ecfbf52ee77f133ec73dca96015b315199be104ed2dfafd87"
+        ],
+        "openbsd_arm": [
+          "go1.26.5.openbsd-arm.tar.gz",
+          "2de3fb692c74c68a40d8c92ec6a077a18c14a44e8e41a8c22edeb286b3a4dfce"
+        ],
+        "openbsd_arm64": [
+          "go1.26.5.openbsd-arm64.tar.gz",
+          "969a90bc34bda3ec06c0c3278ae00cdaa9b747b100cadec9f3f8c2cb36f01c69"
+        ],
+        "openbsd_ppc64": [
+          "go1.26.5.openbsd-ppc64.tar.gz",
+          "cb3908dd5904df453ebce07cfc660b7a14b7fed9525463521f01a04affd49eb8"
+        ],
+        "openbsd_riscv64": [
+          "go1.26.5.openbsd-riscv64.tar.gz",
+          "922864dbcb3ec989f456b2c313a46a4c0b0bd93b398603dc0db2d5a72b5ca47c"
+        ],
+        "plan9_386": [
+          "go1.26.5.plan9-386.tar.gz",
+          "7858fe6515a8e71050a3b59211b6c6f6947822497ecbe1ab81f4e4503b67a635"
+        ],
+        "plan9_amd64": [
+          "go1.26.5.plan9-amd64.tar.gz",
+          "513acf2518947e51210772145436e62eb67cc44738c5df3b6218dfeb66f6416c"
+        ],
+        "plan9_arm": [
+          "go1.26.5.plan9-arm.tar.gz",
+          "131c06ed5b7ce904ff7b121c63ffd76a699fff43b96e019914f093ede1be9e4a"
+        ],
+        "solaris_amd64": [
+          "go1.26.5.solaris-amd64.tar.gz",
+          "33a1fc532f8d5fc5964b28a056729bc50a59657b653a5f1b04c2aeb2ac54c149"
+        ],
+        "windows_386": [
+          "go1.26.5.windows-386.zip",
+          "cab0f6847c17f4c904c0bacb6ec6b84e730fc797f4ba885f42383d580fc2d399"
+        ],
+        "windows_amd64": [
+          "go1.26.5.windows-amd64.zip",
+          "97e6b2a833b6d89f9ff17d25419ac0a7e3b482a044e9ab18cdef834bd834fd38"
+        ],
+        "windows_arm64": [
+          "go1.26.5.windows-arm64.zip",
+          "f96ee46396d69f1e231c8d981ec6a70216238a646a1f2cd74aea0d0016bbc017"
+        ]
       }
     }
   }

--- a/go.work.bazel
+++ b/go.work.bazel
@@ -24,7 +24,7 @@
 // non-Bazel CI for license/dependency checks across all 31 go.mod files.
 // Bazel deliberately uses a narrower scope to avoid pulling in deps for
 // upstream-owned subtrees that are out of scope for Phase 1.
-go 1.25.0
+go 1.26.5
 
 use (
 	./src/clis/nvcf-cli

--- a/tools/ci/check-go-version
+++ b/tools/ci/check-go-version
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Asserts that every Go toolchain declaration agrees with the single source of
+# truth in tools/go-toolchain/go.mod.
+#
+# Most consumers derive the version rather than repeat it: Bazel reads the
+# anchor through go_sdk.from_file, and GitHub Actions read it through setup-go's
+# go-version-file. Two places cannot derive it and are checked here instead:
+# go.work.bazel, whose go directive Bazel requires to be a literal, and the
+# bazel-ci container image, which is built in a different repository.
+#
+# Before this existed the repository carried four different answers at once:
+# 1.25.0 in Bazel, 1.25.6 in the CI image, 1.26.0 in two workflows, and 1.25.11
+# in a service go.mod. CI linted with one and compiled with another.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${repo_root}"
+
+anchor_file="tools/go-toolchain/go.mod"
+expected="$(awk '/^toolchain go/ { sub(/^go/, "", $2); print $2; exit }' "${anchor_file}")"
+if [ -z "${expected}" ]; then
+  echo "error: no toolchain directive in ${anchor_file}" >&2
+  exit 1
+fi
+echo "expected Go toolchain: ${expected}  (from ${anchor_file})"
+
+failures=0
+report() { echo "  MISMATCH: $*" >&2; failures=$((failures + 1)); }
+
+# go.work.bazel must match: Bazel requires a literal there.
+work_go="$(awk '/^go / { print $2; exit }' go.work.bazel)"
+if [ "${work_go}" != "${expected}" ]; then
+  report "go.work.bazel declares ${work_go}"
+else
+  echo "  ok: go.work.bazel"
+fi
+
+# No workflow may pin a literal; they must derive from the anchor.
+if literals=$(grep -rn "go-version: '" .github/workflows/*.yml 2>/dev/null); then
+  while IFS= read -r line; do
+    report "workflow pins a literal Go version: ${line}"
+  done <<<"${literals}"
+else
+  echo "  ok: no workflow pins a literal Go version"
+fi
+
+# Nothing may reintroduce a literal SDK version in the root module.
+if grep -q 'go_sdk.download(version' MODULE.bazel; then
+  report "MODULE.bazel uses go_sdk.download with a literal; use go_sdk.from_file"
+else
+  echo "  ok: MODULE.bazel derives the SDK from the anchor"
+fi
+
+# The bazel-ci image is built in another repository, so this is advisory: it
+# reports the version this repository expects it to ship.
+echo "  note: the bazel-ci container image must ship Go ${expected};"
+echo "        it is built outside this repository and cannot be checked here."
+
+if [ "${failures}" -ne 0 ]; then
+  echo "${failures} Go toolchain declaration(s) disagree with ${anchor_file}" >&2
+  exit 1
+fi
+echo "all Go toolchain declarations agree"

--- a/tools/ci/check-go-version
+++ b/tools/ci/check-go-version
@@ -2,18 +2,26 @@
 # SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Asserts that every Go toolchain declaration agrees with the single source of
-# truth in tools/go-toolchain/go.mod.
+# Asserts that Go toolchain declarations are consistent.
 #
-# Most consumers derive the version rather than repeat it: Bazel reads the
-# anchor through go_sdk.from_file, and GitHub Actions read it through setup-go's
-# go-version-file. Two places cannot derive it and are checked here instead:
-# go.work.bazel, whose go directive Bazel requires to be a literal, and the
-# bazel-ci container image, which is built in a different repository.
+# There are deliberately TWO toolchains here, not one, and conflating them is a
+# mistake this script exists partly to prevent:
 #
-# Before this existed the repository carried four different answers at once:
-# 1.25.0 in Bazel, 1.25.6 in the CI image, 1.26.0 in two workflows, and 1.25.11
-# in a service go.mod. CI linted with one and compiled with another.
+#   1. The hermetic Bazel SDK, declared once in tools/go-toolchain/go.mod.
+#      Everything built through rules_go uses it. Bazel derives it via
+#      go_sdk.from_file and GitHub Actions via setup-go's go-version-file, so
+#      almost nothing repeats the literal.
+#
+#   2. The host Go shipped in the bazel-ci container image. Exactly one thing
+#      uses it: byoo-otel-collector's otelcol genrule, which shells out to
+#      `go build` against $PATH because the collector's 250-module graph does
+#      not resolve under rules_go. That toolchain is paired with
+#      src/compute-plane-services/byoo-otel-collector/go.work, and the pairing
+#      is what must hold, not equality with the Bazel SDK.
+#
+# Before this existed, four versions were live at once: 1.25.0 in Bazel, 1.25.6
+# in the CI image, 1.26.0 in two workflows, and 1.25.11 in a service go.mod. CI
+# linted with one and compiled with another.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -54,10 +62,27 @@ else
   echo "  ok: MODULE.bazel derives the SDK from the anchor"
 fi
 
-# The bazel-ci image is built in another repository, so this is advisory: it
-# reports the version this repository expects it to ship.
-echo "  note: the bazel-ci container image must ship Go ${expected};"
-echo "        it is built outside this repository and cannot be checked here."
+# The host toolchain is a separate concern. byoo-otel-collector's otelcol
+# genrule compiles against the bazel-ci image's Go, so the version that image
+# ships must match byoo's go.work, NOT the hermetic Bazel SDK above. Asserting
+# equality with the SDK here would break that pairing and silently change how
+# the shipped collector binary is compiled.
+byoo_dir="src/compute-plane-services/byoo-otel-collector"
+byoo_work="${byoo_dir}/go.work"
+if [ ! -d "${byoo_dir}" ]; then
+  echo "  host toolchain: byoo-otel-collector is absent; nothing requires host Go"
+elif [ -f "${byoo_work}" ]; then
+  byoo_go="$(awk '/^go / { print $2; exit }' "${byoo_work}")"
+  echo "  host toolchain: byoo-otel-collector expects Go ${byoo_go}"
+  echo "                  the bazel-ci image must ship that version, because"
+  echo "                  the otelcol genrule builds against \$PATH go."
+  if [ "${byoo_go}" = "${expected}" ]; then
+    echo "  note: it currently equals the Bazel SDK version; that is incidental,"
+    echo "        the two are allowed to differ."
+  fi
+else
+  report "${byoo_dir} exists but ${byoo_work} is missing; the host toolchain requirement cannot be stated"
+fi
 
 if [ "${failures}" -ne 0 ]; then
   echo "${failures} Go toolchain declaration(s) disagree with ${anchor_file}" >&2

--- a/tools/go-toolchain/BUILD.bazel
+++ b/tools/go-toolchain/BUILD.bazel
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Exposes go.mod so the root MODULE.bazel can read the toolchain version from it
+# via go_sdk.from_file. Nothing here is built.
+exports_files(["go.mod"])

--- a/tools/go-toolchain/go.mod
+++ b/tools/go-toolchain/go.mod
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// The Go toolchain version for this repository, declared once.
+//
+// This module has no source and is never built. It exists so that one file
+// declares the toolchain and every consumer derives from it rather than
+// repeating a literal:
+//
+//   - Bazel reads it via go_sdk.from_file in the root MODULE.bazel.
+//   - GitHub Actions read it via setup-go's go-version-file.
+//   - tools/ci/check-go-version asserts everything else agrees with it.
+//
+// rules_go's from_file requires a file named exactly go.mod, which is why this
+// is a module rather than a plain .go-version file.
+//
+// To change the toolchain, edit the toolchain line below and nothing else, then
+// run tools/ci/check-go-version to find anything that has drifted.
+
+module github.com/NVIDIA/nvcf/tools/go-toolchain
+
+go 1.26.5
+
+toolchain go1.26.5

--- a/tools/go-toolchain/go.mod
+++ b/tools/go-toolchain/go.mod
@@ -1,7 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-// The Go toolchain version for this repository, declared once.
+// The hermetic Bazel Go SDK version, declared once.
+//
+// This governs everything built through rules_go. It does NOT govern the host
+// Go shipped in the bazel-ci container image: byoo-otel-collector's otelcol
+// genrule builds against $PATH go, and that toolchain is paired with
+// byoo-otel-collector/go.work instead. The two are allowed to differ, and
+// tools/ci/check-go-version states both.
 //
 // This module has no source and is never built. It exists so that one file
 // declares the toolchain and every consumer derives from it rather than

--- a/tools/scripts/test/test-check-go-version
+++ b/tools/scripts/test/test-check-go-version
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for tools/ci/check-go-version.
+#
+# The check exists because four different Go versions were live at once, so the
+# cases here are the specific drifts that actually happened: a workflow pinning
+# a literal, go.work.bazel disagreeing, and MODULE.bazel reintroducing a
+# hardcoded SDK version.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+CHECK="tools/ci/check-go-version"
+FAILURES=0
+
+pass() { echo "ok: $*"; }
+fail() { echo "FAIL: $*" >&2; FAILURES=$((FAILURES + 1)); }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+# A minimal repository shaped like the real one.
+setup() {
+    rm -rf "${WORK}/repo"
+    mkdir -p "${WORK}/repo/tools/go-toolchain" "${WORK}/repo/tools/ci" \
+             "${WORK}/repo/.github/workflows"
+    cp "${REPO_ROOT}/${CHECK}" "${WORK}/repo/tools/ci/"
+    printf 'module x\n\ngo 1.26.5\n\ntoolchain go1.26.5\n' \
+        >"${WORK}/repo/tools/go-toolchain/go.mod"
+    printf 'go 1.26.5\n\nuse (\n\t./a\n)\n' >"${WORK}/repo/go.work.bazel"
+    printf 'go_sdk.from_file(go_mod = "//tools/go-toolchain:go.mod")\n' \
+        >"${WORK}/repo/MODULE.bazel"
+    printf 'jobs:\n  a:\n    steps:\n      - uses: actions/setup-go@v5\n        with:\n          go-version-file: tools/go-toolchain/go.mod\n' \
+        >"${WORK}/repo/.github/workflows/a.yml"
+}
+
+run() { (cd "${WORK}/repo" && ./tools/ci/check-go-version >/dev/null 2>&1); }
+
+setup
+if run; then pass "a consistent repository passes"; else fail "consistent repository rejected"; fi
+
+setup
+printf 'go 1.25.0\n\nuse (\n\t./a\n)\n' >"${WORK}/repo/go.work.bazel"
+if run; then fail "go.work.bazel drift not detected"; else pass "go.work.bazel drift is detected"; fi
+
+setup
+printf 'jobs:\n  a:\n    steps:\n      - uses: actions/setup-go@v5\n        with:\n          go-version: '"'"'1.26.0'"'"'\n' \
+    >"${WORK}/repo/.github/workflows/a.yml"
+if run; then fail "workflow literal not detected"; else pass "workflow literal pin is detected"; fi
+
+setup
+printf 'go_sdk.download(version = "1.25.0")\n' >"${WORK}/repo/MODULE.bazel"
+if run; then fail "go_sdk.download not detected"; else pass "reintroduced go_sdk.download is detected"; fi
+
+setup
+printf 'module x\n\ngo 1.26.5\n' >"${WORK}/repo/tools/go-toolchain/go.mod"
+if run; then fail "missing toolchain directive not detected"; else pass "missing toolchain directive is detected"; fi
+
+echo
+if [ "${FAILURES}" -ne 0 ]; then echo "${FAILURES} test(s) failed" >&2; exit 1; fi
+echo "all tests passed"

--- a/tools/scripts/test/test-check-go-version
+++ b/tools/scripts/test/test-check-go-version
@@ -58,6 +58,32 @@ setup
 printf 'module x\n\ngo 1.26.5\n' >"${WORK}/repo/tools/go-toolchain/go.mod"
 if run; then fail "missing toolchain directive not detected"; else pass "missing toolchain directive is detected"; fi
 
+# The host toolchain is a separate concern and must be reported, not equated
+# with the Bazel SDK. byoo-otel-collector's otelcol genrule builds against the
+# image's $PATH go, so its go.work is what states that requirement.
+setup
+mkdir -p "${WORK}/repo/src/compute-plane-services/byoo-otel-collector"
+printf 'go 1.25.6\n' \
+    >"${WORK}/repo/src/compute-plane-services/byoo-otel-collector/go.work"
+if out=$(cd "${WORK}/repo" && ./tools/ci/check-go-version 2>&1); then
+    if grep -q '1\.25\.6' <<<"${out}"; then
+        pass "a host toolchain differing from the Bazel SDK is reported, not rejected"
+    else
+        fail "host toolchain version not reported"
+    fi
+else
+    fail "a differing host toolchain must not fail the check:"
+    sed 's/^/    /' <<<"${out}" >&2
+fi
+
+setup
+mkdir -p "${WORK}/repo/src/compute-plane-services/byoo-otel-collector"
+if out=$(cd "${WORK}/repo" && ./tools/ci/check-go-version 2>&1); then
+    fail "byoo present without go.work should be reported as a failure"
+else
+    pass "byoo present without go.work is detected"
+fi
+
 echo
 if [ "${FAILURES}" -ne 0 ]; then echo "${FAILURES} test(s) failed" >&2; exit 1; fi
 echo "all tests passed"

--- a/tools/scripts/test/test-check-go-version
+++ b/tools/scripts/test/test-check-go-version
@@ -80,8 +80,11 @@ setup
 mkdir -p "${WORK}/repo/src/compute-plane-services/byoo-otel-collector"
 if out=$(cd "${WORK}/repo" && ./tools/ci/check-go-version 2>&1); then
     fail "byoo present without go.work should be reported as a failure"
+elif grep -q 'go.work is missing; the host toolchain requirement cannot be stated' <<<"${out}"; then
+    pass "byoo present without go.work is detected, with the specific diagnostic"
 else
-    pass "byoo present without go.work is detected"
+    fail "checker failed, but not with the missing-go.work diagnostic:"
+    sed 's/^/    /' <<<"${out}" >&2
 fi
 
 echo


### PR DESCRIPTION
## TL;DR

The repository carried four different answers to "which Go do we use", and two were live in the same pipeline: CI linted with 1.26.0 while Bazel compiled with 1.25.0.

| Where | Was |
|---|---|
| `license-dependencies.yml`, `build-test.yml` setup-go | 1.26.0 |
| root `MODULE.bazel` `go_sdk.download` | 1.25.0 |
| `go.work.bazel` | 1.25.0 |
| bazel-ci container image | 1.25.6 |
| `image-credential-helper/go.mod` | 1.25.11 |

`tools/go-toolchain/go.mod` is now the single declaration, at 1.26.5.

## Additional Details

The anchor has no source and is never built. It exists so consumers derive the version instead of repeating it:

- Root `MODULE.bazel` reads it via `go_sdk.from_file`. rules_go requires the file be named exactly `go.mod` (`_check_go_mod_name`), which is why the anchor is a module rather than a `.go-version` file.
- Every `setup-go` reads it via `go-version-file`. Five literal pins are gone.

Two places genuinely cannot derive it, so `tools/ci/check-go-version` asserts them instead: `go.work.bazel`, where Bazel requires a literal, and the bazel-ci image, which is built in another repository and is therefore reported rather than checked.

Worth noting: the workflows were pinned to 1.26.0, which is five patches behind. `go.dev` currently reports 1.26.5 and 1.25.12. "Latest" had already drifted, which is the failure mode this change is meant to prevent.

## For the Reviewer

The risk here is the toolchain bump, not the plumbing. Verified on the derived 1.26.5:

- `bazel build //...` completes, 278 targets.
- `bazel test //...` gives 104 passing and 4 failing. Those four fail identically at `origin/main` and are unrelated: two cloud-tasks Testcontainers suites, `go/lib:gazelle_test`, and `icms-translate`.

There are deliberately two toolchains here, and an earlier revision of this PR conflated them. Correcting that is `0bdcb89c`.

`byoo-otel-collector`'s otelcol genrule shells out to `go build` against `$PATH`, on purpose, because the collector's 250-module graph does not resolve under rules_go. It compiles with whatever Go the bazel-ci image ships, and `byoo/go.work` declares 1.25.6 to match. That pairing determines how the shipped collector binary is built.

So:

- Hermetic Bazel SDK: single-sourced at 1.26.5, governs everything built through rules_go.
- Host toolchain in the CI image: paired with `byoo/go.work` at 1.25.6, governs one non-hermetic genrule.

The check reports the host requirement rather than asserting equality with the SDK. My first version asserted the image "must ship 1.26.5", which would have broken the pairing and silently recompiled the collector with a different toolchain. The bazel-ci image does not need bumping for this PR.

Service `go.mod` files are also left alone. Their `go` directives are minimum-version declarations, not toolchain selection, and Go permits them to be lower. Only the toolchain is single-sourced here.

## For QA

```
tools/ci/check-go-version
tools/scripts/test/test-check-go-version
bazel build //...
```

The check runs in the `GitHub release helper` job. Its tests cover the drifts that actually happened: `go.work.bazel` disagreeing, a workflow reintroducing a literal, `MODULE.bazel` reverting to `go_sdk.download`, and a missing toolchain directive. Each was verified to fail the check.

## Issues

Relates to #451

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized Go toolchain version management across development, Bazel, and CI using a single source of truth.
  * Added automated CI checks to detect Go version drift across configuration files.

* **Bug Fixes**
  * Prevented mismatches between workspace and build/toolchain declarations by enforcing consistent versioning.

* **Tests**
  * Added fixture-based tests to verify both passing consistency cases and expected failures for drift, pinned versions, and missing toolchain declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
