### PR TITLE
Draft: fix(cassandra): restore ESS legacy auth compatibility

### DIFF
--- a/migrations/cassandra/keyspaces/ess_api/03_init_tables.up.sql
+++ b/migrations/cassandra/keyspaces/ess_api/03_init_tables.up.sql
@@ -27,6 +27,7 @@ CREATE TYPE IF NOT EXISTS ess_api.entity_type (
 CREATE TABLE IF NOT EXISTS ess_api.namespaces (
     namespace                             text,
     oauth_authorizations                  map<text, frozen<authorization>>, -- new primary column for tenant (non-notary) auths, oauth wins over ssa on read-merge
+    ssa_authorizations                    map<text, frozen<authorization>>, -- legacy column kept until all supported ESS versions stop selecting it
     notary_authorizations                 map<text, frozen<authorization>>,
     entity_types                          map<text, frozen<entity_type>>,
     created_at                            timestamp,

--- a/migrations/cassandra/keyspaces/ess_api/04_init_ncp_namespace.up.sql
+++ b/migrations/cassandra/keyspaces/ess_api/04_init_ncp_namespace.up.sql
@@ -5,6 +5,7 @@ INSERT INTO ess_api.namespaces (
   updated_at,
   entity_hash_size,
   require_lwt_for_secret_version_writes,
+  ssa_authorizations,
   notary_authorizations
 )
 VALUES (
@@ -14,5 +15,6 @@ VALUES (
   toTimestamp(now()),
   10,
   False,
+  {'nvcf-api': {id: 'nvcf-api', name: 'nvcf api service client', jwks_url: 'http://openbao-server.vault-system.svc.cluster.local:8200/v1/services/ess-api/jwt/jwks', issuer: 'http://ess-api.ess.svc.cluster.local', type: 'SSA'}},
   {'nvcf-api': {id: 'nvcf-api', name: 'nvcf notary client', jwks_url: 'http://notary.nvcf.svc.cluster.local:8080/.well-known/jwks.json', issuer: 'http://notary.nvcf.svc.cluster.local:8080', type: 'NOTARY'}}
 );

--- a/migrations/cassandra/keyspaces/ess_api/05_add_nvct_authorizations.up.sql
+++ b/migrations/cassandra/keyspaces/ess_api/05_add_nvct_authorizations.up.sql
@@ -1,0 +1,28 @@
+-- SSA registration unblocks nvct-api -> ess-api outbound calls, such as
+-- nvct-api writing task secrets.
+--
+-- NOTARY registration unblocks ess-init -> ess-api secret reads from the
+-- worker pod. ess-init presents the notary-signed assertion JWT with sub=
+-- nvct-api, and ess-api looks the subject up in notary_authorizations.
+
+UPDATE ess_api.namespaces
+SET
+  ssa_authorizations = ssa_authorizations + {
+    'nvct-api': {
+      id: 'nvct-api',
+      name: 'nvct api service client',
+      jwks_url: 'http://openbao-server.vault-system.svc.cluster.local:8200/v1/services/ess-api/jwt/jwks',
+      issuer: 'http://ess-api.ess.svc.cluster.local',
+      type: 'SSA'
+    }
+  },
+  notary_authorizations = notary_authorizations + {
+    'nvct-api': {
+      id: 'nvct-api',
+      name: 'nvct api notary client',
+      jwks_url: 'http://notary.nvcf.svc.cluster.local:8080/.well-known/jwks.json',
+      issuer: 'http://notary.nvcf.svc.cluster.local:8080',
+      type: 'NOTARY'
+    }
+  }
+WHERE namespace = 'nvcf';

--- a/migrations/cassandra/keyspaces/ess_api/09_restore_legacy_ssa_authorizations.up.sql
+++ b/migrations/cassandra/keyspaces/ess_api/09_restore_legacy_ssa_authorizations.up.sql
@@ -1,0 +1,28 @@
+-- Keep 0.6.1 compatible with ESS images that still select the legacy
+-- ssa_authorizations column while oauth_authorizations migration is in flight.
+-- The column can be removed in a later release after all supported ESS images
+-- stop selecting it.
+
+ALTER TABLE ess_api.namespaces ADD IF NOT EXISTS (
+    ssa_authorizations map<text, frozen<authorization>>
+);
+
+UPDATE ess_api.namespaces
+SET
+  ssa_authorizations = ssa_authorizations + {
+    'nvcf-api': {
+      id: 'nvcf-api',
+      name: 'nvcf api service client',
+      jwks_url: 'http://openbao-server.vault-system.svc.cluster.local:8200/v1/services/ess-api/jwt/jwks',
+      issuer: 'http://ess-api.ess.svc.cluster.local',
+      type: 'SSA'
+    },
+    'nvct-api': {
+      id: 'nvct-api',
+      name: 'nvct api service client',
+      jwks_url: 'http://openbao-server.vault-system.svc.cluster.local:8200/v1/services/ess-api/jwt/jwks',
+      issuer: 'http://ess-api.ess.svc.cluster.local',
+      type: 'SSA'
+    }
+  }
+WHERE namespace = 'nvcf';


### PR DESCRIPTION
## TL;DR

Restore legacy ESS Cassandra authorization compatibility for self-managed installs while the service migration from `ssa_authorizations` to `oauth_authorizations` is still in progress.

## Additional Details

Supported ESS images still select `ess_api.namespaces.ssa_authorizations`. Fresh installs with the OAuth-only schema fail because that legacy column is absent.

This change keeps the forward OAuth migration path intact while restoring compatibility:

- adds `ssa_authorizations` back to the fresh ESS namespace schema
- restores the initial `nvcf-api` SSA authorization seed
- restores the `nvct-api` ESS authorization seed
- adds a forward migration that recreates and seeds `ssa_authorizations` if a cluster already consumed an OAuth-only migration set

The legacy column should be removed only after all supported ESS versions stop selecting it.

## For the Reviewer

Please focus on `migrations/cassandra/keyspaces/ess_api`.

The compatibility migration is intentionally additive. It does not remove or rewrite `oauth_authorizations`.

## For QA

Ran:

```sh
bash migrations/cassandra/tests/test-execute-sqls.sh
git diff --check
```

QA needed: yes. Validate a fresh self-managed install with the next 0.6.1 RC and confirm account bootstrap no longer fails on `ssa_authorizations`.

## Issues

Closes #474

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring SSA authorization details for NVCF and NVCT services.
  * Added authorization metadata for the NVCF API client.
  * Preserved compatibility with older clients that still use legacy SSA authorization data.
  * Extended namespace authorization configuration with the required service credentials and issuer information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->