### PR TITLE
docs: document merge preparation guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,6 +313,14 @@ motivation without doing detective work. Always include:
 <new or updated third-party packages, license review result, NOTICE update status, or "None">
 ```
 
+### Merge preparation
+
+Before merging:
+
+- Set the Pull Request title to the intended squash commit subject.
+- Refresh the description. Remove outdated plans, status, and test results.
+- Squash merge with a concise message that omits intermediate work logs.
+
 ## PR scope and batching
 
 Group changes that share a root cause into one Pull Request. Do not open one PR


### PR DESCRIPTION
## TL;DR

Add concise merge preparation guidance for curating Pull Request metadata and squash commit messages.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

Long-lived Pull Requests can accumulate outdated plans and intermediate work logs. The new guidance requires a final title, a refreshed description, and a concise squash message.

Dependencies: None.

## For the Reviewer

Review the merge preparation wording in AGENTS.md.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

QA is not needed for this documentation-only change. Ran the documentation check, diff check, and skill fanout validation. The documentation check passed with its existing advisory version-sync warning.

## Issues

Closes #476

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes. Documentation-only change; no code tests apply.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added merge preparation guidance, including checklist items for PR titles, descriptions, and concise squash-merge messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->