### PR TITLE
feat(self-managed): wire observability infrastructure stack

### DIFF
--- a/deploy/stacks/observability/README.md
+++ b/deploy/stacks/observability/README.md
@@ -1,8 +1,8 @@
 # nvcf-observability-stack
 
 Reusable Helmfile stack scaffold for self-hosted NVCF observability. It is
-intended to be consumed by self-managed control-plane deployments and optional
-standalone compute-plane deployments once the distribution wiring lands.
+consumed by self-managed control-plane deployments and optional standalone
+compute-plane deployments.
 
 The stack can own:
 

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -133,6 +133,30 @@ global:
       # global.observability.metrics.enabled
       enabled: false
 
+# Shared observability infrastructure. Self-managed control-plane installs keep
+# this on because the function autoscaler depends on a populated TSDB.
+observability:
+  mode: install
+
+prometheusOperatorCrds:
+  # Disable this when the cluster already owns Prometheus Operator CRDs, such as
+  # through an existing kube-prometheus-stack install, to avoid CRD conflicts.
+  enabled: true
+
+opentelemetryOperator:
+  enabled: true
+
+controlPlaneCollector:
+  enabled: true
+
+victoriaMetrics:
+  enabled: true
+
+defaultMonitors:
+  enabled: true
+  controlPlane:
+    enabled: true
+
 accounts:
   limits:
     maxFunctions: 10
@@ -277,7 +301,7 @@ addons:
     enabled: false
 
 stateMetrics:
-  enabled: false
+  enabled: true
   # Disable ServiceMonitor for environments without Prometheus Operator
   serviceMonitor:
     enabled: false

--- a/deploy/stacks/self-managed/helmfile.d/00-observability-infrastructure.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/00-observability-infrastructure.yaml.gotmpl
@@ -1,0 +1,29 @@
+environments:
+  default:
+    values:
+      - ../environments/base.yaml
+      - ../environments/{{ requiredEnv "HELMFILE_ENV" }}.yaml
+
+---
+
+{{- $observability := dig "observability" (dict) .Values }}
+{{- $mode := dig "mode" "disabled" $observability }}
+{{- if not (has $mode (list "install" "existing" "disabled")) }}
+{{- fail (printf "observability.mode must be install, existing, or disabled, got %q" $mode) }}
+{{- end }}
+{{- if ne $mode "disabled" }}
+helmfiles:
+  - path: ../../observability/helmfile.d/01-observability.yaml.gotmpl
+    selectorsInherited: true
+    values:
+      - global:
+          {{- toYaml (dig "global" (dict) .Values) | nindent 10 }}
+      - observability:
+          {{- toYaml $observability | nindent 10 }}
+      {{- range $key := list "prometheusOperatorCrds" "opentelemetryOperator" "controlPlaneCollector" "victoriaMetrics" "defaultMonitors" }}
+      {{- with (index $.Values $key) }}
+      - {{ $key }}:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
+      {{- end }}
+{{- end }}


### PR DESCRIPTION
## TL;DR
Wire the self-managed stack to install the shared observability infrastructure before self-managed observability services. This enables the infrastructure needed by always-on self-managed control-plane observability and turns on `state-metrics`.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
- Adds `helmfile.d/00-observability-infrastructure.yaml.gotmpl` to delegate self-managed observability infrastructure installation to `deploy/stacks/observability`.
- Enables the existing standalone observability components from self-managed values:
  - Prometheus Operator CRDs
  - OpenTelemetry Operator
  - control-plane collector
  - VictoriaMetrics
  - default control-plane monitors
- Keeps BYOO and NVCA collector behavior owned by the standalone observability stack and default-off there.
- Leaves function-autoscaler wiring for a follow-up change.

## For the Reviewer
Please focus on the Helmfile boundary:
- `deploy/stacks/self-managed/helmfile.d/00-observability-infrastructure.yaml.gotmpl`
- `deploy/stacks/self-managed/environments/base.yaml`

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
Validation performed:
- `HELMFILE_ENV=base helmfile -f helmfile.d/00-observability-infrastructure.yaml.gotmpl --environment default build`
- `HELMFILE_ENV=base helmfile --environment default --selector release-group=observability --allow-no-matching-release build`
- `/tmp/chartproof/dist/chartproof run --chart deploy/stacks/observability/charts/nvcf-otel-collector --budget standard --progress-mode ci --kubeconform=false`
- `/tmp/chartproof/dist/chartproof run --chart deploy/stacks/observability/charts/nvcf-default-monitors --budget standard --progress-mode ci --kubeconform=false`
- `git diff --check`

## Issues
Relates to #15

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable observability infrastructure for self-managed deployments.
  * Supports installing observability components, using existing infrastructure, or disabling observability entirely.
  * Enabled state metrics reporting by default.
  * Adds Prometheus, OpenTelemetry, a control-plane collector, VictoriaMetrics, and default control-plane monitors.

* **Documentation**
  * Updated observability guidance to clarify the supported consumption model for the self-managed scaffold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->