### PR TITLE
fix(cassandra): preserve 0.6.1 migration compatibility

### DIFF
--- a/migrations/cassandra/Dockerfile
+++ b/migrations/cassandra/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/cassandra:5.0.6
+FROM cassandra:5.0.8
 
 ARG TARGETARCH
 ARG KUBECTL_VERSION="1.36.1"
@@ -8,7 +8,7 @@ USER root
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl gettext-base && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl gettext-base && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     if [ -n "$KUBECTL_VERSION" ]; then \

--- a/migrations/cassandra/README.md
+++ b/migrations/cassandra/README.md
@@ -43,7 +43,7 @@ chmod +x files/migrate-arm64
 
 ## Building the container
 
-The `Dockerfile` defaults to the `bitnami/cassandra:5.0.6` base image. Override the FROM via your own build pipeline if you need a different base.
+The `Dockerfile` defaults to the official `cassandra:5.0.8` base image. Override the FROM via your own build pipeline if you need a different base.
 
 ```bash
 docker build \
@@ -62,10 +62,11 @@ The container reads the following environment variables:
 | `CASSANDRA_USER` | Cassandra superuser used to apply DDL |
 | `CASSANDRA_PASSWORD` | Cassandra superuser password |
 | `SERVICE_ROLE_PASSWORD` | Substituted into the per-keyspace login role passwords (`02_init_roles.up.sql`) |
+| `REPLICA_COUNT` | Replication factor for service keyspaces (defaults to `3`) |
 
 For each keyspace under `keyspaces/`, the container:
 
-1. Pre-processes any `*.up.sql` and `*.cql` files via `envsubst` so that `${SERVICE_ROLE_PASSWORD}` is substituted (other environment variables are intentionally not substituted).
+1. Pre-processes any `*.sql` and `*.cql` files via `envsubst` so that `${SERVICE_ROLE_PASSWORD}` and `${REPLICA_COUNT}` are substituted (other environment variables are intentionally not substituted).
 2. Runs `migrate up` with the `cassandra://` driver, using the keyspace name as the migrations table name.
 
 A failure in any keyspace's migration set stops the run.
@@ -93,9 +94,9 @@ cqlsh -u "$CASSANDRA_USER" -p "$CASSANDRA_PASSWORD" "$CASSANDRA_HOSTS" \
 
 The migration may have applied some statements before the failure. Decide whether to roll the schema back to `<N-1>` or roll it forward to `<N>`:
 
-- **Re-apply migration `<N>` from `<N-1>`** (recommended when the migration is fully idempotent). Most bundled migrations use `CREATE TABLE IF NOT EXISTS`, `CREATE TYPE IF NOT EXISTS`, and similar idempotent forms; if the failing file is fully idempotent, fix the root cause of the failure (network, capacity, malformed CQL) and re-running migration `<N>` will be safe. Plan to `force <N-1>` in step 3.
-- **Roll back manually** to `<N-1>`. If the migration is not idempotent, drop any tables / types / columns the partial run created so the schema matches the post-`<N-1>` state, then `force <N-1>` in step 3.
-- **Roll forward manually** to `<N>`. Run the remaining CQL statements from `<N>` by hand so the schema matches the post-`<N>` state, then `force <N>` in step 3.
+- Re-apply migration `<N>` from `<N-1>` (recommended when the migration is fully idempotent). Most bundled migrations use `CREATE TABLE IF NOT EXISTS`, `CREATE TYPE IF NOT EXISTS`, and similar idempotent forms; if the failing file is fully idempotent, fix the root cause of the failure (network, capacity, malformed CQL) and re-running migration `<N>` will be safe. Plan to `force <N-1>` in step 3.
+- Roll back manually to `<N-1>`. If the migration is not idempotent, drop any tables / types / columns the partial run created so the schema matches the post-`<N-1>` state, then `force <N-1>` in step 3.
+- Roll forward manually to `<N>`. Run the remaining CQL statements from `<N>` by hand so the schema matches the post-`<N>` state, then `force <N>` in step 3.
 
 #### 3. Clear the dirty flag and re-run
 
@@ -149,7 +150,7 @@ NN_description.up.sql
 
 For a brand-new keyspace, the conventional sequence is:
 
-1. `01_init_keyspace.up.sql` - creates the keyspace with `NetworkTopologyStrategy` (uses `{{ $replicaCount }}` template variable, substituted upstream).
+1. `01_init_keyspace.up.sql` - creates the keyspace with `NetworkTopologyStrategy` and substitutes `${REPLICA_COUNT}` before migration.
 2. `02_init_roles.up.sql` - creates the application role and grants, with the login password supplied by `${SERVICE_ROLE_PASSWORD}`.
 3. `03_init_tables.up.sql` - the canonical schema (UDTs, tables, indexes) for the keyspace.
 

--- a/migrations/cassandra/execute_sqls.sh
+++ b/migrations/cassandra/execute_sqls.sh
@@ -14,18 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-timeout=120
-interval=5
-while [ $timeout -gt 0 ]; do
-  if nc -z -w 1 ${CASSANDRA_HOSTS} 9042; then
-    echo "Cassandra hosts are up"
-    break
-  fi
-  echo "Waiting for Cassandra hosts to be available..."
-  sleep $interval
-  timeout=$((timeout - interval))
-done
+REPLICA_COUNT=${REPLICA_COUNT:-3}
+case "$REPLICA_COUNT" in
+  ''|*[!0-9]*|0*)
+    echo "ERROR: REPLICA_COUNT must be an integer from 1 to 2147483647, got: $REPLICA_COUNT" >&2
+    exit 1
+    ;;
+esac
+if [ "${#REPLICA_COUNT}" -gt 10 ] || [ "$REPLICA_COUNT" -gt 2147483647 ]; then
+  echo "ERROR: REPLICA_COUNT must be an integer from 1 to 2147483647, got: $REPLICA_COUNT" >&2
+  exit 1
+fi
+export REPLICA_COUNT
 
 # Verify the superuser and the cqlsh listener is available
 max_retries=10 # 10 * 1s = 10s
@@ -43,17 +43,22 @@ echo "Cassandra cqlsh superuser is available"
 
 #
 # Pre-process SQL files with environment variable substitution
-# This allows configurable values like SERVICE_ROLE_PASSWORD
+# This allows configurable values like SERVICE_ROLE_PASSWORD and REPLICA_COUNT
 #
 # SECURITY: Only explicitly listed variables are substituted to prevent
 # unintended substitution of other environment variables
-ENVSUBST_VARS='$SERVICE_ROLE_PASSWORD'
+# shellcheck disable=SC2016
+ENVSUBST_VARS='$SERVICE_ROLE_PASSWORD $REPLICA_COUNT'
 
 TEMP_KEYSPACES="/tmp/keyspaces"
 echo "Pre-processing SQL files with environment variable substitution..."
 echo "Allowed variables: ${ENVSUBST_VARS}"
 
 for keyspace_dir in /app/keyspaces/*; do
+  # Only directories are keyspaces. keyspaces/ also holds README.md, which would
+  # otherwise become a keyspace named README.md and fail the migrate call below.
+  [ -d "$keyspace_dir" ] || continue
+
   keyspace_name=$(basename "$keyspace_dir")
   mkdir -p "$TEMP_KEYSPACES/$keyspace_name"
 
@@ -73,6 +78,8 @@ echo "SQL files pre-processed successfully"
 #
 for each in $TEMP_KEYSPACES/*
 do
+  [ -d "${each}" ] || continue
+
   migration_table_name=`basename ${each}`
   echo "Applying ${each}"
   migrate \

--- a/migrations/cassandra/keyspaces/api_keys_api/01_init_keyspace.up.sql
+++ b/migrations/cassandra/keyspaces/api_keys_api/01_init_keyspace.up.sql
@@ -1,2 +1,1 @@
-{{ $replicaCount := envOrDefault "REPLICA_COUNT" "3" }}
-CREATE KEYSPACE IF NOT EXISTS api_keys_api WITH replication = {'class': 'NetworkTopologyStrategy', 'ncp': '{{ $replicaCount }}' }  AND durable_writes = true;
+CREATE KEYSPACE IF NOT EXISTS api_keys_api WITH replication = {'class': 'NetworkTopologyStrategy', 'ncp': '${REPLICA_COUNT}' }  AND durable_writes = true;

--- a/migrations/cassandra/keyspaces/ess_api/01_init_keyspace.up.sql
+++ b/migrations/cassandra/keyspaces/ess_api/01_init_keyspace.up.sql
@@ -1,2 +1,1 @@
-{{ $replicaCount := envOrDefault "REPLICA_COUNT" "3" }}
-CREATE KEYSPACE IF NOT EXISTS ess_api WITH replication = {'class': 'NetworkTopologyStrategy', 'ncp': '{{ $replicaCount }}' }  AND durable_writes = true;
+CREATE KEYSPACE IF NOT EXISTS ess_api WITH replication = {'class': 'NetworkTopologyStrategy', 'ncp': '${REPLICA_COUNT}' }  AND durable_writes = true;

--- a/migrations/cassandra/keyspaces/nvcf_api/01_init_keyspace.up.sql
+++ b/migrations/cassandra/keyspaces/nvcf_api/01_init_keyspace.up.sql
@@ -1,2 +1,1 @@
-{{ $replicaCount := envOrDefault "REPLICA_COUNT" "3" }}
-CREATE KEYSPACE IF NOT EXISTS nvcf_api WITH replication = {'class': 'NetworkTopologyStrategy', 'ncp': '{{ $replicaCount }}' }  AND durable_writes = true;
+CREATE KEYSPACE IF NOT EXISTS nvcf_api WITH replication = {'class': 'NetworkTopologyStrategy', 'ncp': '${REPLICA_COUNT}' }  AND durable_writes = true;

--- a/migrations/cassandra/keyspaces/nvcf_autoscaler/01_init_keyspace.up.sql
+++ b/migrations/cassandra/keyspaces/nvcf_autoscaler/01_init_keyspace.up.sql
@@ -1,0 +1,1 @@
+CREATE KEYSPACE IF NOT EXISTS nvcf_autoscaler WITH replication = {'class': 'NetworkTopologyStrategy', 'ncp': '${REPLICA_COUNT}' }  AND durable_writes = true;

--- a/migrations/cassandra/keyspaces/nvcf_autoscaler/02_init_roles.up.sql
+++ b/migrations/cassandra/keyspaces/nvcf_autoscaler/02_init_roles.up.sql
@@ -1,0 +1,8 @@
+CREATE ROLE IF NOT EXISTS nvcf_autoscaler_app_access;
+GRANT SELECT, MODIFY on keyspace nvcf_autoscaler to nvcf_autoscaler_app_access;
+GRANT SELECT on keyspace system to nvcf_autoscaler_app_access;
+
+CREATE ROLE IF NOT EXISTS nvcf_autoscaler_app_v0 with login = true and password = '${SERVICE_ROLE_PASSWORD}';
+
+INSERT INTO system_auth.role_members (role, member) VALUES ('nvcf_autoscaler_app_access', 'nvcf_autoscaler_app_v0');
+UPDATE system_auth.roles SET member_of = member_of + {'nvcf_autoscaler_app_access'} where role = 'nvcf_autoscaler_app_v0';

--- a/migrations/cassandra/keyspaces/nvcf_autoscaler/03_init_tables.up.sql
+++ b/migrations/cassandra/keyspaces/nvcf_autoscaler/03_init_tables.up.sql
@@ -1,0 +1,76 @@
+-- Canonical schema for nvcf_autoscaler keyspace.
+-- Pinned to the upstream nvcf_autoscaler schema at migration version 9.
+-- account_id (TEXT) consolidates upstream nca_id_string from migrations 02-09. nca_id UUID dropped (NCA IDs are not UUIDs and the column was unused).
+
+-- ============================================================
+-- Tables
+-- ============================================================
+
+-- Functions invoked recently. Rows expire via TTL to track a rolling window.
+CREATE TABLE IF NOT EXISTS nvcf_autoscaler.recently_invoked_functions (
+    function_id         UUID,
+    function_version_id UUID,
+    last_updated_at     TIMESTAMP,
+    account_id          TEXT,
+    PRIMARY KEY ((function_id, function_version_id))
+) WITH default_time_to_live = 600
+  AND compaction = {'class': 'UnifiedCompactionStrategy', 'scaling_parameters': 'T4', 'target_sstable_size': '50MiB', 'base_shard_count': '4', 'expired_sstable_check_frequency_seconds': '300'}
+  AND read_repair = 'NONE';
+
+-- Historical scaling decisions for recently invoked functions, clustered by time.
+CREATE TABLE IF NOT EXISTS nvcf_autoscaler.recently_invoked_functions_history (
+    function_id                           UUID,
+    function_version_id                   UUID,
+    last_updated_at                       TIMESTAMP,
+    account_id                            TEXT STATIC,
+    num_workers                           INT STATIC,
+    last_predicted_desired_instance_count INT,
+    last_predicted_error_code             TEXT,
+    PRIMARY KEY ((function_id, function_version_id), last_updated_at)
+) WITH CLUSTERING ORDER BY (last_updated_at DESC)
+  AND default_time_to_live = 172800
+  AND compaction = {'class': 'UnifiedCompactionStrategy', 'scaling_parameters': 'T4', 'target_sstable_size': '50MiB', 'base_shard_count': '4', 'expired_sstable_check_frequency_seconds': '300'}
+  AND read_repair = 'NONE';
+
+-- Functions with running workers but no recent invocations.
+CREATE TABLE IF NOT EXISTS nvcf_autoscaler.running_functions_without_invocations (
+    function_id         UUID,
+    function_version_id UUID,
+    last_updated_at     TIMESTAMP,
+    account_id          TEXT,
+    PRIMARY KEY ((function_id, function_version_id))
+) WITH default_time_to_live = 600
+  AND compaction = {'class': 'UnifiedCompactionStrategy', 'scaling_parameters': 'T4', 'target_sstable_size': '50MiB', 'base_shard_count': '4', 'expired_sstable_check_frequency_seconds': '300'}
+  AND read_repair = 'NONE';
+
+-- Historical scaling decisions for running functions without invocations, clustered by time.
+CREATE TABLE IF NOT EXISTS nvcf_autoscaler.running_functions_without_invocations_history (
+    function_id                           UUID,
+    function_version_id                   UUID,
+    last_updated_at                       TIMESTAMP,
+    account_id                            TEXT STATIC,
+    num_workers                           INT STATIC,
+    last_predicted_desired_instance_count INT,
+    last_predicted_error_code             TEXT,
+    PRIMARY KEY ((function_id, function_version_id), last_updated_at)
+) WITH CLUSTERING ORDER BY (last_updated_at DESC)
+  AND default_time_to_live = 172800
+  AND compaction = {'class': 'UnifiedCompactionStrategy', 'scaling_parameters': 'T4', 'target_sstable_size': '50MiB', 'base_shard_count': '4', 'expired_sstable_check_frequency_seconds': '300'}
+  AND read_repair = 'NONE';
+
+-- Distributed lock table for autoscaler leader coordination.
+CREATE TABLE IF NOT EXISTS nvcf_autoscaler.locks (
+    lock_name   TEXT PRIMARY KEY,
+    node_id     TEXT,
+    acquired_at TIMESTAMP
+) WITH default_time_to_live = 3600
+  AND compaction = {'class': 'UnifiedCompactionStrategy', 'scaling_parameters': 'T4', 'target_sstable_size': '50MiB', 'base_shard_count': '4', 'expired_sstable_check_frequency_seconds': '300'}
+  AND read_repair = 'NONE';
+
+-- Liveness registry of autoscaler nodes. Rows expire quickly to reflect health.
+CREATE TABLE IF NOT EXISTS nvcf_autoscaler.healthy_nodes (
+    node_id         TEXT PRIMARY KEY,
+    last_updated_at TIMESTAMP
+) WITH default_time_to_live = 180
+  AND compaction = {'class': 'UnifiedCompactionStrategy', 'scaling_parameters': 'T4', 'target_sstable_size': '50MiB', 'base_shard_count': '4', 'expired_sstable_check_frequency_seconds': '300'}
+  AND read_repair = 'NONE';

--- a/migrations/cassandra/keyspaces/nvct_api/01_init_keyspace.up.sql
+++ b/migrations/cassandra/keyspaces/nvct_api/01_init_keyspace.up.sql
@@ -1,0 +1,1 @@
+CREATE KEYSPACE IF NOT EXISTS nvct_api WITH replication = {'class': 'NetworkTopologyStrategy', 'ncp': '${REPLICA_COUNT}' }  AND durable_writes = true;

--- a/migrations/cassandra/keyspaces/nvct_api/02_init_roles.up.sql
+++ b/migrations/cassandra/keyspaces/nvct_api/02_init_roles.up.sql
@@ -1,0 +1,8 @@
+CREATE ROLE IF NOT EXISTS nvct_api_app_access;
+GRANT SELECT, MODIFY on keyspace nvct_api to nvct_api_app_access;
+GRANT SELECT on keyspace system to nvct_api_app_access;
+
+CREATE ROLE IF NOT EXISTS nvct_api_app_v0 with login = true and password = '${SERVICE_ROLE_PASSWORD}';
+
+INSERT INTO system_auth.role_members (role, member) VALUES ('nvct_api_app_access', 'nvct_api_app_v0');
+UPDATE system_auth.roles SET member_of = member_of + {'nvct_api_app_access'} where role = 'nvct_api_app_v0';

--- a/migrations/cassandra/keyspaces/nvct_api/03_init_tables.up.sql
+++ b/migrations/cassandra/keyspaces/nvct_api/03_init_tables.up.sql
@@ -1,0 +1,122 @@
+-- Canonical schema for nvct_api keyspace.
+-- Reference: nvcf/nvct-api v1.5.2 local_env/cassandra/schema/0001_initial_schema.cql
+
+-- ============================================================
+-- User-Defined Types
+-- ============================================================
+
+CREATE TYPE IF NOT EXISTS nvct_api.model_udt (
+    name    TEXT,
+    version TEXT,
+    url     TEXT
+);
+
+CREATE TYPE IF NOT EXISTS nvct_api.resource_udt (
+    name    TEXT,
+    version TEXT,
+    url     TEXT
+);
+
+CREATE TYPE IF NOT EXISTS nvct_api.gpu_spec_udt (
+    instance_type           TEXT,
+    gpu                     TEXT,
+    backend                 TEXT,
+    configuration           TEXT,
+    clusters                FROZEN<SET<TEXT>>,
+    regions                 FROZEN<SET<TEXT>>,
+    attributes              FROZEN<SET<TEXT>>,
+    max_request_concurrency INT,
+    helm_validation_policy  TEXT
+);
+
+CREATE TYPE IF NOT EXISTS nvct_api.health_udt (
+    sis_request_id UUID,
+    gpu            TEXT,
+    backend        TEXT,
+    instance_type  TEXT,
+    error          TEXT
+);
+
+CREATE TYPE IF NOT EXISTS nvct_api.telemetries_udt (
+    logs_telemetry_id    UUID,
+    metrics_telemetry_id UUID,
+    traces_telemetry_id  UUID
+);
+
+-- ============================================================
+-- Tables
+-- ============================================================
+
+-- Primary task store. Each row is a unique task instance.
+CREATE TABLE IF NOT EXISTS nvct_api.tasks_v2 (
+    nca_id                         TEXT,
+    task_id                        UUID,
+    name                           TEXT,
+    description                    TEXT,
+    tags                           FROZEN<SET<TEXT>>,
+    container_image                TEXT,
+    container_args                 TEXT,
+    container_environment          TEXT,
+    models                         FROZEN<SET<model_udt>>,
+    resources                      FROZEN<SET<resource_udt>>,
+    gpu_spec                       gpu_spec_udt,
+    max_runtime_duration           DURATION,
+    max_queued_duration            DURATION,
+    terminal_grace_period_duration DURATION,
+    result_handling_strategy       TEXT,
+    helm_chart                     TEXT,
+    results_location               TEXT,
+    status                         TEXT,
+    telemetries                    FROZEN<telemetries_udt>,
+    health_info                    FROZEN<health_udt>,
+    percent_complete               INT,
+    last_updated_at                TIMESTAMP,
+    last_heartbeat_at              TIMESTAMP,
+    created_at                     TIMESTAMP,
+    has_secrets                    BOOLEAN,
+    PRIMARY KEY ((task_id))
+);
+
+CREATE CUSTOM INDEX IF NOT EXISTS tasks_v2_by_nca_id_sai_idx
+    ON nvct_api.tasks_v2 (nca_id) USING 'StorageAttachedIndex';
+
+-- Tracks active SIS requests per task.
+CREATE TABLE IF NOT EXISTS nvct_api.sis_requests_by_task (
+    task_id            UUID,
+    sis_request_id     UUID,
+    gpu_spec           gpu_spec_udt,
+    total_request_size INT,
+    created_at         TIMESTAMP,
+    PRIMARY KEY ((task_id), sis_request_id)
+);
+
+-- Events emitted during task lifecycle, keyed by task.
+CREATE TABLE IF NOT EXISTS nvct_api.events_by_task (
+    task_id    UUID,
+    event_id   UUID,
+    nca_id     TEXT,
+    message    TEXT,
+    created_at TIMESTAMP,
+    PRIMARY KEY ((task_id), event_id)
+);
+
+-- Results produced by a task, keyed by task.
+CREATE TABLE IF NOT EXISTS nvct_api.results_by_task (
+    task_id    UUID,
+    result_id  UUID,
+    nca_id     TEXT,
+    name       TEXT,
+    metadata   TEXT,
+    created_at TIMESTAMP,
+    PRIMARY KEY ((task_id), result_id)
+);
+
+-- Distributed lock table for scheduled background tasks.
+-- Primary key must be 'name'.
+CREATE TABLE IF NOT EXISTS nvct_api.lock (
+    name      TEXT,
+    lockuntil TIMESTAMP,
+    lockedat  TIMESTAMP,
+    lockedby  TEXT,
+    PRIMARY KEY ((name))
+);

--- a/migrations/cassandra/keyspaces/sis_api/01_init_keyspace.up.sql
+++ b/migrations/cassandra/keyspaces/sis_api/01_init_keyspace.up.sql
@@ -1,2 +1,1 @@
-{{ $replicaCount := envOrDefault "REPLICA_COUNT" "3" }}
-CREATE KEYSPACE IF NOT EXISTS sis_api WITH replication = {'class': 'NetworkTopologyStrategy', 'ncp': '{{ $replicaCount }}' }  AND durable_writes = true;
+CREATE KEYSPACE IF NOT EXISTS sis_api WITH replication = {'class': 'NetworkTopologyStrategy', 'ncp': '${REPLICA_COUNT}' }  AND durable_writes = true;

--- a/migrations/cassandra/tests/test-execute-sqls.sh
+++ b/migrations/cassandra/tests/test-execute-sqls.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -u
+
+test_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+subtree_dir=$(CDPATH='' cd -- "${test_dir}/.." && pwd)
+script="${subtree_dir}/execute_sqls.sh"
+keyspaces="${subtree_dir}/keyspaces"
+status=0
+
+fail()
+{
+  printf 'FAIL: %s\n' "$1" >&2
+  status=1
+}
+
+schema_inventory=$(
+  # shellcheck disable=SC2016
+  sed -n 's/^| `\([^`]*\)`[[:space:]]*| \[[^]]*\].*$/\1/p' \
+    "${keyspaces}/README.md"
+)
+if [ -z "${schema_inventory}" ]; then
+  fail "schema inventory is empty or malformed"
+fi
+for keyspace_name in ${schema_inventory}; do
+  for migration_name in \
+    01_init_keyspace.up.sql \
+    02_init_roles.up.sql \
+    03_init_tables.up.sql
+  do
+    migration="${keyspaces}/${keyspace_name}/${migration_name}"
+    if [ ! -f "${migration}" ]; then
+      fail "schema inventory entry ${keyspace_name} is missing ${migration_name}"
+    fi
+  done
+done
+
+if grep -R -n -F 'envOrDefault "REPLICA_COUNT"' "${keyspaces}"; then
+  fail "keyspace migrations contain templates unsupported by stock golang-migrate"
+fi
+
+envsubst_vars=$(sed -n "s/^ENVSUBST_VARS='\\(.*\\)'$/\\1/p" "${script}")
+# shellcheck disable=SC2016
+if [ "${envsubst_vars}" != '$SERVICE_ROLE_PASSWORD $REPLICA_COUNT' ]; then
+  fail "execute_sqls.sh does not allow REPLICA_COUNT substitution"
+fi
+
+# shellcheck disable=SC2016
+if ! grep -F -q 'REPLICA_COUNT=${REPLICA_COUNT:-3}' "${script}"; then
+  fail "execute_sqls.sh does not preserve the default replica count"
+fi
+
+# shellcheck disable=SC2016
+replica_count_validation=$(
+  sed -n '/^REPLICA_COUNT=${REPLICA_COUNT:-3}$/,/^export REPLICA_COUNT$/p' "${script}"
+)
+for replica_count in 1 3 2147483647; do
+  if ! REPLICA_COUNT="${replica_count}" sh -c "${replica_count_validation}"; then
+    fail "execute_sqls.sh rejects valid replica count ${replica_count}"
+  fi
+done
+for replica_count in 0 01 -1 invalid 2147483648 99999999999; do
+  if REPLICA_COUNT="${replica_count}" sh -c "${replica_count_validation}" 2>/dev/null; then
+    fail "execute_sqls.sh accepts invalid replica count ${replica_count}"
+  fi
+done
+
+for migration in "${keyspaces}"/*/01_init_keyspace.up.sql; do
+  rendered=$(
+    REPLICA_COUNT=2 SERVICE_ROLE_PASSWORD=test-password \
+      envsubst "${envsubst_vars}" < "${migration}"
+  )
+
+  if printf '%s\n' "${rendered}" | grep -q '{{'; then
+    fail "${migration} leaves a Go template in rendered CQL"
+  fi
+
+  if ! printf '%s\n' "${rendered}" | grep -F -q "'ncp': '2'"; then
+    fail "${migration} does not substitute REPLICA_COUNT"
+  fi
+done
+
+if grep -Eq '(^|[[:space:]])nc([[:space:]]|$)' "${script}"; then
+  fail "execute_sqls.sh depends on netcat even though the image does not install it"
+fi
+
+if ! grep -q '^until cqlsh ' "${script}"; then
+  fail "execute_sqls.sh must retain the Cassandra authentication readiness check"
+fi
+
+exit "${status}"


### PR DESCRIPTION
## Why

The 0.6.1 self-managed stack keeps the legacy ESS schema contract while moving Cassandra migrations to the official Cassandra base. The later migration line changed that schema and cannot be consumed by the 0.6.x ESS package.

## What changed

- Restores the required nvcf_autoscaler and nvct_api migration schemas.
- Uses the official Cassandra image, replaces unsupported templating with environment substitution, and removes the unavailable netcat readiness probe.
- Adds migration-source regression coverage.

## Customer Release Notes

Fixes Cassandra migration compatibility for the NVCF 0.6.1 self-managed release.

## Plan Summary

Not applicable.

## Usage

The self-managed release/0.6 stack consumes nvcf-cassandra-migrations:0.10.2.

## Testing

- sh migrations/cassandra/tests/test-execute-sqls.sh
- Image build reaches the official Cassandra base; the public source snapshot intentionally excludes the architecture-specific migration binary provided by the release build.

## Notes

This PR targets the dedicated 0.10 release baseline so the review is limited to the 0.6.1 hotfixes.

## References

- Closes #488
- https://github.com/NVIDIA/nvcf/pull/439
- https://github.com/NVIDIA/nvcf/pull/475

## Related Pull Requests

None

## Dependencies

None