### PR TITLE
fix(cassandra): register nvct with legacy ESS auth

### DIFF
--- a/migrations/cassandra/keyspaces/ess_api/05_add_nvct_authorizations.up.sql
+++ b/migrations/cassandra/keyspaces/ess_api/05_add_nvct_authorizations.up.sql
@@ -1,0 +1,25 @@
+-- Register nvct-api for legacy ESS authentication during the 0.6.x release.
+--
+-- The 0.6.x ESS API validates service assertions from ssa_authorizations and
+-- validates task-secret reads from notary_authorizations.
+UPDATE ess_api.namespaces
+SET
+  ssa_authorizations = ssa_authorizations + {
+    'nvct-api': {
+      id: 'nvct-api',
+      name: 'nvct api service client',
+      jwks_url: 'http://openbao-server.vault-system.svc.cluster.local:8200/v1/services/ess-api/jwt/jwks',
+      issuer: 'http://ess-api.ess.svc.cluster.local',
+      type: 'SSA'
+    }
+  },
+  notary_authorizations = notary_authorizations + {
+    'nvct-api': {
+      id: 'nvct-api',
+      name: 'nvct api notary client',
+      jwks_url: 'http://notary.nvcf.svc.cluster.local:8080/.well-known/jwks.json',
+      issuer: 'http://notary.nvcf.svc.cluster.local:8080',
+      type: 'NOTARY'
+    }
+  }
+WHERE namespace = 'nvcf';

--- a/migrations/cassandra/tests/test-execute-sqls.sh
+++ b/migrations/cassandra/tests/test-execute-sqls.sh
@@ -37,6 +37,26 @@ for keyspace_name in ${schema_inventory}; do
   done
 done
 
+ess_nvct_authorizations="${keyspaces}/ess_api/05_add_nvct_authorizations.up.sql"
+if [ ! -f "${ess_nvct_authorizations}" ]; then
+  fail "ess_api is missing the nvct-api authorization migration"
+else
+  ssa_registration=$(sed -n '/ssa_authorizations = ssa_authorizations + {/,/^  },$/p' "${ess_nvct_authorizations}")
+  notary_registration=$(sed -n '/notary_authorizations = notary_authorizations + {/,/^  }$/p' "${ess_nvct_authorizations}")
+
+  if ! printf '%s\n' "${ssa_registration}" | grep -F -q "'nvct-api': {" || \
+    ! printf '%s\n' "${ssa_registration}" | grep -F -q "type: 'SSA'"
+  then
+    fail "ess_api does not register nvct-api for SSA authentication"
+  fi
+
+  if ! printf '%s\n' "${notary_registration}" | grep -F -q "'nvct-api': {" || \
+    ! printf '%s\n' "${notary_registration}" | grep -F -q "type: 'NOTARY'"
+  then
+    fail "ess_api does not register nvct-api for notary authentication"
+  fi
+fi
+
 if grep -R -n -F 'envOrDefault "REPLICA_COUNT"' "${keyspaces}"; then
   fail "keyspace migrations contain templates unsupported by stock golang-migrate"
 fi


### PR DESCRIPTION
## TL;DR

Restores the legacy ESS authorization records required for nvct-api task creation in the 0.6.1 Cassandra migrations release line.

## Additional Details

The 0.6.x ESS API reads the legacy SSA and notary authorization maps. The v0.10.2 release seeds nvct-api only in the newer OAuth map, causing task creation to fail with a forbidden client-not-registered response.

This adds the missing ordered ESS migration and extends the migration regression test to require both nvct-api registrations. It deliberately does not add the later SSA-column restoration migration because the v0.10 release branch already retains that column.

## Customer Release Notes

Fixes task creation for fresh 0.6.1 self-managed installations.

## Plan Summary

Not applicable.

## Usage

Publish migrations/cassandra/v0.10.3 after this PR merges, then update the 0.6 stack release branch to consume the published image.

## Testing

sh migrations/cassandra/tests/test-execute-sqls.sh

QA is needed: validate task creation on a fresh single-cluster 0.6.1 deployment using the published image.

## Notes

No new third-party dependencies. NOTICE unchanged.

## References

Closes #488

## Related Pull Requests

https://github.com/NVIDIA/nvcf/pull/475

## Dependencies

None

## For the Reviewer

Please verify the nvct-api SSA and notary registrations in the new ordered migration.

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.