### PR TITLE
fix(self-managed): update SIS image repository to icms-service-oss

### DIFF
--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -516,7 +516,7 @@ sis:
   {{- end }}
   image:
     registry: {{ .Values.global.image.registry }}
-    repository: {{ .Values.global.image.repository }}/spot
+    repository: {{ .Values.global.image.repository }}/icms-service-oss
     {{- if dig "sis" "image" "tag" "" .Values }}
     tag: {{ dig "sis" "image" "tag" "" .Values }}
     {{- end }}


### PR DESCRIPTION
## TL;DR
Update the SIS image repository in the self-managed stack from `spot` to `icms-service-oss` to match the renamed OSS image.

## Additional Details

The SIS chart (`helm-nvcf-sis`) was migrated to use the `icms-service-oss` image, but the self-managed Helmfile stack (`deploy/stacks/self-managed/global.yaml.gotmpl`) still hardcoded the old repository path suffix `/spot`. This caused deployments to pull `<registry>/<org>/spot:1.2.2` instead of the intended `<registry>/<org>/icms-service-oss:1.2.2`.

## For the Reviewer

One-line change in `global.yaml.gotmpl` at the `sis.image.repository` field.

## For QA

Deploy the self-managed stack and confirm the SIS pod uses image `icms-service-oss:1.2.2`.

## Testing

The self-managed stack (`deploy/stacks/self-managed/`) has no golden-file render test infrastructure. A Helmfile render assertion for this change cannot be added without first building that infrastructure, which is out of scope for a one-line fix. The change is verified by inspection: the template variable `{{ .Values.global.image.repository }}/icms-service-oss` is structurally identical to all other image references in the same file.

## Issues

NO-REF

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the SIS component to use the correct container image repository for self-managed deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->