### PR TITLE
fix(function-autoscaler): use cp environment labels for byoc count

### DIFF
--- a/src/control-plane-services/function-autoscaler/crates/server/src/work/mod.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/work/mod.rs
@@ -170,7 +170,11 @@ async fn get_byoc_instance_count(
     let env_suffix = if ignore_env {
         String::new()
     } else {
-        let env_val = if env == "stg" { "stage" } else { "prod" };
+        let env_val = if env == "stg" {
+            "staging"
+        } else {
+            "production"
+        };
         format!(r#", environment="{}""#, env_val)
     };
 
@@ -875,6 +879,47 @@ mod tests {
 
         assert_eq!(n, 7);
         assert_eq!(src, MetricSource::ControlPlane);
+    }
+
+    #[tokio::test]
+    async fn test_byoc_instance_count_uses_control_plane_environment_labels() {
+        let fid = Uuid::new_v4();
+        let fvid = Uuid::new_v4();
+        let mut server = mockito::Server::new_async().await;
+        let body = vm_series(
+            &format!(r#""function_id":"{fid}","function_version_id":"{fvid}""#),
+            "3",
+        );
+
+        let _prd = server
+            .mock("GET", "/api/v1/query_range")
+            .match_query(mockito::Matcher::Regex("production".into()))
+            .with_status(200)
+            .with_body(body.clone())
+            .create_async()
+            .await;
+        let _stg = server
+            .mock("GET", "/api/v1/query_range")
+            .match_query(mockito::Matcher::Regex("staging".into()))
+            .with_status(200)
+            .with_body(body)
+            .create_async()
+            .await;
+
+        let client = ts_client(server.url());
+
+        assert_eq!(
+            get_byoc_instance_count(&client, &fid, &fvid, "prd", false)
+                .await
+                .expect("prod cp instance count"),
+            3
+        );
+        assert_eq!(
+            get_byoc_instance_count(&client, &fid, &fvid, "stg", false)
+                .await
+                .expect("stage cp instance count"),
+            3
+        );
     }
 
     /// No worker series and the BYOC query fails -> control-plane with 0 instances.


### PR DESCRIPTION
## TL;DR
Fix the BYOC/control-plane instance-count query to use the environment label values emitted by `nvcf_function_instances_current`: `staging` and `production`.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
The autoscaler’s CP instance-count path was mapping `stg -> stage` and everything else to `prod` when querying `nvcf_function_instances_current`.

That label convention is correct for other autoscaler metric queries, but this CP metric uses `environment="staging"` and `environment="production"`. This caused prod BYOC instance-count lookups to query `environment="prod"` and miss or undercount matching CP metric series.

This change is intentionally scoped to `get_byoc_instance_count`; worker metrics, utilization queries, discovery queries, and the existing active-instance helper are unchanged.

## For the Reviewer
Please focus on `src/control-plane-services/function-autoscaler/crates/server/src/work/mod.rs`.

The new test directly exercises the BYOC/CP instance-count query path and verifies the query uses `production` for `prd` and `staging` for `stg`.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
Verified locally:

- `cargo fmt`
- `cargo test -p rs-autoscaler work::tests`
- `cargo test -p rs-autoscaler`

## Issues
NO-REF

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected environment labeling for BYOC instance-count metrics, ensuring staging and production data are queried with the appropriate labels.
  * Added validation coverage for both staging and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->