### PR TITLE
docs(helm): remove internal README notices

### DIFF
--- a/deploy/helm/cert-manager/README.md
+++ b/deploy/helm/cert-manager/README.md
@@ -1,13 +1,5 @@
 # NVCF cert-manager Helm Chart
 
-> [!IMPORTANT]
-> Active development of the helm-nvcf-cert-manager chart has moved to
-> the NVCF umbrella monorepo. This repository is retained as
-> historical source context only; new commits, issues, and merge
-> requests should target the umbrella.
->
-> Public mirror: https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/cert-manager
-
 ## Scope
 
 This chart installs cert-manager for self-managed NVCF. It is intentionally a minimal wrapper around the pinned upstream Jetstack cert-manager Helm chart, not a fork of cert-manager and not a custom NVCF cert-manager implementation.

--- a/deploy/helm/llm-api-gateway/README.md
+++ b/deploy/helm/llm-api-gateway/README.md
@@ -1,13 +1,5 @@
 # NVCF LLM API Gateway Helm Chart
 
-> [!IMPORTANT]
-> Active development of the helm-nvcf-llm-api-gateway chart has moved to
-> the NVCF umbrella monorepo. This repository is retained as
-> historical source context only; new commits, issues, and merge
-> requests should target the umbrella.
->
-> Public mirror: https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/llm-api-gateway
-
 This repository contains the Helm chart for deploying the NVCF LLM API Gateway on Kubernetes.
 
 ## Overview

--- a/deploy/helm/llm-request-router/README.md
+++ b/deploy/helm/llm-request-router/README.md
@@ -1,13 +1,5 @@
 # NVCF LLM Request Router Helm Chart
 
-> [!IMPORTANT]
-> Active development of the helm-nvcf-llm-request-router chart has moved to
-> the NVCF umbrella monorepo. This repository is retained as
-> historical source context only; new commits, issues, and merge
-> requests should target the umbrella.
->
-> Public mirror: https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/llm-request-router
-
 This repository contains the Helm chart for deploying the NVCF LLM Request Router (Stargate) on Kubernetes.
 
 ## Overview

--- a/deploy/helm/ratelimiter/README.md
+++ b/deploy/helm/ratelimiter/README.md
@@ -1,13 +1,5 @@
 # NVCF Rate Limiter Helm Chart
 
-> [!IMPORTANT]
-> Active development of the helm-nvcf-rate-limiter chart has moved to
-> the NVCF umbrella monorepo. This repository is retained as
-> historical source context only; new commits, issues, and merge
-> requests should target the umbrella.
->
-> Public mirror: https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/ratelimiter
-
 This repository contains the Helm chart for deploying the NVCF Rate Limiter service on Kubernetes.
 
 ## Overview


### PR DESCRIPTION
## TL;DR

Remove internal-only migration notices from four public Helm chart READMEs.

## Why

The notices directed public readers to an inaccessible internal workflow and then linked back to the same public chart paths. They provided no actionable destination and described the public documentation as historical-only.

## What changed

Removed the complete migration callout from the cert-manager, LLM API Gateway, LLM Request Router, and Rate Limiter chart READMEs. The chart deployment documentation is unchanged.

## Customer Release Notes

Not customer visible.

## Plan Summary

Not applicable.

## Usage

Not applicable.

## Testing

Ran git diff --check and verified that the four edited READMEs no longer contain the internal migration language or self-referential Public mirror links. This is a documentation-only change. No automated tests or QA are needed.

## Notes

No other self-referential migration notice remains in the public Helm chart READMEs.

## References

Closes #503

## Related Pull Requests

None.

## Dependencies

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Helm chart documentation for cert-manager, LLM API Gateway, LLM request router, and rate limiter.
  * Removed outdated notices and repository migration references.
  * Chart descriptions and configuration guidance remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->