### PR TITLE
fix(stargate): load CA roots for OTLP trace export over TLS

### DIFF
--- a/src/libraries/rust/stargate/Cargo.lock
+++ b/src/libraries/rust/stargate/Cargo.lock
@@ -3666,6 +3666,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4138,6 +4139,15 @@ name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/src/libraries/rust/stargate/Cargo.toml
+++ b/src/libraries/rust/stargate/Cargo.toml
@@ -70,7 +70,7 @@ tonic = "=0.14.6"
 opentelemetry = "=0.32.0"
 opentelemetry-http = "=0.32.0"
 opentelemetry_sdk = { version = "=0.32.1", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "=0.32.0", default-features = false, features = ["grpc-tonic", "tls-roots", "tls-aws-lc", "trace"] }
+opentelemetry-otlp = { version = "=0.32.0", default-features = false, features = ["grpc-tonic", "tls-roots", "tls-webpki-roots", "tls-aws-lc", "trace"] }
 prometheus = "=0.14.0"
 tracing = "=0.1.44"
 tracing-opentelemetry = "=0.33.0"

--- a/src/libraries/rust/stargate/crates/stargate-telemetry/src/lib.rs
+++ b/src/libraries/rust/stargate/crates/stargate-telemetry/src/lib.rs
@@ -56,6 +56,12 @@ pub fn init_telemetry(
         let mut exporter_builder = opentelemetry_otlp::SpanExporter::builder()
             .with_tonic()
             .with_endpoint(endpoint.trim().to_string());
+        // Load CA roots (webpki set is embedded) so https collectors don't fail
+        // with UnknownIssuer on the distroless image.
+        if endpoint.trim().starts_with("https://") {
+            exporter_builder = exporter_builder
+                .with_tls_config(tonic::transport::ClientTlsConfig::new().with_enabled_roots());
+        }
         if let Some(token) = access_token
             .map(str::trim)
             .filter(|token| !token.is_empty())


### PR DESCRIPTION
## Why
The stargate OTLP span exporter builds its gRPC TLS channel with an empty root store, so exporting traces to an https collector fails the TLS handshake with `invalid peer certificate: UnknownIssuer`, even for publicly trusted certs. On a distroless image the OS trust store is not reliable, so no router/pylon traces reach the collector.

## What changed
- For https endpoints, explicitly set the exporter TLS config with `ClientTlsConfig::new().with_enabled_roots()` in stargate-telemetry.
- Enable the `tls-webpki-roots` feature on `opentelemetry-otlp` so the Mozilla CA set is embedded in the binary, independent of the container filesystem.

Fixes the router and pylon (shared stargate-telemetry).

## Customer Release Notes
Not customer visible.

## Testing
cargo check / fmt / clippy pass for stargate-telemetry. Reproduced the failure on the deployed router: `BatchSpanProcessor.ExportError ... invalid peer certificate: UnknownIssuer` against a publicly signed collector cert; the empty root store is the cause.

## Dependencies
Enables the `tls-webpki-roots` feature on opentelemetry-otlp; pulls in webpki-roots 1.0.7 (MPL-2.0). No new direct crate.

## References
Closes #507

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry export reliability for secure HTTPS endpoints by enabling trusted TLS root certificates.
* **Chores**
  * Cleaned up dependency configuration formatting without changing versions or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->