### PR TITLE
feat(self-managed): add function autoscaler to self-hosted stack

### DIFF
--- a/deploy/helm/function-autoscaler/Chart.yaml
+++ b/deploy/helm/function-autoscaler/Chart.yaml
@@ -19,4 +19,4 @@ description: A Helm chart for NVCF Function Autoscaler Service
 
 type: application
 version: 0.0.0 # autoversioning enabled via release pipeline
-appVersion: "0.0.0"
+appVersion: "1.18.7"

--- a/deploy/helm/function-autoscaler/Chart.yaml
+++ b/deploy/helm/function-autoscaler/Chart.yaml
@@ -19,4 +19,4 @@ description: A Helm chart for NVCF Function Autoscaler Service
 
 type: application
 version: 0.0.0 # autoversioning enabled via release pipeline
-appVersion: "1.18.7"
+appVersion: "1.18.11"

--- a/deploy/helm/function-autoscaler/values.yaml
+++ b/deploy/helm/function-autoscaler/values.yaml
@@ -97,6 +97,9 @@ functionautoscaler:
     - name: probe
       containerPort: 8181
       protocol: TCP
+    - name: metrics
+      containerPort: 41338
+      protocol: TCP
 
   # Stable service DNS. Override for multiple releases in one namespace.
   service:
@@ -109,6 +112,10 @@ functionautoscaler:
       - name: probe
         port: 8181
         targetPort: probe
+        protocol: TCP
+      - name: metrics
+        port: 41338
+        targetPort: metrics
         protocol: TCP
 
   # Additional volumes on the output Deployment definition.

--- a/deploy/helm/function-autoscaler/vault-agent-templates/secrets.json.tmpl
+++ b/deploy/helm/function-autoscaler/vault-agent-templates/secrets.json.tmpl
@@ -27,6 +27,9 @@
       "access_key": ""
     },
     "nvcf_api": {
+      {{- with secret "services/nvcf-api/jwt/sign/nvcf-autoscaler-service" }}
+      "access_token": "{{ .Data.token }}",
+      {{- end }}
       "client_id": "",
       "client_secret": ""
     }

--- a/deploy/stacks/observability/charts/nvcf-default-monitors/templates/servicemonitors.yaml
+++ b/deploy/stacks/observability/charts/nvcf-default-monitors/templates/servicemonitors.yaml
@@ -23,8 +23,12 @@ limitations under the License.
 {{- $groupName := get $group "name" }}
 {{- $groupValues := get $group "values" }}
 {{- if $groupValues.enabled }}
+{{- $disabledServices := default list $groupValues.disabledServices }}
+{{- if not (kindIs "slice" $disabledServices) }}
+{{- fail (printf "%s.disabledServices must be a list" $groupName) }}
+{{- end }}
 {{- range $svc := $groupValues.services }}
-{{- if $svc.enabled }}
+{{- if and $svc.enabled (not (has $svc.name $disabledServices)) }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/deploy/stacks/observability/charts/nvcf-default-monitors/templates/servicemonitors.yaml
+++ b/deploy/stacks/observability/charts/nvcf-default-monitors/templates/servicemonitors.yaml
@@ -23,12 +23,8 @@ limitations under the License.
 {{- $groupName := get $group "name" }}
 {{- $groupValues := get $group "values" }}
 {{- if $groupValues.enabled }}
-{{- $disabledServices := default list $groupValues.disabledServices }}
-{{- if not (kindIs "slice" $disabledServices) }}
-{{- fail (printf "%s.disabledServices must be a list" $groupName) }}
-{{- end }}
 {{- range $svc := $groupValues.services }}
-{{- if and $svc.enabled (not (has $svc.name $disabledServices)) }}
+{{- if $svc.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -142,17 +142,14 @@ observability:
 # Defaults consumed only for the control and all observability profiles.
 functionAutoscaler:
   chartVersion: "0.1.0"
-  image:
-    # Keep the stack's image pin independent of the chart's release metadata.
-    tag: "1.18.3"
   region: local
   cassandra:
     contactPoints: cassandra.cassandra-system.svc.cluster.local
     isDevelopment: false
   nvcfApi:
     grpcAddress: http://api.nvcf.svc.cluster.local:9090
-    # Self-managed NVCF currently uses its internal unauthenticated gRPC path.
-    disableAuth: true
+    # Self-managed auth uses the OpenBao-rendered bearer token.
+    disableAuth: false
     dryRun: false
   timeseriesDb:
     # Self-hosted control-plane metrics do not require the hosted TSDB's

--- a/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
@@ -11,6 +11,9 @@ environments:
 {{- fail (printf "observability.profile must be disabled, control, compute, or all, got %q" $observabilityProfile) }}
 {{- end }}
 {{- $functionAutoscalerEnabled := or (eq $observabilityProfile "control") (eq $observabilityProfile "all") }}
+{{- if and $functionAutoscalerEnabled (not (dig "stateMetrics" "enabled" false .Values)) }}
+{{- fail "function-autoscaler requires stateMetrics.enabled=true for control and all observability profiles" }}
+{{- end }}
 
 repositories:
   - name: nvcf
@@ -69,4 +72,6 @@ releases:
     namespace: nvcf
     inherit:
       - template: functionAutoscaler
+    needs:
+      - nvcf/state-metrics
   {{- end }}

--- a/deploy/stacks/self-managed/tests/observability-autoscaler.sh
+++ b/deploy/stacks/self-managed/tests/observability-autoscaler.sh
@@ -74,7 +74,7 @@ for expected in \
   'CASSANDRA__CONTACT_POINTS: cassandra.cassandra-system.svc.cluster.local' \
   'CASSANDRA__IS_DEVELOPMENT: "false"' \
   'NVCF_API__NVCF_API_GRPC_ADDRESS: http://api.nvcf.svc.cluster.local:9090' \
-  'NVCF_API__DISABLE_AUTH: "true"' \
+  'NVCF_API__DISABLE_AUTH: "false"' \
   'NVCF_API__DRY_RUN: "false"' \
   'TIMESERIES_DB__TIMESERIES_DB_URL: http://vmsingle.monitoring.svc.cluster.local:8428' \
   'TIMESERIES_DB__AUTH_MODE: none' \
@@ -89,7 +89,7 @@ helm template function-autoscaler "$repo_dir/deploy/helm/function-autoscaler" \
   >"$work_dir/autoscaler-manifests.yaml"
 
 autoscaler_manifests="$work_dir/autoscaler-manifests.yaml"
-grep -q 'image: nvcr.io/YOUR_ORG/YOUR_TEAM/nvcf-function-autoscaler:1.18.3' "$autoscaler_manifests" ||
+grep -q 'image: nvcr.io/YOUR_ORG/YOUR_TEAM/nvcf-function-autoscaler:1.18.11' "$autoscaler_manifests" ||
   fail "self-managed stack did not pin the autoscaler image"
 test "$(grep -c '^kind: ConfigMap$' "$autoscaler_manifests")" = "2" ||
   fail "autoscaler chart did not render only its env and Vault template ConfigMaps"

--- a/docs/user/manifest.md
+++ b/docs/user/manifest.md
@@ -157,7 +157,7 @@ The following tables list the complete artifact inventory.
 | `nvcf-invocation-service` | `0.8.5` | Required | Routes stateless HTTP function invocation requests. | `nvcr.io/nvidia/nvcf/nvcf-invocation-service:0.8.5` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/invocation-plane-services/http-invocation) |
 | `nvcf-nats-auth-callout-service` | `0.5.10` | Required | Authorizes NATS clients for NVCF services and workloads. | `nvcr.io/nvidia/nvcf/nvcf-nats-auth-callout-service:0.5.10` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/control-plane-services/nats-auth-callout) |
 | `nvcf-openbao` | `2.5.4-nv-1.3.0` | Required | Stores and manages control-plane secrets. | `nvcr.io/0833294136851237/selfhosted-ga/nvcf-openbao:2.5.4-nv-1.3.0-ea` | [Upstream](https://github.com/openbao/openbao) |
-| `nvcf-openbao-migrations` | `0.16.1` | Required | Applies the OpenBao configuration required by NVCF. | `nvcr.io/nvidia/nvcf/nvcf-openbao-migrations:0.16.1` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/migrations/openbao) |
+| `nvcf-openbao-migrations` | `0.16.2` | Required | Applies the OpenBao configuration required by NVCF. | `nvcr.io/nvidia/nvcf/nvcf-openbao-migrations:0.16.2` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/migrations/openbao) |
 | `nvcf-service-oss` | `1.9.0-hotfix.1` | Required | Provides the primary NVCF control-plane API. | `nvcr.io/nvidia/nvcf/nvcf-service-oss:1.9.0-hotfix.1` |  |
 | `nvct-service-oss` | `1.5.9-hotfix.1` | Required | Provides tenant-scoped NVCF control-plane operations. | `nvcr.io/nvidia/nvcf/nvct-service-oss:1.5.9-hotfix.1` |  |
 | `oss-vault-k8s` | `1.7.4` | Required | Integrates Kubernetes workloads with OpenBao secrets. | `nvcr.io/nvidia/nvcf/oss-vault-k8s:1.7.4` |  |

--- a/docs/user/manifest.md
+++ b/docs/user/manifest.md
@@ -128,11 +128,10 @@ The following tables list the complete artifact inventory.
 | `helm-nvcf-rate-limiter` | `1.0.3` | Optional | Deploys request rate limiting for supported invocation paths. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-rate-limiter:1.0.3` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/ratelimiter) |
 | `helm-nvcf-sis` | `1.18.3` | Required | Deploys the Spot Instance Service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-sis:1.18.3` |  |
 | `helm-nvcf-state-metrics` | `1.0.1` | Optional | Deploys NVCF state metrics for observability. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-state-metrics:1.0.1` |  |
-| `helm-nvcf-ui` | `1.1.2` | Optional | Deploys the optional NVCF UI admin panel. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-ui:1.1.2` |  |
 | `helm-nvcf-vanity-gateway` | `0.1.0-nvcf-10204.1` | Optional | Deploys the optional vanity hostname gateway. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-vanity-gateway:0.1.0-nvcf-10204.1` |  |
 | `helm-reval` | `1.3.8` | Required | Deploys the function revalidation service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-reval:1.3.8` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/helm-reval) |
 | `nvcf-example-dashboards` | `1.6.0` | Optional | Deploys example Grafana dashboards for NVCF telemetry. | `https://helm.ngc.nvidia.com/nvidia/nvcf/nvcf-example-dashboards:1.6.0` |  |
-| `nvcf-gateway-routes` | `1.15.0` | Optional | Deploys Gateway API routes for the reference architecture. | `https://helm.ngc.nvidia.com/nvidia/nvcf/nvcf-gateway-routes:1.15.0` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/gateway-routes) |
+| `nvcf-gateway-routes` | `1.14.0` | Optional | Deploys Gateway API routes for the reference architecture. | `https://helm.ngc.nvidia.com/nvidia/nvcf/nvcf-gateway-routes:1.14.0` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/gateway-routes) |
 | `nvcf-observability-reference-stack` | `1.10.0` | Optional | Deploys a reference observability backend for evaluation. | `https://helm.ngc.nvidia.com/nvidia/nvcf/nvcf-observability-reference-stack:1.10.0` |  |
 
 ### Control plane services and images

--- a/docs/version-catalog/main.yaml
+++ b/docs/version-catalog/main.yaml
@@ -88,7 +88,7 @@ publications:
     version: v1.1.36
     registry: public-images
   - name: nvcf-openbao-migrations
-    version: 0.16.1
+    version: 0.16.2
     registry: public-images
   - name: nvcf-proxy-tls-certs
     version: v1.2.10
@@ -857,7 +857,7 @@ artifacts:
   - name: nvcf-openbao-migrations
     type: image
     registry: staging
-    version: 0.16.1
+    version: 0.16.2
   - name: nvcf-openbao
     type: image
     registry: staging

--- a/src/control-plane-services/function-autoscaler/crates/server/src/nvcf_api/nvcf_client.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/nvcf_api/nvcf_client.rs
@@ -66,6 +66,7 @@ fn parse_function_status(status: &str) -> Option<FunctionStatus> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NvcfApiSettings {
     /// Base URL for the OAuth2 client API used for authentication
+    #[serde(default)]
     pub oauth2_token_api_address: String,
     /// Space-delimited OAuth2 scopes requested for NVCF API gRPC calls
     #[serde(default = "default_oauth2_token_scope")]
@@ -755,6 +756,19 @@ mod tests {
         assert!(!settings
             .oauth2_token_scope
             .contains("autoscaler:fetch_config"));
+    }
+
+    #[test]
+    fn test_nvcf_api_settings_deserialization_defaults_token_api_address_when_missing() {
+        let settings: NvcfApiSettings = serde_json::from_value(json!({
+            "nvcf_api_grpc_address": "https://grpc.example.test",
+            "disable_auth": false,
+            "dry_run": false
+        }))
+        .unwrap();
+
+        assert_eq!(settings.oauth2_token_api_address, "");
+        assert_eq!(settings.oauth2_token_scope, default_oauth2_token_scope());
     }
 
     #[test]

--- a/src/control-plane-services/function-autoscaler/crates/server/src/nvcf_api/oauth2_client.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/nvcf_api/oauth2_client.rs
@@ -136,6 +136,10 @@ impl OAuth2Client {
     }
 
     pub async fn get_jwt_token(&self) -> Result<String, Box<dyn std::error::Error>> {
+        if let Some(token) = self.static_access_token() {
+            return Ok(token);
+        }
+
         // Check if we have a cached valid token
         {
             let cache = self.token_cache.read().await;
@@ -157,6 +161,14 @@ impl OAuth2Client {
         .await
     }
 
+    fn static_access_token(&self) -> Option<String> {
+        self.secrets_watcher
+            .get_config()
+            .nvcf_api
+            .and_then(|creds| creds.access_token)
+            .filter(|token| !token.is_empty())
+    }
+
     async fn refresh_token_internal(
         token_cache: &Arc<RwLock<Option<CachedToken>>>,
         oauth2_api_url: &str,
@@ -170,6 +182,10 @@ impl OAuth2Client {
         let nvcf_creds = secrets
             .nvcf_api
             .ok_or("No NVCF API credentials found in secrets")?;
+
+        if let Some(access_token) = nvcf_creds.access_token.filter(|token| !token.is_empty()) {
+            return Ok(access_token);
+        }
 
         let (new_token, expires_in) = Self::get_token_request_internal(
             oauth2_api_url,
@@ -323,6 +339,33 @@ mod tests {
         let creds = secrets.nvcf_api.unwrap();
         assert_eq!(creds.client_id, "test_client_id");
         assert_eq!(creds.client_secret, "test_client_secret");
+    }
+
+    #[tokio::test]
+    async fn test_get_jwt_token_uses_static_access_token() {
+        let temp_dir = TempDir::new().unwrap();
+        let secrets_file = temp_dir.path().join("secrets.json");
+        let secrets_content = serde_json::json!({
+            "kv": {
+                "nvcf_api": {
+                    "access_token": "vault_rendered_token"
+                }
+            }
+        });
+        fs::write(&secrets_file, secrets_content.to_string())
+            .await
+            .unwrap();
+        let secrets_watcher = SecretFileWatcher::new(&secrets_file).await.unwrap();
+
+        let oauth2_client = OAuth2Client::new(
+            "http://127.0.0.1:1".to_string(),
+            TEST_SCOPE.to_string(),
+            Arc::new(secrets_watcher),
+        )
+        .unwrap();
+
+        let token = oauth2_client.get_jwt_token().await.unwrap();
+        assert_eq!(token, "vault_rendered_token");
     }
 
     #[tokio::test]

--- a/src/control-plane-services/function-autoscaler/crates/server/src/secrets/secrets_config.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/secrets/secrets_config.rs
@@ -60,6 +60,10 @@ pub struct TracingCredentials {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct OAuth2ClientCredentials {
+    #[serde(default)]
     pub client_id: String,
+    #[serde(default)]
     pub client_secret: String,
+    #[serde(default)]
+    pub access_token: Option<String>,
 }


### PR DESCRIPTION
## TL;DR
Add the function autoscaler to the self-hosted stack by default.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
- Adds chart-owned self-managed runtime defaults for the function autoscaler env config.
- Adds the autoscaler metrics port to the chart service/container ports.
- Adds a default monitor selector for the autoscaler ServiceMonitor.
- Adds slim self-managed values wiring for image, vault, and env overrides.
- Adds the `function-autoscaler` release to `03-observability.yaml.gotmpl`, enabled by default through `functionAutoscaler.enabled`.

## For the Reviewer
Please look closely at:
- `deploy/helm/function-autoscaler/values.yaml`
- `deploy/stacks/self-managed/global.yaml.gotmpl`
- `deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl`

The main intent is to keep the stack-level surface small and leave runtime defaults in the chart.

## Issues
Relates to #15

Related context: NVIDIA/nvcf#480

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled Function Autoscaler for self-managed installs by default, aligned to image/chart app version **1.18.7**.
  * Exposed autoscaler **metrics** port **41338** and added Control Plane **ServiceMonitor** integration, honoring disabled-service settings.
* **Deployment Improvements**
  * Added deploy-time validations and improved ServiceMonitor rendering logic.
  * Expanded runtime configuration for Cassandra, timeseries, and NVCF API settings (including auth behavior).
* **Bug Fixes**
  * Improved JWT handling by using a static Vault-provided access token when available.
* **Documentation**
  * Updated the **nvcf-openbao-migrations** artifact to **0.16.2**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->