### PR TITLE
feat(model-preload): ROX shared-volume model preload prototype

### DIFF
--- a/tools/model-preload/AGENTS.md
+++ b/tools/model-preload/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md - tools/model-preload
+
+Prototype tool that preloads an NGC model into a shared ReadOnlyMany volume so
+worker pods mount one read-only copy instead of each downloading it. See
+`README.md` for the flow and design gaps.
+
+## Layout
+
+- `model-preload-rox.py` - the orchestrator (kubectl + NGC REST + python stdlib).
+
+## Run
+
+    export NGC_API_KEY=<nvapi-...>
+    python3 model-preload-rox.py --model <org>/[<team>/]<model>:<version> \
+      --namespace <ns> --name <short> --ngc-secret <secret> --image <img>
+
+## Conventions
+
+- Standard library only. Do not add third-party python deps for this prototype.
+- kubectl is the k8s client. Keep the tool CSI-agnostic via `--csi-driver`;
+  default `nvmesh-csi.excelero.com` (nvcf-sc).
+- Every source file needs the SPDX Apache-2.0 header (check-license CI).
+- This is public OSS. No internal hostnames, cluster names, or private IDs.

--- a/tools/model-preload/CLAUDE.md
+++ b/tools/model-preload/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/tools/model-preload/README.md
+++ b/tools/model-preload/README.md
@@ -1,0 +1,75 @@
+# model-preload (ROX shared-volume prototype)
+
+Prototype for cutting the model-download thundering herd on scale-up. Instead of
+each worker pod downloading the same model from NGC (N downloads, N copies), one
+Job downloads it once into a ReadWriteOnce (RWO) volume, then the same volume is
+re-exposed ReadOnlyMany (ROX) and mounted read-only by every worker.
+
+Result on scale-up: N downloads become 1 download, and N stored copies become 1.
+
+## Why this works
+
+`nvcf-sc` (NVMesh) uses `reclaimPolicy: Retain`, so the underlying CSI volume
+survives PVC deletion. That lets a second PV point at the already-populated
+volume handle in ReadOnlyMany mode. NVMesh supports read-only multi-node attach:
+in production, one ROX nvcf-sc volume is already mounted by many pods across
+several nodes at once.
+
+## Usage
+
+    export NGC_API_KEY=<nvapi-...>          # for the size lookup
+    kubectl create secret generic ngc-key \
+      --from-literal=NGC_API_KEY=$NGC_API_KEY -n <ns>
+
+    python3 model-preload-rox.py \
+      --model <org>/[<team>/]<model>:<version> \
+      --namespace <ns> \
+      --name <model-short-name> \
+      --ngc-secret ngc-key \
+      --image nvcr.io/nvidia/pytorch:24.10-py3
+
+The script prints the ROX PVC name. Worker pods mount it read-only:
+
+    volumes:
+    - name: models
+      persistentVolumeClaim:
+        claimName: <name>-ro
+        readOnly: true
+    # container volumeMounts: [{name: models, mountPath: /models, readOnly: true}]
+
+Flags: `--storage-class` (default `nvcf-sc`), `--multiplier` (default `1.1`),
+`--floor-gi`, `--pull-secret`, `--csi-driver`, `--mount`, `--cli-version`.
+
+## What the script does
+
+1. Reads the model total size from NGC (`totalSizeInBytes`) and sizes the PVC at
+   `size * multiplier`, floored.
+2. Creates a RWO PVC on the storage class and a downloader Job that fetches the
+   NGC CLI and runs `ngc registry model download-version` into it.
+3. Waits for the Job to complete.
+4. Reads the bound PV's CSI `volumeHandle`.
+5. Deletes the Job and RWO PVC (Retain keeps the volume), then creates a ROX PV
+   on the same handle and a ROX PVC bound to it.
+6. Prints the ROX PVC name for workers to mount.
+
+## Design considerations before productionizing
+
+This is a prototype, not a controller. Known gaps:
+
+- Read bandwidth. N readers share one volume's read path. Fine for load-once
+  weight reads; measure before assuming it scales to large N.
+- Immutability and new versions. The ROX PV is `Retain`. A new model version
+  needs a new preload run and a new ROX PVC; old volumes must be garbage
+  collected explicitly (Retain does not reclaim them).
+- Orchestration and timing. Workers must not start until the ROX PVC is Bound.
+  A real version would gate the worker rollout on preload completion (init
+  container, Job dependency, or an operator), not manual ordering.
+- Concurrency. No lock guards two preload runs for the same model racing on the
+  same name. Run one at a time per model, or add a lease.
+- Failure handling. A failed download leaves a RWO PVC behind; clean up before
+  retry. The script does not roll back partial state.
+
+## Cleanup
+
+    kubectl -n <ns> delete pvc <name>-ro
+    kubectl delete pv <name>-ro-pv        # then reclaim the NVMesh volume out of band

--- a/tools/model-preload/model-preload-rox.py
+++ b/tools/model-preload/model-preload-rox.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Preload an NGC model into a shared ReadOnlyMany (ROX) volume so N worker pods
+mount one copy read-only instead of each downloading it. Turns an N-way download
+herd into a single download and stores one copy instead of N.
+
+Pattern: a CSI backend with reclaimPolicy=Retain keeps the underlying volume
+alive across PVC churn, so a ROX PV can be pointed at the populated volume handle
+after a RWO downloader finishes. Proven with NVMesh (nvcf-sc): a ROX volume can
+be attached read-only by many pods across many nodes at once.
+
+Flow:
+  1. read the model's total size from NGC; PVC size = size * multiplier (>= floor)
+  2. create a RWO PVC on the storage class + a downloader Job (ngc download)
+  3. wait for the Job to complete
+  4. read the bound PV's csi volumeHandle
+  5. release the RWO claim (Retain keeps the volume), then create a ROX PV on the
+     same handle + a ROX PVC bound to it
+  6. print the ROX PVC name; worker pods mount it with readOnly: true
+
+Prototype scope: single storage class, single model, no concurrency guard. Not a
+controller. See README.md for the design considerations before productionizing.
+
+Requires: kubectl on PATH with cluster access; python3; an NGC API key in env
+NGC_API_KEY for the size lookup; a k8s secret holding the key (data key
+NGC_API_KEY) for the downloader Job.
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.request
+
+
+def kubectl(args, inp=None, check=True):
+    p = subprocess.run(["kubectl"] + args, input=inp, capture_output=True, text=True)
+    if check and p.returncode != 0:
+        sys.exit(f"kubectl {' '.join(args)} failed:\n{p.stderr}")
+    return p.stdout
+
+
+def ngc_total_size_bytes(model, api_key, api_base="https://api.ngc.nvidia.com"):
+    # model = org/[team/]name:version
+    name, ver = model.rsplit(":", 1)
+    parts = name.split("/")
+    org = parts[0]
+    if len(parts) == 3:
+        team, mdl = parts[1], parts[2]
+        path = f"v2/org/{org}/team/{team}/models/{mdl}/versions/{ver}"
+    else:
+        mdl = parts[1]
+        path = f"v2/org/{org}/models/{mdl}/versions/{ver}"
+    req = urllib.request.Request(
+        f"{api_base}/{path}",
+        headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=30) as r:
+        d = json.load(r)
+    # NGC nests the version under modelVersion on some API revisions, top-level on others.
+    v = d.get("modelVersion", d)
+    size = v.get("totalSizeInBytes") or v.get("total_size_in_bytes")
+    if not size:
+        sys.exit(f"could not read totalSizeInBytes from NGC response: {list(v)[:10]}")
+    return int(size)
+
+
+def apply(manifest):
+    kubectl(["apply", "-f", "-"], inp=manifest)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model", required=True, help="org/[team/]name:version")
+    ap.add_argument("--namespace", required=True)
+    ap.add_argument("--name", required=True, help="base name for the PVCs/Job/PV")
+    ap.add_argument("--storage-class", default="nvcf-sc")
+    ap.add_argument("--ngc-secret", required=True, help="k8s secret with data key NGC_API_KEY")
+    ap.add_argument("--image", required=True, help="downloader image with bash+python3+curl")
+    ap.add_argument("--mount", default="/models")
+    ap.add_argument("--multiplier", type=float, default=1.1)
+    ap.add_argument("--floor-gi", type=int, default=10, help="minimum PVC size, GiB")
+    ap.add_argument("--pull-secret", default="")
+    ap.add_argument("--csi-driver", default="nvmesh-csi.excelero.com")
+    ap.add_argument("--cli-version", default="4.20.1")
+    args = ap.parse_args()
+
+    ns, base, sc = args.namespace, args.name, args.storage_class
+    rwo_pvc = job = f"{base}-dl"
+    rox_pv, rox_pvc = f"{base}-ro-pv", f"{base}-ro"
+
+    # 1. size
+    api_key = os.environ.get("NGC_API_KEY", "")
+    if not api_key:
+        sys.exit("set NGC_API_KEY for the size lookup")
+    size_b = ngc_total_size_bytes(args.model, api_key)
+    gi = max(args.floor_gi, int((size_b * args.multiplier) // (1024**3)) + 1)
+    print(
+        f"[preload] {args.model}: {size_b / 1024**3:.1f} GiB -> PVC {gi} Gi "
+        f"({args.multiplier}x + floor {args.floor_gi})"
+    )
+
+    # 2. RWO PVC + downloader Job
+    ips = f"\n      imagePullSecrets: [{{name: {args.pull_secret}}}]" if args.pull_secret else ""
+    apply(
+        f"""
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata: {{name: {rwo_pvc}, namespace: {ns}}}
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: {sc}
+  resources: {{requests: {{storage: {gi}Gi}}}}
+"""
+    )
+    apply(
+        f"""
+apiVersion: batch/v1
+kind: Job
+metadata: {{name: {job}, namespace: {ns}}}
+spec:
+  backoffLimit: 2
+  template:
+    spec:
+      restartPolicy: Never{ips}
+      containers:
+      - name: dl
+        image: {args.image}
+        command: ["/bin/bash","-c"]
+        args:
+        - |
+          set -e
+          ARCH=$(uname -m); Z=ngccli_linux.zip
+          [ "$ARCH" = aarch64 -o "$ARCH" = arm64 ] && Z=ngccli_arm64.zip
+          curl -skL -o /tmp/n.zip "https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/{args.cli_version}/files/$Z"
+          python3 -c "import zipfile;zipfile.ZipFile('/tmp/n.zip').extractall('/tmp')"; chmod 755 /tmp/ngc-cli/ngc
+          mkdir -p ~/.ngc; printf '[CURRENT]\\napikey = %s\\nformat_type = json\\n' "$NGC_API_KEY" > ~/.ngc/config
+          /tmp/ngc-cli/ngc registry model download-version --dest {args.mount} "{args.model}"
+          echo "[preload] download complete"; ls -la {args.mount}
+        env:
+        - name: NGC_API_KEY
+          valueFrom: {{secretKeyRef: {{name: {args.ngc_secret}, key: NGC_API_KEY}}}}
+        volumeMounts: [{{name: models, mountPath: {args.mount}}}]
+      volumes:
+      - name: models
+        persistentVolumeClaim: {{claimName: {rwo_pvc}}}
+"""
+    )
+
+    # 3. wait for the Job
+    print(f"[preload] waiting for download Job {job} ...")
+    kubectl(["-n", ns, "wait", f"job/{job}", "--for=condition=complete", "--timeout=6h"])
+    print("[preload] download Job complete")
+
+    # 4. read the CSI volume handle from the bound PV
+    pv = kubectl(["-n", ns, "get", "pvc", rwo_pvc, "-o", "jsonpath={.spec.volumeName}"]).strip()
+    handle = kubectl(["get", "pv", pv, "-o", "jsonpath={.spec.csi.volumeHandle}"]).strip()
+    fstype = kubectl(["get", "pv", pv, "-o", "jsonpath={.spec.csi.fsType}"]).strip() or "xfs"
+    print(f"[preload] populated volume handle: {handle}")
+
+    # 5. release the RWO claim (Retain keeps the underlying volume), then bind ROX.
+    #    Deleting the Job frees the single-node RWO attach before the ROX attach.
+    kubectl(["-n", ns, "delete", "job", job, "--wait=true", "--timeout=120s"], check=False)
+    kubectl(["-n", ns, "delete", "pvc", rwo_pvc, "--wait=true", "--timeout=120s"], check=False)
+
+    # 6. ROX PV on the same handle + ROX PVC bound to it (static binding, no dataSource)
+    apply(
+        f"""
+apiVersion: v1
+kind: PersistentVolume
+metadata: {{name: {rox_pv}}}
+spec:
+  capacity: {{storage: {gi}Gi}}
+  accessModes: [ReadOnlyMany]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: {sc}
+  csi:
+    driver: {args.csi_driver}
+    volumeHandle: "{handle}"
+    fsType: {fstype}
+    readOnly: true
+"""
+    )
+    apply(
+        f"""
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata: {{name: {rox_pvc}, namespace: {ns}}}
+spec:
+  accessModes: [ReadOnlyMany]
+  storageClassName: {sc}
+  volumeName: {rox_pv}
+  resources: {{requests: {{storage: {gi}Gi}}}}
+"""
+    )
+    kubectl(
+        ["-n", ns, "wait", f"pvc/{rox_pvc}",
+         "--for=jsonpath={.status.phase}=Bound", "--timeout=120s"],
+        check=False,
+    )
+    print(f"[preload] DONE. Workers mount ROX PVC '{rox_pvc}' with readOnly: true at {args.mount}.")
+    print(f"[preload] volume handle {handle} retained; delete PV {rox_pv} to reclaim.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why
On worker scale-up, each replica downloads the same model from NGC on its own: N downloads of identical bytes and N stored copies. That is slow and wastes storage and download bandwidth, and it is the load pattern behind the cache thundering herd on large fan-outs.

## What changed
Adds a prototype orchestrator under `tools/model-preload/`:
- `model-preload-rox.py` reads the model total size from NGC, creates a ReadWriteOnce PVC sized `size * 1.1`, runs a downloader Job, then re-exposes the same CSI volume as a ReadOnlyMany PV/PVC that all workers mount read-only.
- Relies on `reclaimPolicy: Retain` (nvcf-sc / NVMesh) so a ROX PV can point at the populated volume handle after the RWO downloader finishes. CSI-agnostic via `--csi-driver`.
- Standard-library python + kubectl, no new dependencies.
- `README.md` documents the flow and the design gaps; `AGENTS.md`/`CLAUDE.md` per repo convention.

On scale-up this turns N downloads into 1 and N stored copies into 1.

## Customer Release Notes
Not customer visible (prototype tool, not wired into any chart or release).

## Plan Summary
Not applicable (no infra/chart resources changed; the script creates PVCs/PV/Job at runtime when run manually).

## Usage
    export NGC_API_KEY=<nvapi-...>
    kubectl create secret generic ngc-key --from-literal=NGC_API_KEY=$NGC_API_KEY -n <ns>
    python3 tools/model-preload/model-preload-rox.py \
      --model <org>/[<team>/]<model>:<version> --namespace <ns> \
      --name <short> --ngc-secret ngc-key --image <downloader-image>
Workers then mount the printed `<name>-ro` PVC with `readOnly: true`.

## Testing
Not yet run end-to-end. Draft for prototyping and cluster testing. `python3 -m py_compile` passes and the CLI parses. Next: run against a test namespace on a GB200 cluster and measure single-download vs per-worker-download, plus ROX read bandwidth at scale.

## Notes
Prototype scope only: single model, manual worker-start ordering, no concurrency lock, no rollback of partial state. README lists the productionization gaps (worker start-gate, Retain volume version/GC, read-bandwidth at large N).

## References
Closes #517

## Related Pull Requests
None

## Dependencies
None