### PR TITLE
feat(container-cache): opt-in consistent-hash routing across cache pods

### DIFF
--- a/deploy/helm/container-cache/deploy/files/hf.conf
+++ b/deploy/helm/container-cache/deploy/files/hf.conf
@@ -214,12 +214,6 @@
           return headers["Host"]
         }
 
-{{- if ($.Values.consistentHashRouting).enabled }}
-        # Consistent-hash routing: each blob has one owner pod, so a blob is
-        # cached once across the fleet instead of once per pod. Same routing as
-        # the NGC path; *.hf.co serves the large HF CDN blobs.
-        set $cc_owner "";
-{{- end }}
         location  / {
           proxy_pass_request_headers on;
           # Use Range header for file content - enables partial downloads
@@ -232,32 +226,12 @@
           # Initialize upstream_last_modified to prevent warnings
           set $upstream_last_modified "";
 {{- if ($.Values.consistentHashRouting).enabled }}
-          rewrite_by_lua_block {
-            -- A request that was already relayed is always served locally:
-            -- relaying is at most one hop, even if peers disagree about N
-            -- during a rolling config change.
-            if ngx.req.get_headers()["X-NVCF-CC-Relayed"] then
-              return
-            end
-            -- Routing key: the full proxy_cache_key
-            -- ($request_method|$uri|$arg_versionId|$http_range). Routing on the
-            -- exact key nginx caches on sends each byte-range chunk to its own
-            -- owner, so a large multi-chunk blob spreads across the tier instead
-            -- of pinning to a single pod. arg_versionId/http_range may be unset
-            -- (nil) and render as empty, matching nginx's own key.
-            local n = {{ int $.Values.replicaCount }}
-            local key = ngx.var.request_method .. "|" .. ngx.var.uri .. "|" ..
-                        (ngx.var.arg_versionId or "") .. "|" .. (ngx.var.http_range or "")
-            local owner = tonumber(string.sub(ngx.md5(key), 1, 8), 16) % n
-            -- Self ordinal from the pod hostname (statefulset pod name).
-            local self = tonumber(string.match(ngx.var.hostname, "(%d+)$"))
-            if self ~= nil and owner ~= self then
-              ngx.var.cc_owner = "cc_owner_" .. owner
-              return ngx.exec("@cc_relay")
-            end
-            -- Unparseable hostname falls through to local serving, which is
-            -- safe: it degrades to today's behavior for this pod only.
-          }
+          # Consistent-hash routing to the owner pod (see lua/cc-route.lua).
+          # Route on the same key nginx caches on so each byte-range chunk maps
+          # to its own owner and a large blob spreads across the tier.
+          set $cc_hash_key "$request_method|$uri|$arg_versionId|$http_range";
+          set $cc_replicas {{ int $.Values.replicaCount }};
+          rewrite_by_lua_file /etc/nginx/conf.d/lua/cc-route.lua;
 {{- end }}
           
           # Temporarily disable Lua access control to isolate 503 issue
@@ -266,34 +240,4 @@
           proxy_set_header Host $host;
           proxy_pass $scheme://$host;
         }
-
-{{- if ($.Values.consistentHashRouting).enabled }}
-        location @cc_relay {
-          # Relay to the owner pod. This hop is a pure stream: it never
-          # writes to the local cache or local temp files; only the owner
-          # stores the object. Auth (lua-access) runs on the owner, which
-          # sees the original request headers.
-          proxy_cache off;
-          proxy_http_version 1.1;
-          proxy_pass_request_headers on;
-          proxy_set_header Host $host;
-          proxy_set_header Range $http_range;
-          proxy_set_header X-NVCF-CC-Relayed "1";
-          # Peer serves the same ssl listener; its cert is issued by the
-          # per-pod internal leaf CA, so system-CA verification cannot pass.
-          # Skip verification on the peer hop only. Follow-up: trust the
-          # internal bundle (/etc/certs/ssl-bundle.crt) instead.
-          proxy_ssl_verify off;
-          proxy_ssl_server_name on;
-          proxy_ssl_name $host;
-          # Do not spool large relayed bodies to local disk.
-          proxy_max_temp_file_size 0;
-          # Fail over to the backup ordinal only before the response starts;
-          # never retry mid-body on large transfers.
-          proxy_connect_timeout 2s;
-          proxy_read_timeout 30s;
-          proxy_next_upstream error timeout;
-          proxy_pass https://$cc_owner;
-        }
-{{- end }}
     }

--- a/deploy/helm/container-cache/deploy/files/hf.conf
+++ b/deploy/helm/container-cache/deploy/files/hf.conf
@@ -214,6 +214,12 @@
           return headers["Host"]
         }
 
+{{- if ($.Values.consistentHashRouting).enabled }}
+        # Consistent-hash routing: each blob has one owner pod, so a blob is
+        # cached once across the fleet instead of once per pod. Same routing as
+        # the NGC path; *.hf.co serves the large HF CDN blobs.
+        set $cc_owner "";
+{{- end }}
         location  / {
           proxy_pass_request_headers on;
           # Use Range header for file content - enables partial downloads
@@ -225,6 +231,34 @@
           
           # Initialize upstream_last_modified to prevent warnings
           set $upstream_last_modified "";
+{{- if ($.Values.consistentHashRouting).enabled }}
+          rewrite_by_lua_block {
+            -- A request that was already relayed is always served locally:
+            -- relaying is at most one hop, even if peers disagree about N
+            -- during a rolling config change.
+            if ngx.req.get_headers()["X-NVCF-CC-Relayed"] then
+              return
+            end
+            -- Routing key: the full proxy_cache_key
+            -- ($request_method|$uri|$arg_versionId|$http_range). Routing on the
+            -- exact key nginx caches on sends each byte-range chunk to its own
+            -- owner, so a large multi-chunk blob spreads across the tier instead
+            -- of pinning to a single pod. arg_versionId/http_range may be unset
+            -- (nil) and render as empty, matching nginx's own key.
+            local n = {{ int $.Values.replicaCount }}
+            local key = ngx.var.request_method .. "|" .. ngx.var.uri .. "|" ..
+                        (ngx.var.arg_versionId or "") .. "|" .. (ngx.var.http_range or "")
+            local owner = tonumber(string.sub(ngx.md5(key), 1, 8), 16) % n
+            -- Self ordinal from the pod hostname (statefulset pod name).
+            local self = tonumber(string.match(ngx.var.hostname, "(%d+)$"))
+            if self ~= nil and owner ~= self then
+              ngx.var.cc_owner = "cc_owner_" .. owner
+              return ngx.exec("@cc_relay")
+            end
+            -- Unparseable hostname falls through to local serving, which is
+            -- safe: it degrades to today's behavior for this pod only.
+          }
+{{- end }}
           
           # Temporarily disable Lua access control to isolate 503 issue
           # access_by_lua_file /etc/nginx/conf.d/lua/lua-access.lua;
@@ -232,4 +266,34 @@
           proxy_set_header Host $host;
           proxy_pass $scheme://$host;
         }
+
+{{- if ($.Values.consistentHashRouting).enabled }}
+        location @cc_relay {
+          # Relay to the owner pod. This hop is a pure stream: it never
+          # writes to the local cache or local temp files; only the owner
+          # stores the object. Auth (lua-access) runs on the owner, which
+          # sees the original request headers.
+          proxy_cache off;
+          proxy_http_version 1.1;
+          proxy_pass_request_headers on;
+          proxy_set_header Host $host;
+          proxy_set_header Range $http_range;
+          proxy_set_header X-NVCF-CC-Relayed "1";
+          # Peer serves the same ssl listener; its cert is issued by the
+          # per-pod internal leaf CA, so system-CA verification cannot pass.
+          # Skip verification on the peer hop only. Follow-up: trust the
+          # internal bundle (/etc/certs/ssl-bundle.crt) instead.
+          proxy_ssl_verify off;
+          proxy_ssl_server_name on;
+          proxy_ssl_name $host;
+          # Do not spool large relayed bodies to local disk.
+          proxy_max_temp_file_size 0;
+          # Fail over to the backup ordinal only before the response starts;
+          # never retry mid-body on large transfers.
+          proxy_connect_timeout 2s;
+          proxy_read_timeout 30s;
+          proxy_next_upstream error timeout;
+          proxy_pass https://$cc_owner;
+        }
+{{- end }}
     }

--- a/deploy/helm/container-cache/deploy/files/lua/cc-route.lua
+++ b/deploy/helm/container-cache/deploy/files/lua/cc-route.lua
@@ -1,0 +1,49 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Consistent-hash owner routing for the container-cache proxy tier, shared by
+-- every server block that opts in. Route each request to a single owner pod so
+-- a blob is cached once across the fleet instead of once per pod.
+--
+-- The including location sets, before rewrite_by_lua_file:
+--   $cc_hash_key  this block's proxy_cache_key (the exact cache identity)
+--   $cc_replicas  replicaCount (N)
+-- and $cc_owner is declared at server scope (proxy-common.conf), where the
+-- shared @cc_relay location also lives.
+
+-- A request already relayed is served locally: relaying is at most one hop.
+-- The marker is not authenticated; this is an internal, access-restricted
+-- service (see proxy-common.conf @cc_relay).
+if ngx.req.get_headers()["X-NVCF-CC-Relayed"] then
+  return
+end
+
+local n = tonumber(ngx.var.cc_replicas)
+if not n or n < 2 then
+  return  -- single pod (or unset): nothing to distribute
+end
+
+-- Owner = md5(cache_key) mod N. Same key nginx caches on, so each byte-range
+-- chunk maps to its own owner and a large blob spreads across the tier.
+local owner = tonumber(string.sub(ngx.md5(ngx.var.cc_hash_key), 1, 8), 16) % n
+
+-- Self ordinal from the pod hostname (statefulset pod name).
+local self = tonumber(string.match(ngx.var.hostname, "(%d+)$"))
+if self ~= nil and owner ~= self then
+  ngx.var.cc_owner = "cc_owner_" .. owner
+  return ngx.exec("@cc_relay")
+end
+-- Unparseable hostname falls through to local serving, which is safe: it
+-- degrades to non-routed behavior for this pod only.

--- a/deploy/helm/container-cache/deploy/files/ngc.conf
+++ b/deploy/helm/container-cache/deploy/files/ngc.conf
@@ -46,12 +46,6 @@
           return headers["Host"]
         }
 
-{{- if ($.Values.consistentHashRouting).enabled }}
-        # Consistent-hash routing: each blob has one owner pod,
-        # so a blob is cached once across the fleet instead of once per pod.
-        set $cc_owner "";
-{{- end }}
-
         location  / {
           # Initialize upstream_last_modified to prevent warnings
           set $upstream_last_modified "";
@@ -60,32 +54,12 @@
           proxy_read_timeout 30s;
 
 {{- if ($.Values.consistentHashRouting).enabled }}
-          rewrite_by_lua_block {
-            -- A request that was already relayed is always served locally:
-            -- relaying is at most one hop, even if peers disagree about N
-            -- during a rolling config change.
-            if ngx.req.get_headers()["X-NVCF-CC-Relayed"] then
-              return
-            end
-            -- Routing key: the full proxy_cache_key
-            -- ($request_method|$uri|$arg_versionId|$http_range). Routing on the
-            -- exact key nginx caches on sends each byte-range chunk to its own
-            -- owner, so a large multi-chunk blob spreads across the tier instead
-            -- of pinning to a single pod. arg_versionId/http_range may be unset
-            -- (nil) and render as empty, matching nginx's own key.
-            local n = {{ int $.Values.replicaCount }}
-            local key = ngx.var.request_method .. "|" .. ngx.var.uri .. "|" ..
-                        (ngx.var.arg_versionId or "") .. "|" .. (ngx.var.http_range or "")
-            local owner = tonumber(string.sub(ngx.md5(key), 1, 8), 16) % n
-            -- Self ordinal from the pod hostname (statefulset pod name).
-            local self = tonumber(string.match(ngx.var.hostname, "(%d+)$"))
-            if self ~= nil and owner ~= self then
-              ngx.var.cc_owner = "cc_owner_" .. owner
-              return ngx.exec("@cc_relay")
-            end
-            -- Unparseable hostname falls through to local serving, which is
-            -- safe: it degrades to today's behavior for this pod only.
-          }
+          # Consistent-hash routing to the owner pod (see lua/cc-route.lua).
+          # Route on the same key nginx caches on so each byte-range chunk maps
+          # to its own owner and a large blob spreads across the tier.
+          set $cc_hash_key "$request_method|$uri|$arg_versionId|$http_range";
+          set $cc_replicas {{ int $.Values.replicaCount }};
+          rewrite_by_lua_file /etc/nginx/conf.d/lua/cc-route.lua;
 {{- end }}
 
           proxy_pass_request_headers on;
@@ -95,34 +69,4 @@
           proxy_set_header Host $host;
           proxy_pass $scheme://$host;
         }
-
-{{- if ($.Values.consistentHashRouting).enabled }}
-        location @cc_relay {
-          # Relay to the owner pod. This hop is a pure stream: it never
-          # writes to the local cache or local temp files; only the owner
-          # stores the object. Auth (lua-access) runs on the owner, which
-          # sees the original request headers.
-          proxy_cache off;
-          proxy_http_version 1.1;
-          proxy_pass_request_headers on;
-          proxy_set_header Host $host;
-          proxy_set_header Range $http_range;
-          proxy_set_header X-NVCF-CC-Relayed "1";
-          # Peer serves the same ssl listener; its cert is issued by the
-          # per-pod internal leaf CA, so system-CA verification cannot pass.
-          # Skip verification on the peer hop only. Follow-up:
-          # trust the internal bundle (/etc/certs/ssl-bundle.crt) instead.
-          proxy_ssl_verify off;
-          proxy_ssl_server_name on;
-          proxy_ssl_name $host;
-          # Do not spool large relayed bodies to local disk.
-          proxy_max_temp_file_size 0;
-          # Fail over to the backup ordinal only before the response starts;
-          # never retry mid-body on large transfers.
-          proxy_connect_timeout 2s;
-          proxy_read_timeout 30s;
-          proxy_next_upstream error timeout;
-          proxy_pass https://$cc_owner;
-        }
-{{- end }}
     }

--- a/deploy/helm/container-cache/deploy/files/ngc.conf
+++ b/deploy/helm/container-cache/deploy/files/ngc.conf
@@ -67,12 +67,16 @@
             if ngx.req.get_headers()["X-NVCF-CC-Relayed"] then
               return
             end
-            -- Routing key: the path only. This is the stable subset of the
-            -- cache key ($request_method|$uri|$arg_versionId|$http_range):
-            -- all requests for the same blob map to the same owner, and
-            -- volatile signed-URL query arguments never enter the key.
+            -- Routing key: the full proxy_cache_key
+            -- ($request_method|$uri|$arg_versionId|$http_range). Routing on the
+            -- exact key nginx caches on sends each byte-range chunk to its own
+            -- owner, so a large multi-chunk blob spreads across the tier instead
+            -- of pinning to a single pod. arg_versionId/http_range may be unset
+            -- (nil) and render as empty, matching nginx's own key.
             local n = {{ int $.Values.replicaCount }}
-            local owner = tonumber(string.sub(ngx.md5(ngx.var.uri), 1, 8), 16) % n
+            local key = ngx.var.request_method .. "|" .. ngx.var.uri .. "|" ..
+                        (ngx.var.arg_versionId or "") .. "|" .. (ngx.var.http_range or "")
+            local owner = tonumber(string.sub(ngx.md5(key), 1, 8), 16) % n
             -- Self ordinal from the pod hostname (statefulset pod name).
             local self = tonumber(string.match(ngx.var.hostname, "(%d+)$"))
             if self ~= nil and owner ~= self then

--- a/deploy/helm/container-cache/deploy/files/ngc.conf
+++ b/deploy/helm/container-cache/deploy/files/ngc.conf
@@ -46,12 +46,43 @@
           return headers["Host"]
         }
 
+{{- if ($.Values.consistentHashRouting).enabled }}
+        # Consistent-hash routing (prototype): each blob has one owner pod,
+        # so a blob is cached once across the fleet instead of once per pod.
+        set $cc_owner "";
+{{- end }}
+
         location  / {
           # Initialize upstream_last_modified to prevent warnings
           set $upstream_last_modified "";
 
           # Override common 15s - 16MB chunks from NGC CDN can spike
           proxy_read_timeout 30s;
+
+{{- if ($.Values.consistentHashRouting).enabled }}
+          rewrite_by_lua_block {
+            -- A request that was already relayed is always served locally:
+            -- relaying is at most one hop, even if peers disagree about N
+            -- during a rolling config change.
+            if ngx.req.get_headers()["X-NVCF-CC-Relayed"] then
+              return
+            end
+            -- Routing key: the path only. This is the stable subset of the
+            -- cache key ($request_method|$uri|$arg_versionId|$http_range):
+            -- all requests for the same blob map to the same owner, and
+            -- volatile signed-URL query arguments never enter the key.
+            local n = {{ int $.Values.replicaCount }}
+            local owner = tonumber(string.sub(ngx.md5(ngx.var.uri), 1, 8), 16) % n
+            -- Self ordinal from the pod hostname (statefulset pod name).
+            local self = tonumber(string.match(ngx.var.hostname, "(%d+)$"))
+            if self ~= nil and owner ~= self then
+              ngx.var.cc_owner = "cc_owner_" .. owner
+              return ngx.exec("@cc_relay")
+            end
+            -- Unparseable hostname falls through to local serving, which is
+            -- safe: it degrades to today's behavior for this pod only.
+          }
+{{- end }}
 
           proxy_pass_request_headers on;
           proxy_set_header Range $http_range;
@@ -60,4 +91,34 @@
           proxy_set_header Host $host;
           proxy_pass $scheme://$host;
         }
+
+{{- if ($.Values.consistentHashRouting).enabled }}
+        location @cc_relay {
+          # Relay to the owner pod. This hop is a pure stream: it never
+          # writes to the local cache or local temp files; only the owner
+          # stores the object. Auth (lua-access) runs on the owner, which
+          # sees the original request headers.
+          proxy_cache off;
+          proxy_http_version 1.1;
+          proxy_pass_request_headers on;
+          proxy_set_header Host $host;
+          proxy_set_header Range $http_range;
+          proxy_set_header X-NVCF-CC-Relayed "1";
+          # Peer serves the same ssl listener; its cert is issued by the
+          # per-pod internal leaf CA, so system-CA verification cannot pass.
+          # Prototype: skip verification on the peer hop only. Follow-up:
+          # trust the internal bundle (/etc/certs/ssl-bundle.crt) instead.
+          proxy_ssl_verify off;
+          proxy_ssl_server_name on;
+          proxy_ssl_name $host;
+          # Do not spool large relayed bodies to local disk.
+          proxy_max_temp_file_size 0;
+          # Fail over to the backup ordinal only before the response starts;
+          # never retry mid-body on large transfers.
+          proxy_connect_timeout 2s;
+          proxy_read_timeout 30s;
+          proxy_next_upstream error timeout;
+          proxy_pass https://$cc_owner;
+        }
+{{- end }}
     }

--- a/deploy/helm/container-cache/deploy/files/ngc.conf
+++ b/deploy/helm/container-cache/deploy/files/ngc.conf
@@ -47,7 +47,7 @@
         }
 
 {{- if ($.Values.consistentHashRouting).enabled }}
-        # Consistent-hash routing (prototype): each blob has one owner pod,
+        # Consistent-hash routing: each blob has one owner pod,
         # so a blob is cached once across the fleet instead of once per pod.
         set $cc_owner "";
 {{- end }}
@@ -110,7 +110,7 @@
           proxy_set_header X-NVCF-CC-Relayed "1";
           # Peer serves the same ssl listener; its cert is issued by the
           # per-pod internal leaf CA, so system-CA verification cannot pass.
-          # Prototype: skip verification on the peer hop only. Follow-up:
+          # Skip verification on the peer hop only. Follow-up:
           # trust the internal bundle (/etc/certs/ssl-bundle.crt) instead.
           proxy_ssl_verify off;
           proxy_ssl_server_name on;

--- a/deploy/helm/container-cache/deploy/files/nginx.conf
+++ b/deploy/helm/container-cache/deploy/files/nginx.conf
@@ -114,6 +114,24 @@
         proxy_cache_path /proxy_cache/s3 levels=1:2 min_free={{ printf "%dg" $proxyMinFreeGB }} inactive={{ $.Values.cache.inactive | default "30d" }} keys_zone=proxy_s3:{{ $.Values.cache.keyStorageSize | default "10m" }} use_temp_path=off;
         proxy_cache_path /proxy_cache/ngc levels=1:2 min_free={{ printf "%dg" $proxyMinFreeGB }} inactive={{ $.Values.cache.inactive | default "30d" }} keys_zone=proxy_ngc:{{ $.Values.cache.keyStorageSize | default "10m" }} use_temp_path=off;
 
+{{- if (.Values.consistentHashRouting).enabled }}
+        # Consistent-hash peer routing: one upstream per pod ordinal.
+        # The primary server is the owner pod; the backup is the next
+        # ordinal and is used only when the owner fails its health checks
+        # (availability fallback, never load spill). Peer services select a
+        # single StatefulSet pod by its stable pod-name label.
+        {{- $n := int .Values.replicaCount }}
+        {{- $port := (.Values.consistentHashRouting).peerPort | default 14128 }}
+        {{- range $i := until $n }}
+        upstream cc_owner_{{ $i }} {
+            server {{ $.Release.Name }}-peer-{{ $i }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ $port }} max_fails=3 fail_timeout=15s;
+            {{- if gt $n 1 }}
+            server {{ $.Release.Name }}-peer-{{ mod (add $i 1) $n }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ $port }} backup;
+            {{- end }}
+        }
+        {{- end }}
+{{- end }}
+
         include /etc/nginx/conf.d/sites/default.conf;
         include /etc/nginx/conf.d/sites/container-cache.conf;
         include /etc/nginx/conf.d/sites/proxy-cache.conf;

--- a/deploy/helm/container-cache/deploy/files/nginx.conf
+++ b/deploy/helm/container-cache/deploy/files/nginx.conf
@@ -121,7 +121,8 @@
         # (availability fallback, never load spill). Peer services select a
         # single StatefulSet pod by its stable pod-name label.
         {{- $n := int .Values.replicaCount }}
-        {{- $port := (.Values.consistentHashRouting).peerPort | default 14128 }}
+        {{- /* Peers reach each other on the ssl listener port, fixed to match the `listen` directives. */}}
+        {{- $port := 14128 }}
         {{- range $i := until $n }}
         upstream cc_owner_{{ $i }} {
             server {{ $.Release.Name }}-peer-{{ $i }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ $port }} max_fails=3 fail_timeout=15s;

--- a/deploy/helm/container-cache/deploy/files/proxy-common.conf
+++ b/deploy/helm/container-cache/deploy/files/proxy-common.conf
@@ -146,3 +146,37 @@
 
         # Lua SSL config
         lua_ssl_verify_depth 2;
+
+{{- if ($.Values.consistentHashRouting).enabled }}
+        # Consistent-hash routing: shared owner variable + one-hop relay hop,
+        # used by the ngc and *.hf.co server blocks (see lua/cc-route.lua).
+        # Defined here because proxy-common.conf is included at server scope by
+        # every block, so the relay location is not duplicated per block.
+        set $cc_owner "";
+        location @cc_relay {
+          # Relay to the owner pod: a pure stream that never writes the local
+          # cache or temp files; only the owner stores the object. lua-access
+          # runs on the owner, which sees the original request headers.
+          proxy_cache off;
+          proxy_http_version 1.1;
+          proxy_pass_request_headers on;
+          proxy_set_header Host $host;
+          proxy_set_header Range $http_range;
+          proxy_set_header X-NVCF-CC-Relayed "1";
+          # The peer serves the same ssl listener with a per-pod internal leaf
+          # cert, so system-CA verification cannot pass. Verification is skipped
+          # on this internal peer hop only; the tier is an internal,
+          # access-restricted service.
+          proxy_ssl_verify off;
+          proxy_ssl_server_name on;
+          proxy_ssl_name $host;
+          # Do not spool large relayed bodies to local disk.
+          proxy_max_temp_file_size 0;
+          # Fail over to the backup ordinal only before the response starts;
+          # never retry mid-body on large transfers.
+          proxy_connect_timeout 2s;
+          proxy_read_timeout 30s;
+          proxy_next_upstream error timeout;
+          proxy_pass https://$cc_owner;
+        }
+{{- end }}

--- a/deploy/helm/container-cache/deploy/templates/configmap.yaml
+++ b/deploy/helm/container-cache/deploy/templates/configmap.yaml
@@ -31,5 +31,7 @@ data:
 {{ .Files.Get "files/lua/lua-gen-key.lua" | nindent 4 }}
   lua-ssl.lua: |-
 {{ .Files.Get "files/lua/lua-ssl.lua" | nindent 4 }}
+{{- if (.Values.consistentHashRouting).enabled }}
   cc-route.lua: |-
 {{ .Files.Get "files/lua/cc-route.lua" | nindent 4 }}
+{{- end }}

--- a/deploy/helm/container-cache/deploy/templates/configmap.yaml
+++ b/deploy/helm/container-cache/deploy/templates/configmap.yaml
@@ -31,3 +31,5 @@ data:
 {{ .Files.Get "files/lua/lua-gen-key.lua" | nindent 4 }}
   lua-ssl.lua: |-
 {{ .Files.Get "files/lua/lua-ssl.lua" | nindent 4 }}
+  cc-route.lua: |-
+{{ .Files.Get "files/lua/cc-route.lua" | nindent 4 }}

--- a/deploy/helm/container-cache/deploy/templates/service-peer.yaml
+++ b/deploy/helm/container-cache/deploy/templates/service-peer.yaml
@@ -1,0 +1,50 @@
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Per-ordinal peer services for consistent-hash routing (prototype).
+Each service selects exactly one StatefulSet pod through the stable
+statefulset.kubernetes.io/pod-name label, giving every ordinal a stable
+DNS name without adding a headless service. The StatefulSet has no
+serviceName today and that field is immutable, so per-ordinal services
+avoid a StatefulSet recreate.
+
+A pod that is not Ready drops out of its peer service endpoints, so the
+owner's nginx upstream fails fast and falls back to the backup ordinal.
+*/}}
+{{- if (.Values.consistentHashRouting).enabled }}
+{{- $n := int .Values.replicaCount }}
+{{- $port := (.Values.consistentHashRouting).peerPort | default 14128 }}
+{{- range $i := until $n }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $.Release.Name }}-peer-{{ $i }}
+  namespace: {{ $.Release.Namespace | quote }}
+  labels:
+    app: {{ $.Release.Name }}
+    {{- include "nvcf-container-cache.labels" $ | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    statefulset.kubernetes.io/pod-name: {{ $.Release.Name }}-{{ $i }}
+  ports:
+    - name: https-proxy
+      port: {{ $port }}
+      targetPort: {{ $port }}
+      protocol: TCP
+{{- end }}
+{{- end }}

--- a/deploy/helm/container-cache/deploy/templates/service-peer.yaml
+++ b/deploy/helm/container-cache/deploy/templates/service-peer.yaml
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-Per-ordinal peer services for consistent-hash routing (prototype).
+Per-ordinal peer services for consistent-hash routing.
 Each service selects exactly one StatefulSet pod through the stable
 statefulset.kubernetes.io/pod-name label, giving every ordinal a stable
 DNS name without adding a headless service. The StatefulSet has no

--- a/deploy/helm/container-cache/deploy/templates/service-peer.yaml
+++ b/deploy/helm/container-cache/deploy/templates/service-peer.yaml
@@ -26,7 +26,8 @@ owner's nginx upstream fails fast and falls back to the backup ordinal.
 */}}
 {{- if (.Values.consistentHashRouting).enabled }}
 {{- $n := int .Values.replicaCount }}
-{{- $port := (.Values.consistentHashRouting).peerPort | default 14128 }}
+{{- /* ssl listener port; fixed to match the `listen` directives in the server blocks. */}}
+{{- $port := 14128 }}
 {{- range $i := until $n }}
 ---
 apiVersion: v1

--- a/deploy/helm/container-cache/deploy/templates/statefulset.yaml
+++ b/deploy/helm/container-cache/deploy/templates/statefulset.yaml
@@ -260,6 +260,8 @@ spec:
               path: lua-gen-key.lua
             - key: lua-ssl.lua
               path: lua-ssl.lua
+            - key: cc-route.lua
+              path: cc-route.lua
         - name: nginx-default-config
           configMap:
             name: nvcf-default-config

--- a/deploy/helm/container-cache/deploy/templates/statefulset.yaml
+++ b/deploy/helm/container-cache/deploy/templates/statefulset.yaml
@@ -260,8 +260,10 @@ spec:
               path: lua-gen-key.lua
             - key: lua-ssl.lua
               path: lua-ssl.lua
+            {{- if (.Values.consistentHashRouting).enabled }}
             - key: cc-route.lua
               path: cc-route.lua
+            {{- end }}
         - name: nginx-default-config
           configMap:
             name: nvcf-default-config

--- a/deploy/helm/container-cache/deploy/values.yaml
+++ b/deploy/helm/container-cache/deploy/values.yaml
@@ -135,8 +135,8 @@ proxyService:
   # Leave empty ("") to let Kubernetes assign one automatically.
   clusterIP: ""
 
-# Consistent-hash routing of proxy-cache requests across cache pods
-#. When enabled, each pod computes the owner pod for a request
+# Consistent-hash routing of proxy-cache requests across cache pods.
+# When enabled, each pod computes the owner pod for a request
 # as md5(routing key) mod replicaCount and relays requests it does not own
 # to the owner pod, so each blob is cached on exactly one pod instead of on
 # every pod that happens to receive it (R=1 dedup). The relay hop never
@@ -146,8 +146,6 @@ proxyService:
 # Disabled by default: behavior is identical to today.
 consistentHashRouting:
   enabled: false
-  # Port peers use to reach each other (the ssl proxy listener).
-  peerPort: 14128
 
 # Metrics configuration.
 metrics:

--- a/deploy/helm/container-cache/deploy/values.yaml
+++ b/deploy/helm/container-cache/deploy/values.yaml
@@ -135,6 +135,20 @@ proxyService:
   # Leave empty ("") to let Kubernetes assign one automatically.
   clusterIP: ""
 
+# Consistent-hash routing of proxy-cache requests across cache pods
+# (prototype). When enabled, each pod computes the owner pod for a request
+# as md5(routing key) mod replicaCount and relays requests it does not own
+# to the owner pod, so each blob is cached on exactly one pod instead of on
+# every pod that happens to receive it (R=1 dedup). The relay hop never
+# writes to the local cache; only the owner stores. A request that arrives
+# already relayed is always served locally, so relaying is at most one hop.
+# Owner failure falls back to the next ordinal (availability only).
+# Disabled by default: behavior is identical to today.
+consistentHashRouting:
+  enabled: false
+  # Port peers use to reach each other (the ssl proxy listener).
+  peerPort: 14128
+
 # Metrics configuration.
 metrics:
   cacheMetricsStorageSize: 300m

--- a/deploy/helm/container-cache/deploy/values.yaml
+++ b/deploy/helm/container-cache/deploy/values.yaml
@@ -136,7 +136,7 @@ proxyService:
   clusterIP: ""
 
 # Consistent-hash routing of proxy-cache requests across cache pods
-# (prototype). When enabled, each pod computes the owner pod for a request
+#. When enabled, each pod computes the owner pod for a request
 # as md5(routing key) mod replicaCount and relays requests it does not own
 # to the owner pod, so each blob is cached on exactly one pod instead of on
 # every pod that happens to receive it (R=1 dedup). The relay hop never

--- a/deploy/helm/container-cache/tests/render-consistent-hash-test.sh
+++ b/deploy/helm/container-cache/tests/render-consistent-hash-test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Rendered-output regression tests for opt-in consistent-hash routing
+# (consistentHashRouting.enabled). Run from the chart subtree:
+#   bash tests/render-consistent-hash-test.sh
+set -euo pipefail
+CHART_DIR="$(cd "$(dirname "$0")/.." && pwd)/deploy"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+fail() { echo "FAIL: $*" >&2; exit 1; }
+count() { grep -Ec "$1" "$2" || true; }
+
+helm template t "$CHART_DIR" > "$TMP/off.yaml" 2>/dev/null
+helm template t "$CHART_DIR" --set consistentHashRouting.enabled=false > "$TMP/off2.yaml" 2>/dev/null
+helm template t "$CHART_DIR" --set consistentHashRouting.enabled=true --set replicaCount=3 > "$TMP/on.yaml" 2>/dev/null
+
+echo "1. disabled (default and explicit): no routing directives render"
+for f in "$TMP/off.yaml" "$TMP/off2.yaml"; do
+  [ "$(count 'rewrite_by_lua_file /etc/nginx/conf.d/lua/cc-route' "$f")" = 0 ] || fail "rewrite_by_lua_file leaked when disabled"
+  [ "$(count 'location @cc_relay' "$f")" = 0 ] || fail "@cc_relay leaked when disabled"
+  [ "$(count 'upstream cc_owner_' "$f")" = 0 ] || fail "cc_owner upstream leaked when disabled"
+  [ "$(count 'statefulset.kubernetes.io/pod-name' "$f")" = 0 ] || fail "peer Service leaked when disabled"
+done
+
+echo "2. enabled: @cc_relay is defined exactly once (deduped into proxy-common)"
+n="$(count 'location @cc_relay' "$TMP/on.yaml")"
+[ "$n" = 1 ] || fail "expected 1 @cc_relay, got $n (duplication regressed)"
+
+echo "3. enabled: both routed blocks (ngc + *.hf.co) call the shared lua file"
+n="$(count 'rewrite_by_lua_file /etc/nginx/conf.d/lua/cc-route.lua' "$TMP/on.yaml")"
+[ "$n" = 2 ] || fail "expected 2 rewrite_by_lua_file (ngc + hf), got $n"
+[ "$(count 'rewrite_by_lua_block' "$TMP/on.yaml")" = 0 ] || fail "inline rewrite_by_lua_block must not render (should be the shared file)"
+
+echo "4. enabled: shared routing lua ships in the configmap"
+grep -q 'cc-route.lua:' "$TMP/on.yaml" || fail "cc-route.lua not in configmap"
+
+echo "5. enabled: N peer Services + N owner upstreams on the listener port (14128)"
+[ "$(count 'statefulset.kubernetes.io/pod-name:' "$TMP/on.yaml")" = 3 ] || fail "expected 3 per-ordinal peer Services"
+[ "$(count 'upstream cc_owner_' "$TMP/on.yaml")" = 3 ] || fail "expected 3 cc_owner upstreams"
+[ "$(count 'peer-[0-9].*svc.cluster.local:14128 max_fails' "$TMP/on.yaml")" = 3 ] || fail "peer upstreams must target the ssl listener port 14128"
+
+echo "6. enabled: routing keys on the full cache key; marker rejection + one-hop guard present"
+grep -q 'set $cc_hash_key "$request_method|$uri|$arg_versionId|$http_range"' "$TMP/on.yaml" || fail "routing key must equal the proxy_cache_key"
+grep -q 'X-NVCF-CC-Relayed' "$TMP/on.yaml" || fail "one-hop relay marker missing"
+
+echo "PASS: all consistent-hash routing render assertions hold"

--- a/deploy/helm/container-cache/tests/render-consistent-hash-test.sh
+++ b/deploy/helm/container-cache/tests/render-consistent-hash-test.sh
@@ -22,7 +22,11 @@ for f in "$TMP/off.yaml" "$TMP/off2.yaml"; do
   [ "$(count 'location @cc_relay' "$f")" = 0 ] || fail "@cc_relay leaked when disabled"
   [ "$(count 'upstream cc_owner_' "$f")" = 0 ] || fail "cc_owner upstream leaked when disabled"
   [ "$(count 'statefulset.kubernetes.io/pod-name' "$f")" = 0 ] || fail "peer Service leaked when disabled"
+  [ "$(count 'cc-route.lua' "$f")" = 0 ] || fail "cc-route.lua leaked into the ConfigMap/volume when disabled"
 done
+
+echo "1b. default render == explicit enabled=false render (disabled is a pure no-op)"
+diff "$TMP/off.yaml" "$TMP/off2.yaml" >/dev/null || fail "default and enabled=false renders differ"
 
 echo "2. enabled: @cc_relay is defined exactly once (deduped into proxy-common)"
 n="$(count 'location @cc_relay' "$TMP/on.yaml")"
@@ -40,9 +44,12 @@ echo "5. enabled: N peer Services + N owner upstreams on the listener port (1412
 [ "$(count 'statefulset.kubernetes.io/pod-name:' "$TMP/on.yaml")" = 3 ] || fail "expected 3 per-ordinal peer Services"
 [ "$(count 'upstream cc_owner_' "$TMP/on.yaml")" = 3 ] || fail "expected 3 cc_owner upstreams"
 [ "$(count 'peer-[0-9].*svc.cluster.local:14128 max_fails' "$TMP/on.yaml")" = 3 ] || fail "peer upstreams must target the ssl listener port 14128"
+[ "$(count 'targetPort: 14128' "$TMP/on.yaml")" = 3 ] || fail "each peer Service must expose targetPort 14128 (drift breaks every relay)"
+[ "$(count 'port: 14128' "$TMP/on.yaml")" = 3 ] || fail "each peer Service must expose port 14128"
 
-echo "6. enabled: routing keys on the full cache key; marker rejection + one-hop guard present"
+echo "6. enabled: routing key == proxy_cache_key; marker emitted AND inbound marker rejected"
 grep -q 'set $cc_hash_key "$request_method|$uri|$arg_versionId|$http_range"' "$TMP/on.yaml" || fail "routing key must equal the proxy_cache_key"
-grep -q 'X-NVCF-CC-Relayed' "$TMP/on.yaml" || fail "one-hop relay marker missing"
+grep -q 'proxy_set_header X-NVCF-CC-Relayed "1"' "$TMP/on.yaml" || fail "relay hop must emit the one-hop marker"
+grep -q 'ngx.req.get_headers()\["X-NVCF-CC-Relayed"\]' "$TMP/on.yaml" || fail "cc-route.lua must reject an inbound relay marker (serve locally, prevents relay loops)"
 
 echo "PASS: all consistent-hash routing render assertions hold"


### PR DESCRIPTION
## Why
The proxy-cache runs as a StatefulSet and requests are round-robined across the cache pods. Each pod caches whatever is routed to it, so the same blob is stored on every pod: effective cache capacity is capped at one pod's volume (N pods hold N copies), and each blob is fetched from origin once per pod. For a multi-TB model pulled by many client pods this multiplies both origin egress and cache storage by the cache-pod count and can fill the cache volume.

## What changed
Opt-in consistent-hash routing (`consistentHashRouting.enabled`, default `false`). Each request is routed to a single owner pod derived from the **full proxy_cache_key** (`$request_method|$uri|$arg_versionId|$http_range`), so each byte-range chunk is stored once on its owner and fetched from origin once. Routing on the exact cache key spreads a large multi-chunk blob evenly across the tier instead of pinning a whole file to one pod.

Applied to the two paths that carry the large model blobs:
- NGC file hosts (`ngc.conf`, `*files.ngc.nvidia.com`).
- HuggingFace CDN (`hf.conf`, `*.hf.co`). `huggingface.co` mostly 302-redirects to `*.hf.co`, so the bytes and cache storage live there; the redirect/API and xethub CAS blocks are untouched.

Mechanics:
- A `rewrite_by_lua_block` computes `owner = md5(cache_key) mod replicaCount` and relays to it; the pod's own ordinal comes from its hostname; an `X-NVCF-CC-Relayed` header caps relaying at one hop (loop-safe during a rolling config change).
- `nginx.conf`: per-ordinal upstreams (`cc_owner_i`), primary = owner, backup = next ordinal.
- `service-peer.yaml`: per-ordinal ClusterIP Services selecting `statefulset.kubernetes.io/pod-name`, giving each pod stable DNS without touching the StatefulSet's immutable `serviceName`.
- `values.yaml`: `consistentHashRouting.enabled` (default false) and `peerPort`.

`N` is `replicaCount`, injected at render time (same value drives the Lua divisor, the upstream count, and the peer Services); it does not track live pod health, so a transient pod outage never re-hashes the tier (down pods fall to the upstream backup). Disabled by default: no resource or behavior changes.

## Testing
`helm lint` and `helm template` pass; flag off renders zero routing, flag on renders the peer Services, `cc_owner` upstreams, and the Lua routing on both the NGC and `*.hf.co` blocks.

Validated live on a 3-pod cache tier (300 GB per pod) with a 4-worker herd pulling a ~260 GB NGC model through the cache:
- Storage deduped and balanced: model stored once across the tier, **83.7 / 86.6 / 96.9 GB per pod** (267 GB total, spread ~15% of mean), **zero eviction / ENOSPC**. Without hashing, round-robin would put the full model on each pod and overflow the volume.
- Distribution even: each pod owns ~1/3 of the distinct chunks; per-pod serve counts within ~1.1x.
- Routing on `$uri` alone (an earlier iteration) skewed to ~4.7x because a whole file pins to one owner; routing on the full cache key removed the skew (366/77/234 -> 365/415/376 serve counts).

## Notes
- S3 (`proxy-cache.conf`) still round-robins; extending the same routing to it is a follow-up (its cache key composition differs, so the routing key must match that block).
- Owner mapping is modulo-N. Fine for a fixed replica count; changing the replica count remaps most keys, so scaling the tier is a coordinated redeploy (a hash ring would only be needed to scale under load).
- Config files are mounted via `subPath`, so a configmap change requires a pod restart to take effect (not a live reload).

## Issues
Closes #520

## Related Pull Requests
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional consistent-hash routing for container-cache requests to send each cacheable item to a single “owner” pod, reducing duplicate blob caching.
  * Enabled consistent-hash behavior for both file and HuggingFace CDN caching paths, with a one-hop relay fallback when needed.
  * Added per-ordinal peer Services and the required routing support when enabled via Helm (disabled by default).
* **Tests**
  * Added a Helm-render regression test covering enabled/disabled configurations and expected rendered resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->