### PR TITLE
fix(build): stamp service-owned release tags into Rust version metadata

### DIFF
--- a/src/control-plane-services/function-autoscaler/tools/workspace_status.sh
+++ b/src/control-plane-services/function-autoscaler/tools/workspace_status.sh
@@ -23,12 +23,38 @@ if [ "$COMMIT" != "unknown" ] && [ -n "$(git status --porcelain 2>/dev/null)" ];
     DIRTY="-dirty"
 fi
 
-# CI overrides for VERSION (from git tag or MR sha) and BUILD_USER.
-# When unset, fall back to the values the legacy nvcf-cli Makefile computed.
+# Tag prefixes that identify a release of this service, most current first.
+# A monorepo release commit normally carries tags for several services and
+# Helm stacks at once, so an unfiltered `git describe --exact-match` can
+# return an unrelated tag and stamp it as this service's version. Match only
+# tags this service owns, and strip the prefix so the stamped value is a bare
+# semver rather than a full tag path.
+SERVICE_TAG_PREFIXES="src/control-plane-services/function-autoscaler/v nvcf-function-autoscaler-v"
+
+# Echoes the highest release version tagged on HEAD for this service, or
+# returns non-zero when HEAD carries no tag belonging to it.
+service_version_from_tags() {
+    local prefix candidate
+    for prefix in ${SERVICE_TAG_PREFIXES}; do
+        candidate=$(git tag --points-at HEAD 2>/dev/null \
+            | grep "^${prefix}" \
+            | sed "s|^${prefix}||" \
+            | sort -V \
+            | tail -n 1) || true
+        if [ -n "${candidate}" ]; then
+            printf '%s' "${candidate}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# CI sets NVCF_VERSION explicitly. Otherwise derive the version from a release
+# tag on HEAD, falling back to an MR-style identifier for ordinary dev builds.
 if [ -n "${NVCF_VERSION:-}" ]; then
     VERSION="${NVCF_VERSION}"
-elif TAG=$(git describe --tags --exact-match HEAD 2>/dev/null); then
-    VERSION="${TAG}"
+elif TAG_VERSION=$(service_version_from_tags); then
+    VERSION="${TAG_VERSION}"
 else
     VERSION="mr-${COMMIT}"
 fi

--- a/src/invocation-plane-services/http-invocation/tools/workspace_status.sh
+++ b/src/invocation-plane-services/http-invocation/tools/workspace_status.sh
@@ -23,12 +23,38 @@ if [ "$COMMIT" != "unknown" ] && [ -n "$(git status --porcelain 2>/dev/null)" ];
     DIRTY="-dirty"
 fi
 
-# CI overrides for VERSION (from git tag or MR sha) and BUILD_USER.
-# When unset, fall back to the values the legacy nvcf-cli Makefile computed.
+# Tag prefixes that identify a release of this service, most current first.
+# A monorepo release commit normally carries tags for several services and
+# Helm stacks at once, so an unfiltered `git describe --exact-match` can
+# return an unrelated tag and stamp it as this service's version. Match only
+# tags this service owns, and strip the prefix so the stamped value is a bare
+# semver rather than a full tag path.
+SERVICE_TAG_PREFIXES="src/invocation-plane-services/http-invocation/v"
+
+# Echoes the highest release version tagged on HEAD for this service, or
+# returns non-zero when HEAD carries no tag belonging to it.
+service_version_from_tags() {
+    local prefix candidate
+    for prefix in ${SERVICE_TAG_PREFIXES}; do
+        candidate=$(git tag --points-at HEAD 2>/dev/null \
+            | grep "^${prefix}" \
+            | sed "s|^${prefix}||" \
+            | sort -V \
+            | tail -n 1) || true
+        if [ -n "${candidate}" ]; then
+            printf '%s' "${candidate}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# CI sets NVCF_VERSION explicitly. Otherwise derive the version from a release
+# tag on HEAD, falling back to an MR-style identifier for ordinary dev builds.
 if [ -n "${NVCF_VERSION:-}" ]; then
     VERSION="${NVCF_VERSION}"
-elif TAG=$(git describe --tags --exact-match HEAD 2>/dev/null); then
-    VERSION="${TAG}"
+elif TAG_VERSION=$(service_version_from_tags); then
+    VERSION="${TAG_VERSION}"
 else
     VERSION="mr-${COMMIT}"
 fi


### PR DESCRIPTION
## TL;DR

`tools/workspace_status.sh` for the two Rust services picked the release tag with an unfiltered `git describe --tags --exact-match HEAD`. Monorepo release commits carry tags for several services and Helm stacks at once, so that returns an arbitrary tag and a build can stamp an unrelated component's version as its own. This scopes the lookup to tags the service owns and strips the prefix to a bare semver.

## Additional Details

`STABLE_VERSION` reaches `CARGO_PKG_VERSION` through `rustc_env_files`, and both services report `env!("CARGO_PKG_VERSION")` as the OpenTelemetry `service.version` resource attribute. So whatever the tag lookup returns is what shows up in tracing.

On the two most recent function-autoscaler release commits, the old lookup returns `deploy/stacks/nvcf-compute-plane/v0.2.0-dev.52` and `...dev.32` rather than the autoscaler's own tag. One of those commits carries 18 tags.

This is not limited to the manual image-push path. `.bazelrc` wires the script in with `build --workspace_status_command=tools/workspace_status.sh`, so it runs for every stamped Bazel build of these services.

There was also a smaller issue on the same path: even when the right tag was selected, the full tag was used verbatim, so the stamped version would have been `src/control-plane-services/function-autoscaler/v1.18.5` rather than `1.18.5`.

Unchanged: the `NVCF_VERSION` override that CI sets, and the `mr-<sha>` fallback for ordinary dev builds.

## For the Reviewer

Both changed files are the same edit with a different prefix list. function-autoscaler carries two prefixes because it has pre-cutover releases under `nvcf-function-autoscaler-v`; http-invocation has only the current one.

Worth a look at the `set -euo pipefail` interaction: the tag pipeline uses `|| true` so a no-match `grep` does not abort the script.

## For QA

No separate QA pass expected; this is build-stamping behavior. Verified locally:

- Tag selection on the two real release commits that exposed the bug. Old logic returned `deploy/stacks/nvcf-compute-plane/v0.2.0-dev.52` and `...dev.32`; new logic returns `1.18.5` and `1.18.4`.
- `bash -n` on both scripts.
- Both scripts across all three branches: `NVCF_VERSION` set wins, untagged HEAD falls back to `mr-<sha>`.
- End to end through Bazel: `NVCF_VERSION=1.18.6 bazel build --stamp //crates/server:version_env` produces `CARGO_PKG_VERSION=1.18.6`, and an unstamped build produces `CARGO_PKG_VERSION=0.0.0-dev`.
- Separately confirmed that `rustc_env_files` does override the crate version at compile time, by building `//crates/server:server` with a sentinel and finding it in the linked binary.

## Issues

Closes #526

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic service version detection during builds by using only tags associated with the relevant service.
  - When multiple matching versions are available, the highest semantic version is selected.
  - Preserved support for explicitly provided versions and commit-based fallback identifiers.
  - Prevented unrelated repository tags from affecting reported stable versions and build metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->