### PR TITLE
ci: add dependency audit required gate

### DIFF
--- a/.github/workflows/license-dependencies.yml
+++ b/.github/workflows/license-dependencies.yml
@@ -89,3 +89,28 @@ jobs:
 
       - name: Run dependency docs freshness check
         run: ./tools/ci/check-dependency-docs
+
+  dependency-audit:
+    name: dependency audit
+    needs: [check-license, check-dependency-licenses, check-dependency-docs]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check dependency audit result
+        env:
+          LICENSE_RESULT: ${{ needs.check-license.result }}
+          DEP_LICENSES_RESULT: ${{ needs.check-dependency-licenses.result }}
+          DEP_DOCS_RESULT: ${{ needs.check-dependency-docs.result }}
+        run: |
+          set -euo pipefail
+
+          echo "license headers, NOTICE, and MPL audit: ${LICENSE_RESULT}"
+          echo "dependency licenses: ${DEP_LICENSES_RESULT}"
+          echo "generated dependency docs: ${DEP_DOCS_RESULT}"
+
+          if [ "${LICENSE_RESULT}" != "success" ] || \
+             [ "${DEP_LICENSES_RESULT}" != "success" ] || \
+             [ "${DEP_DOCS_RESULT}" != "success" ]; then
+            echo "dependency audit did not complete successfully"
+            exit 1
+          fi


### PR DESCRIPTION
## TL;DR

Adds one stable `dependency audit` check that summarizes the repository's existing dependency, NOTICE, and license checks. It can be required as one branch-protection status check.

## Additional Details

- The `license-dependencies` workflow already regenerates and compares `dependencies.md`, validates `NOTICE`, and checks third-party Go licenses.
- The new gate runs even if a prerequisite job fails, then fails unless all three audit jobs succeeded. This prevents a skipped aggregate job from satisfying branch protection after an audit failure.

## For the Reviewer

- Confirm that `dependency audit` is the intended single required-check name.

## For QA

- `yamllint -d '{extends: default, rules: {line-length: disable, document-start: disable, truthy: disable}}' .github/workflows/license-dependencies.yml`
- `git diff --check`
- `./tools/ci/check-license`
- `GOCACHE=/private/tmp/nvcf-dependency-audit-go-cache GOPATH=/private/tmp/nvcf-dependency-audit-go-path ./tools/ci/check-dependency-licenses`
- `GOCACHE=/private/tmp/nvcf-dependency-audit-go-cache GOPATH=/private/tmp/nvcf-dependency-audit-go-path go test -C ./tools/collect-dependencies .`
- The unchanged `generated dependency docs` job passed on `main` in [workflow run 30476536748](https://github.com/NVIDIA/nvcf/actions/runs/30476536748). Local execution requires Java 25, which is not installed in this worktree environment.
- QA needed: No. CI-only change.

## Issues

Relates to #485

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated dependency audit to the license and dependency checks.
  * Workflows now report the status of prerequisite checks and fail when any required validation does not succeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->