### PR TITLE
feat(pki): add OpenBao ClusterIssuer chart

### DIFF
--- a/deploy/helm/nvcf-pki/AGENTS.md
+++ b/deploy/helm/nvcf-pki/AGENTS.md
@@ -1,0 +1,68 @@
+# AGENTS.md - NVCF PKI chart
+
+This native Helm chart provisions cluster-scoped PKI resources. It renders no
+resources unless `clusterIssuer.enabled=true`.
+
+## Validate
+
+Run from the repository root:
+
+```bash
+helm lint deploy/helm/nvcf-pki
+helm template nvcf-pki deploy/helm/nvcf-pki >/dev/null
+deploy/helm/nvcf-pki/scripts/check-render.sh
+git diff --check
+```
+
+## Style
+
+Follow the repository root `AGENTS.md` for repository-wide code style and
+public snapshot rules.
+
+- Use two-space indentation in YAML.
+- Keep Helm templates opt-in, validate required values with `required`, and
+  quote rendered string values.
+- Write validation scripts for POSIX `sh`. Use `set -eu` and clean temporary
+  files with a trap.
+
+## Retained issuer lifecycle
+
+The chart marks the `ClusterIssuer` with Helm's `keep` resource policy. Helm
+does not delete it when an upgrade, rollback, or uninstall removes it from the
+rendered release. Helm also stops managing the retained object.
+
+- Setting `clusterIssuer.enabled=false` or uninstalling retains the current
+  issuer.
+- Changing `clusterIssuer.name` creates the new issuer and retains the previous
+  issuer.
+- A rollback can retain an issuer that is absent from the restored release.
+
+Before disabling the issuer or uninstalling the chart, reconfigure or remove
+every certificate consumer. Roll out replacement consumers and verify their
+data paths first.
+
+When changing `clusterIssuer.name`, apply the upgrade and verify that the new
+issuer is ready before moving certificate consumers to it.
+
+After an upgrade, rollback, or uninstall:
+
+1. List active and retained issuers:
+
+   ```bash
+   kubectl get clusterissuers
+   ```
+
+2. List certificate issuer references:
+
+   ```bash
+   kubectl get certificates --all-namespaces \
+     -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,ISSUER-KIND:.spec.issuerRef.kind,ISSUER-NAME:.spec.issuerRef.name
+   ```
+
+3. Set `issuer_name` to the previous `clusterIssuer.name`. Delete the retained
+   issuer only when no active certificate references it:
+
+   ```bash
+   issuer_name=nvcf-openbao-pki
+   kubectl delete clusterissuer "${issuer_name}"
+   ```

--- a/deploy/helm/nvcf-pki/CLAUDE.md
+++ b/deploy/helm/nvcf-pki/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/deploy/helm/nvcf-pki/Chart.yaml
+++ b/deploy/helm/nvcf-pki/Chart.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: helm-nvcf-pki
+description: Provisions environment-level PKI resources for self-managed NVCF
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/deploy/helm/nvcf-pki/README.md
+++ b/deploy/helm/nvcf-pki/README.md
@@ -1,0 +1,156 @@
+# NVCF PKI Helm Chart
+
+This chart creates the cert-manager `ClusterIssuer` used for NVIDIA Cloud
+Functions (NVCF) service TLS in a self-managed deployment. The issuer uses an
+OpenBao PKI signing path and authenticates with a projected Kubernetes
+ServiceAccount token.
+
+The chart is opt-in. It renders no Kubernetes resources unless
+`clusterIssuer.enabled=true`.
+
+## Scope
+
+The chart owns one cluster-scoped `ClusterIssuer`. It does not install or
+configure:
+
+- cert-manager or its custom resource definitions
+- OpenBao
+- the OpenBao PKI mount, signing role, authentication mount, or policy
+- application `Certificate` resources
+
+Provision those dependencies before enabling the issuer. The self-managed
+OpenBao migrations can provision the NVCF service-issuing PKI backend. See the
+[LLM OpenBao addon](../../../migrations/openbao/addons/llm/README.md) for its
+default paths and role bindings.
+
+## Prerequisites
+
+- Kubernetes cluster
+- Helm 3
+- `kubectl` configured for the target cluster
+- cert-manager with the `ClusterIssuer` custom resource definition installed
+- OpenBao with a PKI signing path and JWT authentication role
+- cluster-wide permission to create a `ClusterIssuer`
+
+The cert-manager controller must have permission to request a token for the
+ServiceAccount named by `clusterIssuer.auth.serviceAccount.name`. That
+ServiceAccount must exist in cert-manager's cluster resource namespace,
+typically `cert-manager`.
+
+The OpenBao JWT role must bind the same ServiceAccount name and namespace. Its
+bound audience must match
+`clusterIssuer.auth.serviceAccount.audience`.
+
+## Configuration
+
+Chart defaults are defined in [values.yaml](./values.yaml).
+
+| Value | Default | Description |
+| --- | --- | --- |
+| `clusterIssuer.enabled` | `false` | Creates the `ClusterIssuer` when set to `true`. |
+| `clusterIssuer.name` | `nvcf-openbao-pki` | Name of the cluster-scoped issuer. |
+| `clusterIssuer.server` | empty | OpenBao server URL reachable from cert-manager. |
+| `clusterIssuer.path` | empty | OpenBao PKI signing path, excluding the `/v1/` prefix. |
+| `clusterIssuer.auth.mountPath` | `/v1/auth/jwt` | OpenBao authentication mount used for login. |
+| `clusterIssuer.auth.role` | `cert-manager` | OpenBao JWT authentication role. |
+| `clusterIssuer.auth.serviceAccount.name` | `cert-manager` | ServiceAccount used to request a projected token. |
+| `clusterIssuer.auth.serviceAccount.audience` | empty | Token audience accepted by the OpenBao JWT role. |
+
+The chart fails to render when it is enabled and any required value is empty.
+
+Example values:
+
+```yaml
+clusterIssuer:
+  enabled: true
+  name: nvcf-openbao-pki
+  server: https://openbao.example.com:8200
+  path: services/all/pki/nvcf-service-issuing/sign/nvcf-service-server
+  auth:
+    mountPath: /v1/auth/jwt
+    role: cert-manager
+    serviceAccount:
+      name: cert-manager
+      audience: https://openbao.example.com:8200
+```
+
+## Installation
+
+Install from the repository root with an environment-specific values file:
+
+```bash
+helm upgrade --install nvcf-pki deploy/helm/nvcf-pki \
+  --namespace cert-manager \
+  --create-namespace \
+  --values path/to/nvcf-pki-values.yaml
+```
+
+The Helm release namespace does not set the namespace of the
+`ClusterIssuer`, which is cluster-scoped. Use the cert-manager namespace for
+the release unless your deployment has a different convention.
+
+## Verification
+
+Check the issuer status:
+
+```bash
+kubectl get clusterissuer nvcf-openbao-pki
+kubectl describe clusterissuer nvcf-openbao-pki
+kubectl wait \
+  --for=condition=Ready \
+  clusterissuer/nvcf-openbao-pki \
+  --timeout=2m
+```
+
+If the issuer does not become ready, verify:
+
+- cert-manager can reach `clusterIssuer.server`
+- the signing path and authentication mount exist in OpenBao
+- the JWT role binds the configured ServiceAccount name and namespace
+- the projected token audience matches the OpenBao role's bound audience
+- cert-manager can create a token for the referenced ServiceAccount
+
+## Retained issuer lifecycle
+
+The chart sets `helm.sh/resource-policy: keep` on the `ClusterIssuer`. Helm
+retains the issuer when an upgrade, rollback, or uninstall would otherwise
+delete it. The retained issuer remains active but is no longer managed by the
+release.
+
+These operations retain existing issuers:
+
+- Setting `clusterIssuer.enabled=false`
+- Uninstalling the release
+- Changing `clusterIssuer.name`
+- Rolling back to a revision that does not contain the issuer
+
+Before disabling or uninstalling the chart, move or remove every
+`Certificate` that references the issuer. When changing the issuer name:
+
+1. Upgrade the release with the new name.
+2. Wait for the new issuer to report `Ready=True`.
+3. Move certificate consumers to the new issuer.
+4. Delete the old issuer only after no certificate references it.
+
+List certificate references before deleting a retained issuer:
+
+```bash
+kubectl get certificates --all-namespaces \
+  -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,ISSUER-KIND:.spec.issuerRef.kind,ISSUER-NAME:.spec.issuerRef.name
+```
+
+Delete the retained issuer only after confirming it has no consumers:
+
+```bash
+kubectl delete clusterissuer nvcf-openbao-pki
+```
+
+## Local validation
+
+Run from the repository root:
+
+```bash
+helm lint deploy/helm/nvcf-pki
+helm template nvcf-pki deploy/helm/nvcf-pki >/dev/null
+deploy/helm/nvcf-pki/scripts/check-render.sh
+```

--- a/deploy/helm/nvcf-pki/scripts/check-render.sh
+++ b/deploy/helm/nvcf-pki/scripts/check-render.sh
@@ -1,0 +1,176 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+chart_dir=$(CDPATH= cd -- "${script_dir}/.." && pwd)
+tmpdir=$(mktemp -d)
+
+cleanup() {
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+release_name=nvcf-pki
+namespace=cert-manager
+issuer_name=nvcf-openbao-pki
+server=https://openbao.example.invalid:8200
+signing_path=services/all/pki/nvcf-service-issuing/sign/nvcf-service-server
+auth_mount=/v1/auth/jwt
+auth_role=cert-manager
+service_account=cert-manager
+audience=https://openbao.example.invalid:8200
+
+render() {
+  helm template "$release_name" "$chart_dir" \
+    --namespace "$namespace" \
+    "$@"
+}
+
+render_enabled() {
+  render \
+    --set clusterIssuer.enabled=true \
+    --set-string clusterIssuer.name="$issuer_name" \
+    --set-string clusterIssuer.server="$server" \
+    --set-string clusterIssuer.path="$signing_path" \
+    --set-string clusterIssuer.auth.mountPath="$auth_mount" \
+    --set-string clusterIssuer.auth.role="$auth_role" \
+    --set-string clusterIssuer.auth.serviceAccount.name="$service_account" \
+    --set-string clusterIssuer.auth.serviceAccount.audience="$audience" \
+    "$@"
+}
+
+assert_contains() {
+  file=$1
+  pattern=$2
+
+  if ! grep -Fq -- "$pattern" "$file"; then
+    echo "expected ${file} to contain: ${pattern}" >&2
+    return 1
+  fi
+}
+
+assert_clusterissuer_count() {
+  file=$1
+  expected=$2
+  actual=$(grep -c '^kind: ClusterIssuer$' "$file" || true)
+
+  if [ "$actual" -ne "$expected" ]; then
+    echo "expected ${expected} ClusterIssuer resources, found ${actual}" >&2
+    return 1
+  fi
+}
+
+assert_object_count() {
+  file=$1
+  expected=$2
+  actual=$(grep -c '^apiVersion:' "$file" || true)
+
+  if [ "$actual" -ne "$expected" ]; then
+    echo "expected ${expected} rendered objects, found ${actual}" >&2
+    return 1
+  fi
+}
+
+assert_clusterissuer_manifest() {
+  file=$1
+  expected_name=$2
+  actual="${tmpdir}/actual-$(basename "$file")"
+  expected="${tmpdir}/expected-$(basename "$file")"
+
+  sed -n '/^apiVersion:/,$p' "$file" >"$actual"
+  cat >"$expected" <<EOF
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: "${expected_name}"
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  vault:
+    server: "${server}"
+    path: "${signing_path}"
+    auth:
+      kubernetes:
+        mountPath: "${auth_mount}"
+        role: "${auth_role}"
+        serviceAccountRef:
+          name: "${service_account}"
+          audiences:
+            - "${audience}"
+EOF
+
+  if ! diff -u "$expected" "$actual"; then
+    echo "rendered ClusterIssuer does not match the expected structure" >&2
+    return 1
+  fi
+}
+
+assert_render_fails() {
+  label=$1
+  expected_error=$2
+  shift 2
+  output="${tmpdir}/${label}.yaml"
+  error="${tmpdir}/${label}.err"
+
+  if render_enabled "$@" >"$output" 2>"$error"; then
+    echo "expected ${label} render to fail" >&2
+    return 1
+  fi
+  assert_contains "$error" "$expected_error"
+}
+
+default_render="${tmpdir}/default.yaml"
+render >"$default_render"
+assert_object_count "$default_render" 0
+assert_clusterissuer_count "$default_render" 0
+
+enabled_render="${tmpdir}/enabled.yaml"
+render_enabled >"$enabled_render"
+assert_object_count "$enabled_render" 1
+assert_clusterissuer_count "$enabled_render" 1
+assert_clusterissuer_manifest "$enabled_render" "$issuer_name"
+
+custom_name_render="${tmpdir}/custom-name.yaml"
+render_enabled --set-string clusterIssuer.name=custom-openbao-issuer >"$custom_name_render"
+assert_object_count "$custom_name_render" 1
+assert_clusterissuer_count "$custom_name_render" 1
+assert_clusterissuer_manifest "$custom_name_render" custom-openbao-issuer
+
+assert_render_fails empty-name \
+  "clusterIssuer.name is required when clusterIssuer.enabled=true" \
+  --set-string clusterIssuer.name=
+assert_render_fails empty-server \
+  "clusterIssuer.server is required when clusterIssuer.enabled=true" \
+  --set-string clusterIssuer.server=
+assert_render_fails empty-path \
+  "clusterIssuer.path is required when clusterIssuer.enabled=true" \
+  --set-string clusterIssuer.path=
+assert_render_fails empty-auth-mount \
+  "clusterIssuer.auth.mountPath is required when clusterIssuer.enabled=true" \
+  --set-string clusterIssuer.auth.mountPath=
+assert_render_fails empty-auth-role \
+  "clusterIssuer.auth.role is required when clusterIssuer.enabled=true" \
+  --set-string clusterIssuer.auth.role=
+assert_render_fails empty-service-account \
+  "clusterIssuer.auth.serviceAccount.name is required when clusterIssuer.enabled=true" \
+  --set-string clusterIssuer.auth.serviceAccount.name=
+assert_render_fails empty-audience \
+  "clusterIssuer.auth.serviceAccount.audience is required when clusterIssuer.enabled=true" \
+  --set-string clusterIssuer.auth.serviceAccount.audience=
+
+echo "nvcf-pki render checks passed"

--- a/deploy/helm/nvcf-pki/templates/clusterissuer.yaml
+++ b/deploy/helm/nvcf-pki/templates/clusterissuer.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.clusterIssuer.enabled }}
+{{- $name := required "clusterIssuer.name is required when clusterIssuer.enabled=true" .Values.clusterIssuer.name }}
+{{- $server := required "clusterIssuer.server is required when clusterIssuer.enabled=true" .Values.clusterIssuer.server }}
+{{- $path := required "clusterIssuer.path is required when clusterIssuer.enabled=true" .Values.clusterIssuer.path }}
+{{- $mountPath := required "clusterIssuer.auth.mountPath is required when clusterIssuer.enabled=true" .Values.clusterIssuer.auth.mountPath }}
+{{- $role := required "clusterIssuer.auth.role is required when clusterIssuer.enabled=true" .Values.clusterIssuer.auth.role }}
+{{- $serviceAccountName := required "clusterIssuer.auth.serviceAccount.name is required when clusterIssuer.enabled=true" .Values.clusterIssuer.auth.serviceAccount.name }}
+{{- $audience := required "clusterIssuer.auth.serviceAccount.audience is required when clusterIssuer.enabled=true" .Values.clusterIssuer.auth.serviceAccount.audience }}
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: {{ $name | quote }}
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  vault:
+    server: {{ $server | quote }}
+    path: {{ $path | quote }}
+    auth:
+      kubernetes:
+        mountPath: {{ $mountPath | quote }}
+        role: {{ $role | quote }}
+        serviceAccountRef:
+          name: {{ $serviceAccountName | quote }}
+          audiences:
+            - {{ $audience | quote }}
+{{- end }}

--- a/deploy/helm/nvcf-pki/values.yaml
+++ b/deploy/helm/nvcf-pki/values.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+clusterIssuer:
+  enabled: false
+  name: nvcf-openbao-pki
+  server: ""
+  path: ""
+  auth:
+    mountPath: /v1/auth/jwt
+    role: cert-manager
+    serviceAccount:
+      name: cert-manager
+      audience: ""

--- a/docs/user/manifest.md
+++ b/docs/user/manifest.md
@@ -125,6 +125,7 @@ The following tables list the complete artifact inventory.
 | `helm-nvcf-notary-service` | `1.4.2` | Required | Deploys the notary service for signing and validation. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-notary-service:1.4.2` |  |
 | `helm-nvcf-nvct-api` | `1.4.3` | Required | Deploys the NVCF tenant API service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-nvct-api:1.4.3` |  |
 | `helm-nvcf-openbao-server` | `0.30.23` | Required | Deploys OpenBao secret management. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-openbao-server:0.30.23` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/openbao) / [Upstream](https://github.com/openbao/openbao-helm) |
+| `helm-nvcf-pki` | `0.1.0` | Optional | Provisions the OpenBao-backed ClusterIssuer for NVCF service TLS. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-pki:0.1.0` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/nvcf-pki) |
 | `helm-nvcf-rate-limiter` | `1.0.3` | Optional | Deploys request rate limiting for supported invocation paths. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-rate-limiter:1.0.3` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/ratelimiter) |
 | `helm-nvcf-sis` | `1.18.3` | Required | Deploys the Spot Instance Service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-sis:1.18.3` |  |
 | `helm-nvcf-state-metrics` | `1.0.1` | Optional | Deploys NVCF state metrics for observability. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-state-metrics:1.0.1` |  |

--- a/docs/version-catalog/main.yaml
+++ b/docs/version-catalog/main.yaml
@@ -200,6 +200,10 @@ publications:
     version: 0.30.23
     registry: public-helm
     chart_format: http
+  - name: helm-nvcf-pki
+    version: 0.1.0
+    registry: public-helm
+    chart_format: http
   - name: helm-nvcf-rate-limiter
     version: 1.0.3
     registry: public-helm
@@ -350,6 +354,12 @@ manifest:
       requirement: optional
       description: Deploys the LLM request router.
       github_url: https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/llm-request-router
+    - artifact_id: helm-nvcf-pki
+      plane: control
+      kind: chart
+      requirement: optional
+      description: Provisions the OpenBao-backed ClusterIssuer for NVCF service TLS.
+      github_url: https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/nvcf-pki
     - artifact_id: helm-nvcf-rate-limiter
       plane: control
       kind: chart
@@ -794,6 +804,10 @@ artifacts:
     type: chart
     registry: staging
     version: 0.30.23
+  - name: helm-nvcf-pki
+    type: chart
+    registry: staging
+    version: 0.1.0
   - name: helm-nvcf-rate-limiter
     type: chart
     registry: staging

--- a/tools/ci/github-release-subprojects.json
+++ b/tools/ci/github-release-subprojects.json
@@ -202,6 +202,11 @@
       "legacy_tag_prefix": "helm-nvcf-cert-manager-v"
     },
     {
+      "id": "nvcf-pki",
+      "path": "deploy/helm/nvcf-pki",
+      "service_name": "helm-nvcf-pki"
+    },
+    {
       "id": "llm-request-router",
       "path": "deploy/helm/llm-request-router",
       "service_name": "helm-nvcf-llm-request-router",


### PR DESCRIPTION
## TL;DR

Add an optional `helm-nvcf-pki` chart that provisions the OpenBao-backed cert-manager `ClusterIssuer` required by the self-managed LLM TLS path. Register the chart for semantic release and add version `0.1.0` to the public artifact catalog.

## Additional Details

The LLM request router can create a `Certificate` that references `ClusterIssuer/nvcf-openbao-pki`, but the stack does not currently publish a chart that owns that issuer. This leaves the certificate unissued when the referenced issuer is absent.

The new chart:

- renders no resources by default;
- renders exactly one cluster-scoped `ClusterIssuer` when enabled;
- configures the OpenBao server, signing path, JWT auth mount, role, service account, and token audience;
- validates all required values during rendering; and
- preserves the issuer during chart uninstall so active certificates are not disrupted accidentally.

This is the publication-only PR. Stack consumption remains out of scope until `helm-nvcf-pki:0.1.0` is available from the normal chart source.

## Customer Release Notes

Adds an optional Helm chart for provisioning the OpenBao-backed ClusterIssuer used by NVCF service TLS.

## Plan Summary

The chart adds one optional cluster-scoped cert-manager resource. It adds no pods, images, Secrets, or runtime application dependencies. The default configuration renders no Kubernetes resources.

## Usage

Enable `clusterIssuer.enabled` and provide the issuer name, OpenBao server and signing path, JWT authentication settings, and cert-manager service account identity. The self-managed stack integration will follow in a separate PR after publication.

## For the Reviewer

Please focus on:

- `deploy/helm/nvcf-pki/templates/clusterissuer.yaml` for resource ownership and uninstall behavior;
- `deploy/helm/nvcf-pki/scripts/check-render.sh` for the render validation matrix;
- `tools/ci/github-release-subprojects.json` for release registration; and
- the version catalog entries for artifact metadata.

## For QA

Validated on the exact pushed commit set:

- `helm lint deploy/helm/nvcf-pki`
- `helm template nvcf-pki deploy/helm/nvcf-pki`
- `deploy/helm/nvcf-pki/scripts/check-render.sh`
- `python3 -m unittest tools/ci/test-github-release.py`
- `go test -C tools/docs-version-sync ./...`
- `./tools/ci/check-doc-version-sync`
- `git diff --check origin/main...HEAD`

The docs synchronization wrapper emitted its existing advisory warning because `imports.yaml` is not present in the public checkout. Its Go unit tests passed.

Post-merge QA is required: confirm the `0.1.0` chart is published, render the published artifact, and verify the issuer reaches `Ready=True` in a disposable environment with cert-manager and OpenBao.

## Issues

Relates to #502

## Notes

This is Pull Request 1 of the two-PR rollout. Do not begin stack consumption based only on a local chart override. Pull Request 2 must wait for successful publication of `helm-nvcf-pki:0.1.0`.

Safe rollback removes or reconfigures certificate consumers before issuer management is disabled. The retained `ClusterIssuer` should only be deleted after no active certificate depends on it.

## References

- https://github.com/NVIDIA/nvcf/issues/502

## Related Pull Requests

None.

## Dependencies

None. No new third-party package is added. License review is not required, and `NOTICE` is unchanged.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new optional Helm chart (`helm-nvcf-pki`) to provision a cert-manager `ClusterIssuer` backed by OpenBao for service TLS.
  - Introduced configurable issuer identity, Vault endpoint/path, and cert-manager JWT authentication parameters.
- **Documentation**
  - Expanded chart documentation with prerequisites, install/verify steps, and guidance for enabling, disabling, renaming, and safely cleaning up retained issuers.
  - Registered the chart in the manifest inventory and version catalog as an optional provisioning item.
- **Tests**
  - Added automated Helm render/manifest validation for enabled/disabled scenarios, required-field enforcement, and expected output matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->