### PR TITLE
fix(ci): stop failing PRs that touch only docker-host subtrees

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -331,7 +331,12 @@ jobs:
   bazel:
     name: bazel (${{ matrix.subtree.id }})
     needs: detect
-    if: needs.detect.outputs.any == 'true'
+    # Guard on THIS lane's matrix, not the combined `any`. A change touching
+    # only docker-host subtrees leaves this matrix empty while `any` is still
+    # true; GitHub cannot create a job from an empty matrix vector and resolves
+    # it to `failure`, not `skipped`, which failed the required check on PRs
+    # that had nothing wrong with them. bazel-docker already guards this way.
+    if: needs.detect.outputs.matrix != '[]'
     runs-on: ubuntu-latest
     # Public EC2 Buildbarn cache (grpcs, bearer-token gated). The token is a
     # repo secret, so fork PRs (which never receive secrets) fall back to a
@@ -938,8 +943,14 @@ jobs:
             exit 0
           fi
 
-          if [ "${BAZEL_RESULT}" != "success" ]; then
-            echo "one or more Bazel matrix rows failed, were cancelled, or were skipped"
+          # `skipped` is legitimate here and means the build-container matrix was
+          # empty, i.e. every selected subtree runs in the docker-host lane. The
+          # job's `if` is tied to that matrix being non-empty, so skipped can
+          # only mean "nothing for this lane to do" -- it cannot hide a row that
+          # should have run. The BAZEL_ANY check above already catches the case
+          # where no subtree was selected at all.
+          if [ "${BAZEL_RESULT}" != "success" ] && [ "${BAZEL_RESULT}" != "skipped" ]; then
+            echo "one or more Bazel matrix rows failed or were cancelled"
             exit 1
           fi
 


### PR DESCRIPTION
## Why

PR #548 failed its required Bazel check with nothing wrong in it. The run
contains three jobs: detect succeeded, the one matrix row that ran
(`bazel (cloud-tasks)`) succeeded, and only the aggregate gate failed.

detect emitted `selected 1 subtree(s): build-container=[] docker-host=[cloud-tasks]`.

The `bazel` job is guarded on `needs.detect.outputs.any == 'true'`, the combined
count across both lanes, but its matrix comes from `outputs.matrix`, which was
empty. `any` was true because a subtree had been selected, so the job was asked
to start with an empty matrix. GitHub cannot create a job from an empty matrix
vector and resolves it to `failure`, not `skipped` -- so `needs.bazel.result`
was failure even though no row failed or could have.

The gate then rejected that: its build-container branch accepted only `success`,
while the docker branch three lines below already tolerated `skipped`. That
asymmetry is what turned an empty lane into a red required check.

This blocks any PR whose changes fall entirely in the docker-host lane.

## What changed

Two lines, both needed.

The `bazel` job now guards on `needs.detect.outputs.matrix != '[]'`, its own
lane, exactly as `bazel-docker` already guards on `matrix_docker != '[]'`. That
turns the empty case from `failure` into `skipped`.

The gate then tolerates `skipped` for it, mirroring the docker branch. Fixing
only the guard would not help: the gate would still reject `skipped`.

This does not weaken the check. The job's condition is tied to its matrix being
non-empty, so `skipped` can only mean this lane had nothing to do -- it cannot
mask a row that should have run. The existing `BAZEL_ANY != true` early exit
still covers the case where no subtree was selected at all.

## Customer Release Notes

Not customer visible.

## Plan Summary

Not applicable.

## Usage

Not applicable.

## Testing

The diagnosis is from the failing run itself rather than inference: detect's log
shows the empty build-container lane, the job list shows the only row passing,
and the gate's own env dump shows `BAZEL_RESULT: failure` with `BAZEL_ANY: true`.

The fix is exercised by this PR only insofar as it touches a workflow file. The
case it repairs is a docker-host-only change, which this is not. #548 is the
real reproduction: it should go green once it picks up main, since
`pull_request` runs the workflow from the PR's own ref and cannot inherit the
fix without a branch update.

## Notes

Introduced with the change-aware matrix. It stayed latent because it needs a PR
whose entire change set lands in the docker-host lane, which until cloud-tasks
had active work was rare.

## References

None

## Related Merge Requests/Pull Requests

Unblocks #548.

## Dependencies

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI workflow handling when only Docker-host checks are selected.
  * Prevented skipped build-container checks from being incorrectly reported as failures.
  * Ensured verification results accurately reflect whether applicable checks ran.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->