### PR TITLE
feat(nv-boot): discover NGC auth via authenticate challenge

### DIFF
--- a/src/libraries/java/nv-boot-parent/nv-boot-mock-servers-test/src/main/java/com/nvidia/boot/mock/ngc/MockNgcContainerRegistryServer.java
+++ b/src/libraries/java/nv-boot-parent/nv-boot-mock-servers-test/src/main/java/com/nvidia/boot/mock/ngc/MockNgcContainerRegistryServer.java
@@ -18,9 +18,13 @@
 package com.nvidia.boot.mock.ngc;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static com.nvidia.boot.mock.BootTestConstants.IMAGE_MEDIA_TYPES;
 import static com.nvidia.boot.mock.BootTestConstants.TEST_VALID_CONTAINER_HASH;
 import static com.nvidia.boot.mock.BootTestConstants.TEST_VALID_CONTAINER_NAME;
@@ -30,6 +34,7 @@ import static com.nvidia.boot.mock.BootTestConstants.TEST_VALID_CONTAINER_TAG;
 import static com.nvidia.boot.mock.BootTestConstants.TEST_VALID_ORG_NAME;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import java.net.URI;
 import lombok.Getter;
 import lombok.SneakyThrows;
@@ -38,9 +43,32 @@ import org.springframework.http.MediaType;
 
 public class MockNgcContainerRegistryServer {
 
+    /**
+     * Token endpoint advertised by the challenge. Deliberately not {@code /proxy_auth}: the
+     * client must discover this path from the challenge rather than assume a well-known one.
+     */
+    public static final String MOCK_TOKEN_ENDPOINT_URL = "/mock-token-endpoint";
+    public static final String V2_PING_URL = "/v2/";
+    public static final String MOCK_BEARER_TOKEN = "mockBearerToken";
+    public static final String MOCK_INVALID_REGISTRY_CRED = "invalid-registry-credential";
+    private static final String DOCKER_CONTENT_DIGEST_HEADER = "Docker-Content-Digest";
+
     @Getter
     private static WireMockServer ngcContainerRegistryMockServer;
-    private static final String PROXY_AUTH_URL = "/proxy_auth";
+    private static final String MANIFEST_URL_PATTERN = "/v2/.+/manifests/.+";
+    /**
+     * Scope is templated from the request path, so any repository gets the scope a registry
+     * would advertise for it: path segments are {@code /v2/{org}/{image}/manifests/{reference}}.
+     */
+    private static final String MANIFEST_CHALLENGE =
+            "Bearer realm=\"%s\",scope=\"repository:"
+                    + "{{request.path.[1]}}/{{request.path.[2]}}:pull\"";
+    private static final String CHALLENGE_TOKEN_RESPONSE = """
+            {
+                "expires_in": 3600,
+                "token": "%s"
+            }
+            """.formatted(MOCK_BEARER_TOKEN);
     private static final String VALIDATE_MANIFEST_URL =
             "/v2/" + TEST_VALID_ORG_NAME + "/" + TEST_VALID_CONTAINER_NAME + "/manifests/" +
                     TEST_VALID_CONTAINER_TAG;
@@ -53,12 +81,6 @@ public class MockNgcContainerRegistryServer {
     private static final String VALIDATE_MANIFEST_NOT_EXISTS_URL =
             "/v2/" + TEST_VALID_ORG_NAME + "/" + TEST_VALID_CONTAINER_NAME +
                     "/manifests/" + TEST_VALID_CONTAINER_NOT_EXIST_TAG;
-    private static final String PROXY_AUTH = """
-            {
-                "expires_in": 600,
-                "token": "mockBearerToken"
-            }
-            """;
     private static final String VALIDATE_MANIFEST = """
             589386975/mega-dev/mega-scheduler-service@sha256:d3f9786af0f21490f55299ac0af2f2da871f927865b042def17c63a3699d8d51
             {
@@ -192,46 +214,113 @@ public class MockNgcContainerRegistryServer {
     @SneakyThrows
     public static void start(String ngcRegistryBaseUrl) {
         stop();
-        ngcContainerRegistryMockServer = new WireMockServer(URI.create(ngcRegistryBaseUrl).getPort());
+        var port = URI.create(ngcRegistryBaseUrl).getPort();
+        ngcContainerRegistryMockServer = new WireMockServer(port);
         ngcContainerRegistryMockServer.start();
 
-        ngcContainerRegistryMockServer.stubFor(get(urlPathEqualTo(PROXY_AUTH_URL))
-                                                       .willReturn(aResponse().withStatus(200)
-                                                                           .withHeader(
-                                                                                   HttpHeaders.CONTENT_TYPE,
-                                                                                   MediaType.APPLICATION_JSON_VALUE)
-                                                                           .withBody(PROXY_AUTH)));
-        ngcContainerRegistryMockServer.stubFor(get(urlPathEqualTo(VALIDATE_MANIFEST_URL))
-                                                       .withHeader(HttpHeaders.ACCEPT,
-                                                                   equalTo(IMAGE_MEDIA_TYPES))
-                                                       .willReturn(aResponse().withStatus(200)
-                                                                           .withHeader(
-                                                                                   HttpHeaders.CONTENT_TYPE,
-                                                                                   MediaType.APPLICATION_JSON_VALUE)
-                                                                           .withBody(
-                                                                                   VALIDATE_MANIFEST)));
-        ngcContainerRegistryMockServer.stubFor(
-                get(urlPathEqualTo(VALIDATE_MANIFEST_URL_WITH_DIGEST))
-                        .withHeader(HttpHeaders.ACCEPT,
-                                    equalTo(IMAGE_MEDIA_TYPES))
-                        .willReturn(aResponse().withStatus(200)
-                                            .withHeader(
-                                                    HttpHeaders.CONTENT_TYPE,
-                                                    MediaType.APPLICATION_JSON_VALUE)
-                                            .withBody(
-                                                    VALIDATE_MANIFEST)));
-        ngcContainerRegistryMockServer.stubFor(
-                get(urlPathEqualTo(VALIDATE_MANIFEST_PERMISSION_DENIED_URL))
-                        .withHeader(HttpHeaders.ACCEPT, equalTo(IMAGE_MEDIA_TYPES))
-                        .willReturn(aResponse().withStatus(403)));
-        ngcContainerRegistryMockServer.stubFor(get(urlPathEqualTo(VALIDATE_MANIFEST_NOT_EXISTS_URL))
-                                                       .withHeader(HttpHeaders.ACCEPT,
-                                                                   equalTo(IMAGE_MEDIA_TYPES))
-                                                       .willReturn(aResponse().withStatus(404)));
+        // The realm must be a URL the client can actually dereference. Downstream suites pass
+        // registry hostnames like localhost-ngc:<port> (the unique-hostname convention), which
+        // do not resolve, so the challenge advertises the loopback address the server binds
+        // instead of echoing the caller's hostname - which also exercises the client following
+        // the realm rather than assuming the registry host.
+        registerChallengeDiscoveryStubs("http://localhost:" + port + MOCK_TOKEN_ENDPOINT_URL);
+        registerTokenEndpointStubs();
+
+        registerAuthenticatedManifestStub(VALIDATE_MANIFEST_URL, manifestFoundResponse());
+        registerAuthenticatedManifestStub(VALIDATE_MANIFEST_URL_WITH_DIGEST,
+                                          manifestFoundResponse());
+        registerAuthenticatedManifestStub(VALIDATE_MANIFEST_PERMISSION_DENIED_URL,
+                                          aResponse().withStatus(403));
+        registerAuthenticatedManifestStub(VALIDATE_MANIFEST_NOT_EXISTS_URL,
+                                          aResponse().withStatus(404));
     }
 
+    private static ResponseDefinitionBuilder manifestFoundResponse() {
+        return aResponse().withStatus(200)
+                .withHeader(DOCKER_CONTENT_DIGEST_HEADER, TEST_VALID_CONTAINER_HASH)
+                .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .withBody(VALIDATE_MANIFEST);
+    }
+
+    /**
+     * Answers a manifest request that carries a bearer token. Registered for both GET and HEAD:
+     * the registry client validates with HEAD, while {@link #setResponse} callers still GET.
+     */
+    private static void registerAuthenticatedManifestStub(String url,
+                                                          ResponseDefinitionBuilder response) {
+        ngcContainerRegistryMockServer.stubFor(
+                any(urlPathEqualTo(url))
+                        .withHeader(HttpHeaders.AUTHORIZATION,
+                                    equalTo("Bearer " + MOCK_BEARER_TOKEN))
+                        .withHeader(HttpHeaders.ACCEPT, equalTo(IMAGE_MEDIA_TYPES))
+                        .willReturn(response));
+    }
+
+    /**
+     * Call 1 - discover the authentication challenge. An unauthenticated {@code /v2/} ping
+     * answers 401 with a Bearer challenge whose scope is empty and which advertises no service,
+     * matching what NGC returns on {@code /v2/} today; an unauthenticated manifest request
+     * answers 401 with a repository-scoped challenge. The realm points at
+     * {@link #MOCK_TOKEN_ENDPOINT_URL} rather than the legacy {@code /proxy_auth} so that a
+     * client which hardcodes the old path fails here.
+     *
+     * <p>Registries challenge any unauthenticated {@code /v2/} request, including one for a
+     * repository that does not exist, so the manifest stub deliberately matches before
+     * existence is considered. The response-template transformer derives the challenge scope
+     * from the requested path, the way a registry does, instead of needing one stub per image;
+     * it is applied per-stub so no other fixture's body is ever run through templating.
+     */
+    private static void registerChallengeDiscoveryStubs(String realm) {
+        ngcContainerRegistryMockServer.stubFor(
+                get(urlPathEqualTo(V2_PING_URL))
+                        .willReturn(aResponse().withStatus(401)
+                                            .withHeader(HttpHeaders.WWW_AUTHENTICATE,
+                                                        "Bearer realm=\"%s\",scope=\"\""
+                                                                .formatted(realm))));
+
+        ngcContainerRegistryMockServer.stubFor(
+                any(urlPathMatching(MANIFEST_URL_PATTERN))
+                        .withHeader(HttpHeaders.AUTHORIZATION, absent())
+                        .willReturn(aResponse().withStatus(401)
+                                            .withHeader(HttpHeaders.WWW_AUTHENTICATE,
+                                                        MANIFEST_CHALLENGE.formatted(realm))
+                                            .withTransformers("response-template")));
+    }
+
+    /**
+     * Call 2 - exchange the credential for a token at the advertised realm. Any request
+     * carrying an {@code Authorization} header receives a token - downstream suites use
+     * arbitrary credentials, so no single valid secret is pinned; the exported
+     * {@link #MOCK_INVALID_REGISTRY_CRED} is rejected with 401 via a higher-priority stub.
+     *
+     * <p>A request without the header matches no fixture and draws WireMock's 404 default, so
+     * a client that drops the header still fails loudly. (Real NGC would instead answer 200
+     * with an anonymous token - a silent false pass a credential check must never rely on.)
+     */
+    private static void registerTokenEndpointStubs() {
+        ngcContainerRegistryMockServer.stubFor(
+                get(urlPathEqualTo(MOCK_TOKEN_ENDPOINT_URL))
+                        .withHeader(HttpHeaders.AUTHORIZATION, matching(".+"))
+                        .willReturn(aResponse().withStatus(200)
+                                            .withHeader(HttpHeaders.CONTENT_TYPE,
+                                                        MediaType.APPLICATION_JSON_VALUE)
+                                            .withBody(CHALLENGE_TOKEN_RESPONSE)));
+
+        ngcContainerRegistryMockServer.stubFor(
+                get(urlPathEqualTo(MOCK_TOKEN_ENDPOINT_URL))
+                        .withHeader(HttpHeaders.AUTHORIZATION,
+                                    equalTo("Basic " + MOCK_INVALID_REGISTRY_CRED))
+                        .atPriority(1)
+                        .willReturn(aResponse().withStatus(401)));
+    }
+
+    /**
+     * Stubs a successful response for a URL, whatever the request method. Manifest paths are
+     * validated with HEAD but fetched with GET, and callers only mean "this URL succeeds", so
+     * matching any method keeps them working either way.
+     */
     public static void setResponse(String url, byte[] body) {
-        ngcContainerRegistryMockServer.stubFor(get(urlPathEqualTo(url))
+        ngcContainerRegistryMockServer.stubFor(any(urlPathEqualTo(url))
                                                        .willReturn(aResponse().withStatus(200)
                                                                            .withHeader(
                                                                                    HttpHeaders.CONTENT_TYPE,

--- a/src/libraries/java/nv-boot-parent/nv-boot-starter-registries/src/main/java/com/nvidia/boot/registries/service/registry/client/WebClientUtils.java
+++ b/src/libraries/java/nv-boot-parent/nv-boot-starter-registries/src/main/java/com/nvidia/boot/registries/service/registry/client/WebClientUtils.java
@@ -85,12 +85,14 @@ public class WebClientUtils {
 
     /**
      * Creates a WebClient with standard boot-exception status handlers and
-     * a timeout filter using an injected builder.
+     * a timeout filter using an injected builder. The builder is cloned before
+     * any handler or connector is added, so callers may pass one builder to
+     * several {@code createWebClient} calls without stacking configurations.
      */
     public static WebClient createWebClient(WebClient.Builder webClientBuilder,
                                             String baseUrl,
                                             Duration timeout) {
-        return webClientBuilder
+        return webClientBuilder.clone()
                 .baseUrl(baseUrl)
                 .defaultStatusHandler(HttpStatusCode::is4xxClientError,
                                       WebClientUtils::handle4xxError)
@@ -104,6 +106,9 @@ public class WebClientUtils {
      * Creates a WebClient with granular Reactor Netty timeout configuration and
      * optional retry on 5xx / IO errors. Each retry attempt gets its own
      * per-attempt timeout (exchangeTimeout). 4xx errors are never retried.
+     * The builder is cloned before any handler or connector is added, so callers
+     * may pass one builder to several {@code createWebClient} calls without
+     * stacking configurations.
      *
      * @param webClientBuilder injected WebClient builder
      * @param baseUrl         base URL for all requests
@@ -134,7 +139,7 @@ public class WebClientUtils {
                 .doOnConnected(conn -> conn.addHandlerLast(
                         new WriteTimeoutHandler(writeTimeout.toSeconds(), TimeUnit.SECONDS)));
 
-        var builder = webClientBuilder
+        var builder = webClientBuilder.clone()
                 .baseUrl(baseUrl)
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
                 .defaultStatusHandler(HttpStatusCode::is4xxClientError,

--- a/src/libraries/java/nv-boot-parent/nv-boot-starter-registries/src/main/java/com/nvidia/boot/registries/service/registry/client/ngc/AuthenticateChallengeUtils.java
+++ b/src/libraries/java/nv-boot-parent/nv-boot-starter-registries/src/main/java/com/nvidia/boot/registries/service/registry/client/ngc/AuthenticateChallengeUtils.java
@@ -1,0 +1,204 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.boot.registries.service.registry.client.ngc;
+
+import com.nvidia.boot.exceptions.UpstreamException;
+import com.nvidia.boot.registries.service.registry.client.ngc.dto.WwwAuthenticateChallenge;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Parses {@link WwwAuthenticateChallenge} out of a 401 response's {@code WWW-Authenticate}
+ * headers, per RFC 7235 and the Docker registry token authentication specification.
+ */
+@Slf4j
+@UtilityClass
+class AuthenticateChallengeUtils {
+
+    private static final String BEARER_SCHEME = "Bearer";
+    private static final String REALM_PARAM = "realm";
+    private static final String SERVICE_PARAM = "service";
+    private static final String SCOPE_PARAM = "scope";
+
+    private static final String MESG_NO_BEARER_CHALLENGE =
+            "Registry returned 401 without a usable Bearer challenge. WWW-Authenticate: %s";
+
+    /**
+     * Parses the Bearer challenge out of all {@code WWW-Authenticate} header values of a 401
+     * response.
+     *
+     * <p>Handles several challenges within one header value and spread across several header
+     * values, quoted and unquoted parameters in any order, commas inside quoted strings (such
+     * as the multi-action scope {@code repository:org/image:pull,push}), and backslash-escaped
+     * characters. Scheme and parameter names are matched case-insensitively; a repeated
+     * parameter keeps its first occurrence.
+     *
+     * @throws UpstreamException if no Bearer challenge carrying a non-empty realm is found -
+     *                           the registry speaking broken protocol, not a credential
+     *                           failure, since the probe carries no credential to reject; the
+     *                           message carries the raw header values for diagnostics
+     */
+    static WwwAuthenticateChallenge parse(List<String> wwwAuthenticateHeaderValues) {
+        if (wwwAuthenticateHeaderValues != null) {
+            for (var headerValue : wwwAuthenticateHeaderValues) {
+                var challenge = findBearerChallenge(headerValue);
+                if (challenge != null) {
+                    return challenge;
+                }
+            }
+        }
+
+        var mesg = MESG_NO_BEARER_CHALLENGE.formatted(wwwAuthenticateHeaderValues);
+        log.error(mesg);
+        throw new UpstreamException(mesg);
+    }
+
+    private static WwwAuthenticateChallenge findBearerChallenge(String headerValue) {
+        if (StringUtils.isBlank(headerValue)) {
+            return null;
+        }
+
+        return parseChallenges(headerValue).stream()
+                .filter(candidate -> BEARER_SCHEME.equalsIgnoreCase(candidate.scheme())
+                        && StringUtils.isNotBlank(candidate.params().get(REALM_PARAM)))
+                .findFirst()
+                .map(candidate -> new WwwAuthenticateChallenge(
+                        candidate.params().get(REALM_PARAM),
+                        StringUtils.defaultIfEmpty(candidate.params().get(SERVICE_PARAM), null),
+                        StringUtils.defaultIfEmpty(candidate.params().get(SCOPE_PARAM), null)))
+                .orElse(null);
+    }
+
+    private record RawChallenge(String scheme, Map<String, String> params) {
+
+    }
+
+    /**
+     * Splits one header value into its challenges. Each comma-separated element is either
+     * {@code scheme param=value} or a bare {@code scheme}, which starts a new challenge, or
+     * {@code param=value}, which belongs to the challenge that precedes it.
+     */
+    private static List<RawChallenge> parseChallenges(String headerValue) {
+        var challenges = new ArrayList<RawChallenge>();
+        RawChallenge current = null;
+
+        for (var element : splitOnUnquotedCommas(headerValue)) {
+            var trimmed = element.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+
+            var separator = indexOfUnquoted(trimmed, '=');
+            if (separator < 0) {
+                current = new RawChallenge(trimmed, new HashMap<>());
+                challenges.add(current);
+                continue;
+            }
+
+            var name = trimmed.substring(0, separator).trim();
+            var value = unquote(trimmed.substring(separator + 1).trim());
+
+            var schemeEnd = lastIndexOfWhitespace(name);
+            if (schemeEnd >= 0) {
+                current = new RawChallenge(name.substring(0, schemeEnd).trim(), new HashMap<>());
+                challenges.add(current);
+                name = name.substring(schemeEnd + 1).trim();
+            }
+
+            if (current != null && !name.isEmpty()) {
+                current.params().putIfAbsent(name.toLowerCase(Locale.ROOT), value);
+            }
+        }
+
+        return challenges;
+    }
+
+    private static List<String> splitOnUnquotedCommas(String headerValue) {
+        var elements = new ArrayList<String>();
+        var elementStart = 0;
+        var quoted = false;
+
+        for (var i = 0; i < headerValue.length(); i++) {
+            var current = headerValue.charAt(i);
+            if (quoted && current == '\\') {
+                i++;
+            } else if (current == '"') {
+                quoted = !quoted;
+            } else if (current == ',' && !quoted) {
+                elements.add(headerValue.substring(elementStart, i));
+                elementStart = i + 1;
+            }
+        }
+        elements.add(headerValue.substring(elementStart));
+
+        return elements;
+    }
+
+    private static int indexOfUnquoted(String element, char target) {
+        var quoted = false;
+
+        for (var i = 0; i < element.length(); i++) {
+            var current = element.charAt(i);
+            if (quoted && current == '\\') {
+                i++;
+            } else if (current == '"') {
+                quoted = !quoted;
+            } else if (current == target && !quoted) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static int lastIndexOfWhitespace(String name) {
+        for (var i = name.length() - 1; i >= 0; i--) {
+            if (Character.isWhitespace(name.charAt(i))) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static String unquote(String value) {
+        if (value.length() < 2 || !value.startsWith("\"") || !value.endsWith("\"")) {
+            return value;
+        }
+
+        var quoted = value.substring(1, value.length() - 1);
+        var unquoted = new StringBuilder(quoted.length());
+        for (var i = 0; i < quoted.length(); i++) {
+            var current = quoted.charAt(i);
+            if (current == '\\' && i + 1 < quoted.length()) {
+                i++;
+                unquoted.append(quoted.charAt(i));
+            } else {
+                unquoted.append(current);
+            }
+        }
+
+        return unquoted.toString();
+    }
+}

--- a/src/libraries/java/nv-boot-parent/nv-boot-starter-registries/src/main/java/com/nvidia/boot/registries/service/registry/client/ngc/NgcArtifactRegistryClient.java
+++ b/src/libraries/java/nv-boot-parent/nv-boot-starter-registries/src/main/java/com/nvidia/boot/registries/service/registry/client/ngc/NgcArtifactRegistryClient.java
@@ -104,7 +104,7 @@ public class NgcArtifactRegistryClient {
         this.artifactBaseUrl = baseUrl.replace("-ngc", "");
 
         var authWebClient = WebClientUtils.createWebClient(
-                webClientBuilder.clone(),
+                webClientBuilder,
                 oauth2BaseUrl, Duration.ofSeconds(5));
         this.authServiceStub = WebClientUtils.createStubService(
                 authWebClient, AuthServiceStub.class);
@@ -113,7 +113,7 @@ public class NgcArtifactRegistryClient {
                          + " connectTimeout: {}, responseTimeout: {}, writeTimeout: {}",
                  hostname, exchangeTimeout, connectTimeout, responseTimeout, writeTimeout);
         var artifactWebClient = WebClientUtils.createWebClient(
-                webClientBuilder.clone(),
+                webClientBuilder,
                 artifactBaseUrl, exchangeTimeout, connectTimeout, responseTimeout, writeTimeout, 3);
         this.ngcArtifactRegistryStub = WebClientUtils.createStubService(
                 artifactWebClient, NgcArtifactRegistryStub.class);

--- a/src/libraries/java/nv-boot-parent/nv-boot-starter-registries/src/main/java/com/nvidia/boot/registries/service/registry/client/ngc/NgcChallengeProbeStub.java
+++ b/src/libraries/java/nv-boot-parent/nv-boot-starter-registries/src/main/java/com/nvidia/boot/registries/service/registry/client/ngc/NgcChallengeProbeStub.java
@@ -17,41 +17,35 @@
 
 package com.nvidia.boot.registries.service.registry.client.ngc;
 
-import tools.jackson.databind.PropertyNamingStrategies;
-import tools.jackson.databind.annotation.JsonNaming;
 import java.net.URI;
-import lombok.Data;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.HttpExchange;
 
-public interface NgcContainerRegistryStub {
+/**
+ * Unauthenticated probes used to obtain a {@code WWW-Authenticate} challenge from the registry.
+ *
+ * <p>These return {@link ResponseEntity} so that a 401 and its headers reach the caller. They
+ * must be backed by a WebClient that lets 401 through - every other call in the flow stays on a
+ * client that converts 401 into an exception.
+ */
+interface NgcChallengeProbeStub {
 
     /**
-     * Exchanges a credential for a bearer token at the realm a challenge advertised. The URL is
-     * absolute because the realm may point at a different origin than the registry.
+     * Pings the registry base endpoint (OCI distribution spec {@code end-1}) to trigger a
+     * challenge when no image reference is available.
      */
     @GetExchange
-    NgcRegistryAuthResponse fetchToken(
-            URI tokenUrl,
-            @RequestHeader(HttpHeaders.AUTHORIZATION) String basic);
+    ResponseEntity<Void> probeBaseEndpoint(URI url);
 
     /**
-     * Checks a manifest with HEAD: existence and pullability are signaled by the status alone,
-     * so the body a GET would carry is never needed.
+     * Probes a manifest with HEAD to trigger its challenge. A non-401 answer means the manifest
+     * is accessible without credentials - the probe then doubles as the existence check.
      */
     @HttpExchange(method = "HEAD")
-    void validateManifest(
+    ResponseEntity<Void> probeManifest(
             URI url,
-            @RequestHeader(HttpHeaders.AUTHORIZATION) String bearer,
             @RequestHeader(HttpHeaders.ACCEPT) String imageMediaTypes);
-
-    @Data
-    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    class NgcRegistryAuthResponse {
-
-        private int expiresIn;
-        private String token;
-    }
 }

--- a/src/libraries/java/nv-boot-parent/nv-boot-starter-registries/src/main/java/com/nvidia/boot/registries/service/registry/client/ngc/NgcContainerRegistryClient.java
+++ b/src/libraries/java/nv-boot-parent/nv-boot-starter-registries/src/main/java/com/nvidia/boot/registries/service/registry/client/ngc/NgcContainerRegistryClient.java
@@ -18,23 +18,32 @@
 package com.nvidia.boot.registries.service.registry.client.ngc;
 
 import static com.nvidia.boot.registries.service.registry.client.oci.OciRegistryClient.IMAGE_MEDIA_TYPES;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Expiry;
-import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.github.benmanes.caffeine.cache.Scheduler;
 import com.google.common.annotations.VisibleForTesting;
 import com.nvidia.boot.exceptions.BadRequestException;
-import com.nvidia.boot.exceptions.ForbiddenException;
+import com.nvidia.boot.exceptions.UnauthorizedException;
+import com.nvidia.boot.exceptions.UpstreamException;
 import com.nvidia.boot.registries.service.registry.client.WebClientUtils;
+import com.nvidia.boot.registries.service.registry.client.ngc.dto.WwwAuthenticateChallenge;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
+import reactor.core.publisher.Mono;
 
 /**
  * Client for interacting with NGC Container Registry.
@@ -45,14 +54,26 @@ public class NgcContainerRegistryClient {
 
     private static final String DEFAULT_IMAGE_TAG = "latest";
 
+    private static final String BASE_ENDPOINT_PATH = "/v2/";
+    private static final String SERVICE_PARAM = "service";
+    private static final String SCOPE_PARAM = "scope";
+
     private static final String MESG_INVALID_NGC_DOCKER_IMAGE_URL_FORMAT_RESPONSE =
             "Invalid NGC docker image url format.";
     private static final String MESG_EMPTY_CONTAINER_URL_RESPONSE =
             "Container image URL cannot be null or empty";
-    private static final String MESG_NULL_RESPONSE =
-            "Null response from getting bearer token from registry %s";
+    private static final String MESG_REGISTRY_CREDENTIALS_MISSING =
+            "Registry credentials are required";
+    private static final String MESG_NO_TOKEN_ISSUED =
+            "Registry token endpoint %s returned no token";
+    private static final String MESG_NO_CHALLENGE =
+            "Registry endpoint %s did not present an authentication challenge (status %s), "
+                    + "so the credential cannot be verified";
+    private static final String MESG_INVALID_REALM =
+            "Registry challenge advertised an unusable realm %s";
 
     private final NgcContainerRegistryStub ngcContainerRegistryStub;
+    private final NgcChallengeProbeStub ngcChallengeProbeStub;
     private final String containerBaseUrl;
 
     private record RegistryAuthKey(String repository, String imageName, String apiKey) {
@@ -62,13 +83,16 @@ public class NgcContainerRegistryClient {
     // Base on prod metrics, there are around 1000 request for function/deployment
     // creation or updates per hour. We doubled the number to allow extremely cases.
     private static final int AUTH_TOKEN_CACHE_SIZE = 2048;
-    private final LoadingCache<RegistryAuthKey, NgcContainerRegistryStub.NgcRegistryAuthResponse>
+    // Loaded through get(key, closure) rather than a LoadingCache loader: discovery probes the
+    // manifest being validated, and the manifest reference is deliberately not part of the key
+    // (tag and digest for one repository share a token), so it has to travel with the call.
+    private final Cache<RegistryAuthKey, NgcContainerRegistryStub.NgcRegistryAuthResponse>
             registryAuthCache =
             Caffeine.newBuilder()
                     .maximumSize(AUTH_TOKEN_CACHE_SIZE)
                     .expireAfter(new AuthTokenExpiry())
                     .scheduler(Scheduler.systemScheduler())
-                    .build(this::fetchAuthToken);
+                    .build();
 
     @Getter
     private String hostname;
@@ -119,6 +143,22 @@ public class NgcContainerRegistryClient {
                 0);
         this.ngcContainerRegistryStub = WebClientUtils.createStubService(
                 webClient, NgcContainerRegistryStub.class);
+
+        // A probe reads the WWW-Authenticate challenge off the 401, so the 401 must survive as
+        // a response instead of becoming UnauthorizedException. The empty-Mono handler marks it
+        // as a non-error; registered before the factory's standard handlers because status
+        // handlers are consulted in insertion order and the first match wins. Only the probes
+        // use this client - a token request answered with 401 means the credentials are bad and
+        // must still throw. Cloned so the probe handler stays off the injected builder.
+        var probeBuilder = webClientBuilder.clone()
+                .defaultStatusHandler(status -> status.isSameCodeAs(UNAUTHORIZED),
+                                      response -> Mono.empty());
+        var probeWebClient = WebClientUtils.createWebClient(
+                probeBuilder,
+                containerBaseUrl, exchangeTimeout, connectTimeout, responseTimeout, writeTimeout,
+                0);
+        this.ngcChallengeProbeStub = WebClientUtils.createStubService(
+                probeWebClient, NgcChallengeProbeStub.class);
     }
 
     @VisibleForTesting
@@ -176,49 +216,138 @@ public class NgcContainerRegistryClient {
     }
 
     /**
-     * Validates a container image by checking its existence and accessibility in the NGC registry.
+     * Validates a container image by checking its existence and accessibility in the NGC
+     * registry. With a cached token this is a single authorized manifest check; on a cache miss
+     * the token is acquired through challenge discovery first. Validation never passes without
+     * exercising the credential: NGC requires one for every pull.
      *
      * @param containerImageUrl The container image URL to validate
      * @param base64ApiKey      The base64 encoded API key in format "username:password" for authentication
      * @throws BadRequestException if the image is invalid or inaccessible
      */
     public void validateContainerImage(String containerImageUrl, String base64ApiKey) {
+        requireCredential(base64ApiKey);
         ContainerImageComponents components = parseContainerImageUrl(containerImageUrl);
         RegistryAuthKey authKey =
                 new RegistryAuthKey(components.repository(), components.imageName(), base64ApiKey);
-        String bearerToken = registryAuthCache.get(authKey).getToken();
-        validateImageManifest(components, bearerToken);
+        var authResponse = registryAuthCache.get(
+                authKey, key -> fetchTokenViaChallenge(components, base64ApiKey));
+        validateImageManifest(components, authResponse.getToken());
     }
 
+    /**
+     * Verifies a credential by exchanging it for a token at the realm the registry's challenge
+     * advertises. No image reference is involved, so the challenge is triggered with the
+     * registry base endpoint (OCI distribution spec {@code end-1}). Never cached: the point of
+     * the call is to reach the registry.
+     *
+     * @throws BadRequestException   if the credential is blank; no request is made
+     * @throws UpstreamException     if the registry does not challenge or its challenge is
+     *                               unusable, leaving the credential unverified
+     * @throws UnauthorizedException if the registry rejects the credential or issues no token
+     */
     public String validateCredential(String registryHost, String base64EncodedSecret) {
-        var authResponse = ngcContainerRegistryStub.proxyAuth(
-                "Basic " + base64EncodedSecret, "$oauthtoken", null);
-        return Optional.ofNullable(authResponse)
-                .map(NgcContainerRegistryStub.NgcRegistryAuthResponse::getToken)
-                .orElseThrow(() -> {
-                    var mesg = MESG_NULL_RESPONSE
-                            .formatted(registryHost);
-                    log.error(mesg);
-                    return new ForbiddenException(mesg);
-                });
+        requireCredential(base64EncodedSecret);
+
+        var baseEndpointUrl = URI.create(containerBaseUrl + BASE_ENDPOINT_PATH);
+        var response = ngcChallengeProbeStub.probeBaseEndpoint(baseEndpointUrl);
+        return fetchTokenFromProbe(baseEndpointUrl, response, base64EncodedSecret).getToken();
     }
 
-    private NgcContainerRegistryStub.NgcRegistryAuthResponse fetchAuthToken(
-            RegistryAuthKey authKey) {
-        String base64ApiKey = authKey.apiKey();
-        String scope =
-                "repository:%s:pull".formatted(authKey.repository() + "/" + authKey.imageName());
-        log.info("authenticate registry scope: {}", scope);
-        return ngcContainerRegistryStub.proxyAuth(
-                "Basic " + base64ApiKey, "$oauthtoken", scope);
+    private NgcContainerRegistryStub.NgcRegistryAuthResponse fetchTokenFromChallenge(
+            WwwAuthenticateChallenge challenge, String base64EncodedSecret) {
+        var tokenUrl = buildTokenUrl(challenge);
+        var response = ngcContainerRegistryStub.fetchToken(tokenUrl,
+                                                           "Basic " + base64EncodedSecret);
+        if (response == null || StringUtils.isBlank(response.getToken())) {
+            var mesg = MESG_NO_TOKEN_ISSUED.formatted(challenge.realm());
+            log.error(mesg);
+            throw new UnauthorizedException(mesg);
+        }
+        return response;
+    }
+
+    /**
+     * Builds the token URL from the challenge, replaying exactly the non-empty parameters it
+     * advertised. {@code build(true)} keeps a pre-encoded realm query intact, so the appended
+     * parameters are encoded here; without it the realm would be double-encoded and the
+     * parameters not at all.
+     */
+    private static URI buildTokenUrl(WwwAuthenticateChallenge challenge) {
+        // A realm that cannot form a URL is the registry speaking broken protocol - the same
+        // family as not challenging at all - so it maps to UpstreamException rather than
+        // escaping as the raw IllegalArgumentException (bad characters or encoding) or
+        // IllegalStateException ({braces} parse as URI-template variables and fail expansion).
+        try {
+            var builder = UriComponentsBuilder.fromUriString(challenge.realm());
+            if (challenge.service() != null) {
+                builder.queryParam(SERVICE_PARAM,
+                                   UriUtils.encodeQueryParam(challenge.service(),
+                                                             StandardCharsets.UTF_8));
+            }
+            if (challenge.scope() != null) {
+                builder.queryParam(SCOPE_PARAM,
+                                   UriUtils.encodeQueryParam(challenge.scope(),
+                                                             StandardCharsets.UTF_8));
+            }
+
+            return builder.build(true).toUri();
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            var mesg = MESG_INVALID_REALM.formatted(challenge.realm());
+            log.error(mesg);
+            throw new UpstreamException(mesg);
+        }
+    }
+
+    private static WwwAuthenticateChallenge parseChallenge(ResponseEntity<Void> response) {
+        return AuthenticateChallengeUtils.parse(
+                response.getHeaders().get(HttpHeaders.WWW_AUTHENTICATE));
+    }
+
+    private static void requireCredential(String base64EncodedSecret) {
+        if (StringUtils.isBlank(base64EncodedSecret)) {
+            log.error(MESG_REGISTRY_CREDENTIALS_MISSING);
+            throw new BadRequestException(MESG_REGISTRY_CREDENTIALS_MISSING);
+        }
+    }
+
+    /**
+     * Loads a token for the repository by probing this very manifest for its challenge and
+     * redeeming it at the advertised realm, so the realm and scope always come from the
+     * registry's own answer for the right repository.
+     */
+    private NgcContainerRegistryStub.NgcRegistryAuthResponse fetchTokenViaChallenge(
+            ContainerImageComponents components, String base64ApiKey) {
+        var manifestUrl = manifestUri(components);
+        var response = ngcChallengeProbeStub.probeManifest(manifestUrl, IMAGE_MEDIA_TYPES);
+        return fetchTokenFromProbe(manifestUrl, response, base64ApiKey);
+    }
+
+    /**
+     * Redeems a discovery probe's challenge for a token. NGC requires a credential for every
+     * request, so a probe answer other than the 401 challenge (the probe client already
+     * converts other 4xx/5xx to exceptions) leaves the credential unverified and raises
+     * {@link UpstreamException} - validation never passes without exercising the credential.
+     */
+    private NgcContainerRegistryStub.NgcRegistryAuthResponse fetchTokenFromProbe(
+            URI probedUrl, ResponseEntity<Void> probeResponse, String base64EncodedSecret) {
+        if (!probeResponse.getStatusCode().isSameCodeAs(UNAUTHORIZED)) {
+            var mesg = MESG_NO_CHALLENGE.formatted(probedUrl, probeResponse.getStatusCode());
+            log.error(mesg);
+            throw new UpstreamException(mesg);
+        }
+        return fetchTokenFromChallenge(parseChallenge(probeResponse), base64EncodedSecret);
     }
 
     private void validateImageManifest(ContainerImageComponents components, String bearerToken) {
-        String tag = components.digest() != null ? components.digest() : components.tag();
-        String imagePath = components.repository() + "/" + components.imageName();
-        var uri = URI.create(containerBaseUrl + "/v2/" + imagePath + "/manifests/" + tag);
         ngcContainerRegistryStub.validateManifest(
-                uri, "Bearer " + bearerToken, IMAGE_MEDIA_TYPES);
+                manifestUri(components), "Bearer " + bearerToken, IMAGE_MEDIA_TYPES);
+    }
+
+    private URI manifestUri(ContainerImageComponents components) {
+        String reference = components.digest() != null ? components.digest() : components.tag();
+        String imagePath = components.repository() + "/" + components.imageName();
+        return URI.create(containerBaseUrl + "/v2/" + imagePath + "/manifests/" + reference);
     }
 
     private static class AuthTokenExpiry

--- a/src/libraries/java/nv-boot-parent/nv-boot-starter-registries/src/main/java/com/nvidia/boot/registries/service/registry/client/ngc/dto/WwwAuthenticateChallenge.java
+++ b/src/libraries/java/nv-boot-parent/nv-boot-starter-registries/src/main/java/com/nvidia/boot/registries/service/registry/client/ngc/dto/WwwAuthenticateChallenge.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.boot.registries.service.registry.client.ngc.dto;
+
+/**
+ * A {@code Bearer} challenge parsed from a 401 response's {@code WWW-Authenticate} headers,
+ * as defined by RFC 7235 and the Docker registry token authentication specification.
+ *
+ * <p>{@code realm} is the token endpoint the registry advertises. It is an absolute URL that
+ * may point at a different origin than the registry, and it must never be cached or assumed:
+ * re-read it from every challenge so a registry-side realm move is followed automatically.
+ *
+ * <p>{@code service} and {@code scope} are optional and are {@code null} when the challenge
+ * omits them. An empty value (for example {@code scope=""}, which NGC returns on {@code /v2/})
+ * is normalized to {@code null} so callers replay only the parameters the registry actually
+ * advertised.
+ */
+public record WwwAuthenticateChallenge(String realm, String service, String scope) {
+
+}

--- a/src/libraries/java/nv-boot-parent/nv-boot-starter-registries/src/test/java/com/nvidia/boot/registries/service/registry/client/ngc/AuthenticateChallengeUtilsTest.java
+++ b/src/libraries/java/nv-boot-parent/nv-boot-starter-registries/src/test/java/com/nvidia/boot/registries/service/registry/client/ngc/AuthenticateChallengeUtilsTest.java
@@ -1,0 +1,162 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.boot.registries.service.registry.client.ngc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.nvidia.boot.exceptions.UpstreamException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class AuthenticateChallengeUtilsTest {
+
+    private static final String NGC_REALM = "https://stg.nvcr.io/proxy_auth";
+    private static final String REALM = "https://auth.example.com/token";
+
+    @ParameterizedTest
+    @MethodSource("createParseableChallenges")
+    void parse_ValidBearerChallenge_ExtractsParams(String headerValue,
+                                                   String expectedRealm,
+                                                   String expectedService,
+                                                   String expectedScope) {
+        var challenge = AuthenticateChallengeUtils.parse(List.of(headerValue));
+
+        assertThat(challenge.realm()).isEqualTo(expectedRealm);
+        assertThat(challenge.service()).isEqualTo(expectedService);
+        assertThat(challenge.scope()).isEqualTo(expectedScope);
+    }
+
+    private static Stream<Arguments> createParseableChallenges() {
+        return Stream.of(
+                // All params quoted.
+                Arguments.of("Bearer realm=\"" + REALM + "\",service=\"registry.example.com\","
+                                     + "scope=\"repository:org/image:pull\"",
+                             REALM, "registry.example.com", "repository:org/image:pull"),
+                // Unquoted values.
+                Arguments.of("Bearer realm=" + REALM + ",service=registry.example.com",
+                             REALM, "registry.example.com", null),
+                // Params in shuffled order.
+                Arguments.of("Bearer scope=\"repository:org/image:pull\",realm=\"" + REALM + "\","
+                                     + "service=\"registry.example.com\"",
+                             REALM, "registry.example.com", "repository:org/image:pull"),
+                // Whitespace around delimiters.
+                Arguments.of("Bearer realm = \"" + REALM + "\" , scope = \"s\"",
+                             REALM, null, "s"),
+                // Trailing comma.
+                Arguments.of("Bearer realm=\"" + REALM + "\",service=\"reg\",",
+                             REALM, "reg", null),
+                // Scope absent.
+                Arguments.of("Bearer realm=\"" + REALM + "\",service=\"reg\"",
+                             REALM, "reg", null),
+                // Empty scope is treated as absent.
+                Arguments.of("Bearer realm=\"" + REALM + "\",scope=\"\"",
+                             REALM, null, null),
+                // Empty service is treated as absent.
+                Arguments.of("Bearer realm=\"" + REALM + "\",service=\"\"",
+                             REALM, null, null),
+                // Multi-action scope keeps the comma inside quotes.
+                Arguments.of("Bearer realm=\"" + REALM + "\",scope=\"repository:org/image:pull,push\"",
+                             REALM, null, "repository:org/image:pull,push"),
+                // Escaped quote inside a quoted value.
+                Arguments.of("Bearer realm=\"" + REALM + "\",scope=\"a\\\"b\"",
+                             REALM, null, "a\"b"),
+                // Lowercase scheme.
+                Arguments.of("bearer realm=\"" + REALM + "\"", REALM, null, null),
+                // Uppercase scheme.
+                Arguments.of("BEARER realm=\"" + REALM + "\"", REALM, null, null),
+                // Mixed-case param names.
+                Arguments.of("Bearer REALM=\"" + REALM + "\",Service=\"reg\",SCOPE=\"s\"",
+                             REALM, "reg", "s"),
+                // A duplicate param keeps the first occurrence.
+                Arguments.of("Bearer realm=\"" + REALM + "\",realm=\"https://other.example.com\"",
+                             REALM, null, null),
+                // A Basic challenge precedes the Bearer.
+                Arguments.of("Basic realm=\"basic-zone\", Bearer realm=\"" + REALM + "\",scope=\"s\"",
+                             REALM, null, "s"),
+                // A Basic challenge follows the Bearer without leaking its params.
+                Arguments.of("Bearer realm=\"" + REALM + "\", Basic realm=\"basic-zone\"",
+                             REALM, null, null),
+                // A bare Basic scheme precedes the Bearer.
+                Arguments.of("Basic, Bearer realm=\"" + REALM + "\"", REALM, null, null),
+                // The first Bearer challenge lacking a realm is skipped.
+                Arguments.of("Bearer scope=\"s\", Bearer realm=\"" + REALM + "\"",
+                             REALM, null, null),
+                // A foreign realm is passed through untouched.
+                Arguments.of("Bearer realm=\"https://foreign-auth.example.com/token\"",
+                             "https://foreign-auth.example.com/token", null, null),
+                // Shapes captured from stg.nvcr.io during the P0 spike: the manifest challenge
+                // has no service, and the /v2/ challenge has an empty scope.
+                Arguments.of("Bearer realm=\"" + NGC_REALM + "\",scope=\"repository:org/image:pull\"",
+                             NGC_REALM, null, "repository:org/image:pull"),
+                Arguments.of("Bearer realm=\"" + NGC_REALM + "\",scope=\"\"",
+                             NGC_REALM, null, null));
+    }
+
+    @Test
+    void parse_BearerInLaterHeaderValue_SelectsIt() {
+        var challenge = AuthenticateChallengeUtils.parse(List.of(
+                "Basic realm=\"basic-zone\"",
+                "Bearer realm=\"" + REALM + "\",service=\"reg\"",
+                "Digest realm=\"digest-zone\""));
+
+        assertThat(challenge.realm()).isEqualTo(REALM);
+        assertThat(challenge.service()).isEqualTo("reg");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "Basic realm=\"basic-only\"",
+            "Bearer",
+            "Bearer service=\"reg\",scope=\"repository:org/image:pull\"",
+            "Bearer realm=\"\"",
+            "Bearer realm=\"   \"",
+            "complete garbage text with no challenge"
+    })
+    void parse_NoUsableBearerChallenge_ThrowsCarryingRawHeader(String headerValue) {
+        // The probe carries no credential, so an unusable challenge is the registry speaking
+        // broken protocol - an upstream failure, never a credential rejection.
+        assertThatThrownBy(() -> AuthenticateChallengeUtils.parse(List.of(headerValue)))
+                .isInstanceOf(UpstreamException.class)
+                .hasMessageContaining(headerValue);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "   " })
+    void parse_BlankHeaderValue_Throws(String headerValue) {
+        var headerValues = Arrays.asList(headerValue);
+
+        assertThatThrownBy(() -> AuthenticateChallengeUtils.parse(headerValues))
+                .isInstanceOf(UpstreamException.class);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void parse_NoHeaderValues_Throws(List<String> headerValues) {
+        assertThatThrownBy(() -> AuthenticateChallengeUtils.parse(headerValues))
+                .isInstanceOf(UpstreamException.class);
+    }
+}

--- a/src/libraries/java/nv-boot-parent/nv-boot-starter-registries/src/test/java/com/nvidia/boot/registries/service/registry/client/ngc/NgcContainerRegistryClientTest.java
+++ b/src/libraries/java/nv-boot-parent/nv-boot-starter-registries/src/test/java/com/nvidia/boot/registries/service/registry/client/ngc/NgcContainerRegistryClientTest.java
@@ -17,13 +17,24 @@
 
 package com.nvidia.boot.registries.service.registry.client.ngc;
 
-import com.nvidia.boot.registries.service.registry.client.WebClientUtils;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.head;
+import static com.github.tomakehurst.wiremock.client.WireMock.headRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.nvidia.boot.mock.BootTestConstants.TEST_VALID_CONTAINER_HASH;
 import static com.nvidia.boot.mock.BootTestConstants.TEST_VALID_CONTAINER_NAME;
 import static com.nvidia.boot.mock.BootTestConstants.TEST_VALID_CONTAINER_TAG;
 import static com.nvidia.boot.mock.BootTestConstants.TEST_VALID_ORG_NAME;
+import static com.nvidia.boot.mock.ngc.MockNgcContainerRegistryServer.MOCK_BEARER_TOKEN;
+import static com.nvidia.boot.mock.ngc.MockNgcContainerRegistryServer.MOCK_INVALID_REGISTRY_CRED;
+import static com.nvidia.boot.mock.ngc.MockNgcContainerRegistryServer.MOCK_TOKEN_ENDPOINT_URL;
+import static com.nvidia.boot.mock.ngc.MockNgcContainerRegistryServer.V2_PING_URL;
 import static com.nvidia.boot.registries.service.registry.client.ngc.NgcContainerRegistryClient.parseContainerImageUrl;
 import static com.nvidia.boot.registries.util.TestConstants.MOCK_NGC_CONTAINER_REGISTRY_CRED;
 import static com.nvidia.boot.registries.util.TestConstants.MOCK_NGC_CONTAINER_REGISTRY_URL;
@@ -39,14 +50,22 @@ import static com.nvidia.boot.registries.util.TestConstants.TEST_NGC_CONTAINER_I
 import static com.nvidia.boot.registries.util.TestConstants.TEST_NGC_CONTAINER_IMAGE_WITH_DIGEST;
 import static com.nvidia.boot.registries.util.TestConstants.TEST_NGC_CONTAINER_IMAGE_WITH_INVALID_TAG;
 import static com.nvidia.boot.registries.util.TestConstants.TEST_NGC_CONTAINER_REGISTRY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.nvidia.boot.exceptions.BadRequestException;
 import com.nvidia.boot.exceptions.ForbiddenException;
 import com.nvidia.boot.exceptions.NotFoundException;
+import com.nvidia.boot.exceptions.UnauthorizedException;
+import com.nvidia.boot.exceptions.UpstreamException;
 import com.nvidia.boot.mock.ngc.MockNgcContainerRegistryServer;
+import com.nvidia.boot.registries.service.registry.client.WebClientUtils;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -55,10 +74,22 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
 
 class NgcContainerRegistryClientTest {
+
+    private static final String TEST_IMAGE_SCOPE =
+            "repository:" + TEST_VALID_ORG_NAME + "/" + TEST_VALID_CONTAINER_NAME + ":pull";
+    private static final String TEST_IMAGE_MANIFEST_PATH =
+            "/v2/" + TEST_VALID_ORG_NAME + "/" + TEST_VALID_CONTAINER_NAME + "/manifests/"
+                    + TEST_VALID_CONTAINER_TAG;
+    private static final String EXPIRY_SCENARIO = "token expiry";
+    private static final String TOKEN_REFRESHED_STATE = "token refreshed";
+
     private static NgcContainerRegistryClient ngcContainerRegistryClient;
 
     @BeforeAll
@@ -121,13 +152,18 @@ class NgcContainerRegistryClientTest {
         assertEquals(digest, components.digest());
     }
 
-    @MethodSource("createValidImageUrl")
+    static Stream<Arguments> createResolvableImageUrl() {
+        return Stream.of(Arguments.of(TEST_NGC_CONTAINER_IMAGE.toString()),
+                         Arguments.of(TEST_NGC_CONTAINER_IMAGE_WITH_DIGEST.toString()));
+    }
+
+    @MethodSource("createResolvableImageUrl")
     @ParameterizedTest
     void validateContainerImage_Success(String containerUrl) {
-        if (containerUrl.startsWith("stg.nvcr.io")) {
-            ngcContainerRegistryClient.validateContainerImage(containerUrl,
-                                                              MOCK_NGC_CONTAINER_REGISTRY_CRED);
-        }
+        ngcContainerRegistryClient.validateContainerImage(containerUrl,
+                                                          MOCK_NGC_CONTAINER_REGISTRY_CRED);
+
+        verifyTokenRequests(1, TEST_IMAGE_SCOPE);
     }
 
     @Test
@@ -161,16 +197,13 @@ class NgcContainerRegistryClientTest {
     void validateContainerImage_CachesBearerToken_Success() {
         String containerUrl = TEST_NGC_CONTAINER_IMAGE.toString();
         String apiKey = MOCK_NGC_CONTAINER_REGISTRY_CRED;
-        String targetUrl =
-                "/proxy_auth?account=%24oauthtoken&scope=repository%3Awhw3rcpsilnj%2Ftest-container-image%3Apull";
+
         ngcContainerRegistryClient.validateContainerImage(containerUrl, apiKey);
-        MockNgcContainerRegistryServer.getNgcContainerRegistryMockServer().
-                verify(1, getRequestedFor(urlEqualTo(targetUrl)));
+        verifyTokenRequests(1, TEST_IMAGE_SCOPE);
 
         ngcContainerRegistryClient.validateContainerImage(containerUrl, apiKey);
         // Should use cached authentication token without additional API call
-        MockNgcContainerRegistryServer.getNgcContainerRegistryMockServer().
-                verify(1, getRequestedFor(urlEqualTo(targetUrl)));
+        verifyTokenRequests(1, TEST_IMAGE_SCOPE);
     }
 
     @Test
@@ -178,16 +211,12 @@ class NgcContainerRegistryClientTest {
         String containerUrl = TEST_NGC_CONTAINER_IMAGE.toString();
         String apiKey1 = MOCK_NGC_CONTAINER_REGISTRY_CRED;
         String apiKey2 = "different-" + MOCK_NGC_CONTAINER_REGISTRY_CRED;
-        String targetUrl =
-                "/proxy_auth?account=%24oauthtoken&scope=repository%3Awhw3rcpsilnj%2Ftest-container-image%3Apull";
-        ngcContainerRegistryClient.validateContainerImage(containerUrl, apiKey1);
-        MockNgcContainerRegistryServer.getNgcContainerRegistryMockServer().
-                verify(1, getRequestedFor(urlEqualTo(targetUrl)));
-        ngcContainerRegistryClient.validateContainerImage(containerUrl,
-                                                          apiKey2);
-        MockNgcContainerRegistryServer.getNgcContainerRegistryMockServer().
-                verify(2, getRequestedFor(urlEqualTo(targetUrl)));
 
+        ngcContainerRegistryClient.validateContainerImage(containerUrl, apiKey1);
+        verifyTokenRequests(1, TEST_IMAGE_SCOPE);
+
+        ngcContainerRegistryClient.validateContainerImage(containerUrl, apiKey2);
+        verifyTokenRequests(2, TEST_IMAGE_SCOPE);
     }
 
     @Test
@@ -195,16 +224,13 @@ class NgcContainerRegistryClientTest {
         String containerUrl1 = TEST_NGC_CONTAINER_IMAGE.toString();
         String containerUrl2 = TEST_NGC_CONTAINER_IMAGE_WITH_DIGEST.toString();
         String apiKey = MOCK_NGC_CONTAINER_REGISTRY_CRED;
-        String targetUrl =
-                "/proxy_auth?account=%24oauthtoken&scope=repository%3Awhw3rcpsilnj%2Ftest-container-image%3Apull";
 
         ngcContainerRegistryClient.validateContainerImage(containerUrl1, apiKey);
-        MockNgcContainerRegistryServer.getNgcContainerRegistryMockServer().
-                verify(1, getRequestedFor(urlEqualTo(targetUrl)));
+        verifyTokenRequests(1, TEST_IMAGE_SCOPE);
 
+        // Tag and digest address the same repository, so they share one token.
         ngcContainerRegistryClient.validateContainerImage(containerUrl2, apiKey);
-        MockNgcContainerRegistryServer.getNgcContainerRegistryMockServer().
-                verify(1, getRequestedFor(urlEqualTo(targetUrl)));
+        verifyTokenRequests(1, TEST_IMAGE_SCOPE);
     }
 
     @Test
@@ -212,20 +238,16 @@ class NgcContainerRegistryClientTest {
         String containerUrl1 = TEST_NGC_CONTAINER_IMAGE.toString();
         String containerUrl2 = TEST_NGC_CONTAINER_IMAGE_2.toString();
         String apiKey = MOCK_NGC_CONTAINER_REGISTRY_CRED;
-        String targetUrl1 =
-                "/proxy_auth?account=%24oauthtoken&scope=repository%3Awhw3rcpsilnj%2Ftest-container-image%3Apull";
-        ngcContainerRegistryClient.validateContainerImage(containerUrl1, apiKey);
-        MockNgcContainerRegistryServer.getNgcContainerRegistryMockServer().
-                verify(1, getRequestedFor(urlEqualTo(targetUrl1)));
+        String otherImageScope =
+                "repository:" + TEST_VALID_ORG_NAME + "/" + TEST_VALID_CONTAINER_NAME + "-2:pull";
 
-        String targetUrl2 =
-                "/proxy_auth?account=%24oauthtoken&scope=repository%3Awhw3rcpsilnj%2Ftest-container-image-2%3Apull";
+        ngcContainerRegistryClient.validateContainerImage(containerUrl1, apiKey);
+        verifyTokenRequests(1, TEST_IMAGE_SCOPE);
+
         assertThrows(NotFoundException.class, () ->
                 ngcContainerRegistryClient.validateContainerImage(containerUrl2, apiKey));
-        MockNgcContainerRegistryServer.getNgcContainerRegistryMockServer().
-                verify(1, getRequestedFor(urlEqualTo(targetUrl1)));
-        MockNgcContainerRegistryServer.getNgcContainerRegistryMockServer().
-                verify(1, getRequestedFor(urlEqualTo(targetUrl2)));
+        verifyTokenRequests(1, TEST_IMAGE_SCOPE);
+        verifyTokenRequests(1, otherImageScope);
     }
 
     @Test
@@ -233,21 +255,152 @@ class NgcContainerRegistryClientTest {
         String containerUrl1 = TEST_NGC_CONTAINER_IMAGE.toString();
         String containerUrl2 = TEST_NGC_CONTAINER_IMAGE_UNKNOWN_ORG.toString();
         String apiKey = MOCK_NGC_CONTAINER_REGISTRY_CRED;
+        String otherOrgScope =
+                "repository:someone-org/" + TEST_VALID_CONTAINER_NAME + ":pull";
 
-        String targetUrl1 =
-                "/proxy_auth?account=%24oauthtoken&scope=repository%3Awhw3rcpsilnj%2Ftest-container-image%3Apull";
         ngcContainerRegistryClient.validateContainerImage(containerUrl1, apiKey);
-        MockNgcContainerRegistryServer.getNgcContainerRegistryMockServer().
-                verify(1, getRequestedFor(urlEqualTo(targetUrl1)));
+        verifyTokenRequests(1, TEST_IMAGE_SCOPE);
 
-        String targetUrl2 =
-                "/proxy_auth?account=%24oauthtoken&scope=repository%3Asomeone-org%2Ftest-container-image%3Apull";
         assertThrows(NotFoundException.class, () ->
                 ngcContainerRegistryClient.validateContainerImage(containerUrl2, apiKey));
-        MockNgcContainerRegistryServer.getNgcContainerRegistryMockServer().
-                verify(1, getRequestedFor(urlEqualTo(targetUrl1)));
-        MockNgcContainerRegistryServer.getNgcContainerRegistryMockServer().
-                verify(1, getRequestedFor(urlEqualTo(targetUrl2)));
+        verifyTokenRequests(1, TEST_IMAGE_SCOPE);
+        verifyTokenRequests(1, otherOrgScope);
+    }
+
+    @Test
+    void validateContainerImage_StaleToken_FailsUntilCacheEvicted() {
+        String containerUrl = TEST_NGC_CONTAINER_IMAGE.toString();
+        String apiKey = MOCK_NGC_CONTAINER_REGISTRY_CRED;
+        ngcContainerRegistryClient.validateContainerImage(containerUrl, apiKey);
+        verifyTokenRequests(1, TEST_IMAGE_SCOPE);
+
+        // The cached token is now rejected, as it would be after out-of-band invalidation.
+        var stale = mockServer().stubFor(
+                head(urlPathEqualTo(TEST_IMAGE_MANIFEST_PATH))
+                        .withHeader(HttpHeaders.AUTHORIZATION, matching(".+"))
+                        .atPriority(1)
+                        .inScenario(EXPIRY_SCENARIO)
+                        .whenScenarioStateIs(Scenario.STARTED)
+                        .willSetStateTo(TOKEN_REFRESHED_STATE)
+                        .willReturn(aResponse().withStatus(401)
+                                            .withHeader(HttpHeaders.WWW_AUTHENTICATE,
+                                                        challengeFor(TEST_IMAGE_SCOPE))));
+        var refreshed = mockServer().stubFor(
+                head(urlPathEqualTo(TEST_IMAGE_MANIFEST_PATH))
+                        .withHeader(HttpHeaders.AUTHORIZATION, matching(".+"))
+                        .atPriority(1)
+                        .inScenario(EXPIRY_SCENARIO)
+                        .whenScenarioStateIs(TOKEN_REFRESHED_STATE)
+                        .willReturn(aResponse().withStatus(200)));
+        withTemporaryStubs(() -> {
+            // No retry: a live cached token the registry rejects fails the call outright.
+            assertThatThrownBy(() -> ngcContainerRegistryClient.validateContainerImage(
+                    containerUrl, apiKey))
+                    .isInstanceOf(UnauthorizedException.class);
+            verifyTokenRequests(1, TEST_IMAGE_SCOPE);
+
+            // Eviction (forced here; the TTL in production) rediscovers and recovers.
+            ngcContainerRegistryClient.resetAuthTokenCache();
+            ngcContainerRegistryClient.validateContainerImage(containerUrl, apiKey);
+            verifyTokenRequests(2, TEST_IMAGE_SCOPE);
+        }, stale, refreshed);
+    }
+
+    @Test
+    void validateContainerImage_TokenRejected_FailsWithoutRetry() {
+        var alwaysRejects = mockServer().stubFor(
+                head(urlPathEqualTo(TEST_IMAGE_MANIFEST_PATH))
+                        .atPriority(1)
+                        .willReturn(aResponse().withStatus(401)
+                                            .withHeader(HttpHeaders.WWW_AUTHENTICATE,
+                                                        challengeFor(TEST_IMAGE_SCOPE))));
+        withTemporaryStubs(() -> {
+            assertThatThrownBy(() -> ngcContainerRegistryClient.validateContainerImage(
+                    TEST_NGC_CONTAINER_IMAGE.toString(), MOCK_NGC_CONTAINER_REGISTRY_CRED))
+                    .isInstanceOf(UnauthorizedException.class);
+
+            // One discovery, one token fetch, one authorized attempt - no re-challenge loop.
+            verifyTokenRequests(1, TEST_IMAGE_SCOPE);
+            mockServer().verify(2, headRequestedFor(urlPathEqualTo(TEST_IMAGE_MANIFEST_PATH)));
+        }, alwaysRejects);
+    }
+
+    /**
+     * NGC requires a credential for every pull, so validation must never pass without
+     * exercising the supplied one: a probe answer that skips the challenge - success and
+     * redirect alike - leaves the credential unverified and is an upstream error, mirroring
+     * {@code validateCredential}.
+     */
+    @ParameterizedTest
+    @ValueSource(ints = { 200, 302 })
+    void validateContainerImage_ProbeDoesNotChallenge_Fail(int probeStatus) {
+        var noChallenge = mockServer().stubFor(
+                head(urlPathEqualTo(TEST_IMAGE_MANIFEST_PATH))
+                        .withHeader(HttpHeaders.AUTHORIZATION, absent())
+                        .atPriority(1)
+                        .willReturn(aResponse().withStatus(probeStatus)));
+        withTemporaryStubs(() -> {
+            assertThatThrownBy(() -> ngcContainerRegistryClient.validateContainerImage(
+                    TEST_NGC_CONTAINER_IMAGE.toString(), MOCK_NGC_CONTAINER_REGISTRY_CRED))
+                    .isInstanceOf(UpstreamException.class);
+
+            mockServer().verify(0, getRequestedFor(urlPathEqualTo(MOCK_TOKEN_ENDPOINT_URL)));
+        }, noChallenge);
+    }
+
+    @Test
+    void validateContainerImage_ProbeForbidden_Fail() {
+        // A probe 4xx maps through the standard handlers; widening the probe client's 401
+        // pass-through to other statuses would break exactly here.
+        var forbidden = mockServer().stubFor(
+                head(urlPathEqualTo(TEST_IMAGE_MANIFEST_PATH))
+                        .withHeader(HttpHeaders.AUTHORIZATION, absent())
+                        .atPriority(1)
+                        .willReturn(aResponse().withStatus(403)));
+        withTemporaryStubs(() -> {
+            assertThatThrownBy(() -> ngcContainerRegistryClient.validateContainerImage(
+                    TEST_NGC_CONTAINER_IMAGE.toString(), MOCK_NGC_CONTAINER_REGISTRY_CRED))
+                    .isInstanceOf(ForbiddenException.class);
+
+            mockServer().verify(0, getRequestedFor(urlPathEqualTo(MOCK_TOKEN_ENDPOINT_URL)));
+        }, forbidden);
+    }
+
+    @Test
+    void validateContainerImage_RejectedByTokenEndpoint_Fail() {
+        assertThatThrownBy(() -> ngcContainerRegistryClient.validateContainerImage(
+                TEST_NGC_CONTAINER_IMAGE.toString(), MOCK_INVALID_REGISTRY_CRED))
+                .isInstanceOf(UnauthorizedException.class);
+    }
+
+    @Test
+    void validateContainerImage_UnauthorizedWithoutChallenge_Fail() {
+        // The probe carries no credential, so a 401 without a Bearer challenge cannot mean the
+        // credential was rejected - it is the registry speaking broken protocol, an upstream
+        // failure just like not challenging at all.
+        var noChallenge = mockServer().stubFor(
+                head(urlPathEqualTo(TEST_IMAGE_MANIFEST_PATH))
+                        .withHeader(HttpHeaders.AUTHORIZATION, absent())
+                        .atPriority(1)
+                        .willReturn(aResponse().withStatus(401)));
+        withTemporaryStubs(() -> {
+            assertThatThrownBy(() -> ngcContainerRegistryClient.validateContainerImage(
+                    TEST_NGC_CONTAINER_IMAGE.toString(), MOCK_NGC_CONTAINER_REGISTRY_CRED))
+                    .isInstanceOf(UpstreamException.class);
+
+            mockServer().verify(0, getRequestedFor(urlPathEqualTo(MOCK_TOKEN_ENDPOINT_URL)));
+        }, noChallenge);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "   " })
+    void validateContainerImage_BlankSecret_FailsWithoutCallingRegistry(String blankSecret) {
+        assertThatThrownBy(() -> ngcContainerRegistryClient.validateContainerImage(
+                TEST_NGC_CONTAINER_IMAGE.toString(), blankSecret))
+                .isInstanceOf(BadRequestException.class);
+
+        mockServer().verify(0, headRequestedFor(urlPathEqualTo(TEST_IMAGE_MANIFEST_PATH)));
     }
 
     @ParameterizedTest
@@ -268,11 +421,157 @@ class NgcContainerRegistryClientTest {
 
     @Test
     void validateCredential_Success() {
-        String registryHost = TEST_NGC_CONTAINER_REGISTRY;
-        String apiKey = MOCK_NGC_CONTAINER_REGISTRY_CRED;
+        String token = ngcContainerRegistryClient.validateCredential(
+                TEST_NGC_CONTAINER_REGISTRY, MOCK_NGC_CONTAINER_REGISTRY_CRED);
 
-        String token = ngcContainerRegistryClient.validateCredential(registryHost, apiKey);
-        assertNotNull(token);
-        assertEquals("mockBearerToken", token);
+        assertThat(token).isEqualTo(MOCK_BEARER_TOKEN);
+        // The token endpoint is discovered from the challenge, and the /v2/ challenge advertises
+        // an empty scope, so the token request carries no query parameters at all.
+        mockServer().verify(1, getRequestedFor(urlEqualTo(V2_PING_URL)));
+        mockServer().verify(1, getRequestedFor(urlEqualTo(MOCK_TOKEN_ENDPOINT_URL)));
+    }
+
+    @Test
+    void validateCredential_CalledRepeatedly_IsNotCached() {
+        ngcContainerRegistryClient.validateCredential(
+                TEST_NGC_CONTAINER_REGISTRY, MOCK_NGC_CONTAINER_REGISTRY_CRED);
+        ngcContainerRegistryClient.validateCredential(
+                TEST_NGC_CONTAINER_REGISTRY, MOCK_NGC_CONTAINER_REGISTRY_CRED);
+
+        mockServer().verify(2, getRequestedFor(urlEqualTo(MOCK_TOKEN_ENDPOINT_URL)));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "   " })
+    void validateCredential_BlankSecret_FailsWithoutCallingRegistry(String blankSecret) {
+        assertThatThrownBy(() -> ngcContainerRegistryClient.validateCredential(
+                TEST_NGC_CONTAINER_REGISTRY, blankSecret))
+                .isInstanceOf(BadRequestException.class);
+
+        mockServer().verify(0, getRequestedFor(urlEqualTo(V2_PING_URL)));
+    }
+
+    @Test
+    void validateCredential_RejectedByTokenEndpoint_Fail() {
+        assertThatThrownBy(() -> ngcContainerRegistryClient.validateCredential(
+                TEST_NGC_CONTAINER_REGISTRY, MOCK_INVALID_REGISTRY_CRED))
+                .isInstanceOf(UnauthorizedException.class);
+    }
+
+    @Test
+    void validateCredential_BlankTokenInResponse_Fail() {
+        // A 200 carrying no token proves nothing about the credential.
+        var blankToken = mockServer().stubFor(
+                get(urlPathEqualTo(MOCK_TOKEN_ENDPOINT_URL))
+                        .atPriority(1)
+                        .willReturn(aResponse().withStatus(200)
+                                            .withHeader(HttpHeaders.CONTENT_TYPE,
+                                                        MediaType.APPLICATION_JSON_VALUE)
+                                            .withBody("{\"expires_in\": 3600}")));
+        withTemporaryStubs(() -> {
+            assertThatThrownBy(() -> ngcContainerRegistryClient.validateCredential(
+                    TEST_NGC_CONTAINER_REGISTRY, MOCK_NGC_CONTAINER_REGISTRY_CRED))
+                    .isInstanceOf(UnauthorizedException.class);
+        }, blankToken);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "Basic realm=\"basic-zone\"", "" })
+    void validateCredential_UnusableChallengeOnProbe_Fail(String wwwAuthenticate) {
+        // A 401 whose WWW-Authenticate carries no usable Bearer challenge is the registry
+        // speaking broken protocol, not a credential rejection - the probe sent no credential.
+        var unusableChallenge = mockServer().stubFor(
+                get(urlPathEqualTo(V2_PING_URL))
+                        .atPriority(1)
+                        .willReturn(aResponse().withStatus(401)
+                                            .withHeader(HttpHeaders.WWW_AUTHENTICATE,
+                                                        wwwAuthenticate)));
+        withTemporaryStubs(() -> {
+            assertThatThrownBy(() -> ngcContainerRegistryClient.validateCredential(
+                    TEST_NGC_CONTAINER_REGISTRY, MOCK_NGC_CONTAINER_REGISTRY_CRED))
+                    .isInstanceOf(UpstreamException.class);
+
+            mockServer().verify(0, getRequestedFor(urlPathEqualTo(MOCK_TOKEN_ENDPOINT_URL)));
+        }, unusableChallenge);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "{oops}", "100%" })
+    void validateCredential_UnusableRealmInChallenge_Fail(String realm) {
+        // A challenge whose realm cannot form a URL is the registry speaking broken protocol.
+        var badRealm = mockServer().stubFor(
+                get(urlPathEqualTo(V2_PING_URL))
+                        .atPriority(1)
+                        .willReturn(aResponse().withStatus(401)
+                                            .withHeader(HttpHeaders.WWW_AUTHENTICATE,
+                                                        "Bearer realm=\"%s\"".formatted(realm))));
+        withTemporaryStubs(() -> {
+            assertThatThrownBy(() -> ngcContainerRegistryClient.validateCredential(
+                    TEST_NGC_CONTAINER_REGISTRY, MOCK_NGC_CONTAINER_REGISTRY_CRED))
+                    .isInstanceOf(UpstreamException.class);
+        }, badRealm);
+    }
+
+    @Test
+    void validateCredential_TokenEndpointServerError_Fail() {
+        var serverError = mockServer().stubFor(
+                get(urlPathEqualTo(MOCK_TOKEN_ENDPOINT_URL))
+                        .atPriority(1)
+                        .willReturn(aResponse().withStatus(500)));
+        withTemporaryStubs(() -> {
+            assertThatThrownBy(() -> ngcContainerRegistryClient.validateCredential(
+                    TEST_NGC_CONTAINER_REGISTRY, MOCK_NGC_CONTAINER_REGISTRY_CRED))
+                    .isInstanceOf(UpstreamException.class);
+        }, serverError);
+    }
+
+    @Test
+    void validateCredential_RegistryDoesNotChallenge_Fail() {
+        // Without a challenge there is nothing to authenticate against, so the credential is
+        // unproven - reporting success would be a false positive.
+        var noChallenge = mockServer().stubFor(get(urlPathEqualTo(V2_PING_URL))
+                                                       .atPriority(1)
+                                                       .willReturn(aResponse().withStatus(200)));
+        withTemporaryStubs(() -> {
+            assertThatThrownBy(() -> ngcContainerRegistryClient.validateCredential(
+                    TEST_NGC_CONTAINER_REGISTRY, MOCK_NGC_CONTAINER_REGISTRY_CRED))
+                    .isInstanceOf(UpstreamException.class);
+        }, noChallenge);
+    }
+
+    private static WireMockServer mockServer() {
+        return MockNgcContainerRegistryServer.getNgcContainerRegistryMockServer();
+    }
+
+    /**
+     * Runs a test body against stubs that exist only for that body, then removes them and
+     * resets scenario state so no test leaks fixtures into the next.
+     */
+    private static void withTemporaryStubs(Runnable body, StubMapping... stubs) {
+        try {
+            body.run();
+        } finally {
+            for (var stub : stubs) {
+                mockServer().removeStub(stub);
+            }
+            mockServer().resetScenarios();
+        }
+    }
+
+    /**
+     * Counts token requests by the scope the challenge advertised, which is what partitions the
+     * token cache. Matching on the decoded query parameter keeps the assertion independent of
+     * how the scope happens to be percent-encoded on the wire.
+     */
+    private static void verifyTokenRequests(int expectedCount, String scope) {
+        mockServer().verify(expectedCount,
+                            getRequestedFor(urlPathEqualTo(MOCK_TOKEN_ENDPOINT_URL))
+                                    .withQueryParam("scope", equalTo(scope)));
+    }
+
+    private static String challengeFor(String scope) {
+        return "Bearer realm=\"%s%s\",scope=\"%s\""
+                .formatted(MOCK_NGC_CONTAINER_REGISTRY_URL, MOCK_TOKEN_ENDPOINT_URL, scope);
     }
 }


### PR DESCRIPTION
## TL;DR
Migrate `NgcContainerRegistryClient.validateContainerImage` and `validateCredential` off the
deprecated hardcoded `GET /proxy_auth` token exchange onto standard Docker Registry v2
`WWW-Authenticate` challenge discovery. The token endpoint is read from the registry's 401
challenge at runtime, so when NGC moves the token realm the client follows with no code or
config change. Ports an internally reviewed and merged change to this snapshot.

## Additional Details
- Image validation is token-first: a cached token means one authorized `HEAD` of the manifest;
  on a cache miss the client probes the manifest unauthenticated, parses the Bearer challenge
  off the 401, and redeems the credential at the advertised realm with Basic auth, replaying
  exactly the non-empty params the challenge carried. `validateCredential` triggers its
  challenge with `GET /v2/` (OCI distribution spec end-1) and is never cached.
- NGC requires a credential for every pull, so any probe answer without a usable challenge
  (2xx/3xx, missing or malformed Bearer challenge, unusable realm) raises `UpstreamException`:
  validation never passes without exercising the credential. Blank credentials fail fast with
  `BadRequestException` and zero HTTP calls.
- New classes are confined to the `ngc` package: `AuthenticateChallengeUtils` (RFC 7235 Bearer
  challenge parser), `dto/WwwAuthenticateChallenge`, and `NgcChallengeProbeStub` (a dedicated
  probe WebClient that passes only 401 through so the challenge headers stay readable).
- `WebClientUtils.createWebClient` now clones the injected builder internally in both
  overloads, so call sites no longer clone it themselves.
- `MockNgcContainerRegistryServer` fixtures flip to the challenge flow atomically with the
  client. The mock advertises its realm on a resolvable host, so downstream suites that use
  unique `localhost-<registry-key>` hostnames keep working unchanged.
- Deliberate contract changes: invalid credential or a token response without a token now
  raise `UnauthorizedException` (was `ForbiddenException`); manifest validation uses `HEAD`
  (was `GET`); image cold path is 3 calls (was 2) and `validateCredential` is 2 calls (was 1);
  the legacy `account=$oauthtoken` query param is gone. Public client API is unchanged.

## For the Reviewer
- `NgcContainerRegistryClient` carries the flow; `AuthenticateChallengeUtils` is the parser.
- The probe status-handler ordering in the client constructor (401 pass-through registered
  before the standard handlers) is load-bearing; see the comment there.

## For QA
- `bazel test //src/libraries/java/nv-boot-parent/... --test_tag_filters=-requires-docker`
  passes: 33 new parser tests, 44 client tests (cache partitioning by token-endpoint request
  counts, stale-token/no-retry, probe-without-challenge, unusable-challenge/realm, blank-secret
  and blank-token defenses), all other registry suites unchanged.
- Consumers (cloud-functions, cloud-tasks, and the managed NVCF/NVCT API services) pick this
  up on their next library bump; staging validation of both flows against the live registry is
  planned before rollout.

## Issues
https://github.com/NVIDIA/nvcf/issues/556

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for NGC-style bearer authentication challenge and token discovery.
  * Improved container image and credential validation, including manifest existence checks.
  * Added token reuse and refreshed-token handling for repeated registry requests.

* **Bug Fixes**
  * Improved handling of unauthorized, forbidden, missing, and invalid registry responses.
  * Added robust parsing for varied `WWW-Authenticate` headers.
  * Prevented repeated WebClient configuration from accumulating across requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->