### PR TITLE
chore(deploy): pin nvcf-api to 1.23.9 and nvct-api to 1.4.3 in self-m…

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -56,16 +56,16 @@ releases:
       - template: service
 
   - name: api
-    version: 1.23.10
+    version: 1.23.9
     namespace: nvcf
     inherit:
       - template: service
     needs:
       # not needed to start, but needed for bootstrapping account which is done with a script in the api helm chart
       - ess/ess-api
-                      
+
   - name: nvct-api
-    version: 1.4.4
+    version: 1.4.3
     namespace: nvcf
     inherit:
       - template: service


### PR DESCRIPTION
## TL;DR

Pins `nvcf-api` back to `1.23.9` and `nvct-api` back to `1.4.3` in the
self-managed stack. The newer chart versions (`1.23.10` and `1.4.4`) require 
DB schema migration that has not yet been applied to the self-managed
environment.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

The migration must land in the self-managed stack before these charts can be
bumped forward again.

## For the Reviewer

Single file change in `deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl`.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

Deploy the self-managed stack with the pinned versions to confirm
it comes up cleanly.

## Issues

NO-REF

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
