### PR TITLE
feat(release): register the Java services for tagging

### DIFF
--- a/tools/ci/github-release-subprojects.json
+++ b/tools/ci/github-release-subprojects.json
@@ -242,6 +242,21 @@
       "path": "src/compute-plane-services/worker-task",
       "service_name": "nvcf-worker-task",
       "legacy_tag_prefix": "nvcf-worker-task-v"
+    },
+    {
+      "id": "cloud-tasks",
+      "path": "src/control-plane-services/cloud-tasks",
+      "service_name": "nvcf-cloud-tasks"
+    },
+    {
+      "id": "notary",
+      "path": "src/control-plane-services/notary",
+      "service_name": "nvcf-notary"
+    },
+    {
+      "id": "api-keys",
+      "path": "src/control-plane-services/api-keys",
+      "service_name": "nvcf-api-keys"
     }
   ]
 }


### PR DESCRIPTION
## Why

cloud-tasks, notary and api-keys build multi-arch images in CI and now have
publish destinations wired in nvcf-internal, but nothing ever cut a tag for
them. They were absent from `tools/ci/github-release-subprojects.json`, so no
tag was created, no GitHub Release existed, nothing dispatched, and the publish
config could not fire.

The registry is normally generated by `tools/generate-subproject-ci` from
`tools/ci/subproject-validations.yaml`. Neither that generator nor its config
exists in this repository -- both live in the GitLab umbrella, whose default
branch is now protected against push and merge by everyone. The generated file
is therefore edited directly here, as with other mirror-only files.

## Version continuity

This is the part that needed care rather than three new rows.

Each service has an established version line in its own upstream project:

| service | upstream project | latest |
|---|---|---|
| cloud-tasks | `nvcf/nvct/nvct-service` | v1.62.2 |
| notary | `nvcf/nvcf-notary/notary-service` | 1.12.0 |
| api-keys | `nvcf/nvcf-api-keys/api-keys-service` | 1.6.0 |

None of those tags is in this repository. `synthesize_initial_version_anchor`
creates an anchor at `INITIAL_RELEASE_FLOOR_VERSION` (0.0.0) for a registered
service with no tags, so registering these alone would have made the first
release `0.1.0` and moved versions backwards for anyone pinning the upstream
line. That is a silent failure: the release succeeds and the number is simply
wrong.

Anchor tags at the current upstream versions were pushed ahead of this change:

    src/control-plane-services/cloud-tasks/v1.62.2
    src/control-plane-services/notary/v1.12.0
    src/control-plane-services/api-keys/v1.6.0

The ordering is deliberate and load-bearing. `release-tags.yml` triggers on
`**/v*`, so those pushes did run the tag workflow -- but while a service is
unregistered `parse_release_tag` cannot match its tags, and the code takes the
`is not a supported release tag; skipping` path. The anchors landed as plain
tags with no GitHub Release and no build, which I verified against the releases
API afterwards. Registering first and anchoring second would have created a
Release for a version that was never built.

`legacy_tag_prefix` is intentionally unset. It selects older tags within this
repository; these services have none, and their history is carried by the
anchors.

## What changed

Three entries in `tools/ci/github-release-subprojects.json`. `id` matches the
`service_id` in the nvcf-internal release config so the dispatch resolves, and
`path` yields the tag prefix via `default_tag_format`.

## Testing

`python3 tools/ci/test-github-release.py` passes (7 tests). Those tests only
constrain services with `dev_prerelease`, which these are not, so they do not
cover the new rows directly.

Verified by loading `github-release` and resolving each new entry against the
pushed anchors:

    cloud-tasks   prefix=src/control-plane-services/cloud-tasks/v   -> 1.62.2
    notary        prefix=src/control-plane-services/notary/v        -> 1.12.0
    api-keys      prefix=src/control-plane-services/api-keys/v      -> 1.6.0

Each resolves to its real upstream version rather than falling through to the
0.0.0 floor, which is the specific regression this guards against.

## Usage

After merge, the next conventional commit touching each subtree cuts
v1.62.3 / 1.12.1 / 1.6.1, creates a Release, dispatches to nvcf-internal, and
publishes to ncp-dev and kaze.

## Notes

The first release for each service is also the first exercise of `subtree: "."`
in the nvcf-internal release backend, since these build from the root module.
Worth watching rather than assuming.

api-keys is the one to reconsider before its first tag: it has an existing
`api-keys-colocated` chart and is widely referenced in nvcf-internal, so it may
already publish an image through another route.

## References

None

## Related Merge Requests/Pull Requests

Paired with the nvcf-internal MR adding the publish destinations.

## Dependencies

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Cloud Tasks, Notary, and API Keys to the automated release configuration.
  * These subprojects can now be included in GitHub release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->