### PR TITLE
feat(nvsnap): make pod networking a supported mode for the agent

### DIFF
--- a/src/compute-plane-services/nvsnap/cmd/agent/main.go
+++ b/src/compute-plane-services/nvsnap/cmd/agent/main.go
@@ -71,6 +71,8 @@ func main() {
 		"NvSnap-server base URL for peer-fanout catalog lookups (e.g. http://nvsnap-server.nvsnap-system.svc.cluster.local:8080). Empty disables cross-node cascade.")
 	flag.StringVar(&config.NodeIP, "node-ip", os.Getenv("HOST_IP"),
 		"This agent's reachable address from peers (downward API status.hostIP when hostNetwork:true). Empty disables peer registration.")
+	flag.StringVar(&config.AdvertiseIP, "advertise-ip", os.Getenv("POD_IP"),
+		"Address peers dial to reach this agent (downward API status.podIP; equals the node IP under hostNetwork). Falls back to --node-ip when empty. See GH #490.")
 	flag.StringVar(&config.BlobStoreURL, "blob-store-url", os.Getenv("NVSNAP_BLOB_STORE_URL"),
 		"NvSnap-blobstore base URL for Phase 5d.2 durable backstop (e.g. http://nvsnap-blobstore.nvsnap-system.svc.cluster.local:9000). Empty disables capture-side upload AND cascade tier-3 fallback.")
 	// Cross-cluster replication (docs/design/cross-cluster-replication.md).
@@ -188,6 +190,8 @@ func main() {
 		"Strategy for restore-side overlay mount prep: inline (do mounts during admission, default) or init-container (delegate to nvsnap-mount-prep init container on the restored pod)")
 	flag.StringVar(&config.Webhook.MountPrepInitImage, "webhook-mount-prep-init-image", "",
 		"Image ref for the nvsnap-mount-prep init container injected when --webhook-restore-prep-strategy=init-container. Must contain /nvsnap-mount-prep (the agent image satisfies this).")
+	flag.StringVar(&config.Webhook.AgentBaseURL, "webhook-agent-base-url", os.Getenv("NVSNAP_WEBHOOK_AGENT_BASE_URL"),
+		"Base URL the injected nvsnap-mount-prep init container uses to reach its node-local agent. Empty uses http://$(NVSNAP_HOST_IP):<port>, which requires hostPort. Set to the internalTrafficPolicy:Local Service under pod networking. See GH #490.")
 	flag.IntVar(&config.Webhook.AgentHostPort, "webhook-agent-host-port", 8081,
 		"Port the nvsnap-mount-prep init container reaches the agent on (matches --listen and the agent DaemonSet's hostPort).")
 

--- a/src/compute-plane-services/nvsnap/deploy/helm/nvsnap/templates/agent-daemonset.yaml
+++ b/src/compute-plane-services/nvsnap/deploy/helm/nvsnap/templates/agent-daemonset.yaml
@@ -42,9 +42,9 @@ spec:
         {{- toYaml .Values.agent.tolerations | nindent 8 }}
       hostPID: {{ .Values.agent.hostPID }}
       hostNetwork: {{ .Values.agent.hostNetwork }}
-      # ClusterFirstWithHostNet so Service DNS still resolves under
-      # hostNetwork (nvsnap-server.<ns>.svc, nvsnap-blobstore.<ns>.svc).
-      dnsPolicy: ClusterFirstWithHostNet
+      # ClusterFirstWithHostNet is only correct under hostNetwork; with pod
+      # networking it is wrong (it points resolution at the node's resolv.conf).
+      dnsPolicy: {{ if .Values.agent.hostNetwork }}ClusterFirstWithHostNet{{ else }}ClusterFirst{{ end }}
       serviceAccountName: nvsnap-agent
       {{- include "nvsnap.imagePullSecrets" . | nindent 6 }}
       initContainers:
@@ -87,6 +87,12 @@ spec:
             # serves them; required returns 401. Roll out on permissive until
             # nvsnap_agent_auth_total{result="missing"} is zero.
             - --auth-mode={{ .Values.agent.auth.mode }}
+            {{- end }}
+            {{- if not .Values.agent.hostNetwork }}
+            # Pod networking: the init container reaches its node-local agent
+            # through the internalTrafficPolicy:Local Service instead of the
+            # node IP, so no hostPort is needed (GH #490).
+            - --webhook-agent-base-url=http://nvsnap-agent-local.{{ .Release.Namespace }}.svc.cluster.local:8081
             {{- end }}
             - --cuda-checkpoint-path=/criu-bundle/cuda-checkpoint
             - --criu-path=/criu-bundle/criu
@@ -174,6 +180,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            # POD_IP is what peers dial (--advertise-ip). Under hostNetwork
+            # kubelet reports status.podIP as the node IP, so this is correct
+            # in both network modes and needs no conditional (GH #490).
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             {{- if .Values.agent.auth.enabled }}
             # Shared bearer token for the agent API (GH #486). Env rather than
             # a flag: flag values are visible in the pod spec and in `ps`.
@@ -242,7 +255,13 @@ spec:
             {{- end }}
           ports:
             - containerPort: 8081
+              {{- if .Values.agent.hostNetwork }}
+              # Binds the API to every node's IP. Only declared under
+              # hostNetwork; with pod networking peers dial the pod IP and
+              # same-node callers use the internalTrafficPolicy:Local
+              # Service, so no node-wide listener is needed (GH #490).
               hostPort: 8081
+              {{- end }}
               name: http-api
             {{- if .Values.webhook.enabled }}
             - containerPort: 8443
@@ -402,4 +421,34 @@ spec:
       targetPort: 8081
       name: http-api
   clusterIP: None
+{{- end }}
+
+{{- if not .Values.agent.hostNetwork }}
+---
+# Node-local Service: the pod-network replacement for hostPort (GH #490).
+#
+# Callers that must reach the agent on THEIR OWN node -- the nvsnap-mount-prep
+# init container is the one that matters -- used to do it via
+# http://$(status.hostIP):8081, which requires the API to be bound to every
+# node's IP. internalTrafficPolicy:Local is the Kubernetes-native way to say
+# the same thing: this ClusterIP only ever routes to the endpoint on the
+# calling node, and has no node-IP listener at all.
+#
+# The headless nvsnap-agent Service above stays for tools that want to address
+# a specific agent; this one is for "whichever agent is on my node".
+apiVersion: v1
+kind: Service
+metadata:
+  name: nvsnap-agent-local
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "nvsnap.agent.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "nvsnap.agent.selectorLabels" . | nindent 4 }}
+  internalTrafficPolicy: Local
+  ports:
+    - port: 8081
+      targetPort: 8081
+      name: http-api
 {{- end }}

--- a/src/compute-plane-services/nvsnap/deploy/helm/nvsnap/templates/network-policy-restore-pods.yaml
+++ b/src/compute-plane-services/nvsnap/deploy/helm/nvsnap/templates/network-policy-restore-pods.yaml
@@ -107,7 +107,7 @@ Only rendered when the init-container strategy is selected AND
 agentHostCIDR is set. The default inline strategy does the mount inside
 the webhook and needs no pod->agent egress.
 */ -}}
-{{- if and .Values.webhook.enabled (eq (.Values.webhook.restorePrepStrategy | default "inline") "init-container") .Values.webhook.agentHostCIDR .Values.agent.l2.restoreNamespaces -}}
+{{- if and .Values.webhook.enabled (eq (.Values.webhook.restorePrepStrategy | default "inline") "init-container") (or (not .Values.agent.hostNetwork) .Values.webhook.agentHostCIDR) .Values.agent.l2.restoreNamespaces -}}
 {{- range $ns := .Values.agent.l2.restoreNamespaces }}
 ---
 apiVersion: networking.k8s.io/v1
@@ -129,8 +129,25 @@ spec:
     - Egress
   egress:
     - to:
+        {{- if $.Values.agent.hostNetwork }}
+        # hostNetwork: the agent carries NODE identity, so a podSelector never
+        # matches it (verified on GKE Dataplane V2 / Cilium) and the rule has
+        # to name the whole node CIDR -- every node, on this port, for every
+        # pod in the namespace.
         - ipBlock:
             cidr: {{ $.Values.webhook.agentHostCIDR }}
+        {{- else }}
+        # Pod networking: the agent has a pod identity again, so the rule can
+        # name exactly the agent pods and nothing else. This is the concrete
+        # payoff of GH #490 -- no operator-supplied CIDR, and the grant shrinks
+        # from "the node network" to "these pods".
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $.Release.Namespace }}
+          podSelector:
+            matchLabels:
+              {{- include "nvsnap.agent.selectorLabels" $ | nindent 14 }}
+        {{- end }}
       ports:
         - protocol: TCP
           port: {{ $.Values.webhook.agentHostPort | default 8081 }}

--- a/src/compute-plane-services/nvsnap/deploy/helm/nvsnap/values.yaml
+++ b/src/compute-plane-services/nvsnap/deploy/helm/nvsnap/values.yaml
@@ -176,9 +176,27 @@ agent:
       effect: NoSchedule
 
   # The agent runs privileged with hostPID/hostNetwork — required to
-  # see host processes (for CRIU) and to expose hostPort 8081 reliably.
-  # Don't disable unless you know what you're trading away.
+  # hostPID is required: CRIU and cuda-checkpoint address target processes by
+  # host PID, and the pre-checkpoint socket sweep opens /proc/<pid>/ns/net.
   hostPID: true
+
+  # hostNetwork is NOT required by any agent capability (GH #490). Everything
+  # that looked like it needed the host netns actually enters the TARGET pod's
+  # namespace: external_tcp.go setns's via /proc/<pid>/ns/net, and CRIU
+  # dump/restore nsenter into the container's netns. The apiserver reaches the
+  # webhook through a Service, not the node IP.
+  #
+  # What it does carry is hostPort 8081 -- which is what binds the agent's
+  # privileged API to every node's IP and makes NetworkPolicy unable to fence
+  # it, since a hostNetwork pod has node identity rather than pod identity.
+  #
+  # Setting this false switches to: peers dial the pod IP (--advertise-ip from
+  # status.podIP), same-node callers use the internalTrafficPolicy:Local
+  # Service, no hostPort is declared, and the restore-pod egress policy
+  # tightens from a node CIDR to a podSelector.
+  #
+  # Still true by default because the flip is a network topology change that
+  # has not been validated on a cluster yet. Do that before flipping.
   hostNetwork: true
 
   # Host paths the agent bind-mounts. Override if your nodes use

--- a/src/compute-plane-services/nvsnap/internal/agent/BUILD.bazel
+++ b/src/compute-plane-services/nvsnap/internal/agent/BUILD.bazel
@@ -91,6 +91,7 @@ go_test(
         "l2_promote_async_test.go",
         "l2_writer_test.go",
         "nim_backend_test.go",
+        "advertise_test.go",
         "auth_test.go",
         "pathsafe_test.go",
         "peer_fanout_test.go",

--- a/src/compute-plane-services/nvsnap/internal/agent/advertise_test.go
+++ b/src/compute-plane-services/nvsnap/internal/agent/advertise_test.go
@@ -1,0 +1,63 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package agent
+
+import "testing"
+
+// selfAgentURL decides what peers dial. Getting it wrong does not fail
+// loudly -- it registers an unreachable address in the catalog and the
+// cascade silently degrades to blobstore-only, so the fallback order is
+// pinned here. See GH #490.
+func TestSelfAgentURL(t *testing.T) {
+	cases := []struct {
+		name        string
+		advertiseIP string
+		nodeIP      string
+		listen      string
+		want        string
+	}{
+		{
+			// Pod networking: peers must dial the pod IP; the node IP would
+			// only reach us via hostPort.
+			name: "advertise wins", advertiseIP: "10.1.2.3", nodeIP: "192.168.0.5",
+			listen: ":8081", want: "http://10.1.2.3:8081",
+		},
+		{
+			// hostNetwork: kubelet reports status.podIP as the node IP, so
+			// both fields hold the same value and the URL is what it always
+			// was. This is why enabling the new field changes nothing at the
+			// default settings.
+			name: "hostNetwork parity", advertiseIP: "192.168.0.5", nodeIP: "192.168.0.5",
+			listen: ":8081", want: "http://192.168.0.5:8081",
+		},
+		{
+			// An older deployment that sets only --node-ip keeps working.
+			name: "falls back to node IP", advertiseIP: "", nodeIP: "192.168.0.5",
+			listen: ":8081", want: "http://192.168.0.5:8081",
+		},
+		{
+			// Neither known: return empty so the caller skips peer
+			// registration rather than advertising a bogus endpoint.
+			name: "no address", advertiseIP: "", nodeIP: "", listen: ":8081", want: "",
+		},
+		{
+			name: "non-default port", advertiseIP: "10.1.2.3", nodeIP: "",
+			listen: ":9090", want: "http://10.1.2.3:9090",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			a := &Agent{config: Config{
+				AdvertiseIP: c.advertiseIP,
+				NodeIP:      c.nodeIP,
+				ListenAddr:  c.listen,
+			}}
+			if got := a.selfAgentURL(); got != c.want {
+				t.Errorf("selfAgentURL() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/src/compute-plane-services/nvsnap/internal/agent/agent.go
+++ b/src/compute-plane-services/nvsnap/internal/agent/agent.go
@@ -74,8 +74,8 @@ type Config struct {
 	AuthToken string
 	// AuthMode is disabled (default), permissive, or required. See auth.go
 	// for why the rollout needs a permissive state.
-	AuthMode AuthMode
-	UseNsenter          bool // Run CRIU/cuda-checkpoint in host mount namespace (for containerized agents)
+	AuthMode   AuthMode
+	UseNsenter bool // Run CRIU/cuda-checkpoint in host mount namespace (for containerized agents)
 
 	// Prewarm enables agent-side page-cache prewarm of the rox-backed
 	// overlay lowerdir on restore (--prewarm, default true). Reads the
@@ -120,6 +120,17 @@ type Config struct {
 	// status.hostIP). Used to advertise the agent's HTTP endpoint
 	// when registering as a peer in the catalog.
 	NodeIP string
+
+	// AdvertiseIP overrides NodeIP as the address peers dial (GH #490).
+	//
+	// Under hostNetwork the two are the same, because kubelet reports a
+	// hostNetwork pod's status.podIP as the node IP. Under pod networking
+	// they differ, and peers must dial the pod IP -- the node IP would only
+	// work via hostPort, which is exactly the node-wide exposure we are
+	// trying not to require. The chart sets this from status.podIP, which
+	// is correct in both modes; NodeIP stays available for the places that
+	// genuinely mean "this node".
+	AdvertiseIP string
 
 	// BlobStoreURL is the base URL of the cluster's nvsnap-blobstore
 	// (Phase 5d.2 durable backstop). Empty disables capture-side

--- a/src/compute-plane-services/nvsnap/internal/agent/cascade_fetch.go
+++ b/src/compute-plane-services/nvsnap/internal/agent/cascade_fetch.go
@@ -576,14 +576,22 @@ func (a *Agent) registerAsPeer(ctx context.Context, checkpointID string) error {
 // agent's peer-server endpoints. Empty string if we don't have
 // enough config to construct it (NodeIP missing).
 func (a *Agent) selfAgentURL() string {
-	if a.config.NodeIP == "" {
+	// AdvertiseIP first: under pod networking peers must dial the pod IP,
+	// since the node IP only resolves to us via hostPort (GH #490). Falls
+	// back to NodeIP so a deployment that sets neither, or only the older
+	// value, keeps working.
+	ip := a.config.AdvertiseIP
+	if ip == "" {
+		ip = a.config.NodeIP
+	}
+	if ip == "" {
 		return ""
 	}
 	port := "8081"
 	if addr := a.config.ListenAddr; len(addr) > 1 && addr[0] == ':' {
 		port = addr[1:]
 	}
-	return fmt.Sprintf("http://%s:%s", a.config.NodeIP, port)
+	return fmt.Sprintf("http://%s:%s", ip, port)
 }
 
 // bytesReader returns an io.Reader for a byte slice. Tiny helper to

--- a/src/compute-plane-services/nvsnap/internal/agent/webhook_integration.go
+++ b/src/compute-plane-services/nvsnap/internal/agent/webhook_integration.go
@@ -87,6 +87,12 @@ type WebhookConfig struct {
 	// reaches the agent on (status.hostIP:AgentHostPort). Defaults to
 	// 8081 (matches the agent's --listen=:8081 default).
 	AgentHostPort int
+
+	// AgentBaseURL overrides the host-IP form the mount-prep init container
+	// uses to reach its node-local agent. Empty keeps
+	// http://$(NVSNAP_HOST_IP):<AgentHostPort>, which needs hostPort. See
+	// GH #490 and internal/webhook/mount_prep_init.go.
+	AgentBaseURL string
 }
 
 // startWebhook starts the agent's mutating-admission TLS server in a
@@ -174,6 +180,7 @@ func (a *Agent) startWebhook(ctx context.Context, cfg WebhookConfig, backend che
 		RestorePrepStrategy: cfg.RestorePrepStrategy,
 		MountPrepInitImage:  cfg.MountPrepInitImage,
 		AgentHostPort:       cfg.AgentHostPort,
+		AgentBaseURL:        cfg.AgentBaseURL,
 	}
 	handler := &webhook.Handler{
 		Mutator: mut,

--- a/src/compute-plane-services/nvsnap/internal/webhook/mount_prep_init.go
+++ b/src/compute-plane-services/nvsnap/internal/webhook/mount_prep_init.go
@@ -23,6 +23,7 @@ package webhook
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -89,12 +90,17 @@ func (m *Mutator) emitMountPrepInitContainer(
 	if agentPort == 0 {
 		agentPort = MountPrepDefaultAgentPort
 	}
-	// NVSNAP_AGENT_URL points at the host IP via downward API
-	// (status.hostIP), so the init container always hits the agent
-	// on its OWN node — same trust boundary as today's hostNetwork
-	// agent endpoints. Cross-node peer routing is the agent's job,
-	// driven by captureNode in the POST body.
+	// Both forms reach the agent on the pod's OWN node; cross-node peer
+	// routing is the agent's job, driven by captureNode in the POST body.
+	//
+	// Default is the downward-API host IP, which depends on the agent
+	// binding hostPort. AgentBaseURL replaces it with the
+	// internalTrafficPolicy:Local Service under pod networking, which routes
+	// to the node-local endpoint with no node-wide listener (GH #490).
 	agentURL := fmt.Sprintf("http://$(NVSNAP_HOST_IP):%d", agentPort)
+	if m.AgentBaseURL != "" {
+		agentURL = strings.TrimRight(m.AgentBaseURL, "/")
+	}
 
 	c := corev1.Container{
 		Name:            MountPrepContainerName,

--- a/src/compute-plane-services/nvsnap/internal/webhook/mutate.go
+++ b/src/compute-plane-services/nvsnap/internal/webhook/mutate.go
@@ -351,6 +351,14 @@ type Mutator struct {
 	// = http://<host-ip>:<AgentHostPort>; host-ip is plumbed via
 	// downward API in the patched pod spec.
 	AgentHostPort int
+
+	// AgentBaseURL overrides how the injected init container addresses the
+	// agent (GH #490). Empty keeps the hostPort form,
+	// http://$(NVSNAP_HOST_IP):<AgentHostPort>, which requires the API to be
+	// bound to every node's IP. Under pod networking the chart sets this to
+	// the internalTrafficPolicy:Local Service instead, which reaches the
+	// agent on the caller's own node without any node-wide listener.
+	AgentBaseURL string
 }
 
 // OverlayPreparer is implemented by *agent.Agent via PrepareOverlay.


### PR DESCRIPTION
## Why

The agent binds its API to every node's IP -- `hostNetwork: true` plus
`hostPort: 8081`, both defaults -- rather than a cluster-internal address.
NetworkPolicy cannot fence that: a hostNetwork pod carries node identity, so a
`podSelector` ingress rule never matches it (the comment at `values.yaml:454`
already records this). #486 closes *who may call* the API; this narrows *who
can reach it at all*.

## What I checked before changing anything

The issue's premise was that `hostNetwork` might only be carrying the
`hostPort`. That needed verifying, not assuming. Nothing in the agent needs the
host network namespace:

| candidate | what it actually does |
|---|---|
| `external_tcp.go` socket sweep | `setns` into the **target pod's** netns via `/proc/<pid>/ns/net`, then restores -- needs hostPID |
| CRIU dump / restore | `nsenter` into the **container's** netns, by PID or by path |
| admission webhook | apiserver reaches it through a **Service**, not the node IP |

So `hostNetwork` was carrying exactly two things: hostPort reachability, and
NodeIP self-advertisement. Two consumers depend on those -- peer agents, and
the `nvsnap-mount-prep` init container, which must reach the agent *on its own
node*.

## What changed

Both have Kubernetes-native replacements:

- **Peers dial the pod IP.** New `--advertise-ip`, set from `status.podIP`.
  Under hostNetwork kubelet reports `status.podIP` *as* the node IP, so one
  field is correct in both modes and today's advertised URL is unchanged.
- **Same-node callers use `nvsnap-agent-local`**, a Service with
  `internalTrafficPolicy: Local` -- it routes only to the endpoint on the
  calling node, which is precisely what hostPort was being used for, without a
  node-wide listener. The webhook points the init container at it via
  `--webhook-agent-base-url`.

`hostPort` and `dnsPolicy` now follow `.Values.agent.hostNetwork`, which they
previously ignored (`dnsPolicy` was hardcoded `ClusterFirstWithHostNet`, which
is wrong under pod networking).

## The payoff, concretely

The restore-pod egress policy is the clearest illustration.

Under hostNetwork it must name an operator-supplied node CIDR -- granting every
pod in the namespace egress to the entire node network on that port -- and the
init-container strategy is simply unavailable if the operator does not supply
one:

```yaml
- to:
    - ipBlock:
        cidr: {{ .Values.webhook.agentHostCIDR }}   # the whole node network
```

Under pod networking the same rule names the agent pods and nothing else, with
no CIDR to configure:

```yaml
- to:
    - namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: nvsnap-system}}
      podSelector:       {matchLabels: {app: nvsnap-agent, ...}}
```

## Customer Release Notes

The nvsnap agent can now run on pod networking instead of host networking.
Still defaults to host networking; set `agent.hostNetwork=false` to opt in.

## Plan Summary

At default settings, adds one env var (`POD_IP`) to the agent DaemonSet and
nothing else. With `agent.hostNetwork=false`: adds the `nvsnap-agent-local`
Service, removes the `hostPort` declaration, and switches `dnsPolicy` to
`ClusterFirst`.

## Usage

```sh
helm upgrade nvsnap ... --set agent.hostNetwork=false
```

## Testing

`TestSelfAgentURL` pins the address-selection order: advertise IP wins, falls
back to node IP for deployments that set only the older flag, empty when
neither is known (so the caller skips peer registration rather than advertising
a bogus endpoint), and a `hostNetwork parity` case asserting both fields
holding the same value yields today's URL.

Chart verified by rendering rather than by assertion. Diffing the default
render against `main`, the *only* difference is the added `POD_IP` env var --
which under hostNetwork equals the host IP, so `selfAgentURL` returns the same
string. With `hostNetwork=false`: zero `hostPort` keys, `dnsPolicy:
ClusterFirst`, the node-local Service present, and the egress policy rendering
as a podSelector. `helm lint` passes.

**Not validated on a cluster.** This is a network topology change touching peer
discovery, init-container reachability and CNI behavior, and the GPU nodes are
held for QA. That is why the default is unchanged: the new path is complete and
ready to exercise, but flipping the default should follow a cluster run.

## Notes

Suggested validation when nodes are free: install with
`agent.hostNetwork=false`, confirm peer registration advertises pod IPs, run a
cross-node cascade restore, and run one restore with
`restorePrepStrategy=init-container` to exercise the node-local Service path.

Stacked on #555 (agent auth), which is stacked on #519 -- all three touch the
agent router or the same chart files. Retarget down the stack as each merges.

## References

Closes #490

## Related Merge Requests/Pull Requests

#519, #555

## Dependencies

None.