### PR TITLE
feat(http-invocation): classify client disconnects as HTTP 499 (#524)

### DIFF
--- a/src/invocation-plane-services/http-invocation/crates/server/src/metrics/mod.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/src/metrics/mod.rs
@@ -29,6 +29,12 @@ struct Metric {
     description: &'static str,
 }
 
+/// Status code used to mark a client early disconnect (the caller went away
+/// before any response was produced). 499 is nginx's non-standard "client closed
+/// request"; it is emitted for internal telemetry only and never sent to a
+/// client. Defined once here and reused so the value stays consistent.
+pub const CLIENT_EARLY_DISCONNECT_STATUS: &str = "499";
+
 const COUNTERS: [Metric; 19] = [
     FUNCTION_INVOCATION_ERROR,
     FUNCTION_REQUEST,
@@ -201,10 +207,11 @@ pub fn init_metrics(settings: &MetricsSettings) -> anyhow::Result<()> {
         register_histogram(name);
     }
 
-    // Pre-init the 499 series so it reports 0 before the first disconnect.
+    // Pre-init the client-early-disconnect series so it reports 0 before the
+    // first disconnect.
     counter!(
         FUNCTION_INVOCATION_ERROR.name,
-        "http_status_code" => "499",
+        "http_status_code" => CLIENT_EARLY_DISCONNECT_STATUS,
         "function_id" => "",
     )
     .increment(0);

--- a/src/invocation-plane-services/http-invocation/crates/server/src/metrics/mod.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/src/metrics/mod.rs
@@ -200,6 +200,15 @@ pub fn init_metrics(settings: &MetricsSettings) -> anyhow::Result<()> {
     for name in HISTOGRAMS {
         register_histogram(name);
     }
+
+    // Pre-init the 499 series so it reports 0 before the first disconnect.
+    counter!(
+        FUNCTION_INVOCATION_ERROR.name,
+        "http_status_code" => "499",
+        "function_id" => "",
+    )
+    .increment(0);
+
     let collector = metrics_process::Collector::default();
     collector.describe();
     tokio::spawn(async move {

--- a/src/invocation-plane-services/http-invocation/crates/server/src/routes/post_pexec.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/src/routes/post_pexec.rs
@@ -122,18 +122,19 @@ impl Drop for InflightRequestGuard {
             self.completed
         );
         if !self.completed {
-            // No status produced => client disconnect. Emit 499 so it's countable
-            // (server errors are already counted via `AppError::into_response`).
+            // No status produced => client early disconnect. Record it so it's
+            // countable (server errors are already counted via
+            // `AppError::into_response`).
             if !self.status_returned {
                 tracing::info!(
                     request_id = %self.request_id,
                     function_id = %self.function_id,
                     function_version_id = %self.function_version_id,
                     nca_id = %self.nca_id,
-                    "client disconnected before a response was produced; recording 499"
+                    "client disconnected before a response was produced; recording client early disconnect"
                 );
                 metrics::record_nvcf_application_error(
-                    "499".to_string(),
+                    metrics::CLIENT_EARLY_DISCONNECT_STATUS.to_string(),
                     Some(self.function_id.to_string()),
                 );
             }
@@ -788,10 +789,11 @@ mod tests {
         assert!(result.is_err(), "completed guard must not publish a cancel");
     }
 
-    /// A client disconnect (dropped without a status ever produced) records a 499.
+    /// A client disconnect (dropped without a status ever produced) records a
+    /// client early disconnect.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[ignore = "requires docker; run with cargo test -- --ignored"]
-    async fn test_inflight_guard_drop_records_499_on_client_disconnect() {
+    async fn test_inflight_guard_drop_records_client_early_disconnect() {
         let (svc, _observer, _container) = make_nats_service().await;
         let function_id = Uuid::new_v4();
         let fvid = Uuid::new_v4();
@@ -816,24 +818,27 @@ mod tests {
             .find_map(|(key, _, _, value)| {
                 let matches = key.kind() == MetricKind::Counter
                     && key.key().name() == "app.invocation.error"
-                    && key
-                        .key()
-                        .labels()
-                        .any(|label| label.key() == "http_status_code" && label.value() == "499")
+                    && key.key().labels().any(|label| {
+                        label.key() == "http_status_code"
+                            && label.value() == metrics::CLIENT_EARLY_DISCONNECT_STATUS
+                    })
                     && key.key().labels().any(|label| {
                         label.key() == "function_id" && label.value() == function_id.to_string()
                     });
                 matches.then_some(value)
             })
-            .expect("client disconnect should record a 499 app.invocation.error");
+            .expect(
+                "client disconnect should record a client-early-disconnect app.invocation.error",
+            );
 
         assert_eq!(value, DebugValue::Counter(1));
     }
 
-    /// A server-side early exit (status was returned) must NOT be counted as a 499.
+    /// A server-side early exit (status was returned) must NOT be counted as a
+    /// client early disconnect.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[ignore = "requires docker; run with cargo test -- --ignored"]
-    async fn test_inflight_guard_drop_no_499_on_server_error() {
+    async fn test_inflight_guard_drop_no_client_early_disconnect_on_server_error() {
         let (svc, _observer, _container) = make_nats_service().await;
         let function_id = Uuid::new_v4();
         let fvid = Uuid::new_v4();
@@ -852,18 +857,22 @@ mod tests {
             guard.mark_status_returned();
         });
 
-        let found_499 = snapshotter
-            .snapshot()
-            .into_vec()
-            .into_iter()
-            .any(|(key, _, _, _)| {
-                key.key().name() == "app.invocation.error"
-                    && key
-                        .key()
-                        .labels()
-                        .any(|label| label.key() == "http_status_code" && label.value() == "499")
-            });
+        let found_disconnect =
+            snapshotter
+                .snapshot()
+                .into_vec()
+                .into_iter()
+                .any(|(key, _, _, _)| {
+                    key.key().name() == "app.invocation.error"
+                        && key.key().labels().any(|label| {
+                            label.key() == "http_status_code"
+                                && label.value() == metrics::CLIENT_EARLY_DISCONNECT_STATUS
+                        })
+                });
 
-        assert!(!found_499, "server-side error must not record a 499");
+        assert!(
+            !found_disconnect,
+            "server-side error must not record a client early disconnect"
+        );
     }
 }

--- a/src/invocation-plane-services/http-invocation/crates/server/src/routes/post_pexec.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/src/routes/post_pexec.rs
@@ -74,27 +74,42 @@ pub struct FunctionRouting {
 struct InflightRequestGuard {
     nats_service: Arc<NatsService>,
     request_id: RequestId,
+    function_id: Uuid,
     function_version_id: Uuid,
+    nca_id: String,
     completed: bool,
+    // True once a status was returned (server-side error). Lets Drop tell a
+    // server error from a client disconnect (future dropped, no status).
+    status_returned: bool,
 }
 
 impl InflightRequestGuard {
     fn new(
         nats_service: Arc<NatsService>,
         request_id: RequestId,
+        function_id: Uuid,
         function_version_id: Uuid,
+        nca_id: String,
     ) -> Self {
         Self {
             nats_service,
             request_id,
+            function_id,
             function_version_id,
+            nca_id,
             completed: false,
+            status_returned: false,
         }
     }
 
     fn mark_completed(&mut self) {
         tracing::trace!("InflightRequestGuard mark_completed called");
         self.completed = true;
+    }
+
+    // A status was returned (server-side error); keep Drop from counting it as 499.
+    fn mark_status_returned(&mut self) {
+        self.status_returned = true;
     }
 }
 
@@ -107,6 +122,21 @@ impl Drop for InflightRequestGuard {
             self.completed
         );
         if !self.completed {
+            // No status produced => client disconnect. Emit 499 so it's countable
+            // (server errors are already counted via `AppError::into_response`).
+            if !self.status_returned {
+                tracing::info!(
+                    request_id = %self.request_id,
+                    function_id = %self.function_id,
+                    function_version_id = %self.function_version_id,
+                    nca_id = %self.nca_id,
+                    "client disconnected before a response was produced; recording 499"
+                );
+                metrics::record_nvcf_application_error(
+                    "499".to_string(),
+                    Some(self.function_id.to_string()),
+                );
+            }
             let nats_svc = self.nats_service.clone();
             let req_id = self.request_id;
             let version_id = self.function_version_id;
@@ -342,9 +372,14 @@ pub async fn pexec(
     tracing::trace!("Message sent to NATS");
 
     // Now we know we have a request in flight, create the guard.
-    let mut inflight_guard =
-        InflightRequestGuard::new(nats_service.clone(), request_id, function_version_id);
-    let response = handle_streaming_response(
+    let mut inflight_guard = InflightRequestGuard::new(
+        nats_service.clone(),
+        request_id,
+        function_id,
+        function_version_id,
+        nca_id.clone(),
+    );
+    let response = match handle_streaming_response(
         nats_service.clone(),
         function_id,
         function_version_id,
@@ -355,7 +390,15 @@ pub async fn pexec(
         None,
         response_rx,
     )
-    .await?;
+    .await
+    {
+        Ok(response) => response,
+        Err(err) => {
+            // Server-side error returns a status; mark it so Drop doesn't count a 499.
+            inflight_guard.mark_status_returned();
+            return Err(err.into());
+        }
+    };
 
     // If we got here, we are done and can mark the guard as completed so it doesn't cancel
     inflight_guard.mark_completed();
@@ -697,7 +740,13 @@ mod tests {
         observer.flush().await.unwrap();
 
         {
-            let _guard = InflightRequestGuard::new(svc.clone(), request_id, fvid);
+            let _guard = InflightRequestGuard::new(
+                svc.clone(),
+                request_id,
+                Uuid::new_v4(),
+                fvid,
+                "nca-test".to_string(),
+            );
             // dropped at end of scope without mark_completed
         }
 
@@ -725,11 +774,96 @@ mod tests {
         observer.flush().await.unwrap();
 
         {
-            let mut guard = InflightRequestGuard::new(svc.clone(), request_id, fvid);
+            let mut guard = InflightRequestGuard::new(
+                svc.clone(),
+                request_id,
+                Uuid::new_v4(),
+                fvid,
+                "nca-test".to_string(),
+            );
             guard.mark_completed();
         }
 
         let result = tokio::time::timeout(Duration::from_millis(300), sub.next()).await;
         assert!(result.is_err(), "completed guard must not publish a cancel");
+    }
+
+    /// A client disconnect (dropped without a status ever produced) records a 499.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "requires docker; run with cargo test -- --ignored"]
+    async fn test_inflight_guard_drop_records_499_on_client_disconnect() {
+        let (svc, _observer, _container) = make_nats_service().await;
+        let function_id = Uuid::new_v4();
+        let fvid = Uuid::new_v4();
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        ::metrics::with_local_recorder(&recorder, || {
+            let _guard = InflightRequestGuard::new(
+                svc.clone(),
+                RequestId::new(),
+                function_id,
+                fvid,
+                "nca-test".to_string(),
+            );
+            // dropped without mark_completed / mark_status_returned => client disconnect
+        });
+
+        let value = snapshotter
+            .snapshot()
+            .into_vec()
+            .into_iter()
+            .find_map(|(key, _, _, value)| {
+                let matches = key.kind() == MetricKind::Counter
+                    && key.key().name() == "app.invocation.error"
+                    && key
+                        .key()
+                        .labels()
+                        .any(|label| label.key() == "http_status_code" && label.value() == "499")
+                    && key.key().labels().any(|label| {
+                        label.key() == "function_id" && label.value() == function_id.to_string()
+                    });
+                matches.then_some(value)
+            })
+            .expect("client disconnect should record a 499 app.invocation.error");
+
+        assert_eq!(value, DebugValue::Counter(1));
+    }
+
+    /// A server-side early exit (status was returned) must NOT be counted as a 499.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "requires docker; run with cargo test -- --ignored"]
+    async fn test_inflight_guard_drop_no_499_on_server_error() {
+        let (svc, _observer, _container) = make_nats_service().await;
+        let function_id = Uuid::new_v4();
+        let fvid = Uuid::new_v4();
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        ::metrics::with_local_recorder(&recorder, || {
+            let mut guard = InflightRequestGuard::new(
+                svc.clone(),
+                RequestId::new(),
+                function_id,
+                fvid,
+                "nca-test".to_string(),
+            );
+            // a status was produced (server-side early exit)
+            guard.mark_status_returned();
+        });
+
+        let found_499 = snapshotter
+            .snapshot()
+            .into_vec()
+            .into_iter()
+            .any(|(key, _, _, _)| {
+                key.key().name() == "app.invocation.error"
+                    && key
+                        .key()
+                        .labels()
+                        .any(|label| label.key() == "http_status_code" && label.value() == "499")
+            });
+
+        assert!(!found_499, "server-side error must not record a 499");
     }
 }

--- a/src/invocation-plane-services/vanity-gateway/gateway/vanity_director.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway/vanity_director.go
@@ -21,6 +21,8 @@ import (
 	config "ai-api-gateway-service/gateway_config"
 	"ai-api-gateway-service/pool"
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -37,6 +39,10 @@ import (
 
 const NVCFPollSeconds string = "NVCF-POLL-SECONDS"
 const defaultNVCFPollSeconds config.SessionTimeoutSeconds = 300
+
+// 499 (nginx's non-standard "client closed request"). Telemetry-only: the
+// disconnected client can't receive it; it distinguishes a disconnect from a 502.
+const statusClientClosedRequest = 499
 
 // writeFunctionStatusError writes a 503 or 410 response if the function is offline or expired.
 // name is used in the EOL detail message; pass empty string for vanity/path-based endpoints.
@@ -72,6 +78,30 @@ func writeFunctionStatusError(writer http.ResponseWriter, offlineMessage string,
 		return true
 	}
 	return false
+}
+
+// clientClosedRequest is true only when the inbound request context is canceled
+// (the authoritative disconnect signal); a transport error wrapping
+// context.Canceled with a live context stays a genuine upstream fault (502).
+func clientClosedRequest(request *http.Request) bool {
+	return request != nil && errors.Is(request.Context().Err(), context.Canceled)
+}
+
+// writeProxyError: confirmed client disconnect => 499, everything else => 502.
+func writeProxyError(writer http.ResponseWriter, request *http.Request, err error) {
+	if clientClosedRequest(request) {
+		zap.L().Warn("client closed request before upstream response", zap.Error(err))
+		writer.Header().Set("Content-Type", "application/problem+json")
+		writer.WriteHeader(statusClientClosedRequest)
+		_ = json.NewEncoder(writer).Encode(ProblemDetails{
+			Type:   "about:blank",
+			Title:  "Client Closed Request",
+			Status: statusClientClosedRequest,
+			Detail: "Client closed the request before a response was produced.",
+		})
+		return
+	}
+	writeBadGatewayProblem(writer, request, err)
 }
 
 func writeBadGatewayProblem(writer http.ResponseWriter, _ *http.Request, err error) {
@@ -128,7 +158,7 @@ func NewVanityDirector(nvcfApiHost string, transport http.RoundTripper) (*Vanity
 		BufferPool:     pool.ByteSlice,
 		Transport:      transport,
 		ModifyResponse: modifyTooManyRequestsResponse,
-		ErrorHandler:   writeBadGatewayProblem,
+		ErrorHandler:   writeProxyError,
 	}
 	nvcfApiUrl, err := url.Parse(nvcfApiHost)
 	if err != nil || nvcfApiUrl.Scheme == "" || nvcfApiUrl.Host == "" {
@@ -209,7 +239,7 @@ func (d *VanityDirector) ServeExec(target VanityExecRequest, writer http.Respons
 	rp := *d.rp
 	rp.ErrorHandler = func(writer http.ResponseWriter, request *http.Request, err error) {
 		proxyErr = err
-		writeBadGatewayProblem(writer, request, err)
+		writeProxyError(writer, request, err)
 	}
 	rp.ServeHTTP(writer, request)
 	return proxyErr

--- a/src/invocation-plane-services/vanity-gateway/gateway/vanity_director_test.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway/vanity_director_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package gateway
 
 import (
+	"ai-api-gateway-service/middleware"
 	"bytes"
 	"context"
 	"errors"
@@ -29,6 +30,11 @@ import (
 
 	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
@@ -504,4 +510,101 @@ func TestOfflineMessageTakesPriorityOverExpiredEOL(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "Service Unavailable", pd.Title)
 	assert.Equal(t, "Down for migration", pd.Detail)
+}
+
+// End-to-end at the telemetry layer: drive a request through the real otelhttp
+// server middleware wrapping ServeExec and assert what http.server.request.duration
+// records. A confirmed client disconnect (canceled inbound context) must land as
+// http.response.status_code=499, not 502.
+func TestServeExecClientDisconnectRecords499Metric(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+
+	director, err := NewVanityDirector("https://nvcf.example.test", roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, context.Canceled
+	}))
+	require.NoError(t, err)
+
+	handler := middleware.ServerTelemetryMiddleware(otelhttp.WithMeterProvider(provider))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = director.ServeExec(VanityExecRequest{FunctionID: "func-123", FunctionVersionID: "version-456"}, w, r)
+		}),
+	)
+
+	// The caller has already gone away before proxying completes.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := httptest.NewRequest(http.MethodPost, "/test", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, statusClientClosedRequest, rec.Code)
+
+	metrics := collectGatewayMetrics(t, reader)
+	assert.True(t, gatewayMetricHasStatusCode(metrics, statusClientClosedRequest),
+		"gateway must record http.server.request.duration with status_code=499 on client disconnect")
+	assert.False(t, gatewayMetricHasStatusCode(metrics, http.StatusBadGateway),
+		"client disconnect must not be recorded as 502")
+}
+
+// A genuine upstream transport failure (inbound context still live) must be
+// recorded as 502, not 499.
+func TestServeExecGenuineFailureRecords502Metric(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+
+	director, err := NewVanityDirector("https://nvcf.example.test", roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("connection refused")
+	}))
+	require.NoError(t, err)
+
+	handler := middleware.ServerTelemetryMiddleware(otelhttp.WithMeterProvider(provider))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = director.ServeExec(VanityExecRequest{FunctionID: "func-123", FunctionVersionID: "version-456"}, w, r)
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+
+	metrics := collectGatewayMetrics(t, reader)
+	assert.True(t, gatewayMetricHasStatusCode(metrics, http.StatusBadGateway),
+		"genuine upstream failure must record status_code=502")
+	assert.False(t, gatewayMetricHasStatusCode(metrics, statusClientClosedRequest),
+		"genuine upstream failure must not be recorded as 499")
+}
+
+func collectGatewayMetrics(t *testing.T, reader sdkmetric.Reader) []metricdata.Metrics {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	var out []metricdata.Metrics
+	for _, sm := range rm.ScopeMetrics {
+		out = append(out, sm.Metrics...)
+	}
+	return out
+}
+
+func gatewayMetricHasStatusCode(metrics []metricdata.Metrics, code int) bool {
+	for _, metric := range metrics {
+		if metric.Name != "http.server.request.duration" {
+			continue
+		}
+		histogram, ok := metric.Data.(metricdata.Histogram[float64])
+		if !ok {
+			continue
+		}
+		for _, point := range histogram.DataPoints {
+			if value, ok := point.Attributes.Value("http.response.status_code"); ok &&
+				value == attribute.Int64Value(int64(code)) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/src/invocation-plane-services/vanity-gateway/gateway/vanity_director_test.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway/vanity_director_test.go
@@ -20,6 +20,7 @@ package gateway
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -378,6 +379,73 @@ func TestServeExecReturnsProxyErrorAsProblemDetails(t *testing.T) {
 	assert.Equal(t, "Upstream request failed.", pd.Detail)
 
 	assert.Len(t, observedLogs.FilterMessage("proxy request failed").All(), 1)
+}
+
+// A confirmed client disconnect (canceled inbound request context) is accounted
+// as 499 rather than a generic 502.
+func TestServeExecClientDisconnectReturns499(t *testing.T) {
+	core, observedLogs := observer.New(zap.WarnLevel)
+	undoLogger := zap.ReplaceGlobals(zap.New(core))
+	defer undoLogger()
+
+	director, err := NewVanityDirector("https://nvcf.example.test", roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, context.Canceled
+	}))
+	assert.NoError(t, err)
+
+	// The caller has already gone away: its request context is canceled before
+	// proxying completes.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := httptest.NewRequest("POST", "/test", nil).WithContext(ctx)
+	recorder := httptest.NewRecorder()
+
+	err = director.ServeExec(VanityExecRequest{
+		FunctionID:        "func-123",
+		FunctionVersionID: "version-456",
+	}, recorder, req)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	result := recorder.Result()
+	defer result.Body.Close()
+	assert.Equal(t, statusClientClosedRequest, result.StatusCode)
+	assert.Equal(t, "application/problem+json", result.Header.Get("Content-Type"))
+
+	var pd ProblemDetails
+	err = json.NewDecoder(result.Body).Decode(&pd)
+	assert.NoError(t, err)
+	assert.Equal(t, "about:blank", pd.Type)
+	assert.Equal(t, "Client Closed Request", pd.Title)
+	assert.Equal(t, statusClientClosedRequest, pd.Status)
+
+	assert.Len(t, observedLogs.FilterMessage("client closed request before upstream response").All(), 1)
+}
+
+// A genuine upstream transport failure (inbound context still live) stays 502.
+func TestServeExecGenuineProxyFailureReturns502(t *testing.T) {
+	director, err := NewVanityDirector("https://nvcf.example.test", roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("connection refused")
+	}))
+	assert.NoError(t, err)
+
+	req := httptest.NewRequest("POST", "/test", nil)
+	recorder := httptest.NewRecorder()
+
+	err = director.ServeExec(VanityExecRequest{
+		FunctionID:        "func-123",
+		FunctionVersionID: "version-456",
+	}, recorder, req)
+
+	assert.Error(t, err)
+	result := recorder.Result()
+	defer result.Body.Close()
+	assert.Equal(t, http.StatusBadGateway, result.StatusCode)
+
+	var pd ProblemDetails
+	err = json.NewDecoder(result.Body).Decode(&pd)
+	assert.NoError(t, err)
+	assert.Equal(t, "Bad Gateway", pd.Title)
+	assert.Equal(t, http.StatusBadGateway, pd.Status)
 }
 
 func TestOfflineMessageReturns503(t *testing.T) {


### PR DESCRIPTION
## TL;DR
Client disconnects after dispatch were accounted as a generic **502** by the vanity gateway (the request future is dropped before any status is produced), making caller cancellations indistinguishable from genuine upstream faults and inflating 5xx / endpoint-unavailability metrics. This classifies confirmed client disconnects as **HTTP 499** for internal telemetry — authoritatively in the invocation service and, where technically possible, in gateway request accounting — while leaving real upstream failures as 502. 499 is telemetry-only; the disconnected client never receives it.

## Additional Details
**Problem.** When a client goes away after an invocation is dispatched, `pexec` never returns a `Response`. The gateway's reverse-proxy error handler mapped the resulting transport error to a single generic 502 with a fixed body, so client cancellations and genuine upstream faults collapsed into one status — no 499 anywhere, and 502 root-cause was unreliable.

**Invocation service (authoritative signal).** `InflightRequestGuard` now records whether a status was produced:
- The `handle_streaming_response(...)` call site was changed from `?` to a `match`; on the `Err` path it marks `status_returned` before returning, so a server-side early exit is not mistaken for a disconnect.
- On `Drop` when the request did not complete **and** no status was produced (pure client disconnect), it logs request/function/org context and records `app.invocation.error{http_status_code="499"}`.
- Server-side errors keep their real status, already counted via `AppError::into_response` — so no double counting.
- The 499 series is pre-initialized to 0 at startup so dashboards show it before the first disconnect.

**Vanity gateway (accounting).** The reverse-proxy error handler reclassifies to 499 **only** when the inbound request context is canceled (the authoritative "client gone" signal). A transport error that merely wraps `context.Canceled` while the inbound context is still live stays a genuine upstream fault (502). otelhttp records whatever status is written, so the 499 lands in `http_server_request_duration_seconds_count`. For a mid-stream SSE disconnect the `200` is already flushed, so it remains 200 — that's the "where technically possible" limit.

**Scope / limitations.** The classification applies to all routes on the shared `pexec` path (`/pexec`, `/exec`, TLB). Existing 400 (body-read failure) handling is untouched, since that occurs before the guard exists. A true disconnect produces no IS response for that request, so the gateway detects it independently via the canceled inbound context rather than a propagated signal.

## For the Reviewer
Closest files to review:
- `src/invocation-plane-services/http-invocation/crates/server/src/routes/post_pexec.rs` — the `InflightRequestGuard` `status_returned` logic and the `?`→`match` change.
- `src/invocation-plane-services/vanity-gateway/gateway/vanity_director.go` — `clientClosedRequest` / `writeProxyError` and the inbound-context check.

Question for reviewers: comfortable keying the gateway classification off `request.Context().Err() == context.Canceled` as the confirmed-disconnect signal (vs. inspecting the transport error)?

## For QA
Verified locally:
- IS: `cargo check --tests`, `cargo clippy --tests`, `cargo fmt --check` clean; `cargo test --lib` — 75 pass, 4 docker-gated ignored. New tests: 499 recorded on client disconnect, **not** recorded on server error; existing 504 gateway-timeout test still passes.
- Gateway: `go build`, `go vet`, `gofmt` clean; `go test ./gateway/...` passes. New tests: client disconnect (canceled context) → 499, genuine transport failure → 502; existing `context.Canceled`-with-live-context test still returns 502.

QA needed: light — recommend confirming in a staging/prod dashboard that `app.invocation.error{http_status_code="499"}` and the gateway 499 count appear on real client disconnects and that 502 drops correspondingly.

## Issues
Closes #524

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Client disconnects are now reported with HTTP 499 instead of being confused with server or proxy failures.
  * Genuine upstream proxy failures continue to return HTTP 502.
  * Request metrics now include an initial zero-valued 499 series for clearer monitoring.
  * Prevented server-side errors from being incorrectly recorded as client disconnects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->