### PR TITLE
test(bdd): cover control observability install

### DIFF
--- a/tests/bdd/PLAN.md
+++ b/tests/bdd/PLAN.md
@@ -131,6 +131,7 @@ refactor in every consumer; that is a feature.
 | `Then yaml file {string} key {string} should contain:` (docstring) | Subset semantics scoped to the subtree at the dotted key path. |
 | `Then the json output should contain rows:` (table) | Parses the last command's stdout as JSON (expected: array of objects). For each table row, asserts an object matching every column value exists in the array. Extra objects are allowed; ordering is not asserted. |
 | `Then the rendered manifests in {string} should not contain:` (table) | Requires a `text` header and one or more fixed strings. Recursively inspects regular files under the repo-relative directory and fails if any listed string appears. `${VAR}` expansion applies to the path and table values. |
+| `Then these ServiceMonitors should exist in namespace {string} using context {string}:` (table) | Requires a `name` header and one or more names. Runs one `kubectl get` with every named ServiceMonitor; exit code 0 proves every listed resource exists. |
 
 #### YAML comparison semantics
 
@@ -447,6 +448,10 @@ func JSONContainsRows(raw string, rows []map[string]string) error
 // FilesDoNotContain recursively inspects regular files under root and
 // fails if any interpolated fixed string appears.
 func FilesDoNotContain(root string, needles []string) error
+
+// ServiceMonitorExistenceCommand builds one kubectl get command whose
+// successful exit proves every named ServiceMonitor exists.
+func ServiceMonitorExistenceCommand(namespace, kubeContext string, names []string) (string, error)
 ```
 
 #### steps package

--- a/tests/bdd/dsl/kubectl.go
+++ b/tests/bdd/dsl/kubectl.go
@@ -1,0 +1,76 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dsl
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ServiceMonitorExistenceCommand builds one kubectl get command whose
+// successful exit proves every named ServiceMonitor exists.
+func ServiceMonitorExistenceCommand(namespace, kubeContext string, names []string) (string, error) {
+	namespace = strings.TrimSpace(Interpolate(namespace))
+	kubeContext = strings.TrimSpace(Interpolate(kubeContext))
+	if namespace == "" {
+		return "", fmt.Errorf("namespace is empty")
+	}
+	if kubeContext == "" {
+		return "", fmt.Errorf("kube context is empty")
+	}
+	if len(names) == 0 {
+		return "", fmt.Errorf("ServiceMonitor names are empty")
+	}
+
+	args := []string{"kubectl", "get"}
+	for _, rawName := range names {
+		name := strings.TrimSpace(Interpolate(rawName))
+		if name == "" {
+			return "", fmt.Errorf("ServiceMonitor name is empty")
+		}
+		args = append(args, quoteCommandArg("servicemonitor/"+name))
+	}
+	args = append(args,
+		"--namespace", quoteCommandArg(namespace),
+		"--context", quoteCommandArg(kubeContext),
+	)
+	return strings.Join(args, " "), nil
+}
+
+func quoteCommandArg(value string) string {
+	if isCommandArgSafe(value) {
+		return value
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func isCommandArgSafe(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, char := range value {
+		if char >= 'a' && char <= 'z' ||
+			char >= 'A' && char <= 'Z' ||
+			char >= '0' && char <= '9' ||
+			strings.ContainsRune("_./:@%+=,-", char) {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/tests/bdd/dsl/kubectl_test.go
+++ b/tests/bdd/dsl/kubectl_test.go
@@ -1,0 +1,42 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dsl
+
+import "testing"
+
+func TestServiceMonitorExistenceCommandBuildsSingleExplicitGet(t *testing.T) {
+	names := []string{
+		"nvcf-default-monitors-state-metrics",
+		"nvcf-default-monitors-grpc-proxy",
+	}
+
+	got, err := ServiceMonitorExistenceCommand("monitoring", "k3d-ncp-local", names)
+	if err != nil {
+		t.Fatalf("build command: %v", err)
+	}
+	want := "kubectl get servicemonitor/nvcf-default-monitors-state-metrics servicemonitor/nvcf-default-monitors-grpc-proxy --namespace monitoring --context k3d-ncp-local"
+	if got != want {
+		t.Fatalf("command = %q, want %q", got, want)
+	}
+}
+
+func TestServiceMonitorExistenceCommandRejectsEmptyNames(t *testing.T) {
+	if _, err := ServiceMonitorExistenceCommand("monitoring", "k3d-ncp-local", nil); err == nil {
+		t.Fatal("expected empty names error")
+	}
+}

--- a/tests/bdd/features/observability-control.feature
+++ b/tests/bdd/features/observability-control.feature
@@ -1,0 +1,91 @@
+@observability @control @ncp-local @single-cluster @helmfile
+Feature: Install local Helmfile observability with the control profile
+  As a self-managed NVCF operator,
+  I want to install the control observability profile on a local k3d cluster,
+  so that the control plane has its shared metrics infrastructure and monitors.
+
+  Background:
+    Given environment variable "NGC_API_KEY" is set
+    And environment variable "SAMPLE_NGC_ORG" is set
+    And environment variable "SAMPLE_NGC_TEAM" is set
+    # Helmfile pulls OCI charts during installation. Keep $NGC_API_KEY unbraced
+    # so the BDD runner does not expand it into command logs.
+    And command has succeeded:
+      """
+      bash -c 'set -eo pipefail; printf %s "$NGC_API_KEY" | helm registry login nvcr.io --username "\$oauthtoken" --password-stdin'
+      """
+    # The public stack ships Makefile.dist. Copy it for this live run so the
+    # ledger restores the untracked development Makefile state afterward.
+    And I copy the file "deploy/stacks/self-managed/Makefile.dist" to "deploy/stacks/self-managed/Makefile"
+    And I copy the file "tests/bdd/fixtures/self-managed-local-bdd.yaml" to "deploy/stacks/self-managed/environments/local-bdd-observability-control.yaml"
+    And I update yaml file "deploy/stacks/self-managed/environments/local-bdd-observability-control.yaml" with keys:
+      | global.imagePullSecrets[0].name | nvcr-pull-secret                     |
+      | global.helm.sources.repository  | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM} |
+      | global.image.repository         | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM} |
+      | observability.profile           | control                              |
+      | functionAutoscaler.chartVersion | 0.2.0                                |
+      | functionAutoscaler.image.tag    | 1.18.10                              |
+    # The shared observability Helmfile receives the same named environment.
+    # It resolves the profile and image-source values while the self-managed
+    # Helmfile owns the rest of the control-plane configuration.
+    And I copy the file "tests/bdd/fixtures/self-managed-local-bdd.yaml" to "deploy/stacks/observability/environments/local-bdd-observability-control.yaml"
+    And I update yaml file "deploy/stacks/observability/environments/local-bdd-observability-control.yaml" with keys:
+      | global.imagePullSecrets[0].name | nvcr-pull-secret                     |
+      | global.helm.sources.repository  | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM} |
+      | global.image.repository         | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM} |
+      | observability.profile           | control                              |
+    And I copy the file "deploy/stacks/self-managed/secrets/secrets.yaml.template" to "deploy/stacks/self-managed/secrets/local-bdd-observability-control-secrets.yaml"
+    And I substitute "REPLACE_WITH_BASE64_DOCKER_CREDENTIAL" in file "deploy/stacks/self-managed/secrets/local-bdd-observability-control-secrets.yaml" with base64 of "$oauthtoken:${NGC_API_KEY}"
+    # Conflict precheck: ncp-local-cp claims host ports that overlap with this
+    # single-cluster topology. From tools/ncp-local-cluster, run
+    # `make destroy CLUSTER_NAME=ncp-local-cp` before retrying.
+    Given I run command "k3d cluster get ncp-local-cp"
+    And the command exit code should be 1
+    And a single-cluster ncp-local cluster is running
+    And the "nvcr-pull-secret" image pull secret exists in namespaces:
+      | cassandra-system |
+      | nats-system      |
+      | nvcf             |
+      | api-keys         |
+      | ess              |
+      | sis              |
+      | vault-system     |
+      | nvca-operator    |
+      | cert-manager     |
+      | monitoring       |
+
+  Scenario: Control profile installs shared infrastructure and control monitors
+    When I run command "make -C deploy/stacks/self-managed install HELMFILE_ENV=local-bdd-observability-control"
+    Then the command exit code should be 0
+
+    When I run command "helm list --all-namespaces --kube-context k3d-ncp-local -o json"
+    Then the json output should contain rows:
+      | name                     | namespace  | status   |
+      | prometheus-operator-crds | monitoring | deployed |
+      | opentelemetry-operator   | monitoring | deployed |
+      | victoria-metrics         | monitoring | deployed |
+      | otel-collector           | monitoring | deployed |
+      | default-monitors         | monitoring | deployed |
+
+    When I run command "kubectl get opentelemetrycollector nvcf-observability -n monitoring --context k3d-ncp-local -o jsonpath='{.spec.targetAllocator.enabled}'"
+    Then the command exit code should be 0
+    And the command output should contain "true"
+
+    When I run command "kubectl get servicemonitor nvcf-default-monitors-state-metrics -n monitoring --context k3d-ncp-local"
+    Then the command exit code should be 0
+    When I run command "kubectl get servicemonitor nvcf-default-monitors-grpc-proxy -n monitoring --context k3d-ncp-local"
+    Then the command exit code should be 0
+    When I run command "kubectl get servicemonitor nvcf-default-monitors-llm-api-gateway -n monitoring --context k3d-ncp-local"
+    Then the command exit code should be 0
+    When I run command "kubectl get servicemonitor nvcf-default-monitors-invocation-service -n monitoring --context k3d-ncp-local"
+    Then the command exit code should be 0
+
+    When I run command "kubectl get servicemonitor nvcf-default-monitors-nvca -n monitoring --context k3d-ncp-local"
+    Then the command exit code should be 1
+    And the command output should contain "NotFound"
+    When I run command "kubectl get podmonitor nvcf-default-monitors-dcgm -n monitoring --context k3d-ncp-local"
+    Then the command exit code should be 1
+    And the command output should contain "NotFound"
+    When I run command "kubectl get podmonitor nvcf-default-monitors-worker -n monitoring --context k3d-ncp-local"
+    Then the command exit code should be 1
+    And the command output should contain "NotFound"

--- a/tests/bdd/features/observability-control.feature
+++ b/tests/bdd/features/observability-control.feature
@@ -70,14 +70,12 @@ Feature: Install local Helmfile observability with the control profile
     Then the command exit code should be 0
     And the command output should contain "true"
 
-    When I run command "kubectl get servicemonitor nvcf-default-monitors-state-metrics -n monitoring --context k3d-ncp-local"
-    Then the command exit code should be 0
-    When I run command "kubectl get servicemonitor nvcf-default-monitors-grpc-proxy -n monitoring --context k3d-ncp-local"
-    Then the command exit code should be 0
-    When I run command "kubectl get servicemonitor nvcf-default-monitors-llm-api-gateway -n monitoring --context k3d-ncp-local"
-    Then the command exit code should be 0
-    When I run command "kubectl get servicemonitor nvcf-default-monitors-invocation-service -n monitoring --context k3d-ncp-local"
-    Then the command exit code should be 0
+    Then these ServiceMonitors should exist in namespace "monitoring" using context "k3d-ncp-local":
+      | name                                             |
+      | nvcf-default-monitors-state-metrics              |
+      | nvcf-default-monitors-grpc-proxy                  |
+      | nvcf-default-monitors-llm-api-gateway             |
+      | nvcf-default-monitors-invocation-service          |
 
     When I run command "kubectl get servicemonitor nvcf-default-monitors-nvca -n monitoring --context k3d-ncp-local"
     Then the command exit code should be 1

--- a/tests/bdd/features/observability-control.feature
+++ b/tests/bdd/features/observability-control.feature
@@ -14,9 +14,6 @@ Feature: Install local Helmfile observability with the control profile
       """
       bash -c 'set -eo pipefail; printf %s "$NGC_API_KEY" | helm registry login nvcr.io --username "\$oauthtoken" --password-stdin'
       """
-    # The public stack ships Makefile.dist. Copy it for this live run so the
-    # ledger restores the untracked development Makefile state afterward.
-    And I copy the file "deploy/stacks/self-managed/Makefile.dist" to "deploy/stacks/self-managed/Makefile"
     # Set the self-managed stack environment.
     And I copy the file "tests/bdd/fixtures/self-managed-local-bdd.yaml" to "deploy/stacks/self-managed/environments/local-bdd-observability-control.yaml"
     And I update yaml file "deploy/stacks/self-managed/environments/local-bdd-observability-control.yaml" with keys:

--- a/tests/bdd/features/observability-control.feature
+++ b/tests/bdd/features/observability-control.feature
@@ -17,6 +17,7 @@ Feature: Install local Helmfile observability with the control profile
     # The public stack ships Makefile.dist. Copy it for this live run so the
     # ledger restores the untracked development Makefile state afterward.
     And I copy the file "deploy/stacks/self-managed/Makefile.dist" to "deploy/stacks/self-managed/Makefile"
+    # Set the self-managed stack environment.
     And I copy the file "tests/bdd/fixtures/self-managed-local-bdd.yaml" to "deploy/stacks/self-managed/environments/local-bdd-observability-control.yaml"
     And I update yaml file "deploy/stacks/self-managed/environments/local-bdd-observability-control.yaml" with keys:
       | global.imagePullSecrets[0].name | nvcr-pull-secret                     |
@@ -25,9 +26,7 @@ Feature: Install local Helmfile observability with the control profile
       | observability.profile           | control                              |
       | functionAutoscaler.chartVersion | 0.2.0                                |
       | functionAutoscaler.image.tag    | 1.18.10                              |
-    # The shared observability Helmfile receives the same named environment.
-    # It resolves the profile and image-source values while the self-managed
-    # Helmfile owns the rest of the control-plane configuration.
+    # Set the shared observability stack environment.
     And I copy the file "tests/bdd/fixtures/self-managed-local-bdd.yaml" to "deploy/stacks/observability/environments/local-bdd-observability-control.yaml"
     And I update yaml file "deploy/stacks/observability/environments/local-bdd-observability-control.yaml" with keys:
       | global.imagePullSecrets[0].name | nvcr-pull-secret                     |

--- a/tests/bdd/godog_test.go
+++ b/tests/bdd/godog_test.go
@@ -469,21 +469,19 @@ func TestSingleClusterHelmfileFeatureFileWiresToSteps(t *testing.T) {
 // shared releases and monitor resources through explicit local context calls.
 func TestObservabilityControlFeatureFileWiresToSteps(t *testing.T) {
 	const (
-		registryLoginCommand = `bash -c 'set -eo pipefail; printf %s "$NGC_API_KEY" | helm registry login nvcr.io --username "\$oauthtoken" --password-stdin'`
-		stateMetricsCommand  = "kubectl get servicemonitor nvcf-default-monitors-state-metrics -n monitoring --context k3d-ncp-local"
-		grpcProxyCommand     = "kubectl get servicemonitor nvcf-default-monitors-grpc-proxy -n monitoring --context k3d-ncp-local"
-		llmGatewayCommand    = "kubectl get servicemonitor nvcf-default-monitors-llm-api-gateway -n monitoring --context k3d-ncp-local"
-		invocationCommand    = "kubectl get servicemonitor nvcf-default-monitors-invocation-service -n monitoring --context k3d-ncp-local"
+		registryLoginCommand   = `bash -c 'set -eo pipefail; printf %s "$NGC_API_KEY" | helm registry login nvcr.io --username "\$oauthtoken" --password-stdin'`
+		serviceMonitorsCommand = "kubectl get servicemonitor/nvcf-default-monitors-state-metrics" +
+			" servicemonitor/nvcf-default-monitors-grpc-proxy" +
+			" servicemonitor/nvcf-default-monitors-llm-api-gateway" +
+			" servicemonitor/nvcf-default-monitors-invocation-service" +
+			" --namespace monitoring --context k3d-ncp-local"
 	)
 	t.Setenv("NGC_API_KEY", "test-key")
 	t.Setenv("SAMPLE_NGC_ORG", "test-org")
 	t.Setenv("SAMPLE_NGC_TEAM", "test-team")
 	suite := newWiringSuite(t, newFakeRunner(map[string]harness.Result{
 		registryLoginCommand:           {ExitCode: 0},
-		stateMetricsCommand:            {ExitCode: 0},
-		grpcProxyCommand:               {ExitCode: 0},
-		llmGatewayCommand:              {ExitCode: 0},
-		invocationCommand:              {ExitCode: 0},
+		serviceMonitorsCommand:         {ExitCode: 0},
 		"k3d cluster get ncp-local-cp": {ExitCode: 1},
 		"helm list --all-namespaces --kube-context k3d-ncp-local -o json": {
 			ExitCode: 0,
@@ -531,10 +529,7 @@ func TestObservabilityControlFeatureFileWiresToSteps(t *testing.T) {
 	runs := suite.Runner.(*fakeRunner).runs
 	for _, command := range []string{
 		registryLoginCommand,
-		stateMetricsCommand,
-		grpcProxyCommand,
-		llmGatewayCommand,
-		invocationCommand,
+		serviceMonitorsCommand,
 	} {
 		if !commandRanExactly(runs, command) {
 			t.Fatalf("exact command was never invoked: %s", command)

--- a/tests/bdd/godog_test.go
+++ b/tests/bdd/godog_test.go
@@ -506,7 +506,6 @@ func TestObservabilityControlFeatureFileWiresToSteps(t *testing.T) {
 	}))
 	seedHelmfileLocalBDDFixture(t, suite.Config.RepoRoot)
 	seedStackSecretsTemplate(t, suite.Config.RepoRoot)
-	seedObservabilityControlMakefile(t, suite.Config.RepoRoot)
 
 	sc := steps.NewScenarioContext(suite)
 	featurePath := mustResolveFeaturePath(t, "observability-control.feature")
@@ -563,17 +562,6 @@ func observabilityControlHelmListJSON() string {
 {"name":"otel-collector","namespace":"monitoring","status":"deployed"},
 {"name":"default-monitors","namespace":"monitoring","status":"deployed"}
 ]`
-}
-
-func seedObservabilityControlMakefile(t *testing.T, repoRoot string) {
-	t.Helper()
-	path := filepath.Join(repoRoot, "deploy", "stacks", "self-managed", "Makefile.dist")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatalf("mkdir self-managed stack: %v", err)
-	}
-	if err := os.WriteFile(path, []byte("install:\n\t@true\n"), 0o644); err != nil {
-		t.Fatalf("write self-managed Makefile.dist: %v", err)
-	}
 }
 
 // TestMultiClusterHelmfileFeatureFileWiresToSteps runs

--- a/tests/bdd/godog_test.go
+++ b/tests/bdd/godog_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cucumber/godog"
 
+	"nvcf-bdd/dsl"
 	"nvcf-bdd/harness"
 	"nvcf-bdd/steps"
 )
@@ -459,6 +460,124 @@ func TestSingleClusterHelmfileFeatureFileWiresToSteps(t *testing.T) {
 	}
 	if !commandRanThatContains(suite.Runner.(*fakeRunner).runs, "api-key generate --description bdd-grpc-load-tester-supreme --for function") {
 		t.Fatal("gRPC sample function API key was not generated for the function service")
+	}
+}
+
+// TestObservabilityControlFeatureFileWiresToSteps runs the live-install
+// observability-control feature against a fake runner. It checks the
+// single-cluster Helmfile path renders and verifies the profile-selected
+// shared releases and monitor resources through explicit local context calls.
+func TestObservabilityControlFeatureFileWiresToSteps(t *testing.T) {
+	const (
+		registryLoginCommand = `bash -c 'set -eo pipefail; printf %s "$NGC_API_KEY" | helm registry login nvcr.io --username "\$oauthtoken" --password-stdin'`
+		stateMetricsCommand  = "kubectl get servicemonitor nvcf-default-monitors-state-metrics -n monitoring --context k3d-ncp-local"
+		grpcProxyCommand     = "kubectl get servicemonitor nvcf-default-monitors-grpc-proxy -n monitoring --context k3d-ncp-local"
+		llmGatewayCommand    = "kubectl get servicemonitor nvcf-default-monitors-llm-api-gateway -n monitoring --context k3d-ncp-local"
+		invocationCommand    = "kubectl get servicemonitor nvcf-default-monitors-invocation-service -n monitoring --context k3d-ncp-local"
+	)
+	t.Setenv("NGC_API_KEY", "test-key")
+	t.Setenv("SAMPLE_NGC_ORG", "test-org")
+	t.Setenv("SAMPLE_NGC_TEAM", "test-team")
+	suite := newWiringSuite(t, newFakeRunner(map[string]harness.Result{
+		registryLoginCommand:           {ExitCode: 0},
+		stateMetricsCommand:            {ExitCode: 0},
+		grpcProxyCommand:               {ExitCode: 0},
+		llmGatewayCommand:              {ExitCode: 0},
+		invocationCommand:              {ExitCode: 0},
+		"k3d cluster get ncp-local-cp": {ExitCode: 1},
+		"helm list --all-namespaces --kube-context k3d-ncp-local -o json": {
+			ExitCode: 0,
+			Stdout:   observabilityControlHelmListJSON(),
+		},
+		"kubectl get opentelemetrycollector nvcf-observability -n monitoring --context k3d-ncp-local -o jsonpath='{.spec.targetAllocator.enabled}'": {
+			ExitCode: 0,
+			Stdout:   "true",
+		},
+		"kubectl get servicemonitor nvcf-default-monitors-nvca -n monitoring --context k3d-ncp-local": {
+			ExitCode: 1,
+			Stderr:   "Error from server (NotFound): servicemonitors.monitoring.coreos.com \"nvcf-default-monitors-nvca\" not found\n",
+		},
+		"kubectl get podmonitor nvcf-default-monitors-dcgm -n monitoring --context k3d-ncp-local": {
+			ExitCode: 1,
+			Stderr:   "Error from server (NotFound): podmonitors.monitoring.coreos.com \"nvcf-default-monitors-dcgm\" not found\n",
+		},
+		"kubectl get podmonitor nvcf-default-monitors-worker -n monitoring --context k3d-ncp-local": {
+			ExitCode: 1,
+			Stderr:   "Error from server (NotFound): podmonitors.monitoring.coreos.com \"nvcf-default-monitors-worker\" not found\n",
+		},
+	}))
+	seedHelmfileLocalBDDFixture(t, suite.Config.RepoRoot)
+	seedStackSecretsTemplate(t, suite.Config.RepoRoot)
+	seedObservabilityControlMakefile(t, suite.Config.RepoRoot)
+
+	sc := steps.NewScenarioContext(suite)
+	featurePath := mustResolveFeaturePath(t, "observability-control.feature")
+	var out strings.Builder
+	status := godog.TestSuite{
+		Name: "observability-control-wiring",
+		ScenarioInitializer: func(ctx *godog.ScenarioContext) {
+			steps.RegisterAll(ctx, sc)
+		},
+		Options: &godog.Options{
+			Format: "pretty",
+			Paths:  []string{featurePath},
+			Strict: true,
+			Output: &out,
+		},
+	}.Run()
+	if status != 0 {
+		t.Fatalf("godog suite status = %d\n%s", status, out.String())
+	}
+	runs := suite.Runner.(*fakeRunner).runs
+	for _, command := range []string{
+		registryLoginCommand,
+		stateMetricsCommand,
+		grpcProxyCommand,
+		llmGatewayCommand,
+		invocationCommand,
+	} {
+		if !commandRanExactly(runs, command) {
+			t.Fatalf("exact command was never invoked: %s", command)
+		}
+	}
+	if !commandRanThatContains(runs, "install HELMFILE_ENV=local-bdd-observability-control") {
+		t.Fatal("control-profile Helmfile install command was never invoked")
+	}
+	environmentPath := filepath.Join(suite.Config.RepoRoot, "deploy", "stacks", "self-managed", "environments", "local-bdd-observability-control.yaml")
+	chartVersion, found, err := dsl.ReadYAMLKey(environmentPath, "functionAutoscaler.chartVersion")
+	if err != nil {
+		t.Fatalf("read control-profile autoscaler chart version: %v", err)
+	}
+	if !found || chartVersion != "0.2.0" {
+		t.Fatalf("control-profile autoscaler chart version = %q, found = %t; want 0.2.0", chartVersion, found)
+	}
+	imageTag, found, err := dsl.ReadYAMLKey(environmentPath, "functionAutoscaler.image.tag")
+	if err != nil {
+		t.Fatalf("read control-profile autoscaler image tag: %v", err)
+	}
+	if !found || imageTag != "1.18.10" {
+		t.Fatalf("control-profile autoscaler image tag = %q, found = %t; want 1.18.10", imageTag, found)
+	}
+}
+
+func observabilityControlHelmListJSON() string {
+	return `[
+{"name":"prometheus-operator-crds","namespace":"monitoring","status":"deployed"},
+{"name":"opentelemetry-operator","namespace":"monitoring","status":"deployed"},
+{"name":"victoria-metrics","namespace":"monitoring","status":"deployed"},
+{"name":"otel-collector","namespace":"monitoring","status":"deployed"},
+{"name":"default-monitors","namespace":"monitoring","status":"deployed"}
+]`
+}
+
+func seedObservabilityControlMakefile(t *testing.T, repoRoot string) {
+	t.Helper()
+	path := filepath.Join(repoRoot, "deploy", "stacks", "self-managed", "Makefile.dist")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir self-managed stack: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("install:\n\t@true\n"), 0o644); err != nil {
+		t.Fatalf("write self-managed Makefile.dist: %v", err)
 	}
 }
 
@@ -1170,6 +1289,15 @@ func TestSingleClusterHelmfile(t *testing.T) {
 	runLiveFeature(t, "single-cluster-helmfile.feature")
 }
 
+// TestObservabilityControl is the live entry point for the control
+// observability profile feature. Skipped under -short.
+func TestObservabilityControl(t *testing.T) {
+	if testing.Short() {
+		t.Skip("live run skipped under -short")
+	}
+	runLiveFeature(t, "observability-control.feature")
+}
+
 // TestSingleClusterHelmfileUpstreamImages is the live entry point for the
 // focused Docker Hub supporting-image override feature. Skipped under -short.
 func TestSingleClusterHelmfileUpstreamImages(t *testing.T) {
@@ -1268,6 +1396,15 @@ func runLiveFeatureTags(t *testing.T, feature, tags string) {
 func commandRanThatContains(runs []string, needle string) bool {
 	for _, run := range runs {
 		if strings.Contains(run, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func commandRanExactly(runs []string, want string) bool {
+	for _, run := range runs {
+		if run == want {
 			return true
 		}
 	}

--- a/tests/bdd/steps/assertion_steps.go
+++ b/tests/bdd/steps/assertion_steps.go
@@ -18,6 +18,7 @@ limitations under the License.
 package steps
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -42,6 +43,7 @@ func registerAssertionSteps(ctx *godog.ScenarioContext, sc *ScenarioContext) {
 	ctx.Step(`^yaml file "([^"]*)" key "([^"]*)" should contain:$`, sc.yamlFileKeyShouldContain)
 	ctx.Step(`^the json output should contain rows:$`, sc.jsonOutputShouldContainRows)
 	ctx.Step(`^the rendered manifests in "([^"]*)" should not contain:$`, sc.renderedManifestsShouldNotContain)
+	ctx.Step(`^these ServiceMonitors should exist in namespace "([^"]*)" using context "([^"]*)":$`, sc.serviceMonitorsShouldExist)
 }
 
 func (sc *ScenarioContext) commandExitCodeShouldBe(expected int) error {
@@ -174,6 +176,21 @@ func tableToSingleColumn(table *godog.Table, header string) ([]string, error) {
 		values = append(values, value)
 	}
 	return values, nil
+}
+
+func (sc *ScenarioContext) serviceMonitorsShouldExist(ctx context.Context, namespace, kubeContext string, table *godog.Table) error {
+	names, err := tableToSingleColumn(table, "name")
+	if err != nil {
+		return err
+	}
+	command, err := dsl.ServiceMonitorExistenceCommand(namespace, kubeContext, names)
+	if err != nil {
+		return err
+	}
+	if err := sc.runAndRecordWith(ctx, command, sc.Suite.Runner.Run); err != nil {
+		return err
+	}
+	return sc.commandExitCodeShouldBe(0)
 }
 
 // tableToJSONRows converts a header-first Godog table into a slice of

--- a/tests/bdd/steps/steps_test.go
+++ b/tests/bdd/steps/steps_test.go
@@ -456,6 +456,27 @@ func TestSingleClusterBootstrapCachesAcrossCalls(t *testing.T) {
 	}
 }
 
+func TestServiceMonitorsShouldExistRunsSingleExplicitGet(t *testing.T) {
+	sc, fake := newScenarioContext(t)
+	fake.result = harness.Result{ExitCode: 0}
+	table := docTable(t, [][]string{
+		{"name"},
+		{"nvcf-default-monitors-state-metrics"},
+		{"nvcf-default-monitors-grpc-proxy"},
+	})
+
+	if err := sc.serviceMonitorsShouldExist(context.Background(), "monitoring", "k3d-ncp-local", table); err != nil {
+		t.Fatalf("assert ServiceMonitors: %v", err)
+	}
+	if len(fake.runs) != 1 {
+		t.Fatalf("runs = %d, want 1", len(fake.runs))
+	}
+	want := "kubectl get servicemonitor/nvcf-default-monitors-state-metrics servicemonitor/nvcf-default-monitors-grpc-proxy --namespace monitoring --context k3d-ncp-local"
+	if fake.runs[0].command != want {
+		t.Fatalf("command = %q, want %q", fake.runs[0].command, want)
+	}
+}
+
 func TestRegisterAllRunsAFeatureFile(t *testing.T) {
 	// End-to-end smoke check that RegisterAll wires every category. A
 	// minimal in-memory feature is driven through a Godog TestSuite so


### PR DESCRIPTION
## Why

Issue #522 requires live coverage for each observability profile. Rendering cannot verify that the `control` profile installs its shared dependencies, selects the correct monitors, or runs the function autoscaler on local arm64.

## What changed

- Add a live `ncp-local` Helmfile scenario for `observability.profile: control`.
- Configure both stack environments and use autoscaler chart `0.2.0` with multi-architecture image `1.18.10`.
- Verify shared releases, target allocation, included control-plane ServiceMonitors, and excluded compute-plane monitors.
- Add one table-driven step that checks named ServiceMonitors with a combined `kubectl get`, plus DSL and wiring tests.

## Customer Release Notes

Not customer visible.

## Plan Summary

Installs the self-managed and observability stacks on `k3d-ncp-local`. Defaults are unchanged.

## Usage

From `tests/bdd`:

```sh
BDD_CLEANUP_MODE=topology-single \
  go test -run '^TestObservabilityControl$' -timeout 90m -count=1 -v .
```

## Testing

- `go test -short ./...`: passed.
- `./scripts/lint.sh`: passed.
- Live `k3d-ncp-local` run: 32/32 steps passed in 3m07s.

## Notes

PR #523 supplies the tracked Makefile wrapper, so the feature invokes plain `make` without staging `Makefile.dist`.

## References

- #522
- #527

## Related Pull Requests

- #509
- #523

## Dependencies

None. No license or NOTICE changes.

## Issues

Relates to #522
