### PR TITLE
ci(release): add self-managed branch-cut job

### DIFF
--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -20,9 +20,10 @@ on:
         type: choice
         options:
           - branch-cut
+          - self-managed-branch-cut
           - auto
       service:
-        description: Optional service id or service_name for operation=auto. Branch-cut always cuts nvca.
+        description: Optional service id or service_name for operation=auto. Branch-cut operations select a fixed service.
         required: false
         type: string
 
@@ -108,6 +109,34 @@ jobs:
           fi
           if [ -z "${NVCF_GITHUB_RELEASE_SERVICE}" ]; then
             echo "ERROR: service is required when operation=branch-cut." >&2
+            exit 1
+          fi
+          ./tools/ci/github-release branch-cut --service "${NVCF_GITHUB_RELEASE_SERVICE}"
+
+  self-managed-release-branch-cut:
+    name: self-managed stack release branch cut
+    if: github.event_name == 'workflow_dispatch' && inputs.operation == 'self-managed-branch-cut'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
+          token: ${{ secrets.NV_GITHUB_TOKEN || github.token }}
+
+      - name: Cut release branch
+        env:
+          NVCF_GITHUB_RELEASE_SERVICE: nvcf-self-managed-stack
+          NV_GITHUB_TOKEN_CONFIGURED: ${{ secrets.NV_GITHUB_TOKEN != '' }}
+          GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          if [ "${NV_GITHUB_TOKEN_CONFIGURED}" != "true" ]; then
+            echo "ERROR: set secret NV_GITHUB_TOKEN before cutting a GitHub release branch." >&2
+            echo "The default GITHUB_TOKEN cannot trigger CI for the generated VERSION bump PR." >&2
             exit 1
           fi
           ./tools/ci/github-release branch-cut --service "${NVCF_GITHUB_RELEASE_SERVICE}"


### PR DESCRIPTION
## TL;DR

- Add a dedicated self-managed stack release branch-cut operation to `release-tags`.

## Additional Details

- Keep the existing `branch-cut` operation fixed to NVCA.
- Run the existing release helper with `nvcf-self-managed-stack` for the new operation.
- No dependency, NOTICE, or documentation changes are needed.

## For QA

- `git diff --check`
- `yq eval '.' .github/workflows/release-tags.yml >/dev/null`
- `python3 tools/ci/test-github-release.py`
- `actionlint -color`
- `./tools/ci/github-release branch-cut --service nvcf-self-managed-stack --dry-run`
- QA is not needed for this workflow-only change.

## Issues

Closes #566

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] Tests cover the updated workflow.
- [x] Documentation is current.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a self-managed branch-cut release option for manually triggered release workflows.
  * Added validation to ensure the required release token is configured before running.
  * Clarified that the service selection applies only to automatic release operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->