### PR TITLE
fix(ci): scope merge-queue runs to the changed subtrees

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -94,6 +94,8 @@ jobs:
         env:
           EVENT: ${{ github.event_name }}
           BEFORE_SHA: ${{ github.event.before }}
+          # merge_group has no `before`; its payload carries the queue base.
+          MERGE_BASE_SHA: ${{ github.event.merge_group.base_sha }}
           HEAD_SHA: ${{ github.sha }}
           BASE_REF: ${{ github.base_ref }}
         run: |
@@ -191,6 +193,24 @@ jobs:
             pull_request)
               if ! changed=$(git diff --name-only "origin/${BASE_REF}...HEAD" 2>/dev/null); then
                 echo "diff vs origin/${BASE_REF} failed; running full matrix"
+                run_all=true
+              fi
+              ;;
+            merge_group)
+              # `github.event.before` does not exist on merge_group, so without
+              # this branch every queue entry fell through to the default arm
+              # and rebuilt all 24 rows regardless of what the pull request
+              # touched. The queue head is the base plus the queued commits, so
+              # diffing from base_sha yields exactly those changes (and, for a
+              # batched entry, every pull request in the batch).
+              if [ -z "${MERGE_BASE_SHA}" ]; then
+                echo "merge_group base_sha missing; running full matrix"
+                run_all=true
+              elif ! git rev-parse --verify -q "${MERGE_BASE_SHA}^{commit}" >/dev/null 2>&1; then
+                echo "merge_group base ${MERGE_BASE_SHA} not in history; running full matrix"
+                run_all=true
+              elif ! changed=$(git diff --name-only "${MERGE_BASE_SHA}...${HEAD_SHA}" 2>/dev/null); then
+                echo "diff ${MERGE_BASE_SHA}...${HEAD_SHA} failed; running full matrix"
                 run_all=true
               fi
               ;;


### PR DESCRIPTION
## Why

Merge queue throughput is the complaint, and the queue was doing far more work
than it needed to: every entry built all 24 matrix rows regardless of what the
pull request changed.

`detect` resolves its diff base from `github.event.before`. That field is
populated on `push` events but does not exist on `merge_group`, so queue entries
hit the case statement's default arm with an empty `BEFORE_SHA` and set
`run_all=true`. The change-aware scheduling that keeps ordinary pull requests
small was inert for precisely the event that gates merging.

Confirmed from a real queue run's detect log:

    selected 24 subtree(s): build-container=[byoo-otel-collector, root, ...]

## Measurements

Two recent `merge_group` runs, both 24 rows:

| run | wall | slowest row | started immediately | rest waited |
|---|---|---|---|---|
| 30526777859 | 885s | 669s (root) | 12 | ~600s |
| 30519497553 | 2132s | 643s (root) | 12 | 1553-1857s |

The slowest row is ~650s in both. The gap between an 885s run and a 2132s run
is almost entirely rows queued waiting for a runner. Full queue-wait
distribution for the slow run:

    3, 4, 4, 4, 7, 11, 19, 21, 22, 22, 37, 46,
    1553, 1565, 1568, 1568, 1569, 1569, 1574, 1580, 1851, 1855, 1855, 1857

Twelve rows start at once, then a 26-minute cliff. That shape is runner
starvation, not a `max-parallel` cap: a binding cap of 8 would produce tiers
roughly one row-duration apart, not a bimodal split at 12.

This change adds no capacity. It removes demand, which is the half we control
from inside the repository.

## What changed

A `merge_group` arm in the case statement using
`github.event.merge_group.base_sha`. The queue head is the base plus the queued
commits, so diffing from it yields the pull request's own changes, and for a
batched entry every pull request in that batch.

## Testing

Validated by simulating a queue-shaped history against the real repository: a
branch at `origin/main` plus one commit touching a single subtree, run through
the exact case logic.

    merge_group with base_sha  -> only the touched path
    merge_group, base missing  -> FULL (no base_sha)
    merge_group, bogus base    -> FULL (base not in history)
    push with empty before     -> FULL (the old behaviour, i.e. the bug)

Both degraded paths fall back to the full matrix rather than selecting nothing,
so a payload change or a shallow checkout cannot silently skip validation.

This pull request touches the workflow itself, so its own runs select the full
matrix by design. The effect shows on the next queue entry that does not touch
workflow files.

## Notes

`max-parallel` is deliberately left alone. The data above shows it is not the
binding constraint, and it exists to stop ~20 runners pulling
`actions/checkout` at once and tripping GitHub's action-download rate limit
(HTTP 429 in "Set up job"). Removing it risks trading slow for flaky without
addressing the wait.

The remaining constraint is hosted-runner concurrency at the organisation
level, which cannot be changed from this repository.

## References

None

## Dependencies

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change detection for merge queue builds.
  * Ensured affected checks run against the correct set of changes.
  * Added fallback handling to run the full validation suite when change information is unavailable or cannot be calculated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->