### PR TITLE
fix(nvsnap): mark the C targets Linux-only

### DIFF
--- a/src/compute-plane-services/nvsnap/lib/nvsnap_intercept/BUILD.bazel
+++ b/src/compute-plane-services/nvsnap/lib/nvsnap_intercept/BUILD.bazel
@@ -75,5 +75,12 @@ cc_binary(
     ],
     linkshared = True,
     linkstatic = True,
+    # Linux-only. The sources interpose io_uring, seccomp and CUDA, and the
+    # link recipe above depends on versioned glibc symbols and ld.bfd. None of
+    # that exists on macOS, so a `bazel build //...` there died here before
+    # reaching anything else. Marking it incompatible makes Bazel skip the
+    # target on other platforms instead of failing the whole invocation, which
+    # is what lets a repository-wide scan run to completion off Linux.
+    target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//visibility:public"],
 )

--- a/src/compute-plane-services/nvsnap/lib/nvsnap_restore_helper/BUILD.bazel
+++ b/src/compute-plane-services/nvsnap/lib/nvsnap_restore_helper/BUILD.bazel
@@ -15,5 +15,9 @@ cc_binary(
         "-Wextra",
     ],
     linkopts = ["-static"],
+    # Linux-only. The source itself is portable, but `-static` is not: macOS
+    # ships no static libc and its linker rejects the flag outright, so this
+    # fails off Linux despite looking cross-platform.
+    target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
## Why

The Pulse team's Black Duck Detector scan of this repository fails on macOS:

    bash <(curl -s -L https://detect.blackduck.com/detect11.sh) \
      --detect.tools=BAZEL --detect.bazel.target="//..." --detect.bazel.mode=BZLMOD

A wildcard build stops at the first target that cannot be configured, so the
scan never reaches the rest of the repository.

Both nvsnap C targets block it, for different reasons:

`libnvsnap_intercept.so` interposes io_uring, seccomp and CUDA, and its link
recipe depends on versioned glibc symbols and `ld.bfd`. There is no macOS
equivalent for any of that.

`nvsnap-restore-helper` is the more interesting one. It is a single `main.c`
with no Linux headers and looks perfectly portable, but it links with
`-static`, and macOS ships no static libc and its linker rejects the flag. It
would still have failed after any amount of work on the Go targets, which is
why the C targets are addressed first.

## What changed

`target_compatible_with = ["@platforms//os:linux"]` on the two `cc_binary`
targets. Bazel then skips them when the target platform is not Linux, rather
than failing the whole invocation.

## Testing

`package(default_target_compatible_with = ...)` does not exist -- Bazel rejects
it with `unexpected keyword argument` -- so this has to be per-target.

The behaviour was verified in an isolated workspace with an equivalent
`cc_binary` (`-static`, same constraint), because this host cannot build the
full repository for macOS:

    $ bazel build --platforms=//pkg:fake_macos //pkg/...
    Target //pkg:helper was skipped
    INFO: Build completed successfully

    $ bazel build //pkg/...        # linux host
    INFO: Build completed successfully

So the target drops out of a wildcard on macOS and still builds on Linux. The
nvsnap row of the Bazel matrix covers the Linux half for the real targets.

Not verified: the actual Black Duck run. Please could the Pulse team re-run
their detect command against this branch.

## Notes

Deliberately scoped to the two C targets rather than the whole subtree. The Go
libraries should be buildable on any platform, and where they are not, that is
a missing build constraint to fix rather than a platform to exclude. nvsnap has
32 `go_library`, 16 `go_test` and 9 `go_binary` targets that are untouched here.

Because `//...` stops at the first failure, these two may not be the only
obstacle -- they are simply where the scan died. A repeat scan will show what,
if anything, is behind them.

This is the first use of `target_compatible_with` in the repository, so it sets
the precedent for how platform-specific targets are excluded.

## References

None

## Dependencies

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform build and repository scan behavior by clearly limiting Linux-only components to Linux environments.
  * Prevented unsupported non-Linux builds from failing unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->