### PR TITLE
ci: run the Bazel matrix on NVIDIA self-hosted runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,15 @@
+# actionlint does not know NVIDIA's self-hosted runner labels and fails the
+# workflow lint with "label ... is unknown". Declare the ones this repository
+# is entitled to use. Entitlement is granted per repository in
+# nv-gha-runners/enterprise-runner-configuration; keep this list in step with
+# the runner groups requested there.
+self-hosted-runner:
+  labels:
+    - linux-amd64-cpu4
+    - linux-amd64-cpu8
+    - linux-amd64-cpu16
+    - linux-amd64-cpu32
+    - linux-arm64-cpu4
+    - linux-arm64-cpu8
+    - linux-arm64-cpu16
+    - linux-arm64-cpu32

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -347,7 +347,16 @@ jobs:
     # was queueing, not work. cpu16 is also 4x the cores of the hosted runner,
     # so it shortens the critical path as well as the wait, which matters
     # because the row is a Bazel build that parallelises well.
-    runs-on: linux-amd64-cpu16
+    # NVIDIA policy blocks `pull_request` events on self-hosted runners, since a
+    # fork's pull request could otherwise execute untrusted code inside the
+    # network: the job is accepted and then killed at setup with "Workflows
+    # triggered by pull_request events are not allowed to run on self-hosted
+    # runners". Pull requests therefore stay on GitHub-hosted capacity.
+    #
+    # merge_group and push run trusted, already-reviewed code, and the merge
+    # queue is where the starvation actually hurt: twelve rows waited 26 to 31
+    # minutes for a runner against a slowest row of ~650s.
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'linux-amd64-cpu16' }}
     # Public EC2 Buildbarn cache (grpcs, bearer-token gated). The token is a
     # repo secret, so fork PRs (which never receive secrets) fall back to a
     # cacheless build automatically. The CA cert is a repo variable (public).

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -337,7 +337,17 @@ jobs:
     # it to `failure`, not `skipped`, which failed the required check on PRs
     # that had nothing wrong with them. bazel-docker already guards this way.
     if: needs.detect.outputs.matrix != '[]'
-    runs-on: ubuntu-latest
+    # NVIDIA self-hosted runners (nv-cpu-general), not GitHub-hosted. Access is
+    # granted per repository in nv-gha-runners/enterprise-runner-configuration
+    # and expires, so it must be renewed there.
+    #
+    # This is a capacity change, not a tuning one. On GitHub-hosted runners a
+    # merge-queue entry saw twelve rows start immediately and the rest wait 26
+    # to 31 minutes for a runner, against a slowest row of ~650s: the wall clock
+    # was queueing, not work. cpu16 is also 4x the cores of the hosted runner,
+    # so it shortens the critical path as well as the wait, which matters
+    # because the row is a Bazel build that parallelises well.
+    runs-on: linux-amd64-cpu16
     # Public EC2 Buildbarn cache (grpcs, bearer-token gated). The token is a
     # repo secret, so fork PRs (which never receive secrets) fall back to a
     # cacheless build automatically. The CA cert is a repo variable (public).


### PR DESCRIPTION
## Why

Runner starvation is the merge-queue bottleneck. Access to `nv-cpu-general` was
granted in nv-gha-runners/enterprise-runner-configuration#413.

Measured on GitHub-hosted runners, a 24-row merge-queue entry:

    queue waits (s), all 24 rows:
      3, 4, 4, 4, 7, 11, 19, 21, 22, 22, 37, 46,
      1553, 1565, 1568, 1568, 1569, 1569, 1574, 1580, 1851, 1855, 1855, 1857

Twelve rows start at once, then a 26-minute cliff waiting for a runner. The
slowest row is 669s, and an identical run finished in 885s rather than 2132s
purely because capacity happened to be free. The work is not slow; the jobs
cannot get machines.

## What changed

`runs-on` for the Bazel matrix is now conditional on the event:

    ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'linux-amd64-cpu16' }}

It is not unconditional, because that does not work. Pointing the matrix
straight at the self-hosted fleet fails: the job is accepted by a runner and
then killed during setup by a pre-job hook with

    Workflows triggered by "pull_request" events are not allowed to run on
    self-hosted runners.

A fork's pull request could otherwise execute untrusted code inside the
network, so this is a deliberate policy rather than a misconfiguration. Pull
requests stay on GitHub-hosted capacity; `merge_group`, `push` and
`workflow_dispatch` run trusted, already-reviewed code and move to
`linux-amd64-cpu16`.

That split lands where the problem actually is. The merge queue was what
starved, not pull request checks.

`.github/actionlint.yaml` declares the self-hosted labels this repository is
entitled to use. Without it the `Lint workflows` check fails with
`label "linux-amd64-cpu16" is unknown`. That list must stay in step with the
runner groups requested in the configuration repository.

`linux-amd64-cpu16` is an `m7i.4xlarge`, four times the cores of a hosted
runner, so it shortens the critical path as well as the wait. The row is a
Bazel build and parallelises well.

## Scope

Only the matrix job. `detect`, the aggregate gate and the docker-host lane stay
on GitHub-hosted runners so this changes one variable at a time. The docker lane
runs Testcontainers against host Docker and deserves its own verification.

`max-parallel: 8` is left alone. It exists to stop a burst of concurrent
`actions/checkout` calls tripping GitHub's action-download rate limit, which is
unchanged by where jobs run. Worth revisiting with data from the new runners.

## Testing

This pull request does NOT test the change it makes. Its own checks run as
`pull_request`, which the expression above deliberately routes to
`ubuntu-latest`. An earlier revision claimed the pull request tested itself;
that stopped being true once `runs-on` became conditional.

Verified instead with a `workflow_dispatch` run on this branch, which resolves
to the self-hosted path:

    completed/success  bazel (nats-auth-callout)  [edc3-l-amd-c16-fpq96-runner-6r8jq]
    in_progress        bazel (root)               [edc3-l-amd-c16-fpq96-runner-nbbq4]
    in_progress        bazel (nvca)               [edc3-l-amd-c16-fpq96-runner-5xb7v]
    in_progress        bazel (ratelimiter)        [edc3-l-amd-c16-fpq96-runner-4qhwh]
    in_progress        bazel (http-invocation)    [edc3-l-amd-c16-fpq96-runner-nv2vc]

Rows land on NVIDIA runners in `nv-cpu-general` and pass, each on its own
instance rather than competing for a shared pool.

`merge_group` is the one event this cannot directly verify before merging.
Evidence it is permitted: `NVIDIA/ncore` runs `on: push: + merge_group:` against
these runners in production. Across the 23 NVIDIA repositories using these
labels, none pairs them with `pull_request`, and several combine them with
`merge_group`.

## Notes

This introduces an external dependency. Runner access is granted per repository
with an expiration date and renewed through the configuration repository; if it
lapses these jobs stop finding runners. The `nvidia-runner-mgmt` GitHub App
opens a warning issue 30 days before expiry, which is why it must remain
installed for this repository.

Native `linux-arm64` runners exist in the same group and are in real use
(`NVIDIA/NemoClaw` runs `linux-arm64-cpu4`). That is a worthwhile follow-up: our
images are multi-arch and the arm64 half is currently cross-compiled through a
hermetic toolchain that needs architecture-specific system libraries baked into
the CI image.

## References

nv-gha-runners/enterprise-runner-configuration#413

## Dependencies

None.
