### PR TITLE
fix(release): align helm-reval version history

### DIFF
--- a/tools/ci/github-release
+++ b/tools/ci/github-release
@@ -103,6 +103,22 @@ def semverish_sort_key(value):
     return [int(part) if part.isdigit() else part for part in re.split(r"(\d+)", value)]
 
 
+def stable_semver_key(version):
+    if not re.fullmatch(STABLE_SEMVER_PATTERN, version):
+        raise SystemExit(f"unsupported stable SemVer: {version}")
+    return tuple(int(part) for part in version.split("."))
+
+
+def configured_stable_version(service, field):
+    raw = str(service.get(field) or "").strip()
+    if not raw:
+        return ""
+    version = raw.lstrip("v")
+    if not re.fullmatch(STABLE_SEMVER_PATTERN, version):
+        raise SystemExit(f"{service['id']}: {field} must contain a stable SemVer, got {raw!r}")
+    return version
+
+
 def default_tag_format(service):
     prefix = str(service.get("path") or "").strip().strip("/")
     if prefix and prefix != ".":
@@ -322,6 +338,80 @@ def synthesize_initial_version_anchor(root, service):
         f"[github-release] {service['id']}: synthesized local initial-version anchor "
         f"{anchor} ({sha}); missing version tags start at {INITIAL_RELEASE_VERSION}"
     )
+
+
+def synthesize_release_floor_anchor(root, service):
+    floor = configured_stable_version(service, "release_floor_version")
+    if not floor:
+        return
+
+    current_prefix = tag_prefix(service)
+    current_tag = latest_service_tag_for_prefix(current_prefix)
+    if current_tag:
+        current_version = current_tag[len(current_prefix) :]
+        if re.fullmatch(STABLE_SEMVER_PATTERN, current_version) and stable_semver_key(current_version) >= stable_semver_key(floor):
+            return
+        sha = tag_sha(root, current_tag)
+    else:
+        first_commits = run(["git", "rev-list", "--reverse", "HEAD", "--", service["path"]], cwd=root, capture=True).splitlines()
+        if first_commits:
+            sha = run(
+                ["git", "rev-parse", "-q", "--verify", f"{first_commits[0]}^"],
+                cwd=root,
+                capture=True,
+                check=False,
+            ).strip() or first_commits[0]
+        else:
+            roots = run(["git", "rev-list", "--max-parents=0", "HEAD"], cwd=root, capture=True).splitlines()
+            sha = roots[-1] if roots else ""
+
+    if not sha:
+        return
+
+    anchor = tag_for_version(service, floor)
+    if run(["git", "rev-parse", "-q", "--verify", f"refs/tags/{anchor}"], cwd=root, capture=True, check=False).strip():
+        return
+
+    run(["git", "tag", anchor, sha], cwd=root)
+    print(f"[github-release] {service['id']}: synthesized local release-floor anchor {anchor} ({sha})")
+
+
+def publish_cutover_release(root, service, dry_run):
+    version = configured_stable_version(service, "cutover_version")
+    if not version:
+        return False
+
+    tag = tag_for_version(service, version)
+    existing = run(["git", "rev-parse", "-q", "--verify", f"refs/tags/{tag}"], cwd=root, capture=True, check=False).strip()
+    if existing:
+        print(f"[github-release] {service['id']}: cutover tag {tag} already exists; skipping")
+        return False
+
+    sha = run(["git", "rev-parse", "--verify", "HEAD^{commit}"], cwd=root, capture=True).strip()
+    note = {
+        "channels": [None],
+        "name": f"v{version}",
+        "gitHead": sha,
+        "gitTag": tag,
+    }
+    existing_note = existing_semantic_release_note(root, sha)
+    if existing_note:
+        raise SystemExit(
+            f"{service['id']}: refs/notes/semantic-release already has a note on {sha}; "
+            "create the cutover tag from a new commit"
+        )
+
+    if dry_run:
+        print(f"[github-release] {service['id']}: would create cutover tag {tag} at {sha}")
+        print(f"[github-release] {service['id']}: would add semantic-release note {json.dumps(note, sort_keys=True)}")
+        return True
+
+    run(["git", "tag", tag, sha], cwd=root)
+    run(["git", "notes", "--ref=refs/notes/semantic-release", "add", "-m", json.dumps(note, sort_keys=True), sha], cwd=root)
+    run(["git", "push", "origin", f"refs/tags/{tag}"], cwd=root)
+    run(["git", "push", "origin", "refs/notes/semantic-release"], cwd=root)
+    print(f"[github-release] {service['id']}: pushed cutover tag {tag} and semantic-release note")
+    return True
 
 
 def only_generated_changes(root, service, generated_paths):
@@ -698,9 +788,13 @@ def auto_release(args):
                 publish_version_file_release(root, service, dry_run=dry_run, draft=draft)
                 continue
 
+            if publish_cutover_release(root, service, dry_run=dry_run):
+                continue
+
+            synthesize_current_prefix_anchor(service)
+            synthesize_release_floor_anchor(root, service)
             if only_generated_changes(root, service, generated_paths):
                 continue
-            synthesize_current_prefix_anchor(service)
             synthesize_initial_version_anchor(root, service)
 
             write_semantic_release_files(

--- a/tools/ci/github-release-subprojects.json
+++ b/tools/ci/github-release-subprojects.json
@@ -135,7 +135,9 @@
       "id": "helm-reval",
       "path": "src/control-plane-services/helm-reval",
       "service_name": "nvcf-helm-reval-api",
-      "legacy_tag_prefix": "nvcf-helm-reval-api-v"
+      "legacy_tag_prefix": "nvcf-helm-reval-api-v",
+      "release_floor_version": "0.17.0",
+      "cutover_version": "0.18.0"
     },
     {
       "id": "ess-agent",

--- a/tools/ci/test-github-release.py
+++ b/tools/ci/test-github-release.py
@@ -115,6 +115,76 @@ class GithubReleaseTest(unittest.TestCase):
             self.assertIn("byoo-otel-collector-v0.153.6 already exists", output.getvalue())
             self.assertIn("skipping", output.getvalue())
 
+    def test_release_floor_anchor_uses_the_highest_internal_history_version(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.init_repo(root)
+            service_dir = root / "src/control-plane-services/helm-reval"
+            service_dir.mkdir(parents=True)
+            (service_dir / "README.md").write_text("initial\n")
+            self.commit_all(root, "initial helm-reval")
+            old_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"], cwd=root, check=True, text=True, stdout=subprocess.PIPE
+            ).stdout.strip()
+            git(root, "tag", "src/control-plane-services/helm-reval/v0.4.0")
+            (service_dir / "README.md").write_text("next\n")
+            self.commit_all(root, "next helm-reval change")
+
+            service = {
+                "id": "helm-reval",
+                "path": "src/control-plane-services/helm-reval",
+                "service_name": "nvcf-helm-reval-api",
+                "release_floor_version": "0.17.0",
+            }
+
+            with chdir(root):
+                self.github_release.synthesize_release_floor_anchor(root, service)
+
+            floor_tag = "src/control-plane-services/helm-reval/v0.17.0"
+            self.assertEqual(
+                subprocess.run(
+                    ["git", "rev-list", "-n", "1", floor_tag], cwd=root, check=True, text=True, stdout=subprocess.PIPE
+                ).stdout.strip(),
+                old_sha,
+            )
+            with chdir(root):
+                self.assertEqual(self.github_release.latest_service_tag(service), floor_tag)
+
+    def test_helm_reval_cutover_is_a_stable_version_above_its_history_floor(self):
+        metadata = json.loads(SCRIPT_PATH.with_name("github-release-subprojects.json").read_text())
+        service = next(service for service in metadata["services"] if service["id"] == "helm-reval")
+
+        floor = self.github_release.configured_stable_version(service, "release_floor_version")
+        cutover = self.github_release.configured_stable_version(service, "cutover_version")
+
+        self.assertEqual(floor, "0.17.0")
+        self.assertEqual(cutover, "0.18.0")
+        self.assertGreater(
+            self.github_release.stable_semver_key(cutover),
+            self.github_release.stable_semver_key(floor),
+        )
+
+    def test_cutover_release_dry_run_creates_the_configured_tag_once(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.init_repo(root)
+            service_dir = root / "src/control-plane-services/helm-reval"
+            service_dir.mkdir(parents=True)
+            (service_dir / "README.md").write_text("cutover\n")
+            self.commit_all(root, "release configuration")
+            service = {
+                "id": "helm-reval",
+                "path": "src/control-plane-services/helm-reval",
+                "service_name": "nvcf-helm-reval-api",
+                "cutover_version": "0.18.0",
+            }
+
+            output = io.StringIO()
+            with chdir(root), contextlib.redirect_stdout(output):
+                self.assertTrue(self.github_release.publish_cutover_release(root, service, dry_run=True))
+
+            self.assertIn("would create cutover tag src/control-plane-services/helm-reval/v0.18.0", output.getvalue())
+
     def test_nvca_branch_cut_uses_path_scoped_release_branch(self):
         service = {
             "id": "nvca",


### PR DESCRIPTION
## TL;DR

- Correct helm-reval release history, which stopped at `v0.4.0` during the GitHub cutover.
- Publish `v0.18.0` once on `main`, then let semantic-release continue from that baseline.

## Additional Details

- Record `0.17.0` as the historical version floor and `0.18.0` as the one-time cutover tag.
- Create the cutover tag and semantic-release note only when the tag is absent.
- Use the floor as a local anchor if an older checkout lacks the cutover tag.

## For the Reviewer

- Review `tools/ci/github-release` for the one-time cutover and future floor behavior.

## For QA

- Not needed. This is release automation only.

## Testing

- `python3 tools/ci/test-github-release.py`
- `GITHUB_REF_TYPE=branch GITHUB_REF_NAME=main NVCF_GITHUB_AUTO_TAGGING_ENABLED=false NVCF_GITHUB_RELEASE_DRY_RUN=true ./tools/ci/github-release auto --service helm-reval`

## Issues

Closes #578

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover the update.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring stable release versions.
  * Added automated release cutovers and release-floor anchors.
  * Added dry-run support for previewing cutover tags and release metadata.
  * Configured release-floor and cutover versions for the `helm-reval` service.

* **Bug Fixes**
  * Added validation to prevent invalid stable versions and duplicate cutover releases.

* **Tests**
  * Added coverage for release-floor selection, version ordering, and dry-run cutover behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->