### PR TITLE
fix(bazel): repin distroless_static and make the nvsnap base multi-arch

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -143,9 +143,14 @@ oci.pull(
 
 # nvsnap base images. nvsnap runs on GPU hosts and is amd64-only, so these are
 # scoped to linux/amd64 and its image targets are single-arch.
+#
+# Repinned 2026-07-30. The previous digest was garbage-collected upstream and
+# gcr.io answers it with "manifest unknown", so any checkout without a warm
+# repository cache fails to analyse //... . CI did not notice because it
+# restores that cache, which made a dead pin look healthy.
 oci.pull(
     name = "distroless_static",
-    digest = "sha256:dd7614b5a12bc4d617b223c588b4e0c833402b8f526c11e612b324a956cd2640",
+    digest = "sha256:9197324ba51d9cd071af8505989365c006adf9d6d2067eada25aef00abbb5278",
     image = "gcr.io/distroless/static",
     platforms = ["linux/amd64"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -141,8 +141,12 @@ oci.pull(
     ],
 )
 
-# nvsnap base images. nvsnap runs on GPU hosts and is amd64-only, so these are
-# scoped to linux/amd64 and its image targets are single-arch.
+# nvsnap base images. Pulled for both architectures like every other service:
+# go_oci_image always emits a _multi_arch target over DEFAULT_PLATFORMS, so a
+# base pulled for one architecture leaves the other branch of the transition
+# with no matching image. `bazel build //...` hid that because those targets are
+# tagged manual and wildcard builds skip them, but `cquery deps(//...)` ignores
+# manual and fails analysis -- which is what blocked the Black Duck scan.
 #
 # Repinned 2026-07-30. The previous digest was garbage-collected upstream and
 # gcr.io answers it with "manifest unknown", so any checkout without a warm
@@ -152,7 +156,12 @@ oci.pull(
     name = "distroless_static",
     digest = "sha256:9197324ba51d9cd071af8505989365c006adf9d6d2067eada25aef00abbb5278",
     image = "gcr.io/distroless/static",
-    platforms = ["linux/amd64"],
+    platforms = [
+        "linux/amd64",
+        # arm64/v8, not arm64: the index publishes its aarch64 manifest under
+        # the v8 variant and rules_oci matches the platform string exactly.
+        "linux/arm64/v8",
+    ],
 )
 oci.pull(
     name = "ubuntu_22_04",
@@ -172,6 +181,7 @@ use_repo(
     "alpine_3_20_linux_amd64",
     "distroless_static",
     "distroless_static_linux_amd64",
+    "distroless_static_linux_arm64_v8",
     "ubuntu_22_04",
     "ubuntu_22_04_linux_amd64",
     "ubuntu_noble",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -379,7 +379,7 @@
     "@@rules_oci+//oci:extensions.bzl%oci": {
       "general": {
         "bzlTransitiveDigest": "IPpbSHX7+8yLBfvZyia9qXU/WRxkP+dWAO8m5+BsBY8=",
-        "usagesDigest": "HCv5iVmsywJDYi04nXaMJHFn8CwQx+Ryy/HVpSiPdaQ=",
+        "usagesDigest": "k+DVGK+TlleQwdSiYAKkaKw7beQwwdsbQ4dL3+p67dI=",
         "recordedInputs": [
           "REPO_MAPPING:aspect_bazel_lib+,bazel_tools bazel_tools",
           "REPO_MAPPING:bazel_features+,bazel_tools bazel_tools",
@@ -428,6 +428,107 @@
                 "@@platforms//cpu:x86_64": "@ubuntu_noble_linux_amd64"
               },
               "bzlmod_repository": "ubuntu_noble",
+              "reproducible": true
+            }
+          },
+          "distroless_static_linux_amd64": {
+            "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_pull",
+            "attributes": {
+              "www_authenticate_challenges": {},
+              "scheme": "https",
+              "registry": "gcr.io",
+              "repository": "distroless/static",
+              "identifier": "sha256:9197324ba51d9cd071af8505989365c006adf9d6d2067eada25aef00abbb5278",
+              "platform": "linux/amd64",
+              "target_name": "distroless_static_linux_amd64",
+              "bazel_tags": []
+            }
+          },
+          "distroless_static_linux_arm64_v8": {
+            "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_pull",
+            "attributes": {
+              "www_authenticate_challenges": {},
+              "scheme": "https",
+              "registry": "gcr.io",
+              "repository": "distroless/static",
+              "identifier": "sha256:9197324ba51d9cd071af8505989365c006adf9d6d2067eada25aef00abbb5278",
+              "platform": "linux/arm64/v8",
+              "target_name": "distroless_static_linux_arm64_v8",
+              "bazel_tags": []
+            }
+          },
+          "distroless_static": {
+            "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_alias",
+            "attributes": {
+              "target_name": "distroless_static",
+              "www_authenticate_challenges": {},
+              "scheme": "https",
+              "registry": "gcr.io",
+              "repository": "distroless/static",
+              "identifier": "sha256:9197324ba51d9cd071af8505989365c006adf9d6d2067eada25aef00abbb5278",
+              "platforms": {
+                "@@platforms//cpu:x86_64": "@distroless_static_linux_amd64",
+                "@@platforms//cpu:arm64": "@distroless_static_linux_arm64_v8"
+              },
+              "bzlmod_repository": "distroless_static",
+              "reproducible": true
+            }
+          },
+          "ubuntu_22_04_linux_amd64": {
+            "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_pull",
+            "attributes": {
+              "www_authenticate_challenges": {},
+              "scheme": "https",
+              "registry": "index.docker.io",
+              "repository": "library/ubuntu",
+              "identifier": "sha256:0e5e4a57c2499249aafc3b40fcd541e9a456aab7296681a3994d631587203f97",
+              "platform": "linux/amd64",
+              "target_name": "ubuntu_22_04_linux_amd64",
+              "bazel_tags": []
+            }
+          },
+          "ubuntu_22_04": {
+            "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_alias",
+            "attributes": {
+              "target_name": "ubuntu_22_04",
+              "www_authenticate_challenges": {},
+              "scheme": "https",
+              "registry": "index.docker.io",
+              "repository": "library/ubuntu",
+              "identifier": "sha256:0e5e4a57c2499249aafc3b40fcd541e9a456aab7296681a3994d631587203f97",
+              "platforms": {
+                "@@platforms//cpu:x86_64": "@ubuntu_22_04_linux_amd64"
+              },
+              "bzlmod_repository": "ubuntu_22_04",
+              "reproducible": true
+            }
+          },
+          "alpine_3_20_linux_amd64": {
+            "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_pull",
+            "attributes": {
+              "www_authenticate_challenges": {},
+              "scheme": "https",
+              "registry": "index.docker.io",
+              "repository": "library/alpine",
+              "identifier": "sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d",
+              "platform": "linux/amd64",
+              "target_name": "alpine_3_20_linux_amd64",
+              "bazel_tags": []
+            }
+          },
+          "alpine_3_20": {
+            "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_alias",
+            "attributes": {
+              "target_name": "alpine_3_20",
+              "www_authenticate_challenges": {},
+              "scheme": "https",
+              "registry": "index.docker.io",
+              "repository": "library/alpine",
+              "identifier": "sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d",
+              "platforms": {
+                "@@platforms//cpu:x86_64": "@alpine_3_20_linux_amd64"
+              },
+              "bzlmod_repository": "alpine_3_20",
               "reproducible": true
             }
           },
@@ -636,6 +737,13 @@
             "ubuntu_noble",
             "ubuntu_noble_linux_arm64_v8",
             "ubuntu_noble_linux_amd64",
+            "distroless_static",
+            "distroless_static_linux_amd64",
+            "distroless_static_linux_arm64_v8",
+            "ubuntu_22_04",
+            "ubuntu_22_04_linux_amd64",
+            "alpine_3_20",
+            "alpine_3_20_linux_amd64",
             "temurin_jre",
             "temurin_jre_linux_arm64_v8",
             "temurin_jre_linux_amd64",
@@ -1389,6 +1497,164 @@
         "windows_arm64": [
           "go1.25.0.windows-arm64.zip",
           "27bab004c72b3d7bd05a69b6ec0fc54a309b4b78cc569dd963d8b3ec28bfdb8c"
+        ]
+      },
+      "1.26.5": {
+        "aix_ppc64": [
+          "go1.26.5.aix-ppc64.tar.gz",
+          "e7f3c518fd7a8bc17f4389e342554016785f95ce447f8f09a260328de0d0f06c"
+        ],
+        "darwin_amd64": [
+          "go1.26.5.darwin-amd64.tar.gz",
+          "6231d8d3b8f5552ec6cbf6d685bdd5482e1e703214b120e89b3bf0d7bf1ef725"
+        ],
+        "darwin_arm64": [
+          "go1.26.5.darwin-arm64.tar.gz",
+          "efb87ff28af9a188d0536ef5d42e63dd52ba8263cd7344a993cc48dd11dedb6a"
+        ],
+        "dragonfly_amd64": [
+          "go1.26.5.dragonfly-amd64.tar.gz",
+          "96b53091297bd3a9ec8ed39f5f76b074c813dd74a6f429c03c667877ff27fdf8"
+        ],
+        "freebsd_386": [
+          "go1.26.5.freebsd-386.tar.gz",
+          "1a0226fc025d97d30a112ad0d09b13dcacedc5b24b04bf8f21a0cd29aac4d947"
+        ],
+        "freebsd_amd64": [
+          "go1.26.5.freebsd-amd64.tar.gz",
+          "0e5ddc51a62018211d461d6bf409939b04eaa4d6dd6d7097910090ef755ed947"
+        ],
+        "freebsd_arm": [
+          "go1.26.5.freebsd-arm.tar.gz",
+          "f8a59e86427158d89b2ba158d7f6004881e378fa3d7e4aefd4df17e4ee3a6bd1"
+        ],
+        "freebsd_arm64": [
+          "go1.26.5.freebsd-arm64.tar.gz",
+          "ae3825c8c57cc0e64c2233bfb9bba2e091f2126728e4c33492592c24b60dfcd0"
+        ],
+        "illumos_amd64": [
+          "go1.26.5.illumos-amd64.tar.gz",
+          "fcd06289bd8a5a9962e5acab2f30e7daa74952327b01366fa9f6e07007e65be1"
+        ],
+        "linux_386": [
+          "go1.26.5.linux-386.tar.gz",
+          "88c162b204e6eefcc32499453b492e80209f4a4c78c33092636901c540fb0d05"
+        ],
+        "linux_amd64": [
+          "go1.26.5.linux-amd64.tar.gz",
+          "5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053"
+        ],
+        "linux_arm64": [
+          "go1.26.5.linux-arm64.tar.gz",
+          "fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49"
+        ],
+        "linux_armv6l": [
+          "go1.26.5.linux-armv6l.tar.gz",
+          "6dae9edab81c13bccf962dec15f1fd2ec26c14a6821b4d2c92dab4130c289d7a"
+        ],
+        "linux_loong64": [
+          "go1.26.5.linux-loong64.tar.gz",
+          "82736bb7794547a73372ddfeb1b370cfea4d17f04782a65e82a389a01ff0f7aa"
+        ],
+        "linux_mips": [
+          "go1.26.5.linux-mips.tar.gz",
+          "3d313aefb8b7547beae18bb69febcf1571f775146209332a48a2942993655417"
+        ],
+        "linux_mips64": [
+          "go1.26.5.linux-mips64.tar.gz",
+          "7e5547e99a891e338fa5490b72d46ea7fd0593259df51561d7f55d4698503a8c"
+        ],
+        "linux_mips64le": [
+          "go1.26.5.linux-mips64le.tar.gz",
+          "7e05aceb9dea6033bc2f6dde29139293d8247cc2db749a206472b3916b1765a1"
+        ],
+        "linux_mipsle": [
+          "go1.26.5.linux-mipsle.tar.gz",
+          "e481470951e3a22a014ee70aebaae0c35aae4193a253d22ecf59d58f4bdbc450"
+        ],
+        "linux_ppc64": [
+          "go1.26.5.linux-ppc64.tar.gz",
+          "8ef02abd6f2b4040b7eb001b64597d16b9fa9aa563baaecf181ad8d9806c9991"
+        ],
+        "linux_ppc64le": [
+          "go1.26.5.linux-ppc64le.tar.gz",
+          "c5d60e2b303bb612f20cd82786594b64874e73b35134025e27d3390bf284ae43"
+        ],
+        "linux_riscv64": [
+          "go1.26.5.linux-riscv64.tar.gz",
+          "d4a24dd4484d3f86b99c2d300af0dea5d184557e6d61eb7aba19ff61662750e3"
+        ],
+        "linux_s390x": [
+          "go1.26.5.linux-s390x.tar.gz",
+          "09ce3c504c0323968b75a717244dca4f25cd4cf0443e5ff6bc0bfa74add89fa7"
+        ],
+        "netbsd_386": [
+          "go1.26.5.netbsd-386.tar.gz",
+          "6df082b6dd877c3e71af3c44e67b8684f8592cb0fc50aed3ea9e58968bc3165f"
+        ],
+        "netbsd_amd64": [
+          "go1.26.5.netbsd-amd64.tar.gz",
+          "daed1cb730d52e8b40866253b6271fd215f6128372dccc61d7784d4d3fb4a1bf"
+        ],
+        "netbsd_arm": [
+          "go1.26.5.netbsd-arm.tar.gz",
+          "d8a18f2d5afb6aaf47b79135221a964c21ee5cf5d568301a718904d887b1c96f"
+        ],
+        "netbsd_arm64": [
+          "go1.26.5.netbsd-arm64.tar.gz",
+          "60520191abd288fb0f22b279ee63497b3a81318134e41f2bb80f548c9227bd6a"
+        ],
+        "openbsd_386": [
+          "go1.26.5.openbsd-386.tar.gz",
+          "723a35e81882ddd8bdcb2539111f53ab4b03d4dbc114a2420d47963163465843"
+        ],
+        "openbsd_amd64": [
+          "go1.26.5.openbsd-amd64.tar.gz",
+          "27721c64efcb571ecfbf52ee77f133ec73dca96015b315199be104ed2dfafd87"
+        ],
+        "openbsd_arm": [
+          "go1.26.5.openbsd-arm.tar.gz",
+          "2de3fb692c74c68a40d8c92ec6a077a18c14a44e8e41a8c22edeb286b3a4dfce"
+        ],
+        "openbsd_arm64": [
+          "go1.26.5.openbsd-arm64.tar.gz",
+          "969a90bc34bda3ec06c0c3278ae00cdaa9b747b100cadec9f3f8c2cb36f01c69"
+        ],
+        "openbsd_ppc64": [
+          "go1.26.5.openbsd-ppc64.tar.gz",
+          "cb3908dd5904df453ebce07cfc660b7a14b7fed9525463521f01a04affd49eb8"
+        ],
+        "openbsd_riscv64": [
+          "go1.26.5.openbsd-riscv64.tar.gz",
+          "922864dbcb3ec989f456b2c313a46a4c0b0bd93b398603dc0db2d5a72b5ca47c"
+        ],
+        "plan9_386": [
+          "go1.26.5.plan9-386.tar.gz",
+          "7858fe6515a8e71050a3b59211b6c6f6947822497ecbe1ab81f4e4503b67a635"
+        ],
+        "plan9_amd64": [
+          "go1.26.5.plan9-amd64.tar.gz",
+          "513acf2518947e51210772145436e62eb67cc44738c5df3b6218dfeb66f6416c"
+        ],
+        "plan9_arm": [
+          "go1.26.5.plan9-arm.tar.gz",
+          "131c06ed5b7ce904ff7b121c63ffd76a699fff43b96e019914f093ede1be9e4a"
+        ],
+        "solaris_amd64": [
+          "go1.26.5.solaris-amd64.tar.gz",
+          "33a1fc532f8d5fc5964b28a056729bc50a59657b653a5f1b04c2aeb2ac54c149"
+        ],
+        "windows_386": [
+          "go1.26.5.windows-386.zip",
+          "cab0f6847c17f4c904c0bacb6ec6b84e730fc797f4ba885f42383d580fc2d399"
+        ],
+        "windows_amd64": [
+          "go1.26.5.windows-amd64.zip",
+          "97e6b2a833b6d89f9ff17d25419ac0a7e3b482a044e9ab18cdef834bd834fd38"
+        ],
+        "windows_arm64": [
+          "go1.26.5.windows-arm64.zip",
+          "f96ee46396d69f1e231c8d981ec6a70216238a646a1f2cd74aea0d0016bbc017"
         ]
       }
     }

--- a/tools/ci/check-oci-pins
+++ b/tools/ci/check-oci-pins
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fail if any oci.pull digest pinned in a MODULE.bazel no longer resolves.
+#
+# Why this exists: the root module pinned a gcr.io/distroless/static digest that
+# upstream had garbage-collected. `bazel build //...` therefore failed at
+# analysis on any checkout without a warm Bazel repository cache, while CI
+# stayed green because it restores that cache. A dead pin looked healthy for as
+# long as the cache survived, and the Actions cache is over quota and evicting
+# continuously, so the failure was one eviction away from reaching main. It also
+# blocked an external Black Duck scan for days with an error that read like a
+# network problem.
+#
+# Digests are supposed to be immutable, but the tags behind them are not:
+# registries garbage-collect untagged manifests, so a pin can rot without anyone
+# editing it. That makes this a scheduled check, not a per-change one.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${root}"
+
+: "${SKOPEO:=skopeo}"
+if ! command -v "${SKOPEO}" >/dev/null 2>&1; then
+    echo "error: ${SKOPEO} not found; cannot verify pins" >&2
+    exit 2
+fi
+
+# Strip a :tag from the final path component before appending @digest. A
+# reference carrying both a tag and a digest is invalid and skopeo rejects it,
+# which reads as "dead" and produces false positives. That mistake was made
+# twice while investigating this, hence both the helper and its test.
+strip_tag() {
+    local ref="$1" head last
+    last="${ref##*/}"
+    head="${ref%"${last}"}"
+    printf '%s%s' "${head}" "${last%%:*}"
+}
+
+# Retry before declaring a pin dead: a registry timeout is not a missing image.
+# Only "manifest unknown" / "not found" is treated as authoritative.
+resolves() {
+    local ref="$1" out i
+    for i in 1 2 3; do
+        if out="$("${SKOPEO}" inspect --raw "docker://${ref}" 2>&1)"; then
+            return 0
+        fi
+        case "${out}" in
+            *"manifest unknown"*|*"not found"*|*"not known"*) return 1 ;;
+        esac
+        sleep 2
+    done
+    echo "  (giving up after retries: ${out})" >&2
+    return 1
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+    fail=0
+    check() {
+        local got; got="$(strip_tag "$1")"
+        if [ "${got}" != "$2" ]; then
+            printf 'FAIL strip_tag %s: got %s want %s\n' "$1" "${got}" "$2" >&2
+            fail=1
+        else
+            printf 'ok   strip_tag %s -> %s\n' "$1" "${got}"
+        fi
+    }
+    check "nvcr.io/nvidia/distroless/go:v4.0.8" "nvcr.io/nvidia/distroless/go"
+    check "nvcr.io/nvidia/distroless/go"        "nvcr.io/nvidia/distroless/go"
+    check "gcr.io/distroless/static"            "gcr.io/distroless/static"
+    check "docker.io/library/ubuntu:24.04"      "docker.io/library/ubuntu"
+    # A registry port must not be mistaken for a tag.
+    check "registry.example.com:5000/img:1.2"   "registry.example.com:5000/img"
+    check "registry.example.com:5000/img"       "registry.example.com:5000/img"
+    [ "${fail}" -eq 0 ] || { echo "check-oci-pins: self-test FAILED" >&2; exit 1; }
+    echo "check-oci-pins: self-test passed"
+    exit 0
+fi
+
+mapfile -t pins < <(
+    git ls-files '*MODULE.bazel' | while read -r f; do
+        python3 - "$f" <<'PY'
+import re,sys
+f=sys.argv[1]
+for m in re.finditer(r'oci\.pull\((.*?)\n\)', open(f).read(), re.S):
+    b=m.group(1)
+    img=re.search(r'image\s*=\s*"([^"]+)"', b)
+    dig=re.search(r'digest\s*=\s*"(sha256:[0-9a-f]+)"', b)
+    if img and dig:
+        print(f"{f}\t{img.group(1)}\t{dig.group(1)}")
+PY
+    done | sort -u
+)
+
+if [ "${#pins[@]}" -eq 0 ]; then
+    echo "error: found no oci.pull pins to check; the parser is probably broken" >&2
+    exit 2
+fi
+
+status=0
+checked=0
+for entry in "${pins[@]}"; do
+    file="${entry%%$'\t'*}"
+    rest="${entry#*$'\t'}"
+    image="${rest%%$'\t'*}"
+    digest="${rest#*$'\t'}"
+    ref="$(strip_tag "${image}")@${digest}"
+    checked=$((checked + 1))
+    if resolves "${ref}"; then
+        printf 'ok   %-46s %s\n' "${image}" "${file}"
+    else
+        printf 'DEAD %-46s %s\n' "${image}" "${file}" >&2
+        printf '     %s\n' "${digest}" >&2
+        status=1
+    fi
+done
+
+if [ "${status}" -ne 0 ]; then
+    cat >&2 <<'MSG'
+
+error: one or more pinned base image digests no longer resolve.
+
+A dead pin does not fail CI while the Bazel repository cache is warm, but it
+fails every cold checkout, including external scanners. Repin to a current
+digest:
+
+    skopeo inspect --raw docker://<image>:<tag> | sha256sum
+
+MSG
+    exit 1
+fi
+
+echo "checked ${checked} pinned base image(s); all resolve"

--- a/tools/ci/check-oci-pins
+++ b/tools/ci/check-oci-pins
@@ -146,19 +146,32 @@ def parse_pins(path: str, text: str) -> list[dict]:
     return pins
 
 
+# A stalled registry or proxy would otherwise block a call forever and hang the
+# whole scheduled sweep until the CI job timeout kills it, losing every result.
+INSPECT_TIMEOUT_SECONDS = 60
+
+
 def fetch_manifest(ref: str, tries: int = 3):
     """Return (manifest, None) or (None, error). Retries transient failures.
 
-    Only an explicit "not found" from the registry is authoritative; a timeout
-    is not evidence that an image is gone.
+    Only an explicit "not found" from the registry is authoritative; neither a
+    timeout nor a network error is evidence that an image is gone, so those are
+    retried and then reported as an unresolved check rather than a dead pin.
     """
     err = ""
     for attempt in range(tries):
-        proc = subprocess.run(
-            [SKOPEO, "inspect", "--raw", f"docker://{ref}"],
-            capture_output=True,
-            text=True,
-        )
+        try:
+            proc = subprocess.run(
+                [SKOPEO, "inspect", "--raw", f"docker://{ref}"],
+                capture_output=True,
+                text=True,
+                timeout=INSPECT_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            err = f"timed out after {INSPECT_TIMEOUT_SECONDS}s"
+            if attempt < tries - 1:
+                time.sleep(2)
+            continue
         if proc.returncode == 0:
             try:
                 return json.loads(proc.stdout), None

--- a/tools/ci/check-oci-pins
+++ b/tools/ci/check-oci-pins
@@ -1,134 +1,335 @@
-#!/usr/bin/env bash
+#!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-#
-# Fail if any oci.pull digest pinned in a MODULE.bazel no longer resolves.
-#
-# Why this exists: the root module pinned a gcr.io/distroless/static digest that
-# upstream had garbage-collected. `bazel build //...` therefore failed at
-# analysis on any checkout without a warm Bazel repository cache, while CI
-# stayed green because it restores that cache. A dead pin looked healthy for as
-# long as the cache survived, and the Actions cache is over quota and evicting
-# continuously, so the failure was one eviction away from reaching main. It also
-# blocked an external Black Duck scan for days with an error that read like a
-# network problem.
-#
-# Digests are supposed to be immutable, but the tags behind them are not:
-# registries garbage-collect untagged manifests, so a pin can rot without anyone
-# editing it. That makes this a scheduled check, not a per-change one.
-set -euo pipefail
+"""Verify every oci.pull pin in a MODULE.bazel is still usable.
 
-root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-cd "${root}"
+Two things rot independently, and this repository has been bitten by both:
 
-: "${SKOPEO:=skopeo}"
-if ! command -v "${SKOPEO}" >/dev/null 2>&1; then
-    echo "error: ${SKOPEO} not found; cannot verify pins" >&2
-    exit 2
-fi
+1. The digest disappears. Digests are immutable but registries garbage-collect
+   untagged manifests, so a pin dies with no commit touching it. The root module
+   pinned a gcr.io/distroless/static digest that upstream had collected;
+   `bazel build //...` then failed at fetch on any checkout without a warm
+   repository cache, while CI stayed green because it restores that cache.
 
-# Strip a :tag from the final path component before appending @digest. A
-# reference carrying both a tag and a digest is invalid and skopeo rejects it,
-# which reads as "dead" and produces false positives. That mistake was made
-# twice while investigating this, hence both the helper and its test.
-strip_tag() {
-    local ref="$1" head last
-    last="${ref##*/}"
-    head="${ref%"${last}"}"
-    printf '%s%s' "${head}" "${last%%:*}"
-}
+2. The digest resolves but the index lacks a platform the pin asks for. That is
+   a separate failure and a quieter one: fetching succeeds and analysis fails
+   later with "could not find an image matching the target platform". nvsnap hit
+   exactly this, pulling one architecture while the shared go_oci_image macro
+   emits a target over two.
 
-# Retry before declaring a pin dead: a registry timeout is not a missing image.
-# Only "manifest unknown" / "not found" is treated as authoritative.
-resolves() {
-    local ref="$1" out i
-    for i in 1 2 3; do
-        if out="$("${SKOPEO}" inspect --raw "docker://${ref}" 2>&1)"; then
-            return 0
-        fi
-        case "${out}" in
-            *"manifest unknown"*|*"not found"*|*"not known"*) return 1 ;;
-        esac
-        sleep 2
-    done
-    echo "  (giving up after retries: ${out})" >&2
-    return 1
-}
+Checking only (1) would have missed (2) entirely, so both are checked here.
 
-if [ "${1:-}" = "--self-test" ]; then
-    fail=0
-    check() {
-        local got; got="$(strip_tag "$1")"
-        if [ "${got}" != "$2" ]; then
-            printf 'FAIL strip_tag %s: got %s want %s\n' "$1" "${got}" "$2" >&2
-            fail=1
-        else
-            printf 'ok   strip_tag %s -> %s\n' "$1" "${got}"
-        fi
-    }
-    check "nvcr.io/nvidia/distroless/go:v4.0.8" "nvcr.io/nvidia/distroless/go"
-    check "nvcr.io/nvidia/distroless/go"        "nvcr.io/nvidia/distroless/go"
-    check "gcr.io/distroless/static"            "gcr.io/distroless/static"
-    check "docker.io/library/ubuntu:24.04"      "docker.io/library/ubuntu"
+Run as a schedule, not per change: nothing in a pull request causes this to
+start failing.
+
+    check-oci-pins              verify every pin in the repository
+    check-oci-pins --self-test  exercise the parsing and matching logic
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import time
+
+SKOPEO = "skopeo"
+
+
+def strip_tag(ref: str) -> str:
+    """Drop a :tag from the final path component.
+
+    A reference carrying both a tag and a digest is invalid and skopeo rejects
+    it, which reads as a dead pin. That mistake produced two separate false
+    positives while investigating this, hence the self-test below. The registry
+    host may itself contain a port, so only the last component is considered.
+    """
+    head, sep, last = ref.rpartition("/")
+    return head + sep + last.split(":", 1)[0]
+
+
+def parse_platform(text: str) -> tuple[str, str, str]:
+    """"linux/arm64/v8" -> ("linux", "arm64", "v8"); variant defaults to ""."""
+    parts = text.strip().split("/")
+    while len(parts) < 3:
+        parts.append("")
+    return parts[0], parts[1], parts[2]
+
+
+def index_platforms(manifest: dict) -> set[tuple[str, str, str]]:
+    """Platforms an index advertises.
+
+    A single-image manifest advertises none: it has no `manifests` list, so a
+    pin naming explicit platforms against it cannot be satisfied.
+    """
+    out: set[tuple[str, str, str]] = set()
+    for entry in manifest.get("manifests", []):
+        p = entry.get("platform") or {}
+        os_ = p.get("os", "")
+        arch = p.get("architecture", "")
+        if not os_ or not arch:
+            continue
+        out.add((os_, arch, p.get("variant", "") or ""))
+    return out
+
+
+def missing_platforms(declared: list[str], manifest: dict) -> list[str]:
+    """Declared platforms absent from the index.
+
+    Matching is exact, including the variant, because rules_oci compares the
+    platform string exactly: "linux/arm64" does not select an index entry
+    published as arm64/v8, and pinning the former against the latter fails at
+    analysis rather than at fetch.
+    """
+    available = index_platforms(manifest)
+    return [d for d in declared if parse_platform(d) not in available]
+
+
+def strip_comments(text: str) -> str:
+    """Remove Starlark line comments, leaving string literals intact.
+
+    Necessary because a comment may quote a platform string while explaining
+    it. function-autoscaler documents why it uses arm64/v8 by naming the wrong
+    value, "linux/arm64", in prose; a naive scan for quoted strings reads that
+    as a declared platform and reports a healthy pin as broken. That false
+    positive is the reason this function and its test exist.
+    """
+    out = []
+    for line in text.splitlines():
+        quote = None
+        cut = len(line)
+        i = 0
+        while i < len(line):
+            ch = line[i]
+            if quote:
+                if ch == "\\":
+                    i += 2
+                    continue
+                if ch == quote:
+                    quote = None
+            elif ch in "\"'":
+                quote = ch
+            elif ch == "#":
+                cut = i
+                break
+            i += 1
+        out.append(line[:cut])
+    return "\n".join(out)
+
+
+PULL_RE = re.compile(r"oci\.pull\((.*?)\n\)", re.S)
+STR_RE = {k: re.compile(rf'{k}\s*=\s*"([^"]+)"') for k in ("image", "digest")}
+PLATFORMS_RE = re.compile(r"platforms\s*=\s*\[(.*?)\]", re.S)
+
+
+def parse_pins(path: str, text: str) -> list[dict]:
+    pins = []
+    for m in PULL_RE.finditer(text):
+        body = strip_comments(m.group(1))
+        image = STR_RE["image"].search(body)
+        digest = STR_RE["digest"].search(body)
+        if not (image and digest):
+            continue
+        plats: list[str] = []
+        pm = PLATFORMS_RE.search(body)
+        if pm:
+            plats = re.findall(r'"([^"]+)"', pm.group(1))
+        pins.append(
+            {
+                "file": path,
+                "image": image.group(1),
+                "digest": digest.group(1),
+                "platforms": plats,
+            }
+        )
+    return pins
+
+
+def fetch_manifest(ref: str, tries: int = 3):
+    """Return (manifest, None) or (None, error). Retries transient failures.
+
+    Only an explicit "not found" from the registry is authoritative; a timeout
+    is not evidence that an image is gone.
+    """
+    err = ""
+    for attempt in range(tries):
+        proc = subprocess.run(
+            [SKOPEO, "inspect", "--raw", f"docker://{ref}"],
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode == 0:
+            try:
+                return json.loads(proc.stdout), None
+            except json.JSONDecodeError as exc:
+                return None, f"unparseable manifest: {exc}"
+        err = (proc.stderr or "").strip().splitlines()[-1:] or [""]
+        err = err[0]
+        if any(s in err for s in ("manifest unknown", "not found", "not known")):
+            return None, err
+        if attempt < tries - 1:
+            time.sleep(2)
+    return None, err
+
+
+def self_test() -> int:
+    failures = []
+
+    def eq(label, got, want):
+        if got != want:
+            failures.append(f"{label}: got {got!r}, want {want!r}")
+            print(f"FAIL {label}: got {got!r}, want {want!r}")
+        else:
+            print(f"ok   {label}")
+
+    eq("strip_tag tag", strip_tag("nvcr.io/nvidia/distroless/go:v4.0.8"),
+       "nvcr.io/nvidia/distroless/go")
+    eq("strip_tag none", strip_tag("gcr.io/distroless/static"),
+       "gcr.io/distroless/static")
     # A registry port must not be mistaken for a tag.
-    check "registry.example.com:5000/img:1.2"   "registry.example.com:5000/img"
-    check "registry.example.com:5000/img"       "registry.example.com:5000/img"
-    [ "${fail}" -eq 0 ] || { echo "check-oci-pins: self-test FAILED" >&2; exit 1; }
-    echo "check-oci-pins: self-test passed"
-    exit 0
-fi
+    eq("strip_tag port", strip_tag("registry.example.com:5000/img"),
+       "registry.example.com:5000/img")
+    eq("strip_tag port+tag", strip_tag("registry.example.com:5000/img:1.2"),
+       "registry.example.com:5000/img")
 
-mapfile -t pins < <(
-    git ls-files '*MODULE.bazel' | while read -r f; do
-        python3 - "$f" <<'PY'
-import re,sys
-f=sys.argv[1]
-for m in re.finditer(r'oci\.pull\((.*?)\n\)', open(f).read(), re.S):
-    b=m.group(1)
-    img=re.search(r'image\s*=\s*"([^"]+)"', b)
-    dig=re.search(r'digest\s*=\s*"(sha256:[0-9a-f]+)"', b)
-    if img and dig:
-        print(f"{f}\t{img.group(1)}\t{dig.group(1)}")
-PY
-    done | sort -u
+    both = {
+        "manifests": [
+            {"platform": {"os": "linux", "architecture": "amd64"}},
+            {"platform": {"os": "linux", "architecture": "arm64", "variant": "v8"}},
+        ]
+    }
+    amd_only = {"manifests": [{"platform": {"os": "linux", "architecture": "amd64"}}]}
+    single = {"schemaVersion": 2, "config": {}, "layers": []}
+
+    eq("both platforms present",
+       missing_platforms(["linux/amd64", "linux/arm64/v8"], both), [])
+    # The nvsnap defect: digest resolves, arm64 absent from the pulled set.
+    eq("missing arm64/v8 detected",
+       missing_platforms(["linux/amd64", "linux/arm64/v8"], amd_only),
+       ["linux/arm64/v8"])
+    # Variant is part of the match: rules_oci compares the string exactly.
+    eq("arm64 != arm64/v8",
+       missing_platforms(["linux/arm64"], both), ["linux/arm64"])
+    eq("single-image manifest satisfies nothing",
+       missing_platforms(["linux/amd64"], single), ["linux/amd64"])
+    eq("no platforms declared is vacuously fine",
+       missing_platforms([], amd_only), [])
+
+    parsed = parse_pins("MODULE.bazel", '''
+oci.pull(
+    name = "x",
+    digest = "sha256:abc",
+    image = "gcr.io/distroless/static",
+    platforms = [
+        "linux/amd64",
+        "linux/arm64/v8",
+    ],
 )
+''')
+    eq("parser finds one pin", len(parsed), 1)
 
-if [ "${#pins[@]}" -eq 0 ]; then
-    echo "error: found no oci.pull pins to check; the parser is probably broken" >&2
-    exit 2
-fi
+    # Regression: a comment naming a platform must not be read as a
+    # declaration. This exact shape produced a false "missing linux/arm64".
+    commented = parse_pins("MODULE.bazel", '''
+oci.pull(
+    name = "cc",
+    digest = "sha256:abc",
+    image = "nvcr.io/nvidia/distroless/cc",
+    platforms = [
+        "linux/amd64",
+        # arm64/v8, not arm64: rules_oci matches the platform string exactly,
+        # so "linux/arm64" fails the pull outright.
+        "linux/arm64/v8",
+    ],
+)
+''')
+    eq("comment text is not parsed as a platform",
+       commented[0]["platforms"] if commented else None,
+       ["linux/amd64", "linux/arm64/v8"])
+    if parsed:
+        eq("parser reads platforms", parsed[0]["platforms"],
+           ["linux/amd64", "linux/arm64/v8"])
 
-status=0
-checked=0
-for entry in "${pins[@]}"; do
-    file="${entry%%$'\t'*}"
-    rest="${entry#*$'\t'}"
-    image="${rest%%$'\t'*}"
-    digest="${rest#*$'\t'}"
-    ref="$(strip_tag "${image}")@${digest}"
-    checked=$((checked + 1))
-    if resolves "${ref}"; then
-        printf 'ok   %-46s %s\n' "${image}" "${file}"
-    else
-        printf 'DEAD %-46s %s\n' "${image}" "${file}" >&2
-        printf '     %s\n' "${digest}" >&2
-        status=1
-    fi
-done
+    if failures:
+        print(f"\ncheck-oci-pins: self-test FAILED ({len(failures)})", file=sys.stderr)
+        return 1
+    print("\ncheck-oci-pins: self-test passed")
+    return 0
 
-if [ "${status}" -ne 0 ]; then
-    cat >&2 <<'MSG'
 
-error: one or more pinned base image digests no longer resolve.
+def main() -> int:
+    if "--self-test" in sys.argv[1:]:
+        return self_test()
 
-A dead pin does not fail CI while the Bazel repository cache is warm, but it
-fails every cold checkout, including external scanners. Repin to a current
-digest:
+    # Deliberately after the self-test branch: --self-test exercises pure logic
+    # and must work on a machine without skopeo.
+    if shutil.which(SKOPEO) is None:
+        print(f"error: {SKOPEO} not found; cannot verify pins", file=sys.stderr)
+        return 2
 
-    skopeo inspect --raw docker://<image>:<tag> | sha256sum
+    files = subprocess.run(["git", "ls-files", "*MODULE.bazel"],
+                           capture_output=True, text=True).stdout.split()
+    pins: list[dict] = []
+    for f in files:
+        try:
+            pins.extend(parse_pins(f, open(f).read()))
+        except OSError:
+            continue
 
-MSG
-    exit 1
-fi
+    seen = set()
+    unique = []
+    for p in pins:
+        key = (p["image"], p["digest"], tuple(p["platforms"]))
+        if key not in seen:
+            seen.add(key)
+            unique.append(p)
 
-echo "checked ${checked} pinned base image(s); all resolve"
+    if not unique:
+        print("error: parsed no oci.pull pins; the parser is probably broken",
+              file=sys.stderr)
+        return 2
+
+    status = 0
+    for p in unique:
+        ref = f"{strip_tag(p['image'])}@{p['digest']}"
+        manifest, err = fetch_manifest(ref)
+        if manifest is None:
+            print(f"DEAD    {p['image']:44} {p['file']}", file=sys.stderr)
+            print(f"        {p['digest']}", file=sys.stderr)
+            print(f"        {err}", file=sys.stderr)
+            status = 1
+            continue
+        missing = missing_platforms(p["platforms"], manifest)
+        if missing:
+            print(f"NOPLAT  {p['image']:44} {p['file']}", file=sys.stderr)
+            print(f"        digest resolves but lacks: {', '.join(missing)}",
+                  file=sys.stderr)
+            have = sorted("/".join(x for x in t if x)
+                          for t in index_platforms(manifest))
+            print(f"        index advertises: {', '.join(have) or 'none'}",
+                  file=sys.stderr)
+            status = 1
+            continue
+        plats = ", ".join(p["platforms"]) if p["platforms"] else "unconstrained"
+        print(f"ok      {p['image']:44} [{plats}]")
+
+    if status:
+        print(
+            "\nerror: one or more pins are unusable.\n"
+            "\n"
+            "A dead digest fails every cold checkout while a warm Bazel\n"
+            "repository cache hides it in CI. A missing platform fetches fine\n"
+            "and fails later at analysis. Repin with:\n"
+            "\n"
+            "    skopeo inspect --raw docker://<image>:<tag> | sha256sum\n",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"\nchecked {len(unique)} pin(s); all resolve with the platforms they declare")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

The Black Duck scan of this repository has been failing, and the cause is two
defects here rather than anything in the scanner. Both were found by reproducing
its command locally:

    bazel cquery --noimplicit_deps 'kind(j.*import, deps(//...))' --output build

**1. A dead base image digest.** The root module pinned a
`gcr.io/distroless/static` digest that upstream had garbage-collected:

    WARNING: Download from https://gcr.io/v2/distroless/static/manifests/
      sha256:dd7614b5... failed: GET returned 404 Not Found
    ERROR: nvsnap_server_image_pre_transitioned depends on
      @@rules_oci++oci+distroless_static which failed to fetch

The tag still resolves; the manifest behind that digest does not. Digests are
immutable, but registries garbage-collect untagged manifests, so a pin rots
without anyone editing it.

**2. A base/macro platform mismatch, hidden behind the first.** With the digest
repinned, analysis failed one layer deeper:

    ERROR: configurable attribute "actual" in @@rules_oci++oci+distroless_static
      doesn't match this configuration: could not find an image matching the
      target platform.
    ERROR: Analysis of target nvsnap_agent_image_multi_arch failed

`go_oci_image` always emits a `_multi_arch` target over `DEFAULT_PLATFORMS`
(arm64 and x86_64), but `@distroless_static` was pulled `linux/amd64` only, so
the arm64 branch of the transition had no image. nvsnap was the only service
whose base disagreed with the shared macro.

## Why CI never caught either

`bazel build //...` skips these targets because they are tagged `manual`.
`cquery 'deps(//...)'` ignores `manual` and analyses them, so an external scan
hits what our own wildcard build never touches.

The dead pin was additionally masked because CI restores the Bazel repository
cache, so the fetch was served from cache and the pin looked healthy. That was
live risk, not theory: the Actions cache is over quota and evicting
continuously, so this was one eviction away from breaking main with an error
that reads like a network blip.

## What changed

`distroless_static` is repinned to a current digest and pulled for both
architectures, matching the macro and every other service. Its `use_repo` gains
the `_linux_arm64_v8` entry.

`tools/ci/check-oci-pins` verifies that every `oci.pull` digest still resolves,
across all 23 pins in the repository. It is meant to run on a schedule rather
than per change, since a pin rots with no commit touching it.

## Testing

The scanner's exact command now succeeds on Linux against `//...`:

    EXIT=0
    java_import targets found: 347

Previously it produced no output at all. `nvsnap_agent_image_multi_arch` also
analyses cleanly.

`check-oci-pins` reports all 23 pins resolving. It ships with a self-test
(`--self-test`) covering its reference handling, because while investigating
this I twice reported healthy pins as dead: appending `@digest` to a reference
that already carries a tag yields an invalid reference that skopeo rejects. The
check also retries before declaring a pin dead, so a registry timeout is not
mistaken for a missing image, and it fails if it parses zero pins rather than
reporting success over an empty set.

## Notes

Worth knowing for the SBOM effort: a scan of `//...` from the repository root
covers only the root Bazel module. The ~20 nested modules each have their own
`MODULE.bazel` and are not in that target universe, so this unblocks the scan
but does not by itself make it complete. Our CI already enumerates those
modules and their workdirs.

## References

None

## Dependencies

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Distroless base image pin to support both **linux/amd64** and **linux/arm64/v8**.
  * Repinned the base image digest for correctness.

* **Chores**
  * Replaced the OCI pin verification with a Python-based checker that validates **image/digest** pins and declared platform support.
  * Improved parsing (ignores comment text), adds inspection timeouts with retries, enhanced per-pin status reporting, and includes a **self-test** mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->