### PR TITLE
fix(function-autoscaler): bump container version to 1.19.0

### DIFF
--- a/deploy/helm/function-autoscaler/Chart.yaml
+++ b/deploy/helm/function-autoscaler/Chart.yaml
@@ -19,4 +19,4 @@ description: A Helm chart for NVCF Function Autoscaler Service
 
 type: application
 version: 0.0.0 # autoversioning enabled via release pipeline
-appVersion: "1.18.11"
+appVersion: "1.19.0"

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -141,7 +141,7 @@ observability:
 
 # Defaults consumed only for the control and all observability profiles.
 functionAutoscaler:
-  chartVersion: "0.1.0"
+  chartVersion: "0.2.1"
   region: local
   cassandra:
     contactPoints: cassandra.cassandra-system.svc.cluster.local

--- a/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
@@ -68,7 +68,7 @@ releases:
 
   {{- if $functionAutoscalerEnabled }}
   - name: function-autoscaler
-    version: {{ dig "functionAutoscaler" "chartVersion" "0.1.0" .Values | quote }}
+    version: {{ dig "functionAutoscaler" "chartVersion" "0.2.1" .Values | quote }}
     namespace: nvcf
     inherit:
       - template: functionAutoscaler

--- a/deploy/stacks/self-managed/tests/observability-autoscaler.sh
+++ b/deploy/stacks/self-managed/tests/observability-autoscaler.sh
@@ -89,7 +89,7 @@ helm template function-autoscaler "$repo_dir/deploy/helm/function-autoscaler" \
   >"$work_dir/autoscaler-manifests.yaml"
 
 autoscaler_manifests="$work_dir/autoscaler-manifests.yaml"
-grep -q 'image: nvcr.io/YOUR_ORG/YOUR_TEAM/nvcf-function-autoscaler:1.18.11' "$autoscaler_manifests" ||
+grep -q 'image: nvcr.io/YOUR_ORG/YOUR_TEAM/nvcf-function-autoscaler:1.19.0' "$autoscaler_manifests" ||
   fail "self-managed stack did not pin the autoscaler image"
 test "$(grep -c '^kind: ConfigMap$' "$autoscaler_manifests")" = "2" ||
   fail "autoscaler chart did not render only its env and Vault template ConfigMaps"


### PR DESCRIPTION
## TL;DR
Bumps the function autoscaler Helm chart app version to 1.19.0.

## Additional Details
Updates the default function autoscaler container version.

## For the Reviewer
Please verify `deploy/helm/function-autoscaler/Chart.yaml`.

## For QA
- `helm lint deploy/helm/function-autoscaler`
- QA is not needed.

## Issues
Relates to #15

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for DCO compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded the Function Autoscaler Helm chart to target the newer autoscaler release (chart revision bumped, and the autoscaler image is now based on version **1.19.0**).
* **Tests**
  * Updated the self-managed observability autoscaler test expectations to verify the autoscaler manifests reference **1.19.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->