### PR TITLE
ci: run release-tags on the self-hosted fleet

### DIFF
--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -46,10 +46,20 @@ env:
   GITHUB_TOKEN: ${{ secrets.NV_GITHUB_TOKEN || github.token }}
 
 jobs:
+  # NVIDIA self-hosted runners. Eligible without a conditional because this
+  # workflow has no pull_request trigger: it fires on pushes to main and to
+  # release branches, on tags, and on manual dispatch, all of which run trusted
+  # reviewed code. The bazel matrix needs an event-conditional runs-on for
+  # exactly that reason; this does not.
+  #
+  # cpu4 rather than cpu16: these jobs shell out to the GitHub API to cut tags
+  # and create releases. They are latency-bound, not CPU-bound, and were sitting
+  # in the GitHub-hosted queue behind the build matrix while doing almost no
+  # work.
   service-release:
     name: service release automation
     if: github.ref_type != 'tag' && (github.event_name != 'workflow_dispatch' || inputs.operation == 'auto')
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: write
       packages: read
@@ -84,7 +94,7 @@ jobs:
   release-branch-cut:
     name: NVCA release branch cut
     if: github.event_name == 'workflow_dispatch' && inputs.operation == 'branch-cut'
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: write
       pull-requests: write
@@ -116,7 +126,7 @@ jobs:
   self-managed-release-branch-cut:
     name: self-managed stack release branch cut
     if: github.event_name == 'workflow_dispatch' && inputs.operation == 'self-managed-branch-cut'
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: write
       pull-requests: write
@@ -144,7 +154,7 @@ jobs:
   tag-release-notes:
     name: tag release notes
     if: github.ref_type == 'tag'
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Why

Release tagging still runs on GitHub-hosted capacity, which is the pool that
was starving. Two tags pushed today sat queued:

    queued   src/control-plane-services/api-keys/v1.6.1
    queued   src/control-plane-services/notary/v1.12.1
    success  src/control-plane-services/cloud-tasks/v1.62.3

This is worse than a slow build, because it stalls a chain. nvcf-internal polls
for GitHub Releases, so until the tag job runs and creates the Release, no
release pipeline is dispatched and no image is published.

## Why no conditional is needed

The bazel matrix uses an event-conditional `runs-on` because NVIDIA blocks
`pull_request` events on self-hosted runners. This workflow has no
`pull_request` trigger at all:

    on:
      push:
        branches: [main, 'release-**/v*']
        tags: ['*-v*', '**/v*']
      workflow_dispatch:

Every one of those runs trusted, already-reviewed code, so all four jobs move
unconditionally.

## What changed

`service-release`, `release-branch-cut`, `self-managed-release-branch-cut` and
`tag-release-notes` move from `ubuntu-latest` to `linux-amd64-cpu4`.

cpu4 rather than cpu16 deliberately: these jobs shell out to the GitHub API to
cut tags and create releases. They are latency-bound, not CPU-bound, and asking
for 16 cores to make API calls would waste capacity the build matrix wants.

## Testing

Not verifiable from a pull request: its own checks run as `pull_request`, which
is exactly the event that cannot use these runners, so this PR exercises the old
path. The change takes effect on the next tag push or merge to main.

What to watch on the first tag after merge: the job picks up an `edc3-l-amd-c4-`
runner rather than `GitHub Actions`, and the Release is created without the
queue delay seen above.

If it fails at setup with "Workflows triggered by ... are not allowed to run on
self-hosted runners", the policy is broader than `pull_request` and this should
be reverted rather than worked around.

## Notes

Access is granted per repository with an expiry and renewed through
nv-gha-runners/enterprise-runner-configuration. If it lapses, these jobs stop
finding runners, which would silently stall releases rather than fail loudly.
That is an argument for monitoring the expiry, not against the move.

## References

nv-gha-runners/enterprise-runner-configuration#413

## Dependencies

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to run on dedicated infrastructure.
  * Added documentation clarifying release workflow runner choices and execution conditions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->