### PR TITLE
fix(release): cut dependent releases for Java framework changes

### DIFF
--- a/docs/dev/github-release-process.md
+++ b/docs/dev/github-release-process.md
@@ -141,6 +141,48 @@ release rules as the generated GitLab release jobs:
 - `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `test:`, and
   `build:` do not create releases
 
+## Java framework dependency releases
+
+`semantic-release-monorepo` scopes a service's commits to its own
+subtree path. A change to the shared Java framework under
+`src/libraries/java/` lands outside every service directory, so
+semantic-release sees no commits for any dependent service and releases
+nothing. CI still rebuilds and tests each dependent service, but the
+rebuilt artifact never leaves the CI job.
+
+`tools/ci/github-release auto` closes that gap. It reads the
+per-component `bazel-java-ci.json` descriptors, the same files
+`.github/workflows/bazel.yml` reads to schedule its matrix, so the
+framework-to-service edge is declared once:
+
+- `component_kind: java-framework` marks a shared framework path.
+- `component_kind: java-service` marks a component that is rebuilt when
+  any framework path changes.
+
+For a registered subproject whose path matches a `java-service`
+descriptor, the script cuts a dependency-triggered release when all of
+the following hold:
+
+- semantic-release computed no version for that service on this run. If
+  the same push also touched the service, semantic-release owns the
+  version and nothing extra is tagged.
+- The service already has a release tag to bump from.
+- At least one commit touching a framework path landed since that tag.
+
+The synthesized bump is always a patch, including when the framework
+commit is a `feat:`. A framework feature adds no capability to a service
+that has not adopted it, and the service's own changelog has nothing to
+substantiate a minor. A service that does adopt a new framework API does
+so in a commit under its own directory, which semantic-release turns
+into the correct bump; the fan-out does not run in that case.
+
+The release notes state that the release is dependency-triggered and
+list the framework commits, so a reader of a GitHub Release with no
+changes in the service directory can see why the version moved.
+
+Dry-run mode prints the tag and notes it would create and creates
+nothing, the same as every other release path in this script.
+
 ## Release notes for pushed tags
 
 On tag pushes, the workflow validates the tag and creates lightweight

--- a/docs/dev/github-release-process.md
+++ b/docs/dev/github-release-process.md
@@ -167,7 +167,12 @@ the following hold:
   the same push also touched the service, semantic-release owns the
   version and nothing extra is tagged.
 - The service already has a release tag to bump from.
-- At least one commit touching a framework path landed since that tag.
+- At least one release-worthy commit touching a framework path landed
+  since that tag. Release-worthiness uses the same rules listed above: a
+  framework `feat:`, `fix:`, `perf:`, or breaking `!` commit fans out; a
+  framework `docs:`, `chore:`, `ci:`, `style:`, `refactor:`, `test:`, or
+  `build:` commit releases nothing for the framework and so releases
+  nothing for its dependents either.
 
 The synthesized bump is always a patch, including when the framework
 commit is a `feat:`. A framework feature adds no capability to a service

--- a/tools/ci/github-release
+++ b/tools/ci/github-release
@@ -29,6 +29,19 @@ VERSION_PLACEHOLDER = "${version}"
 INITIAL_RELEASE_VERSION = "0.1.0"
 INITIAL_RELEASE_FLOOR_VERSION = "0.0.0"
 
+# Java component descriptors. These are the same per-component files
+# `.github/workflows/bazel.yml` discovers to build its matrix and to apply the
+# framework -> service reverse-dependency edge. The dependency graph is declared
+# there and only there; this script reads it rather than restating it, so the
+# two cannot drift.
+JAVA_CI_DESCRIPTOR = "bazel-java-ci.json"
+JAVA_FRAMEWORK_KIND = "java-framework"
+JAVA_SERVICE_KIND = "java-service"
+JAVA_COMPONENT_KINDS = (JAVA_FRAMEWORK_KIND, JAVA_SERVICE_KIND)
+# Framework commits quoted in dependency-triggered release notes. A service that
+# is many framework commits behind should still get readable notes.
+MAX_QUOTED_FRAMEWORK_COMMITS = 20
+
 
 def bool_env(name, default=False):
     raw = os.environ.get(name)
@@ -264,10 +277,10 @@ def latest_service_tag_for_prefix(prefix):
     return sorted(candidates, key=lambda item: semverish_sort_key(item[0]))[-1][1]
 
 
-def latest_service_tag(service):
+def latest_service_tag(service, root=None):
     candidates = []
     for prefix in tag_prefixes(service):
-        raw = run(["git", "tag", "-l", f"{prefix}*"], capture=True)
+        raw = run(["git", "tag", "-l", f"{prefix}*"], cwd=root, capture=True)
         for line in raw.splitlines():
             tag = line.strip()
             if tag:
@@ -471,6 +484,170 @@ def publish_tag_for_version(root, service, version, dry_run, draft, reason):
     create_release(tag, tag, notes, draft, dry_run=False)
 
 
+def java_ci_components(root):
+    """Java components declared by the per-component bazel-java-ci.json files.
+
+    This is the single declaration of the Java dependency graph in the repo:
+    `.github/workflows/bazel.yml` reads the same descriptors to schedule every
+    `java-service` row when a `java-framework` path changes. Reading them here
+    keeps release fan-out and CI scheduling on one source of truth instead of a
+    second hardcoded list that can silently drift.
+    """
+    components = []
+    src = root / "src"
+    if not src.is_dir():
+        return components
+    for manifest in sorted(src.rglob(JAVA_CI_DESCRIPTOR)):
+        try:
+            descriptor = json.loads(manifest.read_text())
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"{manifest}: invalid {JAVA_CI_DESCRIPTOR}: {exc}") from exc
+        kind = descriptor.get("component_kind")
+        if kind not in JAVA_COMPONENT_KINDS:
+            raise SystemExit(
+                f"{manifest}: component_kind must be one of {', '.join(JAVA_COMPONENT_KINDS)}, got {kind!r}"
+            )
+        components.append(
+            {
+                "id": descriptor.get("id", ""),
+                "path": manifest.parent.relative_to(root).as_posix(),
+                "component_kind": kind,
+            }
+        )
+    return components
+
+
+def java_framework_paths(components):
+    return [c["path"] for c in components if c["component_kind"] == JAVA_FRAMEWORK_KIND]
+
+
+def is_java_service(components, service):
+    path = str(service.get("path") or "").strip("/")
+    return any(c["component_kind"] == JAVA_SERVICE_KIND and c["path"] == path for c in components)
+
+
+def next_patch_version(version):
+    major, minor, patch = (int(part) for part in version.split("."))
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def framework_commits_since(root, framework_paths, since_tag):
+    raw = run(
+        ["git", "log", "--format=%h %s", f"{since_tag}..HEAD", "--", *framework_paths],
+        cwd=root,
+        capture=True,
+    )
+    return [line.strip() for line in raw.splitlines() if line.strip()]
+
+
+def framework_dependency_reason(service, framework_paths, since_tag, commits):
+    quoted = commits[:MAX_QUOTED_FRAMEWORK_COMMITS]
+    lines = [
+        "dependency-triggered release. This service has no release-worthy commits of its own "
+        f"under {service['path']} since {since_tag}.",
+        "",
+        "It is released because shared Java framework code it is built from changed:",
+    ]
+    lines.extend(f"  - {path}" for path in framework_paths)
+    lines.append("")
+    lines.append(f"Framework commits since {since_tag}:")
+    lines.extend(f"  - {commit}" for commit in quoted)
+    if len(commits) > len(quoted):
+        lines.append(f"  - ... and {len(commits) - len(quoted)} more")
+    lines.append("")
+    lines.append(
+        "The service source is unchanged; this release ships it rebuilt against the "
+        "updated framework."
+    )
+    return "\n".join(lines)
+
+
+def publish_framework_dependency_release(root, service, components, dry_run, draft):
+    """Cut a patch release for a Java service that a framework change rebuilt.
+
+    Fires only when the service would otherwise cut nothing, and only when the
+    framework actually changed since that service's last release tag. Always a
+    patch bump: the framework change adds no user-visible capability to this
+    service, and the service's own changelog has nothing to substantiate a
+    minor. A service that genuinely adopts a new framework API does so in a
+    commit under its own directory, which semantic-release turns into the right
+    bump, and this fan-out then does not run at all.
+    """
+    if not is_java_service(components, service):
+        return False
+    framework_paths = java_framework_paths(components)
+    if not framework_paths:
+        return False
+
+    last_tag = latest_service_tag(service, root)
+    if not last_tag:
+        print(
+            f"[github-release] {service['id']}: no existing release tag to bump from; "
+            "skipping Java framework dependency release"
+        )
+        return False
+
+    current_version = version_from_tag(service, last_tag)
+    if not re.fullmatch(STABLE_SEMVER_PATTERN, current_version):
+        print(
+            f"[github-release] {service['id']}: last tag {last_tag} is not a stable X.Y.Z; "
+            "skipping Java framework dependency release"
+        )
+        return False
+
+    commits = framework_commits_since(root, framework_paths, last_tag)
+    if not commits:
+        print(
+            f"[github-release] {service['id']}: no Java framework commits since {last_tag}; "
+            "nothing to release"
+        )
+        return False
+
+    version = next_patch_version(current_version)
+    print(
+        f"[github-release] {service['id']}: {len(commits)} Java framework commit(s) since "
+        f"{last_tag} with no service release; cutting dependency patch release {version}"
+    )
+    publish_tag_for_version(
+        root,
+        service,
+        version,
+        dry_run,
+        draft,
+        framework_dependency_reason(service, framework_paths, last_tag, commits),
+    )
+    return True
+
+
+def resolve_release_outcome(exit_code, output):
+    """Classify a semantic-release run: it released, it released nothing, or it is unreadable."""
+    if parse_next_version(output):
+        return "released"
+    if exit_code == 0 and no_release_output(output):
+        return "no-release"
+    return "unknown"
+
+
+def finish_semantic_release(root, service, components, exit_code, output, dry_run, draft):
+    """Apply the semantic-release result, falling back to dependency fan-out.
+
+    semantic-release owns the version whenever it computed one, so a push that
+    touched both a framework and the service is never double-tagged.
+    """
+    outcome = resolve_release_outcome(exit_code, output)
+    if outcome == "released":
+        version = parse_next_version(output)
+        if dry_run:
+            print(f"[github-release] {service['id']}: would create {tag_for_version(service, version)}")
+        else:
+            print(f"[github-release] {service['id']}: semantic-release created {tag_for_version(service, version)}")
+        return outcome
+    if outcome == "no-release":
+        print(f"[github-release] {service['id']}: no release-worthy commits")
+        publish_framework_dependency_release(root, service, components, dry_run=dry_run, draft=draft)
+    return outcome
+
+
 def publish_version_file_release(root, service, dry_run, draft):
     version = validate_version_file(root, service)
     existing = existing_tag_for_version(root, service, version)
@@ -665,6 +842,7 @@ def auto_release(args):
     draft = bool_env("NVCF_GITHUB_RELEASE_DRAFT", False)
     service_filter = args.service or os.environ.get("NVCF_GITHUB_RELEASE_SERVICE", "")
     generated_paths = metadata.get("release_generated_paths", [])
+    java_components = java_ci_components(root)
     branch = current_branch(root)
     default_branch = os.environ.get("GITHUB_DEFAULT_BRANCH", "main")
 
@@ -699,6 +877,13 @@ def auto_release(args):
                 continue
 
             if only_generated_changes(root, service, generated_paths):
+                # A shared Java framework change lands outside every service
+                # directory, so semantic-release (scoped to the service path by
+                # semantic-release-monorepo) would see nothing and ship nothing.
+                # Fan the framework change out here instead.
+                publish_framework_dependency_release(
+                    root, service, java_components, dry_run=dry_run, draft=draft
+                )
                 continue
             synthesize_current_prefix_anchor(service)
             synthesize_initial_version_anchor(root, service)
@@ -714,12 +899,10 @@ def auto_release(args):
 
             if dry_run:
                 code, output = stream(["npx", "semantic-release", "--dry-run", "--no-ci", "--debug"], cwd=service_dir)
-                next_version = parse_next_version(output)
-                if next_version:
-                    print(f"[github-release] {service['id']}: would create {tag_for_version(service, next_version)}")
-                elif code == 0 and no_release_output(output):
-                    print(f"[github-release] {service['id']}: no release-worthy commits")
-                else:
+                outcome = finish_semantic_release(
+                    root, service, java_components, code, output, dry_run=True, draft=draft
+                )
+                if outcome == "unknown":
                     # Preview could not compute a version (for example the
                     # semantic-release child was killed on a large history).
                     # Do not fail the inert workflow on a preview; record it so
@@ -728,7 +911,21 @@ def auto_release(args):
                     print(f"[github-release] WARNING: {service['id']}: {reason}; continuing (dry-run preview)")
                     dry_run_failures.append((service["id"], reason))
             else:
-                run(["npx", "semantic-release", "--no-ci"], cwd=service_dir)
+                # Streamed rather than run() so the result is readable: a
+                # dependency fan-out must only fire when semantic-release itself
+                # released nothing.
+                cmd = ["npx", "semantic-release", "--no-ci"]
+                code, output = stream(cmd, cwd=service_dir)
+                if code != 0:
+                    raise subprocess.CalledProcessError(code, cmd)
+                outcome = finish_semantic_release(
+                    root, service, java_components, code, output, dry_run=False, draft=draft
+                )
+                if outcome == "unknown":
+                    print(
+                        f"[github-release] WARNING: {service['id']}: semantic-release reported "
+                        "neither a version nor a no-release result; not cutting a dependency release"
+                    )
         finally:
             print("::endgroup::")
 

--- a/tools/ci/github-release
+++ b/tools/ci/github-release
@@ -41,6 +41,8 @@ JAVA_COMPONENT_KINDS = (JAVA_FRAMEWORK_KIND, JAVA_SERVICE_KIND)
 # Framework commits quoted in dependency-triggered release notes. A service that
 # is many framework commits behind should still get readable notes.
 MAX_QUOTED_FRAMEWORK_COMMITS = 20
+# Conventional Commit subject prefix, for example "fix(nv-boot)!: subject".
+COMMIT_SUBJECT_PATTERN = re.compile(r"^(?P<type>[a-zA-Z]+)(?:\([^)]*\))?(?P<breaking>!)?:")
 
 
 def bool_env(name, default=False):
@@ -531,13 +533,44 @@ def next_patch_version(version):
     return f"{major}.{minor}.{patch + 1}"
 
 
-def framework_commits_since(root, framework_paths, since_tag):
+def releases_a_version(subject):
+    """Whether a commit subject releases a version under RELEASE_RULES.
+
+    Derived from RELEASE_RULES so the fan-out applies exactly the rules
+    semantic-release is configured with: `feat`, `fix`, and `perf` release, the
+    other declared types do not, and a `!` breaking marker always releases. A
+    subject that is not a Conventional Commit releases nothing, the same as it
+    would inside a service directory.
+    """
+    match = COMMIT_SUBJECT_PATTERN.match(subject)
+    if not match:
+        return False
+    if match.group("breaking"):
+        return True
+    releasing = {rule["type"] for rule in RELEASE_RULES if rule["release"]}
+    return match.group("type").lower() in releasing
+
+
+def release_worthy_framework_commits_since(root, framework_paths, since_tag):
+    """Framework commits since a tag that would have released, had they been in a service.
+
+    A framework `docs:` or `chore:` commit releases nothing for the framework,
+    so it must not release anything for the framework's dependents either.
+    """
     raw = run(
         ["git", "log", "--format=%h %s", f"{since_tag}..HEAD", "--", *framework_paths],
         cwd=root,
         capture=True,
     )
-    return [line.strip() for line in raw.splitlines() if line.strip()]
+    commits = []
+    for line in raw.splitlines():
+        commit = line.strip()
+        if not commit:
+            continue
+        _sha, _, subject = commit.partition(" ")
+        if releases_a_version(subject):
+            commits.append(commit)
+    return commits
 
 
 def framework_dependency_reason(service, framework_paths, since_tag, commits):
@@ -595,18 +628,19 @@ def publish_framework_dependency_release(root, service, components, dry_run, dra
         )
         return False
 
-    commits = framework_commits_since(root, framework_paths, last_tag)
+    commits = release_worthy_framework_commits_since(root, framework_paths, last_tag)
     if not commits:
         print(
-            f"[github-release] {service['id']}: no Java framework commits since {last_tag}; "
-            "nothing to release"
+            f"[github-release] {service['id']}: no release-worthy Java framework commits since "
+            f"{last_tag}; nothing to release"
         )
         return False
 
     version = next_patch_version(current_version)
     print(
-        f"[github-release] {service['id']}: {len(commits)} Java framework commit(s) since "
-        f"{last_tag} with no service release; cutting dependency patch release {version}"
+        f"[github-release] {service['id']}: {len(commits)} release-worthy Java framework "
+        f"commit(s) since {last_tag} with no service release; cutting dependency patch "
+        f"release {version}"
     )
     publish_tag_for_version(
         root,

--- a/tools/ci/github-release
+++ b/tools/ci/github-release
@@ -655,9 +655,14 @@ def publish_framework_dependency_release(root, service, components, dry_run, dra
 
 def resolve_release_outcome(exit_code, output):
     """Classify a semantic-release run: it released, it released nothing, or it is unreadable."""
+    if exit_code != 0:
+        # A run that died is untrustworthy even if it printed a version before
+        # dying: the publish run may not reproduce it. Report it rather than
+        # previewing a tag that may never be created.
+        return "unknown"
     if parse_next_version(output):
         return "released"
-    if exit_code == 0 and no_release_output(output):
+    if no_release_output(output):
         return "no-release"
     return "unknown"
 
@@ -941,7 +946,7 @@ def auto_release(args):
                     # semantic-release child was killed on a large history).
                     # Do not fail the inert workflow on a preview; record it so
                     # it is visible and gets resolved before the cutover.
-                    reason = f"semantic-release dry-run exited {code} with no NEXT_VERSION"
+                    reason = f"semantic-release dry-run exited {code} without a trustworthy release decision"
                     print(f"[github-release] WARNING: {service['id']}: {reason}; continuing (dry-run preview)")
                     dry_run_failures.append((service["id"], reason))
             else:

--- a/tools/ci/test-github-release.py
+++ b/tools/ci/test-github-release.py
@@ -66,6 +66,283 @@ class GithubReleaseTest(unittest.TestCase):
         git(root, "add", ".")
         git(root, "commit", "-m", message)
 
+    def write_java_component(self, root, path, component_id, component_kind):
+        component_dir = root / path
+        component_dir.mkdir(parents=True, exist_ok=True)
+        (component_dir / "bazel-java-ci.json").write_text(
+            json.dumps(
+                {
+                    "ci_lane": "build-container",
+                    "component_kind": component_kind,
+                    "id": component_id,
+                    "tests_skip": False,
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        (component_dir / "README.md").write_text(f"{component_id}\n")
+
+    JAVA_FRAMEWORK_PATH = "src/libraries/java/nv-boot-parent"
+    JAVA_SERVICES = (
+        ("cloud-tasks", "src/control-plane-services/cloud-tasks", "1.6.2"),
+        ("notary", "src/control-plane-services/notary", "1.8.4"),
+    )
+
+    def java_service_metadata(self, service_id, path):
+        return {
+            "id": service_id,
+            "path": path,
+            "service_name": f"nvcf-{service_id}",
+        }
+
+    def init_java_repo(self, root):
+        """Repo with one Java framework, two Java services, and a release tag per service."""
+        self.init_repo(root)
+        self.write_java_component(root, self.JAVA_FRAMEWORK_PATH, "nv-boot-parent", "java-framework")
+        for service_id, path, _version in self.JAVA_SERVICES:
+            self.write_java_component(root, path, service_id, "java-service")
+        self.commit_all(root, "seed java components")
+        for _service_id, path, version in self.JAVA_SERVICES:
+            git(root, "tag", f"{path}/v{version}")
+
+    def commit_framework_change(self, root, message="fix(nv-boot): bump shared framework"):
+        (root / self.JAVA_FRAMEWORK_PATH / "README.md").write_text("framework change\n")
+        self.commit_all(root, message)
+
+    def fanout_dry_run(self, root, service):
+        components = self.github_release.java_ci_components(root)
+        output = io.StringIO()
+        with chdir(root), contextlib.redirect_stdout(output):
+            created = self.github_release.publish_framework_dependency_release(
+                root, service, components, dry_run=True, draft=False
+            )
+        return created, output.getvalue()
+
+    def test_java_ci_components_match_registered_subprojects(self):
+        root = SCRIPT_PATH.parents[2]
+        components = self.github_release.java_ci_components(root)
+        kinds = {component["path"]: component["component_kind"] for component in components}
+        self.assertEqual(kinds.get("src/libraries/java/nv-boot-parent"), "java-framework")
+        self.assertTrue(self.github_release.java_framework_paths(components))
+
+        metadata = json.loads(SCRIPT_PATH.with_name("github-release-subprojects.json").read_text())
+        registered = {service["path"] for service in metadata["services"]}
+        services = [c for c in components if c["component_kind"] == "java-service"]
+        self.assertGreater(len(services), 0)
+        for component in services:
+            with self.subTest(component=component["id"]):
+                # A java-service that is not a registered subproject can never
+                # receive a dependency-triggered release.
+                self.assertIn(component["path"], registered)
+                self.assertTrue(
+                    self.github_release.is_java_service(
+                        components, {"id": component["id"], "path": component["path"]}
+                    )
+                )
+
+    def test_framework_change_fans_out_a_patch_release_to_every_dependent_service(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.init_java_repo(root)
+            self.commit_framework_change(root)
+
+            for service_id, path, version in self.JAVA_SERVICES:
+                with self.subTest(service=service_id):
+                    service = self.java_service_metadata(service_id, path)
+                    created, text = self.fanout_dry_run(root, service)
+                    self.assertTrue(created)
+                    expected = self.github_release.next_patch_version(version)
+                    self.assertIn(f"would create {path}/v{expected}", text)
+                    self.assertIn("dependency-triggered release", text)
+                    self.assertIn(self.JAVA_FRAMEWORK_PATH, text)
+                    self.assertIn("fix(nv-boot): bump shared framework", text)
+
+    def test_framework_fanout_skips_a_component_that_is_not_a_java_service(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.init_java_repo(root)
+            self.commit_framework_change(root)
+
+            framework = {
+                "id": "nv-boot-parent",
+                "path": self.JAVA_FRAMEWORK_PATH,
+                "service_name": "nv-boot-parent",
+            }
+            created, _text = self.fanout_dry_run(root, framework)
+            self.assertFalse(created)
+
+            go_service = {
+                "id": "ratelimiter",
+                "path": "src/invocation-plane-services/ratelimiter",
+                "service_name": "nvcf-ratelimiter",
+            }
+            created, _text = self.fanout_dry_run(root, go_service)
+            self.assertFalse(created)
+
+    def test_no_framework_change_since_the_last_service_tag_releases_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.init_java_repo(root)
+            self.commit_framework_change(root)
+            # Release each service at the fanned-out patch, then assert a rerun
+            # over the same framework commit is a no-op.
+            for service_id, path, version in self.JAVA_SERVICES:
+                git(root, "tag", f"{path}/v{self.github_release.next_patch_version(version)}")
+
+            for service_id, path, _version in self.JAVA_SERVICES:
+                with self.subTest(service=service_id):
+                    service = self.java_service_metadata(service_id, path)
+                    created, text = self.fanout_dry_run(root, service)
+                    self.assertFalse(created)
+                    self.assertIn("no Java framework commits since", text)
+                    self.assertNotIn("would create", text)
+
+    def test_framework_fanout_needs_an_existing_service_release_tag(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.init_repo(root)
+            self.write_java_component(root, self.JAVA_FRAMEWORK_PATH, "nv-boot-parent", "java-framework")
+            self.write_java_component(root, "src/control-plane-services/notary", "notary", "java-service")
+            self.commit_all(root, "seed java components")
+            self.commit_framework_change(root)
+
+            service = self.java_service_metadata("notary", "src/control-plane-services/notary")
+            created, text = self.fanout_dry_run(root, service)
+            self.assertFalse(created)
+            self.assertIn("no existing release tag to bump from", text)
+
+    def test_framework_fanout_dry_run_creates_no_tag_and_no_release(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.init_java_repo(root)
+            self.commit_framework_change(root)
+            before = self.list_tags(root)
+
+            releases = []
+            self.github_release.create_release = lambda *a, **k: releases.append(a)
+            for service_id, path, _version in self.JAVA_SERVICES:
+                created, _text = self.fanout_dry_run(root, self.java_service_metadata(service_id, path))
+                self.assertTrue(created)
+
+            self.assertEqual(self.list_tags(root), before)
+            self.assertEqual(releases, [])
+
+    def test_framework_fanout_publish_mode_tags_pushes_and_releases(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            remote = Path(tmp) / "remote.git"
+            root.mkdir()
+            subprocess.run(
+                ["git", "init", "--bare", "--initial-branch=main", str(remote)],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            self.init_java_repo(root)
+            git(root, "remote", "add", "origin", str(remote))
+            git(root, "push", "origin", "HEAD")
+            self.commit_framework_change(root)
+
+            releases = []
+            self.github_release.create_release = lambda tag, title, notes, draft, dry_run: releases.append(
+                (tag, notes, draft, dry_run)
+            )
+            components = self.github_release.java_ci_components(root)
+            service_id, path, version = self.JAVA_SERVICES[0]
+            service = self.java_service_metadata(service_id, path)
+            with chdir(root), contextlib.redirect_stdout(io.StringIO()):
+                created = self.github_release.publish_framework_dependency_release(
+                    root, service, components, dry_run=False, draft=False
+                )
+
+            expected_tag = f"{path}/v{self.github_release.next_patch_version(version)}"
+            self.assertTrue(created)
+            self.assertIn(expected_tag, self.list_tags(root))
+            self.assertIn(expected_tag, self.list_tags(remote))
+            self.assertEqual(len(releases), 1)
+            self.assertEqual(releases[0][0], expected_tag)
+            self.assertIn("dependency-triggered release", releases[0][1])
+
+    def test_semantic_release_version_wins_over_dependency_fanout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.init_java_repo(root)
+            self.commit_framework_change(root)
+            service_id, path, version = self.JAVA_SERVICES[0]
+            (root / path / "README.md").write_text("service change\n")
+            self.commit_all(root, "fix(cloud-tasks): service change")
+            before = self.list_tags(root)
+
+            releases = []
+            self.github_release.create_release = lambda *a, **k: releases.append(a)
+            components = self.github_release.java_ci_components(root)
+            service = self.java_service_metadata(service_id, path)
+            semantic_release_output = (
+                "[semantic-release] > Analyzing commit: fix(cloud-tasks): service change\n"
+                "[semantic-release] > The next release version is 1.6.3\n"
+            )
+
+            output = io.StringIO()
+            with chdir(root), contextlib.redirect_stdout(output):
+                outcome = self.github_release.finish_semantic_release(
+                    root, service, components, 0, semantic_release_output, dry_run=False, draft=False
+                )
+
+            text = output.getvalue()
+            self.assertEqual(outcome, "released")
+            self.assertIn(f"semantic-release created {path}/v1.6.3", text)
+            self.assertNotIn("dependency-triggered", text)
+            self.assertNotIn("dependency patch release", text)
+            # No extra tag: the fan-out would have proposed the same patch line
+            # and double-tagged the push.
+            self.assertEqual(self.list_tags(root), before)
+            self.assertEqual(releases, [])
+            self.assertEqual(
+                self.github_release.next_patch_version(version), "1.6.3", "fan-out would collide"
+            )
+
+    def test_semantic_release_no_release_falls_through_to_dependency_fanout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.init_java_repo(root)
+            self.commit_framework_change(root)
+            components = self.github_release.java_ci_components(root)
+            service_id, path, version = self.JAVA_SERVICES[0]
+            service = self.java_service_metadata(service_id, path)
+            no_release_output = "[semantic-release] > There are no relevant changes, so no new version is released.\n"
+
+            output = io.StringIO()
+            with chdir(root), contextlib.redirect_stdout(output):
+                outcome = self.github_release.finish_semantic_release(
+                    root, service, components, 0, no_release_output, dry_run=True, draft=False
+                )
+
+            text = output.getvalue()
+            self.assertEqual(outcome, "no-release")
+            expected = self.github_release.next_patch_version(version)
+            self.assertIn(f"would create {path}/v{expected}", text)
+            self.assertIn("dependency-triggered release", text)
+
+    def test_resolve_release_outcome_classifies_semantic_release_runs(self):
+        self.assertEqual(
+            self.github_release.resolve_release_outcome(0, "The next release version is 2.4.0"),
+            "released",
+        )
+        self.assertEqual(
+            self.github_release.resolve_release_outcome(
+                0, "There are no relevant changes, so no new version is released."
+            ),
+            "no-release",
+        )
+        self.assertEqual(self.github_release.resolve_release_outcome(1, "boom"), "unknown")
+
+    def list_tags(self, root):
+        result = subprocess.run(
+            ["git", "tag", "-l"], cwd=root, check=True, stdout=subprocess.PIPE, text=True
+        )
+        return sorted(line.strip() for line in result.stdout.splitlines() if line.strip())
+
     def test_version_file_release_skips_existing_current_tag_on_previous_commit(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tools/ci/test-github-release.py
+++ b/tools/ci/test-github-release.py
@@ -373,6 +373,38 @@ class GithubReleaseTest(unittest.TestCase):
             "no-release",
         )
         self.assertEqual(self.github_release.resolve_release_outcome(1, "boom"), "unknown")
+        # A run that printed a version and then died is not trustworthy: the
+        # publish run may not reproduce it, so it must be reported rather than
+        # previewed as a tag.
+        self.assertEqual(
+            self.github_release.resolve_release_outcome(1, "The next release version is 2.4.0"),
+            "unknown",
+        )
+        self.assertEqual(
+            self.github_release.resolve_release_outcome(
+                137, "There are no relevant changes, so no new version is released."
+            ),
+            "unknown",
+        )
+
+    def test_failed_semantic_release_run_does_not_fan_out(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.init_java_repo(root)
+            self.commit_framework_change(root)
+            components = self.github_release.java_ci_components(root)
+            service_id, path, _version = self.JAVA_SERVICES[0]
+            service = self.java_service_metadata(service_id, path)
+
+            output = io.StringIO()
+            with chdir(root), contextlib.redirect_stdout(output):
+                outcome = self.github_release.finish_semantic_release(
+                    root, service, components, 137, "killed mid-run\n", dry_run=True, draft=False
+                )
+
+            self.assertEqual(outcome, "unknown")
+            self.assertNotIn("would create", output.getvalue())
+            self.assertNotIn("dependency-triggered", output.getvalue())
 
     def list_tags(self, root):
         result = subprocess.run(

--- a/tools/ci/test-github-release.py
+++ b/tools/ci/test-github-release.py
@@ -107,7 +107,7 @@ class GithubReleaseTest(unittest.TestCase):
             git(root, "tag", f"{path}/v{version}")
 
     def commit_framework_change(self, root, message="fix(nv-boot): bump shared framework"):
-        (root / self.JAVA_FRAMEWORK_PATH / "README.md").write_text("framework change\n")
+        (root / self.JAVA_FRAMEWORK_PATH / "README.md").write_text(f"{message}\n")
         self.commit_all(root, message)
 
     def fanout_dry_run(self, root, service):
@@ -195,8 +195,45 @@ class GithubReleaseTest(unittest.TestCase):
                     service = self.java_service_metadata(service_id, path)
                     created, text = self.fanout_dry_run(root, service)
                     self.assertFalse(created)
-                    self.assertIn("no Java framework commits since", text)
+                    self.assertIn("no release-worthy Java framework commits since", text)
                     self.assertNotIn("would create", text)
+
+    def test_non_release_worthy_framework_commits_release_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.init_java_repo(root)
+            for message in (
+                "docs(nv-boot): document the shared framework",
+                "chore(nv-boot): reformat",
+                "refactor(nv-boot): extract a helper",
+                "no conventional prefix at all",
+            ):
+                self.commit_framework_change(root, message)
+
+            for service_id, path, _version in self.JAVA_SERVICES:
+                with self.subTest(service=service_id):
+                    service = self.java_service_metadata(service_id, path)
+                    created, text = self.fanout_dry_run(root, service)
+                    self.assertFalse(created)
+                    self.assertIn("no release-worthy Java framework commits since", text)
+
+            # One release-worthy framework commit is enough to fan out, and the
+            # notes quote only the release-worthy ones.
+            self.commit_framework_change(root, "perf(nv-boot): trim startup work")
+            service_id, path, version = self.JAVA_SERVICES[0]
+            created, text = self.fanout_dry_run(root, self.java_service_metadata(service_id, path))
+            self.assertTrue(created)
+            self.assertIn(f"would create {path}/v{self.github_release.next_patch_version(version)}", text)
+            self.assertIn("perf(nv-boot): trim startup work", text)
+            self.assertNotIn("chore(nv-boot): reformat", text)
+
+    def test_releases_a_version_follows_the_configured_release_rules(self):
+        releases_a_version = self.github_release.releases_a_version
+        for subject in ("feat: x", "fix(scope): x", "perf: x", "chore(scope)!: x", "FIX: x"):
+            self.assertTrue(releases_a_version(subject), subject)
+        for subject in ("chore: x", "ci(scope): x", "docs: x", "style: x", "refactor: x",
+                        "test: x", "build: x", "not a conventional commit"):
+            self.assertFalse(releases_a_version(subject), subject)
 
     def test_framework_fanout_needs_an_existing_service_release_tag(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Why

A change to the shared Java framework `src/libraries/java/nv-boot-parent`
rebuilds every dependent Java service in CI but releases none of them.

The build-side edge already exists. `.github/workflows/bazel.yml` discovers
Java rows from per-component `bazel-java-ci.json` descriptors, sets
`java_framework_changed=true` at line 249 when a changed path sits under a
`component_kind: java-framework` component, and at line 326 schedules every
`component_kind: java-service` row. So `cloud-tasks`, `notary`, and `api-keys`
are built and tested against the new framework.

The release side has no matching edge. `tools/ci/github-release auto` runs
`npx semantic-release` per registered subproject with `semantic-release-monorepo`
(`write_semantic_release_files`, line 367), which scopes commits to the service
directory. A commit touching only `src/libraries/java/nv-boot-parent` matches no
registered service path, so every dependent reports "no relevant changes" and
cuts nothing. `nv-boot-parent` is not itself one of the 42 registered
subprojects in `tools/ci/github-release-subprojects.json`, so nothing is
released for the framework either.

Net effect: a framework change can alter the behaviour of three services, pass
CI, and ship no new version of any of them. The rebuilt artifacts exist only
inside the CI job.

This is not hypothetical on current `main`. HEAD is
`feat(nv-boot): discover NGC auth via authenticate challenge (#557)`, a
framework-only commit that landed after the last release tag of all three
dependents.

## What changed

`tools/ci/github-release` gains a dependency fan-out for Java services.

- `java_ci_components()` reads the same `src/**/bazel-java-ci.json` descriptors
  `bazel.yml` reads. The framework-to-service edge stays declared in exactly one
  place; no second list is introduced and no field is added to the generated
  release metadata (its generator is not mirrored here).
- `publish_framework_dependency_release()` cuts a patch release through the
  existing `publish_tag_for_version()` helper, with a `reason` that says the
  release is dependency-triggered and lists the framework commits.
- `resolve_release_outcome()` / `finish_semantic_release()` classify a
  semantic-release run. semantic-release wins whenever it computed a version, so
  a push touching both a framework and a service is never double-tagged.
- `auto_release()` calls the fan-out on both paths that end in "nothing to
  release": the `only_generated_changes()` early return, and the
  semantic-release "no relevant changes" result.
- The publish-mode `npx semantic-release` invocation now streams its output
  instead of discarding it, because the fan-out decision depends on whether
  semantic-release released anything. A non-zero exit still raises, as before.

Guards, all of which have tests:

- Only components whose path matches a `java-service` descriptor are eligible.
- The service must already have a stable `X.Y.Z` release tag to bump from.
- At least one release-worthy commit must have touched a framework path since
  that tag, bounded by `latest_service_tag()`, so a rerun over the same
  framework commit is a no-op. Release-worthiness is derived from the existing
  `RELEASE_RULES` constant, so a framework `docs:` or `chore:` commit fans out
  nothing, exactly as it would release nothing inside a service directory.
- Dry-run and `auto_tagging_enabled=false` are honored by reusing
  `publish_tag_for_version()`, which prints the tag and notes and creates
  nothing.

### Design decision: patch, not minor, even for a framework `feat:`

The synthesized bump is always a patch, including when the framework commit is a
`feat:`. Reasons, in order:

1. A framework feature adds no capability to a service that has not adopted it.
   The service's public surface is unchanged; only its build inputs moved. Minor
   would advertise functionality the service does not have.
2. The dependent's release notes contain no service commits, so a minor has
   nothing in that service's changelog to substantiate it.
3. Dependency-triggered releases stay in the patch lane, so a framework change
   can never consume a service's minor line or collide with a planned minor.
   Minor and major bumps remain owned by commits in the service's own directory.
4. A service that genuinely adopts a new framework API does so in a commit under
   its own directory. semantic-release computes the correct bump from that
   commit, and this fan-out does not run at all in that case.

The same argument applies more strongly to a framework `BREAKING CHANGE`: a
silent major fan-out would be the most surprising outcome of all, so it is not
implemented. A breaking framework change should be adopted deliberately in each
service.

This behaviour is documented in `docs/dev/github-release-process.md` under
"Java framework dependency releases", so it is not a surprise at the console.

## Customer Release Notes

Not customer visible. Release automation only.

## Plan Summary

Not applicable. No infrastructure, chart, or deploy changes.

## Usage

No new commands. The existing entrypoint covers it:

```bash
./tools/ci/github-release auto
```

Behaviour is unchanged for every non-Java subproject and for Java subprojects
whose own directory changed.

## Testing

`tools/ci/test-github-release.py` (run by `.github/workflows/build-test.yml`)
goes from 7 tests to 20, all passing:

```
Ran 20 tests in 0.49s
OK
```

New coverage:

- a framework change with no service change produces a patch bump for every
  dependent service
- framework `docs:` / `chore:` / `refactor:` / non-conventional commits fan out
  nothing, and the release notes quote only the release-worthy commits
- a framework change plus a service change does not double-tag; the
  semantic-release version wins and no extra tag is created
- no framework change since the last service tag produces nothing
- dry-run creates no tag and no GitHub Release
- publish mode creates the tag, pushes it to a real bare remote, and passes the
  dependency-triggered notes to `create_release`
- a service with no prior release tag is skipped rather than seeded
- non-Java subprojects and the framework component itself are never fanned out
- `java-service` descriptors and registered subprojects are checked for drift
  against the real repo, so a new Java service that is not registered fails the
  suite instead of silently never releasing
- `releases_a_version()` matches the configured `RELEASE_RULES` for every
  declared type
- a semantic-release run that exits non-zero is classified as undecided and
  produces neither a preview tag nor a dependency fan-out

Also validated against real `main` state by running the new helpers over the
actual checkout.

Read this table as a demonstration of the mechanism against the anchors that
exist on `main` today, not as the versions these services should be released at.
Two of the three anchors are on the wrong version line, which is the merge-order
dependency described under Notes. The "would cut" column is what the fan-out
computes from the current, incorrect anchors.

| service | latest tag on `main` today | release-worthy framework commits since | would cut from that anchor | correct line |
| --- | --- | --- | --- | --- |
| cloud-tasks | `src/control-plane-services/cloud-tasks/v1.62.2` | 1 | 1.62.3 | 1.6.x |
| notary | `src/control-plane-services/notary/v1.12.0` | 1 | 1.12.1 | 1.8.x |
| api-keys | `src/control-plane-services/api-keys/v1.6.1` | 1 | 1.6.2 | 1.6.x |

Not run: an end-to-end `github-release auto` against `main`, which needs npm and
network access to install semantic-release. The semantic-release interaction is
covered by feeding recorded semantic-release output through
`finish_semantic_release()`.

## Notes

### Where the base version comes from

There is no hardcoded base or current version anywhere in this PR, and none in
this repository. The base version is read from Git tags in this repository:

1. `tools/ci/github-release-subprojects.json` gives each service its `path`.
2. `default_tag_format()` (line 121) turns that path into `<path>/v${version}`,
   and `tag_prefix()` (line 132) strips the placeholder to get the tag prefix.
3. `latest_service_tag()` (line 282) runs `git tag -l "<prefix>*"` and returns
   the semver-max match, ordered by `semverish_sort_key()` (line 117).
4. `publish_framework_dependency_release()` (line 598) takes that tag, extracts
   the version with `version_from_tag()` (line 159), and increments the patch
   with `next_patch_version()` (line 531).

So the base version is whatever the highest existing tag on `main` says. The
service `pom.xml` files are all `0.0.1-SNAPSHOT` and are not a version source,
and none of these three services has a `VERSION` file. Nothing in this code
path reads a version from outside this repository.

### Merge-order dependency: fix the version anchors first

Because the base version is the semver-max existing tag, a wrong anchor
propagates. `notary` and `cloud-tasks` are on the wrong version line today:

| service | latest tag on `main` | correct current version |
| --- | --- | --- |
| cloud-tasks | `src/control-plane-services/cloud-tasks/v1.62.2` | 1.6.2 |
| notary | `src/control-plane-services/notary/v1.12.0` | 1.8.1 |

Adding a correct anchor is not sufficient on its own. `semverish_sort_key()`
compares numerically per component, so with both `v1.12.0` and a new `v1.8.1`
present, the max is still `v1.12.0`, and with both `v1.62.2` and a new `v1.6.2`
present, the max is still `v1.62.2`. Verified against the function.

Required order before auto-tagging is enabled:

1. Delete the wrong anchors `src/control-plane-services/notary/v1.12.0` and
   `src/control-plane-services/cloud-tasks/v1.62.2`.
2. Re-anchor `notary` at 1.8.1 and `cloud-tasks` at 1.6.2.
3. Only then set `NVCF_GITHUB_AUTO_TAGGING_ENABLED=true`.

Merging this PR before that is safe: `NVCF_GITHUB_AUTO_TAGGING_ENABLED` defaults
to `false`, so `release-tags.yml` runs dry-run only and creates no tag and no
Release.

`api-keys` needs confirmation, not correction: `main` carries both
`src/control-plane-services/api-keys/v1.6.0` and `v1.6.1`, so `latest_service_tag()`
returns `v1.6.1` and the fan-out would cut 1.6.2. If `v1.6.1` is a real release
that is already correct. If it is a stray anchor and 1.6.0 is current, it should
be deleted along with the other two.

### Scope

- `nv-boot-parent` itself is still not a registered subproject and still cuts no
  tag of its own. This PR does not change that; it makes the framework change
  reach released artifacts through its dependents. Registering the framework as
  its own release line is a separate decision.
- The descriptors declare the edge as "any framework affects every service",
  which is exactly what `bazel.yml` implements today. If a per-service framework
  allowlist is ever needed, it belongs in the descriptors so both consumers pick
  it up.

## References

Fixes #594

## Related Merge Requests/Pull Requests

None.

## Review follow-ups

- Review flagged that the first pass fanned out on any commit touching a
  framework path, including a framework-only `docs:` or `chore:`. Fixed in
  b9f41b87: the commit list is now filtered through `RELEASE_RULES`.
- Review flagged that `resolve_release_outcome()` ignored the exit code when the
  output contained a version, so a dry-run that printed a version and then died
  previewed a tag the publish run may never create. Fixed in 6ba76cd4: any
  non-zero exit is `unknown` and lands in the dry-run preview summary. Publish
  mode is unaffected; it already raises on a non-zero exit.

## Dependencies

None. No new third-party packages; standard library only.

## Issues

Fixes #594

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

