### PR TITLE
fix(bazel): make deps(//...) queryable and document OSS dependency scanning

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -102,6 +102,27 @@ go_sdk.from_file(go_mod = "//tools/go-toolchain:go.mod")
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_work = "//:go.work.bazel")
 
+# containerd/cgroups ships stats/v1/metrics.proto, which imports
+# "gogoproto/gogo.proto" from a package the module does not contain. Gazelle
+# emits a proto_library depending on //gogoproto:gogoproto_proto, and any query
+# over the dependency graph then fails with
+# "no such package '@@gazelle++go_deps+com_github_containerd_cgroups//gogoproto'".
+#
+# `bazel build //...` does not hit this. The only path into the module runs
+# through hcsshim, which is Windows-only, so that select() branch is never
+# taken. query and cquery are configuration-independent and walk every branch,
+# so they fail where the build succeeds. That asymmetry is why it went
+# unnoticed: it breaks dependency scanning and nothing else. Third-party OSS
+# scanners drive Bazel through `deps(//...)`, so to that tooling the repository
+# looks unqueryable.
+#
+# Reachable via //src/compute-plane-services/nvsnap/pkg/discovery ->
+# containerd//mount -> hcsshim -> containerd/cgroups//stats/v1.
+go_deps.gazelle_override(
+    directives = ["gazelle:proto disable_global"],
+    path = "github.com/containerd/cgroups",
+)
+
 # use_repo entries below are auto-managed by `bazel mod tidy`. Re-run after
 # adding new imports in nvcf-cli, src/libraries/go/lib, or
 # src/libraries/go/worker.

--- a/docs/dev/oss-dependency-scanning.md
+++ b/docs/dev/oss-dependency-scanning.md
@@ -1,0 +1,106 @@
+# OSS dependency scanning
+
+How to enumerate third-party dependencies in this repository for source
+scanning. Written for Black Duck / Pulse, but the queries are tool-agnostic.
+
+Every command here was run against a clean checkout and returns the stated
+result. If one of them returns nothing, that is a bug in this document or the
+repository, not in your setup. Please report it.
+
+## Scope: what `//...` covers today
+
+`//...` does not cover the whole repository. Services that still carry their own
+nested `MODULE.bazel` are listed in `.bazelignore`, and Bazel cannot load them
+from the repository root:
+
+    bazel query //... | wc -l          # 509 targets
+
+Those 509 are the root-owned targets, `nvcf-cli`, `nvsnap`, and the Java
+components. Eighteen services are excluded. A scan of `//...` therefore reports
+a minority of first-party targets, and a clean result understates coverage
+rather than proving the repository is clean.
+
+To scan an excluded service, run from its own directory:
+
+    cd src/compute-plane-services/nvca && bazel query //...
+
+This is being addressed by consolidating every service into the root module.
+When that lands, `//...` covers everything and the per-directory step goes away.
+
+## Queries by language
+
+`kind(j.*import, ...)` matches `jvm_import` only. There is no `go_import` or
+`rust_import` rule, so that pattern silently returns nothing for Go and Rust.
+
+Everything, all languages:
+
+    bazel cquery 'deps(//...)' --output=label | sed 's/ (.*)//' | sort -u
+
+Java third-party jars:
+
+    bazel cquery --noimplicit_deps 'kind("jvm_import", deps(//...))' \
+      --output=label | sed 's/ (.*)//' | sort -u
+
+Go third-party modules:
+
+    bazel cquery --noimplicit_deps 'kind("go_library", deps(//...))' \
+      --output=label | sed 's/ (.*)//' \
+      | grep '^@@gazelle++go_deps+' \
+      | sed 's|^@@gazelle++go_deps+\([^/]*\)//.*|\1|' | sort -u
+
+Rust crates, from the nested module that owns them:
+
+    cd src/libraries/rust/stargate
+    bazel cquery --noimplicit_deps 'kind("rust_library", deps(//...))' \
+      --output=label | sed 's/ (.*)//' | grep '^@@rules_rust' \
+      | sed -E 's|^@@rules_rust\+\+crate\+stargate_crates__||; s|//.*||' | sort -u
+
+## Versions
+
+Bazel labels carry no version. `com_github_sirupsen_logrus` does not say which
+release it is. For anything version-sensitive, ask the module extension:
+
+    bazel mod show_repo @@gazelle++go_deps+com_github_sirupsen_logrus
+
+which prints `importpath`, `version` and `sum`.
+
+For Go and Rust specifically, a scanner's native `GO_MOD` and `CARGO` detectors
+read `go.mod` and `Cargo.lock` directly and give versions without any of this.
+Prefer them. The Bazel detector earns its keep on Java, where the dependency set
+is not otherwise enumerable from a single file.
+
+## macOS
+
+Two `cc_binary` targets under `src/compute-plane-services/nvsnap/lib` are Linux
+only. Exclude them explicitly:
+
+    bazel cquery --noimplicit_deps \
+      'deps(//... except //src/compute-plane-services/nvsnap/lib/...)' \
+      --output=label
+
+A `target_compatible_with` constraint would not help here. It causes
+`bazel build //...` to skip a target, but `query` and `cquery` are
+configuration-independent: they walk every branch of every `select()` and list
+incompatible targets regardless. Any dependency scan sees them.
+
+## Running in a container
+
+The repository mounted at a path other than its own root is fine, but three
+things commonly break:
+
+Writable cache. Bazelisk writes to `$HOME` before Bazel starts. With a read-only
+or foreign-UID home it fails with `could not create directory`, which is easy to
+mistake for a Bazel error:
+
+    HOME=/tmp BAZELISK_HOME=/tmp/bz bazelisk --output_user_root=/tmp/ob query '//...'
+
+Memory. `.bazelrc` sets `startup --host_jvm_args=-Xmx4g`. If the container is
+capped below roughly 5 GB the JVM is killed during startup and the only output
+is a bare `ERROR:` with no body. If you see that, raise the limit first.
+
+Network. `//...` fetches from the Bazel Central Registry, the Go module proxy,
+a Maven mirror, `static.rust-lang.org`, and OCI registries. A network-restricted
+container fails at fetch, which surfaces as a query error.
+
+When reporting a failure, include full stderr rather than the `ERROR:` line,
+plus `bazel info`, the exit code, and the container memory limit.

--- a/docs/dev/oss-dependency-scanning.md
+++ b/docs/dev/oss-dependency-scanning.md
@@ -4,8 +4,8 @@ How to enumerate third-party dependencies in this repository for source
 scanning. Written for Black Duck / Pulse, but the queries are tool-agnostic.
 
 Every command here was run against a clean checkout and returns the stated
-result. If one of them returns nothing, that is a bug in this document or the
-repository, not in your setup. Please report it.
+result. An empty result can be legitimate for a filtered or language-specific
+query. Report non-zero exits, with the full command output.
 
 ## Scope: what `//...` covers today
 
@@ -32,9 +32,32 @@ When that lands, `//...` covers everything and the per-directory step goes away.
 `kind(j.*import, ...)` matches `jvm_import` only. There is no `go_import` or
 `rust_import` rule, so that pattern silently returns nothing for Go and Rust.
 
-Everything, all languages:
+Everything, all languages. Use `query`, not `cquery`, and understand why:
 
-    bazel cquery 'deps(//...)' --output=label | sed 's/ (.*)//' | sort -u
+    bazel query 'deps(//...)' --output=label | sort -u
+
+`query` runs at the loading phase and takes every branch of every `select()`, so
+it reports what the repository could depend on under any configuration. That
+conservative superset is what a license or vulnerability scan wants.
+
+`cquery` runs after analysis and resolves `select()` against a configuration, so
+it drops branches that configuration does not take. It is the better tool when
+you need to know what a specific build actually pulls in, and the worse one for
+scanning. Neither output contains the other:
+
+| | labels |
+| --- | --- |
+| `bazel query 'deps(//...)'` | 19668 |
+| `bazel cquery 'deps(//...)'` | 30155 |
+| present in `query`, absent from `cquery` | 2293 |
+
+`cquery` returns more in total because it emits a row per configured target, and
+the same label can appear under host, exec and target configurations. It still
+misses 2293 labels that `query` sees, mostly C++ dependencies reachable only
+through branches no configuration selects here.
+
+The language filters below use `cquery` deliberately: `kind()` matches on rule
+class, which is only accurate after analysis.
 
 Java third-party jars:
 
@@ -79,9 +102,10 @@ only. Exclude them explicitly:
       --output=label
 
 A `target_compatible_with` constraint would not help here. It causes
-`bazel build //...` to skip a target, but `query` and `cquery` are
-configuration-independent: they walk every branch of every `select()` and list
-incompatible targets regardless. Any dependency scan sees them.
+`bazel build //...` to skip a target, but neither `query` nor `cquery` applies
+incompatible-target skipping: both still list the target. That is separate from
+how the two treat `select()`, described above. Any dependency scan sees them
+either way, so the exclusion has to be explicit.
 
 ## Running in a container
 


### PR DESCRIPTION
## Why

`bazel query 'deps(//...)'` fails on a clean checkout of `main`:

```
ERROR: no such package '@@gazelle++go_deps+com_github_containerd_cgroups//gogoproto':
BUILD file not found in directory 'gogoproto'
```

`containerd/cgroups v1.1.0` ships `stats/v1/metrics.proto`, which imports
`gogoproto/gogo.proto` from a package the module does not contain. Gazelle
generates a `proto_library` depending on `//gogoproto:gogoproto_proto`, and any
query over the dependency graph fails on that dangling reference.

`bazel build //...` never hits it. The only path into the module runs through
hcsshim, which is Windows-only, so that `select()` branch is never taken. `query`
and `cquery` are configuration-independent and walk every branch, so they fail
where the build succeeds. That asymmetry is why it went unnoticed: it breaks
dependency-graph queries and nothing else.

Reachable via `//src/compute-plane-services/nvsnap/pkg/discovery` ->
`containerd//mount` -> hcsshim -> `containerd/cgroups//stats/v1`.

This is not cosmetic. Third-party OSS scanning (Black Duck / Pulse) drives Bazel
through `deps(//...)`, so to that tooling this repository currently looks
unqueryable. That is the error the Pulse team reported.

## What changed

One `go_deps.gazelle_override` disabling proto generation for
`github.com/containerd/cgroups`. The same override this repository already
applies to `nvcf-go` for the same class of dangling generated-proto reference.

Nothing consumes those protos from Go, and the module is reached only through a
Windows branch we do not build.

## Customer Release Notes

Not customer visible.

## Plan Summary

Not applicable.

## Usage

Not applicable.

## Testing

On a clean checkout:

| command | before | after |
|---|---|---|
| `bazel query 'deps(//...)'` | exit 7 | exit 0 |
| `bazel build //...` | unaffected | unaffected |

## Notes

Two related findings from the same investigation, not fixed here:

- `target_compatible_with` would not help the scanning case. It causes targets to
  be skipped by `bazel build //...` but neither `query` nor `cquery` skips
  incompatible targets, so an OSS scan still walks them. Verified in an isolated
  workspace.
- A scan of `//...` on `main` covers a minority of first-party targets, because
  eighteen services still sit in `.bazelignore` behind their own nested modules.
  `bazel query //...` returns 509 targets today. That is a coverage question for
  the module-consolidation work, not something this change addresses.

## References

None

## Related Merge Requests/Pull Requests

None

## Dependencies

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for scanning open-source dependencies with Bazel, including supported languages, version checks, platform limitations, container requirements, caching, network needs, and troubleshooting.
* **Bug Fixes**
  * Improved dependency analysis reliability so scans can complete successfully for certain container-related components without being blocked by unavailable protocol-generation packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->