### PR TITLE
feat(self-managed): advance nvcf-api helm chart to 1.23.11

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -56,7 +56,7 @@ releases:
       - template: service
 
   - name: api
-    version: 1.23.9
+    version: 1.23.11
     namespace: nvcf
     inherit:
       - template: service


### PR DESCRIPTION
## TL;DR

Advance the `nvcf-api` helm chart in the self-managed stack from `1.23.9` to `1.23.11`.

## Additional Details

This change tracks two upstream releases from `nvcf-api-colocated-deploy`:

- Chart `1.23.10`: upgrades the `nvcf-api` app from `1.9.0-hotfix.1` to `1.12.1`
- Chart `1.23.11`: upgrades the `nvcf-api` app from `1.12.1` to `1.12.6`

Latest change in `1.12.6`: makes `maxFunctionsAllowed` and `maxTasksAllowed` at account creation configurable via `AccountLimitsProperties` (`nvcf.account.max-functions-allowed` / `nvcf.account.max-tasks-allowed`). Self-hosted deployments default to no effective cap (`Integer.MAX_VALUE`)

## For the Reviewer

Single line change in `deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl`.

## For QA

QA is needed to validate the new nvcf-api version in a self-managed environment.

## Issues

NVBug: 6510568
NO-REF

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.