### PR TITLE
feat(sis): Adding deployment_id and gpu_spec_id and index for them to  instances table

### DIFF
--- a/migrations/cassandra/keyspaces/sis_api/07_add_deployment_and_gpu_spec_id.up.sql
+++ b/migrations/cassandra/keyspaces/sis_api/07_add_deployment_and_gpu_spec_id.up.sql
@@ -1,0 +1,2 @@
+-- Add deployment_id and gpu_specification_id UUID to instances table
+ALTER TABLE sis_api.instances ADD IF NOT EXISTS (deployment_id uuid, gpu_specification_id uuid);

--- a/migrations/cassandra/keyspaces/sis_api/08_add_indexes_for_deployment_and_gpu_spec_id.up.sql
+++ b/migrations/cassandra/keyspaces/sis_api/08_add_indexes_for_deployment_and_gpu_spec_id.up.sql
@@ -1,0 +1,3 @@
+-- Indexes for deployment_id and gpu_specification_id
+CREATE CUSTOM INDEX IF NOT EXISTS idx_instances_by_deployment_id ON sis_api.instances (deployment_id) USING 'StorageAttachedIndex';
+CREATE CUSTOM INDEX IF NOT EXISTS idx_instances_by_gpu_specification_id ON sis_api.instances (gpu_specification_id) USING 'StorageAttachedIndex';


### PR DESCRIPTION


## TL;DR
Adding deployment_id and gpu_spec_id and their indexes for them to  instances table

## Issues
Resolves NVIDIA/nvcf#11152


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Instances can now be associated with a deployment and GPU specification.
  * Added database indexes to improve lookup performance for these associations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->