### PR TITLE
docs(self-managed): use stable 0.6.1 stack resource

### DIFF
--- a/docs/v0.6.1/image-mirroring.md
+++ b/docs/v0.6.1/image-mirroring.md
@@ -195,7 +195,7 @@ First, ensure you have the [NGC CLI installed and configured](https://org.ngc.nv
 
 ```bash
 # Set stack versions
-export STACK_VERSION="0.6.1-rc.6"
+export STACK_VERSION="0.6.1"
 export COMPUTE_STACK_VERSION="1.0.6"
 
 # Download a specific control-plane stack version
@@ -225,7 +225,7 @@ and its listed artifact versions are QA-qualified together.
 
 ```bash
 # Set the version
-export VERSION="0.6.1-rc.6"
+export VERSION="0.6.1"
 
 ngc registry resource download-version "nvidia/nvcf/nvcf-self-managed-stack:${VERSION}" && \
    mkdir -p nvcf-self-managed-stack && \


### PR DESCRIPTION
## TL;DR

Update the versioned 0.6.1 self-managed documentation to use the stable `nvcf-self-managed-stack:0.6.1` resource instead of the release candidate.

## Additional Details

- Set the self-managed stack version and distribution path to `0.6.1` in the 0.6.1 artifact manifest.
- Set both stack download examples to `0.6.1`.
- Sweep the 104-file 0.6.1 documentation tree and its Fern navigation for remaining release-candidate references. No additional text references remain.

## For the Reviewer

This PR follows merged PR #605. The review contains only three version replacements in two documentation files.

## For QA

- `./tools/ci/check-docs` passed with zero errors and the existing advisory version-sync warning because `imports.yaml` is not present in this public checkout.
- `git diff --check origin/main...HEAD` passed.
- Targeted RC-reference sweeps across `docs/v0.6.1` and `fern/versions/v0.6.1.yml` passed.
- QA needed: No.

## Customer Release Notes

Not customer visible. This corrects the stable resource version in the existing 0.6.1 documentation.

## Plan Summary

Not applicable.

## Usage

Not applicable.

## Notes

PR #605 has merged. This branch is rebased onto its squash commit on `main`.

## References

None.

## Related Pull Requests

- Follow-up to #605.

## Dependencies

None. No license or NOTICE changes.

## Issues

Closes #611

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the documented stack version from prerelease `0.6.1-rc.6` to stable release `0.6.1`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->