### PR TITLE
fix(bazel): ignore nvcf-bdd module and nvkit tool-pin dir for scans

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -62,6 +62,12 @@ docs
 fern
 infra
 migrations
+# tests/bdd is the standalone `nvcf-bdd` Go module. It is not in go.work.bazel,
+# so its deps (cucumber/godog and friends) are not registered in the root
+# MODULE.bazel. It is run directly with `go test`, not Bazel. Ignore it so
+# `bazel build //...` and query do not try to analyze generated BUILD targets
+# that reference unresolvable external repos.
+tests/bdd
 
 # Note: tools/ is not ignored here so //tools/bazel/java (the root-owned Java
 # build helpers) is loadable. Gazelle is still kept out of tools/ via the
@@ -77,6 +83,12 @@ migrations
 # from MODULE.bazel via Gazelle's go_deps extension, not from on-disk vendor.
 src/libraries/go/lib/vendor
 src/clis/nvcf-cli/vendor
+
+# Tool-pin directory: holds only a //go:build tools file for go.mod and yields
+# no Bazel package. Skipped directly here because some Bazel commands (build
+# //..., query) load packages without consulting BUILD-level gazelle:exclude,
+# which otherwise fails when the transient build/ dir is missing during a scan.
+src/libraries/go/lib/pkg/nvkit/build
 
 # Bazel-managed caches we keep inside the workspace for CI cache: paths.
 .bazel-cache


### PR DESCRIPTION
tests/bdd is the standalone nvcf-bdd Go module whose deps are not registered in the root MODULE.bazel, and src/libraries/go/lib/pkg/nvkit/build holds only a go:build tools file that yields no Bazel package. Bazel commands that load packages without consulting BUILD-level gazelle:exclude (build //..., query) fail on both, so ignore them at the workspace level.

## TL;DR
<!--Provide a brief description of what changed and why it is needed.-->

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
<!-- - explain the problem, requirement, review comment, or CI blocker driving this MR -->
<!-- - explain how the changed pieces connect -->
<!-- - link upstream MRs/PRs, tickets, bugs, or related reviews when relevant -->
<!-- - any limitations or possible things missing from this PR -->

## For the Reviewer
<!--mention reviewers you wish to review this MR-->
<!--call out specific files that should be looked at closely-->
<!--anything you need answered pertaining to this review-->

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
<!--list steps you took to verify this change-->
<!--Is QA Needed?-->

## Issues
<!--
Required: add a valid NVIDIA/nvcf issue reference below.
Accepted: "Closes #123", "Fixes #123", "Resolves NVIDIA/nvcf#123",
"Relates to #123", or last-resort "NO-REF".
Do not use Jira/private tracker keys, private bug IDs, private URLs, title-only
refs, other-repo refs, or commented-out template examples. If context is
private, create a generic public issue without private details.
-->


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to exclude standalone test and tool-pin directories from Bazel processing.
  * Added comments documenting the exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->