### PR TITLE
fix(helm-reval): render nested JWT auth config

### DIFF
--- a/deploy/helm/helm-reval/scripts/check-render-auth.sh
+++ b/deploy/helm/helm-reval/scripts/check-render-auth.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+chart_dir=${CHART_DIR:-.}
+
+rendered=$(
+  helm template reval "$chart_dir" \
+    --namespace nvcf \
+    --values "$chart_dir/values.yaml" \
+    --set reval.serviceConfig.auth.jwt.enabled=true \
+    --set reval.serviceConfig.auth.jwt.jwkSetUrl=https://identity.example.test/jwks
+)
+
+printf '%s\n' "$rendered" | grep -Fqx '      jwt:'
+printf '%s\n' "$rendered" | grep -Fqx '        enabled: true'
+printf '%s\n' "$rendered" | grep -Fqx '        jwk-set-url: "https://identity.example.test/jwks"'
+! printf '%s\n' "$rendered" | grep -Fqx '      jwk-set-url: "https://identity.example.test/jwks"'

--- a/deploy/helm/helm-reval/templates/configmap.yaml
+++ b/deploy/helm/helm-reval/templates/configmap.yaml
@@ -53,11 +53,12 @@ data:
       deployment-environment-name: {{ .Values.reval.serviceConfig.telemetry.deploymentEnvironmentName | quote }}
 
     auth:
-      enabled: {{ .Values.reval.serviceConfig.auth.enabled }}
-    {{- if .Values.reval.serviceConfig.auth.enabled }}
-      jwk-set-url: {{ .Values.reval.serviceConfig.auth.jwkSetUrl | quote }}
-      validate-required-scopes: {{ .Values.reval.serviceConfig.auth.validateRequiredScopes | quote }}
-      render-required-scopes: {{ .Values.reval.serviceConfig.auth.renderRequiredScopes | quote }}
+      jwt:
+        enabled: {{ .Values.reval.serviceConfig.auth.jwt.enabled }}
+    {{- if .Values.reval.serviceConfig.auth.jwt.enabled }}
+        jwk-set-url: {{ .Values.reval.serviceConfig.auth.jwt.jwkSetUrl | quote }}
+        validate-required-scopes: {{ .Values.reval.serviceConfig.auth.jwt.validateRequiredScopes | quote }}
+        render-required-scopes: {{ .Values.reval.serviceConfig.auth.jwt.renderRequiredScopes | quote }}
     {{- end }}
     {{- if .Values.reval.serviceConfig.auth.oidc.enabled }}
       oidc:

--- a/deploy/helm/helm-reval/values.yaml
+++ b/deploy/helm/helm-reval/values.yaml
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 # Default values for the reval-service chart.
-# Set serviceConfig.auth.enabled=true and serviceConfig.auth.jwkSetUrl before
-# installing; the server refuses to start otherwise.
+# Set serviceConfig.auth.jwt.enabled=true and serviceConfig.auth.jwt.jwkSetUrl
+# to enable local JWT authentication.
 reval:
   image:
     registry: ""
@@ -101,10 +101,11 @@ reval:
       zapConfiguration: "production"
 
     auth:
-      enabled: false
-      jwkSetUrl: ""
-      validateRequiredScopes: ""
-      renderRequiredScopes: ""
+      jwt:
+        enabled: false
+        jwkSetUrl: ""
+        validateRequiredScopes: ""
+        renderRequiredScopes: ""
       oidc:
         enabled: false
         introspectUrl: ""

--- a/src/control-plane-services/helm-reval/test/config.yaml
+++ b/src/control-plane-services/helm-reval/test/config.yaml
@@ -36,7 +36,8 @@ tracing:
 
 # Targets the mock JWKS started by `make mock-jwks` (token at /tmp/reval-test-token).
 auth:
-  enabled: true
-  jwk-set-url: "http://localhost:8888/jwks.json"
-  validate-required-scopes: "helmreval:validate"
-  render-required-scopes: "helmreval:render"
+  jwt:
+    enabled: true
+    jwk-set-url: "http://localhost:8888/jwks.json"
+    validate-required-scopes: "helmreval:validate"
+    render-required-scopes: "helmreval:render"


### PR DESCRIPTION
## TL;DR

Fix the ReVal Helm chart so its documented JWT values render beneath `auth.jwt`, matching the ReVal application configuration.

## Additional Details

The ReVal application and chart README use `auth.jwt.*`, but the chart defaults and ConfigMap template still placed the JWT fields directly under `auth.*`. As a result, setting the documented `reval.serviceConfig.auth.jwt.enabled=true` value did not enable the local JWT authorizer in the generated `config.yaml`.

This change moves the JWT chart values and rendered configuration under `auth.jwt`, updates the ReVal test-server fixture to the same structure, and adds a focused Helm render regression test for the JWT mapping.

## For the Reviewer

Please focus on the value-to-ConfigMap mapping in `deploy/helm/helm-reval` and the indentation assertions in the new render test.

## For QA

QA is not required beyond the automated and local chart checks.

Validated with:

- `helm lint deploy/helm/helm-reval`
- `CHART_DIR=deploy/helm/helm-reval deploy/helm/helm-reval/scripts/check-render-auth.sh`
- `go test ./pkg/reval/config/... ./pkg/authorizers/...`
- `git diff --check`

## Issues

Fixes #631

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
