### PR TITLE
fix(helm-reval): render nested JWT auth config

### DIFF
--- a/deploy/helm/helm-reval/templates/configmap.yaml
+++ b/deploy/helm/helm-reval/templates/configmap.yaml
@@ -53,11 +53,12 @@ data:
       deployment-environment-name: {{ .Values.reval.serviceConfig.telemetry.deploymentEnvironmentName | quote }}
 
     auth:
-      enabled: {{ .Values.reval.serviceConfig.auth.enabled }}
-    {{- if .Values.reval.serviceConfig.auth.enabled }}
-      jwk-set-url: {{ .Values.reval.serviceConfig.auth.jwkSetUrl | quote }}
-      validate-required-scopes: {{ .Values.reval.serviceConfig.auth.validateRequiredScopes | quote }}
-      render-required-scopes: {{ .Values.reval.serviceConfig.auth.renderRequiredScopes | quote }}
+      jwt:
+        enabled: {{ .Values.reval.serviceConfig.auth.jwt.enabled }}
+    {{- if .Values.reval.serviceConfig.auth.jwt.enabled }}
+        jwk-set-url: {{ .Values.reval.serviceConfig.auth.jwt.jwkSetUrl | quote }}
+        validate-required-scopes: {{ .Values.reval.serviceConfig.auth.jwt.validateRequiredScopes | quote }}
+        render-required-scopes: {{ .Values.reval.serviceConfig.auth.jwt.renderRequiredScopes | quote }}
     {{- end }}
     {{- if .Values.reval.serviceConfig.auth.oidc.enabled }}
       oidc:

--- a/deploy/helm/helm-reval/values.yaml
+++ b/deploy/helm/helm-reval/values.yaml
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 # Default values for the reval-service chart.
-# Set serviceConfig.auth.enabled=true and serviceConfig.auth.jwkSetUrl before
-# installing; the server refuses to start otherwise.
+# Set serviceConfig.auth.jwt.enabled=true and serviceConfig.auth.jwt.jwkSetUrl
+# to enable local JWT authentication.
 reval:
   image:
     registry: ""
@@ -101,10 +101,11 @@ reval:
       zapConfiguration: "production"
 
     auth:
-      enabled: false
-      jwkSetUrl: ""
-      validateRequiredScopes: ""
-      renderRequiredScopes: ""
+      jwt:
+        enabled: false
+        jwkSetUrl: ""
+        validateRequiredScopes: ""
+        renderRequiredScopes: ""
       oidc:
         enabled: false
         introspectUrl: ""

--- a/src/control-plane-services/helm-reval/test/config.yaml
+++ b/src/control-plane-services/helm-reval/test/config.yaml
@@ -36,7 +36,8 @@ tracing:
 
 # Targets the mock JWKS started by `make mock-jwks` (token at /tmp/reval-test-token).
 auth:
-  enabled: true
-  jwk-set-url: "http://localhost:8888/jwks.json"
-  validate-required-scopes: "helmreval:validate"
-  render-required-scopes: "helmreval:render"
+  jwt:
+    enabled: true
+    jwk-set-url: "http://localhost:8888/jwks.json"
+    validate-required-scopes: "helmreval:validate"
+    render-required-scopes: "helmreval:render"


### PR DESCRIPTION
## TL;DR

Fix the ReVal Helm chart so its documented JWT values render beneath `auth.jwt`, matching the ReVal application configuration.

## Additional Details

The ReVal application and chart README use `auth.jwt.*`, but the chart defaults and ConfigMap template still placed the JWT fields directly under `auth.*`. As a result, setting the documented `reval.serviceConfig.auth.jwt.enabled=true` value did not enable the local JWT authorizer in the generated `config.yaml`.

This change moves the JWT chart values and rendered configuration under `auth.jwt` and updates the ReVal test-server fixture to the same structure.

## For the Reviewer

Please focus on the value-to-ConfigMap mapping in `deploy/helm/helm-reval` and the matching test-server fixture.


## Issues

Fixes #631


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated Helm configuration to organize JWT authentication settings under a dedicated `auth.jwt` section.
  * Added clearer configuration options for JWT enablement, JWK URL, and required scopes.
  * Updated sample values and test configuration to reflect the new nested structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->