### PR TITLE
fix(llm-gateway): map auth INVALID_ARGUMENT to HTTP 400

### DIFF
--- a/src/invocation-plane-services/llm-api-gateway/api/auth_middleware.go
+++ b/src/invocation-plane-services/llm-api-gateway/api/auth_middleware.go
@@ -150,6 +150,8 @@ func nvcfAuthHTTPError(err error) error {
 	switch status.Code(err) {
 	case codes.OK:
 		return nil
+	case codes.InvalidArgument:
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	case codes.Unauthenticated:
 		return echo.NewHTTPError(http.StatusUnauthorized, err.Error())
 	case codes.PermissionDenied:

--- a/src/invocation-plane-services/llm-api-gateway/api/auth_middleware_test.go
+++ b/src/invocation-plane-services/llm-api-gateway/api/auth_middleware_test.go
@@ -25,10 +25,44 @@ import (
 	"testing"
 
 	echo "github.com/labstack/echo/v4"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/NVIDIA/nvcf/src/invocation-plane-services/llm-gateway/config"
 	"github.com/NVIDIA/nvcf/src/invocation-plane-services/llm-gateway/nvcf"
 )
+
+func TestNVCFAuthHTTPErrorMapsCodes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{"invalid argument -> 400", status.Error(codes.InvalidArgument, "bad routing key"), http.StatusBadRequest},
+		{"unauthenticated -> 401", status.Error(codes.Unauthenticated, "auth failed"), http.StatusUnauthorized},
+		{"permission denied -> 403", status.Error(codes.PermissionDenied, "nope"), http.StatusForbidden},
+		{"not found -> 404", status.Error(codes.NotFound, "not found"), http.StatusNotFound},
+		{"deadline -> 504", status.Error(codes.DeadlineExceeded, "slow"), http.StatusGatewayTimeout},
+		{"unavailable -> 503", status.Error(codes.Unavailable, "down"), http.StatusServiceUnavailable},
+		{"internal -> 502", status.Error(codes.Internal, "boom"), http.StatusBadGateway},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			he, ok := nvcfAuthHTTPError(tc.err).(*echo.HTTPError)
+			if !ok {
+				t.Fatalf("want *echo.HTTPError, got %T", nvcfAuthHTTPError(tc.err))
+			}
+			if he.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", he.Code, tc.wantStatus)
+			}
+		})
+	}
+}
 
 func TestNVCFAuthMiddlewareEnrichesRequestContext(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
A malformed LLM routing key (non-UUID `model` prefix) returned `502` instead of a `4xx`.

`nvcfAuthHTTPError` had no case for `codes.InvalidArgument`, so it fell through to the `default -> 502`. Add the `InvalidArgument -> 400` mapping.

Pairs with the nvcf-core change that makes a non-UUID routing key throw `INVALID_ARGUMENT` (instead of surfacing as `INTERNAL`); together, case 2 in the QA report returns `400` instead of `502`.

Related to NVBUG-6552177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid request errors are now correctly returned as HTTP 400 Bad Request responses.
  * Improved consistency when translating service errors into HTTP responses.

* **Tests**
  * Added coverage to verify error-to-HTTP status code mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->