### PR TITLE
feat(cassandra): add llm_config column to nvcf_api schema

### DIFF
--- a/migrations/cassandra/README.md
+++ b/migrations/cassandra/README.md
@@ -154,7 +154,7 @@ For a brand-new keyspace, the conventional sequence is:
 2. `02_init_roles.up.sql` - creates the application role and grants, with the login password supplied by `${SERVICE_ROLE_PASSWORD}`.
 3. `03_init_tables.up.sql` - the canonical schema (UDTs, tables, indexes) for the keyspace.
 
-Subsequent files (`04_*`, `05_*`, `06_*`) are incremental DDL deltas applied as the schema evolves.
+Subsequent files (`04_*` and later) are incremental DDL deltas applied as the schema evolves.
 
 The `03_init_tables.up.sql` follows a clean-slate model: it is updated in place when the canonical schema changes rather than accumulating `ALTER TABLE` history. Existing clusters apply only the deltas that postdate their last applied migration.
 

--- a/migrations/cassandra/README.md
+++ b/migrations/cassandra/README.md
@@ -154,7 +154,7 @@ For a brand-new keyspace, the conventional sequence is:
 2. `02_init_roles.up.sql` - creates the application role and grants, with the login password supplied by `${SERVICE_ROLE_PASSWORD}`.
 3. `03_init_tables.up.sql` - the canonical schema (UDTs, tables, indexes) for the keyspace.
 
-Subsequent files (`04_*` and later) are incremental DDL deltas applied as the schema evolves.
+Subsequent files (`04_*` and later) are incremental migrations applied as the schema evolves. Most are DDL; `ess_api/04_*` is a data seed.
 
 The `03_init_tables.up.sql` follows a clean-slate model: it is updated in place when the canonical schema changes rather than accumulating `ALTER TABLE` history. Existing clusters apply only the deltas that postdate their last applied migration.
 

--- a/migrations/cassandra/keyspaces/README.md
+++ b/migrations/cassandra/keyspaces/README.md
@@ -25,7 +25,7 @@ pinned version reference is bumped accordingly.
 | `ess_api`         | [ess_api/03_init_tables.up.sql](ess_api/03_init_tables.up.sql)                 | `v0.48.26`     | `200fd74d` |
 | `event_ledger`    | [event_ledger/03_init_tables.up.sql](event_ledger/03_init_tables.up.sql)       | `0.10.0`       | `adc2ff44` |
 | `nvcf_autoscaler` | [nvcf_autoscaler/03_init_tables.up.sql](nvcf_autoscaler/03_init_tables.up.sql) | `v1.15.0`      | `bff903c`  |
-| `nvcf_api`        | [nvcf_api/03_init_tables.up.sql](nvcf_api/03_init_tables.up.sql)               | `v1.5.1`       | `7a422ff1` |
+| `nvcf_api`        | [nvcf_api/03_init_tables.up.sql](nvcf_api/03_init_tables.up.sql)               | `v1.10.0`      | `fcaea0c1` |
 | `nvct_api`        | [nvct_api/03_init_tables.up.sql](nvct_api/03_init_tables.up.sql)               | `v1.5.2`       | `a0247478` |
 | `sis_api`         | [sis_api/03_init_tables.up.sql](sis_api/03_init_tables.up.sql)                 | `v1.531.2`     | `8a492a2e` |
 
@@ -43,7 +43,7 @@ pinned version reference is bumped accordingly.
 | `01_init_keyspace.up.sql` | Creates the keyspace with `NetworkTopologyStrategy` replication. Uses `${REPLICA_COUNT}`, which the entrypoint substitutes before migration.                                                                    |
 | `02_init_roles.up.sql`    | Creates the application role, grants privileges, and sets the service login password via `${SERVICE_ROLE_PASSWORD}`.                                                                                               |
 | `03_init_tables.up.sql`   | Complete canonical schema with all UDTs, tables, and indexes at the pinned upstream version.                                                                                                                       |
-| `04_*`, `05_*`, `06_*`    | Incremental deltas for rolling upgrades. These add tables/columns that are not in `03_init_tables.up.sql` at the version that was applied on existing clusters. `ess_api/04_*` is a data seed (deployment-specific values). `sis_api/04_*`-`06_*` and `nvcf_api/04_*`-`05_*` are DDL deltas. |
+| `04_*` and later          | Incremental deltas for rolling upgrades. These add tables/columns that are not in `03_init_tables.up.sql` at the version that was applied on existing clusters. `ess_api/04_*` is a data seed (deployment-specific values). The `sis_api` and `nvcf_api` deltas are DDL. |
 
 ---
 

--- a/migrations/cassandra/keyspaces/nvcf_api/03_init_tables.up.sql
+++ b/migrations/cassandra/keyspaces/nvcf_api/03_init_tables.up.sql
@@ -82,6 +82,7 @@ CREATE TABLE IF NOT EXISTS nvcf_api.functions_v3 (
     container_image               TEXT,
     utils_container_image         TEXT,
     model_specs                   MAP<TEXT, TEXT>,
+    llm_config                    TEXT,
     container_args                TEXT,
     container_environment         TEXT,
     helm_chart                    TEXT,

--- a/migrations/cassandra/keyspaces/nvcf_api/08_add_llm_config.up.sql
+++ b/migrations/cassandra/keyspaces/nvcf_api/08_add_llm_config.up.sql
@@ -1,0 +1,6 @@
+-- Add llm_config column to functions_v3, matching the pinned schema version in
+-- keyspaces/README.md.
+-- Function-level LLM configuration, stored as JSON. Distinct from the per-model
+-- configuration embedded in model_specs.
+
+ALTER TABLE nvcf_api.functions_v3 ADD IF NOT EXISTS llm_config TEXT;


### PR DESCRIPTION
## TL;DR

Adds the `llm_config` column to `functions_v3` in the self-hosted `nvcf_api` keyspace, so the self-hosted schema matches the managed NVCF API schema. Without it, a self-hosted NVCF API build that carries the LLM invocation config fails against its own database.

## Additional Details

The column is added in two places because fresh installs and existing clusters take different paths:

- `03_init_tables.up.sql` is the canonical schema that fresh installs apply.
- `08_add_llm_config.up.sql` is for existing clusters. It uses `ADD IF NOT EXISTS`, so it is also a no-op on fresh installs that already have the column.

The `keyspaces/README.md` pin for `nvcf_api` moves to the managed release that introduced the column. Both READMEs listed the deltas as `04_*`, `05_*`, `06_*`, which was already stale before this change and would be more so with `08` added, so they now say `04_*` and later.

## For the Reviewer

The pin row in `keyspaces/README.md` moves from `v1.5.1`/`7a422ff1` to `v1.10.0`/`fcaea0c1`, the release that introduced `llm_config`.

## For QA

No QA needed for this change on its own; it takes effect with the migrations image release.

Verified locally: `migrations/cassandra/tests/test-execute-sqls.sh` passes, and a column-level comparison against the managed schema file shows no remaining differences, with `llm_config` at the same ordinal position in both. The repo's migration test harness inventories migration files and validates the runner; it has no schema-content assertions, so there is no test to extend for a new column.

## Issues

Closes #622

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for storing language model configuration with functions.
  - Updated the database schema to include the new configuration field.

- **Documentation**
  - Clarified migration guidance, including the distinction between schema updates and seeded data.
  - Updated the documented schema source version for improved accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->