### PR TITLE
build: derive `STABLE_VERSION` from `NVCF_VERSION` or `mr-<sha>` only

### DIFF
--- a/BAZEL.md
+++ b/BAZEL.md
@@ -322,7 +322,7 @@ bazel run --stamp //src/clis/nvcf-cli:image_push
 
 The image push uses `tools/workspace_status.sh` to compute tags. With
 `--stamp` enabled, the index is published with `latest`, the version
-(from `git describe` or `mr-<sha>`), and the short commit.
+(`$NVCF_VERSION` on release builds, else `mr-<sha>`), and the short commit.
 
 ### Generate or refresh BUILD files
 
@@ -538,7 +538,7 @@ archive/package/publish/ngc-push stages still consume
 
 | Symbol | Source |
 |---|---|
-| `main.Version` | `git describe --tags`, falls back to `mr-<short-sha>`, override via `$NVCF_VERSION` |
+| `main.Version` | `$NVCF_VERSION` when set (release builds), else `mr-<short-sha>` |
 | `main.GitCommit` | `git rev-parse --short HEAD` (with `-dirty` suffix if working tree is dirty) |
 | `main.GitBranch` | `git rev-parse --abbrev-ref HEAD` |
 | `main.BuildDate` | UTC ISO timestamp |
@@ -590,13 +590,10 @@ it in the rules of the Bazel-driven publish job:
 
 Knock-on choices that follow from the cadence:
 
-- Version derivation (`tools/workspace_status.sh`). The CLI uses
-  `git describe --tags --exact-match HEAD || mr-<sha>` because tag-only
-  publish makes that the meaningful version. Per-merge services usually
-  want a SHA-style version (`<short-sha>` or `0.0.0-<short-sha>`) so
-  every main commit produces a distinct OCI tag without semver implication.
-  Either fork `workspace_status.sh` per service or add an env-driven
-  branch (`NVCF_VERSION_STYLE=sha` etc.).
+- Version derivation (`tools/workspace_status.sh`). The version is
+  `$NVCF_VERSION` when set (release builds pass the clean semver) and
+  `mr-<sha>` otherwise, so every non-release build produces a distinct
+  SHA-style OCI tag without semver implication.
 
 - OCI tag set on push. Tag-driven services typically push
   `:latest`, `:<semver>`, `:<short-sha>`. Per-merge services usually

--- a/tools/scripts/test/test-workspace-status.sh
+++ b/tools/scripts/test/test-workspace-status.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
+script="$repo_root/tools/workspace_status.sh"
+
+fail() { echo "test-workspace-status: FAIL: $*" >&2; exit 1; }
+stable_version() { awk '/^STABLE_VERSION /{print $2}'; }
+
+# NVCF_VERSION, when set, is used verbatim.
+got="$( (cd "$repo_root" && env NVCF_VERSION=1.2.3 bash "$script") | stable_version )"
+[ "$got" = "1.2.3" ] || fail "NVCF_VERSION=1.2.3 -> '$got' (want 1.2.3)"
+
+# Without NVCF_VERSION the version is mr-<short-sha>, and a path-prefixed tag on
+# HEAD must NOT leak in. Use a deterministic fixture that has exactly such a tag.
+fixture="$(mktemp -d)"
+trap 'rm -rf "$fixture"' EXIT
+git -C "$fixture" init -q
+git -C "$fixture" config user.name "Test User"
+git -C "$fixture" config user.email "test@example.com"
+git -C "$fixture" config commit.gpgsign false
+printf 'x\n' > "$fixture/f"
+git -C "$fixture" add -A
+git -C "$fixture" commit -qm init
+git -C "$fixture" tag "deploy/stacks/example/v9.9.9"   # path-prefixed tag on HEAD
+
+sha="$(git -C "$fixture" rev-parse --short HEAD)"
+got="$( (cd "$fixture" && env -u NVCF_VERSION bash "$script") | stable_version )"
+[ "$got" = "mr-${sha}" ] || fail "path-prefixed tag at HEAD -> '$got' (want mr-${sha})"
+
+echo "test-workspace-status: PASS"

--- a/tools/workspace_status.sh
+++ b/tools/workspace_status.sh
@@ -23,12 +23,9 @@ if [ "$COMMIT" != "unknown" ] && [ -n "$(git status --porcelain 2>/dev/null)" ];
     DIRTY="-dirty"
 fi
 
-# CI overrides for VERSION (from git tag or MR sha) and BUILD_USER.
-# When unset, fall back to the values the legacy nvcf-cli Makefile computed.
+# VERSION comes from NVCF_VERSION (set by release builds) or mr-<sha> otherwise.
 if [ -n "${NVCF_VERSION:-}" ]; then
     VERSION="${NVCF_VERSION}"
-elif TAG=$(git describe --tags --exact-match HEAD 2>/dev/null); then
-    VERSION="${TAG}"
 else
     VERSION="mr-${COMMIT}"
 fi


### PR DESCRIPTION
## Why
`tools/workspace_status.sh` derived `STABLE_VERSION` from `git describe --tags --exact-match HEAD` when `NVCF_VERSION` was unset. In this monorepo a single commit carries many path-prefixed tags for unrelated artifacts (`deploy/stacks/*`, `src/*/v*`), and `git describe` returns an arbitrary one. So a local `--stamp` build could stamp an unrelated tag such as `deploy/stacks/nvcf-compute-plane/v0.2.0-dev.231` as a service's version (it then flows into `/info` and image tags).

## What changed
Drop the `git describe --exact-match` branch. `STABLE_VERSION` now comes from `NVCF_VERSION` (set by the release build to the clean, `tag_prefix`-stripped semver) or falls back to `mr-<sha>` for dev/MR builds.

Release builds are unaffected: `NVCF_VERSION` is set on the release `bazel run --stamp` path, so they already take that branch. Only local/dev builds change, from an arbitrary path-prefixed tag to `mr-<sha>`.

## Testing
```
bash tools/workspace_status.sh              # tagged commit -> STABLE_VERSION mr-<sha>
NVCF_VERSION=1.2.3 bash tools/workspace_status.sh   # -> STABLE_VERSION 1.2.3
```

## Issues
Relates to #315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release version selection now honors the configured `NVCF_VERSION`.
  * Releases without an explicit version use a consistent commit-based identifier.
  * Simplified version detection for more reliable release identification.

* **Documentation**
  * Updated Bazel release guidance to explain explicit release versions and commit-based fallback versions.

* **Tests**
  * Added coverage to verify explicit version selection, fallback behavior, and prevention of unintended tag-based versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->