### PR TITLE
fix(release): register instance-cluster-management as a release subproject

### DIFF
--- a/tools/ci/github-release-subprojects.json
+++ b/tools/ci/github-release-subprojects.json
@@ -262,6 +262,11 @@
       "id": "api-keys",
       "path": "src/control-plane-services/api-keys",
       "service_name": "nvcf-api-keys"
+    },
+    {
+      "id": "instance-cluster-management",
+      "path": "src/control-plane-services/instance-cluster-management",
+      "service_name": "icms-service-oss"
     }
   ]
 }


### PR DESCRIPTION
## Why

main is red and has been since #595 merged.

ICMS was imported in #573 carrying a `bazel-java-ci.json` that declares `"component_kind": "java-service"`. #595 then added the assertion that every java-service must be a registered release subproject, and ICMS never was:

```
test_java_ci_components_match_registered_subprojects
AssertionError: 'src/control-plane-services/instance-cluster-management' not found in {...}
```

Neither PR was wrong on its own. The invariant #595 introduced is violated by code #573 had already landed.

## What changed

One entry in `tools/ci/github-release-subprojects.json`. `service_name` is `icms-service-oss`, matching the `DOCKER_IMAGE_NAME` its pre-Bazel CI published, and matching the release config registered on the nvcf-internal side in that repo's !110.

## Testing

`python3 tools/ci/test-github-release.py` -> 20 tests, OK. It fails on main without this change.

## Notes

This is the source half. The nvcf-internal half (destinations, promote config) merged separately; the two together are what let ICMS actually release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added the instance cluster management service to the release configuration.
  * Release automation can now recognize and publish releases for this service using its designated source path and release service name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->