### PR TITLE
fix(function-autoscaler): shard discovery queries

### DIFF
--- a/src/control-plane-services/function-autoscaler/crates/server/src/work/discovery.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/work/discovery.rs
@@ -295,7 +295,7 @@ async fn fetch_timeseries_db_active_functions(
     );
 
     let mut active_map: HashMap<(Uuid, Uuid), ActiveFunctionDetails> = HashMap::new();
-    let mut failures = Vec::new();
+    let mut failed_sources = 0usize;
 
     match recent_result {
         Ok(functions) => {
@@ -309,7 +309,7 @@ async fn fetch_timeseries_db_active_functions(
         }
         Err(error) => {
             tracing::error!(error = %error, "Recently invoked function discovery failed");
-            failures.push(format!("recent invocations: {error}"));
+            failed_sources += 1;
         }
     }
 
@@ -317,33 +317,40 @@ async fn fetch_timeseries_db_active_functions(
         Ok(functions) => {
             tracing::info!("Got {} running functions (includes BYOC)", functions.len());
             for function in functions {
-                active_map
-                    .entry((function.function_id, function.function_version_id))
-                    .or_insert(function);
+                merge_worker_details(&mut active_map, function);
             }
         }
         Err(error) => {
             tracing::error!(error = %error, "Running function discovery failed");
-            failures.push(format!("workers and active instances: {error}"));
+            failed_sources += 1;
         }
     }
 
-    if failures.len() == 2 {
+    if failed_sources == 2 {
         return Err(anyhow!(
-            "all TimeseriesDb function discovery sources failed: {}",
-            failures.join("; ")
+            "all TimeseriesDb function discovery sources failed"
         ));
     }
 
-    if !failures.is_empty() {
+    if failed_sources > 0 {
         tracing::warn!(
-            failed_sources = failures.len(),
+            failed_sources,
             functions_found = active_map.len(),
             "Function discovery completed with partial TimeseriesDb results"
         );
     }
 
     Ok(active_map.into_values().collect())
+}
+
+fn merge_worker_details(
+    active_map: &mut HashMap<(Uuid, Uuid), ActiveFunctionDetails>,
+    function: ActiveFunctionDetails,
+) {
+    active_map
+        .entry((function.function_id, function.function_version_id))
+        .and_modify(|existing| existing.num_workers = function.num_workers)
+        .or_insert(function);
 }
 
 /// Step 3: Find TimeseriesDb-active functions not yet in the DB
@@ -564,7 +571,7 @@ async fn get_recently_invoked_functions_with_semaphore(
 
     let mut recently_invoked_functions = Vec::new();
     let mut seen_functions: HashSet<(Uuid, Uuid, String)> = HashSet::new();
-    let mut failures = Vec::new();
+    let mut failed_queries = 0usize;
     let mut successful_queries = 0usize;
 
     for (source, shard, query_result) in query_results {
@@ -587,7 +594,7 @@ async fn get_recently_invoked_functions_with_semaphore(
                     error = %error,
                     "Recently invoked query failed"
                 );
-                failures.push(format!("{} shard {}: {}", source.name(), shard_name, error));
+                failed_queries += 1;
                 continue;
             }
         };
@@ -644,17 +651,16 @@ async fn get_recently_invoked_functions_with_semaphore(
     // Discovery can safely consume partial shards because it only inserts
     // positive observations. Per-function scaling remains fail-closed: both
     // invocation sources must succeed before an empty result can mean idle.
-    if successful_queries == 0 || (function_version_id_filter.is_some() && !failures.is_empty()) {
+    if successful_queries == 0 || (function_version_id_filter.is_some() && failed_queries > 0) {
         return Err(anyhow!(
-            "recently invoked TimeseriesDb query failure: {}",
-            failures.join("; ")
+            "recently invoked TimeseriesDb queries failed: {successful_queries} succeeded, {failed_queries} failed"
         ));
     }
 
-    if !failures.is_empty() {
+    if failed_queries > 0 {
         tracing::warn!(
             successful_queries,
-            failed_queries = failures.len(),
+            failed_queries,
             functions_found = recently_invoked_functions.len(),
             "Recently invoked discovery completed with partial shard results"
         );
@@ -1068,7 +1074,10 @@ mod tests {
         )
         .await;
 
-        assert!(result.is_err());
+        let error = result.expect_err("a partial per-function result must fail closed");
+        let message = format!("{error:#}");
+        assert!(message.contains("1 succeeded, 1 failed"));
+        assert!(!message.contains("boom"));
         invocation.assert_async().await;
         grpc.assert_async().await;
     }
@@ -1109,6 +1118,23 @@ mod tests {
         assert_eq!(functions[0].function_id, function_id);
         recent.assert_async().await;
         workers.assert_async().await;
+    }
+
+    #[test]
+    fn worker_count_is_preserved_when_discovery_sources_overlap() {
+        let function_id = Uuid::new_v4();
+        let function_version_id = Uuid::new_v4();
+        let recent = ActiveFunctionDetails::new(function_id, function_version_id, "recent".into());
+        let mut worker =
+            ActiveFunctionDetails::new(function_id, function_version_id, "worker".into());
+        worker.num_workers = Some(3);
+        let mut active_map = HashMap::from([((function_id, function_version_id), recent)]);
+
+        merge_worker_details(&mut active_map, worker);
+
+        let merged = active_map.get(&(function_id, function_version_id)).unwrap();
+        assert_eq!(merged.nca_id.as_deref(), Some("recent"));
+        assert_eq!(merged.num_workers, Some(3));
     }
 
     #[test]

--- a/src/control-plane-services/function-autoscaler/crates/server/src/work/discovery.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/work/discovery.rs
@@ -21,11 +21,13 @@ use crate::cassandra::{
 use crate::metrics;
 use crate::models::ActiveFunctionDetails;
 use crate::timeseries_db::timeseries_db_client::TimeseriesDbClient;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use chrono::{Duration, Utc};
+use futures::{stream, StreamExt};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration as StdDuration;
+use tokio::sync::Semaphore;
 use tokio::time::Instant;
 use tracing;
 use uuid::Uuid;
@@ -33,9 +35,76 @@ use uuid::Uuid;
 pub const LOCK_NAME_FUNCTION_DISCOVERY: &str = "function_discovery";
 
 /// Lookback window (minutes) for "recently invoked" in discovery. Functions with no invocations
-/// in this window are moved from recently_invoked to running_functions. Aligns with
-/// recently_invoked_functions table TTL (300s): rows expire after 5 min if not re-inserted.
+/// in this window are moved from recently_invoked to running_functions.
 pub const DISCOVERY_RECENTLY_INVOKED_LOOKBACK_MINUTES: i64 = 5;
+const DISCOVERY_QUERY_CONCURRENCY: usize = 4;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DiscoveryShard {
+    Hex0To3,
+    Hex4To7,
+    Hex8ToB,
+    HexCToF,
+}
+
+impl DiscoveryShard {
+    const ALL: [Self; 4] = [Self::Hex0To3, Self::Hex4To7, Self::Hex8ToB, Self::HexCToF];
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::Hex0To3 => "0-3",
+            Self::Hex4To7 => "4-7",
+            Self::Hex8ToB => "8-b",
+            Self::HexCToF => "c-f",
+        }
+    }
+
+    fn function_id_regex(self) -> &'static str {
+        match self {
+            Self::Hex0To3 => "[0-3].*",
+            Self::Hex4To7 => "[4-7].*",
+            Self::Hex8ToB => "[89ab].*",
+            Self::HexCToF => "[c-f].*",
+        }
+    }
+
+    fn order(self) -> u8 {
+        match self {
+            Self::Hex0To3 => 0,
+            Self::Hex4To7 => 1,
+            Self::Hex8ToB => 2,
+            Self::HexCToF => 3,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum InvocationMetricSource {
+    InvocationService,
+    GrpcProxy,
+}
+
+impl InvocationMetricSource {
+    fn name(self) -> &'static str {
+        match self {
+            Self::InvocationService => "invocation_service",
+            Self::GrpcProxy => "grpc_proxy",
+        }
+    }
+
+    fn order(self) -> u8 {
+        match self {
+            Self::InvocationService => 0,
+            Self::GrpcProxy => 1,
+        }
+    }
+}
+
+struct RecentInvocationQuery {
+    source: InvocationMetricSource,
+    shard: Option<DiscoveryShard>,
+    query: String,
+}
 
 const QUERY_INVOCATION_SERVICE: &str = r#"(
     sum by (function_id, function_version_id, nca_id) (function_request{env_filter} > 0)
@@ -92,22 +161,64 @@ fn get_timeseries_db_query(
     env: &str,
     ignore_env: bool,
     function_version_filter: Option<Uuid>,
+    shard: Option<DiscoveryShard>,
 ) -> String {
-    match (ignore_env, function_version_filter) {
-        (true, None) => template.replace("{env_filter}", ""),
-        (false, None) => {
-            let env_filter = format!(r#"{{aws_env="{}"}}"#, env);
-            template.replace("{env_filter}", &env_filter)
-        }
-        (true, Some(fv)) => {
-            let env_filter = format!(r#"{{function_version_id="{}"}}"#, fv);
-            template.replace("{env_filter}", &env_filter)
-        }
-        (false, Some(fv)) => {
-            let env_filter = format!(r#"{{function_version_id="{}", aws_env="{}"}}"#, fv, env);
-            template.replace("{env_filter}", &env_filter)
-        }
+    let mut matchers = Vec::new();
+    if !ignore_env {
+        matchers.push(format!(r#"aws_env="{}""#, env));
     }
+    if let Some(function_version_id) = function_version_filter {
+        matchers.push(format!(r#"function_version_id="{}""#, function_version_id));
+    }
+    if let Some(shard) = shard {
+        matchers.push(format!(r#"function_id=~"{}""#, shard.function_id_regex()));
+    }
+
+    let selector = if matchers.is_empty() {
+        String::new()
+    } else {
+        format!("{{{}}}", matchers.join(", "))
+    };
+    template.replace("{env_filter}", &selector)
+}
+
+fn recent_invocation_queries(
+    env: &str,
+    ignore_env: bool,
+    function_version_filter: Option<Uuid>,
+) -> Vec<RecentInvocationQuery> {
+    let shards: Vec<Option<DiscoveryShard>> = if function_version_filter.is_some() {
+        vec![None]
+    } else {
+        DiscoveryShard::ALL.into_iter().map(Some).collect()
+    };
+
+    let mut queries = Vec::with_capacity(shards.len() * 2);
+    for shard in shards {
+        queries.push(RecentInvocationQuery {
+            source: InvocationMetricSource::InvocationService,
+            shard,
+            query: get_timeseries_db_query(
+                QUERY_INVOCATION_SERVICE,
+                env,
+                ignore_env,
+                function_version_filter,
+                shard,
+            ),
+        });
+        queries.push(RecentInvocationQuery {
+            source: InvocationMetricSource::GrpcProxy,
+            shard,
+            query: get_timeseries_db_query(
+                QUERY_GRPC_PROXY,
+                env,
+                ignore_env,
+                function_version_filter,
+                shard,
+            ),
+        });
+    }
+    queries
 }
 
 /// Current state of functions across different sources.
@@ -140,41 +251,9 @@ async fn fetch_function_state(
         )
         .await?;
 
-    tracing::info!("Getting recently invoked functions...");
-    let timeseries_db_recently_invoked = get_recently_invoked_functions(
-        timeseries_db_client,
-        None,
-        DISCOVERY_RECENTLY_INVOKED_LOOKBACK_MINUTES,
-        env,
-        timeseries_db_ignore_env,
-    )
-    .await?;
-    tracing::debug!(
-        "Got {} recently invoked functions",
-        timeseries_db_recently_invoked.len()
-    );
-
-    tracing::info!("Getting running functions (workers + BYOC active instances)...");
-    let timeseries_db_running_functions =
-        get_functions_with_workers(timeseries_db_client, env, timeseries_db_ignore_env).await?;
-    tracing::info!(
-        "Got {} running functions (includes BYOC)",
-        timeseries_db_running_functions.len()
-    );
-
-    // Union both TimeseriesDb sources — everything active belongs in the single table
-    let mut timeseries_db_active_map: HashMap<(Uuid, Uuid), ActiveFunctionDetails> =
-        timeseries_db_recently_invoked
-            .into_iter()
-            .map(|f| ((f.function_id, f.function_version_id), f))
-            .collect();
-    for f in timeseries_db_running_functions {
-        timeseries_db_active_map
-            .entry((f.function_id, f.function_version_id))
-            .or_insert(f);
-    }
-    let timeseries_db_active_functions: Vec<ActiveFunctionDetails> =
-        timeseries_db_active_map.into_values().collect();
+    let timeseries_db_active_functions =
+        fetch_timeseries_db_active_functions(timeseries_db_client, env, timeseries_db_ignore_env)
+            .await?;
 
     let state = FunctionState {
         db_recently_invoked: db_recently_invoked
@@ -184,6 +263,87 @@ async fn fetch_function_state(
     };
 
     Ok((state, timeseries_db_active_functions))
+}
+
+/// Fetch active functions from independent invocation and worker metric sources.
+/// A failed source is unknown, not empty: keep every successful result, and fail
+/// only when neither source produced a usable response.
+async fn fetch_timeseries_db_active_functions(
+    timeseries_db_client: &TimeseriesDbClient,
+    env: &str,
+    timeseries_db_ignore_env: bool,
+) -> Result<Vec<ActiveFunctionDetails>> {
+    tracing::info!("Getting recently invoked and running functions...");
+    let query_semaphore = Arc::new(Semaphore::new(DISCOVERY_QUERY_CONCURRENCY));
+    let workers_semaphore = Arc::clone(&query_semaphore);
+    let (recent_result, workers_result) = tokio::join!(
+        get_recently_invoked_functions_with_semaphore(
+            timeseries_db_client,
+            None,
+            DISCOVERY_RECENTLY_INVOKED_LOOKBACK_MINUTES,
+            env,
+            timeseries_db_ignore_env,
+            Some(query_semaphore),
+        ),
+        async {
+            let _permit = workers_semaphore
+                .acquire_owned()
+                .await
+                .expect("discovery query semaphore must remain open");
+            get_functions_with_workers(timeseries_db_client, env, timeseries_db_ignore_env).await
+        },
+    );
+
+    let mut active_map: HashMap<(Uuid, Uuid), ActiveFunctionDetails> = HashMap::new();
+    let mut failures = Vec::new();
+
+    match recent_result {
+        Ok(functions) => {
+            tracing::debug!("Got {} recently invoked functions", functions.len());
+            for function in functions {
+                active_map.insert(
+                    (function.function_id, function.function_version_id),
+                    function,
+                );
+            }
+        }
+        Err(error) => {
+            tracing::error!(error = %error, "Recently invoked function discovery failed");
+            failures.push(format!("recent invocations: {error}"));
+        }
+    }
+
+    match workers_result {
+        Ok(functions) => {
+            tracing::info!("Got {} running functions (includes BYOC)", functions.len());
+            for function in functions {
+                active_map
+                    .entry((function.function_id, function.function_version_id))
+                    .or_insert(function);
+            }
+        }
+        Err(error) => {
+            tracing::error!(error = %error, "Running function discovery failed");
+            failures.push(format!("workers and active instances: {error}"));
+        }
+    }
+
+    if failures.len() == 2 {
+        return Err(anyhow!(
+            "all TimeseriesDb function discovery sources failed: {}",
+            failures.join("; ")
+        ));
+    }
+
+    if !failures.is_empty() {
+        tracing::warn!(
+            failed_sources = failures.len(),
+            functions_found = active_map.len(),
+            "Function discovery completed with partial TimeseriesDb results"
+        );
+    }
+
+    Ok(active_map.into_values().collect())
 }
 
 /// Step 3: Find TimeseriesDb-active functions not yet in the DB
@@ -334,64 +494,104 @@ pub async fn get_recently_invoked_functions(
     env: &str,
     timeseries_db_ignore_env: bool,
 ) -> Result<Vec<ActiveFunctionDetails>> {
+    get_recently_invoked_functions_with_semaphore(
+        timeseries_db_client,
+        function_version_id_filter,
+        lookback_period_minutes,
+        env,
+        timeseries_db_ignore_env,
+        None,
+    )
+    .await
+}
+
+async fn get_recently_invoked_functions_with_semaphore(
+    timeseries_db_client: &TimeseriesDbClient,
+    function_version_id_filter: Option<Uuid>,
+    lookback_period_minutes: i64,
+    env: &str,
+    timeseries_db_ignore_env: bool,
+    query_semaphore: Option<Arc<Semaphore>>,
+) -> Result<Vec<ActiveFunctionDetails>> {
     let end_time = Utc::now();
     let start_time = end_time - Duration::minutes(lookback_period_minutes);
     let step = StdDuration::from_secs(60); // 1 minute step
 
-    tracing::info!("Executing PromQL queries for recently invoked functions");
-
-    let invocation_query = get_timeseries_db_query(
-        QUERY_INVOCATION_SERVICE,
-        env,
-        timeseries_db_ignore_env,
-        function_version_id_filter,
-    );
-    let grpc_query = get_timeseries_db_query(
-        QUERY_GRPC_PROXY,
-        env,
-        timeseries_db_ignore_env,
-        function_version_id_filter,
-    );
-
+    let queries =
+        recent_invocation_queries(env, timeseries_db_ignore_env, function_version_id_filter);
+    let query_count = queries.len();
     tracing::info!(
-        "Will execute invocation service query: {}",
-        invocation_query
+        query_count,
+        sharded = function_version_id_filter.is_none(),
+        "Executing PromQL queries for recently invoked functions"
     );
-    tracing::info!("Will execute gRPC proxy query: {}", grpc_query);
 
-    let response_invocation_service = match timeseries_db_client
-        .query_range(&invocation_query, start_time, end_time, step)
-        .await
-    {
-        Ok(response) => {
-            tracing::info!("Successfully executed invocation service query");
-            response
+    // Discovery runs eight queries (two sources across four shards) through one
+    // shared concurrency bound. Per-function scaling remains two unsharded
+    // queries. Every query is polled even when another source or shard fails.
+    let mut query_results = stream::iter(queries.into_iter().map(|query_spec| {
+        let query_semaphore = query_semaphore.clone();
+        async move {
+            let _permit = match query_semaphore {
+                Some(semaphore) => Some(
+                    semaphore
+                        .acquire_owned()
+                        .await
+                        .expect("discovery query semaphore must remain open"),
+                ),
+                None => None,
+            };
+            let source = query_spec.source;
+            let shard = query_spec.shard;
+            let result = timeseries_db_client
+                .query_range(&query_spec.query, start_time, end_time, step)
+                .await;
+            (source, shard, result)
         }
-        Err(e) => {
-            tracing::error!("Failed to execute invocation service query: {}", e);
-            return Err(e);
-        }
-    };
+    }))
+    .buffer_unordered(DISCOVERY_QUERY_CONCURRENCY.min(query_count))
+    .collect::<Vec<_>>()
+    .await;
 
-    let response_grpc_proxy = match timeseries_db_client
-        .query_range(&grpc_query, start_time, end_time, step)
-        .await
-    {
-        Ok(response) => {
-            tracing::info!("Successfully executed gRPC proxy query");
-            response
-        }
-        Err(e) => {
-            tracing::error!("Failed to execute gRPC proxy query: {}", e);
-            return Err(e);
-        }
-    };
+    // Preserve the original source precedence even though requests complete
+    // out of order. This keeps deduplication independent of query latency.
+    query_results.sort_by_key(|(source, shard, _)| {
+        (
+            source.order(),
+            shard.map(DiscoveryShard::order).unwrap_or(0),
+        )
+    });
 
     let mut recently_invoked_functions = Vec::new();
     let mut seen_functions: HashSet<(Uuid, Uuid, String)> = HashSet::new();
+    let mut failures = Vec::new();
+    let mut successful_queries = 0usize;
 
-    // Process both responses to extract function details
-    for response in [&response_invocation_service, &response_grpc_proxy] {
+    for (source, shard, query_result) in query_results {
+        let shard_name = shard.map(DiscoveryShard::name).unwrap_or("none");
+        let response = match query_result {
+            Ok(response) => {
+                successful_queries += 1;
+                tracing::info!(
+                    source = source.name(),
+                    shard = shard_name,
+                    series = response.data.result.len(),
+                    "Recently invoked query succeeded"
+                );
+                response
+            }
+            Err(error) => {
+                tracing::error!(
+                    source = source.name(),
+                    shard = shard_name,
+                    error = %error,
+                    "Recently invoked query failed"
+                );
+                failures.push(format!("{} shard {}: {}", source.name(), shard_name, error));
+                continue;
+            }
+        };
+
         for result in &response.data.result {
             if let Some(function_version_id_str) = &result.metric.function_version_id {
                 // Parse UUIDs from strings (nca_id is kept as string, not UUID)
@@ -439,6 +639,25 @@ pub async fn get_recently_invoked_functions(
                 tracing::info!("Missing function_version_id in result: {:?}", result.metric);
             }
         }
+    }
+
+    // Discovery can safely consume partial shards because it only inserts
+    // positive observations. Per-function scaling remains fail-closed: both
+    // invocation sources must succeed before an empty result can mean idle.
+    if successful_queries == 0 || (function_version_id_filter.is_some() && !failures.is_empty()) {
+        return Err(anyhow!(
+            "recently invoked TimeseriesDb query failure: {}",
+            failures.join("; ")
+        ));
+    }
+
+    if !failures.is_empty() {
+        tracing::warn!(
+            successful_queries,
+            failed_queries = failures.len(),
+            functions_found = recently_invoked_functions.len(),
+            "Recently invoked discovery completed with partial shard results"
+        );
     }
 
     tracing::info!(
@@ -699,6 +918,198 @@ mod tests {
     use crate::timeseries_db::timeseries_db_client::{
         Metric, ResponseData, TimeseriesDbResponse, TimeseriesDbResult,
     };
+    use crate::timeseries_db::TimeseriesDbSettings;
+
+    fn fast_backoff() -> backon::ExponentialBuilder {
+        backon::ExponentialBuilder::default()
+            .with_max_times(1)
+            .with_min_delay(StdDuration::from_millis(1))
+            .with_max_delay(StdDuration::from_millis(2))
+    }
+
+    fn ts_client(url: String) -> TimeseriesDbClient {
+        let config = TimeseriesDbSettings {
+            timeseries_db_url: url,
+            disable_auth: true,
+            env: "stg".to_string(),
+            ignore_env: true,
+            backoff: Some(fast_backoff()),
+            ..Default::default()
+        };
+        TimeseriesDbClient::new(&config, None).expect("build test client")
+    }
+
+    fn vm_series(metric_name: &str, function_id: Uuid, function_version_id: Uuid) -> String {
+        format!(
+            r#"{{"status":"success","data":{{"resultType":"matrix","result":[{{"metric":{{"__name__":"{metric_name}","function_id":"{function_id}","function_version_id":"{function_version_id}","nca_id":"nca"}},"values":[[1700000000,"1"]]}}]}}}}"#
+        )
+    }
+
+    #[test]
+    fn discovery_queries_cover_four_fixed_shards_for_both_sources() {
+        let queries = recent_invocation_queries("prd", false, None);
+        assert_eq!(queries.len(), 8);
+
+        for shard in DiscoveryShard::ALL {
+            let matcher = format!(r#"function_id=~"{}""#, shard.function_id_regex());
+            let shard_queries: Vec<_> = queries
+                .iter()
+                .filter(|query| query.shard == Some(shard))
+                .collect();
+            assert_eq!(shard_queries.len(), 2);
+            for query in shard_queries {
+                assert_eq!(query.query.matches(&matcher).count(), 4);
+                assert_eq!(query.query.matches(r#"aws_env="prd""#).count(), 4);
+            }
+        }
+    }
+
+    #[test]
+    fn per_function_recent_invocation_queries_are_not_sharded() {
+        let function_version_id = Uuid::new_v4();
+        let queries = recent_invocation_queries("stg", true, Some(function_version_id));
+
+        assert_eq!(queries.len(), 2);
+        for query in queries {
+            assert!(query.shard.is_none());
+            assert!(!query.query.contains("function_id=~"));
+            assert_eq!(
+                query
+                    .query
+                    .matches(&format!(r#"function_version_id="{function_version_id}""#))
+                    .count(),
+                4
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn invocation_failure_does_not_suppress_grpc_discovery_shards() {
+        let function_id = Uuid::new_v4();
+        let function_version_id = Uuid::new_v4();
+        let mut server = mockito::Server::new_async().await;
+        let invocation = server
+            .mock("GET", "/api/v1/query_range")
+            .match_query(mockito::Matcher::Regex(
+                r"function_request(?:%7B|\{)".to_string(),
+            ))
+            .with_status(500)
+            .with_body("boom")
+            .expect_at_least(4)
+            .create_async()
+            .await;
+        let grpc = server
+            .mock("GET", "/api/v1/query_range")
+            .match_query(mockito::Matcher::Regex(
+                "function_request_total".to_string(),
+            ))
+            .with_status(200)
+            .with_body(vm_series(
+                "function_request_total",
+                function_id,
+                function_version_id,
+            ))
+            .expect(4)
+            .create_async()
+            .await;
+
+        let functions = get_recently_invoked_functions(
+            &ts_client(server.url()),
+            None,
+            DISCOVERY_RECENTLY_INVOKED_LOOKBACK_MINUTES,
+            "stg",
+            true,
+        )
+        .await
+        .expect("gRPC shard results should survive invocation failures");
+
+        assert_eq!(functions.len(), 1);
+        assert_eq!(functions[0].function_id, function_id);
+        invocation.assert_async().await;
+        grpc.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn per_function_invocation_failure_still_queries_grpc_but_fails_closed() {
+        let function_id = Uuid::new_v4();
+        let function_version_id = Uuid::new_v4();
+        let mut server = mockito::Server::new_async().await;
+        let invocation = server
+            .mock("GET", "/api/v1/query_range")
+            .match_query(mockito::Matcher::Regex(
+                r"function_request(?:%7B|\{)".to_string(),
+            ))
+            .with_status(500)
+            .with_body("boom")
+            .expect_at_least(1)
+            .create_async()
+            .await;
+        let grpc = server
+            .mock("GET", "/api/v1/query_range")
+            .match_query(mockito::Matcher::Regex(
+                "function_request_total".to_string(),
+            ))
+            .with_status(200)
+            .with_body(vm_series(
+                "function_request_total",
+                function_id,
+                function_version_id,
+            ))
+            .expect(1)
+            .create_async()
+            .await;
+
+        let result = get_recently_invoked_functions(
+            &ts_client(server.url()),
+            Some(function_version_id),
+            DISCOVERY_RECENTLY_INVOKED_LOOKBACK_MINUTES,
+            "stg",
+            true,
+        )
+        .await;
+
+        assert!(result.is_err());
+        invocation.assert_async().await;
+        grpc.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn workers_query_survives_total_invocation_discovery_failure() {
+        let function_id = Uuid::new_v4();
+        let function_version_id = Uuid::new_v4();
+        let mut server = mockito::Server::new_async().await;
+        let recent = server
+            .mock("GET", "/api/v1/query_range")
+            .match_query(mockito::Matcher::Regex("function_request".to_string()))
+            .with_status(500)
+            .with_body("boom")
+            .expect_at_least(8)
+            .create_async()
+            .await;
+        let workers = server
+            .mock("GET", "/api/v1/query_range")
+            .match_query(mockito::Matcher::Regex(
+                "worker_thread_count_total".to_string(),
+            ))
+            .with_status(200)
+            .with_body(vm_series(
+                "nvcf_worker_service_worker_thread_count_total",
+                function_id,
+                function_version_id,
+            ))
+            .expect(1)
+            .create_async()
+            .await;
+
+        let functions = fetch_timeseries_db_active_functions(&ts_client(server.url()), "stg", true)
+            .await
+            .expect("worker results should survive invocation discovery failure");
+
+        assert_eq!(functions.len(), 1);
+        assert_eq!(functions[0].function_id, function_id);
+        recent.assert_async().await;
+        workers.assert_async().await;
+    }
 
     #[test]
     fn test_get_functions_with_workers_response_parsing() {

--- a/src/control-plane-services/function-autoscaler/crates/server/src/work/mod.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/work/mod.rs
@@ -29,7 +29,7 @@ use crate::{
     cassandra::cassandra_service::CassandraServiceManager,
     timeseries_db::timeseries_db_client::TimeseriesDbClient,
 };
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use chrono::{Duration, Utc};
 use moka::sync::Cache;
 
@@ -518,6 +518,7 @@ async fn make_scaling_requests_for_table(
 ) -> Result<()> {
     let bucket_ranges = bucket_manager.get_all_bucket_ranges();
     let mut task_failures = 0usize;
+    let mut first_task_error = None;
 
     if bucket_ranges.is_empty() {
         tracing::warn!("No buckets assigned to this node, skipping scaling logic");
@@ -732,7 +733,11 @@ async fn make_scaling_requests_for_table(
             // Wait for all scaling requests in this bucket to complete. JoinSet
             // returns two result layers: the task's Result and Tokio's JoinError.
             // Count both while continuing to drain independent work.
-            task_failures += drain_scaling_tasks(&mut join_set, *bucket_index).await;
+            let (failure_count, error) = drain_scaling_tasks(&mut join_set).await;
+            task_failures += failure_count;
+            if first_task_error.is_none() {
+                first_task_error = error.map(|error| (*bucket_index, error));
+            }
 
             tracing::debug!("Completed processing bucket {}", bucket_index);
         } else {
@@ -743,40 +748,37 @@ async fn make_scaling_requests_for_table(
         }
     }
 
-    if task_failures > 0 {
-        Err(anyhow!(
-            "{} per-function scaling task(s) failed",
-            task_failures
-        ))
+    if let Some((bucket_index, error)) = first_task_error {
+        Err(error.context(format!(
+            "{task_failures} per-function scaling task(s) failed for table {table:?}; first failure was in bucket {bucket_index}"
+        )))
     } else {
         Ok(())
     }
 }
 
-async fn drain_scaling_tasks(join_set: &mut JoinSet<Result<()>>, bucket_index: usize) -> usize {
+async fn drain_scaling_tasks(join_set: &mut JoinSet<Result<()>>) -> (usize, Option<anyhow::Error>) {
     let mut failures = 0usize;
-    while let Some(result) = join_set.join_next().await {
-        match result {
+    let mut first_task_error = None;
+    let mut first_join_error = None;
+    while let Some(join_result) = join_set.join_next().await {
+        match join_result {
             Ok(Ok(())) => {}
             Ok(Err(error)) => {
                 failures += 1;
-                tracing::error!(
-                    bucket_index,
-                    error = %error,
-                    "Scaling task failed"
-                );
+                if first_task_error.is_none() {
+                    first_task_error = Some(error);
+                }
             }
             Err(join_error) => {
                 failures += 1;
-                tracing::error!(
-                    bucket_index,
-                    error = %join_error,
-                    "Scaling task panicked or was cancelled"
-                );
+                if first_join_error.is_none() {
+                    first_join_error = Some(join_error.into());
+                }
             }
         }
     }
-    failures
+    (failures, first_task_error.or(first_join_error))
 }
 
 // Function that determines if we should skip a scaling request
@@ -857,17 +859,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn drain_scaling_tasks_counts_inner_and_join_errors() {
+    async fn drain_scaling_tasks_preserves_inner_and_counts_join_errors() {
         let mut join_set: JoinSet<Result<()>> = JoinSet::new();
         join_set.spawn(async { Ok(()) });
-        join_set.spawn(async { Err(anyhow!("sentinel task error")) });
+        join_set.spawn(async { Err(anyhow::anyhow!("sentinel task error")) });
         join_set.spawn(async {
             panic!("sentinel task panic");
             #[allow(unreachable_code)]
             Ok(())
         });
 
-        assert_eq!(drain_scaling_tasks(&mut join_set, 7).await, 2);
+        let (failures, error) = drain_scaling_tasks(&mut join_set).await;
+        assert_eq!(failures, 2);
+        assert!(format!("{:#}", error.expect("first task error")).contains("sentinel task error"));
     }
 
     /// Worker series present -> use worker metrics, no control-plane fallback.

--- a/src/control-plane-services/function-autoscaler/crates/server/src/work/mod.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/work/mod.rs
@@ -29,7 +29,7 @@ use crate::{
     cassandra::cassandra_service::CassandraServiceManager,
     timeseries_db::timeseries_db_client::TimeseriesDbClient,
 };
-use anyhow::Result;
+use anyhow::{anyhow, Context, Result};
 use chrono::{Duration, Utc};
 use moka::sync::Cache;
 
@@ -517,6 +517,7 @@ async fn make_scaling_requests_for_table(
     function_state_cache: Arc<FunctionStateCache>,
 ) -> Result<()> {
     let bucket_ranges = bucket_manager.get_all_bucket_ranges();
+    let mut task_failures = 0usize;
 
     if bucket_ranges.is_empty() {
         tracing::warn!("No buckets assigned to this node, skipping scaling logic");
@@ -601,7 +602,13 @@ async fn make_scaling_requests_for_table(
                         ignore_env,
                         &scaling_settings,
                     )
-                    .await?;
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "gathering scaling inputs for {}:{}",
+                            function.function_id, function.function_version_id
+                        )
+                    })?;
                     let current_instances = inputs.current_instances;
 
                     tracing::info!(
@@ -722,12 +729,10 @@ async fn make_scaling_requests_for_table(
                 });
             }
 
-            // Wait for all scaling requests in this bucket to complete
-            while let Some(result) = join_set.join_next().await {
-                if let Err(e) = result {
-                    tracing::error!("Task failed in bucket {}: {}", bucket_index, e);
-                }
-            }
+            // Wait for all scaling requests in this bucket to complete. JoinSet
+            // returns two result layers: the task's Result and Tokio's JoinError.
+            // Count both while continuing to drain independent work.
+            task_failures += drain_scaling_tasks(&mut join_set, *bucket_index).await;
 
             tracing::debug!("Completed processing bucket {}", bucket_index);
         } else {
@@ -738,7 +743,40 @@ async fn make_scaling_requests_for_table(
         }
     }
 
-    Ok(())
+    if task_failures > 0 {
+        Err(anyhow!(
+            "{} per-function scaling task(s) failed",
+            task_failures
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+async fn drain_scaling_tasks(join_set: &mut JoinSet<Result<()>>, bucket_index: usize) -> usize {
+    let mut failures = 0usize;
+    while let Some(result) = join_set.join_next().await {
+        match result {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                failures += 1;
+                tracing::error!(
+                    bucket_index,
+                    error = %error,
+                    "Scaling task failed"
+                );
+            }
+            Err(join_error) => {
+                failures += 1;
+                tracing::error!(
+                    bucket_index,
+                    error = %join_error,
+                    "Scaling task panicked or was cancelled"
+                );
+            }
+        }
+    }
+    failures
 }
 
 // Function that determines if we should skip a scaling request
@@ -816,6 +854,20 @@ mod tests {
     /// A VictoriaMetrics matrix response with no series (empty result).
     fn vm_empty() -> String {
         r#"{"status":"success","data":{"resultType":"matrix","result":[]}}"#.to_string()
+    }
+
+    #[tokio::test]
+    async fn drain_scaling_tasks_counts_inner_and_join_errors() {
+        let mut join_set: JoinSet<Result<()>> = JoinSet::new();
+        join_set.spawn(async { Ok(()) });
+        join_set.spawn(async { Err(anyhow!("sentinel task error")) });
+        join_set.spawn(async {
+            panic!("sentinel task panic");
+            #[allow(unreachable_code)]
+            Ok(())
+        });
+
+        assert_eq!(drain_scaling_tasks(&mut join_set, 7).await, 2);
     }
 
     /// Worker series present -> use worker metrics, no control-plane fallback.


### PR DESCRIPTION
## TL;DR

Shard unfiltered function-discovery invocation queries by UUID prefix, continue using independent TimeseriesDb results when one query fails, and correctly surface per-function errors returned through the scaling JoinSet.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

- Splits unfiltered discovery queries into four fixed, non-overlapping UUID-prefix shards: [0-3].*, [4-7].*, [89ab].*, and [c-f].*.
- Applies sharding to both invocation-service and gRPC-proxy discovery queries.
- Limits discovery TimeseriesDb concurrency to four queries across invocation and worker sources.
- Keeps per-function scaling queries unsharded.
- Executes all invocation-service and gRPC-proxy queries even when another source or shard fails.
- Runs worker/BYOC discovery independently of invocation discovery.
- Retains and deduplicates successful partial discovery results. The cycle fails only when neither invocation nor worker discovery produces a usable response.
- Keeps per-function recent-invocation checks fail-closed if either invocation source fails, avoiding an unsafe scale-to-zero decision.
- Handles both layers returned by JoinSet<Result<()>>, continues processing independent functions and buckets, and returns an aggregate error after all tasks finish.

This PR intentionally does not change the PromQL lookback window, range-query evaluation mode, retry policy, or TimeseriesDb metrics.

## For the Reviewer

Please focus on:

- Shard construction and selector injection in work/discovery.rs.
- Partial-result behavior across invocation, gRPC-proxy, and worker sources.
- The shared discovery query concurrency limit.
- Nested JoinSet error handling in work/mod.rs.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

Validated from the function-autoscaler subtree:

    cargo fmt -p rs-autoscaler
    cargo clippy -p rs-autoscaler --all-targets -- -D warnings
    cargo test -p rs-autoscaler

Results: 127 tests passed, 11 integration tests ignored, and no failures.

## Issues

NO-REF

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved function discovery reliability by querying multiple sources and shards concurrently.
  * Partial discovery results are retained when individual queries or sources fail.
  * Discovery now fails only when all available sources are unavailable.
  * Improved handling of overlapping results and recovery from worker-based discovery failures.
  * Per-function lookups now fail safely when required data cannot be retrieved.
  * Scaling-input collection continues processing remaining functions and reports task failures collectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
