### PR TITLE
fix(nvca): persist workload config after Helm updates

### DIFF
--- a/src/compute-plane-services/nvca/internal/miniservice/reconcile.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/reconcile.go
@@ -897,7 +897,7 @@ func needsWorkloadUpdate(ms *v1alpha1.MiniService) bool {
 func (r *Reconciler) prepareUpdateWorkload(ctx context.Context,
 	ms *v1alpha1.MiniService,
 	icmsReq *nvcav2beta1.ICMSRequest,
-) ([]client.Object, []v1alpha1.ResourceStatus, string, string, error) {
+) ([]client.Object, []v1alpha1.ResourceStatus, *v1alpha1.WorkloadConfig, string, string, error) {
 	log := logf.FromContext(ctx)
 
 	log.Info("Preparing MiniService workload update", "revision", ms.Status.Revision)
@@ -905,18 +905,18 @@ func (r *Reconciler) prepareUpdateWorkload(ctx context.Context,
 	funcLaunchSpec := icmsReq.Spec.CreationMsgInfo.FunctionLaunchSpecification
 	taskLaunchSpec := icmsReq.Spec.CreationMsgInfo.TaskLaunchSpecification
 	if funcLaunchSpec == nil && taskLaunchSpec == nil {
-		return nil, nil, "", "", reconcile.TerminalError(
+		return nil, nil, nil, "", "", reconcile.TerminalError(
 			fmt.Errorf("both function and task launch specs are empty in ICMSRequest %s", icmsReq.Name))
 	}
 
 	functionName, taskName, err := getFunctionNameAndTaskName(funcLaunchSpec, taskLaunchSpec)
 	if err != nil {
-		return nil, nil, "", "", reconcile.TerminalError(fmt.Errorf("failed to get function name and task name: %w", err))
+		return nil, nil, nil, "", "", reconcile.TerminalError(fmt.Errorf("failed to get function name and task name: %w", err))
 	}
 
 	objsData, isRendered, err := r.getRenderedData(ctx, ms)
 	if err != nil {
-		return nil, nil, "", "", err
+		return nil, nil, nil, "", "", err
 	}
 
 	if !isRendered {
@@ -930,14 +930,14 @@ func (r *Reconciler) prepareUpdateWorkload(ctx context.Context,
 		failed := r.failedWorkloadUpdateRevisionCache[failedWorkloadUpdateRevisionCacheKey]
 		r.failedWorkloadUpdateRevisionCacheLock.RUnlock()
 		if failed != nil {
-			return nil, nil, "", "", failed
+			return nil, nil, nil, "", "", failed
 		}
 
 		if objsData, err = r.render(ctx, ms, icmsReq); err != nil {
 			r.failedWorkloadUpdateRevisionCacheLock.Lock()
 			r.failedWorkloadUpdateRevisionCache[failedWorkloadUpdateRevisionCacheKey] = err
 			r.failedWorkloadUpdateRevisionCacheLock.Unlock()
-			return nil, nil, "", "", err
+			return nil, nil, nil, "", "", err
 		}
 
 		// Clear the cache on a successful render for prior revisions to this MiniService
@@ -949,16 +949,16 @@ func (r *Reconciler) prepareUpdateWorkload(ctx context.Context,
 		r.failedWorkloadUpdateRevisionCacheLock.Unlock()
 
 		if err := r.saveRenderedData(ctx, ms, objsData); err != nil {
-			return nil, nil, "", "", err
+			return nil, nil, nil, "", "", err
 		}
 	}
 
-	workloadObjs, resources, _, err := decodeObjects(ctx, r.Decoder, objsData)
+	workloadObjs, resources, workloadConfig, err := decodeObjects(ctx, r.Decoder, objsData)
 	if err != nil {
-		return nil, nil, "", "", err
+		return nil, nil, nil, "", "", err
 	}
 
-	return workloadObjs, resources, functionName, taskName, nil
+	return workloadObjs, resources, workloadConfig, functionName, taskName, nil
 }
 
 // doUpdateWorkload performs a workload update for a MiniService, doing almost the same operations as doInstall,
@@ -970,7 +970,7 @@ func (r *Reconciler) doUpdateWorkload(ctx context.Context,
 ) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	workloadObjs, resources, functionName, taskName, err := r.prepareUpdateWorkload(ctx, ms, icmsReq)
+	workloadObjs, resources, workloadConfig, functionName, taskName, err := r.prepareUpdateWorkload(ctx, ms, icmsReq)
 	if err != nil {
 		// Workload preparation may result in terminal errors that would cause workload cleanup.
 		// To let the un-updated workload continue running, warn the user with a non-terminal error.
@@ -1026,6 +1026,10 @@ func (r *Reconciler) doUpdateWorkload(ctx context.Context,
 			log.Error(err, "Failed to apply workload objects with terminal error. MiniService must be updated with new values to progress update; "+
 				"successfully applied objects prior to this error may need to be cleaned up manually")
 		}
+		return reconcile.Result{}, err
+	}
+
+	if err := r.saveWorkloadConfig(ctx, ms, workloadConfig); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/src/compute-plane-services/nvca/internal/miniservice/reconcile_update_test.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/reconcile_update_test.go
@@ -674,7 +674,7 @@ func TestReconcile_UpdateWorkloadConfig_ConfigRemoved(t *testing.T) {
 	prior := &v1alpha1.WorkloadConfig{
 		FeatureFlags: map[string]bool{featureflag.StatusByWorkerReadiness: true},
 	}
-	// Empty configYAML → no nvcf-workload-config in the rendered output.
+	// An empty configYAML omits nvcf-workload-config from the rendered output.
 	renderedData := newUpdateRenderedDataWithWorkloadConfig(t, workloadObjName, "v2", "")
 	r, req := setupUpdateReconcileForWorkloadConfig(t, prior, renderedData, workloadObjName)
 

--- a/src/compute-plane-services/nvca/internal/miniservice/reconcile_update_test.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/reconcile_update_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/util/k8sutil"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/v1alpha1"
 	nvcav2beta1 "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/v2beta1"
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/featureflag"
 	featureflagmock "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/featureflag/mock"
 )
 
@@ -496,4 +497,240 @@ func TestReconcile_FailedUpdateRetryReusesCache(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, reconcile.Result{}, gotRes)
 	assert.Equal(t, 0, reval.calls, "expected retry to reuse cached render data without ReVal call")
+}
+
+// newUpdateRenderedDataWithWorkloadConfig returns a serialized rendered-objects payload that
+// includes a regular workload ConfigMap and, when configYAML is non-empty, the
+// nvcf-workload-config control ConfigMap that decodeObjects extracts as a WorkloadConfig.
+// Passing an empty configYAML simulates a Helm revision that omits nvcf-workload-config.
+func newUpdateRenderedDataWithWorkloadConfig(t *testing.T, workloadObjName, workloadValue, configYAML string) []byte {
+	t.Helper()
+
+	workloadCM := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String(), Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: workloadObjName},
+		Data:       map[string]string{"key": workloadValue},
+	}
+	workloadBytes, err := json.Marshal(workloadCM)
+	require.NoError(t, err)
+
+	objects := []json.RawMessage{workloadBytes}
+
+	if configYAML != "" {
+		configCM := &corev1.ConfigMap{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+			ObjectMeta: metav1.ObjectMeta{Name: featureflag.WorkloadConfigConfigMapName},
+			Data:       map[string]string{featureflag.WorkloadConfigDataKey: configYAML},
+		}
+		configBytes, err := json.Marshal(configCM)
+		require.NoError(t, err)
+		objects = append(objects, configBytes)
+	}
+
+	out, err := json.Marshal(objects)
+	require.NoError(t, err)
+	return out
+}
+
+// setupUpdateReconcileForWorkloadConfig creates the fake client and reconciler for workload-config
+// persistence tests. It pre-populates the rendered data cache so ReVal is never called.
+// initialWorkloadConfig is set on the MiniService spec before it is stored in the fake client;
+// pass nil when the prior revision had no workload config.
+// workloadObjName is the name of the workload ConfigMap in the rendered data; it must pre-exist
+// in the fake client so that the SSA apply in applySSAWorkload can patch it.
+func setupUpdateReconcileForWorkloadConfig(
+	t *testing.T,
+	initialWorkloadConfig *v1alpha1.WorkloadConfig,
+	renderedData []byte,
+	workloadObjName string,
+) (*Reconciler, reconcile.Request) {
+	t.Helper()
+	ctx := newTestContext()
+	testScheme := mgrScheme
+
+	ms := newUpdateMiniService(`{"key":"value-v2"}`)
+	ms.Spec.WorkloadConfig = initialWorkloadConfig
+
+	c, _ := newFakeClient(testScheme,
+		ms,
+		newUpdateICMSRequest(true),
+		newReadyUtilsPod(),
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: updateTestNamespace}},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      workloadObjName,
+				Namespace: updateTestNamespace,
+			},
+		},
+	)
+	r := newUpdateTestReconciler(t, c, testScheme)
+
+	existing := &v1alpha1.MiniService{}
+	require.NoError(t, r.Client.Get(ctx, client.ObjectKey{Name: updateMSName}, existing))
+	require.NoError(t, r.saveRenderedData(ctx, existing, renderedData))
+	require.NoError(t, r.Client.Status().Update(ctx, existing))
+
+	return r, reconcile.Request{NamespacedName: client.ObjectKey{Name: updateMSName}}
+}
+
+// setupDoUpdateWorkloadForWorkloadConfig creates the fake client, reconciler, and a MiniService
+// struct for doUpdateWorkload-level workload-config tests. The MiniService is stored in the fake
+// client so saveWorkloadConfig can patch it, and the rendered data cache is pre-populated so
+// ReVal is never called. initialWorkloadConfig is the prior spec.workloadConfig value.
+func setupDoUpdateWorkloadForWorkloadConfig(
+	t *testing.T,
+	initialWorkloadConfig *v1alpha1.WorkloadConfig,
+	renderedData []byte,
+	workloadObjName string,
+) (*Reconciler, *v1alpha1.MiniService) {
+	t.Helper()
+	ctx := newTestContext()
+	testScheme := mgrScheme
+
+	ms := newUpdateMiniService(`{"key":"value-v2"}`)
+	ms.Spec.WorkloadConfig = initialWorkloadConfig
+
+	c, _ := newFakeClient(testScheme,
+		ms,
+		newUpdateICMSRequest(true),
+		newReadyUtilsPod(),
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: updateTestNamespace}},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: workloadObjName, Namespace: updateTestNamespace},
+		},
+	)
+	r := newUpdateTestReconciler(t, c, testScheme)
+
+	// Fetch the stored MS so its ResourceVersion matches the fake client, then populate the
+	// render cache and persist the updated status so getRenderedData can find the hash.
+	stored := &v1alpha1.MiniService{}
+	require.NoError(t, r.Client.Get(ctx, client.ObjectKey{Name: updateMSName}, stored))
+	require.NoError(t, r.saveRenderedData(ctx, stored, renderedData))
+	require.NoError(t, r.Client.Status().Update(ctx, stored))
+
+	// Return stored so the caller has an in-sync MS to pass to doUpdateWorkload.
+	return r, stored
+}
+
+// TestDoUpdateWorkload_PersistsWorkloadConfig_NoConfigToEnabled verifies that a successful Helm
+// update whose rendered output includes nvcf-workload-config with StatusByWorkerReadiness: true
+// calls saveWorkloadConfig and sets the flag on the MiniService spec.
+// Unrelated spec fields (namespace, ICMSRequestName, HelmChartConfig) must not be modified.
+func TestDoUpdateWorkload_PersistsWorkloadConfig_NoConfigToEnabled(t *testing.T) {
+	ctx := newTestContext()
+	const workloadObjName = "workload-cm"
+
+	configYAML := "featureFlags:\n  " + featureflag.StatusByWorkerReadiness + ": true\n"
+	renderedData := newUpdateRenderedDataWithWorkloadConfig(t, workloadObjName, "v2", configYAML)
+	r, ms := setupDoUpdateWorkloadForWorkloadConfig(t, nil, renderedData, workloadObjName)
+	icmsReq := newUpdateICMSRequest(true)
+
+	gotRes, err := r.doUpdateWorkload(ctx, ms, icmsReq)
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, gotRes)
+	assert.Equal(t, v1alpha1.MiniServiceInstalled, ms.Status.Phase)
+
+	require.NotNil(t, ms.Spec.WorkloadConfig, "saveWorkloadConfig must be called after successful apply")
+	assert.True(t, ms.Spec.WorkloadConfig.IsFeatureFlagEnabled(featureflag.StatusByWorkerReadiness))
+
+	// Unrelated spec fields must not be modified by workload-config persistence.
+	assert.Equal(t, updateTestNamespace, ms.Spec.Namespace)
+	assert.Equal(t, updateICMSName, ms.Spec.ICMSRequestName)
+	assert.Equal(t, "https://helm.ngc.nvidia.com/myorg/charts/foo-1.0.0.tgz", ms.Spec.HelmChartConfig.URL)
+}
+
+// TestDoUpdateWorkload_PersistsWorkloadConfig_EnabledToDisabled verifies that a successful Helm
+// update whose rendered output includes nvcf-workload-config with StatusByWorkerReadiness: false
+// calls saveWorkloadConfig and replaces the previously enabled config with the disabled one.
+func TestDoUpdateWorkload_PersistsWorkloadConfig_EnabledToDisabled(t *testing.T) {
+	ctx := newTestContext()
+	const workloadObjName = "workload-cm"
+
+	prior := &v1alpha1.WorkloadConfig{
+		FeatureFlags: map[string]bool{featureflag.StatusByWorkerReadiness: true},
+	}
+	configYAML := "featureFlags:\n  " + featureflag.StatusByWorkerReadiness + ": false\n"
+	renderedData := newUpdateRenderedDataWithWorkloadConfig(t, workloadObjName, "v2", configYAML)
+	r, ms := setupDoUpdateWorkloadForWorkloadConfig(t, prior, renderedData, workloadObjName)
+	icmsReq := newUpdateICMSRequest(true)
+
+	gotRes, err := r.doUpdateWorkload(ctx, ms, icmsReq)
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, gotRes)
+	assert.Equal(t, v1alpha1.MiniServiceInstalled, ms.Status.Phase)
+
+	require.NotNil(t, ms.Spec.WorkloadConfig)
+	assert.False(t, ms.Spec.WorkloadConfig.IsFeatureFlagEnabled(featureflag.StatusByWorkerReadiness),
+		"prior enabled flag must be replaced with disabled after successful update")
+}
+
+// TestReconcile_UpdateWorkloadConfig_ConfigRemoved verifies that a successful Helm update
+// whose rendered output omits nvcf-workload-config clears spec.workloadConfig,
+// removing the previously persisted flag.
+func TestReconcile_UpdateWorkloadConfig_ConfigRemoved(t *testing.T) {
+	ctx := newTestContext()
+	const workloadObjName = "workload-cm"
+
+	prior := &v1alpha1.WorkloadConfig{
+		FeatureFlags: map[string]bool{featureflag.StatusByWorkerReadiness: true},
+	}
+	// Empty configYAML → no nvcf-workload-config in the rendered output.
+	renderedData := newUpdateRenderedDataWithWorkloadConfig(t, workloadObjName, "v2", "")
+	r, req := setupUpdateReconcileForWorkloadConfig(t, prior, renderedData, workloadObjName)
+
+	gotRes, err := r.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, gotRes)
+
+	updated := &v1alpha1.MiniService{}
+	require.NoError(t, r.Client.Get(ctx, client.ObjectKey{Name: updateMSName}, updated))
+	assert.Equal(t, v1alpha1.MiniServiceInstalled, updated.Status.Phase)
+	assert.Nil(t, updated.Spec.WorkloadConfig, "spec.workloadConfig must be cleared when nvcf-workload-config is absent")
+}
+
+// TestDoUpdateWorkload_FailedApply_RetainsPriorWorkloadConfig verifies that when workload
+// object apply fails, the previously persisted WorkloadConfig is left unchanged so status
+// behavior remains aligned with the workload revision that is still serving.
+// This is tested at the doUpdateWorkload level to directly assert that saveWorkloadConfig
+// is not called on the failure path.
+func TestDoUpdateWorkload_FailedApply_RetainsPriorWorkloadConfig(t *testing.T) {
+	ctx := newTestContext()
+	testScheme := mgrScheme
+	const workloadObjName = "workload-cm"
+
+	prior := &v1alpha1.WorkloadConfig{
+		FeatureFlags: map[string]bool{featureflag.StatusByWorkerReadiness: true},
+	}
+	configYAML := "featureFlags:\n  " + featureflag.StatusByWorkerReadiness + ": false\n"
+	renderedData := newUpdateRenderedDataWithWorkloadConfig(t, workloadObjName, "v2", configYAML)
+
+	c, _ := newFakeClientWithInterceptors(testScheme,
+		interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if cm, ok := obj.(*corev1.ConfigMap); ok && cm.Name == workloadObjName {
+					return apierrors.NewForbidden(
+						schema.GroupResource{Group: "", Resource: "configmaps"},
+						cm.Name,
+						fmt.Errorf("forbidden by test"),
+					)
+				}
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+		},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: updateTestNamespace}},
+		newReadyUtilsPod(),
+	)
+	r := newUpdateTestReconciler(t, c, testScheme)
+
+	ms := newUpdateMiniService(`{"key":"value-v2"}`)
+	ms.Spec.WorkloadConfig = prior
+	icmsReq := newUpdateICMSRequest(true)
+	require.NoError(t, r.saveRenderedData(ctx, ms, renderedData))
+
+	_, err := r.doUpdateWorkload(ctx, ms, icmsReq)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "is forbidden")
+	assert.Equal(t, v1alpha1.MiniServiceInstalling, ms.Status.Phase)
+	// saveWorkloadConfig must not have been called: prior config is unchanged.
+	assert.Equal(t, prior, ms.Spec.WorkloadConfig, "prior workload config must be retained after failed apply")
 }


### PR DESCRIPTION
## TL;DR
The Helm-update path in doUpdateWorkload discarded the WorkloadConfig decoded
from the nvcf-workload-config control ConfigMap. A successful revision could
apply new workload objects while MiniService.spec.workloadConfig kept describing
the prior revision. Status reconciliation then used stale config, for example
leaving StatusByWorkerReadiness disabled after a revision that enabled it.

Fix: prepareUpdateWorkload now returns the decoded WorkloadConfig, and
doUpdateWorkload calls saveWorkloadConfig after a successful apply. The existing
targeted SSA contract from #626 is preserved: miniservice-controller owns only
spec.workloadConfig and unrelated MiniService spec fields are untouched.

## Additional Details

The root cause is a single discarded return value. decodeObjects has always
returned a `*v1alpha1.WorkloadConfig` as its third value. The install path
(`doInstall`) captured it and called `saveWorkloadConfig`. The update path
(`prepareUpdateWorkload`) assigned it to `_`, so the decoded config was never
propagated.

Key behavior:
- Absent `nvcf-workload-config` in the rendered output clears `spec.workloadConfig`,
  consistent with how `saveWorkloadConfig` handles a nil desired value via SSA.
- Render, validation, or apply failures return before `saveWorkloadConfig` is
  called, so the prior config stays aligned with the workload revision still serving.
- `saveWorkloadConfig` is called unchanged, so the targeted SSA payload introduced
  in #626 continues to restrict ownership to `spec.workloadConfig` only.

## For the Reviewer

`reconcile.go`: two mechanical changes only. `prepareUpdateWorkload` return
signature gets a new `*v1alpha1.WorkloadConfig` slot; all early returns updated.
`doUpdateWorkload` unpacks the new return value and calls `saveWorkloadConfig`
after `applySSAWorkload`.

`reconcile_update_test.go`: four new tests and two setup helpers, all
self-contained. No existing tests were modified.

## For QA

Ran:

```shell
go test ./internal/miniservice/... \
  -ldflags '-X github.com/NVIDIA/k8s-dra-driver-gpu/internal/info.version=v25.8.0' \
  -count=1
```

All tests pass. The only failure in the package is TestController, which is
pre-existing and unrelated to this change. QA not needed: the fix is contained
to the in-process reconcile path with full unit coverage added.

## Issues
Closes [#651](https://github.com/NVIDIA/nvcf/issues/651)



## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workload configuration is now correctly saved when workload updates succeed.
  * Updated configurations replace previous values, while removing the configuration clears it as expected.
  * Existing workload configuration is preserved when an update fails.
  * Unrelated MiniService settings remain unchanged during workload updates.
  * Workload configuration handling now behaves consistently across supported update scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->