### PR TITLE
fix(text-fixtures): bundled local_env compose assests in icms-core test fixtures

### DIFF
--- a/src/control-plane-services/instance-cluster-management/BAZEL.md
+++ b/src/control-plane-services/instance-cluster-management/BAZEL.md
@@ -18,13 +18,19 @@ The service does not own nested Bazel configuration:
 
 The root uses `local_jdk`. Install a full JDK 25 and set `JAVA_HOME`.
 
-## Build
+## Output root and clean
 
 Use one portable output root:
 
 ```bash
 export BAZEL_OUTPUT_USER_ROOT="${TMPDIR:-/tmp}/nvcf-bazel-cache"
+
+bazel --output_user_root="${BAZEL_OUTPUT_USER_ROOT}" clean
 ```
+
+Use `clean --expunge` only to reset a corrupted cache.
+
+## Build
 
 Build every ICMS target:
 
@@ -37,6 +43,32 @@ Build the core library only:
 ```bash
 bazel --output_user_root="${BAZEL_OUTPUT_USER_ROOT}" build //src/control-plane-services/instance-cluster-management/icms-core:icms_core
 ```
+
+Build the test-fixtures target consumed by `icms-service` tests and by
+downstream Bzlmod consumers:
+
+```bash
+bazel --output_user_root="${BAZEL_OUTPUT_USER_ROOT}" build //src/control-plane-services/instance-cluster-management/icms-core:test_fixtures
+```
+
+The fixtures jar is:
+
+```text
+bazel-bin/src/control-plane-services/instance-cluster-management/icms-core/libtest_fixtures.jar
+```
+
+The fixtures jar keeps the test resources at its root, so `application-test.yaml`
+and paths such as `requests/cluster_create_request.json` stay resolvable through
+`ClassPathResource`. The `local_env/` Compose bundle ships beside it in
+`libintegration_local_env_resources.jar`, which reaches consumers through
+`runtime_deps`. Both land at the classpath root, matching the Maven tests jar.
+
+`IntegrationTest` resolves `local_env/docker-compose.test.yml` from the
+classpath and only falls back to the working directory, so downstream consumers
+outside this monorepo take the bundle from that jar instead of vendoring a copy.
+A consumer pinned to a commit that predates the bundle fails during
+`IntegrationTest` static initialization with `Missing classpath resource
+local_env/docker-compose.test.yml`.
 
 Build the executable Spring Boot jar:
 

--- a/src/control-plane-services/instance-cluster-management/icms-core/BUILD.bazel
+++ b/src/control-plane-services/instance-cluster-management/icms-core/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_library")
 load("//rules/java:defs.bzl", "nv_boot_library", "nv_boot_library_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -126,6 +127,21 @@ nv_boot_library(
     resources = ICMS_CORE_RESOURCES,
 )
 
+# Maven's copy-integration-local-env writes local_env under
+# testOutputDirectory while the test resources sit at its root, so both are
+# root-relative in the tests jar. A target has one resource_strip_prefix and
+# cannot produce both, so the bundle needs its own library with a shallower
+# prefix. Keeping the test resources at the root preserves the paths that
+# TestUtil.readFileAsBytes and IcmsTest resolve through ClassPathResource.
+java_library(
+    name = "integration_local_env_resources",
+    testonly = True,
+    resource_strip_prefix = "src/control-plane-services/instance-cluster-management",
+    resources = [
+        "//src/control-plane-services/instance-cluster-management:integration_local_env_files",
+    ],
+)
+
 nv_boot_library(
     name = "test_fixtures",
     srcs = ICMS_CORE_TEST_SRCS,
@@ -156,6 +172,7 @@ nv_boot_library(
     ],
     resource_strip_prefix = "src/control-plane-services/instance-cluster-management/icms-core/src/test/resources",
     resources = ICMS_CORE_TEST_RESOURCES,
+    runtime_deps = [":integration_local_env_resources"],
     testonly = True,
 )
 


### PR DESCRIPTION

## TL;DR
Ship the local_env Compose bundle inside the icms-core test-fixtures jar so downstream Bzlmod consumers can run ICMS integration tests without vendoring a copy of docker-compose.test.yml. This restores behavior the standalone Maven build already had and that the Bazel port dropped.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
- IntegrationTest.resolveComposeAssetDirectory reads local_env/docker-compose.test.yml from the classpath and only falls back to the working directory. Consumers outside this monorepo have no such working directory, so without the bundle in the jar they must vendor a duplicate compose file that drifts from the source of truth in icms-core.
- The standalone Maven build bundled these assets through a copy-integration-local-env execution whose comment states it exists so downstream modules do not have to duplicate them. That step was not carried over when icms-core moved to Bazel.
- The fix mirrors cloud-tasks/nvct-core exactly: strip resources to the service directory and append the integration_local_env_files filegroup to the same resources list. No new rule, wrapper, or runtime_deps is introduced.
- A target has a single resource_strip_prefix, so placing local_env at the jar root moves icms-core's own test resources from the root of the fixtures jar to icms-core/src/test/resources/. This is safe because icms-service and downstream consumers each ship their own application-test.yaml and bootstrap-test.yaml, and nothing loads icms-core's copies out of the fixtures jar. It also removes a latent collision where icms-core's application-test.yaml sat at the jar root beside the consumer's own copy and classpath order decided which one Spring used. 
- BAZEL.md gains the Output root and clean section the other control-plane services already have, plus documentation of the test-fixtures target and the bundle it carries.
- No Java sources, third-party dependencies, or other Bazel targets change.

## For the Reviewer
- The resource_strip_prefix change in icms-core/BUILD.bazel and its side effect of demoting icms-core test resources within the fixtures jar
- That this matches nvct-core:nvct_core_test_fixtures rather than introducing a new pattern
- That icms-service:tests, the in-repo consumer of test_fixtures, still passes after the demotion
- That NOTICE, runtime inventory, and OSRB dependency delta outputs are unchanged, since no third-party dependencies change

## For QA 
Validated on Java 25:

- bazel build //src/control-plane-services/instance-cluster-management/... passes. bazel test //src/control-plane-services/instance-cluster-management/... passes all four targets uncached: icms-core:tests in 625s, icms-service:tests in 42s, icms-service:image_contract_test, and notice_check_test.
- Inspected libtest_fixtures.jar and confirmed local_env/docker-compose.test.yml sits at the jar root along with the aws, cassandra, nats, and vault directories.
- Built a downstream Bzlmod consumer against this change with --override_module and its ICMS-based integration tests passed with no vendored compose file.
- Reproduced the negative case against a pin without this change: the consumer fails during IntegrationTest static initialization with "Missing classpath resource local_env/docker-compose.test.yml".
- No QA beyond CI is needed. This change touches build configuration and test resources only and removes no covered behavior.

## Issues
Closes [#659](https://github.com/NVIDIA/nvcf/issues/659)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Bazel cleanup, cache-reset, and build instructions.
  * Documented how to build and locate integration test fixtures and companion resources.
  * Added guidance for resolving missing Compose resources and understanding fallback behavior.

* **Bug Fixes**
  * Updated integration test fixtures to package local environment files correctly.
  * Improved resource availability and reliability in local integration test environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->