### PR TITLE
ci(nvca): run validation workflows on 3.1 release branch

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -10,11 +10,11 @@
 name: actionlint
 on:
   push:
-    branches: [main]
+    branches: [main, 'release-**']
     paths:
       - ".github/workflows/**"
   pull_request:
-    branches: [main]
+    branches: [main, 'release-**']
     paths:
       - ".github/workflows/**"
 

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -25,9 +25,9 @@ name: bazel
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release-**']
   pull_request:
-    branches: [main]
+    branches: [main, 'release-**']
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
@@ -718,7 +718,7 @@ jobs:
           retention-days: 14
 
   bazel-verification:
-    name: bazel verification
+    name: bazel required checks
     needs: [detect, bazel, bazel-docker]
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -5,9 +5,9 @@ name: build-test
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release-**']
   pull_request:
-    branches: [main]
+    branches: [main, 'release-**']
   merge_group:
     types: [checks_requested]
   workflow_dispatch:

--- a/.github/workflows/license-dependencies.yml
+++ b/.github/workflows/license-dependencies.yml
@@ -5,9 +5,9 @@ name: license-dependencies
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release-**']
   pull_request:
-    branches: [main]
+    branches: [main, 'release-**']
   merge_group:
     types: [checks_requested]
   workflow_dispatch:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -5,9 +5,9 @@ name: secret-scan
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release-**']
   pull_request:
-    branches: [main]
+    branches: [main, 'release-**']
   merge_group:
     types: [checks_requested]
   workflow_dispatch:


### PR DESCRIPTION
## TL;DR

- Backport routine validation triggers to the NVCA 3.1 release branch.
- Enable standard checks for release-targeted changes such as #655.

## Additional Details

- Covers build-test, Bazel, dependency-license, secret-scan, and actionlint workflows.
- Leaves release and publishing workflows unchanged.

## For QA

- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- Verified `main` and `release-**` branch filters in all five workflows.
- QA is not needed. GitHub Actions will validate the events after merge.

## Issues

Relates to #663

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] Existing actionlint validation covers the workflow update.
- [x] No documentation change is required.
