### PR TITLE
ci: run validation workflows on release branches

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -10,11 +10,11 @@
 name: actionlint
 on:
   push:
-    branches: [main]
+    branches: [main, 'release-**']
     paths:
       - ".github/workflows/**"
   pull_request:
-    branches: [main]
+    branches: [main, 'release-**']
     paths:
       - ".github/workflows/**"
 

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -27,9 +27,9 @@ name: bazel
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release-**']
   pull_request:
-    branches: [main]
+    branches: [main, 'release-**']
   merge_group:
     types: [checks_requested]
   workflow_dispatch:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -5,9 +5,9 @@ name: build-test
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release-**']
   pull_request:
-    branches: [main]
+    branches: [main, 'release-**']
   merge_group:
     types: [checks_requested]
   workflow_dispatch:

--- a/.github/workflows/license-dependencies.yml
+++ b/.github/workflows/license-dependencies.yml
@@ -5,9 +5,9 @@ name: license-dependencies
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release-**']
   pull_request:
-    branches: [main]
+    branches: [main, 'release-**']
   merge_group:
     types: [checks_requested]
   workflow_dispatch:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -5,9 +5,9 @@ name: secret-scan
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release-**']
   pull_request:
-    branches: [main]
+    branches: [main, 'release-**']
   merge_group:
     types: [checks_requested]
   workflow_dispatch:


### PR DESCRIPTION
## TL;DR

- Run existing validation workflows for `release-**` pull requests and pushes.
- Leave release, publishing, and component-specific workflows unchanged.

## Additional Details

- Covers build-test, Bazel, dependency-license, secret-scan, and actionlint workflows.
- Restores standard validation for release-targeted changes such as #655.
- Future release branches inherit the trigger configuration from `main`.

## For QA

- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- Verified `main` and `release-**` branch filters in all five workflows.
- QA is not needed. GitHub Actions will validate the events after merge.

## Issues

Closes #663

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] Existing actionlint validation covers the workflow update.
- [x] No documentation change is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated validation to run on both the main branch and release branches.
  * Applies to builds, tests, dependency checks, license checks, secret scanning, and workflow validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->