### PR TITLE
chore(codeowners): assign infra tree

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,7 +21,7 @@
 /deploy/helm/cassandra/ @NVIDIA/nvcf-infra-dev
 /deploy/helm/nats/ @NVIDIA/nvcf-infra-dev
 /deploy/helm/openbao/ @NVIDIA/nvcf-infra-dev
-/infra/cassandra/ @NVIDIA/nvcf-infra-dev
+/infra/ @NVIDIA/nvcf-infra-dev
 /migrations/cassandra/ @NVIDIA/nvcf-infra-dev
 /migrations/openbao/ @NVIDIA/nvcf-infra-dev
 


### PR DESCRIPTION
## TL;DR

Route every path below `/infra/` to the Infrastructure team.

## Additional Details

The prior rule matched only `/infra/cassandra/`, leaving new infrastructure paths to the default owners. This expands the existing routing rule without changing ownership of current paths.

## For the Reviewer

Review `.github/CODEOWNERS`.

## For QA

Ran `git diff --check`.

QA is not needed for this ownership-only metadata change.

## Issues

Closes #666

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes. Not applicable: ownership-only metadata change.
- [x] The documentation is up to date with these changes.