### PR TITLE
fix(function-autoscaler): restore multi-arch OpenSSL paths

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -227,6 +227,20 @@ crate.from_cargo(
     supported_platform_triples = SUPPORTED_TRIPLES,
 )
 
+crate.annotation(
+    build_script_env = {
+        "AARCH64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR": "/usr/include",
+        "AARCH64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR": "/usr/lib/aarch64-linux-gnu",
+        "CFLAGS_aarch64_unknown_linux_gnu": "-I/usr/include/aarch64-linux-gnu",
+        "OPENSSL_INCLUDE_DIR": "/usr/include",
+        "OPENSSL_LIB_DIR": "/usr/lib/x86_64-linux-gnu",
+        "OPENSSL_NO_VENDOR": "1",
+        "X86_64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR": "/usr/include",
+        "X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR": "/usr/lib/x86_64-linux-gnu",
+    },
+    crate = "openssl-sys",
+)
+
 # Only the workspace root Cargo.toml is listed. Naming the member manifest too
 # made `cargo-bazel splice` fail on the public GitHub Actions build with
 # "Failed to splice workspace ... No such file or directory"; cargo-bazel's own

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -239,6 +239,7 @@ crate.annotation(
         "X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR": "/usr/lib/x86_64-linux-gnu",
     },
     crate = "openssl-sys",
+    repositories = ["rs_autoscaler_crates"],
 )
 
 # Only the workspace root Cargo.toml is listed. Naming the member manifest too

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -227,13 +227,13 @@ crate.from_cargo(
     supported_platform_triples = SUPPORTED_TRIPLES,
 )
 
+# The bazel-ci image provides libssl-dev for both Linux architectures. Keep
+# these paths target-specific so macOS triples use native OpenSSL discovery.
 crate.annotation(
     build_script_env = {
         "AARCH64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR": "/usr/include",
         "AARCH64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR": "/usr/lib/aarch64-linux-gnu",
         "CFLAGS_aarch64_unknown_linux_gnu": "-I/usr/include/aarch64-linux-gnu",
-        "OPENSSL_INCLUDE_DIR": "/usr/include",
-        "OPENSSL_LIB_DIR": "/usr/lib/x86_64-linux-gnu",
         "OPENSSL_NO_VENDOR": "1",
         "X86_64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR": "/usr/include",
         "X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR": "/usr/lib/x86_64-linux-gnu",


### PR DESCRIPTION
## TL;DR

Restore the target-specific OpenSSL paths dropped during the root Bazel module
consolidation, unblocking the function-autoscaler ARM64 image build.

## Additional Details

#533 configured `openssl-sys` for both AMD64 and ARM64. When #593 moved the
autoscaler into the root Bazel module, that `crate.annotation` was not
transferred.

The omission caused the manual image push to fail because
`AARCH64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR` was unset:

https://github.com/NVIDIA/nvcf/actions/runs/30954727158

This restores the previous configuration without changing service code,
dependencies, or lockfiles.

## For the Reviewer

Please verify the restored annotation in `MODULE.bazel` matches the Bazel CI
image’s AMD64 and ARM64 OpenSSL paths.

## For QA

- `git diff --check` passed.
- The image build was not run locally because this host lacks Bazel and the
  ARM64 OpenSSL sysroot.
- Validate with the manual image-push workflow against this branch.

## Issues

Relates to #527

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build configuration for autoscaler components across supported architectures.
  * Standardized OpenSSL integration to use architecture-specific system libraries and headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->