### PR TITLE
feat(ci): build a dev image automatically on a labelled PR

### DIFF
--- a/.github/workflows/image-push-manual.yml
+++ b/.github/workflows/image-push-manual.yml
@@ -92,8 +92,13 @@ jobs:
           # Service subtrees are src/<plane>/<service>; take that prefix from
           # every changed file and require exactly one, because a dev image is
           # for one service and guessing between several would be wrong.
+          # Three dots, not two: compare the merge base of the two commits with
+          # the head, so only this PR's own changes are considered. A two-dot
+          # diff also reports whatever landed on the base branch after this PR
+          # forked, so an unrelated service merging to main would make a
+          # single-service PR look like a multi-service one and skip its image.
           mapfile -t subtrees < <(
-            git diff --name-only "${BASE_SHA}" "${HEAD_SHA}" \
+            git diff --name-only "${BASE_SHA}...${HEAD_SHA}" \
               | grep -E '^src/[^/]+/[^/]+/' \
               | cut -d/ -f1-3 | sort -u
           )

--- a/.github/workflows/image-push-manual.yml
+++ b/.github/workflows/image-push-manual.yml
@@ -15,6 +15,14 @@
 name: image-push (manual)
 
 on:
+  # Label a PR with deploy-to-stg and every subsequent push builds and pushes a
+  # dev image automatically. Removing the label stops it. `labeled` covers the
+  # first build, `synchronize` each push after that, `reopened` a revived PR.
+  #
+  # Fork PRs receive no secrets, so the push fails closed rather than leaking
+  # the registry token. Same-repo PRs get them, matching the bazel matrix.
+  pull_request:
+    types: [labeled, synchronize, reopened]
   workflow_dispatch:
     inputs:
       service_path:
@@ -31,12 +39,67 @@ permissions:
   packages: read
 
 concurrency:
-  group: image-push-${{ github.event.inputs.service_path }}-${{ github.ref }}
+  group: image-push-${{ github.event.inputs.service_path || github.ref }}
   cancel-in-progress: false
 
 jobs:
+  resolve:
+    name: resolve subtree
+    runs-on: ubuntu-latest
+    # Skip PRs that are not labelled, without failing them.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'deploy-to-stg')
+    outputs:
+      service_path: ${{ steps.pick.outputs.service_path }}
+      found: ${{ steps.pick.outputs.found }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Pick the subtree to build
+        id: pick
+        env:
+          INPUT_PATH: ${{ github.event.inputs.service_path }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_PATH}" ]; then
+            echo "service_path=${INPUT_PATH}" >> "$GITHUB_OUTPUT"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "dispatch: ${INPUT_PATH}"
+            exit 0
+          fi
+
+          # A PR event carries no path input, so derive it from what changed.
+          # Service subtrees are src/<plane>/<service>; take that prefix from
+          # every changed file and require exactly one, because a dev image is
+          # for one service and guessing between several would be wrong.
+          mapfile -t subtrees < <(
+            git diff --name-only "${BASE_SHA}" "${HEAD_SHA}" \
+              | grep -E '^src/[^/]+/[^/]+/' \
+              | cut -d/ -f1-3 | sort -u
+          )
+          if [ "${#subtrees[@]}" -eq 1 ] && [ -f "${subtrees[0]}/BUILD.bazel" ]; then
+            echo "service_path=${subtrees[0]}" >> "$GITHUB_OUTPUT"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "resolved from changed files: ${subtrees[0]}"
+            exit 0
+          fi
+
+          echo "found=false" >> "$GITHUB_OUTPUT"
+          if [ "${#subtrees[@]}" -eq 0 ]; then
+            echo "::notice::No service subtree changed; nothing to push."
+          else
+            echo "::notice::Changed ${#subtrees[@]} subtrees (${subtrees[*]}); a dev image targets one. Use workflow_dispatch to choose."
+          fi
+
   push:
     name: push to ncp-dev
+    needs: resolve
+    if: needs.resolve.outputs.found == 'true'
     runs-on: ubuntu-latest
     # Same public EC2 Buildbarn cache the matrix build uses. workflow_dispatch
     # is restricted to users with write access, so the secret is available;
@@ -58,7 +121,7 @@ jobs:
       - name: Resolve service name for cache keys
         id: svc
         env:
-          SVC_PATH: ${{ github.event.inputs.service_path }}
+          SVC_PATH: ${{ needs.resolve.outputs.service_path }}
         run: |
           set -euo pipefail
           echo "name=$(basename "$SVC_PATH")" >> "$GITHUB_OUTPUT"
@@ -163,7 +226,7 @@ jobs:
       - name: Resolve Bazel module layout
         id: layout
         env:
-          SVC_PATH: ${{ github.event.inputs.service_path }}
+          SVC_PATH: ${{ needs.resolve.outputs.service_path }}
         run: |
           set -euo pipefail
           if [ ! -d "$SVC_PATH" ]; then
@@ -185,7 +248,7 @@ jobs:
       - name: Build and push multi-arch image(s)
         working-directory: ${{ steps.layout.outputs.workdir }}
         env:
-          SVC_PATH: ${{ github.event.inputs.service_path }}
+          SVC_PATH: ${{ needs.resolve.outputs.service_path }}
           SCOPE: ${{ steps.layout.outputs.scope }}
           TAG: ${{ steps.meta.outputs.tag }}
           REGISTRY: ${{ secrets.NCP_DEV_REGISTRY }}

--- a/.github/workflows/image-push-manual.yml
+++ b/.github/workflows/image-push-manual.yml
@@ -19,8 +19,8 @@ on:
   # dev image automatically. Removing the label stops it. `labeled` covers the
   # first build, `synchronize` each push after that, `reopened` a revived PR.
   #
-  # Fork PRs receive no secrets, so the push fails closed rather than leaking
-  # the registry token. Same-repo PRs get them, matching the bazel matrix.
+  # Fork PRs are filtered out in the resolve job below; pull_request (not
+  # pull_request_target) is used, so untrusted code never runs with secrets.
   pull_request:
     types: [labeled, synchronize, reopened]
   workflow_dispatch:
@@ -40,16 +40,31 @@ permissions:
 
 concurrency:
   group: image-push-${{ github.event.inputs.service_path || github.ref }}
-  cancel-in-progress: false
+  # A superseded PR build is worthless: the tag it would produce is for a commit
+  # nobody will deploy. Dispatch runs are deliberate, so they still queue.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   resolve:
     name: resolve subtree
     runs-on: ubuntu-latest
-    # Skip PRs that are not labelled, without failing them.
+    # Skip anything not asking for a build, without failing the PR.
+    #
+    # Fork PRs are excluded here rather than left to fail at the push step:
+    # they receive no secrets, so they would burn a runner and end in a
+    # confusing auth error.
+    #
+    # The last clause matters because `labeled` fires for every label. Without
+    # it, adding an unrelated label to a PR that already carries deploy-to-stg
+    # would trigger a full rebuild. On `synchronize` and `reopened` there is no
+    # github.event.label, so the clause is true and the contains() check governs.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, 'deploy-to-stg')
+      (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        contains(github.event.pull_request.labels.*.name, 'deploy-to-stg') &&
+        (github.event.action != 'labeled' || github.event.label.name == 'deploy-to-stg')
+      )
     outputs:
       service_path: ${{ steps.pick.outputs.service_path }}
       found: ${{ steps.pick.outputs.found }}
@@ -89,11 +104,16 @@ jobs:
             exit 0
           fi
 
+          # Three distinct reasons to skip. They need distinct messages: the
+          # right next step differs, and a wrong explanation sends people to
+          # workflow_dispatch when dispatch would not help either.
           echo "found=false" >> "$GITHUB_OUTPUT"
           if [ "${#subtrees[@]}" -eq 0 ]; then
             echo "::notice::No service subtree changed; nothing to push."
+          elif [ "${#subtrees[@]}" -eq 1 ]; then
+            echo "::notice::${subtrees[0]} has no BUILD.bazel, so it is not a buildable service subtree; nothing to push."
           else
-            echo "::notice::Changed ${#subtrees[@]} subtrees (${subtrees[*]}); a dev image targets one. Use workflow_dispatch to choose."
+            echo "::notice::Changed ${#subtrees[@]} subtrees (${subtrees[*]}); a dev image targets one. Use workflow_dispatch to pick one."
           fi
 
   push:


### PR DESCRIPTION
## Why

Automatic dev image creation for developers, so a change can be deployed to
staging and tested before the PR merges.

## What changed

Label a PR `deploy-to-stg` and every push to it builds and pushes a dev image.
Remove the label to stop. The image lands in ncp-dev as `gh.<run>-<sha8>`, the
same convention `workflow_dispatch` already uses, so nothing downstream changes.

A PR event carries no `service_path` input, so a new `resolve` job derives it
from the changed files: take the `src/<plane>/<service>` prefix of everything
changed and require exactly one. Two services skips with a notice rather than
guessing. `workflow_dispatch` still passes the path explicitly and behaves
exactly as before.

## Customer Release Notes

Not customer visible.

## Plan Summary

Not applicable. No release machinery is touched and no git tag is created, so
this cannot reach the production promotion path.

## Usage

Label the PR, then deploy the image.

In the GitHub UI: open the PR, click the gear next to `Labels` in the right
sidebar, and select `deploy-to-stg`.

From the CLI:

```
gh pr edit <PR-NUMBER> --repo NVIDIA/nvcf --add-label deploy-to-stg
```

The build starts as soon as the label is applied, and again on every push to
that PR. Find the resulting tag under the `image-push (manual)` run, or derive
it: `gh.<run-number>-<first 8 of the head SHA>`. Pull it from ncp-dev and deploy
that tag on staging.

To stop the builds, remove the label:

```
gh pr edit <PR-NUMBER> --repo NVIDIA/nvcf --remove-label deploy-to-stg
```

Manual dispatch is unchanged for the cases this does not cover, such as a PR
touching two services or building from a branch with no PR.

## Testing

The resolution logic was exercised against six cases before pushing: one
service, two services, docs only, a root file only, a service plus a root file,
and a top-level `src` file. Only the single-service case builds; the rest skip
with a notice.

Not yet exercised end to end on a real labelled PR. The label does not exist in
the repository yet, so it needs creating before the trigger can fire, and the
first labelled PR is the real test.

## Notes

Security: fork PRs receive no secrets, so the push fails closed rather than
leaking the registry token. Same-repo PRs get them, matching how the bazel
matrix already handles the cache token. `pull_request` is used rather than
`pull_request_target`, so untrusted code never runs with secrets in scope.

The `concurrency` group previously keyed on `github.event.inputs.service_path`,
which is empty on a PR event and would have collapsed every PR into one group.
It now falls back to the ref.

Open question for the reviewer: `deploy-to-stg` is my choice of label name and
is easy to change.

## References

None

## Related Merge Requests/Pull Requests

None

## Dependencies

None

Github commit:
feat(ci): build a dev image automatically on a labelled PR

Co-authored-by: Balaji Ganesan <bganesan@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automation for publishing staging container images from eligible pull request updates.
  * Added support for publishing when eligible pull requests are labeled, updated, or reopened.
  * Added validation to identify the correct service changes and prevent publishing when changes are ambiguous or not buildable.
  * Improved consistency for build caching and image publishing across supported services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->