### PR TITLE
fix(nvca): preserve MiniService spec when saving workload config (3.1)

### DIFF
--- a/src/compute-plane-services/nvca/internal/miniservice/reconcile.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/reconcile.go
@@ -138,6 +138,7 @@ var (
 
 const (
 	InferenceNamespaceEnvKey        = "HELM_CHART_NAMESPACE"
+	miniServiceKind                 = "MiniService"
 	miniServiceUnknownPhase         = "Unknown"
 	miniServiceUnknownFailureReason = "Unknown"
 	miniServicePhaseAttrKey         = "nvca.miniservice.phase"
@@ -458,25 +459,37 @@ func (r *Reconciler) saveWorkloadConfig(
 		return nil
 	}
 
-	base := &v1alpha1.MiniService{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: v1alpha1.SchemeGroupVersion.String(),
-			Kind:       "MiniService",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            ms.Name,
-			ResourceVersion: ms.ResourceVersion,
-		},
-		Spec: v1alpha1.MiniServiceSpec{
-			WorkloadConfig: desired.DeepCopy(),
-		},
+	spec := map[string]any{"workloadConfig": nil}
+	if desired != nil {
+		workloadConfig, err := runtime.DefaultUnstructuredConverter.ToUnstructured(desired)
+		if err != nil {
+			return fmt.Errorf("convert miniservice %s workload config: %w", ms.Name, err)
+		}
+		spec["workloadConfig"] = workloadConfig
 	}
-	if err := r.Client.Patch(ctx, base, client.Apply, client.ForceOwnership, client.FieldOwner(managedByValue)); err != nil {
+	// Build the apply payload independently of MiniServiceSpec's compatibility serializer.
+	// This gives the controller ownership of only spec.workloadConfig and prevents zero-valued
+	// namespace, request-name, or Helm fields from entering the SSA request.
+	applyPatch := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": v1alpha1.SchemeGroupVersion.String(),
+		"kind":       miniServiceKind,
+		"metadata": map[string]any{
+			"name": ms.Name,
+		},
+		"spec": spec,
+	}}
+	if err := r.Client.Patch(
+		ctx,
+		applyPatch,
+		client.Apply,
+		client.FieldOwner(managedByValue),
+		client.ForceOwnership,
+	); err != nil {
 		return fmt.Errorf("patch miniservice %s workload config: %w", ms.Name, err)
 	}
 
-	ms.Spec.WorkloadConfig = desired
-	ms.ResourceVersion = base.ResourceVersion
+	ms.Spec.WorkloadConfig = desired.DeepCopy()
+	ms.ResourceVersion = applyPatch.GetResourceVersion()
 	return nil
 }
 
@@ -487,6 +500,16 @@ func (r *Reconciler) saveWorkloadConfig(
 // (observedGeneration is still updated at the end of Reconcile).
 func (r *Reconciler) prepareUpdateIfNeeded(ctx context.Context, ms *v1alpha1.MiniService) error {
 	if ms.Status.ObservedGeneration == 0 || ms.Generation == ms.Status.ObservedGeneration {
+		return nil
+	}
+	// Installing at revision zero means initial object application is still in progress.
+	// doInstall reads the current spec and its render cache is keyed by Helm configuration,
+	// so it can handle spec changes without entering an update path that assumes infra exists.
+	if ms.Status.Phase == v1alpha1.MiniServiceInstalling && ms.Status.Revision == 0 {
+		logf.FromContext(ctx).Info("Spec change detected during initial install, continuing install",
+			"generation", ms.Generation,
+			"observedGeneration", ms.Status.ObservedGeneration,
+		)
 		return nil
 	}
 

--- a/src/compute-plane-services/nvca/internal/miniservice/reconcile_test.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/reconcile_test.go
@@ -5418,3 +5418,66 @@ func TestPatchMiniService(t *testing.T) {
 		})
 	}
 }
+
+func TestSaveWorkloadConfigUsesTargetedSSA(t *testing.T) {
+	ctx := newTestContext()
+	stored := baseMiniServiceForPatchTest()
+	patchType := client.Merge.Type()
+	var patchData []byte
+	var patchOptions client.PatchOptions
+	crClient, _ := newFakeClientWithInterceptors(
+		mgrScheme,
+		interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				patchType = patch.Type()
+				for _, opt := range opts {
+					opt.ApplyToPatch(&patchOptions)
+				}
+				var err error
+				patchData, err = patch.Data(obj)
+				require.NoError(t, err)
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+		},
+		stored,
+	)
+	r := &Reconciler{Client: crClient}
+
+	ms := &v1alpha1.MiniService{}
+	require.NoError(t, crClient.Get(ctx, client.ObjectKeyFromObject(stored), ms))
+	wantSpec := ms.Spec.DeepCopy()
+	desired := &v1alpha1.WorkloadConfig{
+		FeatureFlags: map[string]bool{featureflag.StatusByWorkerReadiness: true},
+	}
+
+	require.NoError(t, r.saveWorkloadConfig(ctx, ms, desired))
+
+	got := &v1alpha1.MiniService{}
+	require.NoError(t, crClient.Get(ctx, client.ObjectKeyFromObject(stored), got))
+	assert.Equal(t, client.Apply.Type(), patchType)
+	assert.Equal(t, managedByValue, patchOptions.FieldManager)
+	if assert.NotNil(t, patchOptions.Force) {
+		assert.True(t, *patchOptions.Force)
+	}
+
+	var gotPatch map[string]any
+	require.NoError(t, json.Unmarshal(patchData, &gotPatch))
+	assert.Equal(t, map[string]any{
+		"apiVersion": v1alpha1.SchemeGroupVersion.String(),
+		"kind":       "MiniService",
+		"metadata": map[string]any{
+			"name": stored.Name,
+		},
+		"spec": map[string]any{
+			"workloadConfig": map[string]any{
+				"featureFlags": map[string]any{
+					featureflag.StatusByWorkerReadiness: true,
+				},
+			},
+		},
+	}, gotPatch)
+	assert.Equal(t, wantSpec.Namespace, got.Spec.Namespace)
+	assert.Equal(t, wantSpec.ICMSRequestName, got.Spec.ICMSRequestName)
+	assert.Empty(t, cmp.Diff(wantSpec.HelmChartConfig, got.Spec.HelmChartConfig))
+	assert.Empty(t, cmp.Diff(desired, got.Spec.WorkloadConfig))
+}

--- a/src/compute-plane-services/nvca/internal/miniservice/revision.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/revision.go
@@ -79,7 +79,7 @@ func (r *Reconciler) saveRevisionHistory(ctx context.Context, ms *v1alpha1.MiniS
 			},
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion: v1alpha1.SchemeGroupVersion.String(),
-				Kind:       "MiniService",
+				Kind:       miniServiceKind,
 				Name:       ms.Name,
 				UID:        ms.UID,
 			}},

--- a/src/compute-plane-services/nvca/internal/miniservice/revision_test.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/revision_test.go
@@ -55,12 +55,15 @@ func TestPrepareUpgradeIfNeeded(t *testing.T) {
 	nsName := "test-ns"
 	msName := "test-ms"
 
+	// Each case describes the MiniService generation and revision state before update detection,
+	// plus the expected lifecycle state after it runs.
 	tests := []struct {
 		name               string
 		generation         int64
 		observedGeneration int64
 		revision           int64
 		specValues         string
+		workloadConfig     *v1alpha1.WorkloadConfig
 		phase              v1alpha1.MiniServicePhase
 		existingCMs        []*corev1.ConfigMap
 		wantUpgrade        bool
@@ -77,6 +80,20 @@ func TestPrepareUpgradeIfNeeded(t *testing.T) {
 			wantUpgrade:        false,
 			wantRevision:       0,
 			wantPhase:          v1alpha1.MiniServiceInstalling,
+		},
+		{
+			name:               "workload config generation during initial install continues install",
+			generation:         2,
+			observedGeneration: 1,
+			revision:           0,
+			specValues:         `{"key": "initial"}`,
+			workloadConfig: &v1alpha1.WorkloadConfig{
+				FeatureFlags: map[string]bool{featureflag.StatusByWorkerReadiness: true},
+			},
+			phase:        v1alpha1.MiniServiceInstalling,
+			wantUpgrade:  false,
+			wantRevision: 0,
+			wantPhase:    v1alpha1.MiniServiceInstalling,
 		},
 		{
 			name:               "same generation, no upgrade",
@@ -160,6 +177,7 @@ func TestPrepareUpgradeIfNeeded(t *testing.T) {
 				Spec: v1alpha1.MiniServiceSpec{
 					Namespace:       nsName,
 					HelmChartConfig: testHelmConfig("https://helm.example.com/chart.tgz", tt.specValues),
+					WorkloadConfig:  tt.workloadConfig,
 				},
 				Status: v1alpha1.MiniServiceStatus{
 					Phase:              tt.phase,
@@ -200,6 +218,8 @@ func TestPrepareUpgradeIfNeeded(t *testing.T) {
 			assert.Equal(t, tt.wantPhase, ms.Status.Phase)
 			if tt.wantUpgrade {
 				assert.Nil(t, ms.Status.RenderDetails)
+			} else {
+				assert.NotNil(t, ms.Status.RenderDetails)
 			}
 		})
 	}

--- a/src/compute-plane-services/nvca/internal/miniservice/transport_tls.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/transport_tls.go
@@ -151,7 +151,7 @@ func shouldOwnTransportTLSConfigMap(ms *nvcav1alpha1.MiniService) bool {
 func transportTLSOwnerReference(ms *nvcav1alpha1.MiniService) metav1.OwnerReference {
 	return metav1.OwnerReference{
 		APIVersion: nvcav1alpha1.SchemeGroupVersion.String(),
-		Kind:       "MiniService",
+		Kind:       miniServiceKind,
 		Name:       ms.Name,
 		UID:        ms.UID,
 	}
@@ -215,7 +215,7 @@ func matchesOwnerReference(ref metav1.OwnerReference, ms *nvcav1alpha1.MiniServi
 
 func isMiniServiceOwnerReference(ref metav1.OwnerReference) bool {
 	return ref.APIVersion == nvcav1alpha1.SchemeGroupVersion.String() &&
-		ref.Kind == "MiniService"
+		ref.Kind == miniServiceKind
 }
 
 func ownerReferencesEqual(a, b metav1.OwnerReference) bool {

--- a/src/compute-plane-services/nvca/pkg/apis/nvca/v1alpha1/miniservice_json.go
+++ b/src/compute-plane-services/nvca/pkg/apis/nvca/v1alpha1/miniservice_json.go
@@ -25,10 +25,13 @@ import (
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/internal/compat"
 )
 
+// miniServiceSpecJSON is the compatibility wire representation of MiniServiceSpec.
+// It preserves legacy request-name decoding while carrying every persisted spec field.
 type miniServiceSpecJSON struct {
 	Namespace       string            `json:"namespace"`
 	ICMSRequestName string            `json:"icmsRequestName"`
 	HelmChartConfig common.HelmConfig `json:"helmChartConfig"`
+	WorkloadConfig  *WorkloadConfig   `json:"workloadConfig,omitempty"`
 }
 
 func (s MiniServiceSpec) MarshalJSON() ([]byte, error) {
@@ -36,6 +39,7 @@ func (s MiniServiceSpec) MarshalJSON() ([]byte, error) {
 		Namespace:       s.Namespace,
 		ICMSRequestName: s.ICMSRequestName,
 		HelmChartConfig: s.HelmChartConfig,
+		WorkloadConfig:  s.WorkloadConfig,
 	})
 }
 
@@ -61,6 +65,7 @@ func (s *MiniServiceSpec) UnmarshalJSON(data []byte) error {
 		Namespace:       payload.Namespace,
 		ICMSRequestName: payload.ICMSRequestName,
 		HelmChartConfig: payload.HelmChartConfig,
+		WorkloadConfig:  payload.WorkloadConfig,
 	}
 	return nil
 }

--- a/src/compute-plane-services/nvca/pkg/apis/nvca/v1alpha1/miniservice_json_test.go
+++ b/src/compute-plane-services/nvca/pkg/apis/nvca/v1alpha1/miniservice_json_test.go
@@ -92,3 +92,20 @@ func TestMiniServiceSpecMarshalUsesCanonicalRequestName(t *testing.T) {
 	assert.Contains(t, string(data), compat.ICMSRequestNameKey)
 	assert.NotContains(t, string(data), compat.LegacyRequestNameKey())
 }
+
+func TestMiniServiceSpecRoundTripsWorkloadConfig(t *testing.T) {
+	want := MiniServiceSpec{
+		Namespace:       "ns-a",
+		ICMSRequestName: "req-a",
+		WorkloadConfig: &WorkloadConfig{
+			FeatureFlags: map[string]bool{"StatusByWorkerReadiness": true},
+		},
+	}
+
+	data, err := json.Marshal(want)
+	require.NoError(t, err)
+
+	var got MiniServiceSpec
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, want.WorkloadConfig, got.WorkloadConfig)
+}


### PR DESCRIPTION
## Customer Summary

Backports the MiniService workload-configuration persistence fix to the NVCA 3.1 release line.

## TL;DR

Cherry-picks the squash-merged mainline fix from #626 onto the current 3.1 tip. NVCA now preserves workload configuration through compatibility JSON, applies only `spec.workloadConfig` with targeted server-side apply, explicitly clears it when the rendered control ConfigMap is removed, and keeps revision-zero MiniServices on the initial-install path.

## Additional Details

This is a direct cherry-pick of merged commit `c3f1503ea2afababbb7c2088f6a49bcdb2a2a705`. It applied without conflicts to `release-src/compute-plane-services/nvca/v3.1`.

The backport retains the mainline ownership model:

- `miniservice-controller` owns only `spec.workloadConfig` through SSA.
- Namespace, ICMS request name, Helm configuration, status, and resource version are absent from the apply payload.
- Removing the control ConfigMap applies `spec.workloadConfig: null` so an older persisted flag is cleared.
- A generation change during initial installation does not enter the workload-update path before revision-zero infrastructure exists.

## For the Reviewer

Please compare this diff with #626. It should contain only the seven files from the squash-merged mainline fix, with no release-specific conflict resolution.

## For QA

Verified on the 3.1 branch:

- Focused Go tests for targeted SSA, configuration removal, revision-zero lifecycle, and JSON serialization passed.
- Full affected Go packages passed, excluding only the local envtest-only `TestController` because `KUBEBUILDER_ASSETS` is not configured in this workstation run.
- Bazel targets `//internal/miniservice:miniservice_test` and `//pkg/apis/nvca/v1alpha1:v1alpha1_test` passed from the standalone 3.1 NVCA module.

Runtime validation remains covered by the linked mainline test workflow and should use the release artifact before release qualification.

## Issues

Relates to #625

Backport of #626

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commit for Developer Certificate of Origin compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.