### PR TITLE
fix(container-cache): make cc_relay timeouts configurable, raise read to 300s

### DIFF
--- a/deploy/helm/container-cache/deploy/files/container-cache.conf
+++ b/deploy/helm/container-cache/deploy/files/container-cache.conf
@@ -117,8 +117,8 @@
             proxy_cache_lock on;
             # Aligned with the canonical values in proxy-common.conf (this block does
             # not include that file).
-            proxy_cache_lock_timeout 1200s;
-            proxy_cache_lock_age 3600s;
+            proxy_cache_lock_timeout {{ ($.Values.cache).lockTimeout | default "1200s" }};
+            proxy_cache_lock_age {{ ($.Values.cache).lockAge | default "3600s" }};
 
             # Some extra settings to maximize cache hits and efficiency
             proxy_force_ranges on;

--- a/deploy/helm/container-cache/deploy/files/ngc.conf
+++ b/deploy/helm/container-cache/deploy/files/ngc.conf
@@ -50,8 +50,18 @@
           # Initialize upstream_last_modified to prevent warnings
           set $upstream_last_modified "";
 
-          # Override common 15s - 16MB chunks from NGC CDN can spike
-          proxy_read_timeout 30s;
+          # Overrides the 15s common default for the NGC CDN origin hop. This is
+          # an inactivity-between-reads timeout, so it bounds a CDN stall, not
+          # the total transfer.
+          #
+          # The previous comment here said "16MB chunks from NGC CDN can spike".
+          # That is no longer the request profile: NGC CLI 4.20.1 issues 512MiB
+          # Range requests (measured on oci-lhr-ct2, dominant span 536870912
+          # bytes). Left at 30s because reads flow continuously once a transfer
+          # starts, so this only trips on a genuine origin stall -- but it is now
+          # configurable so it can be raised without a chart release if the CDN's
+          # first-byte latency for large ranges turns out to need it.
+          proxy_read_timeout {{ ($.Values.cache).originReadTimeout | default "30s" }};
 
 {{- if ($.Values.consistentHashRouting).enabled }}
           # Consistent-hash routing to the owner pod (see lua/cc-route.lua).

--- a/deploy/helm/container-cache/deploy/files/proxy-common.conf
+++ b/deploy/helm/container-cache/deploy/files/proxy-common.conf
@@ -131,8 +131,8 @@
         # lock_timeout covers p99 of observed 10GB fills (2026-07-06 logs: p50 707s,
         # p90 1142s, max ~1200s); a waiter that gives up mid-fill re-downloads from
         # origin, so this must outlast the slow tail, not the average.
-        proxy_cache_lock_timeout 1200s;
-        proxy_cache_lock_age 3600s;
+        proxy_cache_lock_timeout {{ ($.Values.cache).lockTimeout | default "1200s" }};
+        proxy_cache_lock_age {{ ($.Values.cache).lockAge | default "3600s" }};
 
         # Some extra settings to maximize cache hits and efficiency
         proxy_force_ranges on;

--- a/deploy/helm/container-cache/deploy/files/proxy-common.conf
+++ b/deploy/helm/container-cache/deploy/files/proxy-common.conf
@@ -174,8 +174,12 @@
           proxy_max_temp_file_size 0;
           # Fail over to the backup ordinal only before the response starts;
           # never retry mid-body on large transfers.
-          proxy_connect_timeout 2s;
-          proxy_read_timeout 30s;
+          proxy_connect_timeout {{ ($.Values.consistentHashRouting).relayConnectTimeout | default "2s" }};
+          # Waits for the owner's response HEADER. With proxy_cache_lock on, the
+          # owner emits no header until it has filled the object, so this must
+          # exceed a worst-case cold fill of the largest object a client
+          # Range-requests. See consistentHashRouting.relayReadTimeout.
+          proxy_read_timeout {{ ($.Values.consistentHashRouting).relayReadTimeout | default "300s" }};
           proxy_next_upstream error timeout;
           proxy_pass https://$cc_owner;
         }

--- a/deploy/helm/container-cache/deploy/values.yaml
+++ b/deploy/helm/container-cache/deploy/values.yaml
@@ -146,6 +146,26 @@ proxyService:
 # Disabled by default: behavior is identical to today.
 consistentHashRouting:
   enabled: false
+  # How long the relay waits for the owner pod's RESPONSE HEADER before giving
+  # up and failing over (proxy_read_timeout on @cc_relay). This is an
+  # inactivity-between-reads timeout, not a total transfer deadline.
+  #
+  # Sizing: on a cold cache the owner holds the cache lock while it fills the
+  # object from origin, and emits no header until it has something to send. So
+  # this must exceed a worst-case cold fill for the largest object a client
+  # requests, or followers time out and return 504 to the client while the
+  # owner is still working normally.
+  #
+  # 30s was sized for ~16MB chunks. NGC CLI 4.20.1 issues 512MiB Range
+  # requests, and a cold fill of one of those against a cache that is at its
+  # min_free eviction watermark can take minutes. 300s covers that while
+  # staying well under proxy_cache_lock_timeout (1200s), so a genuinely stuck
+  # owner still fails over rather than hanging the client for the full lock.
+  relayReadTimeout: 300s
+  # How long the relay waits to establish the TCP/TLS connection to the owner.
+  # Owner pods are in-cluster peers, so this stays short: a slow connect means
+  # the owner is down, and failing over fast is correct.
+  relayConnectTimeout: 2s
 
 # Metrics configuration.
 metrics:

--- a/deploy/helm/container-cache/deploy/values.yaml
+++ b/deploy/helm/container-cache/deploy/values.yaml
@@ -37,6 +37,20 @@ images:
 cache:
   # Size for storing cache keys.
   keyStorageSize: 50m
+  # How long a waiter blocks for the in-flight fill of the same key before it
+  # gives up and fetches from origin itself (proxy_cache_lock_timeout).
+  #
+  # Sized for the slowest expected upstream fetch, not the average: a waiter that
+  # gives up mid-fill re-downloads from origin. Observed 10GB fills (2026-07-06)
+  # were p50 707s, p90 1142s, max ~1200s, hence the default.
+  #
+  # Keep consistentHashRouting.relayReadTimeout consistent with this: the relay
+  # waits on exactly this mechanism, so a relay timeout well below lockTimeout
+  # means followers 504 while the owner is still filling normally.
+  lockTimeout: 1200s
+  # How long an existing cache entry may be "being filled" before another request
+  # is allowed to start its own fill (proxy_cache_lock_age).
+  lockAge: 3600s
   # Period a resource can remain in cache without being accessed.
   # Immutable blobs (SHA256-addressed) are safe to keep long; disk pressure
   # is handled by the min_free watermark (persistentVolumeClaim.freeProxyPct),

--- a/deploy/helm/container-cache/deploy/values.yaml
+++ b/deploy/helm/container-cache/deploy/values.yaml
@@ -51,6 +51,10 @@ cache:
   # How long an existing cache entry may be "being filled" before another request
   # is allowed to start its own fill (proxy_cache_lock_age).
   lockAge: 3600s
+  # Read timeout on the NGC CDN origin hop (ngc.conf). Inactivity-between-reads,
+  # so it bounds an origin stall rather than the total transfer. Raise only if
+  # the CDN's first-byte latency for large Range requests proves to need it.
+  originReadTimeout: 30s
   # Period a resource can remain in cache without being accessed.
   # Immutable blobs (SHA256-addressed) are safe to keep long; disk pressure
   # is handled by the min_free watermark (persistentVolumeClaim.freeProxyPct),


### PR DESCRIPTION
## Problem

The consistent-hash owner relay hardcodes `proxy_read_timeout 30s`:

```nginx
location @cc_relay {
  proxy_connect_timeout 2s;
  proxy_read_timeout 30s;
  proxy_next_upstream error timeout;
}
```

That is an inactivity-between-reads timeout on the owner's **response header**. With `proxy_cache_lock on`, the owner emits no header until it has filled the object — so on a cold cache the relay abandons the request while the owner is still working normally, and the client gets a 504.

The 30s figure was sized for ~16MB chunks (per the comment on the `ngc` block). **NGC CLI 4.20.1 issues 512MiB Range requests** — 32× larger. Measured from the proxy access log on `nvcf-dgxc-k8s-oci-lhr-ct2`, the dominant range span is `536870912` bytes, 4238 occurrences.

Meanwhile `proxy_cache_lock_timeout` is `1200s`. The relay gives up 40× sooner than the lock it is waiting behind — those two numbers were never reconciled.

## Observed impact

QA validation of a cold NGC model download (~930GB, 230 files) failed on **both** clouds:

| cluster | case | route | result | progress |
|---|---|---|---|---|
| aws-use1-dev1 | 1 | proxy, cold | **FAILED** | 99.42% |
| aws-use1-dev1 | 2 | direct | SUCCEEDED | 100% |
| aws-use1-dev1 | 3 | proxy, warm | SUCCEEDED | 100% |
| oci-lhr-ct2 | 1 | proxy, cold | **FAILED** | 98.53% |
| oci-lhr-ct2 | 2 | direct | SUCCEEDED | 100% |
| oci-lhr-ct2 | 3 | proxy, warm | SUCCEEDED | 100% |

All four Case-1 workers exited NGC CLI with code 3 near completion. Proxy logs for the OCI window show **427 upstream timeouts** — 424 of them `while reading response header from upstream` — and 63 client-facing errors (60×504, 3×502), *all* with `proxy_host=cc_owner_{0,1,2}`. Direct and warm-cache controls succeed, isolating the failure to this relay hop.

## Change

```yaml
consistentHashRouting:
  enabled: false
  relayReadTimeout: 300s     # new
  relayConnectTimeout: 2s    # new
```

`300s` sits well above a cold fill of a 512MiB object while staying well under `proxy_cache_lock_timeout` (1200s), so a genuinely wedged owner still fails over rather than hanging the client for the full lock duration.

**300s is not a measured worst case.** Every failing request was killed *at* the 30s limit, so the observed latencies are right-censored — we know they exceeded 30s, not by how much. Making the value configurable is what allows retuning per cluster without a chart release, and is the substantive half of this PR.

`relayConnectTimeout` stays 2s and is exposed only for symmetry: owner pods are in-cluster peers, so a slow connect means the owner is down and fast failover is correct.

## This addresses the symptom, not the trigger

Evidence points at owner-side storage stalls under **cache eviction pressure**:

- `freeProxyPct: 15` ⇒ `min_free=45g` on a 300Gi volume ⇒ eviction starts at 85% full
- `nvcf-container-cache-1` measured at **84.9%** — sitting exactly on the trigger
- and that pod had the most timeouts: **164**, vs 142 and 121

With `use_temp_path=off` the owner writes 512MiB objects straight into the cache tree while the cache manager force-evicts to hold 45GiB free. No `no space` errors appear — it stalls rather than fails. Cache headroom (`freeProxyPct` or PVC size) should be addressed separately; raising the timeout alone widens the window without removing the pathology.

This also narrows the QA report's open question of whether the delayed header is dominated by origin latency, lock waiting, or owner I/O: `proxy_connect_timeout 2s` succeeds while the header times out, so the owner is reachable and accepting — it is blocking before first byte.

## Testing

- `helm template` renders `300s`/`2s` by default and honours `--set` overrides
- `tests/render-consistent-hash-test.sh` passes (all 6 assertions)
- No behaviour change when `consistentHashRouting.enabled=false` (still a pure no-op)

## Related

- Bug 6383237 — parent NGC model caching / consistent-hash owner-routing work. The relay path only exists because of that change, so this is most likely a regression from it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved container cache relay reliability with configurable connection and response timeouts.
  * Added sensible defaults for fast in-cluster connections and longer cold-cache responses.
  * Replaced fixed response timeouts with configurable deployment settings, including origin response handling.
  * Added configurable cache lock timeout and lock age settings while preserving existing defaults.
  * Updated timeout guidance to clarify behavior for large range requests and in-flight cache fills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->