### PR TITLE
fix(llm-api-gateway): accept uppercase UUID function ids in model prefix

### DIFF
--- a/src/invocation-plane-services/llm-api-gateway/api/BUILD.bazel
+++ b/src/invocation-plane-services/llm-api-gateway/api/BUILD.bazel
@@ -88,6 +88,7 @@ go_test(
         "priority_guard_test.go",
         "rate_limit_accounting_test.go",
         "responses_handler_test.go",
+        "routing_key_case_test.go",
         "session_affinity_test.go",
         "token_count_test.go",
     ],

--- a/src/invocation-plane-services/llm-api-gateway/api/model_ids.go
+++ b/src/invocation-plane-services/llm-api-gateway/api/model_ids.go
@@ -21,10 +21,13 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/google/uuid"
 	echo "github.com/labstack/echo/v4"
 
 	"github.com/NVIDIA/nvcf/src/invocation-plane-services/llm-gateway/requestctx"
 )
+
+const canonicalUUIDLength = 36
 
 func splitOpenAIModelID(modelID string) (routingKey string, routedModel string, hasPrefix bool) {
 	if modelID == "" {
@@ -36,7 +39,23 @@ func splitOpenAIModelID(modelID string) (routingKey string, routedModel string, 
 		return "", modelID, false
 	}
 
-	return routingKey, routedModel, true
+	return canonicalizeRoutingKey(routingKey), routedModel, true
+}
+
+// canonicalizeRoutingKey lowercases routing keys written as standard
+// hyphenated UUIDs. UUID hex digits are case-insensitive on input
+// (RFC 9562 section 4), but routing targets register under the lowercase
+// form, so mixed-case keys must be canonicalized before auth and routing.
+// Non-UUID routing keys are opaque and pass through unchanged.
+func canonicalizeRoutingKey(routingKey string) string {
+	if len(routingKey) != canonicalUUIDLength {
+		return routingKey
+	}
+	parsed, err := uuid.Parse(routingKey)
+	if err != nil {
+		return routingKey
+	}
+	return parsed.String()
 }
 
 func routingKeyFromOpenAIModelID(modelID string) string {

--- a/src/invocation-plane-services/llm-api-gateway/api/model_ids_test.go
+++ b/src/invocation-plane-services/llm-api-gateway/api/model_ids_test.go
@@ -24,6 +24,65 @@ import (
 	"github.com/NVIDIA/nvcf/src/invocation-plane-services/llm-gateway/requestctx"
 )
 
+func TestSplitOpenAIModelIDCanonicalizesUUIDRoutingKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		modelID        string
+		wantRoutingKey string
+		wantModel      string
+	}{
+		{
+			name:           "uppercase uuid lowercased",
+			modelID:        "3F2B1C4D-5E6A-4B7C-8D9E-0A1B2C3D4E5F/company-name/model-name",
+			wantRoutingKey: "3f2b1c4d-5e6a-4b7c-8d9e-0a1b2c3d4e5f",
+			wantModel:      "company-name/model-name",
+		},
+		{
+			name:           "mixed case uuid lowercased",
+			modelID:        "3f2b1c4d-5E6A-4b7c-8D9E-0a1b2c3d4e5f/company-name/model-name",
+			wantRoutingKey: "3f2b1c4d-5e6a-4b7c-8d9e-0a1b2c3d4e5f",
+			wantModel:      "company-name/model-name",
+		},
+		{
+			name:           "lowercase uuid unchanged",
+			modelID:        "3f2b1c4d-5e6a-4b7c-8d9e-0a1b2c3d4e5f/company-name/model-name",
+			wantRoutingKey: "3f2b1c4d-5e6a-4b7c-8d9e-0a1b2c3d4e5f",
+			wantModel:      "company-name/model-name",
+		},
+		{
+			name:           "opaque routing key passes through",
+			modelID:        "Fn-Alpha/company-name/model-name",
+			wantRoutingKey: "Fn-Alpha",
+			wantModel:      "company-name/model-name",
+		},
+		{
+			name:           "36-char non-uuid key passes through",
+			modelID:        "abcdefghijklmnopqrstuvwxyz0123456789/model",
+			wantRoutingKey: "abcdefghijklmnopqrstuvwxyz0123456789",
+			wantModel:      "model",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			routingKey, routedModel, hasPrefix := splitOpenAIModelID(tc.modelID)
+			if !hasPrefix {
+				t.Fatalf("hasPrefix = false, want true")
+			}
+			if routingKey != tc.wantRoutingKey {
+				t.Fatalf("routing key = %q, want %q", routingKey, tc.wantRoutingKey)
+			}
+			if routedModel != tc.wantModel {
+				t.Fatalf("routed model = %q, want %q", routedModel, tc.wantModel)
+			}
+		})
+	}
+}
+
 func TestSetRoutingMethodForModelForwardsTrimmedAuthValue(t *testing.T) {
 	t.Parallel()
 

--- a/src/invocation-plane-services/llm-api-gateway/api/routing_key_case_test.go
+++ b/src/invocation-plane-services/llm-api-gateway/api/routing_key_case_test.go
@@ -1,0 +1,113 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	echo "github.com/labstack/echo/v4"
+
+	"github.com/NVIDIA/nvcf/src/invocation-plane-services/llm-gateway/config"
+	"github.com/NVIDIA/nvcf/src/invocation-plane-services/llm-gateway/nvcf"
+	"github.com/NVIDIA/nvcf/src/invocation-plane-services/llm-gateway/provider"
+)
+
+// echoingInvocationAuthClient mimics the invocation auth RPC, which parses the
+// routing key as a UUID (accepting either hex case) and echoes the
+// caller-supplied routing key back verbatim.
+type echoingInvocationAuthClient struct{}
+
+func (echoingInvocationAuthClient) AuthorizeInvocation(
+	_ context.Context,
+	_ string,
+	routingKey string,
+) (*nvcf.InvocationAuthResponse, error) {
+	return &nvcf.InvocationAuthResponse{
+		RoutingKey:   routingKey,
+		ClientAuthID: "subject-123",
+		RateLimitKey: "nca-456",
+	}, nil
+}
+
+// TestChatCompletionsRoutingKeyUUIDCaseInsensitive covers a request whose model
+// prefix is a UUID written in uppercase. RFC 9562 section 4 makes UUID hex
+// digits case-insensitive on input, but routing targets register under the
+// lowercase form, so the gateway must canonicalize the routing key before
+// routing. Without that, the uppercase spelling is rejected upstream while the
+// lowercase spelling succeeds.
+func TestChatCompletionsRoutingKeyUUIDCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	const canonicalKey = "3f2b1c4d-5e6a-4b7c-8d9e-0a1b2c3d4e5f"
+
+	// Stand-in router: only the registered lowercase routing key has a target.
+	// Any other key gets a 400 with an empty body, which the gateway surfaces
+	// to the caller as the bare message "Bad Request".
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Routing-Key") != canonicalKey {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `data: {"id":"chatcmpl-case","object":"chat.completion.chunk","created":123,"model":"company-name/model-name","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":"stop"}]}`+"\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	stargateProvider, err := provider.NewStargateProvider(config.StargateConfig{URL: upstream.URL})
+	if err != nil {
+		t.Fatalf("new stargate provider: %v", err)
+	}
+
+	cfg := config.Default()
+	e := echo.New()
+	e.Use(NewContextMiddleware(cfg))
+	e.Use(NewNVCFAuthMiddleware(echoingInvocationAuthClient{}))
+	RegisterRoutes(e, NewHandlers(cfg, stargateProvider, nil))
+
+	for _, tc := range []struct {
+		name  string
+		model string
+	}{
+		{"lowercase uuid", canonicalKey + "/company-name/model-name"},
+		{"uppercase uuid", strings.ToUpper(canonicalKey) + "/company-name/model-name"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := fmt.Sprintf(
+				`{"model":%q,"messages":[{"role":"user","content":"hi"}]}`,
+				tc.model,
+			)
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			req.Header.Set(echo.HeaderAuthorization, "Bearer sk-live")
+			rec := httptest.NewRecorder()
+
+			e.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## TL;DR

A function id written in uppercase was rejected with `400 Bad Request`, while
the same id in lowercase worked. The gateway now lowercases the routing key
when it is a standard UUID, so both spellings reach the same function.

## Additional Details

The `model` field carries a function id prefix, for example
`<function-id>/<model>`, and the gateway used that prefix verbatim as the
routing key. UUID hex digits are case-insensitive on input per RFC 9562
section 4, but routing targets register under the lowercase form. The two
spellings therefore became two different keys, and the uppercase one matched
no target.

The fix sits in `splitOpenAIModelID`, which every endpoint that accepts a
model prefix already calls, so chat completions, responses, embeddings and the
audio endpoints are covered by one change. Routing keys that are not UUIDs are
left alone, since their case may be meaningful.

The upstream rejection reached the caller as the bare message `Bad Request`
because the gateway falls back to the HTTP status text when an upstream error
body is empty. Giving that case a clearer message is worth a follow-up and is
not part of this change.

## For the Reviewer

The part worth a close look is the guard in `canonicalizeRoutingKey`.

## For QA

`go test ./...` passes in `src/invocation-plane-services/llm-api-gateway`. The
new route-level test drives a request whose only difference is the case of the
function id, and asserts both spellings succeed.

QA is worth doing on a deployed environment: repeat the original request with
the function id in uppercase and confirm it now resolves.

## Issues

Related to NVBUG-6557727

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - OpenAI model routing now treats UUID-based routing keys consistently, regardless of uppercase or lowercase characters.
  - Non-UUID routing keys continue to be handled without modification.
  - Chat completion requests now route successfully with UUID prefixes in either case.

- **Tests**
  - Added coverage for UUID normalization and case-insensitive routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->