### PR TITLE
chore(codeowners): assign BYOO tooling ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@
 /.github/workflows/ @NVIDIA/nvcf-ci-dev
 /ci/ @NVIDIA/nvcf-ci-dev
 /tools/ @NVIDIA/nvcf-ci-dev
+/tools/byoo/** @NVIDIA/nvcf-compute-plane-dev
 
 # Documentation.
 /docs/ @NVIDIA/nvcf-docs-dev


### PR DESCRIPTION
## TL;DR

Assign CODEOWNERS for `tools/byoo/**` to the compute-plane developer team.

## Additional Details

The broad `/tools/` rule assigns tooling to the CI developer team. A later, scoped rule now routes BYOO tooling to the compute-plane developer team.

## For the Reviewer

Review the one-line CODEOWNERS override and its ordering after `/tools/`.

## For QA

Not needed. This is an ownership-routing change.

Validation: `git diff --check`.

## Issues

Closes #702

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] Existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added ownership rules for files under the compute-plane tools directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->