### PR TITLE
fix(nvca-operator): restore ngc-managed default and fix nil pointer on 3.0.x upgrade

### DIFF
--- a/deploy/helm/nvca-operator/nvca-operator/templates/self-managed-nvcfbackend-cm.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/templates/self-managed-nvcfbackend-cm.yaml
@@ -18,8 +18,8 @@ metadata:
   name: nvcfbackend-self-managed
   namespace: {{ .Release.Namespace }}
   {{- $releaseArtifactNvcaImageRepository := .Values.nvcaImage.repositoryOverride }}
-  {{- $releaseArtifactImageCredentialHelperRepository := .Values.selfManaged.imageCredHelper.imageRepository }}
-  {{- $releaseArtifactSambaRepository := .Values.selfManaged.sharedStorage.imageRepository }}
+  {{- $releaseArtifactImageCredentialHelperRepository := (.Values.selfManaged.imageCredHelper | default dict).imageRepository }}
+  {{- $releaseArtifactSambaRepository := (.Values.selfManaged.sharedStorage | default dict).imageRepository }}
   {{- if or $releaseArtifactNvcaImageRepository $releaseArtifactImageCredentialHelperRepository $releaseArtifactSambaRepository }}
   annotations:
     {{- if $releaseArtifactNvcaImageRepository }}

--- a/deploy/helm/nvca-operator/nvca-operator/values.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/values.yaml
@@ -241,7 +241,7 @@ webhook:
 ## @param ngcConfig.clusterSource Source of the cluster configuration:
 ##     - "ngc-managed": Cluster configuration managed by NGC (default)
 ##     - "helm-managed": Cluster configuration managed by the Helm chart
-##     - "self-managed": Cluster configuration managed by the self-hosted control plane
+##     - "self-managed": Cluster configuration managed by the self-hosted compute plane
 ngcConfig:
   username: '$oauthtoken'
   serviceKey: "dummy-api-key"

--- a/deploy/helm/nvca-operator/nvca-operator/values.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/values.yaml
@@ -239,15 +239,16 @@ webhook:
 ## @param ngcConfig.serviceKeySecretKeyName Key in the secret ngcConfig.serviceKeySecretName containing the NGC ServiceKey (password).
 ## @param ngcConfig.apiURL NGC API URL for requesting auth tokens
 ## @param ngcConfig.clusterSource Source of the cluster configuration:
-##     - "helm-managed": Cluster configuration managed by the helm chart
-##     - "ngc-managed": Cluster configuration managed by NGC
+##     - "ngc-managed": Cluster configuration managed by NGC (default)
+##     - "helm-managed": Cluster configuration managed by the Helm chart
+##     - "self-managed": Cluster configuration managed by the self-hosted control plane
 ngcConfig:
   username: '$oauthtoken'
   serviceKey: "dummy-api-key"
   serviceKeySecretName: "ngc-service-key"
   serviceKeySecretKeyName: "ngcServiceKey"
   apiURL: https://api.ngc.nvidia.com
-  clusterSource: self-managed
+  clusterSource: ngc-managed
 ## @section Vault Configuration
 ## @param vaultConfig.oAuthClientMountPathTemplate Template for constructing the OAuth client mount path in Vault. Use %s as placeholder for clientID. Example: "nvidia/services/oauth/clients/%s/kv/secret"
 ## @param vaultConfig.oAuthClientMountPath (Optional) Full OAuth client mount path. If set, overrides the computed path from template.

--- a/deploy/helm/nvca-operator/scripts/ci_vendor_nvca_operator_chart
+++ b/deploy/helm/nvca-operator/scripts/ci_vendor_nvca_operator_chart
@@ -199,7 +199,7 @@ main() {
 
     # Default various values so chart works OOTB
     echo "🔧 [vendor] Defaulting various values so chart works OOTB..."
-    update_yaml_key ".ngcConfig.clusterSource = \"self-managed\"" "${TARGET_DIR}/values.yaml"
+    update_yaml_key ".ngcConfig.clusterSource = \"ngc-managed\"" "${TARGET_DIR}/values.yaml"
     update_yaml_key ".ngcConfig.serviceKey = \"dummy-api-key\"" "${TARGET_DIR}/values.yaml"
     update_yaml_key ".image.tag = \"${NVCA_OPERATOR_VERSION:?"NVCA_OPERATOR_VERSION is not set"}\"" "${TARGET_DIR}/values.yaml"
     update_yaml_key ".selfManaged.nvcaVersion = \"${NVCA_VERSION:?"NVCA_VERSION is not set"}\"" "${TARGET_DIR}/values.yaml"

--- a/deploy/helm/nvca-operator/tests/cluster_source_defaults_test.sh
+++ b/deploy/helm/nvca-operator/tests/cluster_source_defaults_test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+
+manifest_ngc_managed="${tmp_dir}/manifest-ngc-managed.yaml"
+manifest_self_managed="${tmp_dir}/manifest-self-managed.yaml"
+
+# Render with default values (ngc-managed)
+helm template nvca-operator "${repo_root}/nvca-operator" \
+  --namespace nvca-operator \
+  --values "${repo_root}/nvca-operator/values.yaml" \
+  > "${manifest_ngc_managed}"
+
+# Render with self-managed clusterSource
+helm template nvca-operator "${repo_root}/nvca-operator" \
+  --namespace nvca-operator \
+  --values "${repo_root}/nvca-operator/values.yaml" \
+  --set-string ngcConfig.clusterSource=self-managed \
+  --set-string selfManaged.icmsServiceURL=http://icms.example.invalid:8080 \
+  --set-string selfManaged.revalServiceURL=http://reval.example.invalid:8080 \
+  --set-string selfManaged.natsURL=nats://nats.example.invalid:4222 \
+  > "${manifest_self_managed}"
+
+# --- ngc-managed assertions ---
+
+cluster_source_ngc="$(
+  yq -r 'select(.kind == "Deployment" and .metadata.name == "nvca-operator") |
+    .spec.template.spec.containers[] | select(.name == "nvca-operator") |
+    .env[] | select(.name == "NVCA_CLUSTER_SOURCE") | .value' \
+    "${manifest_ngc_managed}"
+)"
+if [[ "${cluster_source_ngc}" != "ngc-managed" ]]; then
+  echo "expected NVCA_CLUSTER_SOURCE=ngc-managed in default render, got '${cluster_source_ngc}'" >&2
+  exit 1
+fi
+
+helm_managed_data_ngc="$(
+  yq -r 'select(.kind == "ConfigMap" and .metadata.name == "nvcfbackend-helm-managed") | .data // {} | length' \
+    "${manifest_ngc_managed}"
+)"
+if [[ "${helm_managed_data_ngc}" != "0" ]]; then
+  echo "expected nvcfbackend-helm-managed to have empty data for ngc-managed, got ${helm_managed_data_ngc} keys" >&2
+  exit 1
+fi
+
+self_managed_data_ngc="$(
+  yq -r 'select(.kind == "ConfigMap" and .metadata.name == "nvcfbackend-self-managed") | .data // {} | length' \
+    "${manifest_ngc_managed}"
+)"
+if [[ "${self_managed_data_ngc}" != "0" ]]; then
+  echo "expected nvcfbackend-self-managed to have empty data for ngc-managed, got ${self_managed_data_ngc} keys" >&2
+  exit 1
+fi
+
+# --- self-managed assertions ---
+
+cluster_source_sm="$(
+  yq -r 'select(.kind == "Deployment" and .metadata.name == "nvca-operator") |
+    .spec.template.spec.containers[] | select(.name == "nvca-operator") |
+    .env[] | select(.name == "NVCA_CLUSTER_SOURCE") | .value' \
+    "${manifest_self_managed}"
+)"
+if [[ "${cluster_source_sm}" != "self-managed" ]]; then
+  echo "expected NVCA_CLUSTER_SOURCE=self-managed in self-managed render, got '${cluster_source_sm}'" >&2
+  exit 1
+fi
+
+self_managed_data_sm="$(
+  yq -r 'select(.kind == "ConfigMap" and .metadata.name == "nvcfbackend-self-managed") | .data // {} | length' \
+    "${manifest_self_managed}"
+)"
+if [[ "${self_managed_data_sm}" == "0" ]]; then
+  echo "expected nvcfbackend-self-managed to have data for self-managed render, got empty" >&2
+  exit 1
+fi
+
+helm_managed_data_sm="$(
+  yq -r 'select(.kind == "ConfigMap" and .metadata.name == "nvcfbackend-helm-managed") | .data // {} | length' \
+    "${manifest_self_managed}"
+)"
+if [[ "${helm_managed_data_sm}" != "0" ]]; then
+  echo "expected nvcfbackend-helm-managed to have empty data for self-managed, got ${helm_managed_data_sm} keys" >&2
+  exit 1
+fi
+
+echo "clusterSource defaults: ngc-managed renders NVCA_CLUSTER_SOURCE=ngc-managed with empty config maps; self-managed renders NVCA_CLUSTER_SOURCE=self-managed with populated nvcfbackend-self-managed"

--- a/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
+++ b/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
@@ -110,6 +110,8 @@ releases:
         imagePullSecrets:
         {{- toYaml .Values.global.imagePullSecrets | nindent 10 }}
         {{- end }}
+        ngcConfig:
+          clusterSource: self-managed
         clusterName: {{ requiredEnv "CLUSTER_NAME" }}
         ncaId: {{ requiredEnv "NCA_ID" }}
         {{- $selfManaged := dig "nvcaOperator" "selfManaged" dict .Values.global }}

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/values.yaml
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/values.yaml
@@ -259,7 +259,7 @@ webhook:
 ## @param ngcConfig.clusterSource Source of the cluster configuration:
 ##     - "ngc-managed": Cluster configuration managed by NGC (default)
 ##     - "helm-managed": Cluster configuration managed by the Helm chart
-##     - "self-managed": Cluster configuration managed by the self-hosted control plane
+##     - "self-managed": Cluster configuration managed by the self-hosted compute plane
 ngcConfig:
   username: '$oauthtoken'
   serviceKey: ""

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/values.yaml
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/values.yaml
@@ -257,8 +257,9 @@ webhook:
 ## @param ngcConfig.serviceKeySecretKeyName Key in the secret ngcConfig.serviceKeySecretName containing the NGC ServiceKey (password).
 ## @param ngcConfig.apiURL NGC API URL for requesting auth tokens
 ## @param ngcConfig.clusterSource Source of the cluster configuration:
-##     - "helm-managed": Cluster configuration managed by the helm chart
-##     - "ngc-managed": Cluster configuration managed by NGC
+##     - "ngc-managed": Cluster configuration managed by NGC (default)
+##     - "helm-managed": Cluster configuration managed by the Helm chart
+##     - "self-managed": Cluster configuration managed by the self-hosted control plane
 ngcConfig:
   username: '$oauthtoken'
   serviceKey: ""


### PR DESCRIPTION
## Why

Two bugs in the nvca-operator 3.1.0 chart prevented successful NGC-managed installation and upgrade from 3.0.x:

**Bug 1 - Wrong clusterSource default (blocking NGC-managed installs)**

The 3.1.0 vendoring script changed `ngcConfig.clusterSource` from `ngc-managed` to `self-managed`. NGC UI-generated install commands do not include `--set ngcConfig.clusterSource=...`, so any cluster installed using the NGC UI with the 3.1.0 chart ends up in self-managed mode and the NVCA agent never registers.

**Bug 2 - Nil pointer crash on upgrade from 3.0.x (all cluster types)**

`self-managed-nvcfbackend-cm.yaml` evaluates `.Values.selfManaged.imageCredHelper.imageRepository` and `.Values.selfManaged.sharedStorage.imageRepository` in the ConfigMap metadata block. This block runs unconditionally for every cluster type, before the `clusterSource` guard on line 37. Both `imageCredHelper` and `sharedStorage` were added as sub-keys in 3.1.0. When upgrading from 3.0.x with `--reuse-values`, these keys are absent from stored values, making their parent maps nil. Accessing `.imageRepository` on a nil interface panics:
```
nil pointer evaluating interface {}.imageRepository
```

## What changed

- `deploy/helm/nvca-operator/scripts/ci_vendor_nvca_operator_chart`: restore `ngcConfig.clusterSource = "ngc-managed"` (reverts accidental change to `"self-managed"`)
- `deploy/helm/nvca-operator/nvca-operator/values.yaml`: restore `clusterSource: ngc-managed` and update comment to list all three valid values
- `src/compute-plane-services/nvca/deployments/nvca-operator/values.yaml`: same source chart update
- `deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl`: add explicit `ngcConfig.clusterSource: self-managed` so self-hosted stack installs continue to work with the restored default
- `deploy/helm/nvca-operator/nvca-operator/templates/self-managed-nvcfbackend-cm.yaml`: use `| default dict` before accessing `.imageRepository` on `selfManaged.imageCredHelper` and `selfManaged.sharedStorage` to guard against nil parents on upgrade

## Customer Release Notes

Fixes helm upgrade from nvca-operator 3.0.x to 3.1.0 crashing with "nil pointer evaluating interface {}.imageRepository" on all cluster types. Fixes NGC-managed clusters failing to register the NVCA agent after installing nvca-operator 3.1.0 via NGC UI.

## Plan Summary

Not applicable.

## Usage

No operator change required. After this fix, `helm upgrade` from 3.0.x to 3.1.0 and NGC UI install commands work without additional flags.

## Testing

- `helm lint` passes with nil `selfManaged.imageCredHelper` and `selfManaged.sharedStorage`
- `helm template` with `--set selfManaged.imageCredHelper=null --set selfManaged.sharedStorage=null` renders without error
- Verified `clusterSource: ngc-managed` is the new default in both the vendored and source chart

QA should validate:
- Helm upgrade from nvca-operator 3.0.x to 3.1.0 on an NGC-managed cluster
- Fresh NGC UI install on an NGC-managed cluster (no explicit `clusterSource` flag)
- Self-managed stack helmfile install (`make install` from `deploy/stacks/nvcf-compute-plane`)

## Notes

The self-managed stack helmfile now explicitly sets `ngcConfig.clusterSource: self-managed`, making the install independent of the chart default.

## References

Closes #704

## Related Pull Requests

None.

## Dependencies

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearly defined cluster source modes for NGC-managed, Helm-managed, and self-managed deployments.
  - Self-managed compute plane deployments now explicitly select the self-managed mode.
  - The default cluster source is now NGC-managed.

- **Bug Fixes**
  - Improved handling when image credential helper or shared storage settings are omitted.

- **Documentation**
  - Updated cluster source descriptions, ordering, defaults, and terminology for greater clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->