### PR TITLE
feat(release): register nvcf-ui as a releasable subproject

### DIFF
--- a/tools/ci/github-release-subprojects.json
+++ b/tools/ci/github-release-subprojects.json
@@ -272,6 +272,11 @@
       "id": "instance-cluster-management",
       "path": "src/control-plane-services/instance-cluster-management",
       "service_name": "nvcf-instance-cluster-management"
+    },
+    {
+      "id": "nvcf-ui",
+      "path": "src/uis/nvcf-ui",
+      "service_name": "nvcf-ui"
     }
   ]
 }


### PR DESCRIPTION
## Why
`nvcf-ui` has a Bazel matrix row but no entry in
`tools/ci/github-release-subprojects.json`, so `github-release auto` never
considers it and no `src/uis/nvcf-ui/v*` tag is ever cut. Without a tag the
release lane in nvcf-internal !122 can never fire.

## What changed
One entry, 5 lines. `default_tag_format` then yields `src/uis/nvcf-ui/v`, which
is exactly the `tag_prefix` nvcf-internal !122 was written against.

Worth knowing: this file's `generated_by` header is stale.
`tools/generate-subproject-ci` and `tools/ci/subproject-validations.yaml` are no
longer in the repo, so it is hand-maintained. I checked before assuming a regen
was needed.

## Testing
`python3 tools/ci/test-github-release.py` — 20/20 pass. Loaded `github-release`
directly and confirmed the new entry resolves:

```
tag_format    src/uis/nvcf-ui/v${version}
tag_prefix    src/uis/nvcf-ui/v
tag for 0.1.0 src/uis/nvcf-ui/v0.1.0
```

Not exercised: an actual release run, which needs `src/uis/nvcf-ui` on main.

## Notes
Merge after #662 — the path does not exist on main until the UI import lands.
Pairs with nvcf-internal !122, which consumes the tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the `nvcf-ui` service to automated GitHub release configuration.
  * Releases for the service can now be associated with its repository and release service name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->