### PR TITLE
feat(nvca): default self-managed BYOO collector

### DIFF
--- a/deploy/helm/nvca-operator/nvca-operator/values.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/values.yaml
@@ -186,7 +186,8 @@ agent:
   ##     INIT_CONTAINER: "nvcr.io/qtfpt1h0bieu/nvcf-core/nvcf_worker_init:2.97.2"
   ##     UTILS_CONTAINER: "nvcr.io/qtfpt1h0bieu/nvcf-core/nvcf_worker_utils:2.94.0"
   ##     ESS_AGENT_CONTAINER: "nvcr.io/qtfpt1h0bieu/nvcf-core/ess-agent:1.0.5"
-  functionEnvOverrides: {}
+  functionEnvOverrides:
+    BYOO_OTEL_COLLECTOR_CONTAINER: nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector:0.157.11
   ## Environment variable overrides for task workloads.
   ## Available keys: INIT_CONTAINER, UTILS_CONTAINER, OTEL_CONTAINER, BYOO_OTEL_COLLECTOR_CONTAINER,
   ##                 ESS_AGENT_CONTAINER, TASK_CONTAINER
@@ -194,7 +195,8 @@ agent:
   ##   taskEnvOverrides:
   ##     INIT_CONTAINER: "nvcr.io/qtfpt1h0bieu/nvcf-core/nvcf_worker_init:2.97.2"
   ##     UTILS_CONTAINER: "nvcr.io/qtfpt1h0bieu/nvcf-core/nvcf_worker_utils:2.94.0"
-  taskEnvOverrides: {}
+  taskEnvOverrides:
+    BYOO_OTEL_COLLECTOR_CONTAINER: nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector:0.157.11
   overrideEnvironmentVariables: {}
   serviceOAuth:
     helmReVal:

--- a/deploy/helm/nvca-operator/scripts/ci_vendor_nvca_operator_chart
+++ b/deploy/helm/nvca-operator/scripts/ci_vendor_nvca_operator_chart
@@ -174,6 +174,8 @@ main() {
         source "${root_dir}/.env"
     fi
 
+    byoo_otel_collector_image="${BYOO_OTEL_COLLECTOR_IMAGE:-nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector:0.157.11}"
+
     TARGET_DIR="${root_dir}/nvca-operator"
     SOURCE_DIR="${root_dir}/../../../src/compute-plane-services/nvca/deployments/nvca-operator"
 
@@ -201,6 +203,8 @@ main() {
     echo "🔧 [vendor] Defaulting various values so chart works OOTB..."
     update_yaml_key ".ngcConfig.clusterSource = \"self-managed\"" "${TARGET_DIR}/values.yaml"
     update_yaml_key ".ngcConfig.serviceKey = \"dummy-api-key\"" "${TARGET_DIR}/values.yaml"
+    update_yaml_key ".agent.functionEnvOverrides.BYOO_OTEL_COLLECTOR_CONTAINER = \"${byoo_otel_collector_image}\"" "${TARGET_DIR}/values.yaml"
+    update_yaml_key ".agent.taskEnvOverrides.BYOO_OTEL_COLLECTOR_CONTAINER = \"${byoo_otel_collector_image}\"" "${TARGET_DIR}/values.yaml"
     update_yaml_key ".image.tag = \"${NVCA_OPERATOR_VERSION:?"NVCA_OPERATOR_VERSION is not set"}\"" "${TARGET_DIR}/values.yaml"
     update_yaml_key ".selfManaged.nvcaVersion = \"${NVCA_VERSION:?"NVCA_VERSION is not set"}\"" "${TARGET_DIR}/values.yaml"
     update_yaml_key ".selfManaged.icmsServiceURL = \"http://icms.example.invalid:8080\"" "${TARGET_DIR}/values.yaml"

--- a/deploy/helm/nvca-operator/scripts/render_release_supplemental_images.sh
+++ b/deploy/helm/nvca-operator/scripts/render_release_supplemental_images.sh
@@ -132,6 +132,39 @@ END {
 }
 ' "${input_manifest}" | sort -u > "${tmp_images}"
 
+while IFS= read -r encoded_overrides; do
+  if decoded_overrides="$(printf '%s' "$encoded_overrides" | base64 --decode 2>/dev/null)"; then
+    :
+  else
+    decoded_overrides="$(printf '%s' "$encoded_overrides" | base64 -D)"
+  fi
+
+  byoo_otel_collector_image="$(printf '%s' "$decoded_overrides" | sed -n 's/.*"BYOO_OTEL_COLLECTOR_CONTAINER"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+  case "$byoo_otel_collector_image" in
+    */*:*|*/*@*)
+      printf '%s\n' "$byoo_otel_collector_image" >> "$tmp_images"
+      ;;
+  esac
+done < <(
+  awk '
+    /-[[:space:]]+--(function|task)-env-overrides-b64$/ {
+      expect_value = 1
+      next
+    }
+    expect_value && /^[[:space:]]*-[[:space:]]*/ {
+      value = $0
+      sub(/^[[:space:]]*-[[:space:]]*/, "", value)
+      gsub(/^"/, "", value)
+      gsub(/"$/, "", value)
+      print value
+      expect_value = 0
+    }
+  ' "${input_manifest}"
+)
+
+sort -u "${tmp_images}" > "${tmp_images}.sorted"
+mv "${tmp_images}.sorted" "${tmp_images}"
+
 if [[ ! -s "${tmp_images}" ]]; then
   cat > "${output_manifest}" <<'EOF'
 apiVersion: v1

--- a/deploy/helm/nvca-operator/scripts/render_release_supplemental_images.sh
+++ b/deploy/helm/nvca-operator/scripts/render_release_supplemental_images.sh
@@ -132,19 +132,43 @@ END {
 }
 ' "${input_manifest}" | sort -u > "${tmp_images}"
 
+is_valid_image_reference() {
+  local image="$1"
+
+  [[ "${image}" =~ ^[a-z0-9][a-z0-9._-]*(:[0-9]+)?/[a-z0-9][a-z0-9._-]*(/[a-z0-9][a-z0-9._-]*)*(:[A-Za-z0-9_][A-Za-z0-9_.-]*(@[A-Za-z][A-Za-z0-9_+.-]*:[A-Fa-f0-9]+)?|@[A-Za-z][A-Za-z0-9_+.-]*:[A-Fa-f0-9]+)$ ]]
+}
+
 while IFS= read -r encoded_overrides; do
   if decoded_overrides="$(printf '%s' "$encoded_overrides" | base64 --decode 2>/dev/null)"; then
     :
+  elif decoded_overrides="$(printf '%s' "$encoded_overrides" | base64 -D 2>/dev/null)"; then
+    :
   else
-    decoded_overrides="$(printf '%s' "$encoded_overrides" | base64 -D)"
+    echo "invalid base64 environment overrides in rendered manifest" >&2
+    exit 1
   fi
 
-  byoo_otel_collector_image="$(printf '%s' "$decoded_overrides" | sed -n 's/.*"BYOO_OTEL_COLLECTOR_CONTAINER"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
-  case "$byoo_otel_collector_image" in
-    */*:*|*/*@*)
-      printf '%s\n' "$byoo_otel_collector_image" >> "$tmp_images"
-      ;;
-  esac
+  if ! printf '%s' "$decoded_overrides" | yq -e 'type == "!!map"' >/dev/null; then
+    echo "invalid JSON environment overrides in rendered manifest" >&2
+    exit 1
+  fi
+
+  if ! printf '%s' "$decoded_overrides" | yq -e 'has("BYOO_OTEL_COLLECTOR_CONTAINER")' >/dev/null; then
+    continue
+  fi
+
+  if ! printf '%s' "$decoded_overrides" | yq -e '.BYOO_OTEL_COLLECTOR_CONTAINER | type == "!!str"' >/dev/null; then
+    echo "BYOO_OTEL_COLLECTOR_CONTAINER must be a string" >&2
+    exit 1
+  fi
+
+  byoo_otel_collector_image="$(printf '%s' "$decoded_overrides" | yq -er '.BYOO_OTEL_COLLECTOR_CONTAINER')"
+  if ! is_valid_image_reference "$byoo_otel_collector_image"; then
+    echo "invalid BYOO_OTEL_COLLECTOR_CONTAINER image reference" >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$byoo_otel_collector_image" >> "$tmp_images"
 done < <(
   awk '
     /-[[:space:]]+--(function|task)-env-overrides-b64$/ {

--- a/deploy/helm/nvca-operator/tests/release_image_manifest_test.sh
+++ b/deploy/helm/nvca-operator/tests/release_image_manifest_test.sh
@@ -45,6 +45,8 @@ spec:
           args:
             - --function-env-overrides-b64
             - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTU3LjExIn0="
+            - --task-env-overrides-b64
+            - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTU3LjExIn0="
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -108,6 +110,39 @@ fi
 
 if ! grep -Fq "nvca-release-supplemental-images" "${supplemental_manifest}"; then
   echo "expected supplemental manifest to contain the synthetic Pod" >&2
+  exit 1
+fi
+
+invalid_manifest="${tmp_dir}/invalid-rendered.yaml"
+invalid_supplemental_manifest="${tmp_dir}/invalid-supplemental.yaml"
+invalid_output="${tmp_dir}/invalid-output.log"
+
+cat > "${invalid_manifest}" <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nvca-operator
+spec:
+  template:
+    spec:
+      containers:
+        - name: operator
+          args:
+            - --function-env-overrides-b64
+            - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6InJlcG8vaW1hZ2U6In0="
+EOF
+
+if "${repo_root}/scripts/render_release_supplemental_images.sh" \
+  "${invalid_manifest}" \
+  "${invalid_supplemental_manifest}" \
+  >"${invalid_output}" 2>&1; then
+  echo "expected invalid BYOO collector image reference to fail" >&2
+  exit 1
+fi
+
+if ! grep -Fq "invalid BYOO_OTEL_COLLECTOR_CONTAINER image reference" "${invalid_output}"; then
+  echo "expected invalid image reference error" >&2
+  cat "${invalid_output}" >&2
   exit 1
 fi
 

--- a/deploy/helm/nvca-operator/tests/release_image_manifest_test.sh
+++ b/deploy/helm/nvca-operator/tests/release_image_manifest_test.sh
@@ -42,6 +42,9 @@ spec:
           env:
             - name: NVCA_IMAGE_REPO
               value: "nvcr.io/nvidia/nvcf-byoc/nvca"
+          args:
+            - --function-env-overrides-b64
+            - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTU3LjExIn0="
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -86,6 +89,7 @@ expected_images=(
   "nvcr.io/nvidia/nvcf-byoc/nvcf-image-credential-helper:0.5.0"
   "nvcr.io/nvidia/nvcf-byoc/nvcf-otel-collector:0.143.2"
   "nvcr.io/nvidia/nvcf-byoc/samba:1.0.5"
+  "nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector:0.157.11"
 )
 
 for image in "${expected_images[@]}"; do
@@ -96,8 +100,8 @@ for image in "${expected_images[@]}"; do
 done
 
 line_count="$(wc -l < "${image_manifest}" | tr -d '[:space:]')"
-if [[ "${line_count}" != "5" ]]; then
-  echo "expected exactly 5 unique images, got ${line_count}" >&2
+if [[ "${line_count}" != "6" ]]; then
+  echo "expected exactly 6 unique images, got ${line_count}" >&2
   cat "${image_manifest}" >&2
   exit 1
 fi

--- a/deploy/helm/nvca-operator/tests/self_managed_nvca_image_reference_test.sh
+++ b/deploy/helm/nvca-operator/tests/self_managed_nvca_image_reference_test.sh
@@ -79,6 +79,18 @@ image_credential_helper_repository="$(yq -r '.selfManaged.imageCredHelper.imageR
 image_credential_helper_tag="$(yq -r '.selfManaged.imageCredHelper.imageTag' "${repo_root}/nvca-operator/values.yaml")"
 samba_repository="$(yq -r '.selfManaged.sharedStorage.imageRepository' "${repo_root}/values.release-sbom.yaml")"
 samba_tag="$(yq -r '.selfManaged.sharedStorage.imageTag' "${repo_root}/nvca-operator/values.yaml")"
+byoo_function_image="$(yq -r '.agent.functionEnvOverrides.BYOO_OTEL_COLLECTOR_CONTAINER' "${repo_root}/nvca-operator/values.yaml")"
+byoo_task_image="$(yq -r '.agent.taskEnvOverrides.BYOO_OTEL_COLLECTOR_CONTAINER' "${repo_root}/nvca-operator/values.yaml")"
+
+if [[ "${byoo_function_image}" != "${byoo_task_image}" ]]; then
+  echo "expected function and task BYOO collector defaults to match" >&2
+  exit 1
+fi
+
+if [[ "${byoo_function_image}" != "nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector:0.157.11" ]]; then
+  echo "unexpected BYOO collector default: ${byoo_function_image}" >&2
+  exit 1
+fi
 
 expected_annotations=(
   "release-artifact-nvca-image: \"${nvca_image_repository}:${nvca_version}\""


### PR DESCRIPTION
## TL;DR

- Default self-managed function and task workloads to BYOO collector 0.157.11.
- Include the indirectly injected collector image in the release SBOM inputs.

## Additional Details

- The vendoring overlay accepts `BYOO_OTEL_COLLECTOR_IMAGE` from local `.env` or CI.
- The pinned default keeps the packaged chart usable before release automation provides an override.
- The release image scanner decodes function and task environment overrides to collect the image.

## For the Reviewer

- Review the vendoring default and the SBOM supplemental-image extraction together.

## For QA

- `make lint`
- `make template`
- `make validate`
- Chart release asset test targets
- QA needed: No. This changes chart packaging defaults and release metadata only.

## Issues

Closes #719

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Github

Github commit:
feat(nvca): default self-managed BYOO collector

Default function and task workloads to BYOO 0.157.11 and include the injected
image in release SBOM inputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a default BYOO OpenTelemetry collector image for function and task workloads.
  - Release image manifests now automatically include the configured collector image.
  - Collector image settings can be customized through deployment environment overrides.

- **Bug Fixes**
  - Improved image discovery and validation across rendered deployment configurations.
  - Removed duplicate image entries from supplemental release manifests.
  - Invalid collector image references now produce a clear rendering failure.

- **Tests**
  - Added coverage verifying consistent collector image references and expected release image contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->