### PR TITLE
test(ess): bump local_env and integration-test Cassandra to 5

### DIFF
--- a/src/control-plane-services/ess/ess-core/src/test/java/com/nvidia/ess/testing/CustomCassandraContainer.java
+++ b/src/control-plane-services/ess/ess-core/src/test/java/com/nvidia/ess/testing/CustomCassandraContainer.java
@@ -29,7 +29,7 @@ public class CustomCassandraContainer implements Startable {
   // This means that we are not calling container.stop() anywhere explicitly.
   // However, ryuk container will be responsible for full cleanup of the testcontainers after all tests are run
 
-  private static final CassandraContainer cassandraContainer = new CassandraContainer(DockerImageName.parse("cassandra:4"))
+  private static final CassandraContainer cassandraContainer = new CassandraContainer(DockerImageName.parse("cassandra:5"))
       .withEnv("HEAP_NEWSIZE", "128M")
       .withEnv("MAX_HEAP_SIZE", "512M")
       .withInitScript(new ClassPathResource("local_env/cassandra/schema/schema.cql").getPath())

--- a/src/control-plane-services/ess/ess-encryption/src/test/java/com/nvidia/ess/encryption/testing/CustomCassandraContainer.java
+++ b/src/control-plane-services/ess/ess-encryption/src/test/java/com/nvidia/ess/encryption/testing/CustomCassandraContainer.java
@@ -27,7 +27,7 @@ public class CustomCassandraContainer implements Startable {
   // This means that we are not calling container.stop() anywhere explicitly.
   // However, ryuk container will be responsible for full cleanup of the testcontainers after all tests are run
 
-  private static final CassandraContainer cassandraContainer = new CassandraContainer(DockerImageName.parse("cassandra:4"))
+  private static final CassandraContainer cassandraContainer = new CassandraContainer(DockerImageName.parse("cassandra:5"))
       .withEnv("HEAP_NEWSIZE", "128M")
       .withEnv("MAX_HEAP_SIZE", "512M")
       .withInitScript(new ClassPathResource("local_env/cassandra/schema/schema.cql").getPath())

--- a/src/control-plane-services/ess/ess-service/src/test/java/com/nvidia/ess/testing/CustomCassandraContainer.java
+++ b/src/control-plane-services/ess/ess-service/src/test/java/com/nvidia/ess/testing/CustomCassandraContainer.java
@@ -29,7 +29,7 @@ public class CustomCassandraContainer implements Startable {
   // This means that we are not calling container.stop() anywhere explicitly.
   // However, ryuk container will be responsible for full cleanup of the testcontainers after all tests are run
 
-  private static final CassandraContainer cassandraContainer = new CassandraContainer(DockerImageName.parse("cassandra:4"))
+  private static final CassandraContainer cassandraContainer = new CassandraContainer(DockerImageName.parse("cassandra:5"))
       .withEnv("HEAP_NEWSIZE", "128M")
       .withEnv("MAX_HEAP_SIZE", "512M")
       .withInitScript(new ClassPathResource("local_env/cassandra/schema/schema.cql").getPath())

--- a/src/control-plane-services/ess/local_env/docker-compose.yaml
+++ b/src/control-plane-services/ess/local_env/docker-compose.yaml
@@ -16,7 +16,7 @@ name: ess-local
 
 services:
   cassandra:
-    image: cassandra:4.1.0
+    image: cassandra:5
     ports:
       - "9042:9042"
     environment:
@@ -28,7 +28,7 @@ services:
       - cassandra_data:/var/lib/cassandra
 
   cassandra-init:
-    image: cassandra:4.1.0
+    image: cassandra:5
     networks:
       - cassandra_network
     volumes:


### PR DESCRIPTION
## TL;DR
Align ESS with the other control-plane Java services (api-keys, cloud-tasks,
instance-cluster-management) by bumping Cassandra from 4 to 5 in the ESS
`local_env` docker-compose and in the integration-test testcontainers. This
keeps ESS on the same Cassandra major version as the rest of the fleet and
catches any Cassandra 5 behavior differences during local and integration
testing.

## Additional Details
- `src/control-plane-services/ess/local_env/docker-compose.yaml`: `cassandra`
  and `cassandra-init` images `4.1.0` -> `5`.
- Three `CustomCassandraContainer` testcontainers (`ess-core`, `ess-encryption`,
  `ess-service`): `cassandra:4` -> `cassandra:5`.
- The remaining `4.x` strings in `src/control-plane-services/ess/NOTICE` are
  Spring Boot artifact versions (for example `spring-boot-cassandra:4.0.7`), not
  the Cassandra server image, so they are unchanged.

## For the Reviewer
Test-only change. No production/runtime chart or deployment behavior is
modified.

## For QA
Ran `//src/control-plane-services/ess/ess-encryption:base_integration_tests`
locally against Cassandra 5; it passed. No manual QA needed.

## Issues
Closes #729

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.