### PR TITLE
fix(nvsnap): sync chart image tags and fail on drift

### DIFF
--- a/src/compute-plane-services/nvsnap/deploy/helm/nvsnap/values.yaml
+++ b/src/compute-plane-services/nvsnap/deploy/helm/nvsnap/values.yaml
@@ -137,7 +137,7 @@ agent:
     # is no AppVersion fallback (see _helpers.tpl) — empty tag fails
     # the chart render with a clear error rather than templating a
     # known-broken image ref.
-    tag: "v0.1.3"
+    tag: "v0.2.32"
     pullPolicy: Always
 
   # nodeSelector is intentionally empty — GPU detection runs through

--- a/src/compute-plane-services/nvsnap/scripts/sync-versions.sh
+++ b/src/compute-plane-services/nvsnap/scripts/sync-versions.sh
@@ -27,6 +27,38 @@ source "$(dirname "${BASH_SOURCE[0]}")/versions.sh"
 
 DIRS=(deploy/k8s deploy)
 
+# Helm values files spell an image as split `repository:` / `tag:` fields
+# rather than one registry/name:tag token, so the substitution below can
+# never see them and the grep-based check below can never flag them. They
+# are handled separately by chart_tag()/set_chart_tag().
+CHART_VALUES=(deploy/helm/nvsnap/values.yaml)
+
+# Print the tag a chart values file pins for <image-name>, or nothing when
+# that repository isn't present. \042 and \047 are " and ' — spelled in
+# octal so this awk program survives shell quoting intact.
+chart_tag() {
+    awk -v name="$2" '
+        $1 == "repository:" { pending = ($2 == name) }
+        pending && $1 == "tag:" { gsub(/[\042\047]/, "", $2); print $2; exit }
+    ' "$1"
+}
+
+# Rewrite the tag a chart values file pins for <image-name>, preserving the
+# original indentation.
+set_chart_tag() {
+    local file="$1"
+    awk -v name="$2" -v ver="$3" '
+        $1 == "repository:" { pending = ($2 == name) }
+        pending && $1 == "tag:" {
+            match($0, /^[ \t]*/)
+            print substr($0, 1, RLENGTH) "tag: \"" ver "\""
+            pending = 0
+            next
+        }
+        { print }
+    ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+}
+
 # image-name → version-var
 declare -A IMAGES=(
     [nvsnap-agent]="$NVSNAP_APP_VERSION"
@@ -49,6 +81,10 @@ for name in "${!IMAGES[@]}"; do
     for dir in "${DIRS[@]}"; do
         find "$dir" -name "*.yaml" -exec sed -i -E "${sed_re}" {} \;
     done
+    for f in "${CHART_VALUES[@]}"; do
+        [ -f "$f" ] && [ -n "$(chart_tag "$f" "$name")" ] || continue
+        set_chart_tag "$f" "$name" "$ver"
+    done
     echo "Synced ${name} -> ${new}"
 done
 
@@ -64,6 +100,30 @@ for name in "${!IMAGES[@]}"; do
             echo "$remaining" >&2
             fail=1
         fi
+    fi
+done
+
+# Same check for chart values. The grep above matches a combined
+# registry/name:tag token, which split repository:/tag: fields never form —
+# so without this loop a drifting chart tag passes verification silently.
+# That is exactly how the chart shipped nvsnap-agent v0.1.3 against an
+# NVSNAP_APP_VERSION of v0.2.32 (nvsnap#731).
+for f in "${CHART_VALUES[@]}"; do
+    [ -f "$f" ] || continue
+    for name in "${!IMAGES[@]}"; do
+        actual=$(chart_tag "$f" "$name")
+        [ -n "$actual" ] || continue
+        if [ "$actual" != "${IMAGES[$name]}" ]; then
+            echo "WARNING: ${f} pins ${name} tag ${actual}, expected ${IMAGES[$name]}" >&2
+            fail=1
+        fi
+    done
+    # The chart builds refs as <imageRegistry>/<repository>:<tag>, so a
+    # drifting registry breaks every image at once.
+    registry=$(awk '$1 == "imageRegistry:" { print $2; exit }' "$f")
+    if [ -n "$registry" ] && [ "$registry" != "$NVSNAP_REGISTRY" ]; then
+        echo "WARNING: ${f} imageRegistry is ${registry}, expected ${NVSNAP_REGISTRY}" >&2
+        fail=1
     fi
 done
 


### PR DESCRIPTION
Fixes #731.

## Why

The nvsnap Helm chart pinned `agent.image.tag: v0.1.3` while `scripts/versions.sh` was at `NVSNAP_APP_VERSION=v0.2.32`. `install-nvsnap.sh` is the documented install path, so a fresh install deployed a 31-version-old agent. Caught while validating the chart on nvcf-dgxc-k8s-aws-usw2-dev2 -- `test-e2e.sh` refused to run:

```
[ERROR] Deployed agent (.../nvsnap-agent:v0.1.3) != expected (.../nvsnap-agent:v0.2.32)
```

`sync-versions.sh` already targeted the chart (`DIRS=(deploy/k8s deploy)`). The substitution matched a single `registry/name:tag` token, which is how `deploy/k8s` spells an image reference. Chart values split the same reference across `repository:` and `tag:` lines, so the pattern matched nothing and the sed no-opped -- while still printing `Synced nvsnap-agent -> ...:v0.2.32`.

The staleness check below used the same `/name:` anchor, so it also matched nothing in the chart and passed vacuously. Nothing in the pipeline could catch the drift. A verification step that passes without finding anything is the part that let this sit.

## What changed

- `chart_tag()` / `set_chart_tag()` read and rewrite the split `repository:`/`tag:` form, preserving indentation. Run alongside the existing sed so both spellings stay in sync.
- Verification now compares every chart tag against its expected version, so drift fails loudly instead of passing silently.
- Verification also checks `imageRegistry`, since the chart composes refs as `<imageRegistry>/<repository>:<tag>` and a drifting registry breaks every image at once. `sync-versions.sh` never rewrites that field, so it is a genuinely reachable failure.
- `values.yaml` agent tag v0.1.3 -> v0.2.32 (the actual drift).

Deliberately not asserting that every image in `IMAGES` appears somewhere: `nvsnap-init` and `pyzmq-builder` currently appear in zero manifests, so that assertion would fail falsely.

## Testing

On nvcf-dgxc-k8s-aws-usw2-dev2:

- Sync updates only the stale agent tag; no other chart line moves.
- Mutation test, chart-sync step disabled + tag reverted: fails with `pins nvsnap-agent tag v0.1.3, expected v0.2.32`.
- Mutation test, `imageRegistry` corrupted: fails with `imageRegistry is stg.nvcr.io/zq9tgrjzrfpo, expected nvcr.io/0651155215864979/ncp-dev`.
- Clean tree exits 0.
- `./scripts/test-e2e.sh vllm-small` PASSES on the resulting install: 33G checkpoint, 8m51s total, post-restore inference OK. This is also the rule-10 gate that #472 merged without.

## Customer Release Notes

Fixed the nvsnap Helm chart installing an outdated agent image.

## Plan Summary

Not applicable.

## Usage

`./scripts/sync-versions.sh` -- now also rewrites chart values and exits non-zero on drift.

## Notes

Workaround before this lands: `./scripts/install-nvsnap.sh --set agent.image.tag=v0.2.32`.

`nvsnap-l2-wait` appears in the chart but has no version variable in `versions.sh`, so it is left alone. Worth deciding whether it should be managed.

## References

#731

## Related Merge Requests/Pull Requests

None

## Dependencies

None