### PR TITLE
fix(nvsnap): warn when L2 fan-out is disabled at install time

### DIFF
--- a/src/compute-plane-services/nvsnap/scripts/install-nvsnap.sh
+++ b/src/compute-plane-services/nvsnap/scripts/install-nvsnap.sh
@@ -227,6 +227,32 @@ else
     info "skipping cert-manager + webhook (--without-webhook)"
 fi
 
+# L2 per-capture PVC fan-out is off unless agent.l2.storageClass names an
+# RWX-capable class. Left empty the install still succeeds, but restore
+# fan-out silently degrades to the L3 peer cascade — a large throughput
+# difference that only shows up under multi-node fan-out, long after the
+# installer has printed a clean banner. Say so at install time.
+#
+# Reported, not auto-selected: picking the wrong class yields PVCs that
+# never bind, and the right choice depends on cluster topology. RWX
+# capability isn't exposed on the StorageClass API, so candidates are
+# matched on known RWX provisioners.
+if ! printf '%s\n' "${EXTRA_HELM_ARGS[@]}" | grep -q "agent.l2.storageClass="; then
+    rwx_re='smb\.csi|nfs\.csi|efs\.csi|filestore\.csi|azurefile|excelero|nvmesh|cephfs'
+    candidates=$(kubectl get storageclass -o jsonpath='{range .items[*]}{.metadata.name}{" ("}{.provisioner}{")"}{"\n"}{end}' 2>/dev/null \
+        | grep -iE "$rwx_re" || true)
+    echo "     WARNING: agent.l2.storageClass is unset — L2 per-capture PVC fan-out is DISABLED." >&2
+    echo "              Restore falls back to the L3 peer cascade (slower multi-node fan-out)." >&2
+    if [ -n "$candidates" ]; then
+        echo "              RWX-capable StorageClasses on this cluster:" >&2
+        echo "$candidates" | sed 's/^/                /' >&2
+        echo "              Enable with: --set agent.l2.storageClass=<name>" >&2
+    else
+        echo "              No RWX-capable StorageClass detected; L2 needs one provisioned first." >&2
+        echo "              Reference: deploy/k8s/nvcf-cluster-prep/storage-classes.yaml" >&2
+    fi
+fi
+
 # ─── 6. Helm install ───────────────────────────────────────────────────
 
 step "[6/7] helm install / upgrade nvsnap"


### PR DESCRIPTION
Found while validating the chart on nvcf-dgxc-k8s-aws-usw2-dev2.

## Why

`agent.l2.storageClass` defaults to empty, which disables the L2 per-capture PVC tier. The install still succeeds and prints a clean success banner, while restore fan-out silently degrades to the L3 peer cascade. The only signal today is an info-level agent log line that scrolls past during rollout:

```
L2 disabled: agent.L2.StorageClass not set (cluster prerequisite missing
 -- restore fan-out will fall back to L3 peer cascade)
```

That is a throughput cliff that only becomes visible under multi-node fan-out, long after install. It is easy to conclude the cluster is fully configured when it is not. dev2 has six RWX-capable StorageClasses available and still came up with L2 off.

## What changed

Report the condition during the existing step-5 cluster auto-detect, and list the RWX-capable StorageClasses actually present so the operator can act immediately:

```
WARNING: agent.l2.storageClass is unset -- L2 per-capture PVC fan-out is DISABLED.
         Restore falls back to the L3 peer cascade (slower multi-node fan-out).
         RWX-capable StorageClasses on this cluster:
           nvcf-cc-sc (nvmesh-csi.excelero.com)
           nvcf-function-storage-sc (nvmesh-csi.excelero.com)
           nvcf-sc (nvmesh-csi.excelero.com)
           nvmesh-concatenated (nvmesh-csi.excelero.com)
           nvmesh-raid0 (nvmesh-csi.excelero.com)
           nvmesh-raid1 (nvmesh-csi.excelero.com)
         Enable with: --set agent.l2.storageClass=<name>
```

Reported rather than auto-selected on purpose: the wrong class yields PVCs that never bind, and the right choice depends on cluster topology. RWX capability is not exposed on the StorageClass API, so candidates are matched against known RWX provisioners (`smb.csi`, `nfs.csi`, `efs.csi`, `filestore.csi`, `azurefile`, `excelero`/`nvmesh`, `cephfs`). When none match, the message points at the reference StorageClass manifest instead.

Suppressed when the operator already passed `agent.l2.storageClass`.

## Customer Release Notes

The installer now reports when L2 restore fan-out is disabled and lists eligible StorageClasses.

## Plan Summary

Not applicable.

## Usage

`./scripts/install-nvsnap.sh` -- warning appears in step 5 when L2 is unconfigured.

## Testing

On nvcf-dgxc-k8s-aws-usw2-dev2:
- `--dry-run` with `storageClass` unset: warning plus the six nvmesh candidates above.
- `--dry-run --set agent.l2.storageClass=nvcf-sc`: no warning emitted.
- `bash -n` clean.

## Notes

Advisory only; it does not change install behavior or exit status. Auto-selection was considered and rejected for the reason above.

## References

None

## Related Merge Requests/Pull Requests

#732

## Dependencies

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an installation-time warning when no L2 storage class is configured.
  * Detects compatible RWX storage classes and explains how to enable L2 PVC fan-out.
  * Provides guidance to provision an RWX storage class when none is available.
  * Clarifies that restores will use the slower L3 cascade when L2 fan-out is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->