### PR TITLE
fix(ess): note integration tests use Cassandra 5 in README

### DIFF
--- a/src/control-plane-services/ess/README.md
+++ b/src/control-plane-services/ess/README.md
@@ -16,7 +16,7 @@ ESS is a Bazel-only component in the root `nvcf` module. See [BAZEL.md](BAZEL.md
 for build, test, NOTICE, Docker, and local startup commands.
 
 Unit tests run without external services. Integration tests require a running
-Docker daemon and use Testcontainers to start an ephemeral Cassandra instance.
+Docker daemon and use Testcontainers to start an ephemeral Cassandra 5 instance.
 
 ## Run locally
 


### PR DESCRIPTION
## TL;DR
Doc-only clarification in the ESS README to state that integration tests spin up
a Cassandra 5 instance (matching the recent Cassandra 5 bump). Deliberately
committed as `fix(ess)` to exercise the ESS release automation patch bump
(v0.4.9 -> v0.4.10).

## Additional Details
- `src/control-plane-services/ess/README.md`: reword one sentence to say
  "Cassandra 5" instead of "Cassandra".
- No code or behavior change. The `fix` type is intentional here to validate
  that a release-worthy ESS commit computes the expected patch version.

## For the Reviewer
This is primarily a release-automation validation. If we do not want a doc-only
change to appear in ESS release notes as a fix, we can retype it before merge.

## For QA
No QA needed. Verify the release helper resolves ESS to v0.4.10 for this commit.

## Issues
Relates to #729

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated integration-test documentation to specify Cassandra 5 as the required Cassandra version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->