### PR TITLE
fix(ess-helm): correct README wording to reference directory not repository

### DIFF
--- a/deploy/helm/ess/README.md
+++ b/deploy/helm/ess/README.md
@@ -1,6 +1,6 @@
 # NVCF ESS API Helm Chart
 
-This repository contains the Helm chart for deploying the NVCF ESS (Encrypted Secrets Service) API on Kubernetes.
+This directory contains the Helm chart for deploying the NVCF ESS (Encrypted Secrets Service) API on Kubernetes.
 
 ## Overview
 


### PR DESCRIPTION
## TL;DR
Test auto tagging for the ess-helm chart. This is a doc-only `fix(ess-helm)`
under `deploy/helm/ess` intended to exercise the release automation: with the
`initial_version: "1.7.0"` floor anchor and no existing published tag, a `fix`
should produce the first published ess-helm tag `1.7.1`.

## Additional Details
- `deploy/helm/ess/README.md`: reword "This repository contains" to
  "This directory contains", accurate now that the chart lives in the monorepo.
- No chart, template, or values behavior changes.
- `fix` type is intentional: it is release-worthy and scoped to
  `deploy/helm/ess`, so semantic-release computes a patch bump from the 1.7.0
  floor to 1.7.1.

## For the Reviewer
Primarily a release-automation validation for ess-helm. Confirm the "GitHub
release helper" check resolves ess-helm to 1.7.1. Whether a tag is actually
pushed still depends on the dry-run gate.

## For QA
No QA needed. Verify the release helper output shows ess-helm 1.7.1.

## Issues
Relates to #729

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that the directory contains the NVCF ESS API Helm chart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->