### PR TITLE
fix(nvca-operator): restore ngc-managed default on 3.1

### DIFF
--- a/deploy/helm/nvca-operator/nvca-operator/templates/self-managed-nvcfbackend-cm.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/templates/self-managed-nvcfbackend-cm.yaml
@@ -18,8 +18,8 @@ metadata:
   name: nvcfbackend-self-managed
   namespace: {{ .Release.Namespace }}
   {{- $releaseArtifactNvcaImageRepository := .Values.nvcaImage.repositoryOverride }}
-  {{- $releaseArtifactImageCredentialHelperRepository := .Values.selfManaged.imageCredHelper.imageRepository }}
-  {{- $releaseArtifactSambaRepository := .Values.selfManaged.sharedStorage.imageRepository }}
+  {{- $releaseArtifactImageCredentialHelperRepository := (.Values.selfManaged.imageCredHelper | default dict).imageRepository }}
+  {{- $releaseArtifactSambaRepository := (.Values.selfManaged.sharedStorage | default dict).imageRepository }}
   {{- if or $releaseArtifactNvcaImageRepository $releaseArtifactImageCredentialHelperRepository $releaseArtifactSambaRepository }}
   annotations:
     {{- if $releaseArtifactNvcaImageRepository }}

--- a/deploy/helm/nvca-operator/nvca-operator/values.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/values.yaml
@@ -251,15 +251,16 @@ webhook:
 ## @param ngcConfig.serviceKeySecretKeyName Key in the secret ngcConfig.serviceKeySecretName containing the NGC ServiceKey (password).
 ## @param ngcConfig.apiURL NGC API URL for requesting auth tokens
 ## @param ngcConfig.clusterSource Source of the cluster configuration:
-##     - "helm-managed": Cluster configuration managed by the helm chart
-##     - "ngc-managed": Cluster configuration managed by NGC
+##     - "ngc-managed": Cluster configuration managed by NGC (default)
+##     - "helm-managed": Cluster configuration managed by the Helm chart
+##     - "self-managed": Cluster configuration managed by the self-hosted compute plane
 ngcConfig:
   username: '$oauthtoken'
   serviceKey: "dummy-api-key"
   serviceKeySecretName: "ngc-service-key"
   serviceKeySecretKeyName: "ngcServiceKey"
   apiURL: https://api.ngc.nvidia.com
-  clusterSource: self-managed
+  clusterSource: ngc-managed
 ## @section Vault Configuration
 ## @param vaultConfig.oAuthClientMountPathTemplate Template for constructing the OAuth client mount path in Vault. Use %s as placeholder for clientID. Example: "nvidia/services/oauth/clients/%s/kv/secret"
 ## @param vaultConfig.oAuthClientMountPath (Optional) Full OAuth client mount path. If set, overrides the computed path from template.

--- a/deploy/helm/nvca-operator/tests/cluster_source_defaults_test.sh
+++ b/deploy/helm/nvca-operator/tests/cluster_source_defaults_test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+
+manifest_ngc_managed="${tmp_dir}/manifest-ngc-managed.yaml"
+manifest_self_managed="${tmp_dir}/manifest-self-managed.yaml"
+
+# Render with default values (ngc-managed)
+helm template nvca-operator "${repo_root}/nvca-operator" \
+  --namespace nvca-operator \
+  --values "${repo_root}/nvca-operator/values.yaml" \
+  > "${manifest_ngc_managed}"
+
+# Render with self-managed clusterSource
+helm template nvca-operator "${repo_root}/nvca-operator" \
+  --namespace nvca-operator \
+  --values "${repo_root}/nvca-operator/values.yaml" \
+  --set-string ngcConfig.clusterSource=self-managed \
+  --set-string selfManaged.icmsServiceURL=http://icms.example.invalid:8080 \
+  --set-string selfManaged.revalServiceURL=http://reval.example.invalid:8080 \
+  --set-string selfManaged.natsURL=nats://nats.example.invalid:4222 \
+  > "${manifest_self_managed}"
+
+# --- ngc-managed assertions ---
+
+cluster_source_ngc="$(
+  yq -r 'select(.kind == "Deployment" and .metadata.name == "nvca-operator") |
+    .spec.template.spec.containers[] | select(.name == "nvca-operator") |
+    .env[] | select(.name == "NVCA_CLUSTER_SOURCE") | .value' \
+    "${manifest_ngc_managed}"
+)"
+if [[ "${cluster_source_ngc}" != "ngc-managed" ]]; then
+  echo "expected NVCA_CLUSTER_SOURCE=ngc-managed in default render, got '${cluster_source_ngc}'" >&2
+  exit 1
+fi
+
+helm_managed_data_ngc="$(
+  yq -r 'select(.kind == "ConfigMap" and .metadata.name == "nvcfbackend-helm-managed") | .data // {} | length' \
+    "${manifest_ngc_managed}"
+)"
+if [[ "${helm_managed_data_ngc}" != "0" ]]; then
+  echo "expected nvcfbackend-helm-managed to have empty data for ngc-managed, got ${helm_managed_data_ngc} keys" >&2
+  exit 1
+fi
+
+self_managed_data_ngc="$(
+  yq -r 'select(.kind == "ConfigMap" and .metadata.name == "nvcfbackend-self-managed") | .data // {} | length' \
+    "${manifest_ngc_managed}"
+)"
+if [[ "${self_managed_data_ngc}" != "0" ]]; then
+  echo "expected nvcfbackend-self-managed to have empty data for ngc-managed, got ${self_managed_data_ngc} keys" >&2
+  exit 1
+fi
+
+# --- self-managed assertions ---
+
+cluster_source_sm="$(
+  yq -r 'select(.kind == "Deployment" and .metadata.name == "nvca-operator") |
+    .spec.template.spec.containers[] | select(.name == "nvca-operator") |
+    .env[] | select(.name == "NVCA_CLUSTER_SOURCE") | .value' \
+    "${manifest_self_managed}"
+)"
+if [[ "${cluster_source_sm}" != "self-managed" ]]; then
+  echo "expected NVCA_CLUSTER_SOURCE=self-managed in self-managed render, got '${cluster_source_sm}'" >&2
+  exit 1
+fi
+
+self_managed_data_sm="$(
+  yq -r 'select(.kind == "ConfigMap" and .metadata.name == "nvcfbackend-self-managed") | .data // {} | length' \
+    "${manifest_self_managed}"
+)"
+if [[ "${self_managed_data_sm}" == "0" ]]; then
+  echo "expected nvcfbackend-self-managed to have data for self-managed render, got empty" >&2
+  exit 1
+fi
+
+helm_managed_data_sm="$(
+  yq -r 'select(.kind == "ConfigMap" and .metadata.name == "nvcfbackend-helm-managed") | .data // {} | length' \
+    "${manifest_self_managed}"
+)"
+if [[ "${helm_managed_data_sm}" != "0" ]]; then
+  echo "expected nvcfbackend-helm-managed to have empty data for self-managed, got ${helm_managed_data_sm} keys" >&2
+  exit 1
+fi
+
+echo "clusterSource defaults: ngc-managed renders NVCA_CLUSTER_SOURCE=ngc-managed with empty config maps; self-managed renders NVCA_CLUSTER_SOURCE=self-managed with populated nvcfbackend-self-managed"

--- a/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
+++ b/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
@@ -101,6 +101,8 @@ releases:
         imagePullSecrets:
         {{- toYaml .Values.global.imagePullSecrets | nindent 10 }}
         {{- end }}
+        ngcConfig:
+          clusterSource: self-managed
         clusterName: {{ requiredEnv "CLUSTER_NAME" }}
         ncaId: {{ requiredEnv "NCA_ID" }}
         {{- $selfManaged := dig "nvcaOperator" "selfManaged" dict .Values.global }}

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/values.yaml
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/values.yaml
@@ -270,8 +270,9 @@ webhook:
 ## @param ngcConfig.serviceKeySecretKeyName Key in the secret ngcConfig.serviceKeySecretName containing the NGC ServiceKey (password).
 ## @param ngcConfig.apiURL NGC API URL for requesting auth tokens
 ## @param ngcConfig.clusterSource Source of the cluster configuration:
-##     - "helm-managed": Cluster configuration managed by the helm chart
-##     - "ngc-managed": Cluster configuration managed by NGC
+##     - "ngc-managed": Cluster configuration managed by NGC (default)
+##     - "helm-managed": Cluster configuration managed by the Helm chart
+##     - "self-managed": Cluster configuration managed by the self-hosted compute plane
 ngcConfig:
   username: '$oauthtoken'
   serviceKey: ""


### PR DESCRIPTION
## TL;DR

- Backports #706 to the NVCA 3.1 release branch. Fresh NGC installs now default to `ngc-managed`.
- Keeps self-managed compute-plane installs explicit and prevents nil values during 3.0.x upgrades.

## Additional Details

- Updates both the source and vendored chart values.
- Adds a render regression test for default NGC-managed and explicit self-managed configurations.

## For the Reviewer

- Check the `ngcConfig.clusterSource` defaults and the self-managed Helmfile override.

## For QA

- `helm lint deploy/helm/nvca-operator/nvca-operator`
- `helm lint src/compute-plane-services/nvca/deployments/nvca-operator`
- `bash deploy/helm/nvca-operator/tests/cluster_source_defaults_test.sh`
- QA: fresh NGC install with no `clusterSource` argument, plus a self-managed stack install.

## Issues

Relates to #704

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.