### PR TITLE
fix(examples): signal task readiness before collector health

### DIFF
--- a/examples/task-samples/task-byoo-sample/main.py
+++ b/examples/task-samples/task-byoo-sample/main.py
@@ -288,6 +288,18 @@ def check_collector_health() -> bool:
         logger.error(f"Collector health check error: {str(e)}")
         return False
 
+
+def prepare_task_container() -> bool:
+    while not os.path.exists(ROOT_OUTPUT_DIR):
+        logger.info(f"Waiting for {ROOT_OUTPUT_DIR} to be created")
+        time.sleep(2)
+
+    update_task_progress_file(0, PROGRESS_FILE, "")
+    Thread(target=heartbeat, args=(PROGRESS_FILE,), daemon=True).start()
+
+    return check_collector_health()
+
+
 if __name__ == "__main__":
     # first wait for secrets file to be ready. BYOO requires secrets file
     ACCOUNTS_SECRETS_PATH = os.getenv("ACCOUNTS_SECRETS_PATH", "/var/secrets/accounts-secrets.json")
@@ -295,8 +307,14 @@ if __name__ == "__main__":
         logger.error(f"Secrets file {ACCOUNTS_SECRETS_PATH} not available after maximum retries")
         exit(1)
 
+    try:
+        collector_ready = prepare_task_container()
+    except Exception as e:
+        logger.exception(f"Failed to initialize task progress heartbeat: {e}")
+        exit(1)
+
     # wait for BYOO collector to be ready
-    if check_collector_health() == False:
+    if not collector_ready:
         logger.error("BYOO Collector is not ready, exit")
         exit(1)
 
@@ -322,17 +340,6 @@ if __name__ == "__main__":
     add_metadata = False
     if INCLUDE_METADATA.lower() == "true":
         add_metadata = True
-
-    while not os.path.exists(ROOT_OUTPUT_DIR):
-        logger.info(f"Waiting for {ROOT_OUTPUT_DIR} to be created")
-        time.sleep(2)
-
-    t = Thread(target=heartbeat, args=(PROGRESS_FILE,), daemon=True)
-    try:
-        t.start()
-    except Exception as e:
-        logger.exception(f"Failed to start heartbeat thread: {e}")
-        exit(1)
 
     # start generating dummy results
     for i in range(NUM_OF_RESULTS):

--- a/examples/task-samples/task-byoo-sample/test_main.py
+++ b/examples/task-samples/task-byoo-sample/test_main.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).with_name("main.py")
+SPEC = importlib.util.spec_from_file_location("task_byoo_sample_main", MODULE_PATH)
+task_main = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = task_main
+SPEC.loader.exec_module(task_main)
+
+
+class PrepareTaskContainerTest(unittest.TestCase):
+    def test_signals_running_before_checking_collector_health(self):
+        events = []
+
+        with (
+            mock.patch.object(task_main.os.path, "exists", return_value=True),
+            mock.patch.object(
+                task_main,
+                "update_task_progress_file",
+                side_effect=lambda *args: events.append("progress"),
+            ) as update_progress,
+            mock.patch.object(task_main, "Thread") as thread,
+            mock.patch.object(
+                task_main,
+                "check_collector_health",
+                side_effect=lambda: events.append("health") or True,
+            ),
+        ):
+            thread.return_value.start.side_effect = lambda: events.append("heartbeat")
+
+            self.assertTrue(task_main.prepare_task_container())
+
+        update_progress.assert_called_once_with(0, task_main.PROGRESS_FILE, "")
+        self.assertEqual(events, ["progress", "heartbeat", "health"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## TL;DR

Create the initial NVCT progress record and start its heartbeat before waiting for BYOO collector health. This prevents delayed collector startup from appearing as a task-container readiness failure.

## Additional Details

- Root cause: the sample polled collector health for up to 60 seconds before creating the progress file that NVCT uses as its RUNNING signal.
- `prepare_task_container()` now waits for the results directory, writes valid 0 percent progress, starts the heartbeat, and then polls collector health.
- Telemetry initialization and task result generation remain gated on a healthy collector.
- Collector health failure still exits nonzero after the existing retry limit.
- Regression coverage verifies the `progress -> heartbeat -> health` startup order.

## For the Reviewer

Focus on startup ordering in `examples/task-samples/task-byoo-sample/main.py` and its regression test.

## For QA

- `python3 -m unittest -v test_main.py` passed.
- `python3 -m py_compile main.py test_main.py` passed.
- `docker build -t task-byoo-sample:progress-readiness .` passed.
- Container smoke test with an unavailable collector created valid 0 percent progress JSON during health retries, then exited 1 after six failed checks as expected.
- QA needed: publish the updated sample image and rerun the affected BYOO task scenario.

## Issues

Fixes #742

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task container startup reliability by initializing progress tracking, starting heartbeat monitoring, and validating collector availability before processing.
  * Added graceful handling when container preparation fails or the collector is unavailable.

* **Tests**
  * Added coverage verifying startup signals occur before collector health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->