### PR TITLE
fix(release): stop losing releases to a checkout behind main

### DIFF
--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -64,10 +64,23 @@ jobs:
       contents: write
       packages: read
     steps:
+      # ref is the branch, not the pushed SHA. Two reasons, both about the gap
+      # between when a push happens and when this job actually runs:
+      #
+      # 1. semantic-release refuses to publish from a branch behind its remote.
+      #    A checkout pinned to the pushed SHA goes stale as soon as anything
+      #    else merges, and the release is silently skipped.
+      # 2. The concurrency group cancels queued runs, so a superseded commit
+      #    never gets a run of its own. Only a run that releases from the branch
+      #    tip covers the commits whose runs were cancelled.
+      #
+      # Releasing from the tip is also simply what this job means: cut whatever
+      # tags the branch is currently due, not what it was due minutes ago.
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
+          ref: ${{ github.ref_name }}
           token: ${{ secrets.NV_GITHUB_TOKEN || github.token }}
 
       - uses: actions/setup-node@v4

--- a/tools/ci/github-release
+++ b/tools/ci/github-release
@@ -422,9 +422,25 @@ def no_release_output(output):
         for phrase in (
             "no relevant changes",
             "There are no commits",
-            "is behind the remote",
         )
     )
+
+
+def stale_checkout_output(output):
+    """True when semantic-release refused to publish because the checkout is behind main.
+
+    This is a race, not a verdict on the commits. The workflow checks out a
+    branch tip, but main can still move between checkout and the moment
+    semantic-release runs, which is minutes later once npm install has run.
+    semantic-release then reports "The local branch main is behind the remote
+    one" and publishes nothing.
+
+    Treating that as no-release loses the release silently: the run exits 0 and
+    goes green having tagged nothing. Worse, the concurrency group cancels
+    queued runs, so the superseded commit gets no second chance from its own
+    push. It is classified separately so it can be reported and retried.
+    """
+    return "is behind the remote" in output
 
 
 def validate_version_file(root, service):
@@ -674,6 +690,11 @@ def resolve_release_outcome(exit_code, output):
         return "unknown"
     if parse_next_version(output):
         return "released"
+    if stale_checkout_output(output):
+        # Checked before no_release_output: semantic-release prints the
+        # behind-the-remote notice instead of a verdict on the commits, so this
+        # must not be mistaken for "nothing to release".
+        return "stale-checkout"
     if no_release_output(output):
         return "no-release"
     return "unknown"
@@ -692,6 +713,14 @@ def finish_semantic_release(root, service, components, exit_code, output, dry_ru
             print(f"[github-release] {service['id']}: would create {tag_for_version(service, version)}")
         else:
             print(f"[github-release] {service['id']}: semantic-release created {tag_for_version(service, version)}")
+        return outcome
+    if outcome == "stale-checkout":
+        # No fan-out: semantic-release never judged the commits, so a dependency
+        # release here would invent a version the service may not be due.
+        print(
+            f"[github-release] {service['id']}: semantic-release saw a checkout behind main "
+            "and published nothing; this is a race, not a no-release"
+        )
         return outcome
     if outcome == "no-release":
         print(f"[github-release] {service['id']}: no release-worthy commits")
@@ -909,6 +938,11 @@ def auto_release(args):
     # must not fail the job; publish mode below still fails hard.
     dry_run_failures = []
 
+    # Services whose semantic-release run hit the behind-the-remote race. These
+    # fail the job in publish mode: the release was lost, and a green run would
+    # hide that.
+    stale_checkouts = []
+
     for service in metadata.get("services", []):
         if not should_process_auto_service(service, service_filter, branch, default_branch):
             continue
@@ -953,7 +987,11 @@ def auto_release(args):
                 outcome = finish_semantic_release(
                     root, service, java_components, code, output, dry_run=True, draft=draft
                 )
-                if outcome == "unknown":
+                if outcome == "stale-checkout":
+                    reason = "semantic-release dry-run saw a checkout behind main; preview is meaningless"
+                    print(f"[github-release] WARNING: {service['id']}: {reason}; continuing (dry-run preview)")
+                    dry_run_failures.append((service["id"], reason))
+                elif outcome == "unknown":
                     # Preview could not compute a version (for example the
                     # semantic-release child was killed on a large history).
                     # Do not fail the inert workflow on a preview; record it so
@@ -972,7 +1010,9 @@ def auto_release(args):
                 outcome = finish_semantic_release(
                     root, service, java_components, code, output, dry_run=False, draft=draft
                 )
-                if outcome == "unknown":
+                if outcome == "stale-checkout":
+                    stale_checkouts.append(service["id"])
+                elif outcome == "unknown":
                     print(
                         f"[github-release] WARNING: {service['id']}: semantic-release reported "
                         "neither a version nor a no-release result; not cutting a dependency release"
@@ -987,6 +1027,18 @@ def auto_release(args):
         )
         for sid, reason in dry_run_failures:
             print(f"[github-release]   - {sid}: {reason}")
+
+    if stale_checkouts:
+        # Fail rather than exit green. The release for these services was not
+        # cut and nothing else will retry it: the push that should have released
+        # them is already behind main, and the concurrency group cancels the
+        # queued runs that would otherwise pick it up.
+        raise SystemExit(
+            f"[github-release] ERROR: {len(stale_checkouts)} service(s) lost a release to a "
+            f"checkout behind {branch or 'the release branch'}: {', '.join(sorted(stale_checkouts))}. "
+            "Re-run this workflow on the current branch tip (workflow_dispatch, operation=auto) "
+            "to cut the missing tags."
+        )
 
 
 def parse_release_tag(tag, metadata):

--- a/tools/ci/test-github-release.py
+++ b/tools/ci/test-github-release.py
@@ -387,6 +387,55 @@ class GithubReleaseTest(unittest.TestCase):
             "unknown",
         )
 
+    def test_stale_checkout_is_not_classified_as_no_release(self):
+        # Regression guard for the ess v0.4.10 miss: semantic-release printed
+        # "is behind the remote", the helper called that a no-release, and the
+        # run went green having tagged nothing.
+        behind = (
+            "[semantic-release] i The local branch main is behind the remote one, "
+            "therefore a new version won't be published.\n"
+        )
+        self.assertEqual(
+            self.github_release.resolve_release_outcome(0, behind), "stale-checkout"
+        )
+        self.assertFalse(self.github_release.no_release_output(behind))
+        self.assertTrue(self.github_release.stale_checkout_output(behind))
+        # A genuine no-release must stay a no-release.
+        self.assertEqual(
+            self.github_release.resolve_release_outcome(
+                0, "There are no relevant changes, so no new version is released."
+            ),
+            "no-release",
+        )
+        # A stale checkout that also died is still just untrustworthy.
+        self.assertEqual(self.github_release.resolve_release_outcome(1, behind), "unknown")
+
+    def test_stale_checkout_does_not_fan_out_a_dependency_release(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.init_java_repo(root)
+            self.commit_framework_change(root)
+            components = self.github_release.java_ci_components(root)
+            service_id, path, _version = self.JAVA_SERVICES[0]
+            service = self.java_service_metadata(service_id, path)
+            behind = (
+                "[semantic-release] i The local branch main is behind the remote one, "
+                "therefore a new version won't be published.\n"
+            )
+
+            output = io.StringIO()
+            with chdir(root), contextlib.redirect_stdout(output):
+                outcome = self.github_release.finish_semantic_release(
+                    root, service, components, 0, behind, dry_run=True, draft=False
+                )
+
+            text = output.getvalue()
+            self.assertEqual(outcome, "stale-checkout")
+            # The no-release path fans out a dependency release; this one must not.
+            self.assertNotIn("would create", text)
+            self.assertNotIn("dependency-triggered", text)
+            self.assertIn("race, not a no-release", text)
+
     def test_failed_semantic_release_run_does_not_fan_out(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Why

A service can silently lose a release when the `release-tags` job runs late.

`service-release` checks out the pushed SHA. If anything merges to `main` between the push and the moment `semantic-release` actually runs, the checkout is behind the remote and semantic-release publishes nothing. `tools/ci/github-release` treated `"is behind the remote"` as a legitimate no-release, so the run printed "no release-worthy commits", exited 0, and went green having tagged nothing.

PR #738 lost `src/control-plane-services/ess/v0.4.10` this way: its run queued at 17:26:45, started at 18:40:32, and by then two commits had landed on main. Nothing about the PR was wrong.

It does not self-correct. The push is already behind main, and the `release-tags` concurrency group cancels queued runs, so a superseded commit never gets a run of its own.

## What changed

- `.github/workflows/release-tags.yml`: check out `ref: github.ref_name` (the branch tip) instead of the pushed SHA, matching what the sibling `release-branch-cut` job already does. The surviving run now releases whatever the branch is currently due, which also covers commits whose runs were cancelled.
- `tools/ci/github-release`: `"is behind the remote"` becomes its own `stale-checkout` outcome instead of folding into `no_release_output()`. It no longer fans out a dependency release for a service semantic-release never judged, and it now fails the job so a lost release is visible rather than green.

No new tooling: both files already existed, and `tools/AGENTS.md` only restricts adding *new* Python-based tooling.

## Testing

`python3 -m pytest tools/ci/test-github-release.py` - 26 passed.

Two new tests, both verified to fail when the old classification is restored:

```
FAILED test_stale_checkout_is_not_classified_as_no_release
FAILED test_stale_checkout_does_not_fan_out_a_dependency_release
AssertionError: 'no-release' != 'stale-checkout'
```

Closes #745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release automation reliability by ensuring it runs against the latest branch state.
  * Added detection for outdated checkouts during releases.
  * Prevented stale release results from triggering dependent releases.
  * Publish releases now fail with clear rerun guidance when the checkout is outdated.
  * Dry-run releases record stale results without failing.

* **Tests**
  * Added coverage for stale checkout detection and dependency-release prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->