### PR TITLE
feat(cf): Added helm chart

### DIFF
--- a/deploy/helm/cloud-tasks/.gitignore
+++ b/deploy/helm/cloud-tasks/.gitignore
@@ -1,0 +1,4 @@
+vault-secrets.json
+
+bin/
+packaged-charts/

--- a/deploy/helm/cloud-tasks/AGENTS.md
+++ b/deploy/helm/cloud-tasks/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md
+
+## Repo Role
+- Repo: `nvct-api-colocated-deploy`
+- Workspace(s): `self-hosted-nvcf`
+- Tier: `chart`
+- Team: `@NVIDIA/nvcf-dev`
+- Default owner: `@NVIDIA/nvcf-dev`.
+- Manifest description: Helm chart for NVCT API / nvct-service (helm-nvcf-nvct-api)
+
+## Use `nvcf-agentic-dev` As The Routing Layer
+Before making changes, use the `nvcf-agentic-dev` workspace repo to confirm whether this repo is actually the right place for the task. Treat that repo as the source of truth for workspace membership, repo ownership, deployment dependencies, and available agent skills.
+
+Check these files first when they exist in your local workspace:
+- `nvcf-agentic-dev/workspaces/self-hosted-nvcf/repos.yaml`: repo ownership and workspace membership
+- `nvcf-agentic-dev/workspaces/self-hosted-nvcf/skills.yaml`: related agent skills and sourced commands
+- `nvcf-agentic-dev/workspaces/self-hosted-nvcf/docs/deployment-sequence.md`: deployment order and stage gates
+- `nvcf-agentic-dev/workspaces/self-hosted-nvcf/docs/deployment-dependencies-with-links.yaml`: release dependencies and upstream/downstream links
+
+## Routing Rules
+- Stay in this repo for Helm templates, values, hooks, chart metadata, and Kubernetes deployment behavior.
+- If the request is about application logic, APIs, jobs, or binaries running inside the container, route to the paired image-source repo (`nvct-service`).
+- If the request is about cross-chart ordering, stage selection, or environment-wide configuration, route to `nvcf-self-managed-stack`.
+- OpenBao paths and JWT roles for this service are provisioned in `nvcf-openbao-migrations` (see `migrations/18_setup_nvct.sh`).
+
+## Working In This Repo
+- Read this repo's top-level `README*`, build files, and CI config before making assumptions about language or tooling.
+- Search for existing patterns with `rg` before adding new structure.
+- Keep changes scoped to the owning repo once routing is confirmed; only fan out when the workspace docs show an explicit dependency.
+
+## Completion Expectations
+- Validate with the repo-native command set if one exists (`make`, Maven, Helm, npm, etc.).
+- If you change cross-repo behavior, mention the adjacent repo(s) that may also need follow-up.
+- In your final summary, state that routing was confirmed through `nvcf-agentic-dev` and name the workspace context used.
+
+## Commit Types for Version Bumps
+
+Match the conventional commit type to the version bump type:
+
+- `fix(<scope>):` for patch version bumps (e.g., 1.2.0 -> 1.2.1)
+- `feat(<scope>):` for minor version bumps (e.g., 1.2.0 -> 1.3.0)
+- `feat(<scope>)!:` or `BREAKING CHANGE:` footer for major version bumps (e.g., 1.2.0 -> 2.0.0)
+
+The CI tag generation pipeline uses the commit type to determine the release level.
+Using `chore` or other non-`fix`/`feat` types will skip tag creation entirely.

--- a/deploy/helm/cloud-tasks/Makefile
+++ b/deploy/helm/cloud-tasks/Makefile
@@ -1,0 +1,91 @@
+# Variables
+release ?= nvct-api
+namespace ?= nvcf
+helm_dir ?= ./nvct-api
+values := $(helm_dir)/values.yaml
+
+# OPTIONAL for deploy target: Path to an additional Helm values file.
+# Example: make deploy values=my-values.yaml additional_values=override.yaml
+additional_values ?=
+
+# OCI Registry details
+OCI_REGISTRY_HOST ?= nvcr.io
+OCI_REGISTRY_NAMESPACE ?= 0651155215864979/ncp-dev
+
+# Automatically determine chart name and version from Chart.yaml
+# IMPORTANT: For this setup, CHART_NAME is expected to include any desired OCI prefix (e.g., "helm-yourchart")
+# as defined in helm/Chart.yaml's 'name' field.
+CHART_NAME := $(shell yq -r .name $(helm_dir)/Chart.yaml)
+CHART_VERSION := $(shell yq -r .version $(helm_dir)/Chart.yaml)
+
+.PHONY: deploy delete status lint template clean package push-oci install uninstall validate
+
+install:
+ifndef values
+	$(error "values" variable is not set. Please specify with 'make deploy values=<path-to-your-values.yaml>')
+endif
+	@echo "Deploying $(release) to namespace $(namespace) using values file '$(values)'..."
+	@echo "Additional values file: '$(if $(additional_values),$(additional_values),N/A)'"
+	helm install $(release) $(helm_dir) \
+		--namespace $(namespace) \
+		--values $(values) \
+		$(if $(additional_values),--values $(additional_values),) \
+		--atomic \
+		--create-namespace \
+		--wait \
+		--wait-for-jobs \
+		--timeout 20m
+
+uninstall:
+	@echo "Deleting $(release) from namespace $(namespace)..."
+	helm uninstall $(release) --namespace $(namespace)
+
+status:
+	@echo "Checking status of $(release) in namespace $(namespace)..."
+	helm status $(release) --namespace $(namespace)
+
+lint:
+	@echo "Linting chart $(helm_dir)..."
+	helm lint $(helm_dir) \
+		$(if $(values),--values $(values),) \
+		$(if $(additional_values),--values $(additional_values),)
+
+template:
+	@echo "Templating chart $(helm_dir)..."
+	@mkdir -p bin
+	helm template $(release) $(helm_dir) \
+		--namespace $(namespace) \
+		$(if $(values),--values $(values),) \
+		$(if $(additional_values),--values $(additional_values),) \
+		> bin/manifest.yaml
+	@echo "Rendered manifest to bin/manifest.yaml"
+
+validate: template
+	@echo "Validating manifest with kubeconform..."
+	@kubeconform -strict -summary -output pretty -kubernetes-version 1.31.5 bin/manifest.yaml
+
+
+# Publish Chart
+# NOTE: this is manual until the CI pipeline is updated to push the chart to the NVCR OCI registry
+clean:
+	rm -rf ./bin
+	rm -rf ./packaged-charts
+
+package: clean lint
+	@echo "[package] Packaging Helm chart $(CHART_NAME) version $(CHART_VERSION)..."
+	@mkdir -p ./packaged-charts
+	@helm package $(helm_dir) -d ./packaged-charts/
+	@echo "[package] Packaged chart to ./packaged-charts/$(CHART_NAME)-$(CHART_VERSION).tgz"
+
+push-oci:
+	@echo "[push-oci] Pushing chart $(CHART_NAME) version $(CHART_VERSION) to oci://$(OCI_REGISTRY_HOST)/$(OCI_REGISTRY_NAMESPACE)/$(CHART_NAME):$(CHART_VERSION)"
+	@echo "[push-oci] Note: You must be logged into oci://$(OCI_REGISTRY_HOST) for the push to succeed."
+	@if [ ! -f ./packaged-charts/$(CHART_NAME)-$(CHART_VERSION).tgz ]; then \
+		echo "[push-oci] Error: Packaged chart ./packaged-charts/$(CHART_NAME)-$(CHART_VERSION).tgz not found. Run 'make package' first."; \
+		exit 1; \
+	fi
+	@helm push ./packaged-charts/$(CHART_NAME)-$(CHART_VERSION).tgz oci://$(OCI_REGISTRY_HOST)/$(OCI_REGISTRY_NAMESPACE)
+	@echo "[push-oci] Successfully pushed chart to OCI registry."
+	@echo "[push-oci] Cleaning up temporary package directory..."
+	@rm -rf ./packaged-charts
+	@echo "[push-oci] Cleanup complete."

--- a/deploy/helm/cloud-tasks/README.md
+++ b/deploy/helm/cloud-tasks/README.md
@@ -1,0 +1,42 @@
+# NVCT API (nvct-service) deployment
+
+This repository contains a Helm chart for deploying nvct-service (NVCT API) in colocated / self-managed environments.
+
+## Prerequisites
+
+- Kubernetes cluster with Helm installed
+- Access to the container registry that hosts the nvct-service image
+- OpenBao / Vault Agent Injector configured for JWT auth; service account and policies must match `nvcf-openbao-migrations` (`migrations/18_setup_nvct.sh`)
+
+## Deployment
+
+The Kubernetes `ServiceAccount` name **must** be `nvct-api` and the pod namespace **must** match the JWT role bound in OpenBao (default from migrations: namespace `nvcf`).
+
+```bash
+helm install nvct-api ./nvct-api --namespace nvcf --create-namespace \
+  --values nvct-api/values.yaml \
+  --values values.local.yaml
+```
+
+Use `make template` or `make lint` to render and validate the chart locally.
+
+## Configuration
+
+- Image registry, repository, and tag: `nvct-api/values.yaml` under `nvctApi.image`
+- Runtime environment: `nvctApi.env` (Spring relaxed binding / `NVCT_*`, `SPRING_*`, `KAIZEN_*`, etc.)
+- Vault-injected secrets template: `nvct-api/vault-agent-templates/secrets.json.tmpl` (paths under `/services/nvct-service/kv/...` and shared `services/all/...` keys)
+
+## Remote Config RBAC
+
+`spring-cloud-kubernetes` (v3.3.0, shipped in nvct-service `1.4.x`) calls `listNamespacedConfigMap` without a `fieldSelector=metadata.name` filter and matches the target name in memory. Because the API request is unfiltered, the Role must grant `list`/`watch` on the configmaps collection itself — no `resourceNames` scoping for those verbs — so the `nvct-api` SA can read every ConfigMap in the namespace. Chart assumes none are sensitive; clusters that block broad namespace reads need a policy exception.
+
+Set `nvctApi.remoteConfig.enabled: false` to opt out: the chart no longer renders the broad RBAC, and the service runs on JAR sidecar defaults in `application-ncp.yaml`. The SA keeps default-token automount on (the K8s default) so the vault-k8s injector's fallback service-account discovery continues to find a mount. Hot reload is unavailable.
+
+## Troubleshooting Steps
+
+```bash
+kubectl get pods -n nvcf -l app.kubernetes.io/name=helm-nvcf-nvct-api
+kubectl logs -n nvcf deployment/<release-name>-helm-nvcf-nvct-api
+```
+
+Health endpoints are on the management port (default `8181`): `/actuator/health/liveness` and `/actuator/health/readiness`.

--- a/deploy/helm/cloud-tasks/nvct-api/.helmignore
+++ b/deploy/helm/cloud-tasks/nvct-api/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/helm/cloud-tasks/nvct-api/Chart.yaml
+++ b/deploy/helm/cloud-tasks/nvct-api/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: helm-nvcf-nvct-api
+description: NCP Compatible deployment of NVCT API (nvct-service)
+
+type: application
+version: 0.0.0 # autoversioning enabled via release pipeline
+appVersion: "1.6.2"

--- a/deploy/helm/cloud-tasks/nvct-api/templates/NOTES.txt
+++ b/deploy/helm/cloud-tasks/nvct-api/templates/NOTES.txt
@@ -1,0 +1,7 @@
+NVCT API (nvct-service) has been deployed.
+
+HTTP:  http://nvct-api.{{ include "nvct-api.namespace" . }}.svc.cluster.local:8080
+gRPC:  nvct-api.{{ include "nvct-api.namespace" . }}.svc.cluster.local:9090
+Management (actuator):  {{ include "nvct-api.fullname" . }}.{{ include "nvct-api.namespace" . }}.svc.cluster.local:8181
+
+For more information, see the nvct-service application repository and self-hosted deployment docs.

--- a/deploy/helm/cloud-tasks/nvct-api/templates/_helpers.tpl
+++ b/deploy/helm/cloud-tasks/nvct-api/templates/_helpers.tpl
@@ -1,0 +1,100 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nvct-api.name" -}}
+{{- default .Chart.Name .Values.nvctApi.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nvct-api.fullname" -}}
+{{- if .Values.nvctApi.fullnameOverride }}
+{{- .Values.nvctApi.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nvctApi.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nvct-api.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Allow the release namespace to be overridden
+*/}}
+{{- define "nvct-api.namespace" -}}
+{{- default .Release.Namespace .Values.nvctApi.namespace -}}
+{{- end -}}
+
+{{/*
+Derive the full image value
+*/}}
+{{- define "nvct-api.image" -}}
+{{- $registry := required "A valid image registry (.Values.nvctApi.image.registry) is required!" .Values.nvctApi.image.registry -}}
+{{- $repository := required "A valid image repository (.Values.nvctApi.image.repository) is required!" .Values.nvctApi.image.repository -}}
+{{- $tag := .Values.nvctApi.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "nvct-api.labels" -}}
+helm.sh/chart: {{ include "nvct-api.chart" . }}
+{{ include "nvct-api.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "nvct-api.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nvct-api.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Remote config ConfigMap name. Default: <fullname>-remote-config (release-scoped
+to avoid collisions across installs in the same namespace). Override via
+.Values.nvctApi.remoteConfig.configMapName when a fixed external name is required.
+*/}}
+{{- define "nvct-api.remoteConfigName" -}}
+{{- .Values.nvctApi.remoteConfig.configMapName | default (printf "%s-remote-config" (include "nvct-api.fullname" .)) -}}
+{{- end -}}
+
+{{/*
+Remote config Role/RoleBinding name. Release-scoped via the fullname helper.
+*/}}
+{{- define "nvct-api.remoteConfigReaderName" -}}
+{{- printf "%s-remote-config-reader" (include "nvct-api.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Vault Agent Injector Annotations for JWT Auth
+Bound OpenBao JWT role and KSA name: nvct-api (see nvcf-openbao-migrations migrations/20_setup_nvct.sh).
+*/}}
+{{- define "nvct-api.vaultAnnotations" -}}
+vault.hashicorp.com/agent-inject: "true"
+vault.hashicorp.com/role: "nvct-api"
+vault.hashicorp.com/auth-path: "auth/jwt"
+vault.hashicorp.com/auth-config-token-path: "/var/run/secrets/openbao/token"
+vault.hashicorp.com/agent-copy-volume-mounts: {{ .Chart.Name }}
+vault.hashicorp.com/agent-run-as-same-user: "true"
+vault.hashicorp.com/agent-inject-template-file-secrets.json: "/vault/config/templates/secrets.json.tmpl"
+vault.hashicorp.com/secret-volume-path: "/home/app/vault"
+vault.hashicorp.com/template-static-secret-render-interval: "1h"
+{{- end }}

--- a/deploy/helm/cloud-tasks/nvct-api/templates/configmap-env.yaml
+++ b/deploy/helm/cloud-tasks/nvct-api/templates/configmap-env.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.nvctApi.env -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nvct-api.fullname" . }}-env
+  namespace: {{ include "nvct-api.namespace" . }}
+  labels:
+    {{- include "nvct-api.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.nvctApi.env }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end -}}

--- a/deploy/helm/cloud-tasks/nvct-api/templates/configmap-remote-config.yaml
+++ b/deploy/helm/cloud-tasks/nvct-api/templates/configmap-remote-config.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.nvctApi.remoteConfig.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nvct-api.remoteConfigName" . }}
+  namespace: {{ include "nvct-api.namespace" . }}
+  labels:
+    {{- include "nvct-api.labels" . | nindent 4 }}
+data:
+  nvct-api.yaml: |-
+{{ toYaml .Values.nvctApi.remoteConfig.configData | indent 4 }}
+{{- end }}

--- a/deploy/helm/cloud-tasks/nvct-api/templates/configmap-vault-agent-template.yaml
+++ b/deploy/helm/cloud-tasks/nvct-api/templates/configmap-vault-agent-template.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nvct-api.fullname" . }}-vault-agent-tpl
+  namespace: {{ include "nvct-api.namespace" . }}
+  labels:
+    {{- include "nvct-api.labels" . | nindent 4 }}
+data:
+  secrets.json.tmpl: |-
+{{ .Files.Get "vault-agent-templates/secrets.json.tmpl" | indent 4 }}

--- a/deploy/helm/cloud-tasks/nvct-api/templates/deployment.yaml
+++ b/deploy/helm/cloud-tasks/nvct-api/templates/deployment.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "nvct-api.fullname" . }}
+  namespace: {{ include "nvct-api.namespace" . }}
+  labels:
+    {{- include "nvct-api.labels" . | nindent 4 }}
+spec:
+  replicas: {{ default 1 .Values.nvctApi.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "nvct-api.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- include "nvct-api.vaultAnnotations" . | nindent 8 }}
+        {{- with .Values.nvctApi.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.nvctApi.env }}
+        checksum/config-env: {{ toYaml .Values.nvctApi.env | sha256sum }}
+        {{- end }}
+      labels:
+        {{- include "nvct-api.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.nvctApi.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: nvct-api
+      securityContext:
+        {{- toYaml .Values.nvctApi.podSecurityContext | nindent 8 }}
+      volumes:
+        {{- with .Values.nvctApi.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        - name: vault-config-templates
+          configMap:
+            name: {{ include "nvct-api.fullname" . }}-vault-agent-tpl
+            items:
+              - key: secrets.json.tmpl
+                path: secrets.json.tmpl
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.nvctApi.securityContext | nindent 12 }}
+          image: "{{ include "nvct-api.image" . }}"
+          imagePullPolicy: {{ .Values.nvctApi.image.pullPolicy }}
+          volumeMounts:
+            {{- with .Values.nvctApi.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: {{ .Values.nvctApi.springProfilesActive | default "ncp" | quote }}
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- if .Values.nvctApi.remoteConfig.enabled }}
+            - name: REMOTE_CONFIG_ENABLED
+              value: "true"
+            - name: REMOTE_CONFIG_NAME
+              value: {{ include "nvct-api.remoteConfigName" . | quote }}
+            {{- end }}
+          {{- if .Values.nvctApi.env }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "nvct-api.fullname" . }}-env
+          {{- end }}
+          ports:
+            {{- range .Values.nvctApi.ports }}
+            - name: {{ .name }}
+              containerPort: {{ .containerPort }}
+              protocol: {{ .protocol }}
+            {{- end }}
+          {{- with .Values.nvctApi.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.nvctApi.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.nvctApi.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.nvctApi.resources | nindent 12 }}
+      {{- with .Values.nvctApi.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nvctApi.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nvctApi.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/cloud-tasks/nvct-api/templates/hpa.yaml
+++ b/deploy/helm/cloud-tasks/nvct-api/templates/hpa.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.nvctApi.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "nvct-api.fullname" . }}
+  namespace: {{ include "nvct-api.namespace" . }}
+  labels:
+    {{- include "nvct-api.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "nvct-api.fullname" . }}
+  minReplicas: {{ .Values.nvctApi.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.nvctApi.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.nvctApi.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.nvctApi.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.nvctApi.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.nvctApi.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/cloud-tasks/nvct-api/templates/rbac-config-reader.yaml
+++ b/deploy/helm/cloud-tasks/nvct-api/templates/rbac-config-reader.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.nvctApi.remoteConfig.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "nvct-api.remoteConfigReaderName" . }}
+  namespace: {{ include "nvct-api.namespace" . }}
+  labels:
+    {{- include "nvct-api.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "nvct-api.remoteConfigReaderName" . }}
+  namespace: {{ include "nvct-api.namespace" . }}
+  labels:
+    {{- include "nvct-api.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: nvct-api
+    namespace: {{ include "nvct-api.namespace" . }}
+roleRef:
+  kind: Role
+  name: {{ include "nvct-api.remoteConfigReaderName" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/deploy/helm/cloud-tasks/nvct-api/templates/service.yaml
+++ b/deploy/helm/cloud-tasks/nvct-api/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nvct-api
+  namespace: {{ include "nvct-api.namespace" . }}
+  labels:
+    {{- include "nvct-api.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.nvctApi.service.type }}
+  ports:
+    {{- range .Values.nvctApi.service.ports }}
+    - port: {{ .port }}
+      targetPort: {{ .targetPort }}
+      protocol: {{ .protocol }}
+      name: {{ .name }}
+    {{- end }}
+  selector:
+    {{- include "nvct-api.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/cloud-tasks/nvct-api/templates/serviceaccount.yaml
+++ b/deploy/helm/cloud-tasks/nvct-api/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nvct-api
+  namespace: {{ include "nvct-api.namespace" . }}
+  labels:
+    {{- include "nvct-api.labels" . | nindent 4 }}

--- a/deploy/helm/cloud-tasks/nvct-api/values.yaml
+++ b/deploy/helm/cloud-tasks/nvct-api/values.yaml
@@ -3,7 +3,7 @@ nvctApi:
     registry: "" # must be supplied
     repository: "" # must be supplied
     pullPolicy: IfNotPresent
-    tag: "1.6.2"
+    tag: "1.63.2"
 
   # Namespace to deploy the resources. The default value is the release namespace.
   namespace: ""

--- a/deploy/helm/cloud-tasks/nvct-api/values.yaml
+++ b/deploy/helm/cloud-tasks/nvct-api/values.yaml
@@ -1,0 +1,144 @@
+nvctApi:
+  image:
+    registry: "" # must be supplied
+    repository: "" # must be supplied
+    pullPolicy: IfNotPresent
+    tag: "1.6.2"
+
+  # Namespace to deploy the resources. The default value is the release namespace.
+  namespace: ""
+
+  nameOverride: ""
+  fullnameOverride: ""
+
+  replicaCount: 1
+
+  podAnnotations: {}
+  podLabels: {}
+
+  podSecurityContext: {}
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+      add:
+        - NET_BIND_SERVICE
+    runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    ports:
+      - name: http
+        port: 8080
+        targetPort: 8080
+        protocol: TCP
+      - name: grpc
+        port: 9090
+        targetPort: 9090
+        protocol: TCP
+
+  resources:
+    limits:
+      cpu: 2
+      memory: 4Gi
+    requests:
+      cpu: 1
+      memory: 2Gi
+
+  livenessProbe:
+    httpGet:
+      path: /actuator/health/liveness
+      port: management
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 6
+
+  readinessProbe:
+    httpGet:
+      path: /actuator/health/readiness
+      port: management
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 1
+
+  startupProbe:
+    httpGet:
+      path: /actuator/health/readiness
+      port: management
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 30
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 80
+
+  volumes:
+    - name: token
+      projected:
+        sources:
+        - serviceAccountToken:
+            path: token
+            expirationSeconds: 3600
+            audience: http://openbao-server.vault-system.svc.cluster.local:8200
+
+  volumeMounts:
+    - name: token
+      mountPath: /var/run/secrets/openbao
+      readOnly: true
+    - name: vault-config-templates
+      mountPath: /vault/config/templates
+      readOnly: true
+
+  # Remote configuration via spring-cloud-kubernetes-client-config.
+  # When enabled, the chart renders the ConfigMap + Role/RoleBinding + REMOTE_CONFIG_*
+  # env vars. Set to false to opt out. service then falls back to JAR defaults in application-ncp.yaml.
+  # See README "Remote Config RBAC".
+  remoteConfig:
+    enabled: true
+    # ConfigMap metadata.name. Empty -> defaults to <fullname>-remote-config
+    # (release-scoped, collision-safe across installs in the same namespace).
+    # Override with a fixed string only when an external contract pins the name.
+    configMapName: ""
+    # Can be used for remote configuration by adding NVCT-specific properties here.
+    # Add only the keys you need to override.
+    # Placeholders like ${nvct.sidecars.hostname} resolve from environment variables
+    # (NVCT_SIDECARS_HOSTNAME / NVCT_SIDECARS_REPOSITORY).
+    # Examples:
+    #   configData:
+    #     nvct:
+    #       sidecars:
+    #         init-container: "${nvct.sidecars.hostname}/${nvct.sidecars.repository}/nvcf_worker_init:2.103.0"
+    #       scheduled-routines:
+    #         migration-job-1: # use specific migration job name here
+    #           enabled: false
+    configData:
+      nvct:
+        sidecars:
+          init-container: "${nvct.sidecars.hostname}/${nvct.sidecars.repository}/nvcf_worker_init:2.107.0"
+          utils-container: "${nvct.sidecars.hostname}/${nvct.sidecars.repository}/nvcf_worker_task:2.107.0"
+          otel-container: dummy
+          ess-agent-container: "${nvct.sidecars.hostname}/${nvct.sidecars.repository}/ess-agent:1.1.0"
+          otel-collector-container: dummy
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+  ports:
+    - name: http
+      containerPort: 8080
+      protocol: TCP
+    - name: grpc
+      containerPort: 9090
+      protocol: TCP
+    - name: management
+      containerPort: 8181
+      protocol: TCP
+
+  env:
+    HOSTNAME: "nvct-api"
+    AWS_REGION: "ncp"

--- a/deploy/helm/cloud-tasks/nvct-api/vault-agent-templates/secrets.json.tmpl
+++ b/deploy/helm/cloud-tasks/nvct-api/vault-agent-templates/secrets.json.tmpl
@@ -1,0 +1,35 @@
+{
+  "kv": {
+    "cassandra": {
+      {{- with secret "/services/nvct-api/kv/data/cassandra/creds" }}
+      "username": "{{ .Data.data.username }}",
+      "password": "{{ .Data.data.password }}"
+      {{- end }}
+    },
+    "tokens": {
+    {{- with secret `services/nvcf-api/jwt/sign/nvct-api-nvcf` }}
+      "nvcf": "{{ .Data.token }}",
+    {{- end }}
+    {{- with secret `services/nvcf-api/jwt/sign/nvct-api-notary` }}
+      "notary": "{{ .Data.token }}",
+    {{- end }}
+    {{- with secret `services/sis-api/jwt/sign/nvct-api` }}
+      "icms": "{{ .Data.token }}",
+    {{- end }}
+    {{- with secret `services/ess-api/jwt/sign/nvct-api` }}
+      "ess": "{{ .Data.token }}",
+    {{- end }}
+    {{- with secret `services/api-keys-api/jwt/sign/nvct-api` }}
+      "api-keys": "{{ .Data.token }}",
+    {{- end }}
+    {{- with secret `services/reval/jwt/sign/nvct-api` }}
+      "reval": "{{ .Data.token }}"
+    {{- end }}
+    },
+    "sidecars": {
+      {{- with secret "/services/nvct-api/kv/data/sidecars/image-pull-secret" }}
+      "image-pull-secret": "{{ .Data.data.secret }}"
+      {{- end }}
+    }
+  }
+}

--- a/deploy/helm/cloud-tasks/values.local.yaml
+++ b/deploy/helm/cloud-tasks/values.local.yaml
@@ -1,0 +1,4 @@
+nvctApi:
+  image:
+    registry: nvcr.io
+    repository: 0651155215864979/ncp-dev/nvct-service-oss

--- a/tools/ci/github-release-subprojects.json
+++ b/tools/ci/github-release-subprojects.json
@@ -283,8 +283,8 @@
     {
       "id": "cloud-tasks-helm",
       "path": "deploy/helm/cloud-tasks",
-      "service_name": "helm-cloud-tasks-api",
-      "legacy_tag_prefix": "deploy/helm/cloud-tasks"
+      "service_name": "helm-nvcf-nvct-api",
+      "initial_version": "1.4.4"
     },
     {
       "id": "instance-cluster-management",

--- a/tools/ci/github-release-subprojects.json
+++ b/tools/ci/github-release-subprojects.json
@@ -281,6 +281,12 @@
       "legacy_tag_prefix": "deploy/helm/ess/v"
     },
     {
+      "id": "cloud-tasks-helm",
+      "path": "deploy/helm/cloud-tasks",
+      "service_name": "helm-cloud-tasks-api",
+      "legacy_tag_prefix": "deploy/helm/cloud-tasks"
+    },
+    {
       "id": "instance-cluster-management",
       "path": "src/control-plane-services/instance-cluster-management",
       "service_name": "nvcf-instance-cluster-management"

--- a/tools/ci/test-github-release.py
+++ b/tools/ci/test-github-release.py
@@ -600,11 +600,13 @@ class GithubReleaseTest(unittest.TestCase):
                 self.github_release.synthesize_initial_version_anchor(root, service)
             self.assertIn("deploy/helm/cloud-tasks/v0.0.0", self._tags(root))
 
-    def test_initial_version_anchor_honors_metadata(self):
-        metadata = json.loads(
-            Path(__file__).with_name("github-release-subprojects.json").read_text()
-        )
-        service = self.github_release.find_service(metadata, "cloud-tasks-helm")
+    def test_cf_initial_version_anchor_honors_metadata(self):
+        service = {
+                "id": "cloud-tasks-helm",
+                "path": "deploy/helm/cloud-tasks",
+                "service_name": "helm-cloud-tasks-api",
+                "initial_version": "1.6.0",
+        }
         expected_tag = self.github_release.tag_for_version(service, service["initial_version"])
         default_floor_tag = self.github_release.tag_for_version(
             service, self.github_release.INITIAL_RELEASE_FLOOR_VERSION
@@ -618,7 +620,7 @@ class GithubReleaseTest(unittest.TestCase):
             self.assertIn(expected_tag, tags)
             self.assertNotIn(default_floor_tag, tags)
 
-    def test_initial_version_anchor_rejects_bad_semver(self):
+    def test_cf_initial_version_anchor_rejects_bad_semver(self):
         service = {
             "id": "cloud-tasks-helm",
             "path": "deploy/helm/cloud-tasks",
@@ -628,7 +630,7 @@ class GithubReleaseTest(unittest.TestCase):
         with self.assertRaises(SystemExit):
             self.github_release.initial_floor_version(service)
 
-    def test_initial_version_anchor_rejects_empty_string(self):
+    def test_cf_initial_version_anchor_rejects_empty_string(self):
         service = {
             "id": "cloud-tasks-helm",
             "path": "deploy/helm/cloud-tasks",

--- a/tools/ci/test-github-release.py
+++ b/tools/ci/test-github-release.py
@@ -578,6 +578,66 @@ class GithubReleaseTest(unittest.TestCase):
         with self.assertRaises(SystemExit):
             self.github_release.initial_floor_version(service)
 
+    def _make_ct_service_repo(self, root):
+        self.init_repo(root)
+        (root / "README.md").write_text("root\n")
+        self.commit_all(root, "chore: init")
+        service_dir = root / "deploy/helm/cloud-tasks"
+        service_dir.mkdir(parents=True, exist_ok=True)
+        (service_dir / "Chart.yaml").write_text("name: helm-cloud-tasks-api\n")
+        self.commit_all(root, "feat: import cloud tasks chart")
+
+    def test_cf_initial_version_anchor_defaults_to_floor(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._make_service_repo(root)
+            service = {
+                "id": "cloud-tasks-helm",
+                "path": "deploy/helm/cloud-tasks",
+                "service_name": "helm-cloud-tasks-api",
+            }
+            with chdir(root), contextlib.redirect_stdout(io.StringIO()):
+                self.github_release.synthesize_initial_version_anchor(root, service)
+            self.assertIn("deploy/helm/cloud-tasks/v0.0.0", self._tags(root))
+
+    def test_initial_version_anchor_honors_metadata(self):
+        metadata = json.loads(
+            Path(__file__).with_name("github-release-subprojects.json").read_text()
+        )
+        service = self.github_release.find_service(metadata, "cloud-tasks-helm")
+        expected_tag = self.github_release.tag_for_version(service, service["initial_version"])
+        default_floor_tag = self.github_release.tag_for_version(
+            service, self.github_release.INITIAL_RELEASE_FLOOR_VERSION
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._make_service_repo(root)
+            with chdir(root), contextlib.redirect_stdout(io.StringIO()):
+                self.github_release.synthesize_initial_version_anchor(root, service)
+            tags = self._tags(root)
+            self.assertIn(expected_tag, tags)
+            self.assertNotIn(default_floor_tag, tags)
+
+    def test_initial_version_anchor_rejects_bad_semver(self):
+        service = {
+            "id": "cloud-tasks-helm",
+            "path": "deploy/helm/cloud-tasks",
+            "service_name": "helm-cloud-tasks-api",
+            "initial_version": "not-a-version",
+        }
+        with self.assertRaises(SystemExit):
+            self.github_release.initial_floor_version(service)
+
+    def test_initial_version_anchor_rejects_empty_string(self):
+        service = {
+            "id": "cloud-tasks-helm",
+            "path": "deploy/helm/cloud-tasks",
+            "service_name": "helm-cloud-tasks-api",
+            "initial_version": "",
+        }
+        with self.assertRaises(SystemExit):
+            self.github_release.initial_floor_version(service)
+
     def test_nvca_branch_cut_uses_path_scoped_release_branch(self):
         service = {
             "id": "nvca",

--- a/tools/ci/test-github-release.py
+++ b/tools/ci/test-github-release.py
@@ -605,7 +605,7 @@ class GithubReleaseTest(unittest.TestCase):
                 "id": "cloud-tasks-helm",
                 "path": "deploy/helm/cloud-tasks",
                 "service_name": "helm-cloud-tasks-api",
-                "initial_version": "1.6.0",
+                "initial_version": "1.0.5",
         }
         expected_tag = self.github_release.tag_for_version(service, service["initial_version"])
         default_floor_tag = self.github_release.tag_for_version(

--- a/tools/ci/test-github-release.py
+++ b/tools/ci/test-github-release.py
@@ -584,17 +584,17 @@ class GithubReleaseTest(unittest.TestCase):
         self.commit_all(root, "chore: init")
         service_dir = root / "deploy/helm/cloud-tasks"
         service_dir.mkdir(parents=True, exist_ok=True)
-        (service_dir / "Chart.yaml").write_text("name: helm-cloud-tasks-api\n")
+        (service_dir / "Chart.yaml").write_text("name: helm-nvcf-nvct-api\n")
         self.commit_all(root, "feat: import cloud tasks chart")
 
     def test_cf_initial_version_anchor_defaults_to_floor(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            self._make_service_repo(root)
+            self._make_ct_service_repo(root)
             service = {
                 "id": "cloud-tasks-helm",
                 "path": "deploy/helm/cloud-tasks",
-                "service_name": "helm-cloud-tasks-api",
+                "service_name": "helm-nvcf-nvct-api",
             }
             with chdir(root), contextlib.redirect_stdout(io.StringIO()):
                 self.github_release.synthesize_initial_version_anchor(root, service)
@@ -604,8 +604,8 @@ class GithubReleaseTest(unittest.TestCase):
         service = {
                 "id": "cloud-tasks-helm",
                 "path": "deploy/helm/cloud-tasks",
-                "service_name": "helm-cloud-tasks-api",
-                "initial_version": "1.0.5",
+                "service_name": "helm-nvcf-nvct-api",
+                "initial_version": "1.4.4",
         }
         expected_tag = self.github_release.tag_for_version(service, service["initial_version"])
         default_floor_tag = self.github_release.tag_for_version(
@@ -613,7 +613,7 @@ class GithubReleaseTest(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            self._make_service_repo(root)
+            self._make_ct_service_repo(root)
             with chdir(root), contextlib.redirect_stdout(io.StringIO()):
                 self.github_release.synthesize_initial_version_anchor(root, service)
             tags = self._tags(root)
@@ -624,7 +624,7 @@ class GithubReleaseTest(unittest.TestCase):
         service = {
             "id": "cloud-tasks-helm",
             "path": "deploy/helm/cloud-tasks",
-            "service_name": "helm-cloud-tasks-api",
+            "service_name": "helm-nvcf-nvct-api",
             "initial_version": "not-a-version",
         }
         with self.assertRaises(SystemExit):
@@ -634,11 +634,33 @@ class GithubReleaseTest(unittest.TestCase):
         service = {
             "id": "cloud-tasks-helm",
             "path": "deploy/helm/cloud-tasks",
-            "service_name": "helm-cloud-tasks-api",
+            "service_name": "helm-nvcf-nvct-api",
             "initial_version": "",
         }
         with self.assertRaises(SystemExit):
             self.github_release.initial_floor_version(service)
+
+    def test_cloud_tasks_chart_continues_its_published_lineage(self):
+        # This chart migrated in from its own colocated-deploy repo with 11
+        # versions already published as helm-nvcf-nvct-api, the newest 1.4.4.
+        #
+        # Both fields below are load-bearing and both have a plausible wrong
+        # value. Without initial_version the floor is 0.0.0, so the first
+        # release computed here would land below everything already published.
+        # And 1.6.x, the number the chart's own appVersion carries, belongs to
+        # the cloud-tasks service, not to the chart.
+        #
+        # service_name is what the chart is published as. A service-shaped
+        # name would open an empty second chart repo and strand all 11
+        # existing versions while the pipeline still reported success.
+        metadata = json.loads(SCRIPT_PATH.with_name("github-release-subprojects.json").read_text())
+        service = next(s for s in metadata["services"] if s["id"] == "cloud-tasks-helm")
+        self.assertEqual(service["service_name"], "helm-nvcf-nvct-api")
+        self.assertEqual(service["initial_version"], "1.4.4")
+        self.assertEqual(
+            self.github_release.tag_for_version(service, service["initial_version"]),
+            "deploy/helm/cloud-tasks/v1.4.4",
+        )
 
     def test_nvca_branch_cut_uses_path_scoped_release_branch(self):
         service = {


### PR DESCRIPTION

Add support for Cloud-Tasks Helm charts

Closes https://github.com/NVIDIA/nvcf/issues/749



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Helm-based deployment support for the NVCT API in self-managed environments.
  - Added configurable services, health checks, resources, autoscaling, security, scheduling, and local deployment values.
  - Added optional remote configuration, Vault-backed secret injection, and access permissions.
  - Added commands for installation, validation, packaging, and OCI publishing.
  - Added release versioning and tagging integration for the Helm deployment.

- **Documentation**
  - Added setup, configuration, troubleshooting, endpoint, and health-check guidance.

- **Tests**
  - Added release version validation and tagging coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->