### PR TITLE
fix(nvca): default managed worker images

### DIFF
--- a/deploy/helm/nvca-operator/nvca-operator/templates/self-managed-nvcfbackend-cm.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/templates/self-managed-nvcfbackend-cm.yaml
@@ -18,8 +18,8 @@ metadata:
   name: nvcfbackend-self-managed
   namespace: {{ .Release.Namespace }}
   {{- $releaseArtifactNvcaImageRepository := .Values.nvcaImage.repositoryOverride }}
-  {{- $releaseArtifactImageCredentialHelperRepository := (.Values.selfManaged.imageCredHelper | default dict).imageRepository }}
-  {{- $releaseArtifactSambaRepository := (.Values.selfManaged.sharedStorage | default dict).imageRepository }}
+  {{- $releaseArtifactImageCredentialHelperRepository := .Values.selfManaged.imageCredHelper.imageRepository }}
+  {{- $releaseArtifactSambaRepository := .Values.selfManaged.sharedStorage.imageRepository }}
   {{- if or $releaseArtifactNvcaImageRepository $releaseArtifactImageCredentialHelperRepository $releaseArtifactSambaRepository }}
   annotations:
     {{- if $releaseArtifactNvcaImageRepository }}

--- a/deploy/helm/nvca-operator/nvca-operator/values.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/values.yaml
@@ -202,6 +202,10 @@ agent:
   ##     ESS_AGENT_CONTAINER: "nvcr.io/qtfpt1h0bieu/nvcf-core/ess-agent:1.0.5"
   functionEnvOverrides:
     BYOO_OTEL_COLLECTOR_CONTAINER: nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector:0.157.11
+    INIT_CONTAINER: nvcr.io/qtfpt1h0bieu/nvcf-core/nvcf_worker_init:2.114.0
+    UTILS_CONTAINER: nvcr.io/qtfpt1h0bieu/nvcf-core/nvcf_worker_utils:2.114.0
+    NICLLS_CONTAINER: nvcr.io/qtfpt1h0bieu/nvcf-core/nvcf_worker_niclls:2.114.0
+    ESS_AGENT_CONTAINER: nvcr.io/qtfpt1h0bieu/nvcf-core/ess-agent:1.4.0
   ## Environment variable overrides for task workloads.
   ## Available keys: INIT_CONTAINER, UTILS_CONTAINER, OTEL_CONTAINER, BYOO_OTEL_COLLECTOR_CONTAINER,
   ##                 ESS_AGENT_CONTAINER, TASK_CONTAINER
@@ -211,6 +215,9 @@ agent:
   ##     UTILS_CONTAINER: "nvcr.io/qtfpt1h0bieu/nvcf-core/nvcf_worker_utils:2.94.0"
   taskEnvOverrides:
     BYOO_OTEL_COLLECTOR_CONTAINER: nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector:0.157.11
+    INIT_CONTAINER: nvcr.io/qtfpt1h0bieu/nvcf-core/nvcf_worker_init:2.114.0
+    UTILS_CONTAINER: nvcr.io/qtfpt1h0bieu/nvcf-core/nvcf_worker_utils:2.114.0
+    ESS_AGENT_CONTAINER: nvcr.io/qtfpt1h0bieu/nvcf-core/ess-agent:1.4.0
   overrideEnvironmentVariables: {}
   serviceOAuth:
     helmReVal:

--- a/deploy/helm/nvca-operator/scripts/ci_vendor_nvca_operator_chart
+++ b/deploy/helm/nvca-operator/scripts/ci_vendor_nvca_operator_chart
@@ -175,6 +175,12 @@ main() {
     fi
 
     byoo_otel_collector_image="${BYOO_OTEL_COLLECTOR_IMAGE:-nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector:0.157.11}"
+    worker_image_repository="${NVCF_WORKER_IMAGE_REPOSITORY:-nvcr.io/qtfpt1h0bieu/nvcf-core}"
+    worker_version="${NVCF_WORKER_VERSION:-2.114.0}"
+    worker_init_image="${NVCF_WORKER_INIT_IMAGE:-${worker_image_repository}/nvcf_worker_init:${worker_version}}"
+    worker_utils_image="${NVCF_WORKER_UTILS_IMAGE:-${worker_image_repository}/nvcf_worker_utils:${worker_version}}"
+    worker_niclls_image="${NVCF_WORKER_NICLLS_IMAGE:-${worker_image_repository}/nvcf_worker_niclls:${worker_version}}"
+    ess_agent_image="${ESS_AGENT_IMAGE:-${worker_image_repository}/ess-agent:1.4.0}"
 
     TARGET_DIR="${root_dir}/nvca-operator"
     SOURCE_DIR="${root_dir}/../../../src/compute-plane-services/nvca/deployments/nvca-operator"
@@ -205,6 +211,13 @@ main() {
     update_yaml_key ".ngcConfig.serviceKey = \"dummy-api-key\"" "${TARGET_DIR}/values.yaml"
     update_yaml_key ".agent.functionEnvOverrides.BYOO_OTEL_COLLECTOR_CONTAINER = \"${byoo_otel_collector_image}\"" "${TARGET_DIR}/values.yaml"
     update_yaml_key ".agent.taskEnvOverrides.BYOO_OTEL_COLLECTOR_CONTAINER = \"${byoo_otel_collector_image}\"" "${TARGET_DIR}/values.yaml"
+    update_yaml_key ".agent.functionEnvOverrides.INIT_CONTAINER = \"${worker_init_image}\"" "${TARGET_DIR}/values.yaml"
+    update_yaml_key ".agent.functionEnvOverrides.UTILS_CONTAINER = \"${worker_utils_image}\"" "${TARGET_DIR}/values.yaml"
+    update_yaml_key ".agent.functionEnvOverrides.NICLLS_CONTAINER = \"${worker_niclls_image}\"" "${TARGET_DIR}/values.yaml"
+    update_yaml_key ".agent.functionEnvOverrides.ESS_AGENT_CONTAINER = \"${ess_agent_image}\"" "${TARGET_DIR}/values.yaml"
+    update_yaml_key ".agent.taskEnvOverrides.INIT_CONTAINER = \"${worker_init_image}\"" "${TARGET_DIR}/values.yaml"
+    update_yaml_key ".agent.taskEnvOverrides.UTILS_CONTAINER = \"${worker_utils_image}\"" "${TARGET_DIR}/values.yaml"
+    update_yaml_key ".agent.taskEnvOverrides.ESS_AGENT_CONTAINER = \"${ess_agent_image}\"" "${TARGET_DIR}/values.yaml"
     update_yaml_key ".image.tag = \"${NVCA_OPERATOR_VERSION:?"NVCA_OPERATOR_VERSION is not set"}\"" "${TARGET_DIR}/values.yaml"
     update_yaml_key ".selfManaged.nvcaVersion = \"${NVCA_VERSION:?"NVCA_VERSION is not set"}\"" "${TARGET_DIR}/values.yaml"
     update_yaml_key ".selfManaged.icmsServiceURL = \"http://icms.example.invalid:8080\"" "${TARGET_DIR}/values.yaml"

--- a/deploy/helm/nvca-operator/scripts/render_release_supplemental_images.sh
+++ b/deploy/helm/nvca-operator/scripts/render_release_supplemental_images.sh
@@ -153,22 +153,32 @@ while IFS= read -r encoded_overrides; do
     exit 1
   fi
 
-  if ! printf '%s' "$decoded_overrides" | yq -e 'has("BYOO_OTEL_COLLECTOR_CONTAINER")' >/dev/null; then
-    continue
-  fi
+  for override_image_key in \
+    INIT_CONTAINER \
+    UTILS_CONTAINER \
+    OTEL_CONTAINER \
+    BYOO_OTEL_COLLECTOR_CONTAINER \
+    NICLLS_CONTAINER \
+    ESS_AGENT_CONTAINER \
+    INFERENCE_CONTAINER \
+    TASK_CONTAINER; do
+    if ! printf '%s' "$decoded_overrides" | yq -e "has(\"${override_image_key}\")" >/dev/null 2>&1; then
+      continue
+    fi
 
-  if ! printf '%s' "$decoded_overrides" | yq -e '.BYOO_OTEL_COLLECTOR_CONTAINER | type == "!!str"' >/dev/null; then
-    echo "BYOO_OTEL_COLLECTOR_CONTAINER must be a string" >&2
-    exit 1
-  fi
+    if ! printf '%s' "$decoded_overrides" | yq -e ".${override_image_key} | type == \"!!str\"" >/dev/null 2>&1; then
+      echo "${override_image_key} must be a string" >&2
+      exit 1
+    fi
 
-  byoo_otel_collector_image="$(printf '%s' "$decoded_overrides" | yq -er '.BYOO_OTEL_COLLECTOR_CONTAINER')"
-  if ! is_valid_image_reference "$byoo_otel_collector_image"; then
-    echo "invalid BYOO_OTEL_COLLECTOR_CONTAINER image reference" >&2
-    exit 1
-  fi
+    override_image="$(printf '%s' "$decoded_overrides" | yq -er ".${override_image_key}")"
+    if ! is_valid_image_reference "$override_image"; then
+      echo "invalid ${override_image_key} image reference" >&2
+      exit 1
+    fi
 
-  printf '%s\n' "$byoo_otel_collector_image" >> "$tmp_images"
+    printf '%s\n' "$override_image" >> "$tmp_images"
+  done
 done < <(
   awk '
     /-[[:space:]]+--(function|task)-env-overrides-b64$/ {

--- a/deploy/helm/nvca-operator/tests/release_image_manifest_test.sh
+++ b/deploy/helm/nvca-operator/tests/release_image_manifest_test.sh
@@ -44,9 +44,9 @@ spec:
               value: "nvcr.io/nvidia/nvcf-byoc/nvca"
           args:
             - --function-env-overrides-b64
-            - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTU3LjExIn0="
+            - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTU3LjExIiwiSU5JVF9DT05UQUlORVIiOiJudmNyLmlvL3F0ZnB0MWgwYmlldS9udmNmLWNvcmUvbnZjZl93b3JrZXJfaW5pdDoyLjExNC4wIiwiVVRJTFNfQ09OVEFJTkVSIjoibnZjci5pby9xdGZwdDFoMGJpZXUvbnZjZi1jb3JlL252Y2Zfd29ya2VyX3V0aWxzOjIuMTE0LjAiLCJOSUNMTFNfQ09OVEFJTkVSIjoibnZjci5pby9xdGZwdDFoMGJpZXUvbnZjZi1jb3JlL252Y2Zfd29ya2VyX25pY2xsczoyLjExNC4wIiwiRVNTX0FHRU5UX0NPTlRBSU5FUiI6Im52Y3IuaW8vcXRmcHQxaDBiaWV1L252Y2YtY29yZS9lc3MtYWdlbnQ6MS40LjAifQ=="
             - --task-env-overrides-b64
-            - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTU3LjExIn0="
+            - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTU3LjExIiwiSU5JVF9DT05UQUlORVIiOiJudmNyLmlvL3F0ZnB0MWgwYmlldS9udmNmLWNvcmUvbnZjZl93b3JrZXJfaW5pdDoyLjExNC4wIiwiVVRJTFNfQ09OVEFJTkVSIjoibnZjci5pby9xdGZwdDFoMGJpZXUvbnZjZi1jb3JlL252Y2Zfd29ya2VyX3V0aWxzOjIuMTE0LjAiLCJFU1NfQUdFTlRfQ09OVEFJTkVSIjoibnZjci5pby9xdGZwdDFoMGJpZXUvbnZjZi1jb3JlL2Vzcy1hZ2VudDoxLjQuMCJ9"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -92,6 +92,10 @@ expected_images=(
   "nvcr.io/nvidia/nvcf-byoc/nvcf-otel-collector:0.143.2"
   "nvcr.io/nvidia/nvcf-byoc/samba:1.0.5"
   "nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector:0.157.11"
+  "nvcr.io/qtfpt1h0bieu/nvcf-core/nvcf_worker_init:2.114.0"
+  "nvcr.io/qtfpt1h0bieu/nvcf-core/nvcf_worker_utils:2.114.0"
+  "nvcr.io/qtfpt1h0bieu/nvcf-core/nvcf_worker_niclls:2.114.0"
+  "nvcr.io/qtfpt1h0bieu/nvcf-core/ess-agent:1.4.0"
 )
 
 for image in "${expected_images[@]}"; do
@@ -102,8 +106,8 @@ for image in "${expected_images[@]}"; do
 done
 
 line_count="$(wc -l < "${image_manifest}" | tr -d '[:space:]')"
-if [[ "${line_count}" != "6" ]]; then
-  echo "expected exactly 6 unique images, got ${line_count}" >&2
+if [[ "${line_count}" != "10" ]]; then
+  echo "expected exactly 10 unique images, got ${line_count}" >&2
   cat "${image_manifest}" >&2
   exit 1
 fi

--- a/deploy/helm/nvca-operator/tests/render_values_from_stack_env_test.sh
+++ b/deploy/helm/nvca-operator/tests/render_values_from_stack_env_test.sh
@@ -81,4 +81,18 @@ if [[ "${actual_nvca_version}" != "2.52.0-rc.5" ]]; then
   exit 1
 fi
 
-echo "render_values_from_stack_env.sh keeps upgrade version fields aligned with vendored defaults"
+for key in INIT_CONTAINER UTILS_CONTAINER NICLLS_CONTAINER ESS_AGENT_CONTAINER; do
+  if ! yq -e ".agent.functionEnvOverrides.${key} == null" "${output_file}" >/dev/null; then
+    echo "expected self-managed function override ${key} to be removed" >&2
+    exit 1
+  fi
+done
+
+for key in INIT_CONTAINER UTILS_CONTAINER ESS_AGENT_CONTAINER; do
+  if ! yq -e ".agent.taskEnvOverrides.${key} == null" "${output_file}" >/dev/null; then
+    echo "expected self-managed task override ${key} to be removed" >&2
+    exit 1
+  fi
+done
+
+echo "render_values_from_stack_env.sh keeps version fields aligned and removes managed worker defaults"

--- a/deploy/helm/nvca-operator/values.local.yml
+++ b/deploy/helm/nvca-operator/values.local.yml
@@ -19,6 +19,20 @@ ngcConfig:
   clusterSource: self-managed
   serviceKey: "not-used"
 
+# The managed chart defaults below use NGC-managed worker images. Remove only
+# those defaults for self-managed installs while retaining the BYOO collector
+# override that is packaged for the self-managed chart.
+agent:
+  functionEnvOverrides:
+    INIT_CONTAINER: null
+    UTILS_CONTAINER: null
+    NICLLS_CONTAINER: null
+    ESS_AGENT_CONTAINER: null
+  taskEnvOverrides:
+    INIT_CONTAINER: null
+    UTILS_CONTAINER: null
+    ESS_AGENT_CONTAINER: null
+
 selfManaged:
   icmsServiceURL: "http://icms.example.invalid:8080"
   icmsServiceHostHeaderOverride: ""


### PR DESCRIPTION
## TL;DR

Default managed NVCA chart worker images to released versions. Self-managed installs remove the new defaults while retaining the existing BYOO collector override.

## Additional Details

- Add managed defaults for the init, utils, NICLLS, and ESS sidecars.
- Apply NICLLS only to function workloads. Do not override customer function or task images.
- Include image references encoded in workload override arguments in the release SBOM input.
- Re-vendor the chart from its source chart.

## For the Reviewer

- Review the managed and self-managed values layering in `ci_vendor_nvca_operator_chart` and `values.local.yml`.
- Confirm the release image manifest covers every default image encoded in the chart arguments.

## For QA

- `make lint`
- `make validate`
- `make test-release-image-manifest`
- `make test-render-values`
- Rendered self-managed values retain only the BYOO collector override.

## Issues

Relates to #404

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable image overrides for function and task workload containers, including worker, utility, networking, and ESS agent images.
  * Added default image settings for self-managed deployments while preserving BYOO collector configuration.

* **Bug Fixes**
  * Improved validation of supplemental container image overrides, with clear errors for invalid image references.
  * Corrected handling of self-managed image repository settings.

* **Tests**
  * Expanded release image checks to cover all supported workload images.
  * Added verification that managed worker defaults are removed where appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->