### PR TITLE
fix(ess): note service directory in README

### DIFF
--- a/src/control-plane-services/encrypted-secret-store/README.md
+++ b/src/control-plane-services/encrypted-secret-store/README.md
@@ -4,6 +4,8 @@ Encrypted Secret Store (ESS) provides a reactive REST API for storing secrets
 with tenant-scoped encryption and authorization. Its API design follows the
 Vault KV v2 model to support workload secret injection.
 
+The service lives under `src/control-plane-services/encrypted-secret-store/`.
+
 ## Modules
 
 | Module | Purpose |


### PR DESCRIPTION
## TL;DR
Doc-only `fix(ess)` under the renamed path to mint the first release tag under the new `encrypted-secret-store` prefix. Release automation resolves the prior version via `legacy_tag_prefix` and cuts the next patch (`v0.4.12` -> `v0.4.13`) as `src/control-plane-services/encrypted-secret-store/v0.4.13`.

## Additional Details
- `src/control-plane-services/encrypted-secret-store/README.md`: add one sentence stating the service directory path.
- No code or behavior change. The `fix` type is intentional to exercise the patch bump under the renamed prefix and confirm lineage carried across the rename.

## For the Reviewer
Follows the ESS directory rename (#748). Validates that `legacy_tag_prefix` continues the version line under the new path prefix rather than resetting.

## For QA
No QA needed. Verify the release helper resolves ESS to `v0.4.13` under `src/control-plane-services/encrypted-secret-store/`.

## Issues
Relates to #747

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the service directory path to the encrypted secret store README introduction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->