### PR TITLE
chore: bump state-metrics, stargate, and llm-request-router artifacts

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
@@ -58,7 +58,7 @@ releases:
 
   # --- Observability Services ---
   - name: state-metrics
-    version: 1.0.1
+    version: 1.0.2
     namespace: nvcf
     condition: stateMetrics.enabled # From global.yaml.gotmpl or env overrides
     inherit:

--- a/docs/user/manifest.md
+++ b/docs/user/manifest.md
@@ -119,7 +119,7 @@ The following tables list the complete artifact inventory.
 | `helm-nvcf-grpc-proxy` | `1.6.7` | Required | Deploys the gRPC proxy service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-grpc-proxy:1.6.7` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/grpc-proxy) |
 | `helm-nvcf-invocation-service` | `1.5.5` | Required | Deploys the HTTP invocation service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-invocation-service:1.5.5` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/http-invocation) |
 | `helm-nvcf-llm-api-gateway` | `1.2.0` | Optional | Deploys the OpenAI-compatible LLM API gateway. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-llm-api-gateway:1.2.0` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/llm-api-gateway) |
-| `helm-nvcf-llm-request-router` | `1.6.3` | Optional | Deploys the LLM request router. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-llm-request-router:1.6.3` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/llm-request-router) |
+| `helm-nvcf-llm-request-router` | `1.6.6` | Optional | Deploys the LLM request router. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-llm-request-router:1.6.6` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/llm-request-router) |
 | `helm-nvcf-nats` | `0.7.1` | Required | Deploys NATS messaging for the control plane. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-nats:0.7.1` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/nats) / [Upstream](https://github.com/nats-io/k8s) |
 | `helm-nvcf-nats-auth-callout-service` | `1.1.3` | Required | Deploys the NATS authorization callout service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-nats-auth-callout-service:1.1.3` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/nats-auth-callout) |
 | `helm-nvcf-notary-service` | `1.4.2` | Required | Deploys the notary service for signing and validation. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-notary-service:1.4.2` |  |
@@ -128,7 +128,7 @@ The following tables list the complete artifact inventory.
 | `helm-nvcf-pki` | `0.1.0` | Optional | Provisions the OpenBao-backed ClusterIssuer for NVCF service TLS. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-pki:0.1.0` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/nvcf-pki) |
 | `helm-nvcf-rate-limiter` | `1.0.3` | Optional | Deploys request rate limiting for supported invocation paths. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-rate-limiter:1.0.3` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/ratelimiter) |
 | `helm-nvcf-sis` | `1.18.3` | Required | Deploys the Spot Instance Service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-sis:1.18.3` |  |
-| `helm-nvcf-state-metrics` | `1.0.1` | Optional | Deploys NVCF state metrics for observability. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-state-metrics:1.0.1` |  |
+| `helm-nvcf-state-metrics` | `1.0.2` | Optional | Deploys NVCF state metrics for observability. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-state-metrics:1.0.2` |  |
 | `helm-nvcf-ui` | `1.1.2` | Optional | Deploys the optional NVCF UI admin panel. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-ui:1.1.2` |  |
 | `helm-nvcf-vanity-gateway` | `0.1.0-nvcf-10204.1` | Optional | Deploys the optional vanity hostname gateway. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-vanity-gateway:0.1.0-nvcf-10204.1` |  |
 | `helm-reval` | `1.3.8` | Required | Deploys the function revalidation service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-reval:1.3.8` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/helm-reval) |
@@ -148,7 +148,7 @@ The following tables list the complete artifact inventory.
 | `cert-manager-webhook` | `v1.20.2` | Required | Validates and converts cert-manager API resources. | `nvcr.io/nvidia/nvcf/cert-manager-webhook:v1.20.2` | [Upstream](https://github.com/cert-manager/cert-manager) |
 | `ess-api` | `v0.57.26` | Required | Provides encrypted application secrets to NVCF workloads. | `nvcr.io/nvidia/nvcf/ess-api:v0.57.26` |  |
 | `llm-api-gateway` | `0.8.3` | Optional | Exposes OpenAI-compatible APIs for LLM functions. | `nvcr.io/0833294136851237/selfhosted-ga/llm-api-gateway:0.8.3-ea` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/invocation-plane-services/llm-api-gateway) |
-| `llm-request-router` | `0.3.0` | Optional | Routes LLM requests to eligible worker instances. | `nvcr.io/0833294136851237/selfhosted-ga/stargate:0.3.0-ea` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/libraries/rust/stargate) |
+| `llm-request-router` | `0.3.2` | Optional | Routes LLM requests to eligible worker instances. | `nvcr.io/nvidia/nvcf/stargate:0.3.2` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/libraries/rust/stargate) |
 | `nats-box` | `0.19.7-nonroot` | Required | Provides NATS administration and diagnostic utilities. | `nvcr.io/nvidia/nvcf/nats-box:0.19.7-nonroot` | [Upstream](https://github.com/nats-io/nats-box) |
 | `nats-server` | `2.11.17-alpine3.22` | Required | Provides messaging for function deployment and invocation. | `nvcr.io/nvidia/nvcf/nats-server:2.11.17-alpine3.22` | [Upstream](https://github.com/nats-io/nats-server) |
 | `nats-server-config-reloader` | `0.23.0` | Required | Reloads NATS server configuration when mounted settings change. | `docker.io/natsio/nats-server-config-reloader:0.23.0` | [Upstream](https://github.com/nats-io/k8s) |
@@ -160,6 +160,7 @@ The following tables list the complete artifact inventory.
 | `nvcf-openbao` | `2.5.4-nv-1.3.0` | Required | Stores and manages control-plane secrets. | `nvcr.io/0833294136851237/selfhosted-ga/nvcf-openbao:2.5.4-nv-1.3.0-ea` | [Upstream](https://github.com/openbao/openbao) |
 | `nvcf-openbao-migrations` | `0.16.2` | Required | Applies the OpenBao configuration required by NVCF. | `nvcr.io/nvidia/nvcf/nvcf-openbao-migrations:0.16.2` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/migrations/openbao) |
 | `nvcf-service-oss` | `1.9.0-hotfix.1` | Required | Provides the primary NVCF control-plane API. | `nvcr.io/nvidia/nvcf/nvcf-service-oss:1.9.0-hotfix.1` |  |
+| `nvcf-state-metrics-service` | `1.23.7` | Optional | Exports NVCF resource state as Prometheus metrics. | `nvcr.io/nvidia/nvcf/nvcf-state-metrics-service:1.23.7` |  |
 | `nvct-service-oss` | `1.5.9-hotfix.1` | Required | Provides tenant-scoped NVCF control-plane operations. | `nvcr.io/nvidia/nvcf/nvct-service-oss:1.5.9-hotfix.1` |  |
 | `oss-vault-k8s` | `1.7.4` | Required | Integrates Kubernetes workloads with OpenBao secrets. | `nvcr.io/nvidia/nvcf/oss-vault-k8s:1.7.4` |  |
 | `reval-server` | `0.2.2` | Required | Revalidates function state in the background. | `nvcr.io/nvidia/nvcf/reval-server:0.2.2` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/control-plane-services/helm-reval) |

--- a/docs/version-catalog/main.yaml
+++ b/docs/version-catalog/main.yaml
@@ -96,6 +96,9 @@ publications:
   - name: nvcf-service-oss
     version: 1.9.0-hotfix.1
     registry: public-images
+  - name: nvcf-state-metrics-service
+    version: 1.23.7
+    registry: public-images
   - name: nvcf_worker_init
     version: 1.0.1
     registry: public-images
@@ -122,9 +125,8 @@ publications:
     published_version: 0.8.3-ea
     registry: selfhosted-ga
   - name: llm-request-router
-    version: 0.3.0
-    published_version: 0.3.0-ea
-    registry: selfhosted-ga
+    version: 0.3.2
+    registry: public-images
   - name: nats-server-config-reloader
     version: 0.23.0
     registry: nats-upstream-images
@@ -177,7 +179,7 @@ publications:
     registry: public-helm
     chart_format: http
   - name: helm-nvcf-llm-request-router
-    version: 1.6.3
+    version: 1.6.6
     registry: public-helm
     chart_format: http
   - name: helm-nvcf-nats-auth-callout-service
@@ -213,7 +215,7 @@ publications:
     registry: public-helm
     chart_format: http
   - name: helm-nvcf-state-metrics
-    version: 1.0.1
+    version: 1.0.2
     registry: public-helm
     chart_format: http
   - name: helm-nvcf-ui
@@ -252,9 +254,6 @@ version_overrides:
   - name: llm-api-gateway
     version: 0.8.3
     source: supplemental artifact missing from artifacts-0.6.0.txt
-  - name: llm-request-router
-    version: 0.3.0
-    source: helm-nvcf-llm-request-router:1.6.3 (image missing from artifacts-0.6.0.txt)
 manifest:
   entries:
     - artifact_id: helm-nvcf-api-keys
@@ -537,6 +536,11 @@ manifest:
       requirement: optional
       description: Routes LLM requests to eligible worker instances.
       github_url: https://github.com/NVIDIA/nvcf/tree/main/src/libraries/rust/stargate
+    - artifact_id: nvcf-state-metrics-service
+      plane: control
+      kind: service-image
+      requirement: optional
+      description: Exports NVCF resource state as Prometheus metrics.
     - artifact_id: bitnami-cassandra
       plane: control
       kind: ea-cve
@@ -792,7 +796,7 @@ artifacts:
   - name: helm-nvcf-llm-request-router
     type: chart
     registry: staging
-    version: 1.6.3
+    version: 1.6.6
   - name: helm-nvcf-nats-auth-callout-service
     type: chart
     registry: staging
@@ -828,7 +832,7 @@ artifacts:
   - name: helm-nvcf-state-metrics
     type: chart
     registry: staging
-    version: 1.0.1
+    version: 1.0.2
   - name: helm-nvcf-ui
     type: chart
     registry: staging
@@ -893,6 +897,10 @@ artifacts:
     type: image
     registry: staging
     version: 1.9.0-hotfix.1
+  - name: nvcf-state-metrics-service
+    type: image
+    registry: staging
+    version: 1.23.7
   - name: nvcf_worker_init
     type: image
     registry: staging
@@ -954,7 +962,7 @@ supplemental_artifacts:
     type: image
     registry: staging
     repository_name: stargate
-    version: 0.3.0
+    version: 0.3.2
   - name: nvcf-image-credential-helper
     type: image
     registry: staging


### PR DESCRIPTION
## Why

Routine artifact version bump to pick up the latest published charts and
images for state-metrics, the LLM request router, and the stargate image
that backs it. The stargate image also graduates out of the EA registry
(`selfhosted-ga`) to the public `nvcr.io/nvidia/nvcf` namespace at this
version.

## What changed

- `helm-nvcf-state-metrics` chart: `1.0.1` -> `1.0.2`
- `nvcf-state-metrics-service` image: new entry at `1.23.7` (`nvcr.io/nvidia/nvcf/nvcf-state-metrics-service:1.23.7`)
- `helm-nvcf-llm-request-router` chart: `1.6.3` -> `1.6.6`
- `llm-request-router` / stargate image: `0.3.0-ea` (selfhosted-ga) -> `0.3.2` (`nvcr.io/nvidia/nvcf/stargate:0.3.2`)

The version catalog (`docs/version-catalog/main.yaml`) is the source of
truth. The helmfile release version (`03-observability.yaml.gotmpl`) and
the generated manifest table (`docs/user/manifest.md`) are updated to
match.

The `llm-request-router` version override entry is removed from the
catalog because the image is now a first-class public artifact and no
longer requires a supplemental workaround.

## Customer Release Notes

- State metrics chart updated to `1.0.2`; image available at `nvcr.io/nvidia/nvcf/nvcf-state-metrics-service:1.23.7`
- LLM request router chart updated to `1.6.6`; stargate image promoted to the public NGC registry at `nvcr.io/nvidia/nvcf/stargate:0.3.2`

## Plan Summary

Not applicable

## Usage

No operator action required beyond pulling the new versions during the
next stack deployment.

## Testing

Docs regenerated with `go run -C tools/docs-version-sync . --target main`
and confirmed clean. Unit tests pass (`go test ./...` in
`tools/docs-version-sync`). No QA needed for a version bump.

## Notes

None

## References

None

## Related Pull Requests

None

## Dependencies

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the optional NVCF state metrics service artifact to available releases.

* **Improvements**
  * Updated the LLM request router and state metrics components to newer versions.
  * Refreshed artifact manifests and release catalog entries to reflect the latest component versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->