### PR TITLE
docs(byoo): document upstream telemetry compatibility

### DIFF
--- a/docs/user/cluster-management/byoo-telemetry-compatibility.md
+++ b/docs/user/cluster-management/byoo-telemetry-compatibility.md
@@ -1,60 +1,67 @@
 # BYOO Telemetry Compatibility
 
-NVIDIA Cloud Functions (NVCF) Bring Your Own Observability (BYOO) preserves
-valid telemetry as its upstream components emit it. Collector upgrades can
-change metric names, types, labels, label values, or histogram buckets. Treat
-these changes as part of the upstream component's interface.
+## Summary
 
-## Compatibility policy
+NVIDIA Cloud Functions (NVCF) Bring Your Own Observability (BYOO) uses
+telemetry from upstream components such as the OpenTelemetry Collector and
+cAdvisor. Their output changes over time as those projects move forward. We
+preserve valid upstream telemetry instead of rewriting new output to look like
+an earlier version. This keeps the telemetry true to its source, but a valid
+upgrade can require changes to dashboards, alerts, or automation.
 
-NVCF follows these rules for upstream telemetry:
+The upstream components are the source of truth for metric semantics. Our
+generated metric references and validation fixtures follow that output.
 
-- Preserve valid upstream metric names, types, labels, and label values.
-- Do not rename, filter, or modify a valid metric only to retain an earlier
-  NVCF output shape.
-- Treat OpenTelemetry Collector and cAdvisor telemetry as authoritative unless
-  NVCF documents a user-facing reason for a transformation.
-- Update generated metric references and validation fixtures after a verified
-  upstream behavior change.
+## Key decisions
+
+1. We preserve valid upstream metric names, types, labels, label values, and
+   histogram buckets.
+1. We do not rename, filter, or modify a valid metric only to retain an earlier
+   NVCF output shape.
+1. We transform upstream telemetry only when we have a documented user-facing
+   reason.
+1. We update generated metric references and validation fixtures after we
+   verify an upstream behavior change.
 
 This policy does not prevent documented filters that limit telemetry to an
 NVCF workload, remove sensitive metadata, or apply a customer-configured metric
 subset. It prevents compatibility rules that hide valid upstream changes only
 to make new output match an old validation baseline.
 
-## What to expect during upgrades
+## What changes during upgrades
 
 Review dashboards, alerts, recording rules, and automation when the BYOO
 OpenTelemetry Collector version changes. A valid upstream change can require
 updates even when telemetry collection continues to work.
 
-For example, an OpenTelemetry Collector release changed some `otelcol_*`
-counter names so they no longer included the `_total` suffix. NVCF preserves
-the names emitted by the collector instead of adding the suffix to retain the
-earlier shape.
+For example, an OpenTelemetry Collector release exposed some `otelcol_*`
+counter metrics without the `_total` suffix used by an earlier version. We keep
+the names emitted by the collector instead of adding the suffix back.
 
 cAdvisor also emits pod-sandbox metrics with the label `container="POD"`.
 These are valid upstream series and can provide pod network, CPU, and memory
-telemetry. NVCF preserves these series instead of dropping them because the
+telemetry. We keep these series instead of dropping them because the
 container label does not name an application container.
 
-## Validation behavior
+## How we validate changes
 
-NVCF validation compares observed telemetry with generated metric references
-and golden fixtures. A difference from an older fixture is not automatically a
-collector regression.
+We use generated metric references and golden fixtures to catch differences in
+observed telemetry. These checks tell us that the output changed. They do not
+make an older fixture the permanent telemetry contract.
 
 When an upstream component changes its telemetry, maintainers:
 
 1. Verify the observed metric against the upstream component behavior.
-2. Confirm that the metric is valid and belongs to the supported BYOO scope.
-3. Update generated metric references and golden fixtures to the new output.
-4. Add a transformation only when a documented user-facing requirement needs
+1. Confirm that the metric is valid and belongs to the supported BYOO scope.
+1. Update generated metric references and golden fixtures to the new output.
+1. Add a transformation only when a documented user-facing requirement needs
    one.
 
 Do not ignore a valid metric, alias its name, synthesize labels, or rewrite
 label values only to make it pass an older fixture. Document any intentional
 transformation and its user-visible reason.
+
+## Further reading
 
 For BYOO collector options, refer to
 [NVCA Configuration](./configuration.md#agent-config-merging).

--- a/docs/user/cluster-management/byoo-telemetry-compatibility.md
+++ b/docs/user/cluster-management/byoo-telemetry-compatibility.md
@@ -1,0 +1,60 @@
+# BYOO Telemetry Compatibility
+
+NVIDIA Cloud Functions (NVCF) Bring Your Own Observability (BYOO) preserves
+valid telemetry as its upstream components emit it. Collector upgrades can
+change metric names, types, labels, label values, or histogram buckets. Treat
+these changes as part of the upstream component's interface.
+
+## Compatibility policy
+
+NVCF follows these rules for upstream telemetry:
+
+- Preserve valid upstream metric names, types, labels, and label values.
+- Do not rename, filter, or modify a valid metric only to retain an earlier
+  NVCF output shape.
+- Treat OpenTelemetry Collector and cAdvisor telemetry as authoritative unless
+  NVCF documents a user-facing reason for a transformation.
+- Update generated metric references and validation fixtures after a verified
+  upstream behavior change.
+
+This policy does not prevent documented filters that limit telemetry to an
+NVCF workload, remove sensitive metadata, or apply a customer-configured metric
+subset. It prevents compatibility rules that hide valid upstream changes only
+to make new output match an old validation baseline.
+
+## What to expect during upgrades
+
+Review dashboards, alerts, recording rules, and automation when the BYOO
+OpenTelemetry Collector version changes. A valid upstream change can require
+updates even when telemetry collection continues to work.
+
+For example, an OpenTelemetry Collector release changed some `otelcol_*`
+counter names so they no longer included the `_total` suffix. NVCF preserves
+the names emitted by the collector instead of adding the suffix to retain the
+earlier shape.
+
+cAdvisor also emits pod-sandbox metrics with the label `container="POD"`.
+These are valid upstream series and can provide pod network, CPU, and memory
+telemetry. NVCF preserves these series instead of dropping them because the
+container label does not name an application container.
+
+## Validation behavior
+
+NVCF validation compares observed telemetry with generated metric references
+and golden fixtures. A difference from an older fixture is not automatically a
+collector regression.
+
+When an upstream component changes its telemetry, maintainers:
+
+1. Verify the observed metric against the upstream component behavior.
+2. Confirm that the metric is valid and belongs to the supported BYOO scope.
+3. Update generated metric references and golden fixtures to the new output.
+4. Add a transformation only when a documented user-facing requirement needs
+   one.
+
+Do not ignore a valid metric, alias its name, synthesize labels, or rewrite
+label values only to make it pass an older fixture. Document any intentional
+transformation and its user-visible reason.
+
+For BYOO collector options, refer to
+[NVCA Configuration](./configuration.md#agent-config-merging).

--- a/fern/versions/dev.yml
+++ b/fern/versions/dev.yml
@@ -159,6 +159,8 @@ navigation:
     contents:
       - page: Observability
         path: ../../docs/user/observability.md
+      - page: BYOO Telemetry Compatibility
+        path: ../../docs/user/cluster-management/byoo-telemetry-compatibility.md
       - page: Example Dashboards
         path: ../../docs/user/example-dashboards.md
       - section: Metrics


### PR DESCRIPTION
## TL;DR

Document the BYOO telemetry compatibility policy so users and maintainers treat
valid upstream OpenTelemetry Collector and cAdvisor metric semantics as
authoritative. This closes the documentation gap left after #693 restored valid
collector and pod-sandbox metrics.

## Additional Details

- Define the preservation policy for metric names, types, labels, label values,
  and histogram buckets.
- Explain why NVCF does not add compatibility rewrites only to retain an older
  validation shape.
- Use the OpenTelemetry counter-name and cAdvisor `container="POD"` changes as
  concrete examples.
- Document how maintainers verify upstream changes before updating generated
  metric references and golden fixtures.
- Add the page to the latest `dev` documentation navigation under
  Observability.

Customer release notes: Documentation only. No runtime behavior changes.

Plan summary: Not applicable.

Dependencies: None. No license review or NOTICE update is required.

Related pull request: #693.

## For the Reviewer

Review the boundary between preserving valid upstream telemetry and applying
documented filters for workload scope, sensitive metadata, or customer metric
subsets.

## For QA

- `./tools/ci/check-docs` passed. The advisory version-sync check could not find
  the repository root after the worktree resolved under `/private/tmp`.
- `fern check --warnings` found zero errors. It reported one warning because the
  redirects check requires Fern authentication.
- `git diff --check` passed.

QA is not needed for this documentation-only change.

## Issues

Closes #705

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a BYOO telemetry compatibility policy covering metric names, types, labels, values, and histogram behavior.
  - Documented supported filtering scenarios, upgrade considerations, validation requirements, and transformation rules.
  - Added examples for OpenTelemetry Collector counters and cAdvisor pod-sandbox metrics.
  - Added the new guidance page to the Observability documentation navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->