### PR TITLE
fix(nvca-operator): restore generated image pull secret default

### DIFF
--- a/deploy/helm/nvca-operator/Makefile
+++ b/deploy/helm/nvca-operator/Makefile
@@ -44,7 +44,7 @@ OCI_REGISTRY_NAMESPACE ?= <your-org>
 CHART_NAME := $(shell yq -r .name $(helm_dir)/Chart.yaml)
 CHART_VERSION := $(shell yq -r .version $(helm_dir)/Chart.yaml)
 
-.PHONY: install uninstall status lint template validate clean package push-oci sync-chart check-synced-chart render-values-from-stack install-from-stack test-render-values test-build-release-assets test-release-image-manifest test-release-artifact-permissions test-package-release-assets test-attach-release-assets test-release-sbom-wrapper test-self-managed-nvca-image-reference
+.PHONY: install uninstall status lint template validate clean package push-oci sync-chart check-synced-chart render-values-from-stack install-from-stack test-render-values test-build-release-assets test-release-image-manifest test-release-artifact-permissions test-package-release-assets test-attach-release-assets test-release-sbom-wrapper test-self-managed-nvca-image-reference test-image-pull-secret-defaults
 
 install:
 ifndef values
@@ -112,6 +112,9 @@ test-release-sbom-wrapper:
 
 test-self-managed-nvca-image-reference:
 	@bash ./tests/self_managed_nvca_image_reference_test.sh
+
+test-image-pull-secret-defaults:
+	@bash ./tests/image_pull_secret_defaults_test.sh
 
 uninstall:
 	@echo "Deleting $(release) from namespace $(namespace)..."

--- a/deploy/helm/nvca-operator/nvca-operator/values.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/values.yaml
@@ -46,7 +46,7 @@ otelCollector:
       cpu: 200m
       memory: 256Mi
 ## @param generateImagePullSecret Use the ngcConfig.serviceKey to generate an image pull secret for nvca and nvca-operator Pods
-generateImagePullSecret: false
+generateImagePullSecret: true
 ## @param imagePullSecretName Name of the image pull secret to use for nvca and nvca-operator Pods.
 imagePullSecretName: "nvca-operator-image-pull"
 ## @param imagePullSecrets List of pre-existing imagePullSecret objects in the nvca-operator namespace to use for nvca and nvca-operator Pods. Each object must have a 'name' field. Example: [{name: "foo-bar"}, {name: "baz"}]

--- a/deploy/helm/nvca-operator/scripts/ci_vendor_nvca_operator_chart
+++ b/deploy/helm/nvca-operator/scripts/ci_vendor_nvca_operator_chart
@@ -98,8 +98,8 @@ insert_release_artifact_image_annotations() {
         print
         if ($0 == "  namespace: {{ .Release.Namespace }}") {
           print "  {{- $releaseArtifactNvcaImageRepository := .Values.nvcaImage.repositoryOverride }}"
-          print "  {{- $releaseArtifactImageCredentialHelperRepository := .Values.selfManaged.imageCredHelper.imageRepository }}"
-          print "  {{- $releaseArtifactSambaRepository := .Values.selfManaged.sharedStorage.imageRepository }}"
+          print "  {{- $releaseArtifactImageCredentialHelperRepository := (.Values.selfManaged.imageCredHelper | default dict).imageRepository }}"
+          print "  {{- $releaseArtifactSambaRepository := (.Values.selfManaged.sharedStorage | default dict).imageRepository }}"
           print "  {{- if or $releaseArtifactNvcaImageRepository $releaseArtifactImageCredentialHelperRepository $releaseArtifactSambaRepository }}"
           print "  annotations:"
           print "    {{- if $releaseArtifactNvcaImageRepository }}"
@@ -270,7 +270,6 @@ main() {
     # placeholder leaks through and helm releases report appVersion="1.0"
     # regardless of which NVCA Operator the chart is actually wired to.
     update_yaml_key ".appVersion = \"${NVCA_OPERATOR_VERSION:?"NVCA_OPERATOR_VERSION is not set"}\"" "${TARGET_DIR}/Chart.yaml"
-    update_yaml_key ".generateImagePullSecret = false" "${TARGET_DIR}/values.yaml"
     update_yaml_key ".selfManaged.sharedStorage.imageTag = \"${NVCA_SHARED_STORAGE_IMAGE_TAG:?"NVCA_SHARED_STORAGE_IMAGE_TAG is not set"}\"" "${TARGET_DIR}/values.yaml"
     update_yaml_key ".nameOverride = \"nvca-operator\"" "${TARGET_DIR}/values.yaml"
     update_yaml_key ".fullnameOverride = \"nvca-operator\"" "${TARGET_DIR}/values.yaml"

--- a/deploy/helm/nvca-operator/tests/image_pull_secret_defaults_test.sh
+++ b/deploy/helm/nvca-operator/tests/image_pull_secret_defaults_test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+
+manifest_default="${tmp_dir}/manifest-default.yaml"
+manifest_disabled="${tmp_dir}/manifest-disabled.yaml"
+
+image_repository="stg.nvcr.io/nvidia/nvcf-byoc/nvca-operator"
+
+# Render with vendored defaults. An ngc-managed install derives its registry
+# credentials from ngcConfig.serviceKey, so the chart must generate the pull
+# secret without the operator passing an extra flag.
+helm template nvca-operator "${repo_root}/nvca-operator" \
+  --namespace nvca-operator \
+  --values "${repo_root}/nvca-operator/values.yaml" \
+  --set-string "image.repository=${image_repository}" \
+  > "${manifest_default}"
+
+# Render with the generated secret turned off, as self-hosted installs do when
+# they supply their own imagePullSecrets.
+helm template nvca-operator "${repo_root}/nvca-operator" \
+  --namespace nvca-operator \
+  --values "${repo_root}/nvca-operator/values.yaml" \
+  --set-string "image.repository=${image_repository}" \
+  --set generateImagePullSecret=false \
+  > "${manifest_disabled}"
+
+# --- default render assertions ---
+
+secret_type="$(
+  yq -r 'select(.kind == "Secret" and .metadata.name == "nvca-operator-image-pull") | .type' \
+    "${manifest_default}"
+)"
+if [[ "${secret_type}" != "kubernetes.io/dockerconfigjson" ]]; then
+  echo "expected generated nvca-operator-image-pull Secret of type kubernetes.io/dockerconfigjson by default, got '${secret_type}'" >&2
+  exit 1
+fi
+
+registry_host="$(
+  yq -r 'select(.kind == "Secret" and .metadata.name == "nvca-operator-image-pull") | .data.".dockerconfigjson"' \
+    "${manifest_default}" | base64 -d | yq -r '.auths | keys | .[0]'
+)"
+if [[ "${registry_host}" != "stg.nvcr.io" ]]; then
+  echo "expected generated dockerconfigjson to carry an auth entry for stg.nvcr.io, got '${registry_host}'" >&2
+  exit 1
+fi
+
+pull_secret_ref="$(
+  yq -r 'select(.kind == "Deployment" and .metadata.name == "nvca-operator") |
+    .spec.template.spec.imagePullSecrets[] | .name' \
+    "${manifest_default}"
+)"
+if [[ "${pull_secret_ref}" != "nvca-operator-image-pull" ]]; then
+  echo "expected nvca-operator Deployment to reference the generated pull secret, got '${pull_secret_ref}'" >&2
+  exit 1
+fi
+
+# --- disabled render assertions ---
+
+secret_disabled="$(
+  yq -r 'select(.kind == "Secret" and .metadata.name == "nvca-operator-image-pull") | .metadata.name' \
+    "${manifest_disabled}" | grep -c . || true
+)"
+if [[ "${secret_disabled}" != "0" ]]; then
+  echo "expected no generated pull secret when generateImagePullSecret=false, got ${secret_disabled}" >&2
+  exit 1
+fi
+
+echo "image pull secret defaults: chart generates nvca-operator-image-pull from ngcConfig.serviceKey by default and omits it when generateImagePullSecret=false"

--- a/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
+++ b/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
@@ -181,6 +181,12 @@ releases:
         imagePullSecrets:
         {{- toYaml .Values.global.imagePullSecrets | nindent 10 }}
         {{- end }}
+        {{- /* Self-hosted clusters supply their own registry credentials through
+               global.imagePullSecrets and have no NGC service key to derive one
+               from, so the chart's generated pull secret is disabled here. The
+               chart default stays enabled for ngc-managed installs, which rely
+               on it being generated from ngcConfig.serviceKey. */}}
+        generateImagePullSecret: false
         ngcConfig:
           clusterSource: self-managed
         clusterName: {{ requiredEnv "CLUSTER_NAME" }}


### PR DESCRIPTION
## Customer Summary

Restores generated image pull secrets for NGC-managed NVCA Operator installs so the agent can pull its image without additional Helm flags.

## TL;DR

Backports #764 to the NVCA v3.2 release branch. This restores the chart default for NGC-managed installs while keeping generated secrets disabled for self-hosted installs that provide their own registry credentials.

## Additional Details

The v3.2 chart defaults generateImagePullSecret to false. NGC-managed installs have no other credential source, so the operator-created agent Deployment cannot pull its image even though Helm reports the release as deployed.

This PR cherry-picks the two functional commits from #764. It intentionally omits the source branch merge commit because that commit only synchronized unrelated main-branch release tooling.

Changes:

- Remove the vendoring overlay that forced generateImagePullSecret to false.
- Disable generated secrets explicitly in the self-hosted compute-plane stack.
- Preserve nil-safe image credential helper and shared-storage lookups during chart vendoring.
- Add and wire a regression test for managed and self-hosted defaults.

## For the Reviewer

Review the vendoring behavior in deploy/helm/nvca-operator/scripts/ci_vendor_nvca_operator_chart and the self-hosted override in deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl.

## For QA

Passed:

- env NVCA_OPERATOR_VERSION=3.0.4 NVCA_VERSION=3.0.4 NVCA_SHARED_STORAGE_IMAGE_TAG=1.0.5 make check-vendor-chart
- make test-image-pull-secret-defaults
- helm lint with tools/ci/helm-validate-values/nvca-operator.yaml
- helm template with tools/ci/helm-validate-values/nvca-operator.yaml

QA is needed. Verify that an NGC-managed install from the generated Helm command brings the agent to a running state without extra flags.

## Issues

Relates to #760

## Related Pull Requests

- #764

## Dependencies

None. No third-party dependencies changed, and NOTICE is unchanged.

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for DCO compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
