### PR TITLE
feat(nvcf/nvct/configurable-iss-jwks): allow overriding NVCF/NVCT API issuer, JWKS, and ICMS base URL via values

### DIFF
--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -413,6 +413,15 @@ api:
     NVCF_REGISTRIES_RECOGNIZED_RESOURCE_NGC_HOSTNAME: "api.ngc.nvidia.com"
     NVCF_REGISTRIES_RECOGNIZED_RESOURCE_NGC_OAUTH2_BASE_URL: "https://authn.nvidia.com"
     NVCF_REGISTRIES_RECOGNIZED_RESOURCE_NGC_OAUTH2_GROUP_SCOPE: "ngc"
+    {{- with dig "api" "icmsBaseUrl" nil .Values }}
+    NVCF_ICMS_BASE_URL: {{ . | quote }}
+    {{- end }}
+    {{- with dig "api" "jwt" "issuerUri" nil .Values }}
+    SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI: {{ . | quote }}
+    {{- end }}
+    {{- with dig "api" "jwt" "jwkSetUri" nil .Values }}
+    SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: {{ . | quote }}
+    {{- end }}
     # Observability
     MANAGEMENT_TRACING_ENABLED: {{ .Values.global.observability.tracing.enabled | quote }}
     {{- if .Values.global.observability.tracing.enabled }}

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -483,6 +483,15 @@ nvctApi:
     NVCT_ESS_BASE_URL: {{ . | quote }}
     NVCT_ESS_WORKER_BASE_URL: {{ . | quote }}
     {{- end }}
+    {{- with dig "nvctApi" "icmsBaseUrl" nil .Values }}
+    NVCT_ICMS_BASE_URL: {{ . | quote }}
+    {{- end }}
+    {{- with dig "nvctApi" "jwt" "issuerUri" nil .Values }}
+    SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI: {{ . | quote }}
+    {{- end }}
+    {{- with dig "nvctApi" "jwt" "jwkSetUri" nil .Values }}
+    SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: {{ . | quote }}
+    {{- end }}
     # Observability
     MANAGEMENT_TRACING_ENABLED: {{ .Values.global.observability.tracing.enabled }}
     {{- if .Values.global.observability.tracing.enabled }}


### PR DESCRIPTION
## Summary

Surface optional values on the self-managed `api` (NVCF) and `nvct-api` (NVCT) releases so
each service's inbound JWT issuer/JWKS and its ICMS base URL can be set from
`environments/<env>.yaml` instead of editing the shared template or injecting env with
`kubectl`.

## Additional Details
`global.yaml.gotmpl` builds the `nvcf-api` and `nvct-api` `env` from fixed key lists and
passes no arbitrary `env` through, so these keys were previously unreachable via config.

NVCF API (`api` release):
- `api.icmsBaseUrl`   → `NVCF_ICMS_BASE_URL`
- `api.jwt.issuerUri` → `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI`
- `api.jwt.jwkSetUri` → `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI`

NVCT API (`nvct-api` release):
- `nvctApi.icmsBaseUrl`   → `NVCT_ICMS_BASE_URL`
- `nvctApi.jwt.issuerUri` → `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI`
- `nvctApi.jwt.jwkSetUri` → `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI`

Both services are OAuth2 resource servers that read the same standard Spring properties
(`AuthManagerResolverConfiguration` / `JwtAuthManagerConfiguration`), and each calls ICMS
via its own `*_ICMS_BASE_URL`, so the change is symmetric across the two releases. Each key
is emitted only when set (`dig "<release>" ... nil`), so existing deployments are unchanged.
This follows the existing `dig "<release>" ...` convention (already used for the service
images) rather than introducing a generic env merge, keeping parity with the other
control-plane releases. The `ncp` profile sets `jwk-set-uri` explicitly (not derived from
the issuer), which is why both JWT keys are exposed. Complements #236.

Example:

```yaml
api:
  icmsBaseUrl: "https://sis.example.internal"
  jwt:
    issuerUri: "https://issuer.example/oauth2"
    jwkSetUri: "https://issuer.example/oauth2/jwks"
nvctApi:
  icmsBaseUrl: "https://sis.example.internal"
  jwt:
    issuerUri: "https://issuer.example/oauth2"
    jwkSetUri: "https://issuer.example/oauth2/jwks"
```

## For the Reviewer
- Single file: `deploy/stacks/self-managed/global.yaml.gotmpl` (the `api` and `nvct-api` release `env:` blocks).
- The SSA issuer/JWKS is typically stack-wide, so `api.jwt.*` and `nvctApi.jwt.*` will usually carry the same values. Kept them per-release for parity with the existing per-release `env` structure; happy to collapse to a shared key (e.g. `global.jwt.*`) if preferred.
- Happy to rename to `*.security.jwt.*` to mirror the Spring path if that reads better.

## For QA

Verified end-to-end on a live cluster — the new values are optional and fall back to `application-ncp.yaml` when unset.

**Setup**
- Deployed the self-managed `api` and `nvct-api` releases on a local k3d cluster, with the control-plane images sourced from the public `nvcr.io/nvidia/nvcf` catalog (entitled NGC API key).
- Applied this change to `global.yaml.gotmpl` and deployed via `helmfile sync`, then waited for both `nvcf-api` and `nvct-api` pods to reach `2/2` Ready **before** checking any values.
- Verified at two layers: (1) the live env ConfigMaps (`nvcf-api-env` / `nvct-api-env`), and (2) the running pod's behavior via startup logs (the actuator `/env` endpoint is disabled on these images, so logs are the runtime evidence).

**Case A — no override (keys unset)**
- `NVCF_ICMS_BASE_URL` / `NVCT_ICMS_BASE_URL` and the two `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_*` keys are absent from the ConfigMaps.
- The live NVCF API uses the ncp-profile defaults — ICMS `http://api.sis.svc.cluster.local:8080` and the in-cluster JWT issuer/JWKS (startup logs show `IcmsClient` calling `api.sis.svc.cluster.local:8080`).

**Case B — override set (dummy values)**
- The keys render into both ConfigMaps.
- The live NVCF API honors the override: it calls `https://test-icms.example.com/v1/si` (then `UnknownHostException` on the bogus host), confirming the overridden value was read rather than the default.

**Notes**
- Backward-compatible: nil-default via `dig`, so omitting the values leaves existing deployments unchanged.
- NVCF API is exercised at both config and runtime (it makes ICMS calls at startup). NVCT API doesn't emit ICMS calls at startup, so it's verified via the rendered ConfigMap keys (absent → present) plus a healthy `2/2` startup on the same template.
- 

## Issues
Fixes #766

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for DCO compliance.
- [ ] New or existing tests cover these changes. <!-- template-only render change; no unit tests for the helmfile gotmpl -->
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


* **New Features**
  * Added configurable deployment settings for ICMS base URLs, JWT issuer endpoints, and JWT key-set endpoints.
  * These settings are applied conditionally to API and NVCT API deployments, allowing environments to use their configured authentication and service endpoints without requiring fixed values.
  * Existing deployments remain unaffected when these settings are not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->