### PR TITLE
chore(function-autoscaler): remove account ID from invocation query

### DIFF
--- a/src/control-plane-services/function-autoscaler/crates/server/src/work/mod.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/work/mod.rs
@@ -86,9 +86,12 @@ async fn get_function_utilization_history(
     };
 
     let query = if use_control_plane_metrics {
+        // Invocation latency can be split by caller NCA, while capacity belongs to the shared
+        // function-version pool. Aggregate both sides by that shared identity so the query works
+        // with both per-caller and NCA-free latency series.
         format!(
-            r#"100 * sum by(function_id, function_version_id, nca_id) (rate(function_request_latency_sum{{function_id="{id}", function_version_id="{v_id}"{env}}}[2m])) /
-            (avg by(function_id, function_version_id, nca_id) (nvcf_function_instances_current{{function_id="{id}", function_version_id="{v_id}"{env}}}) * avg by(function_id, function_version_id, nca_id) (nvcf_function_concurrency{{function_id="{id}", function_version_id="{v_id}"{env}}})) or vector(0)"#,
+            r#"100 * sum by(function_id, function_version_id) (rate(function_request_latency_sum{{function_id="{id}", function_version_id="{v_id}"{env}}}[2m])) /
+            (avg by(function_id, function_version_id) (nvcf_function_instances_current{{function_id="{id}", function_version_id="{v_id}"{env}}}) * avg by(function_id, function_version_id) (nvcf_function_concurrency{{function_id="{id}", function_version_id="{v_id}"{env}}})) or vector(0)"#,
             id = function_id,
             v_id = function_version_id,
             env = env_suffix
@@ -856,6 +859,45 @@ mod tests {
     /// A VictoriaMetrics matrix response with no series (empty result).
     fn vm_empty() -> String {
         r#"{"status":"success","data":{"resultType":"matrix","result":[]}}"#.to_string()
+    }
+
+    #[tokio::test]
+    async fn test_control_plane_utilization_query_aggregates_shared_function_pool() {
+        let fid = Uuid::new_v4();
+        let fvid = Uuid::new_v4();
+        let expected_query = format!(
+            r#"100 * sum by(function_id, function_version_id) (rate(function_request_latency_sum{{function_id="{fid}", function_version_id="{fvid}"}}[2m])) /
+            (avg by(function_id, function_version_id) (nvcf_function_instances_current{{function_id="{fid}", function_version_id="{fvid}"}}) * avg by(function_id, function_version_id) (nvcf_function_concurrency{{function_id="{fid}", function_version_id="{fvid}"}})) or vector(0)"#
+        );
+        let mut server = mockito::Server::new_async().await;
+        let _utilization = server
+            .mock("GET", "/api/v1/query_range")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "query".to_string(),
+                expected_query,
+            ))
+            .with_status(200)
+            .with_body(vm_series(
+                &format!(r#""function_id":"{fid}","function_version_id":"{fvid}""#),
+                "42",
+            ))
+            .create_async()
+            .await;
+
+        let utilization = get_function_utilization_history(
+            &ts_client(server.url()),
+            &fid,
+            &fvid,
+            "stg",
+            true,
+            true,
+            5,
+            60,
+        )
+        .await
+        .expect("control-plane utilization");
+
+        assert_eq!(utilization, vec![(1_700_000_000, "42".to_string())]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## TL;DR

Update the function autoscaler's control-plane utilization query to aggregate by `function_id` and `function_version_id`, without depending on `nca_id`.

This prepares the autoscaler for the subsequent removal of the `nca_id` label from `function_request_latency`.

## Additional Details

This change:

- aggregates all request latency for the function-version pool
- aggregates capacity using the same function-version identity
- works with both the current NCA-labeled latency series and the future series without `nca_id`
- allows the autoscaler change to be deployed before the invocation-service metric change

The invocation-service metric change will be submitted separately.

## For the Reviewer

Please focus on the control-plane utilization PromQL and its aggregation semantics for a shared function-version resource pool.

## For QA

Automated validation completed:

- focused control-plane query test passed
- full function-autoscaler test suite passed: 128 passed, 11 integration tests ignored
- Clippy passed with warnings denied
- formatting check passed

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated control-plane utilization reporting to correctly aggregate latency, instance, and concurrency metrics across shared function-version pools.
  * Improved utilization results for functions served by multiple network capacity areas.

* **Tests**
  * Added coverage verifying the updated utilization aggregation and returned metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->