### PR TITLE
fix(http-invocation): remove account ID from request latency metric

### DIFF
--- a/src/invocation-plane-services/http-invocation/crates/server/src/metrics/mod.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/src/metrics/mod.rs
@@ -231,13 +231,11 @@ pub fn init_metrics(settings: &MetricsSettings) -> anyhow::Result<()> {
 pub fn record_invocation_end(
     function_id: String,
     function_version_id: String,
-    nca_id: String,
     start_time: SystemTime,
 ) {
     let labels = [
         ("function_id", function_id),
         ("function_version_id", function_version_id),
-        ("nca_id", nca_id),
     ];
     if let Ok(latency) = start_time.elapsed() {
         histogram!(FUNCTION_REQUEST_LATENCY.name, &labels).record(latency);
@@ -355,6 +353,38 @@ mod tests {
     use super::*;
     use metrics_util::debugging::{DebugValue, DebuggingRecorder};
     use metrics_util::MetricKind;
+
+    #[test]
+    fn invocation_latency_omits_nca_id() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        metrics::with_local_recorder(&recorder, || {
+            record_invocation_end(
+                "function-id".to_string(),
+                "function-version-id".to_string(),
+                SystemTime::now() - Duration::from_secs(1),
+            );
+        });
+
+        let metrics = snapshotter.snapshot().into_vec();
+        let (key, _, _, _) = metrics
+            .iter()
+            .find(|(key, _, _, _)| {
+                key.kind() == MetricKind::Histogram
+                    && key.key().name() == FUNCTION_REQUEST_LATENCY.name
+            })
+            .expect("function request latency should be recorded");
+
+        assert!(key
+            .key()
+            .labels()
+            .any(|label| label.key() == "function_id" && label.value() == "function-id"));
+        assert!(key.key().labels().any(|label| {
+            label.key() == "function_version_id" && label.value() == "function-version-id"
+        }));
+        assert!(!key.key().labels().any(|label| label.key() == "nca_id"));
+    }
 
     #[test]
     fn application_error_uses_empty_function_id_when_context_is_missing() {

--- a/src/invocation-plane-services/http-invocation/crates/server/src/routes/post_pexec.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/src/routes/post_pexec.rs
@@ -536,7 +536,6 @@ pub(crate) async fn handle_streaming_response(
                 metrics::record_invocation_end(
                     function_id.to_string(),
                     function_version_id.to_string(),
-                    nca_id.to_string(),
                     start_time,
                 );
             }),


### PR DESCRIPTION
## TL;DR

Remove the `nca_id` label from `function_request_latency` while retaining `function_id` and `function_version_id`.

This reduces histogram series cardinality without changing request handling.

## Additional Details

This change:

- removes `nca_id` from the `record_invocation_end` metric API and histogram labels
- updates the invocation response call site
- adds a regression test confirming that the function and function-version labels remain while `nca_id` is omitted

Rollout order: deploy the autoscaler query change in #769 before deploying this change. The updated autoscaler query supports both the current and new metric label schemas.

## For the Reviewer

Please focus on the emitted `function_request_latency` label set and the rollout relationship with #769.

## For QA

Automated validation completed:

- `cargo test --package nvcf-invocation-service --lib`
- 76 tests passed
- 4 Docker-dependent tests ignored

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated invocation latency metrics to report function and version details without including internal execution identifiers.
  * Improved metric consistency for streaming invocation responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->