### PR TITLE
refactor(stargate): rename multiregion routing algorithms

### DIFF
--- a/docs/user/llm-request-router-load-balancing.md
+++ b/docs/user/llm-request-router-load-balancing.md
@@ -50,21 +50,22 @@ replica loads the same configuration.
 
 Algorithm availability is enforced at separate layers:
 
-| Layer | Input contract | `pulsar-multiregion` support |
-| --- | --- | --- |
-| `lb-config.json` | Canonical Stargate algorithm names | Supported as the default, a model algorithm, or a `request_algorithms` entry. |
-| Current `nvcf-cli` `llmConfig.routingMethod` | `round_robin`, `power_of_two`, `groq_multiregion`, `pulsar`, or `random` | `pulsar_multiregion` is not accepted. |
-| LLM API Gateway | Nonblank routing method from authenticated model metadata | Trimmed, then forwarded as `x-routing-method` without algorithm validation. |
-| Stargate `x-routing-method` | Case-insensitive algorithm name; multiword names may use hyphens or underscores | Normalized, then accepted only when it matches the effective algorithm or a model or top-level `request_algorithms` entry. Otherwise, Stargate returns HTTP `400`. |
+| Layer | Input contract |
+| --- | --- |
+| `lb-config.json` | Canonical Stargate algorithm names: `power-of-two`, `wait-and-widen`, `round-robin`, `random`, `pulsar`, and `pulsar-wait-and-widen`. Legacy `groq-multiregion` and `pulsar-multiregion` aliases remain accepted for existing deployments. |
+| Function model `llmConfig.routingMethod` | The same algorithm names, with underscores accepted in place of hyphens. Legacy aliases remain accepted for existing functions. |
+| LLM API Gateway | Nonblank routing method from authenticated model metadata, trimmed and forwarded as `x-routing-method` without algorithm validation. |
+| Stargate `x-routing-method` | Case-insensitive algorithm name with hyphens or underscores. It must match the effective algorithm or a model or top-level `request_algorithms` entry. Otherwise, Stargate returns HTTP `400`. |
 
 For example, when `power-of-two` is the effective algorithm,
-`groq_multiregion` requires a `groq-multiregion` entry in
-`request_algorithms`.
+`wait_and_widen` requires a `wait-and-widen` entry in `request_algorithms`.
+The legacy `groq_multiregion` value remains accepted and resolves to the same
+algorithm.
 
-Stargate can use `pulsar-multiregion` as its default or a model algorithm when
-no request override is sent. Selecting it through function model metadata
-requires a control-plane API and client path that accepts
-`pulsar_multiregion`. The current `nvcf-cli` does not provide that path.
+Use `wait-and-widen` and `pulsar-wait-and-widen` in new function metadata,
+`lb-config.json` files, request-algorithm maps, and deployment manifests.
+Existing `groq-multiregion` and `pulsar-multiregion` values continue to work
+through the Stargate and control-plane compatibility aliases.
 
 ## Keep router headers trusted
 

--- a/src/clis/nvcf-cli/cmd/function.go
+++ b/src/clis/nvcf-cli/cmd/function.go
@@ -568,7 +568,7 @@ func init() {
 	createCmd.Flags().StringVar(&createFlags.helmChartServiceName, "helm-chart-service", "", "Helm chart service name")
 	createCmd.Flags().StringSliceVar(&createFlags.secrets, "secrets", []string{}, "Secrets in name=value format (e.g., API_KEY=secret123,DB_PASSWORD=pass456)")
 	createCmd.Flags().StringSliceVar(&createFlags.models, "models", []string{}, "Model artifacts (format: name:version:uri)")
-	createCmd.Flags().StringArrayVar(&createFlags.llmModels, "llm-model", []string{}, "LLM model config (format: name=<model>,uris=<uri>|<uri>,routingMethod=<round_robin|power_of_two|groq_multiregion|pulsar|random>,tokenRateLimit=<limit>)")
+	createCmd.Flags().StringArrayVar(&createFlags.llmModels, "llm-model", []string{}, "LLM model config (format: name=<model>,uris=<uri>|<uri>,routingMethod=<round_robin|power_of_two|wait_and_widen|pulsar_wait_and_widen|groq_multiregion|pulsar|random>,tokenRateLimit=<limit>)")
 	createCmd.Flags().StringSliceVar(&createFlags.resources, "resources", []string{}, "Resource artifacts (format: name:version:uri)")
 	createCmd.Flags().StringVar(&createFlags.rateLimit, "rate-limit", "", "Rate limit pattern (e.g., '100-S', '50-M', '10-H', '5-D')")
 	createCmd.Flags().StringSliceVar(&createFlags.rateLimitExempted, "rate-limit-exempted", []string{}, "NCA IDs exempted from rate limiting")
@@ -609,7 +609,7 @@ func init() {
 	updateCmd.Flags().StringVar(&updateFlags.functionID, "function-id", "", "Function ID (required)")
 	updateCmd.Flags().StringVar(&updateFlags.versionID, "version-id", "", "Version ID (required)")
 	updateCmd.Flags().StringSliceVar(&updateFlags.tags, "tags", []string{}, "Function tags (comma-separated)")
-	updateCmd.Flags().StringArrayVar(&updateFlags.llmModelUpdates, "llm-model-update", []string{}, "LLM model update (format: name=<model>,routingMethod=<round_robin|power_of_two|groq_multiregion|pulsar|random>,tokenRateLimit=<limit>)")
+	updateCmd.Flags().StringArrayVar(&updateFlags.llmModelUpdates, "llm-model-update", []string{}, "LLM model update (format: name=<model>,routingMethod=<round_robin|power_of_two|wait_and_widen|pulsar_wait_and_widen|groq_multiregion|pulsar|random>,tokenRateLimit=<limit>)")
 }
 
 // ============================================================================
@@ -818,16 +818,26 @@ func normalizeLLMRoutingMethod(value string) (string, error) {
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "round_robin":
 		return "round_robin", nil
+	case "round-robin":
+		return "round_robin", nil
 	case "power_of_two":
 		return "power_of_two", nil
+	case "power-of-two":
+		return "power_of_two", nil
+	case "wait_and_widen", "wait-and-widen":
+		return "wait_and_widen", nil
+	case "pulsar_wait_and_widen", "pulsar-wait-and-widen":
+		return "pulsar_wait_and_widen", nil
 	case "groq_multiregion":
+		return "groq_multiregion", nil
+	case "groq-multiregion":
 		return "groq_multiregion", nil
 	case "pulsar":
 		return "pulsar", nil
 	case "random":
 		return "random", nil
 	default:
-		return "", fmt.Errorf("unsupported routingMethod %q (expected round_robin, power_of_two, groq_multiregion, pulsar, or random)", value)
+		return "", fmt.Errorf("unsupported routingMethod %q (expected round_robin, power_of_two, wait_and_widen, pulsar_wait_and_widen, groq_multiregion, pulsar, or random)", value)
 	}
 }
 

--- a/src/clis/nvcf-cli/cmd/function_llm_model_test.go
+++ b/src/clis/nvcf-cli/cmd/function_llm_model_test.go
@@ -160,16 +160,29 @@ func TestParseLLMModelString(t *testing.T) {
 func TestParseLLMModelStringAcceptsAdvancedRoutingMethods(t *testing.T) {
 	t.Parallel()
 
-	for _, routingMethod := range []string{"groq_multiregion", "pulsar"} {
-		t.Run(routingMethod, func(t *testing.T) {
+	for _, test := range []struct {
+		input    string
+		expected string
+	}{
+		{input: "groq_multiregion", expected: "groq_multiregion"},
+		{input: "groq-multiregion", expected: "groq_multiregion"},
+		{input: "round-robin", expected: "round_robin"},
+		{input: "power-of-two", expected: "power_of_two"},
+		{input: "wait_and_widen", expected: "wait_and_widen"},
+		{input: "wait-and-widen", expected: "wait_and_widen"},
+		{input: "pulsar_wait_and_widen", expected: "pulsar_wait_and_widen"},
+		{input: "pulsar-wait-and-widen", expected: "pulsar_wait_and_widen"},
+		{input: "pulsar", expected: "pulsar"},
+	} {
+		t.Run(test.input, func(t *testing.T) {
 			t.Parallel()
 
-			model, err := parseLLMModelString("name=dummy-model,uris=/v1/chat/completions,routingMethod=" + routingMethod)
+			model, err := parseLLMModelString("name=dummy-model,uris=/v1/chat/completions,routingMethod=" + test.input)
 			if err != nil {
 				t.Fatalf("parse llm model: %v", err)
 			}
-			if got := stringValue(model.LLMConfig.RoutingMethod); got != routingMethod {
-				t.Fatalf("routingMethod = %q, want %q", got, routingMethod)
+			if got := stringValue(model.LLMConfig.RoutingMethod); got != test.expected {
+				t.Fatalf("routingMethod = %q, want %q", got, test.expected)
 			}
 		})
 	}
@@ -381,16 +394,29 @@ func TestParseLLMModelUpdateString(t *testing.T) {
 func TestParseLLMModelUpdateStringAcceptsAdvancedRoutingMethods(t *testing.T) {
 	t.Parallel()
 
-	for _, routingMethod := range []string{"groq_multiregion", "pulsar"} {
-		t.Run(routingMethod, func(t *testing.T) {
+	for _, test := range []struct {
+		input    string
+		expected string
+	}{
+		{input: "groq_multiregion", expected: "groq_multiregion"},
+		{input: "groq-multiregion", expected: "groq_multiregion"},
+		{input: "round-robin", expected: "round_robin"},
+		{input: "power-of-two", expected: "power_of_two"},
+		{input: "wait_and_widen", expected: "wait_and_widen"},
+		{input: "wait-and-widen", expected: "wait_and_widen"},
+		{input: "pulsar_wait_and_widen", expected: "pulsar_wait_and_widen"},
+		{input: "pulsar-wait-and-widen", expected: "pulsar_wait_and_widen"},
+		{input: "pulsar", expected: "pulsar"},
+	} {
+		t.Run(test.input, func(t *testing.T) {
 			t.Parallel()
 
-			update, err := parseLLMModelUpdateString("name=dummy-model,routingMethod=" + routingMethod)
+			update, err := parseLLMModelUpdateString("name=dummy-model,routingMethod=" + test.input)
 			if err != nil {
 				t.Fatalf("parse llm model update: %v", err)
 			}
-			if got := stringValue(update.LLMConfig.RoutingMethod); got != routingMethod {
-				t.Fatalf("routingMethod = %q, want %q", got, routingMethod)
+			if got := stringValue(update.LLMConfig.RoutingMethod); got != test.expected {
+				t.Fatalf("routingMethod = %q, want %q", got, test.expected)
 			}
 		})
 	}

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/function/management/dto/LlmConfigValidator.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/function/management/dto/LlmConfigValidator.java
@@ -23,7 +23,15 @@ public final class LlmConfigValidator {
 
     // Stargate LoadBalancerAlgorithm values; keep in sync. Blank = router default.
     private static final Set<String> VALID_ROUTING_METHODS = Set.of(
-            "power-of-two", "round-robin", "random", "groq-multiregion", "pulsar");
+            "power-of-two",
+            "wait-and-widen",
+            "round-robin",
+            "random",
+            "pulsar",
+            "pulsar-wait-and-widen",
+            // Deprecated Stargate aliases retained for existing deployments.
+            "groq-multiregion",
+            "pulsar-multiregion");
 
     // Comma-separated '<positiveInteger>-<unit>' entries, no unit repeated.
     private static final Pattern TOKEN_RATE_LIMIT_PATTERN = Pattern.compile(
@@ -31,7 +39,8 @@ public final class LlmConfigValidator {
 
     private static final String MESG_INVALID_ROUTING_METHOD =
             "Invalid request: 'llmConfig.routingMethod' for model '%s' is invalid; supported "
-                    + "values are [power-of-two, round-robin, random, groq-multiregion, pulsar]";
+                    + "values are [power-of-two, wait-and-widen, round-robin, random, pulsar, "
+                    + "pulsar-wait-and-widen, groq-multiregion, pulsar-multiregion]";
     private static final String MESG_INVALID_TOKEN_RATE_LIMIT =
             "Invalid request: 'llmConfig.tokenRateLimit' for model '%s' is invalid; expected "
                     + "comma-separated '<positiveInteger>-<unit>' entries with unit in [S, M, H, D, W] "

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/rest/function/management/dto/LlmConfigValidatorTest.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/rest/function/management/dto/LlmConfigValidatorTest.java
@@ -19,9 +19,11 @@ class LlmConfigValidatorTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
-        "power-of-two", "round-robin", "random", "groq-multiregion", "pulsar",
+        "power-of-two", "wait-and-widen", "round-robin", "random", "pulsar",
+        "pulsar-wait-and-widen", "groq-multiregion", "pulsar-multiregion",
         // Router normalizes case and '_' to '-', so these are accepted too.
-        "Power-Of-Two", "power_of_two", "  pulsar  "
+        "Power-Of-Two", "power_of_two", "wait_and_widen", "pulsar_wait_and_widen",
+        "groq_multiregion", "pulsar_multiregion", "  pulsar  "
     })
     void validRoutingMethodsAccepted(String routingMethod) {
         assertThatCode(() -> LlmConfigValidator.validateRoutingMethod(MODEL, routingMethod))

--- a/src/libraries/rust/stargate/benches/backend-degradation.yaml
+++ b/src/libraries/rust/stargate/benches/backend-degradation.yaml
@@ -102,9 +102,9 @@ algorithms:
   - name: power-of-two
     config:
       default: power-of-two
-  - name: groq-multiregion
+  - name: wait-and-widen
     config:
-      default: groq-multiregion
+      default: wait-and-widen
   - name: pulsar
     config:
       default: power-of-two

--- a/src/libraries/rust/stargate/benches/bursty-8-backends.yaml
+++ b/src/libraries/rust/stargate/benches/bursty-8-backends.yaml
@@ -111,6 +111,6 @@ algorithms:
   - name: random
     config:
       default: random
-  - name: groq-multiregion
+  - name: wait-and-widen
     config:
-      default: groq-multiregion
+      default: wait-and-widen

--- a/src/libraries/rust/stargate/benches/cache-thrash-6-backends.yaml
+++ b/src/libraries/rust/stargate/benches/cache-thrash-6-backends.yaml
@@ -67,9 +67,9 @@ algorithms:
   - name: power-of-two
     config:
       default: power-of-two
-  - name: groq-multiregion
+  - name: wait-and-widen
     config:
-      default: groq-multiregion
+      default: wait-and-widen
   - name: pulsar
     config:
       default: power-of-two
@@ -88,21 +88,21 @@ algorithms:
           seed: cache-thrash-v1
           require_cache_affinity_key: true
           consider_kv_free_tokens: true
-  - name: pulsar-multiregion
+  - name: pulsar-wait-and-widen
     config:
       default: power-of-two
       models:
         dummy-model:
-          algorithm: pulsar-multiregion
+          algorithm: pulsar-wait-and-widen
           seed: cache-thrash-v1
           require_cache_affinity_key: true
           require_input_tokens: true
-  - name: pulsar-multiregion-consider-kv-free-tokens
+  - name: pulsar-wait-and-widen-consider-kv-free-tokens
     config:
       default: power-of-two
       models:
         dummy-model:
-          algorithm: pulsar-multiregion
+          algorithm: pulsar-wait-and-widen
           seed: cache-thrash-v1
           require_cache_affinity_key: true
           consider_kv_free_tokens: true

--- a/src/libraries/rust/stargate/benches/hotset-8-backends-long.yaml
+++ b/src/libraries/rust/stargate/benches/hotset-8-backends-long.yaml
@@ -116,9 +116,9 @@ algorithms:
   - name: random
     config:
       default: random
-  - name: groq-multiregion
+  - name: wait-and-widen
     config:
-      default: groq-multiregion
+      default: wait-and-widen
   - name: pulsar
     config:
       default: power-of-two

--- a/src/libraries/rust/stargate/benches/hotset-8-backends.yaml
+++ b/src/libraries/rust/stargate/benches/hotset-8-backends.yaml
@@ -116,9 +116,9 @@ algorithms:
   - name: random
     config:
       default: random
-  - name: groq-multiregion
+  - name: wait-and-widen
     config:
-      default: groq-multiregion
+      default: wait-and-widen
   - name: pulsar
     config:
       default: power-of-two

--- a/src/libraries/rust/stargate/benches/lb-balance-bursty-4c2p-2s.yaml
+++ b/src/libraries/rust/stargate/benches/lb-balance-bursty-4c2p-2s.yaml
@@ -116,9 +116,9 @@ algorithms:
   - name: random
     config:
       default: random
-  - name: groq-multiregion
+  - name: wait-and-widen
     config:
-      default: groq-multiregion
+      default: wait-and-widen
   - name: pulsar
     config:
       default: power-of-two

--- a/src/libraries/rust/stargate/benches/lb-balance-hotset-8c2p-4s.yaml
+++ b/src/libraries/rust/stargate/benches/lb-balance-hotset-8c2p-4s.yaml
@@ -118,9 +118,9 @@ algorithms:
   - name: random
     config:
       default: random
-  - name: groq-multiregion
+  - name: wait-and-widen
     config:
-      default: groq-multiregion
+      default: wait-and-widen
   - name: pulsar
     config:
       default: power-of-two

--- a/src/libraries/rust/stargate/benches/lb-balance-prefix-reuse-4c2p-2s.yaml
+++ b/src/libraries/rust/stargate/benches/lb-balance-prefix-reuse-4c2p-2s.yaml
@@ -18,7 +18,7 @@ metadata:
   description: Coding-session load run with 64k-token initial contexts and small appended turns across heterogeneous routing clusters.
   tags: [load-balance, grouped-pylons, multi-stargate, heterogeneous, cache, prefix-reuse, coding-session, pulsar]
   expected_runtime: medium
-  expected_signal: Compare cache-affine GMR and no-SLO PULSAR/PULSAR-multiregion cache-primary behavior against TTFT-first routing while heterogeneous cluster capacity shapes latency under misses.
+  expected_signal: Compare cache-affine WaitAndWiden and no-SLO PULSAR/PULSAR-wait-and-widen cache-primary behavior against TTFT-first routing while heterogeneous cluster capacity shapes latency under misses.
 model: dummy-model
 seed: 705
 request_count: 128
@@ -118,16 +118,16 @@ algorithms:
   - name: random
     config:
       default: random
-  - name: groq-multiregion
+  - name: wait-and-widen
     config:
-      default: groq-multiregion
-  - name: groq-multiregion-affinity
+      default: wait-and-widen
+  - name: wait-and-widen-affinity
     config:
       default: power-of-two
       models:
         dummy-model:
-          algorithm: groq-multiregion
-          seed: growing-prefix-load-gmr-affinity-v1
+          algorithm: wait-and-widen
+          seed: growing-prefix-load-wait-and-widen-affinity-v1
           require_cache_affinity_key: true
           require_input_tokens: true
           cache_affinity_backend_selection_count: 1
@@ -149,21 +149,21 @@ algorithms:
           seed: growing-prefix-load-v1
           require_cache_affinity_key: true
           consider_kv_free_tokens: true
-  - name: pulsar-multiregion
+  - name: pulsar-wait-and-widen
     config:
       default: power-of-two
       models:
         dummy-model:
-          algorithm: pulsar-multiregion
+          algorithm: pulsar-wait-and-widen
           seed: growing-prefix-load-v1
           require_cache_affinity_key: true
           require_input_tokens: true
-  - name: pulsar-multiregion-consider-kv-free-tokens
+  - name: pulsar-wait-and-widen-consider-kv-free-tokens
     config:
       default: power-of-two
       models:
         dummy-model:
-          algorithm: pulsar-multiregion
+          algorithm: pulsar-wait-and-widen
           seed: growing-prefix-load-v1
           require_cache_affinity_key: true
           consider_kv_free_tokens: true

--- a/src/libraries/rust/stargate/benches/lb-balance-prefix-reuse-pulsar-wait-and-widen-slo-4c2p-1s.yaml
+++ b/src/libraries/rust/stargate/benches/lb-balance-prefix-reuse-pulsar-wait-and-widen-slo-4c2p-1s.yaml
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: lb-balance-prefix-reuse-pmr-slo-4c2p-1s
+name: lb-balance-prefix-reuse-pulsar-wait-and-widen-slo-4c2p-1s
 metadata:
-  description: Controlled coding-session run for measuring PULSAR-multiregion ranked fallback when an affine primary exceeds an explicit queue SLO.
-  tags: [load-balance, grouped-pylons, heterogeneous, cache, prefix-reuse, coding-session, pulsar, pmr-fallback]
+  description: Controlled coding-session run for measuring PULSAR-wait-and-widen ranked fallback when an affine primary exceeds an explicit queue SLO.
+  tags: [load-balance, grouped-pylons, heterogeneous, cache, prefix-reuse, coding-session, pulsar, pulsar-wait-and-widen-fallback]
   expected_runtime: medium
-  expected_signal: At a controlled 8 req/s offered rate, PULSAR-multiregion must record nonzero fallback route choices under its 4000 ms queue SLO while pylon queue-mismatch admission is disabled; compare its TTFT, cache reuse, and cluster input-capacity balance with the same-ranking PULSAR control.
+  expected_signal: At a controlled 8 req/s offered rate, PULSAR-wait-and-widen must record nonzero fallback route choices under its 4000 ms queue SLO while pylon queue-mismatch admission is disabled; compare its TTFT, cache reuse, and cluster input-capacity balance with the same-ranking PULSAR control.
 model: dummy-model
 seed: 706
 request_count: 128
@@ -111,15 +111,15 @@ traffic_pattern:
     target_rps: 8
 
 algorithms:
-  - name: groq-multiregion-affinity
+  - name: wait-and-widen-affinity
     pylon_queue_admission:
       enabled: false
     config:
       default: power-of-two
       models:
         dummy-model:
-          algorithm: groq-multiregion
-          seed: growing-prefix-pmr-slo-gmr-affinity-v1
+          algorithm: wait-and-widen
+          seed: growing-prefix-pulsar-wait-and-widen-slo-wait-and-widen-affinity-v1
           require_cache_affinity_key: true
           require_input_tokens: true
           cache_affinity_backend_selection_count: 1
@@ -131,18 +131,18 @@ algorithms:
       models:
         dummy-model:
           algorithm: pulsar
-          seed: growing-prefix-pmr-slo-v1
+          seed: growing-prefix-pulsar-wait-and-widen-slo-v1
           require_cache_affinity_key: true
           require_input_tokens: true
-  - name: pulsar-multiregion
+  - name: pulsar-wait-and-widen
     pylon_queue_admission:
       enabled: false
     config:
       default: power-of-two
       models:
         dummy-model:
-          algorithm: pulsar-multiregion
-          seed: growing-prefix-pmr-slo-v1
+          algorithm: pulsar-wait-and-widen
+          seed: growing-prefix-pulsar-wait-and-widen-slo-v1
           require_cache_affinity_key: true
           require_input_tokens: true
           # A full uncached prefill costs 1 s on the fast cluster, 2 s on a

--- a/src/libraries/rust/stargate/benches/lb-balance-prefix-reuse-smoke-2c2p-1s.yaml
+++ b/src/libraries/rust/stargate/benches/lb-balance-prefix-reuse-smoke-2c2p-1s.yaml
@@ -18,7 +18,7 @@ metadata:
   description: Short growing-prefix validation run for coding-style sessions with long shared context and small new suffixes.
   tags: [load-balance, grouped-pylons, cache, prefix-reuse, coding-session, smoke]
   expected_runtime: short
-  expected_signal: Once a session is warm on a cluster, its TTFT should reflect only the appended suffix; compare cache-affine GMR and the no-SLO PULSAR/PULSAR-multiregion primary controls against non-affine routing.
+  expected_signal: Once a session is warm on a cluster, its TTFT should reflect only the appended suffix; compare cache-affine WaitAndWiden and the no-SLO PULSAR/PULSAR-wait-and-widen primary controls against non-affine routing.
 model: dummy-model
 seed: 704
 request_count: 32
@@ -72,16 +72,16 @@ algorithms:
   - name: random
     config:
       default: random
-  - name: groq-multiregion
+  - name: wait-and-widen
     config:
-      default: groq-multiregion
-  - name: groq-multiregion-affinity
+      default: wait-and-widen
+  - name: wait-and-widen-affinity
     config:
       default: power-of-two
       models:
         dummy-model:
-          algorithm: groq-multiregion
-          seed: growing-prefix-smoke-gmr-affinity-v1
+          algorithm: wait-and-widen
+          seed: growing-prefix-smoke-wait-and-widen-affinity-v1
           require_cache_affinity_key: true
           require_input_tokens: true
           cache_affinity_backend_selection_count: 1
@@ -103,21 +103,21 @@ algorithms:
           seed: growing-prefix-smoke-v1
           require_cache_affinity_key: true
           consider_kv_free_tokens: true
-  - name: pulsar-multiregion
+  - name: pulsar-wait-and-widen
     config:
       default: power-of-two
       models:
         dummy-model:
-          algorithm: pulsar-multiregion
+          algorithm: pulsar-wait-and-widen
           seed: growing-prefix-smoke-v1
           require_cache_affinity_key: true
           require_input_tokens: true
-  - name: pulsar-multiregion-consider-kv-free-tokens
+  - name: pulsar-wait-and-widen-consider-kv-free-tokens
     config:
       default: power-of-two
       models:
         dummy-model:
-          algorithm: pulsar-multiregion
+          algorithm: pulsar-wait-and-widen
           seed: growing-prefix-smoke-v1
           require_cache_affinity_key: true
           consider_kv_free_tokens: true

--- a/src/libraries/rust/stargate/benches/lb-balance-smoke-2c2p-1s.yaml
+++ b/src/libraries/rust/stargate/benches/lb-balance-smoke-2c2p-1s.yaml
@@ -71,9 +71,9 @@ algorithms:
   - name: random
     config:
       default: random
-  - name: groq-multiregion
+  - name: wait-and-widen
     config:
-      default: groq-multiregion
+      default: wait-and-widen
   - name: pulsar
     config:
       default: power-of-two

--- a/src/libraries/rust/stargate/benches/mixed-size-pulsar.yaml
+++ b/src/libraries/rust/stargate/benches/mixed-size-pulsar.yaml
@@ -121,9 +121,9 @@ algorithms:
   - name: power-of-two
     config:
       default: power-of-two
-  - name: groq-multiregion
+  - name: wait-and-widen
     config:
-      default: groq-multiregion
+      default: wait-and-widen
   - name: pulsar
     config:
       default: power-of-two

--- a/src/libraries/rust/stargate/benches/overload-6-backends.yaml
+++ b/src/libraries/rust/stargate/benches/overload-6-backends.yaml
@@ -100,9 +100,9 @@ algorithms:
   - name: random
     config:
       default: random
-  - name: groq-multiregion
+  - name: wait-and-widen
     config:
-      default: groq-multiregion
+      default: wait-and-widen
   - name: pulsar
     config:
       default: power-of-two

--- a/src/libraries/rust/stargate/benches/queue-mismatch-retry-ab.yaml
+++ b/src/libraries/rust/stargate/benches/queue-mismatch-retry-ab.yaml
@@ -16,7 +16,7 @@
 name: queue-mismatch-retry-ab
 metadata:
   description: A/B diagnostic for pylon rejection of stale Stargate queue estimates under burst load. The scenario runs 2048 requests per arm for benchmark evidence. Mock backends enforce real concurrent-service, prefill, and decode delays; benchmark pylons pin prompt throughput to the matching 2200 tokens/s profile value. Queue admission intentionally models prompt work only because output residency is unknowable at admission time.
-  tags: [queue-admission, queue-mismatch, ab, groq-multiregion, diagnostic]
+  tags: [queue-admission, queue-mismatch, ab, wait-and-widen, diagnostic]
   expected_runtime: medium
   expected_signal: With the same fixed prompt-throughput estimate and real mock service delays in both arms, the enabled row should record pylon rejections and Stargate queue-mismatch retries; the disabled row should record disabled decisions without those retries.
 model: dummy-model
@@ -60,17 +60,17 @@ traffic_pattern:
   burst_period_requests: 16
 
 algorithms:
-  - name: groq-queue-admission-enabled
+  - name: wait-and-widen-queue-admission-enabled
     config:
-      default: groq-multiregion
+      default: wait-and-widen
     pylon_queue_admission:
       enabled: true
       min_delta_ms: 0
       tolerance_factor: 1.0
       retry_after_ms: 5
-  - name: groq-queue-admission-disabled
+  - name: wait-and-widen-queue-admission-disabled
     config:
-      default: groq-multiregion
+      default: wait-and-widen
     pylon_queue_admission:
       enabled: false
       min_delta_ms: 0

--- a/src/libraries/rust/stargate/crates/stargate-bench/src/config.rs
+++ b/src/libraries/rust/stargate/crates/stargate-bench/src/config.rs
@@ -804,14 +804,14 @@ action: pause_backend
         yaml["algorithms"] = serde_yaml_ng::from_str(
             r#"
 - name: queue-admission-enabled
-  config: { default: groq-multiregion }
+  config: { default: wait-and-widen }
   pylon_queue_admission:
     enabled: true
     min_delta_ms: 0
     tolerance_factor: 1.0
     retry_after_ms: 5
 - name: queue-admission-disabled
-  config: { default: groq-multiregion }
+  config: { default: wait-and-widen }
   pylon_queue_admission:
     enabled: false
     min_delta_ms: 0

--- a/src/libraries/rust/stargate/crates/stargate-bench/src/k8s/tests.rs
+++ b/src/libraries/rust/stargate/crates/stargate-bench/src/k8s/tests.rs
@@ -701,7 +701,7 @@ fn rendered_pylons_include_per_algorithm_queue_admission_args() {
     let config = config();
     let algorithm = AlgorithmConfig {
         name: "queue-admission-enabled".to_string(),
-        config: serde_json::json!({"default": "groq-multiregion"}),
+        config: serde_json::json!({"default": "wait-and-widen"}),
         pylon_queue_admission: Some(crate::config::PylonQueueAdmissionConfig {
             enabled: true,
             min_delta_ms: Some(0),
@@ -714,7 +714,7 @@ fn rendered_pylons_include_per_algorithm_queue_admission_args() {
         &algorithm,
         "sgbench-sg-queue",
         "sgbench-be-queue",
-        r#"{"default":"groq-multiregion"}"#,
+        r#"{"default":"wait-and-widen"}"#,
     );
 
     assert_contains_all(

--- a/src/libraries/rust/stargate/crates/stargate-bench/src/main.rs
+++ b/src/libraries/rust/stargate/crates/stargate-bench/src/main.rs
@@ -92,7 +92,7 @@ enum Command {
     Run(RunArgs),
     /// Compare Raw QUIC, HTTP/3, and WebTransport tunnel transports on loopback
     TransportBench(TransportBenchArgs),
-    /// Measure in-process groq-multiregion/pulsar load-balancer choose-path overhead
+    /// Measure in-process wait-and-widen/pulsar load-balancer choose-path overhead
     LbMicrobench {
         #[arg(long, default_value_t = 100_000, value_name = "N")]
         iterations: usize,
@@ -733,7 +733,7 @@ pylon_requests_total_total{model="dummy-model",status="complete"} 3
         std::fs::create_dir(&run_dir).expect("run dir should create");
         std::fs::write(
             run_dir.join("run-info.json"),
-            r#"{"algorithm_name":"groq-multiregion","extra_metadata":"ignored"}"#,
+            r#"{"algorithm_name":"wait-and-widen","extra_metadata":"ignored"}"#,
         )
         .expect("run-info should write");
 
@@ -741,7 +741,7 @@ pylon_requests_total_total{model="dummy-model",status="complete"} 3
             read_run_info(&run_dir)
                 .expect("run-info extra fields should be ignored")
                 .algorithm_name,
-            "groq-multiregion"
+            "wait-and-widen"
         );
     }
 
@@ -753,7 +753,7 @@ pylon_requests_total_total{model="dummy-model",status="complete"} 3
             &manifest_for_report_test(),
         )
         .expect("manifest should write");
-        let run_dir = tempdir.path().join("run-groq-admission-enabled");
+        let run_dir = tempdir.path().join("run-wait-and-widen-admission-enabled");
         std::fs::create_dir(&run_dir).expect("run dir should create");
         let summary = summarize_with_capacity(&[], std::collections::BTreeMap::new());
         std::fs::write(
@@ -764,7 +764,7 @@ pylon_requests_total_total{model="dummy-model",status="complete"} 3
         std::fs::write(
             run_dir.join("run-info.json"),
             r#"{
-                "algorithm_name": "groq-admission-enabled",
+                "algorithm_name": "wait-and-widen-admission-enabled",
                 "pylon_queue_admission": {
                     "enabled": true,
                     "min_delta_ms": 0,
@@ -782,7 +782,7 @@ pylon_requests_total_total{model="dummy-model",status="complete"} 3
         let report =
             std::fs::read_to_string(tempdir.path().join("report.md")).expect("report should read");
         assert!(report.contains("# Benchmark Report: report-regeneration-test"));
-        assert!(report.contains("| groq-admission-enabled | enabled"));
+        assert!(report.contains("| wait-and-widen-admission-enabled | enabled"));
         assert!(!report.contains("run-missing-summary"));
     }
 
@@ -1049,19 +1049,19 @@ pylon_requests_total_total{model="dummy-model",status="complete"} 3
             "power-of-two",
             "round-robin",
             "random",
-            "groq-multiregion",
+            "wait-and-widen",
             "pulsar",
         ];
         const PREFIX_ALGORITHMS: &[&str] = &[
             "power-of-two",
             "round-robin",
             "random",
-            "groq-multiregion",
-            "groq-multiregion-affinity",
+            "wait-and-widen",
+            "wait-and-widen-affinity",
             "pulsar",
             "pulsar-consider-kv-free-tokens",
-            "pulsar-multiregion",
-            "pulsar-multiregion-consider-kv-free-tokens",
+            "pulsar-wait-and-widen",
+            "pulsar-wait-and-widen-consider-kv-free-tokens",
         ];
         for (scenario, clusters, pylons_per_cluster, stargates) in [
             ("lb-balance-smoke-2c2p-1s", 2, 2, 1),
@@ -1087,35 +1087,35 @@ pylon_requests_total_total{model="dummy-model",status="complete"} 3
             };
             assert_eq!(algorithm_names(&config), expected_algorithms, "{scenario}");
             if prefix_reuse {
-                let affinity = model_config(&config, "groq-multiregion-affinity");
+                let affinity = model_config(&config, "wait-and-widen-affinity");
                 assert_eq!(
                     (
                         affinity["algorithm"].as_str(),
                         affinity["require_cache_affinity_key"].as_bool(),
                         affinity["cache_affinity_backend_selection_count"].as_u64(),
                     ),
-                    (Some("groq-multiregion"), Some(true), Some(1)),
+                    (Some("wait-and-widen"), Some(true), Some(1)),
                     "{scenario}"
                 );
-                let multiregion = model_config(&config, "pulsar-multiregion");
+                let wait_and_widen = model_config(&config, "pulsar-wait-and-widen");
                 assert_eq!(
                     (
-                        multiregion["algorithm"].as_str(),
-                        multiregion["require_cache_affinity_key"].as_bool(),
+                        wait_and_widen["algorithm"].as_str(),
+                        wait_and_widen["require_cache_affinity_key"].as_bool(),
                     ),
-                    (Some("pulsar-multiregion"), Some(true)),
+                    (Some("pulsar-wait-and-widen"), Some(true)),
                     "{scenario}"
                 );
                 let pulsar = model_config(&config, "pulsar");
                 assert_eq!(
-                    multiregion["seed"], pulsar["seed"],
+                    wait_and_widen["seed"], pulsar["seed"],
                     "{scenario} should compare PULSAR fallback modes over the same cache-owner ranking"
                 );
                 for (name, algorithm) in [
                     ("pulsar-consider-kv-free-tokens", "pulsar"),
                     (
-                        "pulsar-multiregion-consider-kv-free-tokens",
-                        "pulsar-multiregion",
+                        "pulsar-wait-and-widen-consider-kv-free-tokens",
+                        "pulsar-wait-and-widen",
                     ),
                 ] {
                     let kv_model = model_config(&config, name);
@@ -1134,16 +1134,16 @@ pylon_requests_total_total{model="dummy-model",status="complete"} 3
     }
 
     #[test]
-    fn pulsar_multiregion_slo_scenario_is_a_controlled_fallback_comparison() {
-        let config = load_scenario("lb-balance-prefix-reuse-pmr-slo-4c2p-1s");
+    fn pulsar_wait_and_widen_slo_scenario_is_a_controlled_fallback_comparison() {
+        let config = load_scenario("lb-balance-prefix-reuse-pulsar-wait-and-widen-slo-4c2p-1s");
 
         config
             .validate()
-            .expect("controlled PMR fallback scenario should validate");
+            .expect("controlled PulsarWaitAndWiden fallback scenario should validate");
         assert_eq!(topology(&config), (4, 2, 1));
         assert_eq!(
             algorithm_names(&config),
-            ["groq-multiregion-affinity", "pulsar", "pulsar-multiregion"]
+            ["wait-and-widen-affinity", "pulsar", "pulsar-wait-and-widen"]
         );
         assert!(config.algorithms.iter().all(|algorithm| {
             algorithm
@@ -1155,15 +1155,15 @@ pylon_requests_total_total{model="dummy-model",status="complete"} 3
             crate::config::TrafficPatternConfig::PrefixReuse(prefix) => assert_eq!(
                 prefix.arrival,
                 crate::config::ArrivalPatternConfig::Poisson { target_rps: 8.0 },
-                "controlled PMR fallback evidence must not overload every candidate at once"
+                "controlled PulsarWaitAndWiden fallback evidence must not overload every candidate at once"
             ),
-            _ => panic!("controlled PMR scenario must use growing prefixes"),
+            _ => panic!("controlled PulsarWaitAndWiden scenario must use growing prefixes"),
         }
-        let pmr = model_config(&config, "pulsar-multiregion");
+        let pulsar_wait_and_widen = model_config(&config, "pulsar-wait-and-widen");
         for key in ["max_queue_time_floor_ms", "max_queue_time_ceil_ms"] {
             assert_eq!(
-                pmr[key], 4000,
-                "controlled PMR scenario must leave enough queue budget for useful fallback routing"
+                pulsar_wait_and_widen[key], 4000,
+                "controlled PulsarWaitAndWiden scenario must leave enough queue budget for useful fallback routing"
             );
         }
     }

--- a/src/libraries/rust/stargate/crates/stargate-bench/src/microbench/lb.rs
+++ b/src/libraries/rust/stargate/crates/stargate-bench/src/microbench/lb.rs
@@ -31,7 +31,7 @@ use stargate::routing::{RoutedClusterSnapshot, RoutingTargetKey};
 use stargate_proto::pb::{InferenceServerStatus, ModelStats};
 
 #[derive(Clone, Copy, PartialEq)]
-enum MultiregionTuning {
+enum WaitAndWidenTuning {
     IgnoreQueue,
     RttOnly,
     Affinity,
@@ -40,11 +40,11 @@ enum MultiregionTuning {
 struct LbMicrobenchScenarioMetadata {
     model_id: &'static str,
     algorithm: LoadBalancerAlgorithm,
-    tuning: Option<MultiregionTuning>,
+    tuning: Option<WaitAndWidenTuning>,
     excluded_clusters: usize,
 }
 
-use MultiregionTuning::{Affinity, IgnoreQueue, RttOnly};
+use WaitAndWidenTuning::{Affinity, IgnoreQueue, RttOnly};
 
 macro_rules! scenarios {
     ($($scenario:ident, $model_id:literal, $algorithm:ident, $tuning:expr, $excluded:literal;)+) => {
@@ -69,17 +69,17 @@ macro_rules! scenarios {
 scenarios! {
     PowerOfTwo, "lb-bench-power-of-two", PowerOfTwo, None, 0;
     PowerOfTwoOneExcluded, "lb-bench-power-of-two-one-excluded", PowerOfTwo, None, 1;
-    GroqMultiregion, "lb-bench-multiregion", GroqMultiregion, None, 0;
-    GroqMultiregionOneExcluded, "lb-bench-multiregion-one-excluded", GroqMultiregion, None, 1;
-    GroqMultiregionIgnoreQueue, "lb-bench-multiregion-ignore-queue", GroqMultiregion, Some(IgnoreQueue), 0;
-    GroqMultiregionIgnoreQueueOneExcluded, "lb-bench-multiregion-ignore-queue-one-excluded", GroqMultiregion, Some(IgnoreQueue), 1;
-    GroqMultiregionIgnoreQueueMultiExcluded, "lb-bench-multiregion-ignore-queue-multi-excluded", GroqMultiregion, Some(IgnoreQueue), 2;
-    GroqMultiregionRttOnly, "lb-bench-multiregion-rtt-only", GroqMultiregion, Some(RttOnly), 0;
-    GroqMultiregionRttOnlyOneExcluded, "lb-bench-multiregion-rtt-only-one-excluded", GroqMultiregion, Some(RttOnly), 1;
-    GroqMultiregionRttOnlyMultiExcluded, "lb-bench-multiregion-rtt-only-multi-excluded", GroqMultiregion, Some(RttOnly), 2;
-    GroqMultiregionAffinity, "lb-bench-multiregion-affinity", GroqMultiregion, Some(Affinity), 0;
-    GroqMultiregionAffinityOneExcluded, "lb-bench-multiregion-affinity-one-excluded", GroqMultiregion, Some(Affinity), 1;
-    GroqMultiregionAffinityMultiExcluded, "lb-bench-multiregion-affinity-multi-excluded", GroqMultiregion, Some(Affinity), 2;
+    WaitAndWiden, "lb-bench-wait-and-widen", WaitAndWiden, None, 0;
+    WaitAndWidenOneExcluded, "lb-bench-wait-and-widen-one-excluded", WaitAndWiden, None, 1;
+    WaitAndWidenIgnoreQueue, "lb-bench-wait-and-widen-ignore-queue", WaitAndWiden, Some(IgnoreQueue), 0;
+    WaitAndWidenIgnoreQueueOneExcluded, "lb-bench-wait-and-widen-ignore-queue-one-excluded", WaitAndWiden, Some(IgnoreQueue), 1;
+    WaitAndWidenIgnoreQueueMultiExcluded, "lb-bench-wait-and-widen-ignore-queue-multi-excluded", WaitAndWiden, Some(IgnoreQueue), 2;
+    WaitAndWidenRttOnly, "lb-bench-wait-and-widen-rtt-only", WaitAndWiden, Some(RttOnly), 0;
+    WaitAndWidenRttOnlyOneExcluded, "lb-bench-wait-and-widen-rtt-only-one-excluded", WaitAndWiden, Some(RttOnly), 1;
+    WaitAndWidenRttOnlyMultiExcluded, "lb-bench-wait-and-widen-rtt-only-multi-excluded", WaitAndWiden, Some(RttOnly), 2;
+    WaitAndWidenAffinity, "lb-bench-wait-and-widen-affinity", WaitAndWiden, Some(Affinity), 0;
+    WaitAndWidenAffinityOneExcluded, "lb-bench-wait-and-widen-affinity-one-excluded", WaitAndWiden, Some(Affinity), 1;
+    WaitAndWidenAffinityMultiExcluded, "lb-bench-wait-and-widen-affinity-multi-excluded", WaitAndWiden, Some(Affinity), 2;
     Pulsar, "lb-bench-pulsar", Pulsar, None, 0;
     PulsarOneExcluded, "lb-bench-pulsar-one-excluded", Pulsar, None, 1;
     Random, "lb-bench-random", Random, None, 0;
@@ -467,20 +467,20 @@ fn config_for_scenario(scenario: LbMicrobenchScenario) -> LoadBalancerAlgorithmC
             .set_seed(Some("lb-microbench-seed".to_string()))
             .expect("pulsar supports deterministic seeding");
     }
-    if let Some(multiregion) = config.multiregion_settings_mut() {
-        multiregion.seed = Some("lb-microbench-seed".to_string());
-        multiregion.ttft_bucket_size_ms = Some(1_000_000);
-        multiregion.n = Some(2);
-        multiregion.max_queued = Some(64);
+    if let Some(wait_and_widen) = config.wait_and_widen_settings_mut() {
+        wait_and_widen.seed = Some("lb-microbench-seed".to_string());
+        wait_and_widen.ttft_bucket_size_ms = Some(1_000_000);
+        wait_and_widen.n = Some(2);
+        wait_and_widen.max_queued = Some(64);
         if metadata.tuning == Some(Affinity) {
-            multiregion.cache_affinity_virtual_nodes = Some(150);
-            multiregion.cache_affinity_backend_selection_count = Some(2);
+            wait_and_widen.cache_affinity_virtual_nodes = Some(150);
+            wait_and_widen.cache_affinity_backend_selection_count = Some(2);
         }
         if matches!(metadata.tuning, Some(IgnoreQueue | RttOnly)) {
-            multiregion.ignore_queue_time = Some(true);
+            wait_and_widen.ignore_queue_time = Some(true);
         }
         if metadata.tuning == Some(RttOnly) {
-            multiregion.ignore_input_processing_time = Some(true);
+            wait_and_widen.ignore_input_processing_time = Some(true);
         }
     }
     config
@@ -640,10 +640,10 @@ mod tests {
     exclusion_tests! {
         random_one_excluded_scenario_never_selects_excluded_backend: RandomOneExcluded => ["cluster-0000"];
         power_of_two_one_excluded_scenario_never_selects_excluded_backend: PowerOfTwoOneExcluded => ["cluster-0000"];
-        groq_multiregion_one_excluded_scenario_never_selects_excluded_backend: GroqMultiregionOneExcluded => ["cluster-0000"];
-        groq_multiregion_affinity_one_excluded_scenario_never_selects_excluded_backend: GroqMultiregionAffinityOneExcluded => ["cluster-0000"];
-        groq_multiregion_affinity_multi_excluded_scenario_never_selects_excluded_backend: GroqMultiregionAffinityMultiExcluded => ["cluster-0000", "cluster-0001"];
-        groq_multiregion_ignore_queue_multi_excluded_scenario_never_selects_excluded_backend: GroqMultiregionIgnoreQueueMultiExcluded => ["cluster-0000", "cluster-0001"];
+        wait_and_widen_one_excluded_scenario_never_selects_excluded_backend: WaitAndWidenOneExcluded => ["cluster-0000"];
+        wait_and_widen_affinity_one_excluded_scenario_never_selects_excluded_backend: WaitAndWidenAffinityOneExcluded => ["cluster-0000"];
+        wait_and_widen_affinity_multi_excluded_scenario_never_selects_excluded_backend: WaitAndWidenAffinityMultiExcluded => ["cluster-0000", "cluster-0001"];
+        wait_and_widen_ignore_queue_multi_excluded_scenario_never_selects_excluded_backend: WaitAndWidenIgnoreQueueMultiExcluded => ["cluster-0000", "cluster-0001"];
         pulsar_one_excluded_scenario_never_selects_excluded_backend: PulsarOneExcluded => ["cluster-0000"];
         round_robin_one_excluded_scenario_never_selects_excluded_backend: RoundRobinOneExcluded => ["cluster-0000"];
         round_robin_multi_excluded_scenario_never_selects_excluded_backend: RoundRobinMultiExcluded => ["cluster-0000", "cluster-0001"];

--- a/src/libraries/rust/stargate/crates/stargate-bench/src/report.rs
+++ b/src/libraries/rust/stargate/crates/stargate-bench/src/report.rs
@@ -432,7 +432,7 @@ fn render_warnings(out: &mut String, context: &ReportContext, entries: &[ReportE
     };
     let cache_focused = has_tag(&["cache", "pulsar", "kv-cache"]);
     let queue_admission_focused = has_tag(&["queue-admission", "queue-mismatch"]);
-    let pmr_fallback_focused = has_tag(&["pmr-fallback"]);
+    let pulsar_wait_and_widen_fallback_focused = has_tag(&["pulsar-wait-and-widen-fallback"]);
     for entry in entries {
         let summary = &entry.summary;
         if summary.success_rate < 1.0 {
@@ -471,11 +471,11 @@ fn render_warnings(out: &mut String, context: &ReportContext, entries: &[ReportE
                 .unwrap();
             }
         }
-        if pmr_fallback_focused
-            && entry.algorithm_name == "pulsar-multiregion"
+        if pulsar_wait_and_widen_fallback_focused
+            && entry.algorithm_name == "pulsar-wait-and-widen"
             && summary.routing_selection_summary.fallback_count == 0.0
         {
-            out.push_str("- pulsar-multiregion did not observe a ranked fallback route choice in the PMR fallback scenario.\n");
+            out.push_str("- pulsar-wait-and-widen did not observe a ranked fallback route choice in the PulsarWaitAndWiden fallback scenario.\n");
         }
     }
     if queue_admission_focused
@@ -591,7 +591,7 @@ mod tests {
             kv_free_token_fallback_count: 1.0,
         };
         let entry = ReportEntry {
-            algorithm_name: "groq-admission-enabled".to_string(),
+            algorithm_name: "wait-and-widen-admission-enabled".to_string(),
             pylon_queue_admission: Some(queue_admission()),
             summary,
         };
@@ -607,7 +607,10 @@ mod tests {
             &std::fs::read(&artifacts.comparison_path).expect("comparison should read"),
         )
         .expect("comparison should parse");
-        assert_eq!(comparison[0]["algorithm_name"], "groq-admission-enabled");
+        assert_eq!(
+            comparison[0]["algorithm_name"],
+            "wait-and-widen-admission-enabled"
+        );
         assert_eq!(comparison[0]["pylon_queue_admission"]["enabled"], true);
         assert_eq!(comparison[0]["p95_ttft_ms"], 17);
         assert_eq!(
@@ -625,7 +628,7 @@ mod tests {
         );
 
         let report = std::fs::read_to_string(&artifacts.report_path).expect("report should read");
-        assert!(report.contains("| groq-admission-enabled | enabled"));
+        assert!(report.contains("| wait-and-widen-admission-enabled | enabled"));
         assert!(report.contains("Pylon Rejected"));
         assert!(report.contains("Fallback Route Choices"));
     }
@@ -725,7 +728,7 @@ mod tests {
 
         let report = render(
             &config(),
-            "groq-admission-enabled",
+            "wait-and-widen-admission-enabled",
             Some(queue_admission()),
             summary,
         );
@@ -734,7 +737,7 @@ mod tests {
         assert!(report.contains("enabled (min=0ms, factor=1, retry-after=5ms)"));
         assert!(report.contains("Pylon Rejected"));
         assert!(report.contains("Fallback Route Choices"));
-        assert!(report.contains("| groq-admission-enabled | enabled"));
+        assert!(report.contains("| wait-and-widen-admission-enabled | enabled"));
         assert!(report.contains("| 2 | 1 | 3 | 0 | 2 | 1 (retry_budget_exhausted=1) |"));
     }
 
@@ -761,19 +764,19 @@ mod tests {
     }
 
     #[test]
-    fn markdown_report_warns_when_a_pmr_fallback_scenario_never_uses_fallback() {
+    fn markdown_report_warns_when_a_pulsar_wait_and_widen_fallback_scenario_never_uses_fallback() {
         let mut config = config();
-        config.metadata.tags = vec!["pmr-fallback".to_string()];
+        config.metadata.tags = vec!["pulsar-wait-and-widen-fallback".to_string()];
 
         let report = render(
             &config,
-            "pulsar-multiregion",
+            "pulsar-wait-and-widen",
             None,
             summarize_with_capacity(&[], BTreeMap::new()),
         );
 
         assert!(
-            report.contains("pulsar-multiregion did not observe a ranked fallback route choice")
+            report.contains("pulsar-wait-and-widen did not observe a ranked fallback route choice")
         );
     }
 }

--- a/src/libraries/rust/stargate/crates/stargate-bench/src/score.rs
+++ b/src/libraries/rust/stargate/crates/stargate-bench/src/score.rs
@@ -982,14 +982,14 @@ stargate_proxy_retry_exhausted_total_total{model="dummy-model",reason="retry_bud
     #[test]
     fn routing_selection_delta_excludes_pre_replay_probe_counters() {
         let baseline = r#"
-stargate_routing_selections_total_total{algorithm="pulsar-multiregion",model="dummy-model",routing_key="",selection="primary"} 3
-stargate_routing_selections_total_total{algorithm="pulsar-multiregion",model="dummy-model",routing_key="",selection="fallback"} 1
-stargate_routing_kv_free_token_fallback_selections_total_total{algorithm="pulsar-multiregion",model="dummy-model",routing_key=""} 1
+stargate_routing_selections_total_total{algorithm="pulsar-wait-and-widen",model="dummy-model",routing_key="",selection="primary"} 3
+stargate_routing_selections_total_total{algorithm="pulsar-wait-and-widen",model="dummy-model",routing_key="",selection="fallback"} 1
+stargate_routing_kv_free_token_fallback_selections_total_total{algorithm="pulsar-wait-and-widen",model="dummy-model",routing_key=""} 1
 "#;
         let post_replay = r#"
-stargate_routing_selections_total_total{algorithm="pulsar-multiregion",model="dummy-model",routing_key="",selection="primary"} 13
-stargate_routing_selections_total_total{algorithm="pulsar-multiregion",model="dummy-model",routing_key="",selection="fallback"} 5
-stargate_routing_kv_free_token_fallback_selections_total_total{algorithm="pulsar-multiregion",model="dummy-model",routing_key=""} 4
+stargate_routing_selections_total_total{algorithm="pulsar-wait-and-widen",model="dummy-model",routing_key="",selection="primary"} 13
+stargate_routing_selections_total_total{algorithm="pulsar-wait-and-widen",model="dummy-model",routing_key="",selection="fallback"} 5
+stargate_routing_kv_free_token_fallback_selections_total_total{algorithm="pulsar-wait-and-widen",model="dummy-model",routing_key=""} 4
 "#;
 
         let summary = routing_selection_summary_delta_from_prometheus(baseline, post_replay);

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/algorithm.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/algorithm.rs
@@ -67,7 +67,7 @@ pub(crate) fn input_work_seconds_for_request(
         candidates
             .iter()
             .filter(|candidate| match config.algorithm() {
-                LoadBalancerAlgorithm::Pulsar | LoadBalancerAlgorithm::PulsarMultiregion => {
+                LoadBalancerAlgorithm::Pulsar | LoadBalancerAlgorithm::PulsarWaitAndWiden => {
                     pulsar::input_work_admission_candidate(config, request, candidate)
                 }
                 _ => !request.excludes_cluster(&candidate.cluster_id),

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/config.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/config.rs
@@ -50,22 +50,22 @@ impl<'de> Deserialize<'de> for LoadBalancerModelConfig {
 pub enum LoadBalancerAlgorithm {
     #[default]
     PowerOfTwo,
-    GroqMultiregion,
+    WaitAndWiden,
     RoundRobin,
     Random,
     Pulsar,
-    PulsarMultiregion,
+    PulsarWaitAndWiden,
 }
 
 impl fmt::Display for LoadBalancerAlgorithm {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match self {
             Self::PowerOfTwo => "power-of-two",
-            Self::GroqMultiregion => "groq-multiregion",
+            Self::WaitAndWiden => "wait-and-widen",
             Self::RoundRobin => "round-robin",
             Self::Random => "random",
             Self::Pulsar => "pulsar",
-            Self::PulsarMultiregion => "pulsar-multiregion",
+            Self::PulsarWaitAndWiden => "pulsar-wait-and-widen",
         };
         f.write_str(name)
     }
@@ -167,7 +167,7 @@ pub struct LoadBalancerRequestPolicy {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
-pub struct GroqMultiregionAlgorithmConfig {
+pub struct WaitAndWidenAlgorithmConfig {
     pub seed: Option<String>,
     pub cache_affinity_virtual_nodes: Option<usize>,
     pub cache_affinity_backend_selection_count: Option<usize>,
@@ -185,22 +185,22 @@ pub struct GroqMultiregionAlgorithmConfig {
 pub enum LoadBalancerAlgorithmSettings {
     #[default]
     PowerOfTwo,
-    GroqMultiregion(GroqMultiregionAlgorithmConfig),
+    WaitAndWiden(WaitAndWidenAlgorithmConfig),
     RoundRobin,
     Random,
     Pulsar(Option<String>),
-    PulsarMultiregion(GroqMultiregionAlgorithmConfig),
+    PulsarWaitAndWiden(WaitAndWidenAlgorithmConfig),
 }
 
 impl LoadBalancerAlgorithmSettings {
     fn algorithm(&self) -> LoadBalancerAlgorithm {
         match self {
             Self::PowerOfTwo => LoadBalancerAlgorithm::PowerOfTwo,
-            Self::GroqMultiregion(_) => LoadBalancerAlgorithm::GroqMultiregion,
+            Self::WaitAndWiden(_) => LoadBalancerAlgorithm::WaitAndWiden,
             Self::RoundRobin => LoadBalancerAlgorithm::RoundRobin,
             Self::Random => LoadBalancerAlgorithm::Random,
             Self::Pulsar(_) => LoadBalancerAlgorithm::Pulsar,
-            Self::PulsarMultiregion(_) => LoadBalancerAlgorithm::PulsarMultiregion,
+            Self::PulsarWaitAndWiden(_) => LoadBalancerAlgorithm::PulsarWaitAndWiden,
         }
     }
 }
@@ -237,8 +237,8 @@ impl LoadBalancerAlgorithmConfig {
     pub fn seed(&self) -> Option<&str> {
         match &self.settings {
             LoadBalancerAlgorithmSettings::Pulsar(seed) => seed.as_deref(),
-            LoadBalancerAlgorithmSettings::GroqMultiregion(config)
-            | LoadBalancerAlgorithmSettings::PulsarMultiregion(config) => config.seed.as_deref(),
+            LoadBalancerAlgorithmSettings::WaitAndWiden(config)
+            | LoadBalancerAlgorithmSettings::PulsarWaitAndWiden(config) => config.seed.as_deref(),
             LoadBalancerAlgorithmSettings::PowerOfTwo
             | LoadBalancerAlgorithmSettings::RoundRobin
             | LoadBalancerAlgorithmSettings::Random => None,
@@ -256,8 +256,8 @@ impl LoadBalancerAlgorithmConfig {
                 *current_seed = seed;
                 Ok(())
             }
-            LoadBalancerAlgorithmSettings::GroqMultiregion(config)
-            | LoadBalancerAlgorithmSettings::PulsarMultiregion(config) => {
+            LoadBalancerAlgorithmSettings::WaitAndWiden(config)
+            | LoadBalancerAlgorithmSettings::PulsarWaitAndWiden(config) => {
                 config.seed = seed;
                 Ok(())
             }
@@ -269,10 +269,10 @@ impl LoadBalancerAlgorithmConfig {
         }
     }
 
-    pub fn multiregion_settings(&self) -> Option<&GroqMultiregionAlgorithmConfig> {
+    pub fn wait_and_widen_settings(&self) -> Option<&WaitAndWidenAlgorithmConfig> {
         match &self.settings {
-            LoadBalancerAlgorithmSettings::GroqMultiregion(config)
-            | LoadBalancerAlgorithmSettings::PulsarMultiregion(config) => Some(config),
+            LoadBalancerAlgorithmSettings::WaitAndWiden(config)
+            | LoadBalancerAlgorithmSettings::PulsarWaitAndWiden(config) => Some(config),
             LoadBalancerAlgorithmSettings::PowerOfTwo
             | LoadBalancerAlgorithmSettings::RoundRobin
             | LoadBalancerAlgorithmSettings::Random
@@ -280,10 +280,10 @@ impl LoadBalancerAlgorithmConfig {
         }
     }
 
-    pub fn multiregion_settings_mut(&mut self) -> Option<&mut GroqMultiregionAlgorithmConfig> {
+    pub fn wait_and_widen_settings_mut(&mut self) -> Option<&mut WaitAndWidenAlgorithmConfig> {
         match &mut self.settings {
-            LoadBalancerAlgorithmSettings::GroqMultiregion(config)
-            | LoadBalancerAlgorithmSettings::PulsarMultiregion(config) => Some(config),
+            LoadBalancerAlgorithmSettings::WaitAndWiden(config)
+            | LoadBalancerAlgorithmSettings::PulsarWaitAndWiden(config) => Some(config),
             LoadBalancerAlgorithmSettings::PowerOfTwo
             | LoadBalancerAlgorithmSettings::RoundRobin
             | LoadBalancerAlgorithmSettings::Random
@@ -305,11 +305,13 @@ impl From<LoadBalancerAlgorithm> for LoadBalancerAlgorithmSettings {
     fn from(algorithm: LoadBalancerAlgorithm) -> Self {
         match algorithm {
             LoadBalancerAlgorithm::PowerOfTwo => Self::PowerOfTwo,
-            LoadBalancerAlgorithm::GroqMultiregion => Self::GroqMultiregion(Default::default()),
+            LoadBalancerAlgorithm::WaitAndWiden => Self::WaitAndWiden(Default::default()),
             LoadBalancerAlgorithm::RoundRobin => Self::RoundRobin,
             LoadBalancerAlgorithm::Random => Self::Random,
             LoadBalancerAlgorithm::Pulsar => Self::Pulsar(None),
-            LoadBalancerAlgorithm::PulsarMultiregion => Self::PulsarMultiregion(Default::default()),
+            LoadBalancerAlgorithm::PulsarWaitAndWiden => {
+                Self::PulsarWaitAndWiden(Default::default())
+            }
         }
     }
 }
@@ -360,9 +362,9 @@ impl RawCommonAlgorithmConfig {
 #[serde(tag = "algorithm", rename_all = "kebab-case")]
 enum RawLoadBalancerAlgorithmConfig {
     PowerOfTwo(RawCommonAlgorithmConfig),
-    GroqMultiregion {
+    WaitAndWiden {
         #[serde(flatten)]
-        settings: GroqMultiregionAlgorithmConfig,
+        settings: WaitAndWidenAlgorithmConfig,
         #[serde(flatten)]
         common: RawCommonAlgorithmConfig,
     },
@@ -374,9 +376,9 @@ enum RawLoadBalancerAlgorithmConfig {
         #[serde(flatten)]
         common: RawCommonAlgorithmConfig,
     },
-    PulsarMultiregion {
+    PulsarWaitAndWiden {
         #[serde(flatten)]
-        settings: GroqMultiregionAlgorithmConfig,
+        settings: WaitAndWidenAlgorithmConfig,
         consider_kv_free_tokens: Option<bool>,
         #[serde(flatten)]
         common: RawCommonAlgorithmConfig,
@@ -393,9 +395,9 @@ impl RawLoadBalancerAlgorithmConfig {
     ) {
         match self {
             Self::PowerOfTwo(common) => (common, LoadBalancerAlgorithmSettings::PowerOfTwo, None),
-            Self::GroqMultiregion { settings, common } => (
+            Self::WaitAndWiden { settings, common } => (
                 common,
-                LoadBalancerAlgorithmSettings::GroqMultiregion(settings),
+                LoadBalancerAlgorithmSettings::WaitAndWiden(settings),
                 None,
             ),
             Self::RoundRobin(common) => (common, LoadBalancerAlgorithmSettings::RoundRobin, None),
@@ -409,13 +411,13 @@ impl RawLoadBalancerAlgorithmConfig {
                 LoadBalancerAlgorithmSettings::Pulsar(seed),
                 consider_kv_free_tokens,
             ),
-            Self::PulsarMultiregion {
+            Self::PulsarWaitAndWiden {
                 settings,
                 consider_kv_free_tokens,
                 common,
             } => (
                 common,
-                LoadBalancerAlgorithmSettings::PulsarMultiregion(settings),
+                LoadBalancerAlgorithmSettings::PulsarWaitAndWiden(settings),
                 consider_kv_free_tokens,
             ),
         }

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/config.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/config.rs
@@ -50,10 +50,12 @@ impl<'de> Deserialize<'de> for LoadBalancerModelConfig {
 pub enum LoadBalancerAlgorithm {
     #[default]
     PowerOfTwo,
+    #[serde(alias = "groq-multiregion")]
     WaitAndWiden,
     RoundRobin,
     Random,
     Pulsar,
+    #[serde(alias = "pulsar-multiregion")]
     PulsarWaitAndWiden,
 }
 
@@ -362,6 +364,7 @@ impl RawCommonAlgorithmConfig {
 #[serde(tag = "algorithm", rename_all = "kebab-case")]
 enum RawLoadBalancerAlgorithmConfig {
     PowerOfTwo(RawCommonAlgorithmConfig),
+    #[serde(alias = "groq-multiregion")]
     WaitAndWiden {
         #[serde(flatten)]
         settings: WaitAndWidenAlgorithmConfig,
@@ -376,6 +379,7 @@ enum RawLoadBalancerAlgorithmConfig {
         #[serde(flatten)]
         common: RawCommonAlgorithmConfig,
     },
+    #[serde(alias = "pulsar-multiregion")]
     PulsarWaitAndWiden {
         #[serde(flatten)]
         settings: WaitAndWidenAlgorithmConfig,

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/factory.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/factory.rs
@@ -15,12 +15,12 @@
 
 use std::sync::Arc;
 
-use super::groq_multiregion::{GroqMultiregionConfig, GroqMultiregionLoadBalancer};
 use super::power_of_two::PowerOfTwoLoadBalancer;
 use super::pulsar::PulsarLoadBalancer;
-use super::pulsar_multiregion::PulsarMultiregionLoadBalancer;
+use super::pulsar_wait_and_widen::PulsarWaitAndWidenLoadBalancer;
 use super::random::RandomLoadBalancer;
 use super::round_robin::RoundRobinLoadBalancer;
+use super::wait_and_widen::{WaitAndWidenConfig, WaitAndWidenLoadBalancer};
 use super::{LoadBalancer, LoadBalancerAlgorithm, LoadBalancerAlgorithmConfig};
 
 pub fn create_load_balancer_with_config(
@@ -29,24 +29,24 @@ pub fn create_load_balancer_with_config(
     if config.considers_kv_free_tokens()
         && !matches!(
             config.algorithm(),
-            LoadBalancerAlgorithm::Pulsar | LoadBalancerAlgorithm::PulsarMultiregion
+            LoadBalancerAlgorithm::Pulsar | LoadBalancerAlgorithm::PulsarWaitAndWiden
         )
     {
         anyhow::bail!(
-            "consider_kv_free_tokens is supported only for pulsar and pulsar-multiregion"
+            "consider_kv_free_tokens is supported only for pulsar and pulsar-wait-and-widen"
         );
     }
 
     match config.algorithm() {
         LoadBalancerAlgorithm::PowerOfTwo => Ok(Arc::new(PowerOfTwoLoadBalancer)),
-        LoadBalancerAlgorithm::GroqMultiregion => Ok(Arc::new(GroqMultiregionLoadBalancer::new(
-            GroqMultiregionConfig::from_algorithm_config(config),
+        LoadBalancerAlgorithm::WaitAndWiden => Ok(Arc::new(WaitAndWidenLoadBalancer::new(
+            WaitAndWidenConfig::from_algorithm_config(config),
         ))),
         LoadBalancerAlgorithm::RoundRobin => Ok(Arc::new(RoundRobinLoadBalancer::new())),
         LoadBalancerAlgorithm::Random => Ok(Arc::new(RandomLoadBalancer)),
         LoadBalancerAlgorithm::Pulsar => Ok(Arc::new(PulsarLoadBalancer::new(config.clone()))),
-        LoadBalancerAlgorithm::PulsarMultiregion => {
-            Ok(Arc::new(PulsarMultiregionLoadBalancer::new(config.clone())))
-        }
+        LoadBalancerAlgorithm::PulsarWaitAndWiden => Ok(Arc::new(
+            PulsarWaitAndWidenLoadBalancer::new(config.clone()),
+        )),
     }
 }

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/mod.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/mod.rs
@@ -26,10 +26,9 @@ macro_rules! impl_display {
 mod algorithm;
 mod config;
 mod factory;
-mod groq_multiregion;
 mod power_of_two;
 mod pulsar;
-mod pulsar_multiregion;
+mod pulsar_wait_and_widen;
 mod random;
 mod request;
 mod round_robin;
@@ -37,15 +36,16 @@ mod router;
 mod target_state;
 #[cfg(test)]
 mod tests;
+mod wait_and_widen;
 
 pub use algorithm::LoadBalancer;
 pub(crate) use algorithm::input_work_seconds_for_request;
 pub(super) use algorithm::{HashInputBuilder, cache_affinity_key_is_cacheable, input_work_units};
 pub use config::{
-    GroqMultiregionAlgorithmConfig, LoadBalancerAlgorithm, LoadBalancerAlgorithmConfig,
-    LoadBalancerAlgorithmOverride, LoadBalancerAlgorithmSettings, LoadBalancerConfig,
-    LoadBalancerModelConfig, LoadBalancerRequestPolicy, LoadBalancerRoutingAlgorithmError,
-    LoadBalancerSeedError,
+    LoadBalancerAlgorithm, LoadBalancerAlgorithmConfig, LoadBalancerAlgorithmOverride,
+    LoadBalancerAlgorithmSettings, LoadBalancerConfig, LoadBalancerModelConfig,
+    LoadBalancerRequestPolicy, LoadBalancerRoutingAlgorithmError, LoadBalancerSeedError,
+    WaitAndWidenAlgorithmConfig,
 };
 pub use factory::create_load_balancer_with_config;
 pub use request::{LoadBalancerCandidateChoice, LoadBalancerRequest};

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/pulsar_wait_and_widen.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/pulsar_wait_and_widen.rs
@@ -13,23 +13,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::groq_multiregion::{GroqMultiregionConfig, GroqMultiregionLoadBalancer};
 use super::pulsar::PulsarLoadBalancer;
+use super::wait_and_widen::{WaitAndWidenConfig, WaitAndWidenLoadBalancer};
 use super::{
     LoadBalancer, LoadBalancerAlgorithmConfig, LoadBalancerCandidateChoice, LoadBalancerRequest,
 };
 use crate::routing_state::RoutedClusterSnapshot;
 
-pub(super) struct PulsarMultiregionLoadBalancer {
+pub(super) struct PulsarWaitAndWidenLoadBalancer {
     ranking: PulsarLoadBalancer,
-    multiregion: GroqMultiregionLoadBalancer,
+    wait_and_widen: WaitAndWidenLoadBalancer,
 }
 
-impl PulsarMultiregionLoadBalancer {
+impl PulsarWaitAndWidenLoadBalancer {
     pub(super) fn new(config: LoadBalancerAlgorithmConfig) -> Self {
         Self {
-            multiregion: GroqMultiregionLoadBalancer::new(
-                GroqMultiregionConfig::from_algorithm_config(&config),
+            wait_and_widen: WaitAndWidenLoadBalancer::new(
+                WaitAndWidenConfig::from_algorithm_config(&config),
             ),
             ranking: PulsarLoadBalancer::new(config),
         }
@@ -51,13 +51,13 @@ impl PulsarMultiregionLoadBalancer {
                     .is_eligible()
             })
             .collect::<Vec<_>>();
-        self.multiregion
+        self.wait_and_widen
             .choose_from_candidate_indices(request, candidates, &eligible)
             .map(|choice| {
                 let rank_depth = ranked_indices
                     .iter()
                     .position(|index| *index == choice.candidate_index)
-                    .expect("multiregion choice must come from the PULSAR ranking")
+                    .expect("wait_and_widen choice must come from the PULSAR ranking")
                     + 1;
                 LoadBalancerCandidateChoice {
                     candidate_index: choice.candidate_index,
@@ -74,9 +74,9 @@ impl PulsarMultiregionLoadBalancer {
     }
 }
 
-impl_display!(PulsarMultiregionLoadBalancer, "pulsar-multiregion");
+impl_display!(PulsarWaitAndWidenLoadBalancer, "pulsar-wait-and-widen");
 
-impl LoadBalancer for PulsarMultiregionLoadBalancer {
+impl LoadBalancer for PulsarWaitAndWidenLoadBalancer {
     fn choose_candidate(
         &self,
         request: &LoadBalancerRequest<'_>,
@@ -89,7 +89,7 @@ impl LoadBalancer for PulsarMultiregionLoadBalancer {
         let ranked_indices = self.ranking.compute_ranking(request, candidates);
         let primary_index = *ranked_indices.first()?;
         let primary = &candidates[primary_index];
-        if !self.multiregion.has_queue_slo(request)
+        if !self.wait_and_widen.has_queue_slo(request)
             && self.ranking.feasibility(request, primary).is_eligible()
         {
             return Some(LoadBalancerCandidateChoice {
@@ -135,8 +135,8 @@ mod tests {
     use super::super::pulsar::PulsarLoadBalancer;
     use super::super::tests::LoadBalancerTestChoiceExt;
     use super::super::{
-        GroqMultiregionAlgorithmConfig, LoadBalancerAlgorithm, LoadBalancerAlgorithmConfig,
-        LoadBalancerRequest,
+        LoadBalancerAlgorithm, LoadBalancerAlgorithmConfig, LoadBalancerRequest,
+        WaitAndWidenAlgorithmConfig,
     };
     use super::*;
     use crate::routing_state::{RoutedClusterSnapshot, RoutingTargetKey};
@@ -165,27 +165,27 @@ mod tests {
         let mut config = LoadBalancerAlgorithmConfig::from(LoadBalancerAlgorithm::Pulsar);
         config
             .set_seed(Some(seed.to_string()))
-            .expect("pulsar-multiregion supports deterministic seeding");
+            .expect("pulsar-wait-and-widen supports deterministic seeding");
         config.request_policy_mut().require_cache_affinity_key = true;
         config.request_policy_mut().require_input_tokens = true;
         config
     }
 
-    fn pulsar_multiregion_algorithm_config(
+    fn pulsar_wait_and_widen_algorithm_config(
         seed: &str,
         consider_kv_free_tokens: bool,
-        configure: impl FnOnce(&mut GroqMultiregionAlgorithmConfig),
+        configure: impl FnOnce(&mut WaitAndWidenAlgorithmConfig),
     ) -> LoadBalancerAlgorithmConfig {
         let mut config =
-            LoadBalancerAlgorithmConfig::from(LoadBalancerAlgorithm::PulsarMultiregion);
+            LoadBalancerAlgorithmConfig::from(LoadBalancerAlgorithm::PulsarWaitAndWiden);
         config
             .set_seed(Some(seed.to_string()))
-            .expect("pulsar-multiregion supports deterministic seeding");
+            .expect("pulsar-wait-and-widen supports deterministic seeding");
         config.request_policy_mut().consider_kv_free_tokens = consider_kv_free_tokens;
         configure(
             config
-                .multiregion_settings_mut()
-                .expect("pulsar-multiregion config should expose multiregion settings"),
+                .wait_and_widen_settings_mut()
+                .expect("pulsar-wait-and-widen config should expose wait_and_widen settings"),
         );
         config
     }
@@ -262,7 +262,7 @@ mod tests {
             pulsar_ranked_indices("hybrid-seed", &target, affinity_key, 0, &candidates)[0];
         candidates[primary_index].stats.num_running_queries = 1;
 
-        let hybrid = PulsarMultiregionLoadBalancer::new(pulsar_multiregion_algorithm_config(
+        let hybrid = PulsarWaitAndWidenLoadBalancer::new(pulsar_wait_and_widen_algorithm_config(
             "hybrid-seed",
             false,
             |settings| {
@@ -303,7 +303,7 @@ mod tests {
         candidates[primary_index].stats.kv_cache_free_tokens = 50;
         candidates[primary_index].stats.kv_cache_used_tokens = 974;
 
-        let hybrid = PulsarMultiregionLoadBalancer::new(pulsar_multiregion_algorithm_config(
+        let hybrid = PulsarWaitAndWidenLoadBalancer::new(pulsar_wait_and_widen_algorithm_config(
             "hybrid-kv-seed",
             true,
             |settings| {
@@ -335,8 +335,8 @@ mod tests {
         candidates[primary_index].stats.kv_cache_free_tokens = 1024;
         candidates[primary_index].stats.kv_cache_used_tokens = 0;
         candidates[primary_index].stats.queued_input_size = 50;
-        let hybrid_with_slo = PulsarMultiregionLoadBalancer::new(
-            pulsar_multiregion_algorithm_config("hybrid-kv-seed", true, |settings| {
+        let hybrid_with_slo = PulsarWaitAndWidenLoadBalancer::new(
+            pulsar_wait_and_widen_algorithm_config("hybrid-kv-seed", true, |settings| {
                 settings.max_queue_time_floor_ms = Some(100);
                 settings.max_queue_time_ceil_ms = Some(100);
                 settings.ttft_bucket_size_ms = Some(100);
@@ -387,7 +387,7 @@ mod tests {
             }
         }
 
-        let hybrid = PulsarMultiregionLoadBalancer::new(pulsar_multiregion_algorithm_config(
+        let hybrid = PulsarWaitAndWidenLoadBalancer::new(pulsar_wait_and_widen_algorithm_config(
             "hybrid-seed",
             false,
             |settings| {

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/tests.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/tests.rs
@@ -20,11 +20,11 @@ use stargate_proto::pb::{InferenceServerStatus, ModelStats};
 
 use super::*;
 use crate::load_balancer::algorithm::{MAX_CACHE_AFFINITY_CACHE_KEY_BYTES, input_work_seconds};
-use crate::load_balancer::groq_multiregion::{
-    GroqMultiregionConfig, GroqMultiregionLoadBalancer, cache_affinity_candidate_indices,
-    cache_affinity_candidates, cache_affinity_virtual_node_hash, groq_multiregion_ttft_components,
-};
 use crate::load_balancer::pulsar::{PulsarLoadBalancer, pulsar_hash64, pulsar_ranked_indices};
+use crate::load_balancer::wait_and_widen::{
+    WaitAndWidenConfig, WaitAndWidenLoadBalancer, cache_affinity_candidate_indices,
+    cache_affinity_candidates, cache_affinity_virtual_node_hash, wait_and_widen_ttft_components,
+};
 use crate::routing::{RoutedClusterSnapshot, RoutingTargetKey};
 use xxhash_rust::xxh3::xxh3_64;
 
@@ -94,24 +94,24 @@ fn request_with_priority<'a>(
     }
 }
 
-fn groq_multiregion_algorithm_config(
-    configure: impl FnOnce(&mut GroqMultiregionAlgorithmConfig),
+fn wait_and_widen_algorithm_config(
+    configure: impl FnOnce(&mut WaitAndWidenAlgorithmConfig),
 ) -> LoadBalancerAlgorithmConfig {
-    let mut config = LoadBalancerAlgorithmConfig::from(LoadBalancerAlgorithm::GroqMultiregion);
+    let mut config = LoadBalancerAlgorithmConfig::from(LoadBalancerAlgorithm::WaitAndWiden);
     configure(
         config
-            .multiregion_settings_mut()
-            .expect("groq-multiregion config should expose multiregion settings"),
+            .wait_and_widen_settings_mut()
+            .expect("wait-and-widen config should expose wait_and_widen settings"),
     );
     config
 }
 
-fn groq_affinity_algorithm_config(
+fn wait_and_widen_affinity_algorithm_config(
     virtual_nodes: usize,
     selection_count: usize,
     sample_count: Option<usize>,
 ) -> LoadBalancerAlgorithmConfig {
-    groq_multiregion_algorithm_config(|settings| {
+    wait_and_widen_algorithm_config(|settings| {
         settings.seed = Some("seed-1".to_string());
         settings.cache_affinity_virtual_nodes = Some(virtual_nodes);
         settings.cache_affinity_backend_selection_count = Some(selection_count);
@@ -119,12 +119,12 @@ fn groq_affinity_algorithm_config(
     })
 }
 
-fn groq_affinity_config(
+fn wait_and_widen_affinity_config(
     virtual_nodes: usize,
     selection_count: usize,
     sample_count: Option<usize>,
-) -> GroqMultiregionConfig {
-    GroqMultiregionConfig::from_algorithm_config(&groq_affinity_algorithm_config(
+) -> WaitAndWidenConfig {
+    WaitAndWidenConfig::from_algorithm_config(&wait_and_widen_affinity_algorithm_config(
         virtual_nodes,
         selection_count,
         sample_count,
@@ -158,11 +158,11 @@ fn set_seed_reports_unsupported_algorithms_without_panicking() {
 }
 
 #[test]
-fn pulsar_multiregion_seed_has_one_authoritative_owner() {
-    let mut config = LoadBalancerAlgorithmConfig::from(LoadBalancerAlgorithm::PulsarMultiregion);
+fn pulsar_wait_and_widen_seed_has_one_authoritative_owner() {
+    let mut config = LoadBalancerAlgorithmConfig::from(LoadBalancerAlgorithm::PulsarWaitAndWiden);
     config
-        .multiregion_settings_mut()
-        .expect("pulsar-multiregion should expose multiregion settings")
+        .wait_and_widen_settings_mut()
+        .expect("pulsar-wait-and-widen should expose wait_and_widen settings")
         .seed = Some("shared-seed".to_string());
 
     assert_eq!(config.seed(), Some("shared-seed"));
@@ -267,7 +267,7 @@ fn max_queue_time(
     elapsed: Duration,
     request_slo: Option<Duration>,
 ) -> Duration {
-    let config = groq_multiregion_algorithm_config(|settings| {
+    let config = wait_and_widen_algorithm_config(|settings| {
         settings.max_queue_time_floor_ms = Some(floor_ms);
         settings.max_queue_time_ceil_ms = Some(ceil_ms);
     });
@@ -277,16 +277,16 @@ fn max_queue_time(
         request_slo,
         ..request(&target, None, Some(0))
     };
-    GroqMultiregionConfig::from_algorithm_config(&config)
+    WaitAndWidenConfig::from_algorithm_config(&config)
         .max_queue_time(&request)
         .expect("floor and ceil should enable max queue time")
 }
 
-fn groq_load_balancer(
-    configure: impl FnOnce(&mut GroqMultiregionAlgorithmConfig),
+fn wait_and_widen_load_balancer(
+    configure: impl FnOnce(&mut WaitAndWidenAlgorithmConfig),
 ) -> std::sync::Arc<dyn LoadBalancer> {
-    create_load_balancer_with_config(&groq_multiregion_algorithm_config(configure))
-        .expect("factory should accept groq-multiregion")
+    create_load_balancer_with_config(&wait_and_widen_algorithm_config(configure))
+        .expect("factory should accept wait-and-widen")
 }
 
 fn assert_repeated_choice(
@@ -324,7 +324,7 @@ fn choose_from_router(
 }
 
 fn assert_excluded_queue_choice(rtt_only: bool, excluded_ids: &[&str]) {
-    let load_balancer = groq_load_balancer(|settings| {
+    let load_balancer = wait_and_widen_load_balancer(|settings| {
         settings.n = Some(2);
         settings.ignore_queue_time = Some(true);
         settings.ignore_input_processing_time = rtt_only.then_some(true);
@@ -351,7 +351,7 @@ fn assert_excluded_queue_choice(rtt_only: bool, excluded_ids: &[&str]) {
 }
 
 type AffinityRetryFixture = (
-    GroqMultiregionConfig,
+    WaitAndWidenConfig,
     RoutingTargetKey,
     Vec<RoutedClusterSnapshot>,
     HashSet<String>,
@@ -359,7 +359,7 @@ type AffinityRetryFixture = (
 );
 
 fn affinity_retry_fixture(excluded_ids: &[&str]) -> AffinityRetryFixture {
-    let config = groq_affinity_config(32, 1, None);
+    let config = wait_and_widen_affinity_config(32, 1, None);
     let target = target();
     let mut candidates = excluded_ids
         .iter()
@@ -397,7 +397,7 @@ fn affinity_retry_fixture(excluded_ids: &[&str]) -> AffinityRetryFixture {
 
 fn assert_cache_affinity_retry(excluded_ids: &[&str]) {
     let (config, target, candidates, excluded, key) = affinity_retry_fixture(excluded_ids);
-    let load_balancer = GroqMultiregionLoadBalancer::new(config);
+    let load_balancer = WaitAndWidenLoadBalancer::new(config);
     let request = request(&target, Some(&key), Some(1));
     choose(&load_balancer, &request, &candidates);
     let retry_request = LoadBalancerRequest {
@@ -414,7 +414,7 @@ fn assert_cache_affinity_retry(excluded_ids: &[&str]) {
     assert_eq!(load_balancer.cached_affinity_key_bytes(), cached_key_bytes);
 }
 
-macro_rules! groq_choice_tests {
+macro_rules! wait_and_widen_choice_tests {
     ($(
         $name:ident:
         $configure:expr;
@@ -425,7 +425,7 @@ macro_rules! groq_choice_tests {
         $(
             #[test]
             fn $name() {
-                let load_balancer = groq_load_balancer($configure);
+                let load_balancer = wait_and_widen_load_balancer($configure);
                 let target = target();
                 let request = ($request)(&target);
                 let candidates = [$($candidate),+];
@@ -570,10 +570,10 @@ where
 
 fn assert_algorithm_overrides(raw: impl Fn(LoadBalancerAlgorithm) -> String) {
     for algorithm in [
-        LoadBalancerAlgorithm::GroqMultiregion,
+        LoadBalancerAlgorithm::WaitAndWiden,
         LoadBalancerAlgorithm::PowerOfTwo,
         LoadBalancerAlgorithm::Pulsar,
-        LoadBalancerAlgorithm::PulsarMultiregion,
+        LoadBalancerAlgorithm::PulsarWaitAndWiden,
         LoadBalancerAlgorithm::Random,
         LoadBalancerAlgorithm::RoundRobin,
     ] {
@@ -589,9 +589,9 @@ fn assert_algorithm_overrides(raw: impl Fn(LoadBalancerAlgorithm) -> String) {
 #[test]
 fn simple_model_config_parses_to_algorithm_enum() {
     let config: LoadBalancerConfig =
-        parse_json(r#"{"default":"groq-multiregion","models":{"model-a":"round-robin"}}"#);
+        parse_json(r#"{"default":"wait-and-widen","models":{"model-a":"round-robin"}}"#);
 
-    assert_eq!(config.default, LoadBalancerAlgorithm::GroqMultiregion);
+    assert_eq!(config.default, LoadBalancerAlgorithm::WaitAndWiden);
     assert!(matches!(
         config.models.get("model-a"),
         Some(LoadBalancerModelConfig::Name(
@@ -710,7 +710,7 @@ fn algorithm_specific_load_balancer_fields_are_rejected_for_other_algorithms() {
             "max_queue_time_floor_ms",
         ),
         (
-            r#"{"algorithm":"groq-multiregion","consider_kv_free_tokens":true}"#,
+            r#"{"algorithm":"wait-and-widen","consider_kv_free_tokens":true}"#,
             "consider_kv_free_tokens",
         ),
     ] {
@@ -725,9 +725,9 @@ fn detailed_algorithm_configs_preserve_all_variant_identities() {
     for (raw, expected, expected_seed, considers_kv_free_tokens) in [
         (r#"{"algorithm":"power-of-two"}"#, PowerOfTwo, None, false),
         (
-            r#"{"algorithm":"groq-multiregion","seed":"groq-seed"}"#,
-            GroqMultiregion,
-            Some("groq-seed"),
+            r#"{"algorithm":"wait-and-widen","seed":"wait-and-widen-seed"}"#,
+            WaitAndWiden,
+            Some("wait-and-widen-seed"),
             false,
         ),
         (r#"{"algorithm":"round-robin"}"#, RoundRobin, None, false),
@@ -739,8 +739,8 @@ fn detailed_algorithm_configs_preserve_all_variant_identities() {
             true,
         ),
         (
-            r#"{"algorithm":"pulsar-multiregion","seed":"hybrid-seed","consider_kv_free_tokens":true}"#,
-            PulsarMultiregion,
+            r#"{"algorithm":"pulsar-wait-and-widen","seed":"hybrid-seed","consider_kv_free_tokens":true}"#,
+            PulsarWaitAndWiden,
             Some("hybrid-seed"),
             true,
         ),
@@ -846,43 +846,43 @@ fn kv_free_token_consideration_is_rejected_for_non_pulsar_algorithms() {
 }
 
 #[test]
-fn detailed_model_config_parses_for_pulsar_multiregion() {
+fn detailed_model_config_parses_for_pulsar_wait_and_widen() {
     let router = router_from_json(
-        r#"{"default":"power-of-two","models":{"model-a":{"algorithm":"pulsar-multiregion","seed":"seed-1","require_cache_affinity_key":true,"require_input_tokens":true,"max_queue_time_floor_ms":100,"max_queue_time_ceil_ms":100,"ttft_bucket_size_ms":50,"n":2}}}"#,
+        r#"{"default":"power-of-two","models":{"model-a":{"algorithm":"pulsar-wait-and-widen","seed":"seed-1","require_cache_affinity_key":true,"require_input_tokens":true,"max_queue_time_floor_ms":100,"max_queue_time_ceil_ms":100,"ttft_bucket_size_ms":50,"n":2}}}"#,
     );
     let model_config = router.algorithm_config("model-a");
     assert_eq!(
         model_config.algorithm(),
-        LoadBalancerAlgorithm::PulsarMultiregion
+        LoadBalancerAlgorithm::PulsarWaitAndWiden
     );
     assert_eq!(model_config.seed(), Some("seed-1"));
     assert!(model_config.requires_cache_affinity_key());
     assert!(model_config.requires_input_tokens());
-    let multiregion_settings = model_config
-        .multiregion_settings()
-        .expect("hybrid config should include multiregion settings");
-    assert_eq!(multiregion_settings.max_queue_time_floor_ms, Some(100));
-    assert_eq!(multiregion_settings.max_queue_time_ceil_ms, Some(100));
-    assert_eq!(multiregion_settings.ttft_bucket_size_ms, Some(50));
-    assert_eq!(multiregion_settings.n, Some(2));
+    let wait_and_widen_settings = model_config
+        .wait_and_widen_settings()
+        .expect("hybrid config should include wait_and_widen settings");
+    assert_eq!(wait_and_widen_settings.max_queue_time_floor_ms, Some(100));
+    assert_eq!(wait_and_widen_settings.max_queue_time_ceil_ms, Some(100));
+    assert_eq!(wait_and_widen_settings.ttft_bucket_size_ms, Some(50));
+    assert_eq!(wait_and_widen_settings.n, Some(2));
 }
 
 #[test]
-fn detailed_model_config_parses_groq_multiregion_cache_affinity() {
+fn detailed_model_config_parses_wait_and_widen_cache_affinity() {
     let router = router_from_json(
-        r#"{"default":"power-of-two","models":{"model-a":{"algorithm":"groq-multiregion","seed":"seed-1","require_cache_affinity_key":true,"cache_affinity_virtual_nodes":64,"cache_affinity_backend_selection_count":2}}}"#,
+        r#"{"default":"power-of-two","models":{"model-a":{"algorithm":"wait-and-widen","seed":"seed-1","require_cache_affinity_key":true,"cache_affinity_virtual_nodes":64,"cache_affinity_backend_selection_count":2}}}"#,
     );
     let model_config = router.algorithm_config("model-a");
     assert_eq!(
         model_config.algorithm(),
-        LoadBalancerAlgorithm::GroqMultiregion
+        LoadBalancerAlgorithm::WaitAndWiden
     );
     assert_eq!(model_config.seed(), Some("seed-1"));
     assert!(model_config.requires_cache_affinity_key());
-    let multiregion_config = GroqMultiregionConfig::from_algorithm_config(model_config);
-    assert_eq!(multiregion_config.cache_affinity_virtual_nodes, 64);
+    let wait_and_widen_config = WaitAndWidenConfig::from_algorithm_config(model_config);
+    assert_eq!(wait_and_widen_config.cache_affinity_virtual_nodes, 64);
     assert_eq!(
-        multiregion_config.cache_affinity_backend_selection_count,
+        wait_and_widen_config.cache_affinity_backend_selection_count,
         Some(2)
     );
 }
@@ -997,12 +997,12 @@ fn request_algorithm_key_must_match_configured_algorithm() {
 }
 
 #[test]
-fn groq_multiregion_config_resolves_internal_defaults() {
+fn wait_and_widen_config_resolves_internal_defaults() {
     let mut algorithm_config =
-        LoadBalancerAlgorithmConfig::from(LoadBalancerAlgorithm::GroqMultiregion);
+        LoadBalancerAlgorithmConfig::from(LoadBalancerAlgorithm::WaitAndWiden);
     let settings = algorithm_config
-        .multiregion_settings_mut()
-        .expect("Groq config should include multiregion settings");
+        .wait_and_widen_settings_mut()
+        .expect("WaitAndWiden config should include wait-and-widen settings");
     settings.cache_affinity_virtual_nodes = Some(0);
     settings.cache_affinity_backend_selection_count = Some(0);
     settings.max_queue_time_floor_ms = Some(100);
@@ -1010,7 +1010,7 @@ fn groq_multiregion_config_resolves_internal_defaults() {
     settings.n = Some(0);
     settings.ignore_queue_time = Some(true);
     settings.ignore_input_processing_time = Some(true);
-    let config = GroqMultiregionConfig::from_algorithm_config(&algorithm_config);
+    let config = WaitAndWidenConfig::from_algorithm_config(&algorithm_config);
 
     assert_eq!(config.cache_affinity_virtual_nodes, 1);
     assert_eq!(config.cache_affinity_backend_selection_count, None);
@@ -1032,13 +1032,13 @@ fn groq_multiregion_config_resolves_internal_defaults() {
 }
 
 #[test]
-fn router_reports_groq_multiregion_algorithm_name() {
+fn router_reports_wait_and_widen_algorithm_name() {
     let router = router_with_model(
         LoadBalancerAlgorithm::PowerOfTwo,
         "model-a",
-        LoadBalancerModelConfig::Name(LoadBalancerAlgorithm::GroqMultiregion),
+        LoadBalancerModelConfig::Name(LoadBalancerAlgorithm::WaitAndWiden),
     );
-    assert_eq!(router.algorithm_name("model-a"), "groq-multiregion");
+    assert_eq!(router.algorithm_name("model-a"), "wait-and-widen");
 }
 
 #[test]
@@ -1377,8 +1377,8 @@ fn request_excluded_clusters_are_not_selected() {
     assert_eq!(chosen.candidate.cluster_id, "cluster-1");
 }
 
-groq_choice_tests! {
-    groq_multiregion_prefers_lower_estimated_ttft:
+wait_and_widen_choice_tests! {
+    wait_and_widen_prefers_lower_estimated_ttft:
     |_| {};
     |target| request(target, None, Some(10));
     [
@@ -1389,8 +1389,8 @@ groq_choice_tests! {
 }
 
 #[test]
-fn groq_multiregion_single_excluded_cluster_is_not_selected() {
-    let lb = groq_load_balancer(|_| {});
+fn wait_and_widen_single_excluded_cluster_is_not_selected() {
+    let lb = wait_and_widen_load_balancer(|_| {});
     let target = target();
     let excluded = HashSet::from(["fast-but-excluded".to_string()]);
     let request = LoadBalancerRequest {
@@ -1405,9 +1405,10 @@ fn groq_multiregion_single_excluded_cluster_is_not_selected() {
 }
 
 #[test]
-fn groq_multiregion_cache_affinity_key_selects_stable_primary() {
-    let lb = create_load_balancer_with_config(&groq_affinity_algorithm_config(8, 1, None))
-        .expect("factory should accept groq-multiregion");
+fn wait_and_widen_cache_affinity_key_selects_stable_primary() {
+    let lb =
+        create_load_balancer_with_config(&wait_and_widen_affinity_algorithm_config(8, 1, None))
+            .expect("factory should accept wait-and-widen");
     let target = target();
     let request = request(&target, Some("prefix-a"), Some(1));
     let candidates = candidates(&["affinity-a", "affinity-b", "affinity-c"]);
@@ -1419,12 +1420,12 @@ fn groq_multiregion_cache_affinity_key_selects_stable_primary() {
 }
 
 #[test]
-fn groq_multiregion_cache_affinity_retry_skips_excluded_primary() {
+fn wait_and_widen_cache_affinity_retry_skips_excluded_primary() {
     assert_cache_affinity_retry(&["excluded-primary"]);
 }
 
 #[test]
-fn groq_multiregion_cache_affinity_retry_returns_candidate_slice_indices() {
+fn wait_and_widen_cache_affinity_retry_returns_candidate_slice_indices() {
     let (config, target, candidates, excluded, key) = affinity_retry_fixture(&["excluded-primary"]);
     let request = request(&target, Some(&key), Some(1));
     let primary = cache_affinity_candidate_indices(&config, &request, &candidates)
@@ -1444,14 +1445,14 @@ fn groq_multiregion_cache_affinity_retry_returns_candidate_slice_indices() {
 }
 
 #[test]
-fn groq_multiregion_cache_affinity_retry_skips_multiple_excluded_primaries() {
+fn wait_and_widen_cache_affinity_retry_skips_multiple_excluded_primaries() {
     assert_cache_affinity_retry(&["excluded-a", "excluded-b"]);
 }
 
 #[test]
-fn groq_multiregion_affinity_cache_invalidates_when_candidates_change() {
-    let config = groq_affinity_config(8, 1, None);
-    let lb = GroqMultiregionLoadBalancer::new(config.clone());
+fn wait_and_widen_affinity_cache_invalidates_when_candidates_change() {
+    let config = wait_and_widen_affinity_config(8, 1, None);
+    let lb = WaitAndWidenLoadBalancer::new(config.clone());
     let target = target();
     let first_candidates = candidates(&["old-a", "old-b", "old-c"]);
 
@@ -1475,9 +1476,9 @@ fn groq_multiregion_affinity_cache_invalidates_when_candidates_change() {
 }
 
 #[test]
-fn groq_multiregion_does_not_cache_oversized_affinity_key() {
-    let config = groq_affinity_config(8, 1, None);
-    let lb = GroqMultiregionLoadBalancer::new(config);
+fn wait_and_widen_does_not_cache_oversized_affinity_key() {
+    let config = wait_and_widen_affinity_config(8, 1, None);
+    let lb = WaitAndWidenLoadBalancer::new(config);
     let target = target();
     let oversized_key = "x".repeat(MAX_CACHE_AFFINITY_CACHE_KEY_BYTES + 1);
     let request = request(&target, Some(&oversized_key), Some(1));
@@ -1490,8 +1491,8 @@ fn groq_multiregion_does_not_cache_oversized_affinity_key() {
 }
 
 #[test]
-fn groq_multiregion_cache_affinity_hash_uses_cluster_identity() {
-    let config = groq_affinity_config(8, 1, None);
+fn wait_and_widen_cache_affinity_hash_uses_cluster_identity() {
+    let config = wait_and_widen_affinity_config(8, 1, None);
     let target = target();
     let request = request(&target, Some("prefix-a"), Some(1));
     let candidate = candidate("inst-a", 1024);
@@ -1510,8 +1511,8 @@ fn groq_multiregion_cache_affinity_hash_uses_cluster_identity() {
 }
 
 #[test]
-fn groq_multiregion_cache_affinity_hash_changes_with_routing_key() {
-    let config = groq_affinity_config(8, 1, None);
+fn wait_and_widen_cache_affinity_hash_changes_with_routing_key() {
+    let config = wait_and_widen_affinity_config(8, 1, None);
     let target_a = target_with_routing_key("tenant-a", "shared-model");
     let target_b = target_with_routing_key("tenant-b", "shared-model");
     let request_a = request(&target_a, Some("same-prefix"), Some(1));
@@ -1528,13 +1529,14 @@ fn groq_multiregion_cache_affinity_hash_changes_with_routing_key() {
 }
 
 #[test]
-fn groq_multiregion_cache_affinity_falls_back_when_primary_is_full() {
-    let lb = create_load_balancer_with_config(&groq_affinity_algorithm_config(1, 1, Some(3)))
-        .expect("factory should accept groq-multiregion");
+fn wait_and_widen_cache_affinity_falls_back_when_primary_is_full() {
+    let lb =
+        create_load_balancer_with_config(&wait_and_widen_affinity_algorithm_config(1, 1, Some(3)))
+            .expect("factory should accept wait-and-widen");
     let target = target();
     let request = request(&target, Some("prefix-a"), Some(1));
     let mut candidates = candidates(&["fallback-a", "fallback-b", "fallback-c"]);
-    let primary_config = groq_affinity_config(1, 1, None);
+    let primary_config = wait_and_widen_affinity_config(1, 1, None);
     let primary = cache_affinity_candidates(&primary_config, &request, &candidates)
         .expect("cache affinity should select a primary")[0]
         .cluster_id
@@ -1551,9 +1553,9 @@ fn groq_multiregion_cache_affinity_falls_back_when_primary_is_full() {
 }
 
 #[test]
-fn groq_multiregion_two_affinity_candidates_still_filter_capacity() {
-    let config = groq_affinity_config(8, 2, Some(2));
-    let lb = GroqMultiregionLoadBalancer::new(config.clone());
+fn wait_and_widen_two_affinity_candidates_still_filter_capacity() {
+    let config = wait_and_widen_affinity_config(8, 2, Some(2));
+    let lb = WaitAndWidenLoadBalancer::new(config.clone());
     let target = target();
     let request = request(&target, Some("prefix-a"), Some(1));
     let mut candidates = candidates(&["two-affinity-a", "two-affinity-b", "two-affinity-c"]);
@@ -1575,8 +1577,8 @@ fn groq_multiregion_two_affinity_candidates_still_filter_capacity() {
 }
 
 #[test]
-fn groq_multiregion_cache_affinity_keys_distribute_across_backends() {
-    let config = groq_affinity_config(32, 1, None);
+fn wait_and_widen_cache_affinity_keys_distribute_across_backends() {
+    let config = wait_and_widen_affinity_config(32, 1, None);
     let target = target();
     let candidates = candidates(&["dist-a", "dist-b", "dist-c"]);
     let mut seen = HashSet::new();
@@ -1599,9 +1601,10 @@ fn groq_multiregion_cache_affinity_keys_distribute_across_backends() {
 }
 
 #[test]
-fn groq_multiregion_cache_affinity_is_skipped_without_header() {
-    let lb = create_load_balancer_with_config(&groq_affinity_algorithm_config(1, 1, Some(3)))
-        .expect("factory should accept groq-multiregion");
+fn wait_and_widen_cache_affinity_is_skipped_without_header() {
+    let lb =
+        create_load_balancer_with_config(&wait_and_widen_affinity_algorithm_config(1, 1, Some(3)))
+            .expect("factory should accept wait-and-widen");
     let target = target();
     let request = request(&target, None, Some(1));
     let candidates = [
@@ -1617,8 +1620,8 @@ fn groq_multiregion_cache_affinity_is_skipped_without_header() {
     );
 }
 
-groq_choice_tests! {
-    groq_multiregion_uses_input_tokens_in_ttft_estimate:
+wait_and_widen_choice_tests! {
+    wait_and_widen_uses_input_tokens_in_ttft_estimate:
     |_| {};
     |target| request(target, None, Some(100));
     [
@@ -1627,7 +1630,7 @@ groq_choice_tests! {
     ];
     1 => "higher-rtt-higher-cap";
 
-    groq_multiregion_can_ignore_input_processing_time_in_ttft_estimate:
+    wait_and_widen_can_ignore_input_processing_time_in_ttft_estimate:
     |settings| settings.ignore_input_processing_time = Some(true);
     |target| request(target, None, Some(100));
     [
@@ -1638,8 +1641,8 @@ groq_choice_tests! {
 }
 
 #[test]
-fn groq_multiregion_limits_selection_to_first_ttft_bucket() {
-    let lb = groq_load_balancer(|_| {});
+fn wait_and_widen_limits_selection_to_first_ttft_bucket() {
+    let lb = wait_and_widen_load_balancer(|_| {});
     let target = target();
     let request = request(&target, None, Some(1));
     let candidates = [
@@ -1654,8 +1657,8 @@ fn groq_multiregion_limits_selection_to_first_ttft_bucket() {
     }
 }
 
-groq_choice_tests! {
-    groq_multiregion_can_ignore_queue_time_in_ttft_estimate:
+wait_and_widen_choice_tests! {
+    wait_and_widen_can_ignore_queue_time_in_ttft_estimate:
     |settings| settings.ignore_queue_time = Some(true);
     |target| request(target, None, Some(0));
     [
@@ -1664,7 +1667,7 @@ groq_choice_tests! {
     ];
     1 => "lower-rtt-higher-queue";
 
-    groq_multiregion_ignore_queue_still_compares_sampled_candidates_by_queue_time:
+    wait_and_widen_ignore_queue_still_compares_sampled_candidates_by_queue_time:
     |settings| {
         settings.n = Some(2);
         settings.ignore_queue_time = Some(true);
@@ -1676,7 +1679,7 @@ groq_choice_tests! {
     ];
     16 => "lower-queue";
 
-    groq_multiregion_ignore_queue_keeps_later_prefill_buckets_locked:
+    wait_and_widen_ignore_queue_keeps_later_prefill_buckets_locked:
     |settings| {
         settings.n = Some(2);
         settings.ignore_queue_time = Some(true);
@@ -1690,17 +1693,17 @@ groq_choice_tests! {
 }
 
 #[test]
-fn groq_multiregion_ignore_queue_skips_single_excluded_backend() {
+fn wait_and_widen_ignore_queue_skips_single_excluded_backend() {
     assert_excluded_queue_choice(false, &["excluded"]);
 }
 
 #[test]
-fn groq_multiregion_ignore_queue_skips_multiple_excluded_backends() {
+fn wait_and_widen_ignore_queue_skips_multiple_excluded_backends() {
     assert_excluded_queue_choice(false, &["excluded-a", "excluded-b"]);
 }
 
-groq_choice_tests! {
-    groq_multiregion_deprioritizes_non_finite_ttft_candidates:
+wait_and_widen_choice_tests! {
+    wait_and_widen_deprioritizes_non_finite_ttft_candidates:
     |_| {};
     |target| request(target, None, Some(10));
     [
@@ -1709,7 +1712,7 @@ groq_choice_tests! {
     ];
     1 => "finite";
 
-    groq_multiregion_uses_last_mean_input_tps_for_prefill_estimates:
+    wait_and_widen_uses_last_mean_input_tps_for_prefill_estimates:
     |_| {};
     |target| request(target, None, Some(100));
     [
@@ -1720,8 +1723,8 @@ groq_choice_tests! {
 }
 
 #[test]
-fn groq_multiregion_unlocks_later_ttft_bucket_after_waiting() {
-    let lb = groq_load_balancer(|settings| {
+fn wait_and_widen_unlocks_later_ttft_bucket_after_waiting() {
+    let lb = wait_and_widen_load_balancer(|settings| {
         settings.n = Some(1);
     });
     let target = target();
@@ -1736,8 +1739,8 @@ fn groq_multiregion_unlocks_later_ttft_bucket_after_waiting() {
     assert_eq!(chosen.candidate.cluster_id, "slower-available");
 }
 
-groq_choice_tests! {
-    groq_multiregion_filters_full_backends:
+wait_and_widen_choice_tests! {
+    wait_and_widen_filters_full_backends:
     |_| {};
     |target| request(target, None, Some(1));
     [
@@ -1746,7 +1749,7 @@ groq_choice_tests! {
     ];
     1 => "available";
 
-    groq_multiregion_filters_backends_over_queue_slo:
+    wait_and_widen_filters_backends_over_queue_slo:
     |settings| {
         settings.max_queue_time_floor_ms = Some(5);
         settings.max_queue_time_ceil_ms = Some(5);
@@ -1759,7 +1762,7 @@ groq_choice_tests! {
     ];
     1 => "under-slo";
 
-    groq_multiregion_filters_queue_slo_before_ttft_bucket_locking:
+    wait_and_widen_filters_queue_slo_before_ttft_bucket_locking:
     |settings| {
         settings.max_queue_time_floor_ms = Some(5);
         settings.max_queue_time_ceil_ms = Some(5);
@@ -1772,7 +1775,7 @@ groq_choice_tests! {
     ];
     1 => "under-slo-later-bucket";
 
-    groq_multiregion_queue_slo_still_applies_when_queue_time_is_ignored_for_ttft:
+    wait_and_widen_queue_slo_still_applies_when_queue_time_is_ignored_for_ttft:
     |settings| {
         settings.ignore_queue_time = Some(true);
         settings.max_queue_time_floor_ms = Some(5);
@@ -1788,8 +1791,8 @@ groq_choice_tests! {
 }
 
 #[test]
-fn groq_multiregion_returns_none_when_only_candidate_exceeds_queue_slo() {
-    let lb = groq_load_balancer(|settings| {
+fn wait_and_widen_returns_none_when_only_candidate_exceeds_queue_slo() {
+    let lb = wait_and_widen_load_balancer(|settings| {
         settings.max_queue_time_floor_ms = Some(5);
         settings.max_queue_time_ceil_ms = Some(5);
     });
@@ -1839,8 +1842,8 @@ fn equal_floor_and_ceil_configures_fixed_max_queue_time() {
     );
 }
 
-groq_choice_tests! {
-    groq_multiregion_compares_by_queue_time_within_unlocked_bucket:
+wait_and_widen_choice_tests! {
+    wait_and_widen_compares_by_queue_time_within_unlocked_bucket:
     |settings| settings.n = Some(2);
     |target| request(target, None, Some(1));
     [
@@ -1849,7 +1852,7 @@ groq_choice_tests! {
     ];
     16 => "lower-queue";
 
-    groq_multiregion_rtt_only_still_compares_sampled_candidates_by_queue_time:
+    wait_and_widen_rtt_only_still_compares_sampled_candidates_by_queue_time:
     |settings| {
         settings.n = Some(2);
         settings.ignore_queue_time = Some(true);
@@ -1862,7 +1865,7 @@ groq_choice_tests! {
     ];
     16 => "lower-queue";
 
-    groq_multiregion_rtt_only_filters_full_backends_before_sampling:
+    wait_and_widen_rtt_only_filters_full_backends_before_sampling:
     |settings| {
         settings.n = Some(2);
         settings.ignore_queue_time = Some(true);
@@ -1875,7 +1878,7 @@ groq_choice_tests! {
     ];
     1 => "available";
 
-    groq_multiregion_rtt_only_keeps_later_rtt_buckets_locked:
+    wait_and_widen_rtt_only_keeps_later_rtt_buckets_locked:
     |settings| {
         settings.n = Some(2);
         settings.ignore_queue_time = Some(true);
@@ -1890,17 +1893,17 @@ groq_choice_tests! {
 }
 
 #[test]
-fn groq_multiregion_rtt_only_skips_single_excluded_backend() {
+fn wait_and_widen_rtt_only_skips_single_excluded_backend() {
     assert_excluded_queue_choice(true, &["excluded"]);
 }
 
 #[test]
-fn groq_multiregion_rtt_only_skips_multiple_excluded_backends() {
+fn wait_and_widen_rtt_only_skips_multiple_excluded_backends() {
     assert_excluded_queue_choice(true, &["excluded-a", "excluded-b"]);
 }
 
-groq_choice_tests! {
-    groq_multiregion_uses_priority_queue_time_estimate:
+wait_and_widen_choice_tests! {
+    wait_and_widen_uses_priority_queue_time_estimate:
     |settings| settings.n = Some(2);
     |target| request_with_priority(target, None, Some(0), 4);
     [
@@ -1912,25 +1915,25 @@ groq_choice_tests! {
 }
 
 #[test]
-fn groq_multiregion_ttft_estimator_uses_priority_queue_and_ignore_flags() {
+fn wait_and_widen_ttft_estimator_uses_priority_queue_and_ignore_flags() {
     let mut candidate = work_candidate("estimated", 7, 100.0, 999);
     candidate.stats.queue_time_estimate_ms_by_priority = HashMap::from([(4, 25)]);
 
-    let full = groq_multiregion_ttft_components(&candidate, Some(200), 4, false, false);
+    let full = wait_and_widen_ttft_components(&candidate, Some(200), 4, false, false);
     assert_eq!(full.queue_ms, 25.0);
     assert_eq!(full.ttft_ms, 2032.0);
 
-    let ignore_queue = groq_multiregion_ttft_components(&candidate, Some(200), 4, true, false);
+    let ignore_queue = wait_and_widen_ttft_components(&candidate, Some(200), 4, true, false);
     assert_eq!(ignore_queue.queue_ms, 25.0);
     assert_eq!(ignore_queue.ttft_ms, 2007.0);
 
-    let ignore_prefill = groq_multiregion_ttft_components(&candidate, Some(200), 4, false, true);
+    let ignore_prefill = wait_and_widen_ttft_components(&candidate, Some(200), 4, false, true);
     assert_eq!(ignore_prefill.queue_ms, 25.0);
     assert_eq!(ignore_prefill.ttft_ms, 32.0);
 }
 
-groq_choice_tests! {
-    groq_multiregion_clamps_priority_to_max_known_queue_time_priority:
+wait_and_widen_choice_tests! {
+    wait_and_widen_clamps_priority_to_max_known_queue_time_priority:
     |settings| settings.n = Some(2);
     |target| request_with_priority(target, None, Some(0), 10);
     [
@@ -1939,7 +1942,7 @@ groq_choice_tests! {
     ];
     16 => "lower-clamped-queue";
 
-    groq_multiregion_uses_next_highest_priority_queue_time_estimate:
+    wait_and_widen_uses_next_highest_priority_queue_time_estimate:
     |settings| settings.n = Some(2);
     |target| request_with_priority(target, None, Some(0), 3);
     [
@@ -1948,7 +1951,7 @@ groq_choice_tests! {
     ];
     16 => "lower-queue";
 
-    groq_multiregion_treats_lower_priority_only_queue_as_zero_for_higher_priority_request:
+    wait_and_widen_treats_lower_priority_only_queue_as_zero_for_higher_priority_request:
     |settings| settings.n = Some(2);
     |target| request_with_priority(target, None, Some(0), 0);
     [

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/tests.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/tests.rs
@@ -592,6 +592,7 @@ fn simple_model_config_parses_to_algorithm_enum() {
         parse_json(r#"{"default":"wait-and-widen","models":{"model-a":"round-robin"}}"#);
 
     assert_eq!(config.default, LoadBalancerAlgorithm::WaitAndWiden);
+    assert_eq!(config.default.to_string(), "wait-and-widen");
     assert!(matches!(
         config.models.get("model-a"),
         Some(LoadBalancerModelConfig::Name(
@@ -865,6 +866,62 @@ fn detailed_model_config_parses_for_pulsar_wait_and_widen() {
     assert_eq!(wait_and_widen_settings.max_queue_time_ceil_ms, Some(100));
     assert_eq!(wait_and_widen_settings.ttft_bucket_size_ms, Some(50));
     assert_eq!(wait_and_widen_settings.n, Some(2));
+}
+
+#[test]
+fn legacy_algorithm_names_remain_compatible_in_short_configs() {
+    let config: LoadBalancerConfig = parse_json(
+        r#"{"default":"groq-multiregion","request_algorithms":{"pulsar-multiregion":"groq-multiregion"},"models":{"model-a":"pulsar-multiregion"}}"#,
+    );
+
+    assert_eq!(config.default, LoadBalancerAlgorithm::WaitAndWiden);
+    assert!(matches!(
+        config
+            .request_algorithms
+            .get(&LoadBalancerAlgorithm::PulsarWaitAndWiden),
+        Some(LoadBalancerModelConfig::Name(
+            LoadBalancerAlgorithm::WaitAndWiden
+        ))
+    ));
+    assert!(matches!(
+        config.models.get("model-a"),
+        Some(LoadBalancerModelConfig::Name(
+            LoadBalancerAlgorithm::PulsarWaitAndWiden
+        ))
+    ));
+
+    for (legacy_name, expected_algorithm) in [
+        ("groq-multiregion", LoadBalancerAlgorithm::WaitAndWiden),
+        (
+            "pulsar-multiregion",
+            LoadBalancerAlgorithm::PulsarWaitAndWiden,
+        ),
+    ] {
+        let algorithm_override = LoadBalancerAlgorithmOverride::parse(legacy_name)
+            .expect("legacy routing override should remain compatible");
+        assert_eq!(algorithm_override.algorithm(), expected_algorithm);
+        assert_eq!(algorithm_override.requested_algorithm(), legacy_name);
+    }
+}
+
+#[test]
+fn legacy_algorithm_names_remain_compatible_in_detailed_configs() {
+    let router = router_from_json(
+        r#"{"default":"power-of-two","models":{"wait-model":{"algorithm":"groq-multiregion","seed":"seed-1"},"pulsar-model":{"algorithm":"pulsar-multiregion","seed":"seed-2","max_queue_time_floor_ms":100,"max_queue_time_ceil_ms":200}}}"#,
+    );
+
+    assert_eq!(
+        router.algorithm_config("wait-model").algorithm(),
+        LoadBalancerAlgorithm::WaitAndWiden
+    );
+    assert_eq!(
+        router.algorithm_config("pulsar-model").algorithm(),
+        LoadBalancerAlgorithm::PulsarWaitAndWiden
+    );
+    assert_eq!(
+        router.algorithm_config("pulsar-model").seed(),
+        Some("seed-2")
+    );
 }
 
 #[test]

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen.rs
@@ -24,8 +24,8 @@ use std::time::Duration;
 use rand::Rng;
 
 use super::{
-    GroqMultiregionAlgorithmConfig, LoadBalancer, LoadBalancerAlgorithmConfig,
-    LoadBalancerCandidateChoice, LoadBalancerRequest,
+    LoadBalancer, LoadBalancerAlgorithmConfig, LoadBalancerCandidateChoice, LoadBalancerRequest,
+    WaitAndWidenAlgorithmConfig,
 };
 use crate::routing_state::RoutedClusterSnapshot;
 use cache_affinity::CacheAffinitySelector;
@@ -39,22 +39,22 @@ pub(super) use cache_affinity::{
     cache_affinity_candidate_indices, cache_affinity_candidates, cache_affinity_virtual_node_hash,
 };
 #[cfg(test)]
-pub(super) use estimates::estimate_ttft_ms as groq_multiregion_ttft_components;
+pub(super) use estimates::estimate_ttft_ms as wait_and_widen_ttft_components;
 
-// Parity notes vs lpu-router MultiRegion:
+// Parity notes vs lpu-router WaitAndWiden:
 // - Stargate uses only the sticky last_mean_input_tps capacity signal for
 //   queue/prefill estimates; there is no separate live input-TPS fallback.
 // - Sparse priority queue maps use the nearest published priority at or below the request priority;
 //   lpu-router clamps only priorities above the max and otherwise treats missing entries as zero.
 // - Stargate does not currently model lpu-router batch-folding queue estimates, LoRA dynamic-model
 //   penalties, backend/datacenter request filters, backend-id overrides, or utilization-max rejection.
-pub(super) struct GroqMultiregionLoadBalancer {
-    config: GroqMultiregionConfig,
+pub(super) struct WaitAndWidenLoadBalancer {
+    config: WaitAndWidenConfig,
     cache_affinity: CacheAffinitySelector,
 }
 
 #[derive(Clone, Debug)]
-pub(super) struct GroqMultiregionConfig {
+pub(super) struct WaitAndWidenConfig {
     pub(super) seed: Option<String>,
     pub(super) cache_affinity_virtual_nodes: usize,
     pub(super) cache_affinity_backend_selection_count: Option<usize>,
@@ -67,15 +67,15 @@ pub(super) struct GroqMultiregionConfig {
     pub(super) ignore_input_processing_time: bool,
 }
 
-impl GroqMultiregionConfig {
+impl WaitAndWidenConfig {
     pub(super) fn from_algorithm_config(config: &LoadBalancerAlgorithmConfig) -> Self {
         let config = config
-            .multiregion_settings()
-            .expect("multiregion settings should match load-balancer algorithm");
+            .wait_and_widen_settings()
+            .expect("wait_and_widen settings should match load-balancer algorithm");
         Self::from_settings(config)
     }
 
-    pub(super) fn from_settings(config: &GroqMultiregionAlgorithmConfig) -> Self {
+    pub(super) fn from_settings(config: &WaitAndWidenAlgorithmConfig) -> Self {
         Self {
             seed: config.seed.clone(),
             // Zero virtual nodes would make affinity routing degenerate; keep the historical minimum.
@@ -115,9 +115,9 @@ impl GroqMultiregionConfig {
     }
 }
 
-impl_display!(GroqMultiregionLoadBalancer, "groq-multiregion");
+impl_display!(WaitAndWidenLoadBalancer, "wait-and-widen");
 
-impl LoadBalancer for GroqMultiregionLoadBalancer {
+impl LoadBalancer for WaitAndWidenLoadBalancer {
     fn choose_candidate(
         &self,
         request: &LoadBalancerRequest<'_>,
@@ -141,8 +141,8 @@ impl LoadBalancer for GroqMultiregionLoadBalancer {
     }
 }
 
-impl GroqMultiregionLoadBalancer {
-    pub(super) fn new(config: GroqMultiregionConfig) -> Self {
+impl WaitAndWidenLoadBalancer {
+    pub(super) fn new(config: WaitAndWidenConfig) -> Self {
         Self {
             config,
             cache_affinity: CacheAffinitySelector::default(),

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen/cache_affinity.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen/cache_affinity.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use parking_lot::RwLock;
 use xxhash_rust::xxh3::xxh3_64;
 
-use super::{GroqMultiregionConfig, RequestExclusions};
+use super::{RequestExclusions, WaitAndWidenConfig};
 use crate::load_balancer::{
     HashInputBuilder, LoadBalancerRequest, cache_affinity_key_is_cacheable,
 };
@@ -35,7 +35,7 @@ pub(super) struct CacheAffinitySelector {
 impl CacheAffinitySelector {
     pub(super) fn candidate_indices(
         &self,
-        config: &GroqMultiregionConfig,
+        config: &WaitAndWidenConfig,
         request: &LoadBalancerRequest<'_>,
         candidates: &[RoutedClusterSnapshot],
     ) -> Option<Arc<Vec<usize>>> {
@@ -337,7 +337,7 @@ fn remove_nested<K: std::hash::Hash + Eq>(
 
 #[cfg(test)]
 pub(in crate::load_balancer) fn cache_affinity_candidate_indices(
-    config: &GroqMultiregionConfig,
+    config: &WaitAndWidenConfig,
     request: &LoadBalancerRequest<'_>,
     candidates: &[RoutedClusterSnapshot],
 ) -> Option<Vec<usize>> {
@@ -348,7 +348,7 @@ pub(in crate::load_balancer) fn cache_affinity_candidate_indices(
 
 #[cfg(test)]
 pub(in crate::load_balancer) fn cache_affinity_candidates(
-    config: &GroqMultiregionConfig,
+    config: &WaitAndWidenConfig,
     request: &LoadBalancerRequest<'_>,
     candidates: &[RoutedClusterSnapshot],
 ) -> Option<Vec<RoutedClusterSnapshot>> {
@@ -361,7 +361,7 @@ pub(in crate::load_balancer) fn cache_affinity_candidates(
 }
 
 fn build_ring(
-    config: &GroqMultiregionConfig,
+    config: &WaitAndWidenConfig,
     request: &LoadBalancerRequest<'_>,
     candidates: &[RoutedClusterSnapshot],
 ) -> Vec<CacheAffinityRingEntry> {
@@ -393,7 +393,7 @@ fn select_candidate_indices(
     candidates: &[RoutedClusterSnapshot],
     cache_affinity_key: &str,
     selection_count: usize,
-    config: &GroqMultiregionConfig,
+    config: &WaitAndWidenConfig,
     exclusions: RequestExclusions<'_>,
 ) -> Vec<usize> {
     if ring.is_empty() {
@@ -460,7 +460,7 @@ fn select_candidate_indices_from_ring(
 const HASH_VERSION: u8 = 1;
 
 fn cache_affinity_key_hash(
-    config: &GroqMultiregionConfig,
+    config: &WaitAndWidenConfig,
     request: &LoadBalancerRequest<'_>,
     cache_affinity_key: &str,
 ) -> u64 {
@@ -471,7 +471,7 @@ fn cache_affinity_key_hash(
 }
 
 pub(in crate::load_balancer) fn cache_affinity_virtual_node_hash(
-    config: &GroqMultiregionConfig,
+    config: &WaitAndWidenConfig,
     request: &LoadBalancerRequest<'_>,
     candidate: &RoutedClusterSnapshot,
     virtual_node: usize,
@@ -485,7 +485,7 @@ pub(in crate::load_balancer) fn cache_affinity_virtual_node_hash(
 
 fn append_ring_prefix(
     bytes: &mut HashInputBuilder,
-    config: &GroqMultiregionConfig,
+    config: &WaitAndWidenConfig,
     request: &LoadBalancerRequest<'_>,
 ) {
     bytes.push(HASH_VERSION);

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen/estimates.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen/estimates.rs
@@ -19,7 +19,7 @@ use crate::load_balancer::{LoadBalancerRequest, input_work_units};
 use crate::routing_state::RoutedClusterSnapshot;
 use stargate_protocol::common::valid_last_mean_input_tps;
 
-use super::GroqMultiregionConfig;
+use super::WaitAndWidenConfig;
 
 #[derive(Clone, Copy, Debug)]
 pub(in crate::load_balancer) struct TtftEstimate {
@@ -41,7 +41,7 @@ pub(super) struct CandidateEstimateAccumulator<'a> {
 
 impl<'a> CandidateEstimateAccumulator<'a> {
     pub(super) fn new(
-        config: &GroqMultiregionConfig,
+        config: &WaitAndWidenConfig,
         request: &LoadBalancerRequest<'_>,
         candidate_capacity: usize,
     ) -> Self {

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen/fast_path.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen/fast_path.rs
@@ -23,7 +23,7 @@ use super::estimates::{
     rtt_ms,
 };
 use super::{
-    GroqMultiregionConfig, RequestExclusions, choice_for_candidate, choose_less_queued_candidate,
+    RequestExclusions, WaitAndWidenConfig, choice_for_candidate, choose_less_queued_candidate,
     shuffle_prefix,
 };
 
@@ -65,7 +65,7 @@ macro_rules! choose_with_fast_path_exclusions {
 }
 
 pub(super) fn choose_from_single_bucket(
-    config: &GroqMultiregionConfig,
+    config: &WaitAndWidenConfig,
     request: &LoadBalancerRequest<'_>,
     candidates: &[RoutedClusterSnapshot],
 ) -> Option<LoadBalancerCandidateChoice> {
@@ -84,7 +84,7 @@ pub(super) fn choose_from_single_bucket(
 }
 
 fn choose_from_single_bucket_filtered(
-    config: &GroqMultiregionConfig,
+    config: &WaitAndWidenConfig,
     request: &LoadBalancerRequest<'_>,
     candidates: &[RoutedClusterSnapshot],
     mut excludes_candidate: impl FnMut(&RoutedClusterSnapshot) -> bool,
@@ -125,7 +125,7 @@ fn choose_from_single_bucket_filtered(
 }
 
 fn choose_from_unlocked_candidate_refs(
-    config: &GroqMultiregionConfig,
+    config: &WaitAndWidenConfig,
     request: &LoadBalancerRequest<'_>,
     mut unlocked_with_capacity: Vec<&RoutedClusterSnapshot>,
     candidates: &[RoutedClusterSnapshot],

--- a/src/libraries/rust/stargate/crates/stargate/src/metrics.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/metrics.rs
@@ -243,7 +243,7 @@ mod tests {
             .routing_selections_total(
                 Some("routing-a"),
                 "model-a",
-                "pulsar-multiregion",
+                "pulsar-wait-and-widen",
                 "fallback",
             )
             .inc();
@@ -251,7 +251,7 @@ mod tests {
             .routing_kv_free_token_fallback_selections_total(
                 Some("routing-a"),
                 "model-a",
-                "pulsar-multiregion",
+                "pulsar-wait-and-widen",
             )
             .inc();
 

--- a/src/libraries/rust/stargate/crates/stargate/src/routing_state/tests.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/routing_state/tests.rs
@@ -21,9 +21,9 @@ use super::reservations::update_reserved_priority_queue_time;
 use super::snapshots::{ClusterBackendUpsert, RoutedClusterState, RoutingTargetGeneration};
 use super::*;
 use crate::load_balancer::{
-    GroqMultiregionAlgorithmConfig, LoadBalancerAlgorithm, LoadBalancerAlgorithmConfig,
-    LoadBalancerAlgorithmSettings, LoadBalancerConfig, LoadBalancerModelConfig,
-    LoadBalancerRequest, LoadBalancerRouter,
+    LoadBalancerAlgorithm, LoadBalancerAlgorithmConfig, LoadBalancerAlgorithmSettings,
+    LoadBalancerConfig, LoadBalancerModelConfig, LoadBalancerRequest, LoadBalancerRouter,
+    WaitAndWidenAlgorithmConfig,
 };
 use InferenceServerStatus::{Active, Inactive};
 use stargate_proto::pb::InferenceServerModelRegistration;
@@ -2245,12 +2245,12 @@ async fn registered_backend_rtt_means_drive_cluster_load_balancer_selection() {
     assert_eq!(steady.rtt, Duration::from_millis(20));
 
     let algorithm_config = LoadBalancerAlgorithmConfig {
-        settings: LoadBalancerAlgorithmSettings::GroqMultiregion(GroqMultiregionAlgorithmConfig {
+        settings: LoadBalancerAlgorithmSettings::WaitAndWiden(WaitAndWidenAlgorithmConfig {
             // Keep the slower TTFT bucket locked regardless of scheduler delay in the test.
             ttft_bucket_size_ms: Some(0),
             next_bucket_unlock_factor: Some(1_000_000.0),
             n: Some(2),
-            ..GroqMultiregionAlgorithmConfig::default()
+            ..WaitAndWidenAlgorithmConfig::default()
         }),
         ..LoadBalancerAlgorithmConfig::default()
     };
@@ -2262,7 +2262,7 @@ async fn registered_backend_rtt_means_drive_cluster_load_balancer_selection() {
             LoadBalancerModelConfig::Detailed(Box::new(algorithm_config)),
         )]),
     })
-    .expect("Groq multiregion router should initialize");
+    .expect("WaitAndWiden router should initialize");
     let request = LoadBalancerRequest {
         routing_target: &target,
         cache_affinity_key: None,

--- a/src/libraries/rust/stargate/crates/stargate/tests/suite/load_balancing.rs
+++ b/src/libraries/rust/stargate/crates/stargate/tests/suite/load_balancing.rs
@@ -847,21 +847,23 @@ async fn power_of_two_uses_cluster_aggregated_metrics_and_backend_round_robin() 
 }
 
 #[tokio::test]
-async fn groq_multiregion_load_balancing_prefers_lower_estimated_ttft() {
+async fn wait_and_widen_load_balancing_prefers_lower_estimated_ttft() {
     let stargate = RunningStargate::start(
-        "test-sg-multiregion",
-        Some(r#"{"default": "power-of-two", "models": {"multiregion-model": "groq-multiregion"}}"#),
+        "test-sg-wait-and-widen",
+        Some(
+            r#"{"default": "power-of-two", "models": {"wait-and-widen-model": "wait-and-widen"}}"#,
+        ),
     )
     .await;
 
     let insts = [
-        ("multiregion-fast", 200.0_f64, 0_u64),
-        ("multiregion-slow", 10.0_f64, 0_u64),
+        ("wait-and-widen-fast", 200.0_f64, 0_u64),
+        ("wait-and-widen-slow", 10.0_f64, 0_u64),
     ];
     let mut backends = Vec::new();
     for (inst_id, last_mean_input_tps, queued_input_size) in insts {
         let backend =
-            RegisteredBackend::active(stargate.grpc_addr, "multiregion-model", inst_id).await;
+            RegisteredBackend::active(stargate.grpc_addr, "wait-and-widen-model", inst_id).await;
         backend.set_stats(CurrentModelStats {
             output_tps: 0.0,
             last_mean_input_tps,
@@ -879,18 +881,18 @@ async fn groq_multiregion_load_balancing_prefers_lower_estimated_ttft() {
 
     wait_for_routing(
         stargate.http_addr,
-        "multiregion-model",
+        "wait-and-widen-model",
         Duration::from_secs(5),
     )
     .await;
 
-    let chat = ChatRequests::new(stargate.http_addr, "multiregion-model");
+    let chat = ChatRequests::new(stargate.http_addr, "wait-and-widen-model");
 
     let mut stable_fast = false;
     let mut poll = tokio::time::interval(Duration::from_millis(100));
     for attempt in 0..60 {
         let resp = chat
-            .request(&format!("req-multiregion-{attempt}"))
+            .request(&format!("req-wait-and-widen-{attempt}"))
             .header("x-input-tokens", "10")
             .send()
             .await
@@ -898,7 +900,7 @@ async fn groq_multiregion_load_balancing_prefers_lower_estimated_ttft() {
 
         if resp.status() == 200 {
             let chosen = response_header(&resp, "x-inference-server-id");
-            if chosen == "multiregion-fast" {
+            if chosen == "wait-and-widen-fast" {
                 stable_fast = true;
                 break;
             }
@@ -909,7 +911,7 @@ async fn groq_multiregion_load_balancing_prefers_lower_estimated_ttft() {
 
     assert!(
         stable_fast,
-        "expected groq-multiregion to prefer lower estimated TTFT"
+        "expected wait-and-widen to prefer lower estimated TTFT"
     );
 
     stop_backends(&mut backends);
@@ -917,24 +919,24 @@ async fn groq_multiregion_load_balancing_prefers_lower_estimated_ttft() {
 }
 
 #[tokio::test]
-async fn groq_multiregion_waits_for_later_bucket_when_fastest_is_full() {
+async fn wait_and_widen_waits_for_later_bucket_when_fastest_is_full() {
     let stargate = RunningStargate::start(
-        "test-sg-multiregion-wait",
+        "test-sg-wait-and-widen-wait",
         Some(
-            r#"{"default": "power-of-two", "models": {"multiregion-wait-model": "groq-multiregion"}}"#,
+            r#"{"default": "power-of-two", "models": {"wait-and-widen-wait-model": "wait-and-widen"}}"#,
         ),
     )
     .await;
 
     let insts = [
-        ("multiregion-fast-full", 0_u64, 1_u64, 1_u64),
-        ("multiregion-slower-available", 10_u64, 0_u64, 1_u64),
+        ("wait-and-widen-fast-full", 0_u64, 1_u64, 1_u64),
+        ("wait-and-widen-slower-available", 10_u64, 0_u64, 1_u64),
     ];
     let mut backends = Vec::new();
     for (inst_id, total_query_input_size, num_running_queries, max_engine_concurrency) in insts {
         let backend = RegisteredBackend::active_with_fast_updates(
             stargate.grpc_addr,
-            "multiregion-wait-model",
+            "wait-and-widen-wait-model",
             inst_id,
         )
         .await;
@@ -952,13 +954,13 @@ async fn groq_multiregion_waits_for_later_bucket_when_fastest_is_full() {
         backends.push(backend);
     }
 
-    let chat = ChatRequests::new(stargate.http_addr, "multiregion-wait-model");
+    let chat = ChatRequests::new(stargate.http_addr, "wait-and-widen-wait-model");
 
     let mut chose_slower = false;
     let mut poll = tokio::time::interval(Duration::from_millis(100));
     for attempt in 0..30 {
         let resp = chat
-            .request(&format!("req-multiregion-wait-{attempt}"))
+            .request(&format!("req-wait-and-widen-wait-{attempt}"))
             .header("x-max-wait-ms", "250")
             .send()
             .await
@@ -966,7 +968,7 @@ async fn groq_multiregion_waits_for_later_bucket_when_fastest_is_full() {
 
         if resp.status() == 200 {
             let chosen = response_header(&resp, "x-inference-server-id");
-            assert_eq!(chosen, "multiregion-slower-available");
+            assert_eq!(chosen, "wait-and-widen-slower-available");
             chose_slower = true;
             break;
         }
@@ -976,7 +978,7 @@ async fn groq_multiregion_waits_for_later_bucket_when_fastest_is_full() {
 
     assert!(
         chose_slower,
-        "expected groq-multiregion to wait for a later TTFT bucket when the fastest backend is full"
+        "expected wait-and-widen to wait for a later TTFT bucket when the fastest backend is full"
     );
 
     stop_backends(&mut backends);
@@ -984,15 +986,15 @@ async fn groq_multiregion_waits_for_later_bucket_when_fastest_is_full() {
 }
 
 #[tokio::test]
-async fn groq_multiregion_cache_affinity_prefers_stable_subset_then_falls_back() {
+async fn wait_and_widen_cache_affinity_prefers_stable_subset_then_falls_back() {
     let stargate = RunningStargate::start(
-        "test-sg-multiregion-affinity",
+        "test-sg-wait-and-widen-affinity",
         Some(
             r#"{
             "default": "power-of-two",
             "models": {
-                "multiregion-affinity-model": {
-                    "algorithm": "groq-multiregion",
+                "wait-and-widen-affinity-model": {
+                    "algorithm": "wait-and-widen",
                     "seed": "test-seed",
                     "require_cache_affinity_key": true,
                     "cache_affinity_virtual_nodes": 8,
@@ -1006,15 +1008,15 @@ async fn groq_multiregion_cache_affinity_prefers_stable_subset_then_falls_back()
     .await;
 
     let insts = [
-        "multiregion-affinity-a",
-        "multiregion-affinity-b",
-        "multiregion-affinity-c",
+        "wait-and-widen-affinity-a",
+        "wait-and-widen-affinity-b",
+        "wait-and-widen-affinity-c",
     ];
     let mut backends = Vec::new();
     for inst_id in insts {
         let backend = RegisteredBackend::active_with_fast_updates(
             stargate.grpc_addr,
-            "multiregion-affinity-model",
+            "wait-and-widen-affinity-model",
             inst_id,
         )
         .await;
@@ -1035,19 +1037,19 @@ async fn groq_multiregion_cache_affinity_prefers_stable_subset_then_falls_back()
     let affinity_key = "stable-prefix";
     wait_for_routing_with_cache_affinity(
         stargate.http_addr,
-        "multiregion-affinity-model",
+        "wait-and-widen-affinity-model",
         affinity_key,
         Duration::from_secs(5),
     )
     .await;
 
-    let chat = ChatRequests::new(stargate.http_addr, "multiregion-affinity-model");
+    let chat = ChatRequests::new(stargate.http_addr, "wait-and-widen-affinity-model");
 
     let mut stable_choice = None;
     for attempt in 0..20 {
         let resp = chat
             .with_affinity(
-                &format!("req-multiregion-affinity-stable-{attempt}"),
+                &format!("req-wait-and-widen-affinity-stable-{attempt}"),
                 affinity_key,
             )
             .send()
@@ -1069,7 +1071,7 @@ async fn groq_multiregion_cache_affinity_prefers_stable_subset_then_falls_back()
         .find_map(|(inst_id, backend)| (*inst_id == primary).then_some(&backend.runtime))
         .expect("primary backend should have runtime state");
     primary_runtime.set_model_stats(
-        "multiregion-affinity-model".to_string(),
+        "wait-and-widen-affinity-model".to_string(),
         CurrentModelStats {
             output_tps: 0.0,
             last_mean_input_tps: 100.0,
@@ -1090,7 +1092,7 @@ async fn groq_multiregion_cache_affinity_prefers_stable_subset_then_falls_back()
         fallback_attempt += 1;
         let resp = chat
             .with_affinity(
-                &format!("req-multiregion-affinity-fallback-{fallback_attempt}"),
+                &format!("req-wait-and-widen-affinity-fallback-{fallback_attempt}"),
                 affinity_key,
             )
             .send()
@@ -1104,7 +1106,7 @@ async fn groq_multiregion_cache_affinity_prefers_stable_subset_then_falls_back()
             }
         }
         if tokio::time::Instant::now() >= deadline {
-            panic!("expected groq-multiregion affinity subset to fall back after {primary} filled");
+            panic!("expected wait-and-widen affinity subset to fall back after {primary} filled");
         }
         poll.tick().await;
     }
@@ -1116,15 +1118,15 @@ async fn groq_multiregion_cache_affinity_prefers_stable_subset_then_falls_back()
 }
 
 #[tokio::test]
-async fn groq_multiregion_requires_cache_affinity_key_when_configured() {
+async fn wait_and_widen_requires_cache_affinity_key_when_configured() {
     let stargate = RunningStargate::start(
-        "test-sg-multiregion-affinity-required",
+        "test-sg-wait-and-widen-affinity-required",
         Some(
             r#"{
             "default": "power-of-two",
             "models": {
-                "multiregion-affinity-required-model": {
-                    "algorithm": "groq-multiregion",
+                "wait-and-widen-affinity-required-model": {
+                    "algorithm": "wait-and-widen",
                     "seed": "test-seed",
                     "require_cache_affinity_key": true,
                     "cache_affinity_virtual_nodes": 8,
@@ -1139,8 +1141,8 @@ async fn groq_multiregion_requires_cache_affinity_key_when_configured() {
 
     let mut backend = RegisteredBackend::active_with_fast_updates(
         stargate.grpc_addr,
-        "multiregion-affinity-required-model",
-        "multiregion-affinity-required-inst",
+        "wait-and-widen-affinity-required-model",
+        "wait-and-widen-affinity-required-inst",
     )
     .await;
     backend.set_stats(CurrentModelStats {
@@ -1157,16 +1159,16 @@ async fn groq_multiregion_requires_cache_affinity_key_when_configured() {
 
     wait_for_routing_with_cache_affinity(
         stargate.http_addr,
-        "multiregion-affinity-required-model",
+        "wait-and-widen-affinity-required-model",
         "affinity-required-key",
         Duration::from_secs(5),
     )
     .await;
 
-    let chat = ChatRequests::new(stargate.http_addr, "multiregion-affinity-required-model");
+    let chat = ChatRequests::new(stargate.http_addr, "wait-and-widen-affinity-required-model");
 
     let missing_resp = chat
-        .request("req-multiregion-affinity-required-missing")
+        .request("req-wait-and-widen-affinity-required-missing")
         .send()
         .await
         .expect("missing affinity request failed");
@@ -1179,7 +1181,7 @@ async fn groq_multiregion_requires_cache_affinity_key_when_configured() {
 
     let present_resp = chat
         .with_affinity(
-            "req-multiregion-affinity-required-present",
+            "req-wait-and-widen-affinity-required-present",
             "affinity-required-key",
         )
         .send()
@@ -1188,7 +1190,7 @@ async fn groq_multiregion_requires_cache_affinity_key_when_configured() {
     assert_eq!(present_resp.status(), 200);
     assert_eq!(
         response_header(&present_resp, "x-inference-server-id"),
-        "multiregion-affinity-required-inst"
+        "wait-and-widen-affinity-required-inst"
     );
     let _ = present_resp.bytes().await;
 
@@ -1197,15 +1199,15 @@ async fn groq_multiregion_requires_cache_affinity_key_when_configured() {
 }
 
 #[tokio::test]
-async fn groq_multiregion_priority_header_uses_matching_queue_estimate() {
+async fn wait_and_widen_priority_header_uses_matching_queue_estimate() {
     let stargate = RunningStargate::start(
-        "test-sg-multiregion-priority",
+        "test-sg-wait-and-widen-priority",
         Some(
             r#"{
             "default": "power-of-two",
             "models": {
-                "multiregion-priority-model": {
-                    "algorithm": "groq-multiregion",
+                "wait-and-widen-priority-model": {
+                    "algorithm": "wait-and-widen",
                     "n": 2
                 }
             }
@@ -1216,12 +1218,12 @@ async fn groq_multiregion_priority_header_uses_matching_queue_estimate() {
 
     let insts = [
         (
-            "multiregion-priority-specific-low",
+            "wait-and-widen-priority-specific-low",
             100_u64,
             HashMap::from([(4_u32, 5_u64)]),
         ),
         (
-            "multiregion-priority-specific-high",
+            "wait-and-widen-priority-specific-high",
             0_u64,
             HashMap::from([(4_u32, 500_u64)]),
         ),
@@ -1230,7 +1232,7 @@ async fn groq_multiregion_priority_header_uses_matching_queue_estimate() {
     for (inst_id, total_query_input_size, priority_queue_estimates) in insts {
         let backend = RegisteredBackend::active_with_fast_updates(
             stargate.grpc_addr,
-            "multiregion-priority-model",
+            "wait-and-widen-priority-model",
             inst_id,
         )
         .await;
@@ -1252,15 +1254,15 @@ async fn groq_multiregion_priority_header_uses_matching_queue_estimate() {
     let state = stargate.handle.state();
     wait_for_priority_cluster_stats(
         &state,
-        "multiregion-priority-model",
+        "wait-and-widen-priority-model",
         &[
             ExpectedPriorityClusterStats {
-                cluster_id: "multiregion-priority-specific-low",
+                cluster_id: "wait-and-widen-priority-specific-low",
                 priority: 4,
                 queue_time_estimate_ms: 5,
             },
             ExpectedPriorityClusterStats {
-                cluster_id: "multiregion-priority-specific-high",
+                cluster_id: "wait-and-widen-priority-specific-high",
                 priority: 4,
                 queue_time_estimate_ms: 500,
             },
@@ -1269,10 +1271,10 @@ async fn groq_multiregion_priority_header_uses_matching_queue_estimate() {
     )
     .await;
 
-    let chat = ChatRequests::new(stargate.http_addr, "multiregion-priority-model");
+    let chat = ChatRequests::new(stargate.http_addr, "wait-and-widen-priority-model");
     for attempt in 0..4 {
         let resp = chat
-            .with_input_tokens(&format!("req-multiregion-priority-assert-{attempt}"), 0)
+            .with_input_tokens(&format!("req-wait-and-widen-priority-assert-{attempt}"), 0)
             .header("x-priority", "4")
             .send()
             .await
@@ -1280,21 +1282,21 @@ async fn groq_multiregion_priority_header_uses_matching_queue_estimate() {
         assert_eq!(resp.status(), 200);
         assert_eq!(
             response_header(&resp, "x-inference-server-id"),
-            "multiregion-priority-specific-low",
+            "wait-and-widen-priority-specific-low",
             "x-priority=4 should choose the backend with the lower priority-specific queue estimate"
         );
         let _ = resp.bytes().await;
     }
 
     let resp = chat
-        .with_input_tokens("req-multiregion-priority-no-header", 0)
+        .with_input_tokens("req-wait-and-widen-priority-no-header", 0)
         .send()
         .await
         .expect("non-priority request failed");
     assert_eq!(resp.status(), 200);
     assert_eq!(
         response_header(&resp, "x-inference-server-id"),
-        "multiregion-priority-specific-high",
+        "wait-and-widen-priority-specific-high",
         "without x-priority the aggregate queue estimate should still choose the lower aggregate queue"
     );
     let _ = resp.bytes().await;

--- a/src/libraries/rust/stargate/docs/load-balancer-configuration.md
+++ b/src/libraries/rust/stargate/docs/load-balancer-configuration.md
@@ -34,6 +34,12 @@ The top-level object has three fields:
 Valid algorithm names are `power-of-two`, `wait-and-widen`, `round-robin`,
 `random`, `pulsar`, and `pulsar-wait-and-widen`.
 
+For backward compatibility, Stargate also accepts `groq-multiregion` as an
+alias for `wait-and-widen` and `pulsar-multiregion` as an alias for
+`pulsar-wait-and-widen` in `default`, `models`, `request_algorithms`, detailed
+algorithm objects, and routing-method overrides. Use the canonical names for
+new configurations.
+
 An entry in `models` or `request_algorithms` can be an algorithm name:
 
 ```json
@@ -174,7 +180,7 @@ Minimal configuration:
 
 ## `pulsar-wait-and-widen`
 
-`pulsar-wait-and-widen` combines Pulsar ranking with WaitAndWiden wait-and-widen fallback.
+`pulsar-wait-and-widen` combines Pulsar ranking with the WaitAndWiden fallback.
 Without queue-SLO fields, an eligible Pulsar primary wins immediately.
 
 When queue-SLO fields are enabled or the primary is ineligible, the algorithm

--- a/src/libraries/rust/stargate/docs/load-balancer-configuration.md
+++ b/src/libraries/rust/stargate/docs/load-balancer-configuration.md
@@ -4,7 +4,7 @@ Stargate selects one load-balancing algorithm for each model. A request can
 select another preconfigured algorithm through a trusted header.
 
 This page defines the `lb-config.json` schema and the behavior of
-`groq-multiregion`, `pulsar`, and `pulsar-multiregion`. Deployment systems own
+`wait-and-widen`, `pulsar`, and `pulsar-wait-and-widen`. Deployment systems own
 the file mount and the `--lb-config-path` argument.
 
 ## Load the configuration
@@ -31,8 +31,8 @@ The top-level object has three fields:
 | `request_algorithms` | object | `{}` | Algorithms that `x-routing-method` may select for every model. |
 | `models` | object | `{}` | Exact model ID to algorithm configuration. |
 
-Valid algorithm names are `power-of-two`, `groq-multiregion`, `round-robin`,
-`random`, `pulsar`, and `pulsar-multiregion`.
+Valid algorithm names are `power-of-two`, `wait-and-widen`, `round-robin`,
+`random`, `pulsar`, and `pulsar-wait-and-widen`.
 
 An entry in `models` or `request_algorithms` can be an algorithm name:
 
@@ -40,7 +40,7 @@ An entry in `models` or `request_algorithms` can be an algorithm name:
 {
   "default": "power-of-two",
   "models": {
-    "model-a": "groq-multiregion"
+    "model-a": "wait-and-widen"
   }
 }
 ```
@@ -52,7 +52,7 @@ Use a detailed object to set algorithm fields:
   "default": "power-of-two",
   "models": {
     "model-a": {
-      "algorithm": "groq-multiregion",
+      "algorithm": "wait-and-widen",
       "require_cache_affinity_key": true
     }
   }
@@ -98,17 +98,17 @@ Choose based on the routing goal and available backend statistics:
 
 | Goal | Algorithm | Required backend signals |
 | --- | --- | --- |
-| Minimize estimated time to first token across heterogeneous or remote clusters. | `groq-multiregion` | Forwarded health RTT and model statistics. Valid `last_mean_input_tps` is needed when queued or request input work is nonzero. |
+| Minimize estimated time to first token across heterogeneous or remote clusters. | `wait-and-widen` | Forwarded health RTT and model statistics. Valid `last_mean_input_tps` is needed when queued or request input work is nonzero. |
 | Keep the same prefix on a stable, capacity-weighted cluster. | `pulsar` | Positive finite `last_mean_input_tps` for every participating cluster. |
-| Keep Pulsar affinity when possible, but escape to lower-latency capacity when the primary cannot meet queue policy. | `pulsar-multiregion` | Pulsar capacity plus the RTT and queue statistics used by `groq-multiregion`. |
+| Keep Pulsar affinity when possible, but escape to lower-latency capacity when the primary cannot meet queue policy. | `pulsar-wait-and-widen` | Pulsar capacity plus the RTT and queue statistics used by `wait-and-widen`. |
 
 Use `power-of-two` when these statistics or affinity requirements are not
 available. Use `round-robin` for deterministic cycling and `random` for uniform
 random selection.
 
-## `groq-multiregion`
+## `wait-and-widen`
 
-`groq-multiregion` estimates time to first token (TTFT) as:
+`wait-and-widen` estimates time to first token (TTFT) as:
 
 ```text
 forwarded health RTT + queue delay + request prefill time
@@ -137,7 +137,7 @@ Minimal configuration:
   "default": "power-of-two",
   "models": {
     "model-a": {
-      "algorithm": "groq-multiregion",
+      "algorithm": "wait-and-widen",
       "require_cache_affinity_key": true,
       "cache_affinity_backend_selection_count": 2
     }
@@ -172,14 +172,14 @@ Minimal configuration:
 }
 ```
 
-## `pulsar-multiregion`
+## `pulsar-wait-and-widen`
 
-`pulsar-multiregion` combines Pulsar ranking with Groq multiregion fallback.
+`pulsar-wait-and-widen` combines Pulsar ranking with WaitAndWiden wait-and-widen fallback.
 Without queue-SLO fields, an eligible Pulsar primary wins immediately.
 
 When queue-SLO fields are enabled or the primary is ineligible, the algorithm
 checks the primary and then exponentially wider ranking bands of 2, 4, 8, and
-so on. Within each band, `groq-multiregion` selects an eligible candidate.
+so on. Within each band, `wait-and-widen` selects an eligible candidate.
 
 Minimal configuration:
 
@@ -188,7 +188,7 @@ Minimal configuration:
   "default": "power-of-two",
   "models": {
     "model-a": {
-      "algorithm": "pulsar-multiregion",
+      "algorithm": "pulsar-wait-and-widen",
       "seed": "model-a-v1",
       "require_cache_affinity_key": true,
       "max_queue_time_floor_ms": 500,
@@ -200,21 +200,21 @@ Minimal configuration:
 
 ## Algorithm fields
 
-`groq-multiregion` supports these cache-affinity fields:
+`wait-and-widen` supports these cache-affinity fields:
 
 | Field | Type | Default | Constraint and effect |
 | --- | --- | --- | --- |
 | `cache_affinity_virtual_nodes` | unsigned integer | `150` | Virtual nodes per cluster. `0` is normalized to `1`. |
 | `cache_affinity_backend_selection_count` | unsigned integer | unset | Enables the affinity subset. `0` disables it. Values above the candidate count select all candidates. |
 
-These fields are accepted in `pulsar-multiregion` JSON but do not affect its
+These fields are accepted in `pulsar-wait-and-widen` JSON but do not affect its
 selection. Pulsar ranking supplies that algorithm's affinity.
 
-`groq-multiregion` and `pulsar-multiregion` support these multiregion fields:
+`wait-and-widen` and `pulsar-wait-and-widen` support these wait-and-widen fields:
 
 | Field | Type | Default | Constraint and effect |
 | --- | --- | --- | --- |
-| `seed` | string | empty | Changes Groq affinity hashing or Pulsar multiregion ranking. Keep it stable across replicas that should make the same choice. |
+| `seed` | string | empty | Changes WaitAndWiden affinity hashing or Pulsar wait-and-widen ranking. Keep it stable across replicas that should make the same choice. |
 | `max_queue_time_floor_ms` | unsigned integer | unset | Queue-SLO lower bound. Has an effect only when `max_queue_time_ceil_ms` is also set. |
 | `max_queue_time_ceil_ms` | unsigned integer | unset | Queue-SLO upper bound. Has an effect only when `max_queue_time_floor_ms` is also set. |
 | `ttft_bucket_size_ms` | unsigned integer | `20` | Maximum TTFT difference within one bucket. |
@@ -240,7 +240,7 @@ bounds, so set the floor less than or equal to the ceiling.
 | `seed` | string | empty | Changes the rendezvous ranking. Keep it stable across replicas. |
 | `consider_kv_free_tokens` | boolean | `false` | Requires KV-cache values to be reported and skips candidates with fewer free tokens than the request input-token estimate. |
 
-`pulsar-multiregion` supports both multiregion fields and
+`pulsar-wait-and-widen` supports both wait-and-widen fields and
 `consider_kv_free_tokens`.
 
 ## Request algorithm overrides
@@ -251,14 +251,14 @@ Preconfigure every algorithm that a request may select:
 {
   "default": "power-of-two",
   "request_algorithms": {
-    "groq-multiregion": "groq-multiregion",
+    "wait-and-widen": "wait-and-widen",
     "pulsar": {
       "algorithm": "pulsar",
       "seed": "request-routing-v1",
       "require_cache_affinity_key": true
     },
-    "pulsar-multiregion": {
-      "algorithm": "pulsar-multiregion",
+    "pulsar-wait-and-widen": {
+      "algorithm": "pulsar-wait-and-widen",
       "seed": "request-routing-v1",
       "require_cache_affinity_key": true
     }
@@ -273,8 +273,8 @@ x-routing-method: pulsar
 ```
 
 Header values are trimmed, converted to lowercase, and normalized from
-underscores to hyphens. For example, `pulsar_multiregion` selects
-`pulsar-multiregion`.
+underscores to hyphens. For example, `pulsar_wait_and_widen` selects
+`pulsar-wait-and-widen`.
 
 An absent header uses the configured model algorithm. A blank, invalid UTF-8,
 unknown, or known but unconfigured value returns HTTP `400`. A model-specific
@@ -309,10 +309,10 @@ contract.
 
 Algorithm fallback is part of load-balancer selection:
 
-- Groq later-bucket fallback depends on elapsed request time.
+- WaitAndWiden later-bucket fallback depends on elapsed request time.
 - Pulsar fallback walks the stable ranking after exclusions or optional KV
   filtering.
-- Pulsar multiregion fallback widens ranking bands and runs Groq selection
+- Pulsar wait-and-widen fallback widens ranking bands and runs WaitAndWiden selection
   within each band.
 
 Proxy retries can exclude a backend or cluster and run selection again. See
@@ -347,9 +347,9 @@ for metric names, labels, and descriptions.
 - `crates/stargate/src/load_balancer/config.rs`
 - `crates/stargate/src/load_balancer/factory.rs`
 - `crates/stargate/src/load_balancer/router.rs`
-- `crates/stargate/src/load_balancer/groq_multiregion.rs`
+- `crates/stargate/src/load_balancer/wait_and_widen.rs`
 - `crates/stargate/src/load_balancer/pulsar.rs`
-- `crates/stargate/src/load_balancer/pulsar_multiregion.rs`
+- `crates/stargate/src/load_balancer/pulsar_wait_and_widen.rs`
 - `crates/stargate/src/http_proxy/`
 - `crates/stargate/src/metrics.rs`
 - `benches/`

--- a/src/libraries/rust/stargate/docs/multi-backend-clusters.md
+++ b/src/libraries/rust/stargate/docs/multi-backend-clusters.md
@@ -106,6 +106,7 @@ All algorithms choose from cluster snapshots.
 
 - `power-of-two`: compares aggregated cluster load.
 - `wait-and-widen`: uses aggregated stats and representative RTT.
+- `pulsar-wait-and-widen`: combines Pulsar ranking with WaitAndWiden fallback.
 - `round-robin`: rounds across clusters.
 - `random`: picks a cluster.
 - `pulsar`: hashes by `cluster_id`, not `backend_id`.

--- a/src/libraries/rust/stargate/docs/multi-backend-clusters.md
+++ b/src/libraries/rust/stargate/docs/multi-backend-clusters.md
@@ -105,7 +105,7 @@ source backend disappears, recompute from remaining active snapshots.
 All algorithms choose from cluster snapshots.
 
 - `power-of-two`: compares aggregated cluster load.
-- `groq-multiregion`: uses aggregated stats and representative RTT.
+- `wait-and-widen`: uses aggregated stats and representative RTT.
 - `round-robin`: rounds across clusters.
 - `random`: picks a cluster.
 - `pulsar`: hashes by `cluster_id`, not `backend_id`.

--- a/tests/bdd/fixtures/self-managed-local-bdd.yaml
+++ b/tests/bdd/fixtures/self-managed-local-bdd.yaml
@@ -79,7 +79,7 @@ addons:
               "power-of-two": "power-of-two",
               "round-robin": "round-robin",
               "random": "random",
-              "groq-multiregion": "groq-multiregion"
+              "wait-and-widen": "wait-and-widen"
             }
           }
 


### PR DESCRIPTION
## Why

Review found that the rename was complete inside Stargate but the integration layers were inconsistent: the control-plane validator and nvcf-cli rejected the canonical names, while the active BDD fixture and user guide still advertised legacy names. Existing deployments also need to keep working without an immediate migration.

## What changed

- Renamed the Rust algorithms to `WaitAndWiden` and `PulsarWaitAndWiden`.
- Added Stargate deserialization aliases for `groq-multiregion` and `pulsar-multiregion` across short configs, detailed configs, request-algorithm maps, and routing overrides.
- Updated control-plane validation to accept canonical names, underscore forms, and legacy aliases.
- Updated nvcf-cli to accept canonical hyphenated names and underscore forms while preserving its existing underscore payload format and legacy aliases.
- Updated the active BDD fixture to use `wait-and-widen`.
- Updated the top-of-tree user guide and Stargate documentation with canonical names, compatibility behavior, migration guidance, and the Pulsar WaitAndWiden entry.
- Left frozen `docs/v0.6.x` historical documentation unchanged.

## Customer Release Notes

Existing configurations using `groq-multiregion` or `pulsar-multiregion` continue to work. New configurations should use `wait-and-widen` or `pulsar-wait-and-widen`.

## Plan Summary

Not applicable.

## Usage

No migration is required for existing deployments. Use the new canonical algorithm names in new function metadata, `lb-config.json` files, request-algorithm maps, deployment manifests, and routing headers.

## Testing

- `rustup run stable cargo fmt --check`
- `rustup run stable cargo test -p stargate --lib` (322 passed)
- `rustup run stable cargo test -p stargate --test stargate_integration wait_and_widen` (5 passed)
- `rustup run stable cargo check -p stargate-bench`
- `go test -short ./...` from `tests/bdd` (passed)
- `go test ./cmd -run '^Test(ParseLLMModel|ParseLLMModelUpdateString)' -count=1` (passed)
- `./tools/ci/check-docs` with a repository-local npm prefix (Fern: 0 errors, 1 warning)
- The full `go test ./cmd` suite remains blocked by an unrelated existing fixture-state failure in `TestRunAccountsList_JSON`; the affected parser tests pass directly.
- The control-plane Bazel test could not run locally because `bazel` is not installed; CI should run that target.

## Notes

Legacy values are accepted on input and normalize to the new enum variants. Algorithm display and reporting use the new canonical names. No dependency or observability schema changes are introduced by the compatibility aliases. No live QA is required for this input-validation and documentation change.

## Issues

Relates to #536

## References

#536

## Related Pull Requests

None

## Dependencies

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the **Wait-and-Widen** load-balancing strategy, including cache-affinity and Pulsar variants.
  * Added support for hyphenated and underscore routing-method names in configuration and CLI workflows.
  * Legacy multiregion configuration names remain supported through compatibility aliases.
* **Documentation**
  * Updated configuration guidance, examples, and multi-backend documentation with the new strategy names.
* **Tests**
  * Expanded routing, queue-admission, load-balancing, metrics, CLI, validation, and benchmark coverage for Wait-and-Widen scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->