### PR TITLE
feat(icms): per-reservation backup opt-out via reservationBackUpDisabled

### DIFF
--- a/migrations/cassandra/keyspaces/sis_api/03_init_tables.up.sql
+++ b/migrations/cassandra/keyspaces/sis_api/03_init_tables.up.sql
@@ -265,6 +265,7 @@ CREATE TABLE IF NOT EXISTS sis_api.reservations (
     end_time           timestamp,
     name               text,
     last_updated_time  timestamp,
+    reservation_backup_disabled boolean,
     PRIMARY KEY (reservation_id)
 );
 

--- a/migrations/cassandra/keyspaces/sis_api/09_add_reservation_backup_disabled.up.sql
+++ b/migrations/cassandra/keyspaces/sis_api/09_add_reservation_backup_disabled.up.sql
@@ -1,0 +1,8 @@
+-- Add the per-reservation backup opt-out column.
+--
+-- Fresh installs get this column from 03_init_tables.up.sql, while this migration
+-- upgrades existing keyspaces created before the column existed.
+-- A null value means backup is allowed, so rows written before this migration keep
+-- the previous behaviour of falling back to another cluster when the primary is unhealthy.
+
+ALTER TABLE sis_api.reservations ADD IF NOT EXISTS reservation_backup_disabled boolean;

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/inbound/rest/controllers/InstanceController.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/inbound/rest/controllers/InstanceController.java
@@ -639,8 +639,8 @@ public class InstanceController {
     }
 
     @GetMapping("/clusters/{zoneName}/instances")
-    @PreAuthorize("hasAuthority('gfn-clusters') or hasAuthority('cluster-instances') "
-            + "or hasAuthority('nvca-cluster') or hasAuthority('apikey:nvca-cluster')")
+    @PreAuthorize("hasAuthority('cluster-instances') or hasAuthority('nvca-cluster') "
+            + "or hasAuthority('apikey:nvca-cluster')")
     @Operation(summary = "Get instances from zone or cluster",
             description = "Request to get instances from zone or cluster",
             responses = {

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/inbound/rest/model/cluster/GpuReservation.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/inbound/rest/model/cluster/GpuReservation.java
@@ -68,4 +68,10 @@ public class GpuReservation {
     @NotNull(message = "gpuUsageByInstanceType must not be null")
     @Schema(description = "Reserved GPU usage and availability per instance type")
     GpuUsageByInstanceType gpuUsageByInstanceType;
+
+    // Nullable so reporters that predate this field keep passing validation.
+    @Nullable
+    @Schema(description = "When true, no backup instances are scheduled in another zone "
+            + "if the reservation's primary zone becomes unhealthy")
+    Boolean reservationBackUpDisabled;
 }

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/outbound/cassandra/reservation/entity/ReservationEntity.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/outbound/cassandra/reservation/entity/ReservationEntity.java
@@ -51,6 +51,7 @@ public class ReservationEntity {
     public static final String COLUMN_NAME = "name";
     public static final String COLUMN_DESCRIPTION = "description";
     public static final String COLUMN_LAST_UPDATED_TIME = "last_updated_time";
+    public static final String COLUMN_RESERVATION_BACKUP_DISABLED = "reservation_backup_disabled";
 
     @NonNull
     @PrimaryKey
@@ -92,6 +93,14 @@ public class ReservationEntity {
     @Column(COLUMN_LAST_UPDATED_TIME)
     private Instant lastUpdatedTime;
 
+    /**
+     * When true, this reservation never falls back to another zone if its primary zone is
+     * unhealthy. Null for rows written before the column existed, and for reporters that do
+     * not send the field, both of which mean backup is allowed.
+     */
+    @Column(COLUMN_RESERVATION_BACKUP_DISABLED)
+    private Boolean reservationBackUpDisabled;
+
     public String toString() {
         return "ReservationEntity{" +
                 "reservationId=" + reservationId +
@@ -104,7 +113,12 @@ public class ReservationEntity {
                 ", endTime=" + endTime +
                 ", name='" + name + '\'' +
                 ", lastUpdatedTime=" + lastUpdatedTime +
+                ", reservationBackUpDisabled=" + reservationBackUpDisabled +
                 '}';
+    }
+
+    public boolean isBackupDisabled() {
+        return Boolean.TRUE.equals(reservationBackUpDisabled);
     }
 
     public boolean isActive() {

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/DescribeAndCancelInstanceService.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/DescribeAndCancelInstanceService.java
@@ -323,18 +323,18 @@ public class DescribeAndCancelInstanceService {
                 ClientRequestDataModel requestData = getClientRequestDataModelForRequest(request);
 
                 for (InstanceV2Entity instanceEntity : instanceEntities) {
-                    String instanceType = requestData.getLaunchSpecification().getInstanceType();
-                    Optional<ZoneInfo> optionalZoneInfo =
-                            populateZoneInfoForInstanceEntity(instanceEntity, clustersCache);
-                    if (optionalZoneInfo.isEmpty()) {
-                        continue;
-                    }
                     // Only filters real lifecycle-terminated rows. Synthetic terminated
                     // placeholders from populateAcknowledgedInstances are already
                     // in the instance list and are NOT affected by includeTerminated, since
                     // they represent failed ACKs rather than lifecycle terminations.
                     if (!includeTerminated
                             && TERMINATED.equals(instanceEntity.getInstanceStateName())) {
+                        continue;
+                    }
+                    String instanceType = requestData.getLaunchSpecification().getInstanceType();
+                    Optional<ZoneInfo> optionalZoneInfo =
+                            populateZoneInfoForInstanceEntity(instanceEntity, clustersCache);
+                    if (optionalZoneInfo.isEmpty()) {
                         continue;
                     }
                     ZoneInfo zoneInfo = optionalZoneInfo.get();

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/internal/ReservationCapacityValidationHelper.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/internal/ReservationCapacityValidationHelper.java
@@ -111,12 +111,21 @@ public class ReservationCapacityValidationHelper {
                                                 @NotNull InstanceRequestV2Entity instanceRequestEntity,
                                                 @NotNull Integer incomingGpuCount) {
         /*
+        0. Validate that the reservation permits backup at all
+            a. Rejects in-flight requests created before the reservation opted out of backup
         1. Validate if the zone for which reservation backup will be provided is healthy
             a. This will help to fast fail the request as primary zone has become healthy so we don't need to serve RESERVATION_BACKUP
         2. Validate if incoming GPUs can be accepted for reservation
          */
 
         try {
+
+            // 0. Validate that the reservation permits backup at all
+            if (reservation.isBackupDisabled()) {
+                reportAndThrowError(String.format(
+                        "Reservation %s has backup disabled, rejecting RESERVATION_BACKUP support",
+                        reservation.getReservationId()));
+            }
 
             // 1. Validate if the zone for which reservation backup will be provided is healthy
             Map<String, CloudHealthEntity> cloudHealthByClusterId = cloudHealthRepository.findAllInMap();

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/inbound/rest/controllers/InstanceControllerTest.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/inbound/rest/controllers/InstanceControllerTest.java
@@ -1026,8 +1026,8 @@ class InstanceControllerTest extends IntegrationTest {
     // Instance listing
     @ParameterizedTest
     @ValueSource(strings = {
-            TestUtil.NON_BYOC_CLUSTER_REGISTRATION_SCOPE,
-            TestUtil.CLUSTER_INSTANCES_SCOPE
+            TestUtil.CLUSTER_INSTANCES_SCOPE,
+            TestUtil.NVCA_CLUSTER_REGISTRATION_SCOPE
     })
     void getActiveInstancesForZone_withSupportedScope_returnsSuccess(String scope)
             throws Exception {
@@ -1076,7 +1076,7 @@ class InstanceControllerTest extends IntegrationTest {
                                         .contentType(MediaType.APPLICATION_JSON)
                                         .header(HttpHeaders.AUTHORIZATION,
                                                 JwtKeyUtils.getAuthHeader(DUMMY_CLUSTER_ID,
-                                                                          TestUtil.NON_BYOC_CLUSTER_REGISTRATION_SCOPE)))
+                                                                          TestUtil.CLUSTER_INSTANCES_SCOPE)))
                         .andExpect(MockMvcResultMatchers.status().isInternalServerError())
                         .andReturn();
 
@@ -1084,6 +1084,25 @@ class InstanceControllerTest extends IntegrationTest {
         Assertions.assertThat(mvcResult.getResponse().getContentAsString())
                 .isEqualTo("{\"error\":\"Internal Server Error\"}");
         verify(instanceService).getActiveInstancesForZone(DUMMY_CLUSTER_ID);
+    }
+
+    // Error: 403 - the cluster registration scope no longer grants instance listing
+    @Test
+    void getActiveInstancesForZone_withClusterRegistrationScope_throwsException()
+            throws Exception {
+        // Act
+        MvcResult mvcResult =
+                mockMvc.perform(
+                                MockMvcRequestBuilders.get(INSTANCE_LISTING_API_URL, DUMMY_CLUSTER_ID)
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .header(HttpHeaders.AUTHORIZATION,
+                                                JwtKeyUtils.getAuthHeader(DUMMY_CLUSTER_ID,
+                                                                          TestUtil.NON_BYOC_CLUSTER_REGISTRATION_SCOPE)))
+                        .andExpect(MockMvcResultMatchers.status().isForbidden()).andReturn();
+
+        // Assert
+        Assertions.assertThat(mvcResult.getResponse().getContentAsString())
+                .isEqualTo("{\"error\":\"Access Denied\"}");
     }
 
     // Error: 401

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/integration/IcmsTest.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/integration/IcmsTest.java
@@ -437,7 +437,7 @@ public class IcmsTest extends IntegrationTest {
                                 .header(HttpHeaders.AUTHORIZATION, ssaAuthHeader))
                 .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
         return objectMapper.readValue(mvcResult.getResponse().getContentAsString(),
-                                      ObjectNode.class).get("clusterId").textValue();
+                                      ObjectNode.class).get("clusterId").stringValue();
     }
 
     private void sendClusterHeartbeat(String path, String clusterId)

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/outbound/cassandra/reservation/entity/ReservationEntityTest.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/outbound/cassandra/reservation/entity/ReservationEntityTest.java
@@ -104,4 +104,37 @@ class ReservationEntityTest {
         // Act & Assert
         assertFalse(reservation.isActive());
     }
+
+    @Test
+    void isBackupDisabled_WhenFlagIsNull_ReturnsFalse() {
+        // Arrange - rows written before the column existed read back as null
+        ReservationEntity reservation = createReservation(builder ->
+            builder.reservationBackUpDisabled(null)
+        );
+
+        // Act & Assert
+        assertFalse(reservation.isBackupDisabled());
+    }
+
+    @Test
+    void isBackupDisabled_WhenFlagIsFalse_ReturnsFalse() {
+        // Arrange
+        ReservationEntity reservation = createReservation(builder ->
+            builder.reservationBackUpDisabled(false)
+        );
+
+        // Act & Assert
+        assertFalse(reservation.isBackupDisabled());
+    }
+
+    @Test
+    void isBackupDisabled_WhenFlagIsTrue_ReturnsTrue() {
+        // Arrange
+        ReservationEntity reservation = createReservation(builder ->
+            builder.reservationBackUpDisabled(true)
+        );
+
+        // Act & Assert
+        assertTrue(reservation.isBackupDisabled());
+    }
 } 

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/outbound/nats/NatsStreamManagerTest.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/outbound/nats/NatsStreamManagerTest.java
@@ -33,16 +33,13 @@ import io.nats.client.ConsumerContext;
 import io.nats.client.JetStreamApiException;
 import io.nats.client.JetStreamManagement;
 import io.nats.client.StreamContext;
-import io.nats.client.api.ApiResponse;
 import io.nats.client.api.ConsumerConfiguration;
 import io.nats.client.api.StreamConfiguration;
 import io.nats.client.api.StreamInfo;
-import io.nats.client.support.JsonValue;
+import io.nats.client.support.Status;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -96,7 +93,7 @@ class NatsStreamManagerTest {
             throws IOException, JetStreamApiException {
         // Mock
         when(jetStreamManagement.getStreamInfo(anyString())).thenThrow(
-                new JetStreamApiException(new TestResponse()));
+                streamNotFoundException());
         when(jetStreamManagement.addStream(any(StreamConfiguration.class))).thenReturn(
                 mock(StreamInfo.class));
 
@@ -194,7 +191,7 @@ class NatsStreamManagerTest {
             throws IOException, InterruptedException, JetStreamApiException {
         // Mock
         when(jetStreamManagement.getStreamInfo("TestStream")).thenThrow(
-                new JetStreamApiException(new TestResponse()));
+                streamNotFoundException());
 
         // Act
         StreamInfo streamInfo = natsStreamManager.getStream("TestStream");
@@ -211,7 +208,7 @@ class NatsStreamManagerTest {
             throws IOException, JetStreamApiException {
         // Mock
         when(jetStreamManagement.getStreamInfo("TestStream")).thenThrow(
-                new JetStreamApiException(new TestResponse()));
+                streamNotFoundException());
         when(jetStreamManagement.addStream(any(StreamConfiguration.class))).thenReturn(
                 mock(StreamInfo.class));
 
@@ -280,18 +277,10 @@ class NatsStreamManagerTest {
     }
 
     /**
-     * Mock implementation of an API response for testing purposes.
+     * Builds the error the JetStream API reports when a stream does not exist.
      */
-    class TestResponse extends ApiResponse<StreamInfo> {
-
-        public TestResponse() {
-            super(getJsonMap());
-        }
-
-        private static JsonValue getJsonMap() {
-            Map<String, JsonValue> m = new HashMap<>();
-            m.put("error", new JsonValue("Stream not found"));
-            return new JsonValue(m);
-        }
+    private static JetStreamApiException streamNotFoundException() {
+        Status notFound = new Status(Status.NOT_FOUND_CODE, "Stream not found");
+        return new JetStreamApiException(io.nats.client.api.Error.convert(notFound));
     }
 }

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/outbound/sqs/model/byoc/ByocSqsMessageModelTest.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/outbound/sqs/model/byoc/ByocSqsMessageModelTest.java
@@ -74,31 +74,31 @@ class ByocSqsMessageModelTest {
         JsonNode jsonNode = objectMapper.readTree(jsonString);
 
         // Validate all fields directly from JSON
-        assertEquals("test-request-id", jsonNode.get("requestId").asText());
-        assertEquals("test-customer", jsonNode.get("sub").asText());
-        assertEquals("test-nca-id", jsonNode.get("ncaId").asText());
-        assertEquals("RequestSpotInstances", jsonNode.get("action").asText());
-        assertEquals("test-instance-type", jsonNode.get("instanceType").asText());
+        assertEquals("test-request-id", jsonNode.get("requestId").asString());
+        assertEquals("test-customer", jsonNode.get("sub").asString());
+        assertEquals("test-nca-id", jsonNode.get("ncaId").asString());
+        assertEquals("RequestSpotInstances", jsonNode.get("action").asString());
+        assertEquals("test-instance-type", jsonNode.get("instanceType").asString());
         assertEquals(2, jsonNode.get("instanceCount").asInt());
-        assertEquals("test-gpu-type", jsonNode.get("gpuType").asText());
+        assertEquals("test-gpu-type", jsonNode.get("gpuType").asString());
         assertEquals(1, jsonNode.get("requestedGPUCount").asInt());
-        assertEquals("test-account-name", jsonNode.get("accountName").asText());
-        assertEquals("test-message-batch-id", jsonNode.get("messageBatchId").asText());
+        assertEquals("test-account-name", jsonNode.get("accountName").asString());
+        assertEquals("test-message-batch-id", jsonNode.get("messageBatchId").asString());
 
         // Validate launchSpecification object
         JsonNode launchSpecNode = jsonNode.get("launchSpecification");
         assertNotNull(launchSpecNode);
-        assertEquals("test-instance-type", launchSpecNode.get("instanceType").asText());
-        assertEquals("test-instance-type-name", launchSpecNode.get("instanceTypeName").asText());
-        assertEquals("test-instance-type-value", launchSpecNode.get("instanceTypeValue").asText());
+        assertEquals("test-instance-type", launchSpecNode.get("instanceType").asString());
+        assertEquals("test-instance-type-name", launchSpecNode.get("instanceTypeName").asString());
+        assertEquals("test-instance-type-value", launchSpecNode.get("instanceTypeValue").asString());
         assertEquals(2, launchSpecNode.get("instanceCount").asInt());
-        assertEquals("test-gpu-type", launchSpecNode.get("gpuType").asText());
+        assertEquals("test-gpu-type", launchSpecNode.get("gpuType").asString());
         assertEquals(1, launchSpecNode.get("requestedGPUCount").asInt());
-        assertEquals("test-container-image", launchSpecNode.get("containerImage").asText());
-        assertEquals("test-environment", launchSpecNode.get("environment").asText());
-        assertEquals("test", launchSpecNode.get("spotEnvironment").asText());
-        assertEquals("test", launchSpecNode.get("icmsEnvironment").asText());
-        assertEquals("test", launchSpecNode.get("cloudProvider").asText());
+        assertEquals("test-container-image", launchSpecNode.get("containerImage").asString());
+        assertEquals("test-environment", launchSpecNode.get("environment").asString());
+        assertEquals("test", launchSpecNode.get("spotEnvironment").asString());
+        assertEquals("test", launchSpecNode.get("icmsEnvironment").asString());
+        assertEquals("test", launchSpecNode.get("cloudProvider").asString());
         assertNotNull(launchSpecNode.get("deploymentId"));
         assertNotNull(launchSpecNode.get("gpuSpecificationId"));
 
@@ -107,7 +107,7 @@ class ByocSqsMessageModelTest {
         assertNotNull(functionDetailsNode);
         assertNotNull(functionDetailsNode.get("functionId"));
         assertNotNull(functionDetailsNode.get("functionVersionId"));
-        assertEquals("DEFAULT", functionDetailsNode.get("functionType").asText());
+        assertEquals("DEFAULT", functionDetailsNode.get("functionType").asString());
 
         // Test 2: Build with pre-built launch specification object
         ByocLaunchSpecification preBuiltLaunchSpec = ByocLaunchSpecification.builder()
@@ -157,17 +157,17 @@ class ByocSqsMessageModelTest {
         // Validate launchSpecification is properly nested in the second model
         JsonNode launchSpecNode2 = jsonNode2.get("launchSpecification");
         assertNotNull(launchSpecNode2);
-        assertEquals("prebuilt-instance-type", launchSpecNode2.get("instanceType").asText());
-        assertEquals("prebuilt-instance-type-name", launchSpecNode2.get("instanceTypeName").asText());
-        assertEquals("prebuilt-instance-type-value", launchSpecNode2.get("instanceTypeValue").asText());
+        assertEquals("prebuilt-instance-type", launchSpecNode2.get("instanceType").asString());
+        assertEquals("prebuilt-instance-type-name", launchSpecNode2.get("instanceTypeName").asString());
+        assertEquals("prebuilt-instance-type-value", launchSpecNode2.get("instanceTypeValue").asString());
         assertEquals(3, launchSpecNode2.get("instanceCount").asInt());
-        assertEquals("prebuilt-gpu-type", launchSpecNode2.get("gpuType").asText());
+        assertEquals("prebuilt-gpu-type", launchSpecNode2.get("gpuType").asString());
         assertEquals(2, launchSpecNode2.get("requestedGPUCount").asInt());
-        assertEquals("prebuilt-container-image", launchSpecNode2.get("containerImage").asText());
-        assertEquals("prebuilt-environment", launchSpecNode2.get("environment").asText());
-        assertEquals("prebuilt", launchSpecNode2.get("spotEnvironment").asText());
-        assertEquals("prebuilt", launchSpecNode2.get("icmsEnvironment").asText());
-        assertEquals("prebuilt", launchSpecNode2.get("cloudProvider").asText());
+        assertEquals("prebuilt-container-image", launchSpecNode2.get("containerImage").asString());
+        assertEquals("prebuilt-environment", launchSpecNode2.get("environment").asString());
+        assertEquals("prebuilt", launchSpecNode2.get("spotEnvironment").asString());
+        assertEquals("prebuilt", launchSpecNode2.get("icmsEnvironment").asString());
+        assertEquals("prebuilt", launchSpecNode2.get("cloudProvider").asString());
         assertNotNull(launchSpecNode2.get("deploymentId"));
         assertNotNull(launchSpecNode2.get("gpuSpecificationId"));
     }

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/service/internal/ReservationCapacityValidationHelperTest.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/service/internal/ReservationCapacityValidationHelperTest.java
@@ -531,6 +531,58 @@ class ReservationCapacityValidationHelperTest {
     }
 
     @Test
+    void testValidateReservedBackupCapacity_BackupDisabled_ThrowsExceptionBeforeHealthLookup() {
+        // Given - reservation opted out of backup while the request was already in flight
+        testReservation.setReservationBackUpDisabled(true);
+
+        // When & Then
+        PreConditionFailedException exception = assertThrows(
+                PreConditionFailedException.class,
+                () -> reservationCapacityValidationHelper.validateReservationBackupCapacityForInstanceStateUpdate(
+                        testReservation, testInstanceRequest)
+        );
+
+        assertTrue(exception.getMessage().contains("has backup disabled"));
+        assertTrue(exception.getMessage().contains(testReservationId.toString()));
+        // Fast fails before any zone health or capacity lookup
+        verify(cloudHealthRepository, never()).findAllInMap();
+        verify(reservationProcessor, never()).calculateAvailableCapacityForUnhealthyZone(any());
+    }
+
+    @Test
+    void testValidateReservationBackupCapacityForRequestStateUpdate_BackupDisabled_ThrowsException() {
+        // Given
+        testReservation.setReservationBackUpDisabled(true);
+
+        // When & Then
+        PreConditionFailedException exception = assertThrows(
+                PreConditionFailedException.class,
+                () -> reservationCapacityValidationHelper.validateReservationBackupCapacityForRequestStateUpdate(
+                        testReservation, testInstanceRequest, 1)
+        );
+
+        assertTrue(exception.getMessage().contains("has backup disabled"));
+        verify(cloudHealthRepository, never()).findAllInMap();
+        verify(reservationProcessor, never()).calculateAvailableCapacityForUnhealthyZone(any());
+    }
+
+    @Test
+    void testValidateReservedBackupCapacity_BackupExplicitlyEnabled_Success() {
+        // Given - explicit false must behave exactly like the legacy null default
+        testReservation.setReservationBackUpDisabled(false);
+        testInstanceRequest.setGpuCountPerInstance(2);
+        when(cloudHealthRepository.findAllInMap()).thenReturn(cloudHealthMap);
+        when(reservationProcessor.calculateAvailableCapacityForUnhealthyZone(testReservation)).thenReturn(4.0);
+
+        // When & Then
+        assertDoesNotThrow(() ->
+            reservationCapacityValidationHelper.validateReservationBackupCapacityForInstanceStateUpdate(
+                testReservation, testInstanceRequest));
+
+        verify(reservationProcessor).calculateAvailableCapacityForUnhealthyZone(testReservation);
+    }
+
+    @Test
     void testValidateAndGetReservationEntity_ReservationJustExpired_ThrowsException() {
         // Given - Reservation that just expired
         testReservation.setEndTime(Instant.now().minusSeconds(1)); // Just expired

--- a/src/control-plane-services/instance-cluster-management/local_env/cassandra/schema/schema.cql
+++ b/src/control-plane-services/instance-cluster-management/local_env/cassandra/schema/schema.cql
@@ -151,6 +151,7 @@ start_time timestamp,
 end_time timestamp,
 name text,
 last_updated_time timestamp,
+reservation_backup_disabled boolean,
 PRIMARY KEY (reservation_id)
 );
 


### PR DESCRIPTION
## TL;DR

- Add a per-reservation `reservationBackUpDisabled` flag so a reservation whose primary cluster becomes unhealthy can be blocked from having RESERVED_BACKUP instances scheduled on a different cluster, which is required for clusters whose reserved workloads must stay put.
- This PR is the ICMS half of the flow: the reservation column, the cluster heartbeat contract, and the scheduling gate. The value is written by the deployed SIS service and reported by the cluster-side reporting service, both tracked separately.
- Also folds in three unrelated cleanups in the same module: drop the retired scope from instance listing, reorder the describe path so terminated instances are filtered before cluster resolution, and clear Jackson 3 and NATS client deprecation warnings left over from the Spring Boot 4 upgrade.

## Additional Details

- The end-to-end path is upstream reservation configuration, to the cluster-side reporting service, to the cluster heartbeat, to ICMS persistence, to the scheduling gate. The reporting service already sends the flag, so this PR gives ICMS somewhere to store it and a place to enforce it.
- Every layer treats absent as "backup allowed", so the change is compatible in both deployment directions and no reservation entry needs updating to preserve current behavior.
- `GpuReservation.reservationBackUpDisabled` is a boxed `Boolean` with no `@NotNull`, so a reporting service build that does not send the field still passes request validation.
- `ReservationEntity.reservationBackUpDisabled` is a boxed `Boolean`, so rows written before the column existed read back as null rather than defaulting to disabled.
- `ReservationEntity.isBackupDisabled()` is the single place that collapses null and false into "backup allowed", so no caller has to null-check the raw field.
- Tolerance for the reverse deployment order is already in place: `JacksonConfiguration` disables `FAIL_ON_UNKNOWN_PROPERTIES`, so a newer reporting service can send the field to an ICMS build without it and heartbeats keep succeeding.
- The gate is added to the private `validateReservedBackupCapacity` rather than to the two public methods, so a single insertion covers both `validateReservationBackupCapacityForInstanceStateUpdate` and `validateReservationBackupCapacityForRequestStateUpdate`.
- It sits at step 0, ahead of `cloudHealthRepository.findAllInMap()`, so an opted-out reservation fast-fails without a cloud health read or a capacity calculation.
- Enforcing on the state-update path, rather than only at admission, is what makes the flag effective for in-flight work: a request admitted before the reservation opted out is rejected at its next state update instead of completing on another cluster.
- The describe reorder is behavior-preserving and produces identical output for both values of `includeTerminated`; it only moves the cheap terminated check ahead of the expensive cluster lookup.
- Previously cluster resolution ran for every instance, including lifecycle-terminated rows that were discarded one line later, and for a terminated instance whose BYOC cluster has been deleted `resolveByocZoneInfo` logs an ERROR and emits a UEC event on every call.
- Because callers keep polling terminated deployments, that produced a continuous stream of errors for instances terminated days earlier; filtering first removes both the noise and the wasted lookup on the default path.
- Only the `includeTerminated=false` path goes quiet. Callers that retry with `includeTerminated=true` after an empty result still resolve clusters and still log, and the separate silent-omission problem on that path is deliberately out of scope here.
- The deprecation fixes are surface-level: `asString()` is behaviorally identical to `asText()` for the node types these assertions touch, while `stringValue()` is the strict variant and is correct in `IcmsTest` where the field is known to be textual.
- `Error.convert(Status)` is the supported way to construct a `JetStreamApiException`, and adopting it lets the test delete a hand-rolled `ApiResponse` subclass.
- No production database migration is included here; only the local development schema is updated.

## For the Reviewer

- The nullable `Boolean` choice at both the DTO and entity layers, and whether `isBackupDisabled()` should remain the only place null is collapsed to "allowed".
- Placement of the gate in the private `validateReservedBackupCapacity`, and confirmation that both public entry points genuinely funnel through it so neither path can bypass the flag.
- Whether rejecting an in-flight request at state-update time is the intended behavior, since a request admitted before the reservation opted out now fails rather than being redirected or allowed to finish.
- The claim that the describe reorder is output-identical: with `includeTerminated=false` terminated rows are dropped either way, and with `includeTerminated=true` the filter is a no-op and cluster resolution runs exactly as before.
- Removal of the legacy scope from `GET /clusters/{zoneName}/instances`, and confirmation that no caller relies on that scope alone. The known caller requests both that scope and `cluster-instances` in a single token, so `cluster-instances` is already provisioned and working.
- The new 403 test is the guard for that removal, asserting the registration scope no longer grants listing.
- The `asString()` versus `stringValue()` split in the deprecation cleanup, since only the latter is strict about node type.
- Deployment ordering, which is a real hazard rather than a nit: the production `reservation_backup_disabled` column must exist before this build is deployed, because the entity maps the column unconditionally.

## For QA

- Run the `icms-core` unit and integration test suites.
- Send a cluster heartbeat that omits `reservationBackUpDisabled` and confirm it still returns success, stores null, and yields `isBackupDisabled() == false`.
- Send a cluster heartbeat that includes the field and confirm the value round-trips to the reservation record.
- Set the flag to true on a reservation, drive a RESERVED_BACKUP request, and confirm it fails with `PreConditionFailedException` on both the instance-state-update and request-state-update paths, with no cloud health or capacity lookup performed.
- Set the flag explicitly to false and confirm behavior is identical to a null row, so existing reservations are unaffected.
- Issue a describe call with `includeTerminated=false` against a deployment whose instances are terminated and whose BYOC cluster has been deleted, and confirm the payload matches the previous build with no cluster-resolution ERROR emitted.
- Confirm no deprecation warnings remain from `ByocSqsMessageModelTest`, `IcmsTest`, or `NatsStreamManagerTest`.
- Verify the production column migration has been applied before this build is promoted, since the entity maps the new column unconditionally.
- Beyond the migration prerequisite and the auth matrix check, no manual QA is expected: the flag defaults to current behavior, and the remaining changes are a behavior-preserving reorder and test-only deprecation fixes.

## Issues

- Closes [#786](https://github.com/NVIDIA/nvcf/issues/786)

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for indicating whether GPU reservation backups are disabled.
  * Preserved backup fallback behavior when the setting is not specified.
* **Bug Fixes**
  * Reservations with backups disabled are rejected before backup capacity validation.
  * Improved instance-listing authorization by limiting access to supported permissions.
  * Prevented unnecessary processing of terminated instances excluded from results.
  * Added clearer access-denied responses for unsupported permissions.
* **Tests**
  * Expanded coverage for backup settings, authorization, and instance-listing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->