### PR TITLE
fix(vanity-gateway): register /info on per-host sub-routers

### DIFF
--- a/src/invocation-plane-services/vanity-gateway/gateway/h2.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway/h2.go
@@ -146,6 +146,7 @@ func registerVanity(hostRouter *middleware.HostRouter, mappings *config.GatewayC
 			})
 		}
 		r.Get(healthPath, healthManager.HandlerFunc)
+		r.Get("/info", golibversion.Handler().ServeHTTP)
 		r.Get("/v1/status/{requestId}", vanityDirector.ServePolling)
 		hostRouter.Register(vanity.Host, chimiddleware.New(r))
 	}
@@ -167,6 +168,7 @@ func registerOpenAI(hostRouter *middleware.HostRouter, mappings *config.GatewayC
 	r.Get("/v1/models/{company}/{model}", openAIDirector.GetModel)
 
 	r.Get(healthPath, healthManager.HandlerFunc)
+	r.Get("/info", golibversion.Handler().ServeHTTP)
 
 	// special domain for openai
 	hostRouter.Register(mappings.OpenAI.Host, chimiddleware.New(r))

--- a/src/invocation-plane-services/vanity-gateway/gateway/info_test.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway/info_test.go
@@ -96,3 +96,79 @@ func TestBuildChiMux_Info_RejectsNonGET(t *testing.T) {
 		})
 	}
 }
+
+// newInfoTestMuxWithHosts builds the chi router with vanity and OpenAI hosts
+// registered so the hostRouter middleware is exercised for /info requests.
+func newInfoTestMuxWithHosts(t *testing.T, vanityHost, openAIHost string) http.Handler {
+	t.Helper()
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(backend.Close)
+
+	cfg := &config.GatewayConfig{}
+	cfg.Vanity = map[string]config.VanityEntry{
+		"test": {Host: vanityHost},
+	}
+	cfg.OpenAI.Host = openAIHost
+
+	mux, err := buildChiMux(cfg, Config{
+		NvcfApiEndpoint:              backend.URL,
+		PrivateModelNameRegexPattern: "^$",
+	})
+	require.NoError(t, err)
+	return mux
+}
+
+func TestBuildChiMux_Info_VanityHost(t *testing.T) {
+	golibversion.Service = "nvcf-ai-api-gateway-service"
+	golibversion.Version = "test-1.0.0"
+	golibversion.GitHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	t.Cleanup(func() {
+		golibversion.Service = ""
+		golibversion.Version = ""
+		golibversion.GitHash = ""
+	})
+
+	const vanityHost = "vanity.example.com"
+	mux := newInfoTestMuxWithHosts(t, vanityHost, "openai.example.com")
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/info", nil)
+	r.Host = vanityHost
+	mux.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	var info map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &info))
+	assert.Equal(t, "nvcf-ai-api-gateway-service", info["service"])
+}
+
+func TestBuildChiMux_Info_OpenAIHost(t *testing.T) {
+	golibversion.Service = "nvcf-ai-api-gateway-service"
+	golibversion.Version = "test-1.0.0"
+	golibversion.GitHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	t.Cleanup(func() {
+		golibversion.Service = ""
+		golibversion.Version = ""
+		golibversion.GitHash = ""
+	})
+
+	const openAIHost = "openai.example.com"
+	mux := newInfoTestMuxWithHosts(t, "vanity.example.com", openAIHost)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/info", nil)
+	r.Host = openAIHost
+	mux.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	var info map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &info))
+	assert.Equal(t, "nvcf-ai-api-gateway-service", info["service"])
+}


### PR DESCRIPTION
## TL;DR

Fixes `GET /info` returning 404 on vanity-gateway when the request carries a Host header matching a configured vanity or OpenAI domain. The hostRouter middleware routes matched-host requests to a per-host sub-router that had no `/info` route, so the handler on the main chi mux was never reached.

## Additional Details

- Adds `r.Get("/info", golibversion.Handler().ServeHTTP)` to the per-host sub-routers in `registerVanity` and `registerOpenAI`, matching the pattern already used for `/health`.
- The root chi mux registration from #709 is unchanged. Requests with no matched host still fall through to it.
- Root cause of the gap: the test in #709 used an empty `GatewayConfig` (no hosts registered), so the hostRouter never activated and every request reached the main mux. The fix adds two tests that build the mux with a vanity host and an OpenAI host configured and send requests with matching Host headers.

## Testing

Confirmed 404 in staging before this fix:

```
$ curl https://stg.integrate.api.nvidia.com/info
404 page not found
```

New tests pass:

```
$ go test ./gateway/... -run TestBuildChiMux_Info -v
--- PASS: TestBuildChiMux_Info
--- PASS: TestBuildChiMux_Info_RejectsNonGET
--- PASS: TestBuildChiMux_Info_VanityHost
--- PASS: TestBuildChiMux_Info_OpenAIHost
```

## References

- #709 (introduced /info, missed sub-router registration)
- POR: https://docs.google.com/document/d/1XigTpFIMVfkR-RgwdF7urquq8YxGYDEVamsrJNJwC-U

Relates to #315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `/info` endpoint to vanity-domain and OpenAI-specific gateways.
  * The endpoint provides service version information in JSON format.
  * The endpoint is available through configured vanity and OpenAI hosts.

* **Bug Fixes**
  * Added coverage to ensure `/info` requests return successful responses with service metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->