### PR TITLE
fix(nats-auth-callout): default to server subcommand when invoked with no args

### DIFF
--- a/src/control-plane-services/nats-auth-callout/cmd/nvcf-nats-auth-callout-service/cli/root.go
+++ b/src/control-plane-services/nats-auth-callout/cmd/nvcf-nats-auth-callout-service/cli/root.go
@@ -18,6 +18,8 @@ limitations under the License.
 package cli
 
 import (
+	"os"
+
 	"github.com/NVIDIA/nvcf/src/control-plane-services/nats-auth-callout/internal/config"
 	"github.com/spf13/cobra"
 )
@@ -27,9 +29,19 @@ func SetEmbeddedConfig(configData []byte) {
 	config.SetEmbeddedDefaults(configData)
 }
 
+// commandArgs returns the args to pass to the root command.
+// When invoked with no subcommand (container default), it defaults to ["server"].
+func commandArgs() []string {
+	if len(os.Args) < 2 {
+		return []string{"server"}
+	}
+	return os.Args[1:]
+}
+
 // Execute runs the root command
 func Execute() error {
 	rootCmd := NewRootCommand()
+	rootCmd.SetArgs(commandArgs())
 	return rootCmd.Execute()
 }
 

--- a/src/control-plane-services/nats-auth-callout/cmd/nvcf-nats-auth-callout-service/cli/root_test.go
+++ b/src/control-plane-services/nats-auth-callout/cmd/nvcf-nats-auth-callout-service/cli/root_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package cli
 
 import (
+	"os"
 	"testing"
 )
 
@@ -32,7 +33,6 @@ func TestNewRootCommand(t *testing.T) {
 	if len(cmd.Commands()) == 0 {
 		t.Error("Expected at least one subcommand to be added")
 	}
-	// Check that the subcommand is 'server'
 	found := false
 	for _, c := range cmd.Commands() {
 		if c.Use == "server" {
@@ -41,5 +41,35 @@ func TestNewRootCommand(t *testing.T) {
 	}
 	if !found {
 		t.Error("Expected 'server' subcommand to be present")
+	}
+}
+
+func TestCommandArgsDefaultsToServer(t *testing.T) {
+	old := os.Args
+	os.Args = []string{"nvcf-nats-auth-callout-service"}
+	defer func() { os.Args = old }()
+
+	args := commandArgs()
+	if len(args) != 1 || args[0] != "server" {
+		t.Errorf("expected [\"server\"], got %v", args)
+	}
+
+	cmd, _, err := NewRootCommand().Traverse(args)
+	if err != nil {
+		t.Fatalf("unexpected traversal error: %v", err)
+	}
+	if cmd.Use != "server" {
+		t.Errorf("expected server command, got %q", cmd.Use)
+	}
+}
+
+func TestCommandArgsPassesExplicitArgs(t *testing.T) {
+	old := os.Args
+	os.Args = []string{"nvcf-nats-auth-callout-service", "version"}
+	defer func() { os.Args = old }()
+
+	args := commandArgs()
+	if len(args) != 1 || args[0] != "version" {
+		t.Errorf("expected [\"version\"], got %v", args)
 	}
 }

--- a/src/control-plane-services/nats-auth-callout/cmd/nvcf-nats-auth-callout-service/main_test.go
+++ b/src/control-plane-services/nats-auth-callout/cmd/nvcf-nats-auth-callout-service/main_test.go
@@ -17,11 +17,17 @@ limitations under the License.
 
 package main
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
-// TestMainFunction ensures the main function runs without error.
+// TestMainFunction ensures the main function runs without panicking for a known-safe subcommand.
 func TestMainFunction(t *testing.T) {
+	old := os.Args
+	os.Args = []string{"nvcf-nats-auth-callout-service", "version"}
 	defer func() {
+		os.Args = old
 		if r := recover(); r != nil {
 			t.Errorf("main() panicked with error: %v", r)
 		}


### PR DESCRIPTION
## TL;DR

Fixes nvcf-nats-auth-callout-service 0.8.0 pods going into CrashLoopBackOff on staging. The binary's cobra root command has no `RunE`, so invoking it with no arguments prints help and exits 0. The Astro FargateDeployment config passes no `args` to the container (the CRD has no field for it), so every pod crashes immediately. Until this merges, the monorepo image cannot deploy to Astro and staging stays on the old `0.1.9` binary lineage.

## Additional Details

- Adds a `commandArgs()` helper that returns `["server"]` when `os.Args` has no subcommand, and `os.Args[1:]` otherwise.
- `Execute()` calls `rootCmd.SetArgs(commandArgs())` before running.
- All explicit subcommands (`server`, `config`, `version`, `completion`) work as before.
- The old 0.1.9 image (a separate binary lineage) auto-started its server on invocation with no args; the monorepo binary requires an explicit `server` subcommand.

## Testing

Reproduced the failure and verified the fix end-to-end on a local k3d cluster.

Failure, observed on staging first: pod `nvcf-nats-auth-callout-service-b97d9975-hrwnd`, 288 restarts, exit code 0 each time, logs showing the cobra help text instead of a running server:

```
$ kubectl logs nvcf-nats-auth-callout-service-b97d9975-hrwnd \
    -n astro-tenant-nvcf-nats-auth-callout-service \
    -c nvcf-nats-auth-callout-service --previous

provide ping and healthz http server

Usage:
  nvcf-nats-auth-callout-service [command]
  ...
```

Reproduced the same crashloop locally by deploying the pre-fix image with no `args` (mimicking the FargateDeployment): pod went CrashLoopBackOff with identical help-text logs.

Verified the fix with a stamped build. The image entrypoint stays the bare binary (`/usr/bin/app`, no `server`), so the default-routing lives in the binary and covers every launch path. Deployed with no `args`:

- pod reaches `1/1 Running`, connects to NATS, starts the HTTP server
- `GET /info` returns 200 `{"service":"nvcf-nats-auth-callout-service","version":"...","commit":"..."}`
- `POST /info` returns 405 with `Allow: GET`
- `GET /health` returns 200

New unit tests pass:

```
$ go test ./cmd/nvcf-nats-auth-callout-service/cli/... -v
--- PASS: TestNewRootCommand
--- PASS: TestCommandArgsDefaultsToServer
--- PASS: TestCommandArgsPassesExplicitArgs
```

## References

- #711 (first release of the monorepo image to staging; exposed the CLI/deploy config mismatch)
- POR: https://docs.google.com/document/d/1XigTpFIMVfkR-RgwdF7urquq8YxGYDEVamsrJNJwC-U

Relates to #315


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - The command-line tool now starts the server automatically when launched without a subcommand.
  - Explicit subcommands, such as `version`, continue to work as entered.

- **Bug Fixes**
  - Improved command-line startup behavior to prevent failures when no arguments are provided.

- **Tests**
  - Added coverage for default startup and explicit subcommand handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
