### PR TITLE
fix(ess-helm): align app version to ESS 0.4.13

### DIFF
--- a/deploy/helm/encrypted-secret-store/ess-api/Chart.yaml
+++ b/deploy/helm/encrypted-secret-store/ess-api/Chart.yaml
@@ -19,4 +19,4 @@ description: ESS API Helm Chart
 
 type: application
 version: 0.0.0 # autoversioning enabled via release pipeline
-appVersion: "v0.58.5"
+appVersion: "0.4.13"

--- a/deploy/helm/encrypted-secret-store/ess-api/values.yaml
+++ b/deploy/helm/encrypted-secret-store/ess-api/values.yaml
@@ -23,7 +23,7 @@ ess:
     # This sets the pull policy for images.
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: v0.58.5
+    tag: 0.4.13
 
   namespace: ""
 

--- a/deploy/helm/encrypted-secret-store/values.local.yaml
+++ b/deploy/helm/encrypted-secret-store/values.local.yaml
@@ -15,8 +15,8 @@
 
 ess:
   image:
-    registry: nvcr.io
-    repository: 0651155215864979/ncp-dev/nvcf-ess
+    registry: ""
+    repository: ""
 
   env:
     # Ensure stacktraces are expanded

--- a/deploy/helm/encrypted-secret-store/values.local.yaml
+++ b/deploy/helm/encrypted-secret-store/values.local.yaml
@@ -15,8 +15,8 @@
 
 ess:
   image:
-    registry: ""
-    repository: ""
+    registry: nvcr.io
+    repository: 0651155215864979/ncp-dev/nvcf-ess
 
   env:
     # Ensure stacktraces are expanded


### PR DESCRIPTION
## TL;DR
Bump the ESS Helm chart's app version from the stale upstream `v0.58.5` to `0.4.13`, the current ESS service release from this monorepo, so a default install deploys the matching image.

## Additional Details
- `ess-api/Chart.yaml` `appVersion`: `v0.58.5` -> `0.4.13`.
- `ess-api/values.yaml` `ess.image.tag`: `v0.58.5` -> `0.4.13` (kept in sync; the tag default is the chart appVersion).
- No template changes. `helm lint` passes.
- `fix(ess-helm)` is scoped to `deploy/helm/encrypted-secret-store`, so release automation cuts a chart patch under the new prefix (`deploy/helm/encrypted-secret-store/v1.7.2`) via `legacy_tag_prefix`. The chart `version` field stays `0.0.0` (autoversioned by the pipeline); only `appVersion` changes here.

## For the Reviewer
`appVersion` (deployed ESS image) is independent of the chart `version` (package release line). This aligns the former to the ESS service released from this repo.

## For QA
No QA needed. `helm lint` and `helm template` render with the CI values file. Verify the release helper resolves ess-helm to `1.7.2` under `deploy/helm/encrypted-secret-store/`.

## Issues
Relates to #747

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the ESS API deployment to version 0.4.13.
  * Aligned chart metadata and container image versions for consistent deployments.
  * Configured the local deployment to use the NVIDIA container registry and ESS image repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->