### PR TITLE
fix: bump nvct version container in Charts.yaml

### DIFF
--- a/deploy/helm/cloud-tasks/nvct-api/Chart.yaml
+++ b/deploy/helm/cloud-tasks/nvct-api/Chart.yaml
@@ -4,4 +4,4 @@ description: NCP Compatible deployment of NVCT API (nvct-service)
 
 type: application
 version: 0.0.0 # autoversioning enabled via release pipeline
-appVersion: "1.6.2"
+appVersion: "1.63.2"


### PR DESCRIPTION
NO-REF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Updates**
  - Updated the deployed application version to 1.63.2.
  - Ensures deployments use the latest published application release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->