### PR TITLE
fix(stargate): permissive default lb config

### DIFF
--- a/docs/user/llm-function-enablement.md
+++ b/docs/user/llm-function-enablement.md
@@ -190,8 +190,8 @@ mean the router knows the target but has no active eligible backend. Check:
 - The request `model` value uses `<function-id>/<model-name>`.
 - The function's `models[].name` matches the model suffix in the request.
 - `models[].llmConfig.uris` includes the invoked path.
-- `addons.llm.requestRouter.loadBalancer.config` includes the algorithm selected
-  by the function's `models[].llmConfig.routingMethod`.
+- When `addons.llm.requestRouter.loadBalancer.config` is set, it includes the
+  algorithm selected by the function's `models[].llmConfig.routingMethod`.
 - The `llm-worker` sidecar connected to `llm-request-router`.
 - The effective LLM request-router worker address is reachable from the worker
   cluster.

--- a/docs/user/llm-function-enablement.md
+++ b/docs/user/llm-function-enablement.md
@@ -79,8 +79,9 @@ the worker address under `api.env`. When the LLM addon is disabled, the stack
 does not pass a staged endpoint to the API chart.
 
 The request router uses `power-of-two` when no load-balancer configuration is
-set. Before a function selects a different routing method, configure the
-effective model algorithm or a request override.
+set, and accepts any supported `routingMethod` from a function. When a
+load-balancer configuration is set, a function can only select an algorithm
+that the configuration enables.
 
 If you mirror images to a registry that does not use the stack's default
 `global.image.registry` and `global.image.repository`, override the

--- a/docs/user/llm-request-router-load-balancing.md
+++ b/docs/user/llm-request-router-load-balancing.md
@@ -39,8 +39,8 @@ The chart supports two configuration sources:
 | `loadBalancer.configPath` | The chart only passes `--lb-config-path=<path>`. The operator must add and maintain the file mount by another mechanism. |
 
 Inline `config` takes precedence when both values are set. When neither value
-is set, Stargate uses its built-in `power-of-two` default and accepts every
-built-in algorithm as a routing-method override.
+is set, Stargate uses its built-in `power-of-two` default and accepts a
+routing-method override when it is in the allowlist of built-in algorithms.
 
 Stargate reads and validates the file only during process startup. The
 StatefulSet does not include a load-balancer ConfigMap checksum in its pod
@@ -60,8 +60,8 @@ Algorithm availability is enforced at separate layers:
 
 For example, when a configuration is set and `power-of-two` is the effective
 algorithm, `wait_and_widen` requires a `wait-and-widen` entry in
-`request_algorithms`. Without a configuration, every built-in algorithm is
-already available as an override. The legacy `groq_multiregion` value remains
+`request_algorithms`. Without a configuration, the allowlist already contains
+every built-in algorithm. The legacy `groq_multiregion` value remains
 accepted and resolves to the same algorithm.
 
 Use `wait-and-widen` and `pulsar-wait-and-widen` in new function metadata,

--- a/docs/user/llm-request-router-load-balancing.md
+++ b/docs/user/llm-request-router-load-balancing.md
@@ -60,9 +60,8 @@ Algorithm availability is enforced at separate layers:
 
 For example, when a configuration is set and `power-of-two` is the effective
 algorithm, `wait_and_widen` requires a `wait-and-widen` entry in
-`request_algorithms`. Without a configuration, the allowlist already contains
-every built-in algorithm. The legacy `groq_multiregion` value remains
-accepted and resolves to the same algorithm.
+`request_algorithms`. The legacy `groq_multiregion` value remains accepted
+and resolves to the same algorithm.
 
 Use `wait-and-widen` and `pulsar-wait-and-widen` in new function metadata,
 `lb-config.json` files, request-algorithm maps, and deployment manifests.

--- a/docs/user/llm-request-router-load-balancing.md
+++ b/docs/user/llm-request-router-load-balancing.md
@@ -39,7 +39,8 @@ The chart supports two configuration sources:
 | `loadBalancer.configPath` | The chart only passes `--lb-config-path=<path>`. The operator must add and maintain the file mount by another mechanism. |
 
 Inline `config` takes precedence when both values are set. When neither value
-is set, Stargate uses its built-in `power-of-two` default.
+is set, Stargate uses its built-in `power-of-two` default and accepts every
+built-in algorithm as a routing-method override.
 
 Stargate reads and validates the file only during process startup. The
 StatefulSet does not include a load-balancer ConfigMap checksum in its pod
@@ -57,10 +58,11 @@ Algorithm availability is enforced at separate layers:
 | LLM API Gateway | Nonblank routing method from authenticated model metadata, trimmed and forwarded as `x-routing-method` without algorithm validation. |
 | Stargate `x-routing-method` | Case-insensitive algorithm name with hyphens or underscores. It must match the effective algorithm or a model or top-level `request_algorithms` entry. Otherwise, Stargate returns HTTP `400`. |
 
-For example, when `power-of-two` is the effective algorithm,
-`wait_and_widen` requires a `wait-and-widen` entry in `request_algorithms`.
-The legacy `groq_multiregion` value remains accepted and resolves to the same
-algorithm.
+For example, when a configuration is set and `power-of-two` is the effective
+algorithm, `wait_and_widen` requires a `wait-and-widen` entry in
+`request_algorithms`. Without a configuration, every built-in algorithm is
+already available as an override. The legacy `groq_multiregion` value remains
+accepted and resolves to the same algorithm.
 
 Use `wait-and-widen` and `pulsar-wait-and-widen` in new function metadata,
 `lb-config.json` files, request-algorithm maps, and deployment manifests.

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/config.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/config.rs
@@ -476,10 +476,8 @@ pub struct LoadBalancerConfig {
 }
 
 impl LoadBalancerConfig {
-    /// Fallback when no config file is provided: `power-of-two` for every
-    /// model, with every built-in algorithm selectable per request. An
-    /// explicit config file keeps its restrictive semantics: only the
-    /// algorithms it lists in `request_algorithms` are selectable.
+    /// Config used when no config file is given: `power-of-two` by default,
+    /// and any built-in algorithm can be selected per request.
     pub fn permissive_default() -> Self {
         Self {
             request_algorithms: LoadBalancerAlgorithm::ALL

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/config.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/config.rs
@@ -59,6 +59,17 @@ pub enum LoadBalancerAlgorithm {
     PulsarWaitAndWiden,
 }
 
+impl LoadBalancerAlgorithm {
+    pub const ALL: [Self; 6] = [
+        Self::PowerOfTwo,
+        Self::WaitAndWiden,
+        Self::RoundRobin,
+        Self::Random,
+        Self::Pulsar,
+        Self::PulsarWaitAndWiden,
+    ];
+}
+
 impl fmt::Display for LoadBalancerAlgorithm {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match self {
@@ -462,4 +473,20 @@ pub struct LoadBalancerConfig {
     pub request_algorithms: HashMap<LoadBalancerAlgorithm, LoadBalancerModelConfig>,
     #[serde(default)]
     pub models: HashMap<String, LoadBalancerModelConfig>,
+}
+
+impl LoadBalancerConfig {
+    /// Fallback when no config file is provided: `power-of-two` for every
+    /// model, with every built-in algorithm selectable per request. An
+    /// explicit config file keeps its restrictive semantics: only the
+    /// algorithms it lists in `request_algorithms` are selectable.
+    pub fn permissive_default() -> Self {
+        Self {
+            request_algorithms: LoadBalancerAlgorithm::ALL
+                .iter()
+                .map(|algorithm| (*algorithm, LoadBalancerModelConfig::Name(*algorithm)))
+                .collect(),
+            ..Self::default()
+        }
+    }
 }

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/tests.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/tests.rs
@@ -1418,6 +1418,84 @@ fn unknown_request_override_returns_error() {
 }
 
 #[test]
+fn permissive_default_resolves_every_builtin_algorithm() {
+    let router = LoadBalancerRouter::from_config(&LoadBalancerConfig::permissive_default())
+        .expect("permissive default config should build");
+
+    for algorithm in LoadBalancerAlgorithm::ALL {
+        let algorithm_override = LoadBalancerAlgorithmOverride::parse(&algorithm.to_string())
+            .expect("routing algorithm override should parse");
+        let config = router
+            .resolve_algorithm_override("any-model", Some(&algorithm_override))
+            .expect("every built-in algorithm should resolve");
+        assert_eq!(config.config().algorithm(), algorithm);
+    }
+}
+
+#[test]
+fn permissive_default_resolves_alias_and_underscore_spellings() {
+    let router = LoadBalancerRouter::from_config(&LoadBalancerConfig::permissive_default())
+        .expect("permissive default config should build");
+    let spellings = [
+        ("power_of_two", LoadBalancerAlgorithm::PowerOfTwo),
+        ("round_robin", LoadBalancerAlgorithm::RoundRobin),
+        ("groq-multiregion", LoadBalancerAlgorithm::WaitAndWiden),
+        ("groq_multiregion", LoadBalancerAlgorithm::WaitAndWiden),
+        (
+            "pulsar-multiregion",
+            LoadBalancerAlgorithm::PulsarWaitAndWiden,
+        ),
+        (
+            "pulsar_multiregion",
+            LoadBalancerAlgorithm::PulsarWaitAndWiden,
+        ),
+    ];
+
+    for (spelling, expected) in spellings {
+        let algorithm_override = LoadBalancerAlgorithmOverride::parse(spelling)
+            .expect("routing algorithm override should parse");
+        let config = router
+            .resolve_algorithm_override("any-model", Some(&algorithm_override))
+            .expect("alias spelling should resolve");
+        assert_eq!(config.config().algorithm(), expected, "{spelling}");
+    }
+}
+
+#[test]
+fn permissive_default_keeps_power_of_two_without_override() {
+    let router = LoadBalancerRouter::from_config(&LoadBalancerConfig::permissive_default())
+        .expect("permissive default config should build");
+
+    let config = router
+        .resolve_algorithm_override("any-model", None)
+        .expect("default algorithm should resolve");
+    assert_eq!(
+        config.config().algorithm(),
+        LoadBalancerAlgorithm::PowerOfTwo
+    );
+}
+
+#[test]
+fn explicit_config_stays_restrictive() {
+    let router = router_from_json(
+        r#"{"default":"power-of-two","request_algorithms":{"round-robin":"round-robin"}}"#,
+    );
+    let algorithm_override = LoadBalancerAlgorithmOverride::parse("pulsar")
+        .expect("routing algorithm override should parse");
+
+    let error = router
+        .resolve_algorithm_override("any-model", Some(&algorithm_override))
+        .expect_err("unlisted routing method should stay unavailable");
+    assert_eq!(
+        error,
+        LoadBalancerRoutingAlgorithmError::Unavailable {
+            raw: "pulsar".to_string(),
+            algorithm: LoadBalancerAlgorithm::Pulsar,
+        }
+    );
+}
+
+#[test]
 fn request_excluded_clusters_are_not_selected() {
     let router = router_with_default(LoadBalancerAlgorithm::RoundRobin);
     let target = target_with_model("model-exclusions");

--- a/src/libraries/rust/stargate/crates/stargate/src/main.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/main.rs
@@ -192,7 +192,8 @@ struct Args {
     /// Skip QUIC TLS certificate verification for outbound connections and relays.
     #[arg(long, default_value_t = false, env = "STARGATE_QUIC_INSECURE")]
     quic_insecure: bool,
-    /// Path to load balancer config JSON file (uses power-of-two default if omitted)
+    /// Path to load balancer config JSON file. If omitted, uses power-of-two
+    /// with every built-in algorithm selectable per request.
     #[arg(long, value_name = "PATH")]
     lb_config_path: Option<String>,
     /// OTLP/gRPC trace export endpoint. Tracing export is disabled if omitted.

--- a/src/libraries/rust/stargate/crates/stargate/src/runtime.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/runtime.rs
@@ -284,7 +284,6 @@ impl StargateRuntime {
         );
         info!(
             default_lb = %lb_config.default,
-            request_algorithms = lb_config.request_algorithms.len(),
             model_overrides = lb_config.models.len(),
             "load balancer config loaded"
         );

--- a/src/libraries/rust/stargate/crates/stargate/src/runtime.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/runtime.rs
@@ -276,7 +276,7 @@ impl StargateRuntime {
                 serde_json::from_slice::<LoadBalancerConfig>(&bytes)
                     .with_context(|| format!("failed to parse lb config file: {path}"))?
             }
-            None => LoadBalancerConfig::default(),
+            None => LoadBalancerConfig::permissive_default(),
         };
         let lb_router = Arc::new(
             LoadBalancerRouter::from_config(&lb_config)
@@ -284,6 +284,7 @@ impl StargateRuntime {
         );
         info!(
             default_lb = %lb_config.default,
+            request_algorithms = lb_config.request_algorithms.len(),
             model_overrides = lb_config.models.len(),
             "load balancer config loaded"
         );

--- a/src/libraries/rust/stargate/docs/load-balancer-configuration.md
+++ b/src/libraries/rust/stargate/docs/load-balancer-configuration.md
@@ -16,12 +16,14 @@ Start Stargate with an optional JSON file:
 ```
 
 When the argument is absent, Stargate uses `power-of-two` for every model and
-accepts every built-in algorithm, with its default settings, as a
-routing-method override. When the argument is present, a request can select
-only the effective algorithm or an algorithm listed in `request_algorithms`.
-Stargate reads and validates the file during startup. A missing file, invalid JSON, unknown top-level field, unsupported
-algorithm field, or invalid algorithm factory configuration prevents startup.
-Stargate does not reload the file after startup.
+accepts a routing-method override when it is in the allowlist of built-in
+algorithms, each with its default settings. When the argument is present, the
+file defines the allowlist: a request can select only the effective algorithm
+or an algorithm listed in `request_algorithms`.
+Stargate reads and validates the file during startup. A missing file, invalid
+JSON, unknown top-level field, unsupported algorithm field, or invalid
+algorithm factory configuration prevents startup. Stargate does not reload
+the file after startup.
 
 ## Schema
 

--- a/src/libraries/rust/stargate/docs/load-balancer-configuration.md
+++ b/src/libraries/rust/stargate/docs/load-balancer-configuration.md
@@ -16,11 +16,10 @@ Start Stargate with an optional JSON file:
 ```
 
 When the argument is absent, Stargate uses `power-of-two` for every model and
-accepts every built-in algorithm as a routing-method override. When the
-argument is present, only the algorithms the file lists in
-`request_algorithms` are selectable per request.
-Stargate reads and validates the file during
-startup. A missing file, invalid JSON, unknown top-level field, unsupported
+accepts every built-in algorithm, with its default settings, as a
+routing-method override. When the argument is present, a request can select
+only the effective algorithm or an algorithm listed in `request_algorithms`.
+Stargate reads and validates the file during startup. A missing file, invalid JSON, unknown top-level field, unsupported
 algorithm field, or invalid algorithm factory configuration prevents startup.
 Stargate does not reload the file after startup.
 

--- a/src/libraries/rust/stargate/docs/load-balancer-configuration.md
+++ b/src/libraries/rust/stargate/docs/load-balancer-configuration.md
@@ -15,8 +15,11 @@ Start Stargate with an optional JSON file:
 --lb-config-path=/config/lb-config.json
 ```
 
-When the argument is absent, Stargate uses `power-of-two` for every model.
-When the argument is present, Stargate reads and validates the file during
+When the argument is absent, Stargate uses `power-of-two` for every model and
+accepts every built-in algorithm as a routing-method override. When the
+argument is present, only the algorithms the file lists in
+`request_algorithms` are selectable per request.
+Stargate reads and validates the file during
 startup. A missing file, invalid JSON, unknown top-level field, unsupported
 algorithm field, or invalid algorithm factory configuration prevents startup.
 Stargate does not reload the file after startup.

--- a/src/libraries/rust/stargate/docs/load-balancer-configuration.md
+++ b/src/libraries/rust/stargate/docs/load-balancer-configuration.md
@@ -18,8 +18,7 @@ Start Stargate with an optional JSON file:
 When the argument is absent, Stargate uses `power-of-two` for every model and
 accepts a routing-method override when it is in the allowlist of built-in
 algorithms, each with its default settings. When the argument is present, the
-file defines the allowlist: a request can select only the effective algorithm
-or an algorithm listed in `request_algorithms`.
+file defines the allowlist.
 Stargate reads and validates the file during startup. A missing file, invalid
 JSON, unknown top-level field, unsupported algorithm field, or invalid
 algorithm factory configuration prevents startup. Stargate does not reload


### PR DESCRIPTION
## TL;DR

A Stargate router started without `--lb-config-path` rejected every
routing-method override except `power-of-two` with an empty 400, because the
default load balancer config has an empty `request_algorithms` allowlist.
Routers without a config file now accept an override when it is in the
allowlist of built-in algorithms, with `power-of-two` still the default.

## Additional Details

- `LoadBalancerConfig::permissive_default()` seeds `request_algorithms` with
  every `LoadBalancerAlgorithm` variant and replaces the plain default in the
  no-config startup path.
- Docs updated for the new no-config behavior: the Stargate load-balancer
  reference and the two user docs.

## For the Reviewer

The behavior change is two lines (`config.rs`, `runtime.rs`); the rest is
tests and doc updates. Tests cover all six algorithms, the deprecated alias
and underscore spellings, the unchanged no-override default, and that an
explicit config file still rejects unlisted algorithms.

## For QA

- QA verification: on a staging router built from this change, invoke an LLM
  function once per supported `routingMethod` value; every value should
  return 200 where previously only `power-of-two` did.

## Issues

NVBUG-6556615

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stargate now defaults to power-of-two load balancing while allowing request-level selection of any built-in routing algorithm.
  * Supported aliases, including the legacy `groq_multiregion` name and underscore spellings, are accepted for overrides.
  * Configured load balancers restrict routing choices to explicitly enabled algorithms.

* **Documentation**
  * Updated user guides, configuration documentation, CLI help, and troubleshooting guidance to clarify routing defaults, overrides, conditional configuration checks, and reload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->