### PR TITLE
ci: point shared actions at current repository

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -112,7 +112,7 @@ jobs:
           persist-credentials: false
 
       - name: CodeQL Analysis
-        uses: NVIDIA/dsx-github-actions/.github/actions/codeql-scan@9a9ce3a7770a8b53d2726afa920be3276bc3ddd7
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/codeql-scan@9a9ce3a7770a8b53d2726afa920be3276bc3ddd7
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run TruffleHog Scan
         # No repository secrets or custom env vars are required; PR comments are disabled.
-        uses: NVIDIA/dsx-github-actions/.github/actions/trufflehog-scan@9a9ce3a7770a8b53d2726afa920be3276bc3ddd7
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/trufflehog-scan@9a9ce3a7770a8b53d2726afa920be3276bc3ddd7
         with:
           # On merge_group there is no push/PR context for TruffleHog to derive a
           # diff range from, so it errors with "BASE == HEAD" and fails the gate,


### PR DESCRIPTION
## Summary

- Point the shared CodeQL and TruffleHog actions at `dsx-ai-factory/dsx-github-actions` after the repository transfer.
- Preserve both action paths and their pinned commit SHA.

## Impact

This is a repository-owner path update only. It does not change action versions or workflow behavior.

## Validation

- Confirmed the diff contains only the two expected `uses:` owner changes.
- Confirmed there are no remaining `NVIDIA/dsx-github-actions` references and exactly two `dsx-ai-factory/dsx-github-actions` references.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning workflows to use the maintained internal action sources.
  * Preserved existing scan configurations and pinned versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->