### PR TITLE
fix(nvca): use nvcf-core BYOO collector images

### DIFF
--- a/deploy/helm/nvca-operator/nvca-operator/templates/_helpers.tpl
+++ b/deploy/helm/nvca-operator/nvca-operator/templates/_helpers.tpl
@@ -165,9 +165,9 @@ Usage: {{ include "nvcaop.byooOtelCollectorImage" . }}
 {{- if .imageRepository -}}
 {{- .imageRepository -}}
 {{- else if hasPrefix "stg.nvcr.io/nvidia/nvcf-byoc" .defaultRepository -}}
-stg.nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector
+stg.nvcr.io/nv-cf/nvcf-core/byoo-otel-collector
 {{- else -}}
-nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector
+nvcr.io/qtfpt1h0bieu/nvcf-core/byoo-otel-collector
 {{- end -}}
 {{- end -}}
 

--- a/deploy/helm/nvca-operator/tests/self_managed_nvca_image_reference_test.sh
+++ b/deploy/helm/nvca-operator/tests/self_managed_nvca_image_reference_test.sh
@@ -207,14 +207,14 @@ if [[ "${byoo_function_image}" != "${byoo_task_image}" ]]; then
   exit 1
 fi
 
-if [[ "${byoo_function_image}" != "nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector:0.157.11" ]]; then
+if [[ "${byoo_function_image}" != "nvcr.io/qtfpt1h0bieu/nvcf-core/byoo-otel-collector:0.157.11" ]]; then
   echo "unexpected BYOO collector default: ${byoo_function_image}" >&2
   exit 1
 fi
 
-if [[ "${stage_byoo_function_image}" != "stg.nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector:0.157.11" || \
+if [[ "${stage_byoo_function_image}" != "stg.nvcr.io/nv-cf/nvcf-core/byoo-otel-collector:0.157.11" || \
   "${stage_byoo_task_image}" != "${stage_byoo_function_image}" ]]; then
-  echo "expected BYOO collector defaults to use the staging image repository" >&2
+  echo "expected BYOO collector defaults to use the staging nvcf-core image repository" >&2
   exit 1
 fi
 

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/templates/_helpers.tpl
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/templates/_helpers.tpl
@@ -165,9 +165,9 @@ Usage: {{ include "nvcaop.byooOtelCollectorImage" . }}
 {{- if .imageRepository -}}
 {{- .imageRepository -}}
 {{- else if hasPrefix "stg.nvcr.io/nvidia/nvcf-byoc" .defaultRepository -}}
-stg.nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector
+stg.nvcr.io/nv-cf/nvcf-core/byoo-otel-collector
 {{- else -}}
-nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector
+nvcr.io/qtfpt1h0bieu/nvcf-core/byoo-otel-collector
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
## TL;DR

Use the release-published `nvcf-core` repositories for default BYOO collector images so worker-sidecar credentials can pull them.

## Why

The NVCA chart derived the BYOO collector repository from the operator staging repository. That selected a repository outside the credential scope provided to worker sidecars, causing image pulls to fail when the default was used.

## What changed

- Updated the staging and production BYOO collector defaults in both the authoritative NVCA source and the vendored chart copy.
- Preserved the explicit `agent.byooOtelCollector.imageRepository` override.
- Updated chart tests to pin both derived defaults and the collector tag.

## Customer Release Notes

Fixed default BYOO OpenTelemetry collector image pulls for self-managed deployments.

## Plan Summary

The chart changes only the default collector repository. No Kubernetes resources, limits, or replica counts change.

## Usage

No operator action is required when using chart defaults. Explicit repository overrides continue to work.

## Testing

- `helm lint deploy/helm/nvca-operator/nvca-operator`
- `deploy/helm/nvca-operator/tests/self_managed_nvca_image_reference_test.sh`
- `deploy/helm/nvca-operator/tests/release_image_manifest_test.sh`
- `deploy/helm/nvca-operator/tests/image_pull_secret_defaults_test.sh`
- `.cursor/hooks/validate-skill-fanout.py`

QA is not needed beyond the existing chart validation.

## Notes

`cluster_source_defaults_test.sh` has a pre-existing failure that reproduces on `origin/main`; it is unrelated to this change.

## For the Reviewer

Please focus on the repository selection branches in the two `_helpers.tpl` copies and their exact-value assertions.

## For QA

No additional QA is needed.

## Issues

Fixes #804

## References

- https://github.com/NVIDIA/nvcf/issues/804

## Related Pull Requests

None.

## Dependencies

None.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default OpenTelemetry collector image locations for staging and production deployments.
  * Corrected image references used by deployment validation checks.
  * Existing custom image repository overrides remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->