### PR TITLE
fix(self-managed): bump ess-api chart pin to 1.7.2

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -99,7 +99,7 @@ releases:
       - nvcf/api
 
   - name: ess-api
-    version: 1.7.0
+    version: 1.7.2
     namespace: ess
     inherit:
       - template: service


### PR DESCRIPTION
## TL;DR
Bump the `ess-api` chart version pinned by the self-managed stack from `1.7.0` to `1.7.2` so a stack install pulls the current ESS API chart.

## Why
The self-managed Helmfile pins each service chart by version. The `ess-api` release was still on `1.7.0`. The ESS chart line has moved forward (appVersion aligned to the ESS `0.4.13` service image), so the stack should consume the newer chart.

## What changed
- `deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl`: `ess-api` release `version: 1.7.0` -> `1.7.2`. No other releases touched.

## Customer Release Notes
Self-managed stack now deploys ESS API chart 1.7.2.

## Plan Summary
Single chart-version pin change. No template or values changes. Rendered topology is unchanged apart from the ess-api chart version.

## Usage
Not applicable (picked up automatically by `make -C deploy/stacks/self-managed install`).

## Testing
`helm lint`/`helm template` for the ess-api chart pass locally. Full stack render/install requires NGC credentials and a k3d cluster (not run here). The `deploy/stacks/self-managed` OCI pull of `helm-nvcf-ess-api:1.7.2` requires that chart version to be published in the registry.

## Notes
Depends on ESS chart `1.7.2` being published to the OCI registry. That release is produced by the ess-helm release automation once #791 (which bumps the chart appVersion) merges and tags `deploy/helm/encrypted-secret-store/v1.7.2`. Do not merge/deploy this stack bump before `1.7.2` is available in the registry, or the install will fail to pull the chart.

## References
None

## Related Pull Requests
- #791 (ess-helm appVersion bump that drives the chart 1.7.2 release)

## Dependencies
None

## Issues
Relates to #747

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the self-managed deployment to use ESS API version 1.7.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->