### PR TITLE
fix(cli): reject negative account quota flags before sending PATCH

### DIFF
--- a/src/clis/nvcf-cli/cmd/admin.go
+++ b/src/clis/nvcf-cli/cmd/admin.go
@@ -210,10 +210,10 @@ func init() {
 	// Account update flags
 	accountsUpdateCmd.Flags().StringVar(&accountUpdateFlags.ncaId, "nca-id", "", "NVIDIA Cloud Account ID (required)")
 	accountsUpdateCmd.Flags().StringVar(&accountUpdateFlags.name, "name", "", "Human readable account/customer name (4-36 chars)")
-	accountsUpdateCmd.Flags().IntVar(&accountUpdateFlags.maxFunctions, "max-functions", -1, "Maximum number of functions allowed")
-	accountsUpdateCmd.Flags().IntVar(&accountUpdateFlags.maxTasks, "max-tasks", -1, "Maximum number of tasks allowed")
-	accountsUpdateCmd.Flags().IntVar(&accountUpdateFlags.maxTelemetries, "max-telemetries", -1, "Maximum number of telemetries allowed (max: 50)")
-	accountsUpdateCmd.Flags().IntVar(&accountUpdateFlags.maxRegistryCredentials, "max-registry-credentials", -1, "Maximum number of registry credentials allowed (max: 50)")
+	accountsUpdateCmd.Flags().IntVar(&accountUpdateFlags.maxFunctions, "max-functions", 0, "Maximum number of functions allowed")
+	accountsUpdateCmd.Flags().IntVar(&accountUpdateFlags.maxTasks, "max-tasks", 0, "Maximum number of tasks allowed")
+	accountsUpdateCmd.Flags().IntVar(&accountUpdateFlags.maxTelemetries, "max-telemetries", 0, "Maximum number of telemetries allowed (max: 50)")
+	accountsUpdateCmd.Flags().IntVar(&accountUpdateFlags.maxRegistryCredentials, "max-registry-credentials", 0, "Maximum number of registry credentials allowed (max: 50)")
 	accountsUpdateCmd.MarkFlagRequired("nca-id")
 
 	// Secret update function flags
@@ -308,7 +308,7 @@ func runAccountsList(cmd *cobra.Command, args []string) error {
 }
 
 func runAccountsUpdate(cmd *cobra.Command, args []string) error {
-	req, err := buildAccountUpdateRequest()
+	req, err := buildAccountUpdateRequest(cmd)
 	if err != nil {
 		return err
 	}
@@ -555,29 +555,46 @@ func warnInlineSecrets(used bool) {
 // buildAccountUpdateRequest validates the at-least-one-field rule and
 // constructs the AccountUpdateRequest from accountUpdateFlags. Extracted
 // to keep runAccountsUpdate below the cognitive-complexity threshold.
-func buildAccountUpdateRequest() (*client.AccountUpdateRequest, error) {
-	if accountUpdateFlags.name == "" && accountUpdateFlags.maxFunctions == -1 &&
-		accountUpdateFlags.maxTasks == -1 && accountUpdateFlags.maxTelemetries == -1 &&
-		accountUpdateFlags.maxRegistryCredentials == -1 {
+//
+// Flag presence is determined via cmd.Flags().Changed rather than a
+// sentinel default value, so a negative quota (e.g. --max-functions -2) is
+// rejected with a flag-specific error instead of being silently dropped
+// from the request.
+func buildAccountUpdateRequest(cmd *cobra.Command) (*client.AccountUpdateRequest, error) {
+	if accountUpdateFlags.name == "" && !cmd.Flags().Changed("max-functions") &&
+		!cmd.Flags().Changed("max-tasks") && !cmd.Flags().Changed("max-telemetries") &&
+		!cmd.Flags().Changed("max-registry-credentials") {
 		return nil, fmt.Errorf("at least one update field must be provided (--name, --max-functions, --max-tasks, --max-telemetries, --max-registry-credentials)")
 	}
 	req := &client.AccountUpdateRequest{}
 	if accountUpdateFlags.name != "" {
 		req.Name = accountUpdateFlags.name
 	}
-	if accountUpdateFlags.maxFunctions >= 0 {
+	if cmd.Flags().Changed("max-functions") {
+		if accountUpdateFlags.maxFunctions < 0 {
+			return nil, fmt.Errorf("--max-functions must be greater than or equal to 0")
+		}
 		req.MaxFunctionsAllowed = &accountUpdateFlags.maxFunctions
 	}
-	if accountUpdateFlags.maxTasks >= 0 {
+	if cmd.Flags().Changed("max-tasks") {
+		if accountUpdateFlags.maxTasks < 0 {
+			return nil, fmt.Errorf("--max-tasks must be greater than or equal to 0")
+		}
 		req.MaxTasksAllowed = &accountUpdateFlags.maxTasks
 	}
-	if accountUpdateFlags.maxTelemetries >= 0 {
+	if cmd.Flags().Changed("max-telemetries") {
+		if accountUpdateFlags.maxTelemetries < 0 {
+			return nil, fmt.Errorf("--max-telemetries must be greater than or equal to 0")
+		}
 		if accountUpdateFlags.maxTelemetries > 50 {
 			return nil, fmt.Errorf("max-telemetries cannot exceed 50")
 		}
 		req.MaxTelemetriesAllowed = &accountUpdateFlags.maxTelemetries
 	}
-	if accountUpdateFlags.maxRegistryCredentials >= 0 {
+	if cmd.Flags().Changed("max-registry-credentials") {
+		if accountUpdateFlags.maxRegistryCredentials < 0 {
+			return nil, fmt.Errorf("--max-registry-credentials must be greater than or equal to 0")
+		}
 		if accountUpdateFlags.maxRegistryCredentials > 50 {
 			return nil, fmt.Errorf("max-registry-credentials cannot exceed 50")
 		}

--- a/src/clis/nvcf-cli/cmd/admin_test.go
+++ b/src/clis/nvcf-cli/cmd/admin_test.go
@@ -29,10 +29,35 @@ import (
 
 	"nvcf-cli/internal/client"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// newAccountsUpdateTestCmd builds a throwaway *cobra.Command carrying the
+// same flag set as accountsUpdateCmd, bound to a fresh accountUpdateFlags
+// value. Using a fresh command per test avoids Changed() state leaking
+// across tests via the package-level singleton.
+func newAccountsUpdateTestCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+	accountUpdateFlags = struct {
+		ncaId                  string
+		name                   string
+		maxFunctions           int
+		maxTasks               int
+		maxTelemetries         int
+		maxRegistryCredentials int
+	}{}
+	cmd := &cobra.Command{Use: "update"}
+	cmd.Flags().StringVar(&accountUpdateFlags.ncaId, "nca-id", "", "")
+	cmd.Flags().StringVar(&accountUpdateFlags.name, "name", "", "")
+	cmd.Flags().IntVar(&accountUpdateFlags.maxFunctions, "max-functions", 0, "")
+	cmd.Flags().IntVar(&accountUpdateFlags.maxTasks, "max-tasks", 0, "")
+	cmd.Flags().IntVar(&accountUpdateFlags.maxTelemetries, "max-telemetries", 0, "")
+	cmd.Flags().IntVar(&accountUpdateFlags.maxRegistryCredentials, "max-registry-credentials", 0, "")
+	return cmd
+}
 
 // Note: the NVCF_CLI_ENABLE_ADMIN env guard is evaluated in init() at package
 // import time, so it cannot be re-exercised after the test binary starts. The
@@ -156,11 +181,13 @@ func TestRunQueuesVersion_JSON(t *testing.T) {
 	queueFlags.ncaId = "nca-1"
 	queueFlags.functionId = "fn-1"
 	queueFlags.versionId = "ver-1"
-	t.Cleanup(func() { queueFlags = struct {
-		ncaId      string
-		functionId string
-		versionId  string
-	}{} })
+	t.Cleanup(func() {
+		queueFlags = struct {
+			ncaId      string
+			functionId string
+			versionId  string
+		}{}
+	})
 
 	output := captureStdout(t, func() {
 		require.NoError(t, runQueuesVersion(nil, nil))
@@ -193,14 +220,16 @@ func TestRunSecretsUpdateFunction_JSONEnvelope(t *testing.T) {
 	secretUpdateFlags.functionId = "fn-1"
 	secretUpdateFlags.versionId = "ver-1"
 	secretUpdateFlags.secretsJSON = `{"FOO":"bar"}`
-	t.Cleanup(func() { secretUpdateFlags = struct {
-		ncaId       string
-		functionId  string
-		versionId   string
-		telemetryId string
-		inputFile   string
-		secretsJSON string
-	}{} })
+	t.Cleanup(func() {
+		secretUpdateFlags = struct {
+			ncaId       string
+			functionId  string
+			versionId   string
+			telemetryId string
+			inputFile   string
+			secretsJSON string
+		}{}
+	})
 
 	output := captureStdout(t, func() {
 		require.NoError(t, runSecretsUpdateFunction(nil, nil))
@@ -236,4 +265,142 @@ func TestRunAccountsList_HumanOutput(t *testing.T) {
 	var parsed map[string]any
 	assert.Error(t, json.Unmarshal([]byte(output), &parsed),
 		"human output should not be valid JSON")
+}
+
+func TestBuildAccountUpdateRequest_NoFieldsProvided(t *testing.T) {
+	cmd := newAccountsUpdateTestCmd(t)
+
+	req, err := buildAccountUpdateRequest(cmd)
+	require.Error(t, err)
+	assert.Nil(t, req)
+	assert.Contains(t, err.Error(), "at least one update field must be provided")
+}
+
+func TestBuildAccountUpdateRequest_ValidQuotas(t *testing.T) {
+	cmd := newAccountsUpdateTestCmd(t)
+	require.NoError(t, cmd.Flags().Set("max-functions", "5"))
+	require.NoError(t, cmd.Flags().Set("max-tasks", "3"))
+	require.NoError(t, cmd.Flags().Set("max-telemetries", "10"))
+	require.NoError(t, cmd.Flags().Set("max-registry-credentials", "2"))
+
+	req, err := buildAccountUpdateRequest(cmd)
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	require.NotNil(t, req.MaxFunctionsAllowed)
+	require.NotNil(t, req.MaxTasksAllowed)
+	require.NotNil(t, req.MaxTelemetriesAllowed)
+	require.NotNil(t, req.MaxRegistryCredentialsAllowed)
+	assert.Equal(t, 5, *req.MaxFunctionsAllowed)
+	assert.Equal(t, 3, *req.MaxTasksAllowed)
+	assert.Equal(t, 10, *req.MaxTelemetriesAllowed)
+	assert.Equal(t, 2, *req.MaxRegistryCredentialsAllowed)
+}
+
+func TestBuildAccountUpdateRequest_ZeroIsAllowed(t *testing.T) {
+	// 0 is a legitimate quota value, not the "unset" sentinel: it must
+	// reach the request when the flag is explicitly passed.
+	cmd := newAccountsUpdateTestCmd(t)
+	require.NoError(t, cmd.Flags().Set("max-functions", "0"))
+
+	req, err := buildAccountUpdateRequest(cmd)
+	require.NoError(t, err)
+	require.NotNil(t, req.MaxFunctionsAllowed)
+	assert.Equal(t, 0, *req.MaxFunctionsAllowed)
+}
+
+func TestBuildAccountUpdateRequest_NegativeQuota_RejectedPerFlag(t *testing.T) {
+	tests := []struct {
+		flag        string
+		wantErrText string
+	}{
+		{"max-functions", "--max-functions must be greater than or equal to 0"},
+		{"max-tasks", "--max-tasks must be greater than or equal to 0"},
+		{"max-telemetries", "--max-telemetries must be greater than or equal to 0"},
+		{"max-registry-credentials", "--max-registry-credentials must be greater than or equal to 0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.flag, func(t *testing.T) {
+			cmd := newAccountsUpdateTestCmd(t)
+			require.NoError(t, cmd.Flags().Set(tt.flag, "-2"))
+
+			req, err := buildAccountUpdateRequest(cmd)
+			require.Error(t, err)
+			assert.Nil(t, req)
+			assert.Equal(t, tt.wantErrText, err.Error())
+		})
+	}
+}
+
+func TestBuildAccountUpdateRequest_QuotaAboveMax_Rejected(t *testing.T) {
+	tests := []struct {
+		flag        string
+		wantErrText string
+	}{
+		{"max-telemetries", "max-telemetries cannot exceed 50"},
+		{"max-registry-credentials", "max-registry-credentials cannot exceed 50"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.flag, func(t *testing.T) {
+			cmd := newAccountsUpdateTestCmd(t)
+			require.NoError(t, cmd.Flags().Set(tt.flag, "51"))
+
+			req, err := buildAccountUpdateRequest(cmd)
+			require.Error(t, err)
+			assert.Nil(t, req)
+			assert.Equal(t, tt.wantErrText, err.Error())
+		})
+	}
+}
+
+func TestRunAccountsUpdate_NegativeQuota_NoRequestSent(t *testing.T) {
+	// Regression test for the empty-PATCH bug: a negative quota flag must
+	// be rejected client-side before any HTTP request reaches the backend.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected request sent to backend: %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	configureAdminTest(t, srv.URL)
+
+	cmd := newAccountsUpdateTestCmd(t)
+	accountUpdateFlags.ncaId = "nca-1"
+	require.NoError(t, cmd.Flags().Set("max-functions", "-2"))
+
+	err := runAccountsUpdate(cmd, nil)
+	require.Error(t, err)
+	assert.Equal(t, "--max-functions must be greater than or equal to 0", err.Error())
+}
+
+func TestRunAccountsUpdate_ValidQuota_SendsPatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/v2/nvcf/accounts/nca-1", r.URL.Path)
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(body, &parsed))
+		assert.Equal(t, float64(5), parsed["maxFunctionsAllowed"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"account":{"ncaId":"nca-1","name":"Acme","maxFunctionsAllowed":5,"maxTasksAllowed":3,"maxTelemetriesAllowed":2,"maxRegistryCredentialsAllowed":1,"adminClientIds":[]}}`))
+	}))
+	defer srv.Close()
+
+	configureAdminTest(t, srv.URL)
+	withJSONOutput(t)
+
+	cmd := newAccountsUpdateTestCmd(t)
+	accountUpdateFlags.ncaId = "nca-1"
+	require.NoError(t, cmd.Flags().Set("max-functions", "5"))
+
+	output := captureStdout(t, func() {
+		require.NoError(t, runAccountsUpdate(cmd, nil))
+	})
+
+	var parsed map[string]map[string]any
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed))
+	assert.Equal(t, "nca-1", parsed["account"]["ncaId"])
 }


### PR DESCRIPTION
## TL;DR
Fixes `nvcf-cli admin accounts update` silently dropping negative quota values (e.g. `--max-functions -2`) instead of rejecting them, which previously caused an empty PATCH request and a confusing backend error.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
The four quota flags (`--max-functions`, `--max-tasks`, `--max-telemetries`, `--max-registry-credentials`) used `-1` as an int flag default to mean "not passed," then only added the field to the request when the value was `>= 0`. A user-supplied negative value was indistinguishable from "not passed" under that check, so it was silently dropped. If it was the only flag given, the CLI sent an empty PATCH and surfaced the backend's generic `Either name, credential fields or limits should be specified` error instead of identifying the invalid flag.

`buildAccountUpdateRequest` now takes the `*cobra.Command` and uses `cmd.Flags().Changed(...)` to detect whether a flag was actually passed, then explicitly rejects negative values per flag with a message like `--max-functions must be greater than or equal to 0` before any request is built. This mirrors the existing `--min-instances` validation pattern in `cmd/deploy.go`. Flag defaults changed from `-1` to `0` since `0` is now a legitimate "unset" default rather than a sentinel.

## For the Reviewer
Main change is in `src/clis/nvcf-cli/cmd/admin.go` (`buildAccountUpdateRequest`, `runAccountsUpdate`). Tests added in `src/clis/nvcf-cli/cmd/admin_test.go`.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
- Added unit tests in `admin_test.go` covering: no fields provided, valid quotas, `0` as an explicit legitimate value, negative values rejected per flag (all four flags), values exceeding the 50 cap, and a regression test asserting no HTTP request is sent when a negative quota is passed.
- `go build ./...` and `go test ./cmd/...` pass for the changed package.
- Verified live against a local self-managed k3d cluster: reproduced the original bug on the pre-fix binary (`--max-functions=-2` sent an empty PATCH and returned the generic 400), then confirmed the fixed binary rejects all four flags client-side with no request sent, and that a valid update (`--max-functions 50`) still round-trips correctly end-to-end.

## Issues
NO-REF

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes. (no user-facing docs changes needed; behavior now matches documented flag semantics)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Account quota updates now correctly support explicit zero values.
  * Negative quota values are rejected with clear, field-specific validation errors.
  * Existing maximum quota limits remain enforced.
  * Invalid quota updates are blocked before any request is sent.

* **Tests**
  * Added coverage for valid, zero, negative, maximum, and missing quota values.
  * Added verification for successful account update requests and JSON output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->