### PR TITLE
feat(charts): port the notary helm chart into the monorepo

### DIFF
--- a/deploy/helm/notary/.gitignore
+++ b/deploy/helm/notary/.gitignore
@@ -1,0 +1,5 @@
+vault-secrets.json
+nvcr.io.txt
+
+
+bin/

--- a/deploy/helm/notary/.gitignore
+++ b/deploy/helm/notary/.gitignore
@@ -3,3 +3,4 @@ nvcr.io.txt
 
 
 bin/
+packaged-charts/

--- a/deploy/helm/notary/AGENTS.md
+++ b/deploy/helm/notary/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Repo Role
+- Repo: `NVIDIA/nvcf` (chart lives at `deploy/helm/notary`)
+- Workspace(s): `self-hosted-nvcf`
+- Tier: `chart`
+- Team: `@NVIDIA/nvcf-dev`
+- Default owner: `@NVIDIA/nvcf-dev`.
+- Manifest description: Helm chart for notary service (helm-nvcf-notary-service)
+
+## Use `nvcf-agentic-dev` As The Routing Layer
+Before making changes, use the `nvcf-agentic-dev` workspace repo to confirm whether this repo is actually the right place for the task. Treat that repo as the source of truth for workspace membership, repo ownership, deployment dependencies, and available agent skills.
+
+Check these files first when they exist in your local workspace:
+- `nvcf-agentic-dev/workspaces/self-hosted-nvcf/repos.yaml`: repo ownership and workspace membership
+- `nvcf-agentic-dev/workspaces/self-hosted-nvcf/skills.yaml`: related agent skills and sourced commands
+- `nvcf-agentic-dev/workspaces/self-hosted-nvcf/docs/deployment-sequence.md`: deployment order and stage gates
+- `nvcf-agentic-dev/workspaces/self-hosted-nvcf/docs/deployment-dependencies-with-links.yaml`: release dependencies and upstream/downstream links
+
+## Routing Rules
+- Stay in this repo for Helm templates, values, hooks, chart metadata, and Kubernetes deployment behavior.
+- If the request is about application logic, APIs, jobs, or binaries running inside the container, route to the paired image-source repo.
+- If the request is about cross-chart ordering, stage selection, or environment-wide configuration, route to `nvcf-self-managed-stack`.
+
+## Working In This Repo
+- Read this repo’s top-level `README*`, build files, and CI config before making assumptions about language or tooling.
+- Search for existing patterns with `rg` before adding new structure.
+- Keep changes scoped to the owning repo once routing is confirmed; only fan out when the workspace docs show an explicit dependency.
+
+## Completion Expectations
+- Validate with the repo-native command set if one exists (`make`, Maven, Helm, npm, etc.).
+- If you change cross-repo behavior, mention the adjacent repo(s) that may also need follow-up.
+- In your final summary, state that routing was confirmed through `nvcf-agentic-dev` and name the workspace context used.

--- a/deploy/helm/notary/CLAUDE.md
+++ b/deploy/helm/notary/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/deploy/helm/notary/Makefile
+++ b/deploy/helm/notary/Makefile
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Variables
+release ?= notary
+namespace ?= nvcf
+helm_dir ?= ./nvcf-notary-service
+values := $(helm_dir)/values.yaml
+# CI-only values for lint/template, shared with the chart validation job.
+validation_values ?= ../../../tools/ci/helm-validate-values/notary.yaml
+
+# OPTIONAL for deploy target: Path to an additional Helm values file.
+# Example: make deploy values=my-values.yaml additional_values=override.yaml
+additional_values ?= 
+
+# OCI Registry details
+OCI_REGISTRY_HOST ?= nvcr.io
+OCI_REGISTRY_NAMESPACE ?= 0651155215864979/ncp-dev
+
+# Automatically determine chart name and version from Chart.yaml
+# IMPORTANT: For this setup, CHART_NAME is expected to include any desired OCI prefix (e.g., "helm-yourchart")
+# as defined in helm/Chart.yaml's 'name' field.
+CHART_NAME := $(shell yq -r .name $(helm_dir)/Chart.yaml)
+CHART_VERSION := $(shell yq -r .version $(helm_dir)/Chart.yaml)
+
+.PHONY: install uninstall status lint template validate clean package push-oci
+
+install:
+ifndef values
+	$(error "values" variable is not set. Please specify with 'make deploy values=<path-to-your-values.yaml>')
+endif
+	@echo "Deploying $(release) to namespace $(namespace) using values file '$(values)'..."
+	@echo "Additional values file: '$(if $(additional_values),$(additional_values),N/A)'"
+	helm install $(release) $(helm_dir) \
+		--namespace $(namespace) \
+		--values $(values) \
+		$(if $(additional_values),--values $(additional_values),) \
+		--atomic \
+		--create-namespace \
+		--wait \
+		--wait-for-jobs \
+		--timeout 20m
+
+uninstall:
+	@echo "Deleting $(release) from namespace $(namespace)..."
+	helm uninstall $(release) --namespace $(namespace)
+
+status:
+	@echo "Checking status of $(release) in namespace $(namespace)..."
+	helm status $(release) --namespace $(namespace)
+
+lint:
+	@echo "Linting chart $(helm_dir)..."
+	helm lint $(helm_dir) \
+		$(if $(validation_values),--values $(validation_values),) \
+		$(if $(additional_values),--values $(additional_values),)
+
+template:
+	@echo "Templating chart $(helm_dir)..."
+	@mkdir -p bin
+	helm template $(release) $(helm_dir) \
+		--namespace $(namespace) \
+		$(if $(validation_values),--values $(validation_values),) \
+		$(if $(additional_values),--values $(additional_values),) \
+		> bin/manifest.yaml
+	@echo "Rendered manifest to bin/manifest.yaml"
+
+validate: template
+	@echo "Validating manifest with kubeconform..."
+	@kubeconform -strict -summary -output pretty -kubernetes-version 1.31.5 bin/manifest.yaml
+
+
+# Publish Chart
+# NOTE: this is manual until the CI pipeline is updated to push the chart to the NVCR OCI registry
+clean:
+	rm -rf ./bin
+	rm -rf ./packaged-charts
+
+package: clean lint
+	@echo "[package] Packaging Helm chart $(CHART_NAME) version $(CHART_VERSION)..."
+	@mkdir -p ./packaged-charts
+	@helm package $(helm_dir) -d ./packaged-charts/
+	@echo "[package] Packaged chart to ./packaged-charts/$(CHART_NAME)-$(CHART_VERSION).tgz"
+
+push-oci:
+	@echo "[push-oci] Pushing chart $(CHART_NAME) version $(CHART_VERSION) to oci://$(OCI_REGISTRY_HOST)/$(OCI_REGISTRY_NAMESPACE)/$(CHART_NAME):$(CHART_VERSION)"
+	@echo "[push-oci] Note: You must be logged into oci://$(OCI_REGISTRY_HOST) for the push to succeed."
+	@if [ ! -f ./packaged-charts/$(CHART_NAME)-$(CHART_VERSION).tgz ]; then \
+		echo "[push-oci] Error: Packaged chart ./packaged-charts/$(CHART_NAME)-$(CHART_VERSION).tgz not found. Run 'make package' first."; \
+		exit 1; \
+	fi
+	@helm push ./packaged-charts/$(CHART_NAME)-$(CHART_VERSION).tgz oci://$(OCI_REGISTRY_HOST)/$(OCI_REGISTRY_NAMESPACE)
+	@echo "[push-oci] Successfully pushed chart to OCI registry."
+	@echo "[push-oci] Cleaning up temporary package directory..."
+	@rm -rf ./packaged-charts
+	@echo "[push-oci] Cleanup complete."

--- a/deploy/helm/notary/README.md
+++ b/deploy/helm/notary/README.md
@@ -31,8 +31,8 @@ notary:
 Install the chart with the default values plus your own overrides:
 
 ```bash
-helm install nvcf-notary-service nvcf-notary-service \
-  --namespace nvcf-notary-service \
+helm install notary nvcf-notary-service \
+  --namespace nvcf \
   --create-namespace \
   --values nvcf-notary-service/values.yaml \
   --values path/to/values.yaml \
@@ -43,8 +43,8 @@ helm install nvcf-notary-service nvcf-notary-service \
 Upgrade an existing release:
 
 ```bash
-helm upgrade nvcf-notary-service nvcf-notary-service \
-  --namespace nvcf-notary-service \
+helm upgrade notary nvcf-notary-service \
+  --namespace nvcf \
   --values nvcf-notary-service/values.yaml \
   --values path/to/values.yaml \
   --wait \
@@ -54,7 +54,7 @@ helm upgrade nvcf-notary-service nvcf-notary-service \
 Uninstall the release:
 
 ```bash
-helm uninstall nvcf-notary-service --namespace nvcf-notary-service
+helm uninstall notary --namespace nvcf
 ```
 
 ## Configuration

--- a/deploy/helm/notary/README.md
+++ b/deploy/helm/notary/README.md
@@ -1,0 +1,77 @@
+# NVCF Notary Service Helm Chart
+
+This repository contains the Helm chart for deploying the NVCF Notary Service on Kubernetes.
+
+## Overview
+
+The chart packages the Notary Service deployment along with its Vault Agent sidecar configuration for fetching signing keys and service credentials from a Vault or OpenBao backend.
+
+The default chart values do not set the required image registry and repository. They must be supplied through an additional values file at install time, and access to those images must be arranged separately.
+
+Example:
+
+```yaml
+notary:
+  image:
+    registry: <your-registry>
+    repository: <your-org>/nvcf-notary-service
+    tag: <appVersion>
+```
+
+## Prerequisites
+
+- Kubernetes cluster
+- Helm 3.x
+- `kubectl`
+- A reachable NVCF API endpoint
+- A reachable Vault or OpenBao instance with a JWT authentication path configured for this service
+
+## Getting Started
+
+Install the chart with the default values plus your own overrides:
+
+```bash
+helm install nvcf-notary-service nvcf-notary-service \
+  --namespace nvcf-notary-service \
+  --create-namespace \
+  --values nvcf-notary-service/values.yaml \
+  --values path/to/values.yaml \
+  --wait \
+  --timeout 10m
+```
+
+Upgrade an existing release:
+
+```bash
+helm upgrade nvcf-notary-service nvcf-notary-service \
+  --namespace nvcf-notary-service \
+  --values nvcf-notary-service/values.yaml \
+  --values path/to/values.yaml \
+  --wait \
+  --timeout 10m
+```
+
+Uninstall the release:
+
+```bash
+helm uninstall nvcf-notary-service --namespace nvcf-notary-service
+```
+
+## Configuration
+
+The default chart configuration lives in `nvcf-notary-service/values.yaml`.
+
+Important settings to review before deployment:
+
+- `notary.image.*` for the notary container image
+- `notary.imagePullSecrets` for private registry access
+- `notary.replicaCount`, resource requests, and limits for your environment
+- `notary.volumes` / `notary.volumeMounts` and the `configmap-vault-agent-template` for the Vault Agent sidecar's JWT auth path, role, and audience
+
+The token issuer, JWKS URL, assertion issuer, and vault secrets path are baked into the image's `ncp` Spring profile rather than set via `notary.env`.
+
+The default values include development-oriented placeholders. Override them before using the chart in any shared or production environment.
+
+## Notes
+
+- If you publish or mirror the required images into another registry, set the image registry, repository, tag, and pull secret values explicitly in your override file.

--- a/deploy/helm/notary/nvcf-notary-service/.helmignore
+++ b/deploy/helm/notary/nvcf-notary-service/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/ 

--- a/deploy/helm/notary/nvcf-notary-service/Chart.yaml
+++ b/deploy/helm/notary/nvcf-notary-service/Chart.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: helm-nvcf-notary-service
+description: A Helm chart for NVCF Notary Service deployment
+
+type: application
+version: 0.0.0 # autoversioning enabled via release pipeline
+appVersion: "1.8.1"

--- a/deploy/helm/notary/nvcf-notary-service/templates/NOTES.txt
+++ b/deploy/helm/notary/nvcf-notary-service/templates/NOTES.txt
@@ -1,0 +1,7 @@
+NVCF Notary Service has been deployed.
+
+Service can be accessed via:
+  HTTP: {{ include "nvcf-notary-service.fullname" . }}.{{ include "nvcf-notary-service.namespace" . }}.svc.cluster.local:8080
+  Management: {{ include "nvcf-notary-service.fullname" . }}.{{ include "nvcf-notary-service.namespace" . }}.svc.cluster.local:8181
+
+For more information about NVCF Notary Service, please refer to the documentation. 

--- a/deploy/helm/notary/nvcf-notary-service/templates/NOTES.txt
+++ b/deploy/helm/notary/nvcf-notary-service/templates/NOTES.txt
@@ -1,7 +1,8 @@
 NVCF Notary Service has been deployed.
 
 Service can be accessed via:
-  HTTP: {{ include "nvcf-notary-service.fullname" . }}.{{ include "nvcf-notary-service.namespace" . }}.svc.cluster.local:8080
-  Management: {{ include "nvcf-notary-service.fullname" . }}.{{ include "nvcf-notary-service.namespace" . }}.svc.cluster.local:8181
+{{- range .Values.notary.service.ports }}
+  {{ .name }}: notary.{{ include "nvcf-notary-service.namespace" $ }}.svc.cluster.local:{{ .port }}
+{{- end }}
 
 For more information about NVCF Notary Service, please refer to the documentation. 

--- a/deploy/helm/notary/nvcf-notary-service/templates/_helpers.tpl
+++ b/deploy/helm/notary/nvcf-notary-service/templates/_helpers.tpl
@@ -1,0 +1,81 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nvcf-notary-service.name" -}}
+{{- default .Chart.Name .Values.notary.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nvcf-notary-service.fullname" -}}
+{{- if .Values.notary.fullnameOverride }}
+{{- .Values.notary.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.notary.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nvcf-notary-service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Allow the release namespace to be overridden
+*/}}
+{{- define "nvcf-notary-service.namespace" -}}
+{{- default .Release.Namespace .Values.notary.namespace -}}
+{{- end -}}
+
+{{/*
+Derive the full image value
+*/}}
+{{- define "nvcf-notary-service.image" -}}
+{{- $registry := required "A valid image registry (.Values.notary.image.registry) is required!" .Values.notary.image.registry -}}
+{{- $repository := required "A valid image repository (.Values.notary.image.repository) is required!" .Values.notary.image.repository -}}
+{{- $tag := .Values.notary.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "nvcf-notary-service.labels" -}}
+helm.sh/chart: {{ include "nvcf-notary-service.chart" . }}
+{{ include "nvcf-notary-service.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "nvcf-notary-service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nvcf-notary-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Vault Agent Injector Annotations for JWT Auth
+*/}}
+{{- define "nvcf-notary-service.vaultAnnotations" -}}
+vault.hashicorp.com/agent-inject: "true"
+vault.hashicorp.com/role: "nvcf-notary"
+vault.hashicorp.com/auth-path: "auth/jwt"
+vault.hashicorp.com/agent-copy-volume-mounts: {{ .Chart.Name }}
+vault.hashicorp.com/agent-run-as-same-user: "true"
+vault.hashicorp.com/agent-inject-template-file-secrets.json: "/vault/config/templates/secrets.json.tmpl" 
+vault.hashicorp.com/secret-volume-path: "/home/app/vault"
+{{- end }}

--- a/deploy/helm/notary/nvcf-notary-service/templates/configmap-env.yaml
+++ b/deploy/helm/notary/nvcf-notary-service/templates/configmap-env.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.notary.env }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nvcf-notary-service.fullname" . }}-env
+  namespace: {{ include "nvcf-notary-service.namespace" . }}
+  labels:
+    {{- include "nvcf-notary-service.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.notary.env }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/notary/nvcf-notary-service/templates/configmap-vault-agent-template.yaml
+++ b/deploy/helm/notary/nvcf-notary-service/templates/configmap-vault-agent-template.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nvcf-notary-service.fullname" . }}-vault-agent-tpl
+  namespace: {{ include "nvcf-notary-service.namespace" . }}
+  labels:
+    {{- include "nvcf-notary-service.labels" . | nindent 4 }}
+data:
+  secrets.json.tmpl: |-
+{{ .Files.Get "vault-agent-templates/secrets.json.tmpl" | indent 4 }} 

--- a/deploy/helm/notary/nvcf-notary-service/templates/deployment.yaml
+++ b/deploy/helm/notary/nvcf-notary-service/templates/deployment.yaml
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "nvcf-notary-service.fullname" . }}
+  namespace: {{ include "nvcf-notary-service.namespace" . }}
+  labels:
+    {{- include "nvcf-notary-service.labels" . | nindent 4 }}
+spec:
+  replicas: {{ default 1 .Values.notary.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "nvcf-notary-service.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- include "nvcf-notary-service.vaultAnnotations" . | nindent 8 }}
+        {{- with .Values.notary.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.notary.env }}
+        checksum/config-env: {{ toYaml .Values.notary.env | sha256sum }}
+        {{- end }}
+      labels:
+        {{- include "nvcf-notary-service.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.notary.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: nvcf-notary
+      securityContext:
+        {{- toYaml .Values.notary.podSecurityContext | nindent 8 }}
+      volumes:
+        {{- with .Values.notary.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        - name: vault-config-templates
+          configMap:
+            name: {{ include "nvcf-notary-service.fullname" . }}-vault-agent-tpl
+            items:
+              - key: secrets.json.tmpl
+                path: secrets.json.tmpl
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.notary.securityContext | nindent 12 }}
+          image: "{{ include "nvcf-notary-service.image" . }}"
+          imagePullPolicy: {{ .Values.notary.image.pullPolicy }}
+          volumeMounts:
+            {{- with .Values.notary.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          {{- if .Values.notary.env }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "nvcf-notary-service.fullname" . }}-env
+          {{- end }}
+          ports:
+            {{- range .Values.notary.ports }}
+            - name: {{ .name }}
+              containerPort: {{ .containerPort }}
+              protocol: {{ .protocol }}
+            {{- end }}
+          {{- with .Values.notary.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.notary.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.notary.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.notary.resources | nindent 12 }}
+      {{- with .Values.notary.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.notary.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.notary.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }} 

--- a/deploy/helm/notary/nvcf-notary-service/templates/hpa.yaml
+++ b/deploy/helm/notary/nvcf-notary-service/templates/hpa.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.notary.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "nvcf-notary-service.fullname" . }}
+  namespace: {{ include "nvcf-notary-service.namespace" . }}
+  labels:
+    {{- include "nvcf-notary-service.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "nvcf-notary-service.fullname" . }}
+  minReplicas: {{ .Values.notary.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.notary.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.notary.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.notary.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.notary.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.notary.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }} 

--- a/deploy/helm/notary/nvcf-notary-service/templates/service.yaml
+++ b/deploy/helm/notary/nvcf-notary-service/templates/service.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: notary # hardcoded value is intentional to fit the addressing scheme
+  namespace: {{ include "nvcf-notary-service.namespace" . }}
+  labels:
+    {{- include "nvcf-notary-service.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.notary.service.type }}
+  ports:
+    {{- range .Values.notary.service.ports }}
+    - port: {{ .port }}
+      targetPort: {{ .targetPort }}
+      protocol: {{ .protocol }}
+      name: {{ .name }}
+    {{- end }}
+  selector:
+    {{- include "nvcf-notary-service.selectorLabels" . | nindent 4 }} 

--- a/deploy/helm/notary/nvcf-notary-service/templates/serviceaccount.yaml
+++ b/deploy/helm/notary/nvcf-notary-service/templates/serviceaccount.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nvcf-notary
+  namespace: {{ include "nvcf-notary-service.namespace" . }}
+  labels:
+    {{- include "nvcf-notary-service.labels" . | nindent 4 }}
+automountServiceAccountToken: false

--- a/deploy/helm/notary/nvcf-notary-service/values.yaml
+++ b/deploy/helm/notary/nvcf-notary-service/values.yaml
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+notary:
+  image:
+    registry: "" # must be supplied
+    repository: "" # must be supplied
+    pullPolicy: IfNotPresent
+    tag: "1.8.1"
+
+  # Namespace to deploy the resources. The default value is the release name.
+  namespace: ""
+
+  nameOverride: ""
+  fullnameOverride: ""
+
+  replicaCount: 1
+
+  podAnnotations: {}
+  podLabels: {}
+
+  podSecurityContext: {}
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+      add:
+        - NET_BIND_SERVICE
+    runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    ports:
+      - name: http
+        port: 8080
+        targetPort: 8080
+        protocol: TCP
+
+  resources:
+    limits:
+      cpu: 2
+      memory: 4Gi
+    requests:
+      cpu: 1
+      memory: 2Gi
+
+  livenessProbe:
+    httpGet:
+      path: /actuator/health/liveness
+      port: management
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 6
+
+  readinessProbe:
+    httpGet:
+      path: /actuator/health/readiness
+      port: management
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 1
+
+  startupProbe:
+    httpGet:
+      path: /actuator/health/readiness
+      port: management
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 30
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 80
+
+  volumes:
+    - name: token
+      projected:
+        sources:
+        - serviceAccountToken:
+            path: token
+            expirationSeconds: 3600
+            audience: http://openbao-server.vault-system.svc.cluster.local:8200
+
+  volumeMounts:
+    - name: token
+      mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      readOnly: true
+    - name: vault-config-templates
+      mountPath: /vault/config/templates
+      readOnly: true
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+  ports:
+    - name: http
+      containerPort: 8080
+      protocol: TCP
+    - name: management
+      containerPort: 8181
+      protocol: TCP
+
+  env:
+    SPRING_PROFILES_ACTIVE: "ncp"

--- a/deploy/helm/notary/nvcf-notary-service/vault-agent-templates/secrets.json.tmpl
+++ b/deploy/helm/notary/nvcf-notary-service/vault-agent-templates/secrets.json.tmpl
@@ -1,0 +1,15 @@
+{
+  "kv": {
+    "signing-key": {
+      {{- with secret "/services/nvcf-notary/kv/data/keys/signing-key" }}
+      "kid": "{{ .Data.data.kid }}",
+      "alg": "{{ .Data.data.alg }}"
+      {{- end }}
+      },
+    "private-key-jwks": {
+      {{- with secret "/services/nvcf-notary/kv/data/keys/signing-key" }}
+      "keys": {{ .Data.data.keys | base64Decode | toJSON }}
+      {{- end }}
+    }
+  }
+}

--- a/deploy/helm/notary/values.local.yaml
+++ b/deploy/helm/notary/values.local.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+notary:
+  image:
+    registry: nvcr.io
+    repository: 0651155215864979/ncp-dev/notary-service-oss
+    tag: "1.8.1"
+
+  env:
+    SPRING_PROFILES_ACTIVE: "ncp"

--- a/tools/ci/github-release-subprojects.json
+++ b/tools/ci/github-release-subprojects.json
@@ -287,6 +287,12 @@
       "initial_version": "1.4.4"
     },
     {
+      "id": "notary-helm",
+      "path": "deploy/helm/notary",
+      "service_name": "helm-nvcf-notary-service",
+      "initial_version": "1.4.2"
+    },
+    {
       "id": "instance-cluster-management",
       "path": "src/control-plane-services/instance-cluster-management",
       "service_name": "nvcf-instance-cluster-management"

--- a/tools/ci/helm-validate-values/notary.yaml
+++ b/tools/ci/helm-validate-values/notary.yaml
@@ -1,0 +1,5 @@
+# CI-only values for helm lint/template validation.
+notary:
+  image:
+    registry: example.com
+    repository: foo/bar/baz


### PR DESCRIPTION
## Why

The chart lived in `ncp/nvcf/application-services/nvcf-notary-service-colocated-deploy`, which was archived before the chart was ported here. It has 14 published versions, the newest 1.4.2, and nothing publishes it now: the source is read-only and no release lane in this repo knows about it. It is stranded.

## What changed

- `deploy/helm/notary/` — the chart, ported from that repo's `main`, one docs commit past the 1.4.2 tag. The chart itself is unchanged.
- `tools/ci/helm-validate-values/notary.yaml` — CI-only values, matching the other charts.
- `tools/ci/github-release-subprojects.json` — registers `notary-helm`.

The release entry is the part worth reviewing:

```json
{
  "id": "notary-helm",
  "path": "deploy/helm/notary",
  "service_name": "helm-nvcf-notary-service",
  "initial_version": "1.4.2"
}
```

`service_name` is the chart's own published name, taken from `Chart.yaml`, not one derived from the service. A service-shaped name would publish into a new empty chart repository and strand the 14 existing versions while the pipeline still reported success.

`initial_version` anchors the lineage at the last published version, so the first release cut here computes 1.4.3 or 1.5.0. Without it the floor is 0.0.0 and the first release would land below everything already published. 1.8.x is not the alternative: that is the notary service version, which is what `appVersion` tracks, not the chart's own counter.

Dropped on the way in, all of them repo-level files that do not belong in a chart directory: `.gitlab-ci.yml`, which released through a GitLab component this repo does not use; the license-header scripts and `.license-header.txt`, which duplicate the repo-level license tooling; and `CODEOWNERS`, `SECURITY.md` and `.oss-allowlist`.

The Makefile's `lint` and `template` targets now read the shared CI values, as the other charts do. The chart leaves `image.registry` and `image.repository` empty on purpose, so it does not render without them.

## Plan Summary

One new chart directory and one new release registration. Nothing publishes until a `deploy/helm/notary/v*` tag exists, and that requires the companion config in the internal repo.

## Usage

```
make -C deploy/helm/notary lint
make -C deploy/helm/notary template
```

## Testing

`helm lint` passes and `helm template` renders 5 resources (ConfigMap, Deployment, Service, ServiceAccount) with the CI values, resolving the image to `example.com/foo/bar/baz:1.8.1`. Verified before opening this PR, not assumed.

Chart identity and versions were read from the registry rather than inferred: the published chart `helm-nvcf-notary-service` has 14 versions with a maximum of 1.4.2, matching the archived repo's newest tag.

## Notes

This does not publish on its own. The companion `config/charts/notary-helm.yaml` in the internal repo, plus the chart's tag prefix in the dispatcher's prefix list, are still needed. A chart config whose prefix is unlisted is inert: the tag is never recognised and the chart silently never publishes.

`appVersion` is `1.8.1`, and `values.local.yaml` points at `notary-service-oss`. The service now publishes `nvcf-notary`, where the newest release is 1.13.2, so both are behind and name a retired image repository. That is the drift the chart image pin work addresses; it is deliberately not mixed into this port, which keeps the chart byte-identical to what was archived.

## References

None.

## Related Merge Requests/Pull Requests

Companion config in the internal repo, to follow.

## Dependencies

None.

Github commit:
feat(charts): port the notary helm chart into the monorepo

Bring the chart in from its archived colocated-deploy repo and register
it for releases, anchored at the last published version so the lineage
continues rather than restarting.

Co-authored-by: Balaji Ganesan <bganesan@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Helm chart deployment support for the NVCF Notary Service.
  * Added configurable installation, upgrades, removal, validation, packaging, and OCI publishing.
  * Added Vault/OpenBao integration, health checks, autoscaling, resource limits, and scheduling options.
  * Added service endpoints, configuration guidance, and local development values.

* **CI/CD**
  * Added chart validation settings and release configuration for automated publishing.
  * Added deployment notes with configured service endpoints and documentation links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->