### PR TITLE
fix(stacks): pin the function-autoscaler chart version literally

### DIFF
--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -144,7 +144,6 @@ observability:
 
 # Defaults consumed only for the control and all observability profiles.
 functionAutoscaler:
-  chartVersion: "0.2.1"
   region: local
   cassandra:
     contactPoints: cassandra.cassandra-system.svc.cluster.local

--- a/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
@@ -68,7 +68,7 @@ releases:
 
   {{- if $functionAutoscalerEnabled }}
   - name: function-autoscaler
-    version: {{ dig "functionAutoscaler" "chartVersion" "0.2.1" .Values | quote }}
+    version: 0.2.1
     namespace: nvcf
     inherit:
       - template: functionAutoscaler

--- a/tests/bdd/features/observability-control.feature
+++ b/tests/bdd/features/observability-control.feature
@@ -21,7 +21,6 @@ Feature: Install local Helmfile observability with the control profile
       | global.helm.sources.repository  | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM} |
       | global.image.repository         | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM} |
       | observability.profile           | control                              |
-      | functionAutoscaler.chartVersion | 0.2.0                                |
       | functionAutoscaler.image.tag    | 1.18.10                              |
     # Set the shared observability stack environment.
     And I copy the file "tests/bdd/fixtures/self-managed-local-bdd.yaml" to "deploy/stacks/observability/environments/local-bdd-observability-control.yaml"

--- a/tests/bdd/godog_test.go
+++ b/tests/bdd/godog_test.go
@@ -538,13 +538,6 @@ func TestObservabilityControlFeatureFileWiresToSteps(t *testing.T) {
 		t.Fatal("control-profile Helmfile install command was never invoked")
 	}
 	environmentPath := filepath.Join(suite.Config.RepoRoot, "deploy", "stacks", "self-managed", "environments", "local-bdd-observability-control.yaml")
-	chartVersion, found, err := dsl.ReadYAMLKey(environmentPath, "functionAutoscaler.chartVersion")
-	if err != nil {
-		t.Fatalf("read control-profile autoscaler chart version: %v", err)
-	}
-	if !found || chartVersion != "0.2.0" {
-		t.Fatalf("control-profile autoscaler chart version = %q, found = %t; want 0.2.0", chartVersion, found)
-	}
 	imageTag, found, err := dsl.ReadYAMLKey(environmentPath, "functionAutoscaler.image.tag")
 	if err != nil {
 		t.Fatalf("read control-profile autoscaler image tag: %v", err)


### PR DESCRIPTION
## Why

`publish-self-managed-stack-release-package` fails, blocking `deploy/stacks/self-managed/v0.8.0-dev.111`:

```
Found 33 unique container images
Resolving digests from nvcr.io/0651155215864979/ncp-dev...
invalid reference "nvcr.io/0651155215864979/ncp-dev/helm-nvcf-function-autoscaler:{{ dig "functionAutoscaler" "chartVersion" "0.2.1" .Values | quote }}"
```

`generate-sbom` reads the helmfiles as text and does not evaluate Go templates, so the version expression reached the registry lookup verbatim. This was the only templated `version:` in any of the four helmfiles; the other 22 charts pin a literal, which is why exactly one of 33 images failed while the rest resolved.

## What changed

- `03-observability.yaml.gotmpl`: `version: 0.2.1`, matching every other chart.
- `environments/base.yaml`: drops `functionAutoscaler.chartVersion`, which nothing reads once the version is literal.
- The observability BDD scenario and its assertion drop the same knob.

0.2.1 is what the expression already evaluated to everywhere. `base.yaml` pinned the same value the `dig` default used, and no shipped environment overrode it. It is also the newest published version of that chart.

Removing the knob rather than leaving it is the deliberate part. With the version literal, `base.yaml`'s `chartVersion` would be read by nothing, and the BDD scenario set it to 0.2.0 while asserting only that the value it had just written was still in the file it wrote. That would have left a test that passes while covering nothing, which is precisely the silent-green failure mode this repository keeps hitting. The image tag assertion is untouched, because that value is still read.

## Plan Summary

One chart version pinned literally instead of templated. No change to which chart version is deployed in any environment.

## Usage

Not applicable.

## Testing

`gofmt -e` parses the edited Go test, `base.yaml` parses as YAML, and no templated `version:` remains in any helmfile.

The published chart was checked rather than assumed: `helm-nvcf-function-autoscaler` in ncp-dev has 0.1.0, 0.2.0 and 0.2.1, so the pinned version exists and is the newest.

Verifying end to end means re-running the stack package job, which needs this merged first.

## Notes

The general fix is to render the helmfiles before scanning, which would tolerate any templated field. `generate-sbom` ships inside `self-hosted-sbom-tools` and the release lane does not control it, so that is a separate change and only worth making if another templated field appears.

This removes the ability to override the autoscaler chart version per environment. Nothing shipped used it, and no other chart in these helmfiles offers it. If per-environment chart version selection is wanted, it should be added uniformly and in a form the SBOM scanner can read.

## References

Failing job: `publish-self-managed-stack-release-package` on the `v0.8.0-dev.111` stack release.

## Related Merge Requests/Pull Requests

None.

## Dependencies

None.

Github commit:
fix(stacks): pin the function-autoscaler chart version literally

The SBOM scanner reads helmfiles as text, so a templated version
expression reached registry digest resolution verbatim and failed the
stack release package.

Co-authored-by: Balaji Ganesan <bganesan@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Standardized the function autoscaler deployment to use chart version 0.2.1.
  * Removed the obsolete chart version setting from environment configuration.

* **Tests**
  * Updated observability validation to reflect the simplified configuration while continuing to verify the autoscaler image tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->