### PR TITLE
fix(nvca): refresh queue credentials after registration

### DIFF
--- a/src/compute-plane-services/nvca/pkg/nvca/agent.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/agent.go
@@ -948,6 +948,11 @@ func (a *Agent) registerWithICMS(ctx context.Context, regBackendGPUs []types.Reg
 		return nil, err
 	}
 
+	if a.queueManager != nil {
+		a.queueManager.updateQueues(a.postProcessQueueCredentials(ctx, res.Credentials))
+		log.Debug("refreshed queue manager with registration credentials")
+	}
+
 	return res, nil
 }
 

--- a/src/compute-plane-services/nvca/pkg/nvca/agent.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/agent.go
@@ -950,7 +950,11 @@ func (a *Agent) registerWithICMS(ctx context.Context, regBackendGPUs []types.Reg
 
 	if a.queueManager != nil {
 		a.queueManager.updateQueues(a.postProcessQueueCredentials(ctx, res.Credentials))
-		log.Debug("refreshed queue manager with registration credentials")
+		log.WithFields(logrus.Fields{
+			"clusterID":      res.ClusterID,
+			"clusterGroupID": res.ClusterGroupID,
+			"ncaID":          a.NCAId,
+		}).Info("Refreshed queue manager with registration credentials")
 	}
 
 	return res, nil

--- a/src/compute-plane-services/nvca/pkg/nvca/agent_test.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/agent_test.go
@@ -192,6 +192,59 @@ func TestAgentApis(t *testing.T) {
 	assert.Equal(t, is.LastReportedStatus, string(types.ICMSInstanceTerminated))
 }
 
+func TestAgentRegisterWithICMSUpdatesQueueManagerCredentials(t *testing.T) {
+	ctx, cancel := context.WithCancel(newTestContext())
+	t.Cleanup(cancel)
+
+	agentOpts := AgentOptions{
+		TokenFetcherOptions: nvcaauth.TokenFetcherOptions{
+			OAuthTokenScope:      "byoc_registration",
+			OAuthClientID:        "foo",
+			OAuthClientSecretKey: "bar",
+		},
+		NCAId:                          "randomNCAId123",
+		ClusterName:                    "bartnvbackend",
+		ClusterID:                      "clusterid-1",
+		ClusterDescription:             "this is a test cluster",
+		ClusterGroupName:               "group of all A30",
+		ComputeBackend:                 "k8s",
+		CloudProvider:                  "on-prem",
+		NamespaceLabels:                labels.Set{"foo": "bar"},
+		K8sVersion:                     "1.27.8",
+		CredRenewInterval:              DefaultCredRenewInterval,
+		HeartbeatInterval:              DefaultHeartBeatInterval,
+		SyncQueueInterval:              defaultSyncQueueInterval,
+		SyncRequestStatusInterval:      DefaultSyncRequestStatusInterval,
+		PeriodicInstanceStatusInterval: DefaultPeriodicInstanceStatusInterval,
+		SyncAcknowledgeRequestInterval: ackReqInterval,
+		GPUCapacity:                    2,
+		FeatureFlagFetcher:             featureflag.DefaultFetcher,
+		MetricsRegisterer:              prometheus.NewRegistry(),
+	}
+	agent := newMockAgentSingleGPU(t, ctx, agentOpts)
+	require.NoError(t, agent.Start(ctx))
+
+	updatedGPU := types.GPUName("H100")
+	updatedQueue := getTestCreationMessageQueueInfo(true)
+	updatedQueue.GPU = string(updatedGPU)
+	updatedCreds := getTestQueueCreds(true)
+	updatedCreds.CreationQueues = types.CreationQueueInfoSet{
+		updatedGPU: updatedQueue,
+	}
+	agent.icmsClient = &mockICMSClient{
+		registrationResponse: &types.ICMSRegistrationResponse{
+			ClusterID:      agent.ClusterID,
+			ClusterGroupID: "test-cluster-group-id",
+			Credentials:    updatedCreds,
+		},
+	}
+
+	_, err := agent.registerWithICMS(ctx, []types.RegistrationGPU{{Name: string(updatedGPU)}})
+	require.NoError(t, err)
+	assert.Equal(t, updatedQueue, agent.queueManager.getCreateQueue(updatedGPU))
+	assert.Empty(t, agent.queueManager.getCreateQueue(testGPUNameDefault).QueueURL)
+}
+
 func TestAgent_getTelemetryAttributes(t *testing.T) {
 	ctx := context.Background()
 	agentOpts := AgentOptions{
@@ -845,6 +898,7 @@ func TestAgentMaintenanceModeInitialization(t *testing.T) {
 type mockICMSClient struct {
 	healthStatusRequests []types.HealthStatusRequest
 	registrationRequests []types.ICMSRegistrationRequest
+	registrationResponse *types.ICMSRegistrationResponse
 	registerErr          error
 }
 
@@ -857,6 +911,9 @@ func (m *mockICMSClient) Register(ctx context.Context, req *types.ICMSRegistrati
 	m.registrationRequests = append(m.registrationRequests, *req)
 	if m.registerErr != nil {
 		return nil, m.registerErr
+	}
+	if m.registrationResponse != nil {
+		return m.registrationResponse, nil
 	}
 	return &types.ICMSRegistrationResponse{
 		ClusterID:      "test-cluster-id",


### PR DESCRIPTION
## TL;DR

- Refresh the running queue manager after registration returns new queue credentials.
- Add regression coverage for a replacement GPU queue without an agent restart.

## Additional Details

- Reuses existing credential post-processing for startup and renewal compatibility.
- Skips the refresh before the queue manager is initialized during startup.

## For the Reviewer

- Review the post-registration queue update and the replacement-queue assertion.

## For QA

- `go test ./pkg/nvca -count=1 -ldflags "-X github.com/NVIDIA/k8s-dra-driver-gpu/internal/info.version=v25.8.0"`
- `go vet -ldflags "-X github.com/NVIDIA/k8s-dra-driver-gpu/internal/info.version=v25.8.0" ./pkg/nvca`
- QA needed: no.

## Issues

Closes #835

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ICMS registration handling by refreshing queue configuration with the latest GPU-specific credentials.
  * Removed outdated GPU queue entries when registration credentials change.
  * Ensured queue updates occur when the queue manager is initialized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->