### PR TITLE
fix(nvca): backport Helm-managed Vault address to 3.2

### DIFF
--- a/deploy/helm/nvca-operator/nvca-operator/README.md
+++ b/deploy/helm/nvca-operator/nvca-operator/README.md
@@ -107,7 +107,7 @@ used in Kubernetes Clusters to run NVCF Workloads.
 
 | Name                                       | Description                                                                                                                                             | Value |
 | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| `vaultConfig.address`                      | Vault server URL for Helm-managed clusters. Required when `helmManaged.oAuthClientID` is set.                                                          | `""`  |
+| `vaultConfig.address`                      | Vault server URL for Helm-managed clusters. Required when `helmManaged.oAuthClientID` is set; must be HTTP(S), without credentials, query, or fragment. | `""`  |
 | `vaultConfig.oAuthClientMountPathTemplate` | Template for constructing the OAuth client mount path in Vault. Use %s as placeholder for clientID. Example: "nvidia/services/oauth/clients/%s/kv/secret" | `""`  |
 | `vaultConfig.oAuthClientMountPath`         | (Optional) Full OAuth client mount path. If set, overrides the computed path from template.                                                             | `""`  |
 

--- a/deploy/helm/nvca-operator/nvca-operator/README.md
+++ b/deploy/helm/nvca-operator/nvca-operator/README.md
@@ -107,6 +107,7 @@ used in Kubernetes Clusters to run NVCF Workloads.
 
 | Name                                       | Description                                                                                                                                             | Value |
 | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| `vaultConfig.address`                      | Vault server URL for Helm-managed clusters. Required when `helmManaged.oAuthClientID` is set.                                                          | `""`  |
 | `vaultConfig.oAuthClientMountPathTemplate` | Template for constructing the OAuth client mount path in Vault. Use %s as placeholder for clientID. Example: "nvidia/services/oauth/clients/%s/kv/secret" | `""`  |
 | `vaultConfig.oAuthClientMountPath`         | (Optional) Full OAuth client mount path. If set, overrides the computed path from template.                                                             | `""`  |
 

--- a/deploy/helm/nvca-operator/nvca-operator/README.md
+++ b/deploy/helm/nvca-operator/nvca-operator/README.md
@@ -107,7 +107,7 @@ used in Kubernetes Clusters to run NVCF Workloads.
 
 | Name                                       | Description                                                                                                                                             | Value |
 | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| `vaultConfig.address`                      | Vault server URL for Helm-managed clusters. Required when `helmManaged.oAuthClientID` is set; must be HTTP(S), without credentials, query, or fragment. | `""`  |
+| `vaultConfig.address`                      | Vault server URL for Helm-managed clusters. Required when `helmManaged.oAuthClientID` is set; must use HTTPS without credentials, query, or fragment. | `""`  |
 | `vaultConfig.oAuthClientMountPathTemplate` | Template for constructing the OAuth client mount path in Vault. Use %s as placeholder for clientID. Example: "nvidia/services/oauth/clients/%s/kv/secret" | `""`  |
 | `vaultConfig.oAuthClientMountPath`         | (Optional) Full OAuth client mount path. If set, overrides the computed path from template.                                                             | `""`  |
 

--- a/deploy/helm/nvca-operator/nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
@@ -39,7 +39,7 @@ data:
     {{- end }}
     {{- if $clientID }}
     {{- if or (ne $vaultAddress (trim $vaultAddress)) (contains "@" $vaultAddress) (contains "?" $vaultAddress) (contains "#" $vaultAddress) }}
-    {{- fail "vaultConfig.address must be an absolute HTTP(S) URL with no credentials, query, or fragment when helmManaged.oAuthClientID is set" }}
+    {{- fail "vaultConfig.address must be an absolute HTTPS URL with no credentials, query, or fragment when helmManaged.oAuthClientID is set" }}
     {{- end }}
     {{- $parsedVaultAddress := urlParse $vaultAddress }}
     {{- $vaultScheme := $parsedVaultAddress.scheme | default "" }}
@@ -47,8 +47,8 @@ data:
     {{- $vaultUserInfo := $parsedVaultAddress.userinfo | default "" }}
     {{- $vaultQuery := $parsedVaultAddress.query | default "" }}
     {{- $vaultFragment := $parsedVaultAddress.fragment | default "" }}
-    {{- if or (not (has $vaultScheme (list "http" "https"))) (not (regexMatch `^(\[[^]]+\]|[^:[:space:]]+)(:[0-9]+)?$` $vaultHost)) $vaultUserInfo $vaultQuery $vaultFragment }}
-    {{- fail "vaultConfig.address must be an absolute HTTP(S) URL with no credentials, query, or fragment when helmManaged.oAuthClientID is set" }}
+    {{- if or (ne $vaultScheme "https") (not (regexMatch `^(\[[^]]+\]|[^:[:space:]]+)(:[0-9]+)?$` $vaultHost)) $vaultUserInfo $vaultQuery $vaultFragment }}
+    {{- fail "vaultConfig.address must be an absolute HTTPS URL with no credentials, query, or fragment when helmManaged.oAuthClientID is set" }}
     {{- end }}
     {{- end }}
     clusterDescription: {{ .clusterDescription | default $.Values.clusterName | quote }}

--- a/deploy/helm/nvca-operator/nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
@@ -38,11 +38,17 @@ data:
     {{- end }}
     {{- end }}
     {{- if $clientID }}
+    {{- if or (ne $vaultAddress (trim $vaultAddress)) (contains "@" $vaultAddress) (contains "?" $vaultAddress) (contains "#" $vaultAddress) }}
+    {{- fail "vaultConfig.address must be an absolute HTTP(S) URL with no credentials, query, or fragment when helmManaged.oAuthClientID is set" }}
+    {{- end }}
     {{- $parsedVaultAddress := urlParse $vaultAddress }}
     {{- $vaultScheme := $parsedVaultAddress.scheme | default "" }}
     {{- $vaultHost := $parsedVaultAddress.host | default "" }}
-    {{- if or (not (has $vaultScheme (list "http" "https"))) (not (regexMatch `^(\[[^]]+\]|[^:[:space:]]+)(:[0-9]+)?$` $vaultHost)) }}
-    {{- fail "vaultConfig.address must be an absolute HTTP(S) URL with a non-empty hostname when helmManaged.oAuthClientID is set" }}
+    {{- $vaultUserInfo := $parsedVaultAddress.userinfo | default "" }}
+    {{- $vaultQuery := $parsedVaultAddress.query | default "" }}
+    {{- $vaultFragment := $parsedVaultAddress.fragment | default "" }}
+    {{- if or (not (has $vaultScheme (list "http" "https"))) (not (regexMatch `^(\[[^]]+\]|[^:[:space:]]+)(:[0-9]+)?$` $vaultHost)) $vaultUserInfo $vaultQuery $vaultFragment }}
+    {{- fail "vaultConfig.address must be an absolute HTTP(S) URL with no credentials, query, or fragment when helmManaged.oAuthClientID is set" }}
     {{- end }}
     {{- end }}
     clusterDescription: {{ .clusterDescription | default $.Values.clusterName | quote }}

--- a/deploy/helm/nvca-operator/nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
@@ -29,10 +29,20 @@ data:
     {{- with .Values.helmManaged }}
     {{- $clientID := .oAuthClientID | default "" }}
     {{- $mountPath := "" }}
+    {{- $vaultAddress := "" }}
     {{- if $.Values.vaultConfig }}
     {{- $mountPath = $.Values.vaultConfig.oAuthClientMountPath }}
+    {{- $vaultAddress = $.Values.vaultConfig.address | default "" }}
     {{- if and (not $mountPath) $clientID $.Values.vaultConfig.oAuthClientMountPathTemplate }}
     {{- $mountPath = printf $.Values.vaultConfig.oAuthClientMountPathTemplate $clientID }}
+    {{- end }}
+    {{- end }}
+    {{- if $clientID }}
+    {{- $parsedVaultAddress := urlParse $vaultAddress }}
+    {{- $vaultScheme := $parsedVaultAddress.scheme | default "" }}
+    {{- $vaultHost := $parsedVaultAddress.host | default "" }}
+    {{- if or (not (has $vaultScheme (list "http" "https"))) (not (regexMatch `^(\[[^]]+\]|[^:[:space:]]+)(:[0-9]+)?$` $vaultHost)) }}
+    {{- fail "vaultConfig.address must be an absolute HTTP(S) URL with a non-empty hostname when helmManaged.oAuthClientID is set" }}
     {{- end }}
     {{- end }}
     clusterDescription: {{ .clusterDescription | default $.Values.clusterName | quote }}
@@ -41,6 +51,8 @@ data:
     nvcaVersion: {{ .nvcaVersion | quote }}
     oAuthClientId: {{ $clientID | quote }}
     oAuthClientMountPath: {{ $mountPath | quote }}
+    vaultConfig:
+      address: {{ $vaultAddress | quote }}
     cloudProvider: {{ .cloudProvider | quote }}
     region: {{ .clusterRegion | quote }}
     attributes: {{ include "nvcaop.jsonListOrEmpty" .clusterAttributes }}

--- a/deploy/helm/nvca-operator/nvca-operator/values.schema.json
+++ b/deploy/helm/nvca-operator/nvca-operator/values.schema.json
@@ -585,6 +585,11 @@
         "vaultConfig": {
             "type": "object",
             "properties": {
+                "address": {
+                    "type": "string",
+                    "description": "Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set.",
+                    "default": ""
+                },
                 "oAuthClientMountPathTemplate": {
                     "type": "string",
                     "description": "Template for constructing the OAuth client mount path in Vault. Use %s as placeholder for clientID. Example: \"nvidia/services/oauth/clients/%s/kv/secret\"",

--- a/deploy/helm/nvca-operator/nvca-operator/values.schema.json
+++ b/deploy/helm/nvca-operator/nvca-operator/values.schema.json
@@ -587,7 +587,7 @@
             "properties": {
                 "address": {
                     "type": "string",
-                    "description": "Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set.",
+                    "description": "Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set; must be HTTP(S), without credentials, query, or fragment.",
                     "default": ""
                 },
                 "oAuthClientMountPathTemplate": {

--- a/deploy/helm/nvca-operator/nvca-operator/values.schema.json
+++ b/deploy/helm/nvca-operator/nvca-operator/values.schema.json
@@ -587,7 +587,7 @@
             "properties": {
                 "address": {
                     "type": "string",
-                    "description": "Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set; must be HTTP(S), without credentials, query, or fragment.",
+                    "description": "Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set; must use HTTPS without credentials, query, or fragment.",
                     "default": ""
                 },
                 "oAuthClientMountPathTemplate": {

--- a/deploy/helm/nvca-operator/nvca-operator/values.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/values.yaml
@@ -269,9 +269,11 @@ ngcConfig:
   apiURL: https://api.ngc.nvidia.com
   clusterSource: ngc-managed
 ## @section Vault Configuration
+## @param vaultConfig.address Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set.
 ## @param vaultConfig.oAuthClientMountPathTemplate Template for constructing the OAuth client mount path in Vault. Use %s as placeholder for clientID. Example: "nvidia/services/oauth/clients/%s/kv/secret"
 ## @param vaultConfig.oAuthClientMountPath (Optional) Full OAuth client mount path. If set, overrides the computed path from template.
 vaultConfig:
+  address: ""
   oAuthClientMountPathTemplate: ""
   oAuthClientMountPath: ""
 ## @section Helm Managed NVCF Backend Configuration

--- a/deploy/helm/nvca-operator/nvca-operator/values.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/values.yaml
@@ -269,7 +269,7 @@ ngcConfig:
   apiURL: https://api.ngc.nvidia.com
   clusterSource: ngc-managed
 ## @section Vault Configuration
-## @param vaultConfig.address Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set; must be HTTP(S), without credentials, query, or fragment.
+## @param vaultConfig.address Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set; must use HTTPS without credentials, query, or fragment.
 ## @param vaultConfig.oAuthClientMountPathTemplate Template for constructing the OAuth client mount path in Vault. Use %s as placeholder for clientID. Example: "nvidia/services/oauth/clients/%s/kv/secret"
 ## @param vaultConfig.oAuthClientMountPath (Optional) Full OAuth client mount path. If set, overrides the computed path from template.
 vaultConfig:

--- a/deploy/helm/nvca-operator/nvca-operator/values.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/values.yaml
@@ -269,7 +269,7 @@ ngcConfig:
   apiURL: https://api.ngc.nvidia.com
   clusterSource: ngc-managed
 ## @section Vault Configuration
-## @param vaultConfig.address Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set.
+## @param vaultConfig.address Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set; must be HTTP(S), without credentials, query, or fragment.
 ## @param vaultConfig.oAuthClientMountPathTemplate Template for constructing the OAuth client mount path in Vault. Use %s as placeholder for clientID. Example: "nvidia/services/oauth/clients/%s/kv/secret"
 ## @param vaultConfig.oAuthClientMountPath (Optional) Full OAuth client mount path. If set, overrides the computed path from template.
 vaultConfig:

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/README.md
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/README.md
@@ -107,7 +107,7 @@ used in Kubernetes Clusters to run NVCF Workloads.
 
 | Name                                       | Description                                                                                                                                             | Value |
 | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| `vaultConfig.address`                      | Vault server URL for Helm-managed clusters. Required when `helmManaged.oAuthClientID` is set.                                                          | `""`  |
+| `vaultConfig.address`                      | Vault server URL for Helm-managed clusters. Required when `helmManaged.oAuthClientID` is set; must be HTTP(S), without credentials, query, or fragment. | `""`  |
 | `vaultConfig.oAuthClientMountPathTemplate` | Template for constructing the OAuth client mount path in Vault. Use %s as placeholder for clientID. Example: "nvidia/services/oauth/clients/%s/kv/secret" | `""`  |
 | `vaultConfig.oAuthClientMountPath`         | (Optional) Full OAuth client mount path. If set, overrides the computed path from template.                                                             | `""`  |
 

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/README.md
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/README.md
@@ -107,6 +107,7 @@ used in Kubernetes Clusters to run NVCF Workloads.
 
 | Name                                       | Description                                                                                                                                             | Value |
 | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| `vaultConfig.address`                      | Vault server URL for Helm-managed clusters. Required when `helmManaged.oAuthClientID` is set.                                                          | `""`  |
 | `vaultConfig.oAuthClientMountPathTemplate` | Template for constructing the OAuth client mount path in Vault. Use %s as placeholder for clientID. Example: "nvidia/services/oauth/clients/%s/kv/secret" | `""`  |
 | `vaultConfig.oAuthClientMountPath`         | (Optional) Full OAuth client mount path. If set, overrides the computed path from template.                                                             | `""`  |
 

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/README.md
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/README.md
@@ -107,7 +107,7 @@ used in Kubernetes Clusters to run NVCF Workloads.
 
 | Name                                       | Description                                                                                                                                             | Value |
 | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| `vaultConfig.address`                      | Vault server URL for Helm-managed clusters. Required when `helmManaged.oAuthClientID` is set; must be HTTP(S), without credentials, query, or fragment. | `""`  |
+| `vaultConfig.address`                      | Vault server URL for Helm-managed clusters. Required when `helmManaged.oAuthClientID` is set; must use HTTPS without credentials, query, or fragment. | `""`  |
 | `vaultConfig.oAuthClientMountPathTemplate` | Template for constructing the OAuth client mount path in Vault. Use %s as placeholder for clientID. Example: "nvidia/services/oauth/clients/%s/kv/secret" | `""`  |
 | `vaultConfig.oAuthClientMountPath`         | (Optional) Full OAuth client mount path. If set, overrides the computed path from template.                                                             | `""`  |
 

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
@@ -39,7 +39,7 @@ data:
     {{- end }}
     {{- if $clientID }}
     {{- if or (ne $vaultAddress (trim $vaultAddress)) (contains "@" $vaultAddress) (contains "?" $vaultAddress) (contains "#" $vaultAddress) }}
-    {{- fail "vaultConfig.address must be an absolute HTTP(S) URL with no credentials, query, or fragment when helmManaged.oAuthClientID is set" }}
+    {{- fail "vaultConfig.address must be an absolute HTTPS URL with no credentials, query, or fragment when helmManaged.oAuthClientID is set" }}
     {{- end }}
     {{- $parsedVaultAddress := urlParse $vaultAddress }}
     {{- $vaultScheme := $parsedVaultAddress.scheme | default "" }}
@@ -47,8 +47,8 @@ data:
     {{- $vaultUserInfo := $parsedVaultAddress.userinfo | default "" }}
     {{- $vaultQuery := $parsedVaultAddress.query | default "" }}
     {{- $vaultFragment := $parsedVaultAddress.fragment | default "" }}
-    {{- if or (not (has $vaultScheme (list "http" "https"))) (not (regexMatch `^(\[[^]]+\]|[^:[:space:]]+)(:[0-9]+)?$` $vaultHost)) $vaultUserInfo $vaultQuery $vaultFragment }}
-    {{- fail "vaultConfig.address must be an absolute HTTP(S) URL with no credentials, query, or fragment when helmManaged.oAuthClientID is set" }}
+    {{- if or (ne $vaultScheme "https") (not (regexMatch `^(\[[^]]+\]|[^:[:space:]]+)(:[0-9]+)?$` $vaultHost)) $vaultUserInfo $vaultQuery $vaultFragment }}
+    {{- fail "vaultConfig.address must be an absolute HTTPS URL with no credentials, query, or fragment when helmManaged.oAuthClientID is set" }}
     {{- end }}
     {{- end }}
     clusterDescription: {{ .clusterDescription | default $.Values.clusterName | quote }}

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
@@ -38,11 +38,17 @@ data:
     {{- end }}
     {{- end }}
     {{- if $clientID }}
+    {{- if or (ne $vaultAddress (trim $vaultAddress)) (contains "@" $vaultAddress) (contains "?" $vaultAddress) (contains "#" $vaultAddress) }}
+    {{- fail "vaultConfig.address must be an absolute HTTP(S) URL with no credentials, query, or fragment when helmManaged.oAuthClientID is set" }}
+    {{- end }}
     {{- $parsedVaultAddress := urlParse $vaultAddress }}
     {{- $vaultScheme := $parsedVaultAddress.scheme | default "" }}
     {{- $vaultHost := $parsedVaultAddress.host | default "" }}
-    {{- if or (not (has $vaultScheme (list "http" "https"))) (not (regexMatch `^(\[[^]]+\]|[^:[:space:]]+)(:[0-9]+)?$` $vaultHost)) }}
-    {{- fail "vaultConfig.address must be an absolute HTTP(S) URL with a non-empty hostname when helmManaged.oAuthClientID is set" }}
+    {{- $vaultUserInfo := $parsedVaultAddress.userinfo | default "" }}
+    {{- $vaultQuery := $parsedVaultAddress.query | default "" }}
+    {{- $vaultFragment := $parsedVaultAddress.fragment | default "" }}
+    {{- if or (not (has $vaultScheme (list "http" "https"))) (not (regexMatch `^(\[[^]]+\]|[^:[:space:]]+)(:[0-9]+)?$` $vaultHost)) $vaultUserInfo $vaultQuery $vaultFragment }}
+    {{- fail "vaultConfig.address must be an absolute HTTP(S) URL with no credentials, query, or fragment when helmManaged.oAuthClientID is set" }}
     {{- end }}
     {{- end }}
     clusterDescription: {{ .clusterDescription | default $.Values.clusterName | quote }}

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
@@ -29,10 +29,20 @@ data:
     {{- with .Values.helmManaged }}
     {{- $clientID := .oAuthClientID | default "" }}
     {{- $mountPath := "" }}
+    {{- $vaultAddress := "" }}
     {{- if $.Values.vaultConfig }}
     {{- $mountPath = $.Values.vaultConfig.oAuthClientMountPath }}
+    {{- $vaultAddress = $.Values.vaultConfig.address | default "" }}
     {{- if and (not $mountPath) $clientID $.Values.vaultConfig.oAuthClientMountPathTemplate }}
     {{- $mountPath = printf $.Values.vaultConfig.oAuthClientMountPathTemplate $clientID }}
+    {{- end }}
+    {{- end }}
+    {{- if $clientID }}
+    {{- $parsedVaultAddress := urlParse $vaultAddress }}
+    {{- $vaultScheme := $parsedVaultAddress.scheme | default "" }}
+    {{- $vaultHost := $parsedVaultAddress.host | default "" }}
+    {{- if or (not (has $vaultScheme (list "http" "https"))) (not (regexMatch `^(\[[^]]+\]|[^:[:space:]]+)(:[0-9]+)?$` $vaultHost)) }}
+    {{- fail "vaultConfig.address must be an absolute HTTP(S) URL with a non-empty hostname when helmManaged.oAuthClientID is set" }}
     {{- end }}
     {{- end }}
     clusterDescription: {{ .clusterDescription | default $.Values.clusterName | quote }}
@@ -41,6 +51,8 @@ data:
     nvcaVersion: {{ .nvcaVersion | quote }}
     oAuthClientId: {{ $clientID | quote }}
     oAuthClientMountPath: {{ $mountPath | quote }}
+    vaultConfig:
+      address: {{ $vaultAddress | quote }}
     cloudProvider: {{ .cloudProvider | quote }}
     region: {{ .clusterRegion | quote }}
     attributes: {{ include "nvcaop.jsonListOrEmpty" .clusterAttributes }}

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/values.schema.json
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/values.schema.json
@@ -585,6 +585,11 @@
         "vaultConfig": {
             "type": "object",
             "properties": {
+                "address": {
+                    "type": "string",
+                    "description": "Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set.",
+                    "default": ""
+                },
                 "oAuthClientMountPathTemplate": {
                     "type": "string",
                     "description": "Template for constructing the OAuth client mount path in Vault. Use %s as placeholder for clientID. Example: \"nvidia/services/oauth/clients/%s/kv/secret\"",

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/values.schema.json
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/values.schema.json
@@ -587,7 +587,7 @@
             "properties": {
                 "address": {
                     "type": "string",
-                    "description": "Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set.",
+                    "description": "Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set; must be HTTP(S), without credentials, query, or fragment.",
                     "default": ""
                 },
                 "oAuthClientMountPathTemplate": {

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/values.schema.json
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/values.schema.json
@@ -587,7 +587,7 @@
             "properties": {
                 "address": {
                     "type": "string",
-                    "description": "Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set; must be HTTP(S), without credentials, query, or fragment.",
+                    "description": "Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set; must use HTTPS without credentials, query, or fragment.",
                     "default": ""
                 },
                 "oAuthClientMountPathTemplate": {

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/values.yaml
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/values.yaml
@@ -290,7 +290,7 @@ ngcConfig:
 
 
 ## @section Vault Configuration
-## @param vaultConfig.address Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set; must be HTTP(S), without credentials, query, or fragment.
+## @param vaultConfig.address Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set; must use HTTPS without credentials, query, or fragment.
 ## @param vaultConfig.oAuthClientMountPathTemplate Template for constructing the OAuth client mount path in Vault. Use %s as placeholder for clientID. Example: "nvidia/services/oauth/clients/%s/kv/secret"
 ## @param vaultConfig.oAuthClientMountPath (Optional) Full OAuth client mount path. If set, overrides the computed path from template.
 vaultConfig:

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/values.yaml
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/values.yaml
@@ -290,9 +290,11 @@ ngcConfig:
 
 
 ## @section Vault Configuration
+## @param vaultConfig.address Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set.
 ## @param vaultConfig.oAuthClientMountPathTemplate Template for constructing the OAuth client mount path in Vault. Use %s as placeholder for clientID. Example: "nvidia/services/oauth/clients/%s/kv/secret"
 ## @param vaultConfig.oAuthClientMountPath (Optional) Full OAuth client mount path. If set, overrides the computed path from template.
 vaultConfig:
+  address: ""
   oAuthClientMountPathTemplate: ""
   oAuthClientMountPath: ""
 

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/values.yaml
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/values.yaml
@@ -290,7 +290,7 @@ ngcConfig:
 
 
 ## @section Vault Configuration
-## @param vaultConfig.address Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set.
+## @param vaultConfig.address Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set; must be HTTP(S), without credentials, query, or fragment.
 ## @param vaultConfig.oAuthClientMountPathTemplate Template for constructing the OAuth client mount path in Vault. Use %s as placeholder for clientID. Example: "nvidia/services/oauth/clients/%s/kv/secret"
 ## @param vaultConfig.oAuthClientMountPath (Optional) Full OAuth client mount path. If set, overrides the computed path from template.
 vaultConfig:

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient.go
@@ -65,12 +65,12 @@ func withRequiredHelmManagedVaultAddress() clusterMapper {
 		parsed, err := url.Parse(address)
 		if err != nil ||
 			address != strings.TrimSpace(address) ||
-			(parsed.Scheme != "http" && parsed.Scheme != "https") ||
+			parsed.Scheme != "https" ||
 			parsed.Hostname() == "" ||
 			parsed.User != nil ||
 			parsed.RawQuery != "" ||
 			parsed.Fragment != "" {
-			return errors.New("vaultConfig.address must be an absolute HTTP(S) URL with no credentials, query, or fragment when OAuth is enabled")
+			return errors.New("vaultConfig.address must be an absolute HTTPS URL with no credentials, query, or fragment when OAuth is enabled")
 		}
 
 		return nil

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient.go
@@ -68,8 +68,7 @@ func withRequiredHelmManagedVaultAddress() clusterMapper {
 			parsed.Scheme != "https" ||
 			parsed.Hostname() == "" ||
 			parsed.User != nil ||
-			parsed.RawQuery != "" ||
-			parsed.Fragment != "" {
+			strings.ContainsAny(address, "?#") {
 			return errors.New("vaultConfig.address must be an absolute HTTPS URL with no credentials, query, or fragment when OAuth is enabled")
 		}
 

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient.go
@@ -19,6 +19,9 @@ package clustermgmt
 
 import (
 	"context"
+	"errors"
+	"net/url"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -42,5 +45,28 @@ func NewHelmManagedClient(
 	vaultMountPathTemplate string,
 ) *HelmManagedClient {
 	return &HelmManagedClient{newConfigMapClient(
-		envType, fetcher, vaultMountPathTemplate, withClusterSourceMapper(nvcaoptypes.ClusterSourceHelmManaged))}
+		envType,
+		fetcher,
+		vaultMountPathTemplate,
+		withRequiredHelmManagedVaultAddress(),
+		withClusterSourceMapper(nvcaoptypes.ClusterSourceHelmManaged),
+	)}
+}
+
+// withRequiredHelmManagedVaultAddress rejects enabled Vault configuration that
+// cannot produce a valid token audience or Vault Agent server address.
+func withRequiredHelmManagedVaultAddress() clusterMapper {
+	return func(_ context.Context, _ nvidiaiov1.EnvType, src *clusterDTO, _ *Cluster) error {
+		if !src.vaultEnabled() {
+			return nil
+		}
+
+		address := strings.TrimSpace(src.VaultConfig.Address)
+		parsed, err := url.Parse(address)
+		if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Hostname() == "" {
+			return errors.New("vaultConfig.address must be an absolute HTTP(S) URL with a non-empty hostname when OAuth is enabled")
+		}
+
+		return nil
+	}
 }

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient.go
@@ -61,10 +61,16 @@ func withRequiredHelmManagedVaultAddress() clusterMapper {
 			return nil
 		}
 
-		address := strings.TrimSpace(src.VaultConfig.Address)
+		address := src.VaultConfig.Address
 		parsed, err := url.Parse(address)
-		if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Hostname() == "" {
-			return errors.New("vaultConfig.address must be an absolute HTTP(S) URL with a non-empty hostname when OAuth is enabled")
+		if err != nil ||
+			address != strings.TrimSpace(address) ||
+			(parsed.Scheme != "http" && parsed.Scheme != "https") ||
+			parsed.Hostname() == "" ||
+			parsed.User != nil ||
+			parsed.RawQuery != "" ||
+			parsed.Fragment != "" {
+			return errors.New("vaultConfig.address must be an absolute HTTP(S) URL with no credentials, query, or fragment when OAuth is enabled")
 		}
 
 		return nil

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient_test.go
@@ -145,7 +145,9 @@ func TestHelmManagedClient_GetCluster_RequiresValidVaultAddress(t *testing.T) {
 		"plain HTTP":             "http://vault.example.test:8200",
 		"surrounding whitespace": " https://vault.example.test:443 ",
 		"credentials":            "https://user@vault.example.test:443",
+		"empty query":            "https://vault.example.test:443?",
 		"query":                  "https://vault.example.test:443?namespace=test",
+		"empty fragment":         "https://vault.example.test:443#",
 		"fragment":               "https://vault.example.test:443#test",
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient_test.go
@@ -142,6 +142,7 @@ func TestHelmManagedClient_GetCluster_RequiresValidVaultAddress(t *testing.T) {
 	for name, address := range map[string]string{
 		"missing address":        "",
 		"address without host":   "https://:443",
+		"plain HTTP":             "http://vault.example.test:8200",
 		"surrounding whitespace": " https://vault.example.test:443 ",
 		"credentials":            "https://user@vault.example.test:443",
 		"query":                  "https://vault.example.test:443?namespace=test",

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient_test.go
@@ -20,6 +20,7 @@ package clustermgmt
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -138,29 +139,30 @@ func TestHelmManagedClient_GetCluster_RequiresValidVaultAddress(t *testing.T) {
 		assert.False(t, cluster.NVCFBackend.Spec.VaultConfig.Enabled)
 	})
 
-	t.Run("missing address", func(t *testing.T) {
-		client := NewHelmManagedClient(
-			nvidiaiov1.EnvTypeProd,
-			dummyFetcher("clusterName: test-backend\noAuthClientId: oauth-client-1", nil),
-			DefaultVaultOAuthClientMountPathTemplate,
-		)
+	for name, address := range map[string]string{
+		"missing address":        "",
+		"address without host":   "https://:443",
+		"surrounding whitespace": " https://vault.example.test:443 ",
+		"credentials":            "https://user@vault.example.test:443",
+		"query":                  "https://vault.example.test:443?namespace=test",
+		"fragment":               "https://vault.example.test:443#test",
+	} {
+		t.Run(name, func(t *testing.T) {
+			clusterYAML := "clusterName: test-backend\noAuthClientId: oauth-client-1"
+			if address != "" {
+				clusterYAML += fmt.Sprintf("\nvaultConfig:\n  address: %q", address)
+			}
+			client := NewHelmManagedClient(
+				nvidiaiov1.EnvTypeProd,
+				dummyFetcher(clusterYAML, nil),
+				DefaultVaultOAuthClientMountPathTemplate,
+			)
 
-		_, err := client.GetCluster(ctx, "test-cluster")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "vaultConfig.address")
-	})
-
-	t.Run("address without host", func(t *testing.T) {
-		client := NewHelmManagedClient(
-			nvidiaiov1.EnvTypeProd,
-			dummyFetcher("clusterName: test-backend\noAuthClientId: oauth-client-1\nvaultConfig:\n  address: https://:443", nil),
-			DefaultVaultOAuthClientMountPathTemplate,
-		)
-
-		_, err := client.GetCluster(ctx, "test-cluster")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "vaultConfig.address")
-	})
+			_, err := client.GetCluster(ctx, "test-cluster")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "vaultConfig.address")
+		})
+	}
 }
 
 func TestHelmManagedClient_GetCluster_InvalidYAML(t *testing.T) {

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient_test.go
@@ -64,6 +64,8 @@ clusterGroupId: "grp-1"
 ncaID: "test-nca"
 nvcaVersion: "1.0.0"
 oAuthClientId: "oauth-client-1"
+vaultConfig:
+  address: "https://vault.example.test:443"
 icmsConfig:
   tokenURL: "https://oauth.example.test/token"
   publicKeysetEndpoint: "https://oauth.example.test/.well-known/jwks.json"
@@ -117,8 +119,48 @@ agent:
 	assert.Equal(t, "https://stage-fnds-oauth.example.test/.well-known/jwks.json", nb.Spec.AgentConfig.FunctionDeploymentStagesStageOAuthPublicKeysetEndpoint)
 	assert.Equal(t, "https://prod-fnds-oauth.example.test/token", nb.Spec.AgentConfig.FunctionDeploymentStagesProdOAuthTokenURL)
 	assert.Equal(t, "https://prod-fnds-oauth.example.test/.well-known/jwks.json", nb.Spec.AgentConfig.FunctionDeploymentStagesProdOAuthPublicKeysetEndpoint)
-	assert.Equal(t, "https://:443", nb.Spec.VaultConfig.Address)
+	assert.Equal(t, "https://vault.example.test:443", nb.Spec.VaultConfig.Address)
 	assert.True(t, nb.Spec.VaultConfig.Enabled)
+}
+
+func TestHelmManagedClient_GetCluster_RequiresValidVaultAddress(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("OAuth disabled", func(t *testing.T) {
+		client := NewHelmManagedClient(
+			nvidiaiov1.EnvTypeProd,
+			dummyFetcher("clusterName: test-backend", nil),
+			DefaultVaultOAuthClientMountPathTemplate,
+		)
+
+		cluster, err := client.GetCluster(ctx, "test-cluster")
+		require.NoError(t, err)
+		assert.False(t, cluster.NVCFBackend.Spec.VaultConfig.Enabled)
+	})
+
+	t.Run("missing address", func(t *testing.T) {
+		client := NewHelmManagedClient(
+			nvidiaiov1.EnvTypeProd,
+			dummyFetcher("clusterName: test-backend\noAuthClientId: oauth-client-1", nil),
+			DefaultVaultOAuthClientMountPathTemplate,
+		)
+
+		_, err := client.GetCluster(ctx, "test-cluster")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "vaultConfig.address")
+	})
+
+	t.Run("address without host", func(t *testing.T) {
+		client := NewHelmManagedClient(
+			nvidiaiov1.EnvTypeProd,
+			dummyFetcher("clusterName: test-backend\noAuthClientId: oauth-client-1\nvaultConfig:\n  address: https://:443", nil),
+			DefaultVaultOAuthClientMountPathTemplate,
+		)
+
+		_, err := client.GetCluster(ctx, "test-cluster")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "vaultConfig.address")
+	})
 }
 
 func TestHelmManagedClient_GetCluster_InvalidYAML(t *testing.T) {

--- a/src/compute-plane-services/nvca/scripts/lint_helm.sh
+++ b/src/compute-plane-services/nvca/scripts/lint_helm.sh
@@ -217,6 +217,7 @@ assert_helm_managed_vault_address() {
   for invalid_address in \
     "" \
     "https://:443" \
+    "http://vault.example.test:8200" \
     " https://vault.example.test:443 " \
     "https://user@vault.example.test:443" \
     "https://vault.example.test:443?namespace=test" \

--- a/src/compute-plane-services/nvca/scripts/lint_helm.sh
+++ b/src/compute-plane-services/nvca/scripts/lint_helm.sh
@@ -199,6 +199,7 @@ assert_helm_managed_vault_address() {
   local chart_dir=${1}
   local chart_label=${2}
   local rendered
+  local invalid_address
   rendered="$(mktemp)"
   trap 'rm -f "${rendered}"' RETURN
 
@@ -213,26 +214,24 @@ assert_helm_managed_vault_address() {
     "$(yq '.data."cluster-dto.yaml" | from_yaml | .vaultConfig.address' "${rendered}")" \
     "${chart_label} helm-managed cluster DTO includes the configured Vault address"
 
-  if helm template test-release "${chart_dir}" \
-    --set "ngcConfig.serviceKey=fakekey" \
-    --set "ngcConfig.clusterSource=helm-managed" \
-    --set-string "helmManaged.oAuthClientID=oauth-client-1" \
-    --show-only templates/helm-managed-nvcfbackend-cm.yaml >"${rendered}" 2>&1; then
-    echo "Expected ${chart_label} helm-managed render with OAuth enabled and no Vault address to fail"
-    return 1
-  fi
-  grep -q "vaultConfig.address" "${rendered}"
-
-  if helm template test-release "${chart_dir}" \
-    --set "ngcConfig.serviceKey=fakekey" \
-    --set "ngcConfig.clusterSource=helm-managed" \
-    --set-string "helmManaged.oAuthClientID=oauth-client-1" \
-    --set-string "vaultConfig.address=https://:443" \
-    --show-only templates/helm-managed-nvcfbackend-cm.yaml >"${rendered}" 2>&1; then
-    echo "Expected ${chart_label} helm-managed render with a hostless Vault address to fail"
-    return 1
-  fi
-  grep -q "vaultConfig.address" "${rendered}"
+  for invalid_address in \
+    "" \
+    "https://:443" \
+    " https://vault.example.test:443 " \
+    "https://user@vault.example.test:443" \
+    "https://vault.example.test:443?namespace=test" \
+    "https://vault.example.test:443#test"; do
+    if helm template test-release "${chart_dir}" \
+      --set "ngcConfig.serviceKey=fakekey" \
+      --set "ngcConfig.clusterSource=helm-managed" \
+      --set-string "helmManaged.oAuthClientID=oauth-client-1" \
+      --set-string "vaultConfig.address=${invalid_address}" \
+      --show-only templates/helm-managed-nvcfbackend-cm.yaml >"${rendered}" 2>&1; then
+      printf 'Expected %s helm-managed render with invalid Vault address %q to fail\n' "${chart_label}" "${invalid_address}"
+      return 1
+    fi
+    grep -q "vaultConfig.address" "${rendered}"
+  done
 }
 
 assert_helm_managed_vault_address "${repo_root}/deployments/nvca-operator" "service chart"

--- a/src/compute-plane-services/nvca/scripts/lint_helm.sh
+++ b/src/compute-plane-services/nvca/scripts/lint_helm.sh
@@ -193,6 +193,51 @@ assert_service_oauth_nil_safe "helm-managed" \
   --set-string "clusterName=ncp-helm-managed-1" \
   --show-only templates/helm-managed-nvcfbackend-cm.yaml
 
+# Helm-managed Vault authentication must carry an explicit, usable server URL
+# into the cluster DTO. This keeps environment selection outside the OSS chart.
+assert_helm_managed_vault_address() {
+  local chart_dir=${1}
+  local chart_label=${2}
+  local rendered
+  rendered="$(mktemp)"
+  trap 'rm -f "${rendered}"' RETURN
+
+  helm template test-release "${chart_dir}" \
+    --set "ngcConfig.serviceKey=fakekey" \
+    --set "ngcConfig.clusterSource=helm-managed" \
+    --set-string "helmManaged.oAuthClientID=oauth-client-1" \
+    --set-string "vaultConfig.address=https://vault.example.test:443" \
+    --show-only templates/helm-managed-nvcfbackend-cm.yaml >"${rendered}"
+
+  assert_eq "https://vault.example.test:443" \
+    "$(yq '.data."cluster-dto.yaml" | from_yaml | .vaultConfig.address' "${rendered}")" \
+    "${chart_label} helm-managed cluster DTO includes the configured Vault address"
+
+  if helm template test-release "${chart_dir}" \
+    --set "ngcConfig.serviceKey=fakekey" \
+    --set "ngcConfig.clusterSource=helm-managed" \
+    --set-string "helmManaged.oAuthClientID=oauth-client-1" \
+    --show-only templates/helm-managed-nvcfbackend-cm.yaml >"${rendered}" 2>&1; then
+    echo "Expected ${chart_label} helm-managed render with OAuth enabled and no Vault address to fail"
+    return 1
+  fi
+  grep -q "vaultConfig.address" "${rendered}"
+
+  if helm template test-release "${chart_dir}" \
+    --set "ngcConfig.serviceKey=fakekey" \
+    --set "ngcConfig.clusterSource=helm-managed" \
+    --set-string "helmManaged.oAuthClientID=oauth-client-1" \
+    --set-string "vaultConfig.address=https://:443" \
+    --show-only templates/helm-managed-nvcfbackend-cm.yaml >"${rendered}" 2>&1; then
+    echo "Expected ${chart_label} helm-managed render with a hostless Vault address to fail"
+    return 1
+  fi
+  grep -q "vaultConfig.address" "${rendered}"
+}
+
+assert_helm_managed_vault_address "${repo_root}/deployments/nvca-operator" "service chart"
+assert_helm_managed_vault_address "${repo_root}/../../../deploy/helm/nvca-operator/nvca-operator" "release chart"
+
 assert_service_oauth_nil_safe "self-managed" \
   --set "generateImagePullSecret=false" \
   --set "ngcConfig.clusterSource=self-managed" \

--- a/src/compute-plane-services/nvca/scripts/lint_helm.sh
+++ b/src/compute-plane-services/nvca/scripts/lint_helm.sh
@@ -220,7 +220,9 @@ assert_helm_managed_vault_address() {
     "http://vault.example.test:8200" \
     " https://vault.example.test:443 " \
     "https://user@vault.example.test:443" \
+    "https://vault.example.test:443?" \
     "https://vault.example.test:443?namespace=test" \
+    "https://vault.example.test:443#" \
     "https://vault.example.test:443#test"; do
     if helm template test-release "${chart_dir}" \
       --set "ngcConfig.serviceKey=fakekey" \


### PR DESCRIPTION
## TL;DR

Backport the Helm-managed Vault address configuration and fail-safe validation from #843 to the NVCA 3.2 release line, including the HTTPS-only hardening from #854.

## Additional Details

- Adds and documents `vaultConfig.address` in the source and generated release charts.
- Renders the address into the Helm-managed cluster DTO.
- Requires an absolute HTTPS Vault URL when OAuth enables Vault integration.
- Rejects plain HTTP, surrounding whitespace, embedded credentials, queries, and fragments consistently in Helm and Go.
- Leaves OAuth-disabled Helm-managed clusters and the NGC-managed path unchanged.
- Cherry-picks the original #843 commits and both exact signed-off validation follow-ups from #854 with source commit references.

## For the Reviewer

The original two commits are a clean backport of #843. Commit `d0e412ee` is the exact cherry-pick of the #854 HTTPS-only follow-up prompted by review feedback on this PR, and `efff9be7` carries its empty-query/fragment-delimiter hardening. HTTPS is required because this address is used to send the projected service-account JWT to Vault and retrieve the OAuth client secret.

## For QA

Passed on the 3.2 branch after the HTTPS-only follow-up:

- `go test -count=1 -ldflags '-X github.com/NVIDIA/k8s-dra-driver-gpu/internal/info.version=v25.8.0' ./pkg/operator/reconcile/clustermgmt`
- `golangci-lint run --allow-parallel-runners -c .golangci.yml ./pkg/operator/reconcile/clustermgmt/...`
- `./scripts/lint_helm.sh`
- `bazel test //src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt:clustermgmt_test`

Runtime QA is still needed after a 3.2 chart containing this change is published and supplied an environment-specific HTTPS Vault address.

## Issues

Relates to #842

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
