### PR TITLE
feat(worker): prefer mounted projected ServiceAccount token for NVCF/NVCT auth

### DIFF
--- a/src/libraries/go/worker/auth/auth.go
+++ b/src/libraries/go/worker/auth/auth.go
@@ -28,6 +28,7 @@ import (
 
 type allowInsecureOauthTokenSource struct {
 	oauth.TokenSource
+	requireTLS bool
 }
 
 func (ts allowInsecureOauthTokenSource) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
@@ -40,13 +41,19 @@ func (ts allowInsecureOauthTokenSource) GetRequestMetadata(context.Context, ...s
 	}, nil
 }
 
+// RequireTransportSecurity is false for legacy NVCF-issued tokens, which may travel over
+// in-cluster plaintext, and true for a mounted projected ServiceAccount token, which must
+// only be presented over TLS.
 func (ts allowInsecureOauthTokenSource) RequireTransportSecurity() bool {
-	return false
+	return ts.requireTLS
 }
 
-func GrpcTokenFromSource(ts oauth2.TokenSource) grpc.CallOption {
+// GrpcTokenFromSource attaches ts as per-RPC bearer credentials. requireTLS must be true
+// when ts serves a mounted projected ServiceAccount token.
+func GrpcTokenFromSource(ts oauth2.TokenSource, requireTLS bool) grpc.CallOption {
 	return grpc.PerRPCCredentials(allowInsecureOauthTokenSource{
-		oauth.TokenSource{TokenSource: ts},
+		TokenSource: oauth.TokenSource{TokenSource: ts},
+		requireTLS:  requireTLS,
 	})
 }
 

--- a/src/libraries/go/worker/auth/auth_test.go
+++ b/src/libraries/go/worker/auth/auth_test.go
@@ -36,7 +36,7 @@ type stubTokenSource struct {
 func (s stubTokenSource) Token() (*oauth2.Token, error) { return s.tok, s.err }
 
 func newSource(ts oauth2.TokenSource) allowInsecureOauthTokenSource {
-	return allowInsecureOauthTokenSource{oauth.TokenSource{TokenSource: ts}}
+	return allowInsecureOauthTokenSource{TokenSource: oauth.TokenSource{TokenSource: ts}}
 }
 
 func TestGetRequestMetadata(t *testing.T) {
@@ -54,10 +54,18 @@ func TestGetRequestMetadata(t *testing.T) {
 	})
 }
 
-func TestRequireTransportSecurityIsFalse(t *testing.T) {
-	// Deliberate posture: worker RPCs carry tokens over in-cluster plaintext.
-	// Pin it so it is not flipped accidentally.
-	require.False(t, newSource(stubTokenSource{}).RequireTransportSecurity())
+func TestRequireTransportSecurity(t *testing.T) {
+	t.Run("legacy NVCF-issued tokens may travel over in-cluster plaintext", func(t *testing.T) {
+		require.False(t, newSource(stubTokenSource{}).RequireTransportSecurity())
+	})
+	t.Run("mounted projected ServiceAccount tokens require TLS", func(t *testing.T) {
+		src := allowInsecureOauthTokenSource{TokenSource: oauth.TokenSource{TokenSource: stubTokenSource{}}, requireTLS: true}
+		require.True(t, src.RequireTransportSecurity())
+	})
+	t.Run("GrpcTokenFromSource propagates the flag", func(t *testing.T) {
+		require.NotNil(t, GrpcTokenFromSource(stubTokenSource{}, true))
+		require.NotNil(t, GrpcTokenFromSource(stubTokenSource{}, false))
+	})
 }
 
 func TestSettableTokenSource(t *testing.T) {

--- a/src/libraries/go/worker/nvcf/client.go
+++ b/src/libraries/go/worker/nvcf/client.go
@@ -128,6 +128,13 @@ func CreateClient(nvcfFqdn string, nvcfFqdnNats *string, nvcfWorkerToken string,
 
 	tokenProvider := auth.NewSettableTokenSource(oauth2.StaticTokenSource(nvcfToken))
 
+	// Prefer a mounted projected ServiceAccount Token (PSAT) over the bootstrap token
+	// when running on a self-hosted cluster with worker identity enabled.
+	if mountedSrc, err := token.NewMountedJWTSource(); err == nil {
+		zap.L().Info("mounted JWT found; using projected ServiceAccount token as NVCF credential")
+		tokenProvider.SetTokenSource(mountedSrc)
+	}
+
 	client := &Client{
 		Client: workerClient,
 		regionalNvcfClients: map[string]pb.WorkerClient{

--- a/src/libraries/go/worker/nvcf/client.go
+++ b/src/libraries/go/worker/nvcf/client.go
@@ -84,6 +84,9 @@ type Client struct {
 	assertionTokenPath      string
 	sharedConfigDir         string
 	clientTimeout           time.Duration
+	// delegatedToken is true when the credential is a mounted projected ServiceAccount
+	// token. NVCF then issues no replacement token and the client persists none.
+	delegatedToken bool
 
 	// for keeping nvcf region state
 	ConnectedRegions       atomic.Pointer[ConnectionRegions]
@@ -130,13 +133,14 @@ func CreateClient(nvcfFqdn string, nvcfFqdnNats *string, nvcfWorkerToken string,
 
 	// Prefer a mounted projected ServiceAccount Token (PSAT) over the bootstrap token
 	// when running on a self-hosted cluster with worker identity enabled.
-	if mountedSrc, err := token.NewMountedJWTSource(); err == nil {
-		zap.L().Info("mounted JWT found; using projected ServiceAccount token as NVCF credential")
-		tokenProvider.SetTokenSource(mountedSrc)
+	delegatedToken, err := token.SelectMountedToken(tokenProvider, nvcfFqdn, "NVCF")
+	if err != nil {
+		return nil, err
 	}
 
 	client := &Client{
-		Client: workerClient,
+		delegatedToken: delegatedToken,
+		Client:         workerClient,
 		regionalNvcfClients: map[string]pb.WorkerClient{
 			nvcfFqdn: workerClient,
 		},
@@ -511,7 +515,7 @@ func (c *Client) GetArtifacts(ctx context.Context) (*types.ArtifactsList, error)
 		var internalResources []types.Artifact
 		var internalInvalidArtifacts int
 
-		stream, err := c.Client.StreamArtifacts(ctx, &pb.ArtifactsRequest{}, auth.GrpcTokenFromSource(c.NvcfTokenProvider))
+		stream, err := c.Client.StreamArtifacts(ctx, &pb.ArtifactsRequest{}, auth.GrpcTokenFromSource(c.NvcfTokenProvider, c.delegatedToken))
 		if err != nil {
 			span.AddEvent(fmt.Sprintf("Failed to start streaming artifacts from NVCF: %s", err.Error()))
 			zap.L().Warn("failed to start streaming artifacts from NVCF", zap.Error(err))

--- a/src/libraries/go/worker/nvcf/client_test.go
+++ b/src/libraries/go/worker/nvcf/client_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 
@@ -31,6 +32,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/NVIDIA/nvcf/src/libraries/go/worker/auth"
+	"github.com/NVIDIA/nvcf/src/libraries/go/worker/token"
 )
 
 // mockTokenSource is a mock implementation of oauth2.TokenSource
@@ -333,6 +335,77 @@ func TestNatsAuthOption_BothPathsComparison(t *testing.T) {
 	// Verify they set different authentication methods
 	assert.NotEqual(t, tokenOpts.TokenHandler != nil, nkeyOpts.TokenHandler != nil)
 	assert.NotEqual(t, tokenOpts.Nkey != "", nkeyOpts.Nkey != "")
+}
+
+// TestCredentialSelection_FallsBackToBootstrap verifies that when no mounted JWT is
+// available, the bootstrap token provided at construction remains active.
+func TestCredentialSelection_FallsBackToBootstrap(t *testing.T) {
+	t.Setenv("NVCF_TOKEN_FILE_PATH", "")
+
+	bootstrapToken := "bootstrap-nvcf-token"
+	nvcfToken := &oauth2.Token{AccessToken: bootstrapToken}
+	tokenProvider := auth.NewSettableTokenSource(oauth2.StaticTokenSource(nvcfToken))
+
+	// Replicate the selection logic from CreateClient.
+	if mountedSrc, err := token.NewMountedJWTSource(); err == nil {
+		tokenProvider.SetTokenSource(mountedSrc)
+	}
+
+	tok, err := tokenProvider.Token()
+	require.NoError(t, err)
+	assert.Equal(t, bootstrapToken, tok.AccessToken, "bootstrap token should be active when no mounted JWT")
+}
+
+// TestCredentialSelection_PrefersMountedJWT verifies that a mounted PSAT replaces
+// the bootstrap token when NVCF_TOKEN_FILE_PATH points to a valid regular file.
+func TestCredentialSelection_PrefersMountedJWT(t *testing.T) {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	claims := base64.RawURLEncoding.EncodeToString(
+		[]byte(`{"sub":"system:serviceaccount:nvcf-backend:nvcf-worker-inst","exp":9999999999}`),
+	)
+	jwtStr := header + "." + claims + ".fakesig"
+
+	f, err := os.CreateTemp("", "psat-*.jwt")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	_, err = f.WriteString(jwtStr)
+	require.NoError(t, err)
+	f.Close()
+
+	t.Setenv("NVCF_TOKEN_FILE_PATH", f.Name())
+
+	bootstrapToken := "bootstrap-nvcf-token"
+	nvcfToken := &oauth2.Token{AccessToken: bootstrapToken}
+	tokenProvider := auth.NewSettableTokenSource(oauth2.StaticTokenSource(nvcfToken))
+
+	// Replicate the selection logic from CreateClient.
+	if mountedSrc, err := token.NewMountedJWTSource(); err == nil {
+		tokenProvider.SetTokenSource(mountedSrc)
+	}
+
+	tok, err := tokenProvider.Token()
+	require.NoError(t, err)
+	assert.Equal(t, jwtStr, tok.AccessToken, "mounted JWT should replace bootstrap token")
+	assert.NotEqual(t, bootstrapToken, tok.AccessToken)
+}
+
+// TestCredentialSelection_SetTokenSourceReplacesProvider verifies that
+// SetTokenSource replaces the active credential after initial construction.
+func TestCredentialSelection_SetTokenSourceReplacesProvider(t *testing.T) {
+	original := &oauth2.Token{AccessToken: "original"}
+	replacement := &oauth2.Token{AccessToken: "replacement"}
+
+	tokenProvider := auth.NewSettableTokenSource(oauth2.StaticTokenSource(original))
+
+	tok, err := tokenProvider.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "original", tok.AccessToken)
+
+	tokenProvider.SetTokenSource(oauth2.StaticTokenSource(replacement))
+
+	tok, err = tokenProvider.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "replacement", tok.AccessToken)
 }
 
 // Helper function to generate a valid user NKey seed for testing

--- a/src/libraries/go/worker/nvcf/client_test.go
+++ b/src/libraries/go/worker/nvcf/client_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"os"
 	"strings"
 	"testing"
 
@@ -32,7 +31,6 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/NVIDIA/nvcf/src/libraries/go/worker/auth"
-	"github.com/NVIDIA/nvcf/src/libraries/go/worker/token"
 )
 
 // mockTokenSource is a mock implementation of oauth2.TokenSource
@@ -335,77 +333,6 @@ func TestNatsAuthOption_BothPathsComparison(t *testing.T) {
 	// Verify they set different authentication methods
 	assert.NotEqual(t, tokenOpts.TokenHandler != nil, nkeyOpts.TokenHandler != nil)
 	assert.NotEqual(t, tokenOpts.Nkey != "", nkeyOpts.Nkey != "")
-}
-
-// TestCredentialSelection_FallsBackToBootstrap verifies that when no mounted JWT is
-// available, the bootstrap token provided at construction remains active.
-func TestCredentialSelection_FallsBackToBootstrap(t *testing.T) {
-	t.Setenv("NVCF_TOKEN_FILE_PATH", "")
-
-	bootstrapToken := "bootstrap-nvcf-token"
-	nvcfToken := &oauth2.Token{AccessToken: bootstrapToken}
-	tokenProvider := auth.NewSettableTokenSource(oauth2.StaticTokenSource(nvcfToken))
-
-	// Replicate the selection logic from CreateClient.
-	if mountedSrc, err := token.NewMountedJWTSource(); err == nil {
-		tokenProvider.SetTokenSource(mountedSrc)
-	}
-
-	tok, err := tokenProvider.Token()
-	require.NoError(t, err)
-	assert.Equal(t, bootstrapToken, tok.AccessToken, "bootstrap token should be active when no mounted JWT")
-}
-
-// TestCredentialSelection_PrefersMountedJWT verifies that a mounted PSAT replaces
-// the bootstrap token when NVCF_TOKEN_FILE_PATH points to a valid regular file.
-func TestCredentialSelection_PrefersMountedJWT(t *testing.T) {
-	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
-	claims := base64.RawURLEncoding.EncodeToString(
-		[]byte(`{"sub":"system:serviceaccount:nvcf-backend:nvcf-worker-inst","exp":9999999999}`),
-	)
-	jwtStr := header + "." + claims + ".fakesig"
-
-	f, err := os.CreateTemp("", "psat-*.jwt")
-	require.NoError(t, err)
-	defer os.Remove(f.Name())
-	_, err = f.WriteString(jwtStr)
-	require.NoError(t, err)
-	f.Close()
-
-	t.Setenv("NVCF_TOKEN_FILE_PATH", f.Name())
-
-	bootstrapToken := "bootstrap-nvcf-token"
-	nvcfToken := &oauth2.Token{AccessToken: bootstrapToken}
-	tokenProvider := auth.NewSettableTokenSource(oauth2.StaticTokenSource(nvcfToken))
-
-	// Replicate the selection logic from CreateClient.
-	if mountedSrc, err := token.NewMountedJWTSource(); err == nil {
-		tokenProvider.SetTokenSource(mountedSrc)
-	}
-
-	tok, err := tokenProvider.Token()
-	require.NoError(t, err)
-	assert.Equal(t, jwtStr, tok.AccessToken, "mounted JWT should replace bootstrap token")
-	assert.NotEqual(t, bootstrapToken, tok.AccessToken)
-}
-
-// TestCredentialSelection_SetTokenSourceReplacesProvider verifies that
-// SetTokenSource replaces the active credential after initial construction.
-func TestCredentialSelection_SetTokenSourceReplacesProvider(t *testing.T) {
-	original := &oauth2.Token{AccessToken: "original"}
-	replacement := &oauth2.Token{AccessToken: "replacement"}
-
-	tokenProvider := auth.NewSettableTokenSource(oauth2.StaticTokenSource(original))
-
-	tok, err := tokenProvider.Token()
-	require.NoError(t, err)
-	assert.Equal(t, "original", tok.AccessToken)
-
-	tokenProvider.SetTokenSource(oauth2.StaticTokenSource(replacement))
-
-	tok, err = tokenProvider.Token()
-	require.NoError(t, err)
-	assert.Equal(t, "replacement", tok.AccessToken)
 }
 
 // Helper function to generate a valid user NKey seed for testing

--- a/src/libraries/go/worker/nvcf/connect.go
+++ b/src/libraries/go/worker/nvcf/connect.go
@@ -64,13 +64,13 @@ func (c *Client) ConnectIndefinitely(ctx context.Context) (context.Context, erro
 				}
 				utils.SleepWithContext(ctx, sleepDuration)
 			}
-		maxElapsed := time.Until(token.Expiry)
-		if maxElapsed <= 0 {
-			maxElapsed = 5 * time.Minute
-		}
-		err = backoff.Retry(func() error {
-			return c.connect(ctx)
-		}, backoff.WithContext(backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(maxElapsed)), ctx))
+			maxElapsed := time.Until(token.Expiry)
+			if maxElapsed <= 0 {
+				maxElapsed = 5 * time.Minute
+			}
+			err = backoff.Retry(func() error {
+				return c.connect(ctx)
+			}, backoff.WithContext(backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(maxElapsed)), ctx))
 			if err != nil {
 				zap.L().Error("failed to reconnect to NVCF", zap.Error(err))
 				return
@@ -91,7 +91,7 @@ func (c *Client) connect(ctx context.Context) error {
 		InstanceId:        c.instanceId,
 		FunctionId:        c.functionId,
 		FunctionVersionId: c.functionVersionId,
-	}, auth.GrpcTokenFromSource(c.NvcfTokenProvider))
+	}, auth.GrpcTokenFromSource(c.NvcfTokenProvider, c.delegatedToken))
 	if err != nil {
 		return fmt.Errorf("failed to send connect request to NVCF: %w", err)
 	}
@@ -99,6 +99,12 @@ func (c *Client) connect(ctx context.Context) error {
 		return fmt.Errorf("nvcf did not respond with a connected region")
 	}
 	c.updateConnectedRegions(connected.ConnectedRegion, connected.OtherRegions)
+	if c.delegatedToken {
+		// The mounted JWT stays the credential for the life of the process; NVCF issues no
+		// replacement token on this path and nothing is persisted.
+		zap.L().Info("connected to NVCF", zap.String("region", connected.ConnectedRegion), zap.Strings("secondaryRegions", connected.OtherRegions))
+		return nil
+	}
 	oauthToken := &oauth2.Token{
 		AccessToken: connected.NvcfWorkerToken,
 		Expiry:      connected.Expiration.AsTime(),

--- a/src/libraries/go/worker/nvcf/ess.go
+++ b/src/libraries/go/worker/nvcf/ess.go
@@ -56,7 +56,7 @@ func (c *Client) getAssertionToken(ctx context.Context) (token.Token, error) {
 		resp, err = c.Client.RequestSecretCredentials(ctx, &pb.SecretCredentialsRequest{
 			FunctionId:        c.functionId,
 			FunctionVersionId: c.functionVersionId,
-		}, auth.GrpcTokenFromSource(c.NvcfTokenProvider))
+		}, auth.GrpcTokenFromSource(c.NvcfTokenProvider, c.delegatedToken))
 		if err != nil {
 			return err
 		}

--- a/src/libraries/go/worker/nvcf/metadata.go
+++ b/src/libraries/go/worker/nvcf/metadata.go
@@ -56,7 +56,7 @@ func (c *Client) getMetadataCredentials(ctx context.Context) (token.Token, error
 				NcaId:             c.ncaId,
 				FunctionId:        c.functionId,
 				FunctionVersionId: c.functionVersionId,
-			}, auth.GrpcTokenFromSource(c.NvcfTokenProvider))
+			}, auth.GrpcTokenFromSource(c.NvcfTokenProvider, c.delegatedToken))
 		return err
 	}, backoff.WithContext(backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 10), ctx))
 

--- a/src/libraries/go/worker/nvcf/psat_client_test.go
+++ b/src/libraries/go/worker/nvcf/psat_client_test.go
@@ -1,0 +1,142 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvcf
+
+import (
+	"context"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pb "github.com/NVIDIA/nvcf/src/libraries/go/worker/proto/nvcf"
+	"github.com/NVIDIA/nvcf/src/libraries/go/worker/token"
+)
+
+func fakePSAT(exp int64) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	claims := base64.RawURLEncoding.EncodeToString([]byte(
+		`{"sub":"system:serviceaccount:inst-1:nvcf-worker","aud":["nvcf-icms:cl-1"],"exp":` +
+			strconv.FormatInt(exp, 10) + `}`))
+	return header + "." + claims + ".fakesig"
+}
+
+// mountPSAT writes a fake PSAT under a temporary allowed root and points the env var at it.
+func mountPSAT(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+	old := token.MountedTokenRoot
+	token.MountedTokenRoot = root + "/"
+	t.Cleanup(func() { token.MountedTokenRoot = old })
+	path := filepath.Join(root, "token")
+	jwt := fakePSAT(time.Now().Add(15 * time.Minute).Unix())
+	require.NoError(t, os.WriteFile(path, []byte(jwt), 0600))
+	t.Setenv(token.MountedTokenPathEnvKey, path)
+	return jwt
+}
+
+func TestCreateClient_NoMountedJWT_UsesBootstrap(t *testing.T) {
+	t.Setenv(token.MountedTokenPathEnvKey, filepath.Join(t.TempDir(), "absent"))
+	fqdn := startMockServer(t, &mockWorkerServer{})
+
+	client, err := CreateClient(fqdn, nil, "bootstrap-token", nil, "nca", "inst", "fn", "fnv", t.TempDir(), DefaultNvcfClientTimeout)
+	require.NoError(t, err)
+	assert.False(t, client.delegatedToken)
+	tok, err := client.NvcfTokenProvider.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "bootstrap-token", tok.AccessToken)
+}
+
+func TestCreateClient_MountedJWT_RequiresHTTPS(t *testing.T) {
+	mountPSAT(t)
+	fqdn := startMockServer(t, &mockWorkerServer{}) // http://
+
+	_, err := CreateClient(fqdn, nil, "bootstrap-token", nil, "nca", "inst", "fn", "fnv", t.TempDir(), DefaultNvcfClientTimeout)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires TLS")
+}
+
+func TestCreateClient_MountedJWT_PreferredOverBootstrapAndCache(t *testing.T) {
+	jwt := mountPSAT(t)
+	sharedDir := t.TempDir()
+	require.NoError(t, token.CacheToken(filepath.Join(sharedDir, cachedNvcfTokenFilename),
+		&oauth2.Token{AccessToken: "cached-token", Expiry: time.Now().Add(time.Hour)}))
+
+	client, err := CreateClient("https://127.0.0.1:1", nil, "bootstrap-token", nil, "nca", "inst", "fn", "fnv", sharedDir, DefaultNvcfClientTimeout)
+	require.NoError(t, err)
+	assert.True(t, client.delegatedToken)
+	tok, err := client.NvcfTokenProvider.Token()
+	require.NoError(t, err)
+	assert.Equal(t, jwt, tok.AccessToken, "mounted JWT wins over cached and bootstrap tokens")
+}
+
+func TestCreateClient_MountedJWT_UnreadableIsAnError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can read mode 0000 files")
+	}
+	mountPSAT(t)
+	require.NoError(t, os.Chmod(os.Getenv(token.MountedTokenPathEnvKey), 0000))
+
+	_, err := CreateClient("https://127.0.0.1:1", nil, "bootstrap-token", nil, "nca", "inst", "fn", "fnv", t.TempDir(), DefaultNvcfClientTimeout)
+	require.Error(t, err)
+	assert.False(t, strings.Contains(err.Error(), "no mounted JWT"), "read failures must not be treated as no token mounted")
+}
+
+// delegatedConnectClient answers ConnectOnce in-process. A real plaintext gRPC connection
+// would reject the per-RPC credentials because a mounted JWT requires TLS.
+type delegatedConnectClient struct {
+	pb.WorkerClient
+}
+
+func (delegatedConnectClient) ConnectOnce(context.Context, *pb.WorkerConnect, ...grpc.CallOption) (*pb.WorkerConnectOnceResponse, error) {
+	return &pb.WorkerConnectOnceResponse{
+		ConnectedRegion: "us-east-1",
+		NvcfWorkerToken: "", // NVCF issues no replacement token on the delegated path
+		Expiration:      timestamppb.New(time.Now().Add(15 * time.Minute)),
+	}, nil
+}
+
+func TestConnect_DelegatedToken_KeepsPSATAndPersistsNothing(t *testing.T) {
+	fqdn := startMockServer(t, &mockWorkerServer{})
+	c := newTestClient(t, fqdn)
+	c.Client = delegatedConnectClient{}
+	c.delegatedToken = true
+	before, err := c.NvcfTokenProvider.Token()
+	require.NoError(t, err)
+
+	require.NoError(t, c.connect(context.Background()))
+
+	after, err := c.NvcfTokenProvider.Token()
+	require.NoError(t, err)
+	assert.Equal(t, before.AccessToken, after.AccessToken, "PSAT source must remain installed")
+	_, statErr := os.Stat(filepath.Join(c.sharedConfigDir, cachedNvcfTokenFilename))
+	assert.True(t, os.IsNotExist(statErr), "no token may be persisted on the delegated path")
+	regions := c.ConnectedRegions.Load()
+	require.NotNil(t, regions)
+	assert.Equal(t, "us-east-1", regions.Primary)
+}

--- a/src/libraries/go/worker/nvct/artifacts.go
+++ b/src/libraries/go/worker/nvct/artifacts.go
@@ -40,7 +40,7 @@ func (c *Client) GetArtifacts(ctx context.Context) (*types.ArtifactsList, error)
 		var err error
 		response, err = c.Client.GetArtifacts(ctx, &pb.ArtifactsRequest{
 			TaskId: c.taskId,
-		}, auth.GrpcTokenFromSource(c.NvctTokenProvider))
+		}, auth.GrpcTokenFromSource(c.NvctTokenProvider, c.delegatedToken))
 		if err != nil {
 			zap.L().Warn("failed to get artifacts from NVCT", zap.Error(err))
 		}

--- a/src/libraries/go/worker/nvct/client.go
+++ b/src/libraries/go/worker/nvct/client.go
@@ -100,12 +100,21 @@ func CreateClient(nvctFqdn string, nvctWorkerToken string, instanceId string, ta
 		zap.L().Info("no cached token found - using environment token")
 	}
 
+	nvctTokenProvider := auth.NewSettableTokenSource(oauth2.StaticTokenSource(nvctToken))
+
+	// Prefer a mounted projected ServiceAccount Token (PSAT) over the bootstrap token
+	// when running on a self-hosted cluster with worker identity enabled.
+	if mountedSrc, err := token.NewMountedJWTSource(); err == nil {
+		zap.L().Info("mounted JWT found; using projected ServiceAccount token as NVCT credential")
+		nvctTokenProvider.SetTokenSource(mountedSrc)
+	}
+
 	return &Client{
 		Client: workerClient,
 		regionalNvctClients: map[string]pb.WorkerClient{
 			nvctFqdn: workerClient,
 		},
-		NvctTokenProvider: auth.NewSettableTokenSource(oauth2.StaticTokenSource(nvctToken)),
+		NvctTokenProvider: nvctTokenProvider,
 		instanceId:        instanceId,
 		taskId:            taskId,
 		instanceType:      instanceType,

--- a/src/libraries/go/worker/nvct/client.go
+++ b/src/libraries/go/worker/nvct/client.go
@@ -56,6 +56,9 @@ type Client struct {
 	instanceType            string
 	clientTimeout           time.Duration
 	sharedConfigDir         string
+	// delegatedToken is true when the credential is a mounted projected ServiceAccount
+	// token. NVCT then issues no replacement token and the client persists none.
+	delegatedToken bool
 }
 
 func CreateClient(nvctFqdn string, nvctWorkerToken string, instanceId string, taskId string, instanceType string, nvctClientTimeout time.Duration, sharedConfigDir string) (*Client, error) {
@@ -104,13 +107,14 @@ func CreateClient(nvctFqdn string, nvctWorkerToken string, instanceId string, ta
 
 	// Prefer a mounted projected ServiceAccount Token (PSAT) over the bootstrap token
 	// when running on a self-hosted cluster with worker identity enabled.
-	if mountedSrc, err := token.NewMountedJWTSource(); err == nil {
-		zap.L().Info("mounted JWT found; using projected ServiceAccount token as NVCT credential")
-		nvctTokenProvider.SetTokenSource(mountedSrc)
+	delegatedToken, err := token.SelectMountedToken(nvctTokenProvider, nvctFqdn, "NVCT")
+	if err != nil {
+		return nil, err
 	}
 
 	return &Client{
-		Client: workerClient,
+		delegatedToken: delegatedToken,
+		Client:         workerClient,
 		regionalNvctClients: map[string]pb.WorkerClient{
 			nvctFqdn: workerClient,
 		},

--- a/src/libraries/go/worker/nvct/client_test.go
+++ b/src/libraries/go/worker/nvct/client_test.go
@@ -19,6 +19,7 @@ package nvct
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -29,11 +30,13 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap"
 	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/nvkit/logs"
+	"go.uber.org/zap"
 
+	"github.com/NVIDIA/nvcf/src/libraries/go/worker/auth"
 	"github.com/NVIDIA/nvcf/src/libraries/go/worker/proto/nvct"
 	"github.com/NVIDIA/nvcf/src/libraries/go/worker/test/testutils"
+	"github.com/NVIDIA/nvcf/src/libraries/go/worker/token"
 	"github.com/NVIDIA/nvcf/src/libraries/go/worker/types"
 
 	"golang.org/x/oauth2"
@@ -374,4 +377,93 @@ func validateArtifacts(artifacts *types.ArtifactsList) error {
 
 	return nil
 
+}
+
+// TestNvctCredentialSelection_FallsBackToBootstrap verifies that when no mounted JWT is
+// available, the bootstrap token provided at construction remains active.
+func TestNvctCredentialSelection_FallsBackToBootstrap(t *testing.T) {
+	t.Setenv("NVCF_TOKEN_FILE_PATH", "")
+
+	bootstrapToken := "bootstrap-nvct-token"
+	nvctToken := &oauth2.Token{AccessToken: bootstrapToken}
+	tokenProvider := auth.NewSettableTokenSource(oauth2.StaticTokenSource(nvctToken))
+
+	// Replicate the selection logic from CreateClient.
+	if mountedSrc, err := token.NewMountedJWTSource(); err == nil {
+		tokenProvider.SetTokenSource(mountedSrc)
+	}
+
+	tok, err := tokenProvider.Token()
+	if err != nil {
+		t.Fatalf("Token() error: %v", err)
+	}
+	if tok.AccessToken != bootstrapToken {
+		t.Errorf("expected bootstrap token %q, got %q", bootstrapToken, tok.AccessToken)
+	}
+}
+
+// TestNvctCredentialSelection_PrefersMountedJWT verifies that a mounted PSAT replaces
+// the bootstrap token when NVCF_TOKEN_FILE_PATH points to a valid regular file.
+func TestNvctCredentialSelection_PrefersMountedJWT(t *testing.T) {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	claims := base64.RawURLEncoding.EncodeToString(
+		[]byte(`{"sub":"system:serviceaccount:nvcf-backend:nvcf-worker-inst","exp":9999999999}`),
+	)
+	jwtStr := header + "." + claims + ".fakesig"
+
+	f, err := os.CreateTemp("", "psat-*.jwt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString(jwtStr); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	t.Setenv("NVCF_TOKEN_FILE_PATH", f.Name())
+
+	bootstrapToken := "bootstrap-nvct-token"
+	nvctToken := &oauth2.Token{AccessToken: bootstrapToken}
+	tokenProvider := auth.NewSettableTokenSource(oauth2.StaticTokenSource(nvctToken))
+
+	// Replicate the selection logic from CreateClient.
+	if mountedSrc, err := token.NewMountedJWTSource(); err == nil {
+		tokenProvider.SetTokenSource(mountedSrc)
+	}
+
+	tok, err := tokenProvider.Token()
+	if err != nil {
+		t.Fatalf("Token() error: %v", err)
+	}
+	if tok.AccessToken != jwtStr {
+		t.Errorf("expected mounted JWT %q, got %q", jwtStr, tok.AccessToken)
+	}
+}
+
+// TestNvctCredentialSelection_SetTokenSourceReplacesProvider verifies that
+// SetTokenSource replaces the active credential after initial construction.
+func TestNvctCredentialSelection_SetTokenSourceReplacesProvider(t *testing.T) {
+	original := &oauth2.Token{AccessToken: "original"}
+	replacement := &oauth2.Token{AccessToken: "replacement"}
+
+	tokenProvider := auth.NewSettableTokenSource(oauth2.StaticTokenSource(original))
+
+	tok, err := tokenProvider.Token()
+	if err != nil {
+		t.Fatalf("Token() error: %v", err)
+	}
+	if tok.AccessToken != "original" {
+		t.Errorf("expected original token, got %q", tok.AccessToken)
+	}
+
+	tokenProvider.SetTokenSource(oauth2.StaticTokenSource(replacement))
+
+	tok, err = tokenProvider.Token()
+	if err != nil {
+		t.Fatalf("Token() error after replacement: %v", err)
+	}
+	if tok.AccessToken != "replacement" {
+		t.Errorf("expected replacement token, got %q", tok.AccessToken)
+	}
 }

--- a/src/libraries/go/worker/nvct/client_test.go
+++ b/src/libraries/go/worker/nvct/client_test.go
@@ -19,7 +19,6 @@ package nvct
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -33,10 +32,8 @@ import (
 	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/nvkit/logs"
 	"go.uber.org/zap"
 
-	"github.com/NVIDIA/nvcf/src/libraries/go/worker/auth"
 	"github.com/NVIDIA/nvcf/src/libraries/go/worker/proto/nvct"
 	"github.com/NVIDIA/nvcf/src/libraries/go/worker/test/testutils"
-	"github.com/NVIDIA/nvcf/src/libraries/go/worker/token"
 	"github.com/NVIDIA/nvcf/src/libraries/go/worker/types"
 
 	"golang.org/x/oauth2"
@@ -179,6 +176,7 @@ func TestSendResultMetadata(t *testing.T) {
 		ctx,
 		mockClient.Client,
 		mockClient.NvctTokenProvider,
+		false,
 	)
 	defer func() {
 		if err := mockStreamingClient.Close(); err != nil {
@@ -377,93 +375,4 @@ func validateArtifacts(artifacts *types.ArtifactsList) error {
 
 	return nil
 
-}
-
-// TestNvctCredentialSelection_FallsBackToBootstrap verifies that when no mounted JWT is
-// available, the bootstrap token provided at construction remains active.
-func TestNvctCredentialSelection_FallsBackToBootstrap(t *testing.T) {
-	t.Setenv("NVCF_TOKEN_FILE_PATH", "")
-
-	bootstrapToken := "bootstrap-nvct-token"
-	nvctToken := &oauth2.Token{AccessToken: bootstrapToken}
-	tokenProvider := auth.NewSettableTokenSource(oauth2.StaticTokenSource(nvctToken))
-
-	// Replicate the selection logic from CreateClient.
-	if mountedSrc, err := token.NewMountedJWTSource(); err == nil {
-		tokenProvider.SetTokenSource(mountedSrc)
-	}
-
-	tok, err := tokenProvider.Token()
-	if err != nil {
-		t.Fatalf("Token() error: %v", err)
-	}
-	if tok.AccessToken != bootstrapToken {
-		t.Errorf("expected bootstrap token %q, got %q", bootstrapToken, tok.AccessToken)
-	}
-}
-
-// TestNvctCredentialSelection_PrefersMountedJWT verifies that a mounted PSAT replaces
-// the bootstrap token when NVCF_TOKEN_FILE_PATH points to a valid regular file.
-func TestNvctCredentialSelection_PrefersMountedJWT(t *testing.T) {
-	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
-	claims := base64.RawURLEncoding.EncodeToString(
-		[]byte(`{"sub":"system:serviceaccount:nvcf-backend:nvcf-worker-inst","exp":9999999999}`),
-	)
-	jwtStr := header + "." + claims + ".fakesig"
-
-	f, err := os.CreateTemp("", "psat-*.jwt")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(f.Name())
-	if _, err := f.WriteString(jwtStr); err != nil {
-		t.Fatal(err)
-	}
-	f.Close()
-
-	t.Setenv("NVCF_TOKEN_FILE_PATH", f.Name())
-
-	bootstrapToken := "bootstrap-nvct-token"
-	nvctToken := &oauth2.Token{AccessToken: bootstrapToken}
-	tokenProvider := auth.NewSettableTokenSource(oauth2.StaticTokenSource(nvctToken))
-
-	// Replicate the selection logic from CreateClient.
-	if mountedSrc, err := token.NewMountedJWTSource(); err == nil {
-		tokenProvider.SetTokenSource(mountedSrc)
-	}
-
-	tok, err := tokenProvider.Token()
-	if err != nil {
-		t.Fatalf("Token() error: %v", err)
-	}
-	if tok.AccessToken != jwtStr {
-		t.Errorf("expected mounted JWT %q, got %q", jwtStr, tok.AccessToken)
-	}
-}
-
-// TestNvctCredentialSelection_SetTokenSourceReplacesProvider verifies that
-// SetTokenSource replaces the active credential after initial construction.
-func TestNvctCredentialSelection_SetTokenSourceReplacesProvider(t *testing.T) {
-	original := &oauth2.Token{AccessToken: "original"}
-	replacement := &oauth2.Token{AccessToken: "replacement"}
-
-	tokenProvider := auth.NewSettableTokenSource(oauth2.StaticTokenSource(original))
-
-	tok, err := tokenProvider.Token()
-	if err != nil {
-		t.Fatalf("Token() error: %v", err)
-	}
-	if tok.AccessToken != "original" {
-		t.Errorf("expected original token, got %q", tok.AccessToken)
-	}
-
-	tokenProvider.SetTokenSource(oauth2.StaticTokenSource(replacement))
-
-	tok, err = tokenProvider.Token()
-	if err != nil {
-		t.Fatalf("Token() error after replacement: %v", err)
-	}
-	if tok.AccessToken != "replacement" {
-		t.Errorf("expected replacement token, got %q", tok.AccessToken)
-	}
 }

--- a/src/libraries/go/worker/nvct/connect.go
+++ b/src/libraries/go/worker/nvct/connect.go
@@ -47,7 +47,7 @@ func (c *Client) Connect(ctx context.Context) error {
 		connectRespnse, connectErr := c.Client.Connect(ctx, &pb.ConnectRequest{
 			InstanceId: c.instanceId,
 			TaskId:     c.taskId,
-		}, auth.GrpcTokenFromSource(c.NvctTokenProvider))
+		}, auth.GrpcTokenFromSource(c.NvctTokenProvider, c.delegatedToken))
 		if connectErr != nil {
 			zap.L().Error("failed to connect to NVCT", zap.Error(connectErr))
 			return connectErr

--- a/src/libraries/go/worker/nvct/coverage_test.go
+++ b/src/libraries/go/worker/nvct/coverage_test.go
@@ -424,7 +424,7 @@ func TestStreamingClientFlushNoStreamer(t *testing.T) {
 	fqdn := startMock(t, srv)
 	c := newClientForMock(t, fqdn)
 
-	sc := NewStreamingClient(context.Background(), c.Client, c.NvctTokenProvider)
+	sc := NewStreamingClient(context.Background(), c.Client, c.NvctTokenProvider, false)
 	// No streamer created yet; Flush -> Close should be a clean no-op.
 	require.NoError(t, sc.Flush())
 }
@@ -434,7 +434,7 @@ func TestStreamingClientSendAndFlush(t *testing.T) {
 	fqdn := startMock(t, srv)
 	c := newClientForMock(t, fqdn)
 
-	sc := NewStreamingClient(context.Background(), c.Client, c.NvctTokenProvider)
+	sc := NewStreamingClient(context.Background(), c.Client, c.NvctTokenProvider, false)
 
 	var progress uint32
 	req := &pb.ResultMetadataRequest{
@@ -463,7 +463,7 @@ func TestStreamingClientClearOldStreamer(t *testing.T) {
 	fqdn := startMock(t, srv)
 	c := newClientForMock(t, fqdn)
 
-	sc := NewStreamingClient(context.Background(), c.Client, c.NvctTokenProvider)
+	sc := NewStreamingClient(context.Background(), c.Client, c.NvctTokenProvider, false)
 
 	var progress uint32
 	req := &pb.ResultMetadataRequest{
@@ -494,7 +494,7 @@ func TestStreamingClientSendResultServerError(t *testing.T) {
 	fqdn := startMock(t, srv)
 	c := newClientForMock(t, fqdn)
 
-	sc := NewStreamingClient(context.Background(), c.Client, c.NvctTokenProvider)
+	sc := NewStreamingClient(context.Background(), c.Client, c.NvctTokenProvider, false)
 
 	var progress uint32
 	req := &pb.ResultMetadataRequest{

--- a/src/libraries/go/worker/nvct/ess.go
+++ b/src/libraries/go/worker/nvct/ess.go
@@ -55,7 +55,7 @@ func (c *Client) getAssertionToken(ctx context.Context) (token.Token, error) {
 		var err error
 		resp, err = c.Client.RequestSecretCredentials(ctx, &pb.SecretCredentialsRequest{
 			TaskId: c.taskId,
-		}, auth.GrpcTokenFromSource(c.NvctTokenProvider))
+		}, auth.GrpcTokenFromSource(c.NvctTokenProvider, c.delegatedToken))
 		if err != nil {
 			return err
 		}

--- a/src/libraries/go/worker/nvct/heartbeat.go
+++ b/src/libraries/go/worker/nvct/heartbeat.go
@@ -93,7 +93,7 @@ func (c *Client) sendHeartbeat(ctx context.Context, request *pb.HeartbeatRequest
 	executionStatus := pb.ExecutionStatus_RUNNING.String()
 
 	err := backoff.Retry(func() error {
-		resp, err := c.Client.SendHeartbeat(ctx, request, auth.GrpcTokenFromSource(c.NvctTokenProvider))
+		resp, err := c.Client.SendHeartbeat(ctx, request, auth.GrpcTokenFromSource(c.NvctTokenProvider, c.delegatedToken))
 		zap.L().Debug(
 			"Got heartbeat response",
 			zap.String("task id", resp.GetTaskId()),

--- a/src/libraries/go/worker/nvct/psat_client_test.go
+++ b/src/libraries/go/worker/nvct/psat_client_test.go
@@ -1,0 +1,153 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvct
+
+import (
+	"context"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/nvcf/src/libraries/go/worker/test/testutils"
+	"github.com/NVIDIA/nvcf/src/libraries/go/worker/token"
+)
+
+// fakePSAT builds an unsigned projected ServiceAccount token shape with an exp claim.
+func fakePSAT(exp int64) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	claims := base64.RawURLEncoding.EncodeToString([]byte(
+		`{"sub":"system:serviceaccount:inst-1:nvcf-worker","aud":["nvcf-icms:cl-1"],"exp":` +
+			strconv.FormatInt(exp, 10) + `}`))
+	return header + "." + claims + ".fakesig"
+}
+
+// mountPSAT writes a JWT under a temporary allowed root and points the env var at it.
+func mountPSAT(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := token.MountedTokenRoot
+	token.MountedTokenRoot = root + "/"
+	t.Cleanup(func() { token.MountedTokenRoot = old })
+	jwt := fakePSAT(time.Now().Add(15 * time.Minute).Unix())
+	path := filepath.Join(root, "token")
+	if err := os.WriteFile(path, []byte(jwt), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(token.MountedTokenPathEnvKey, path)
+	return jwt
+}
+
+func bootstrapJWT(t *testing.T) string {
+	t.Helper()
+	s, err := testutils.GenerateJWT(time.Now().Unix())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func TestCreateClient_NoMountedJWT_UsesBootstrap(t *testing.T) {
+	t.Setenv(token.MountedTokenPathEnvKey, filepath.Join(t.TempDir(), "absent"))
+	bootstrap := bootstrapJWT(t)
+
+	c, err := CreateClient(nvctFQDN, bootstrap, instanceId, taskId, instanceType, DefaultNvctClientTimeout, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.delegatedToken {
+		t.Error("delegatedToken should be false without a mounted JWT")
+	}
+	tok, err := c.NvctTokenProvider.Token()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok.AccessToken != bootstrap {
+		t.Errorf("expected bootstrap token, got %q", tok.AccessToken)
+	}
+}
+
+func TestCreateClient_MountedJWT_RequiresHTTPS(t *testing.T) {
+	mountPSAT(t)
+	_, err := CreateClient(nvctFQDN, bootstrapJWT(t), instanceId, taskId, instanceType, DefaultNvctClientTimeout, t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "requires TLS") {
+		t.Fatalf("expected TLS requirement error for http endpoint, got %v", err)
+	}
+}
+
+func TestCreateClient_MountedJWT_Preferred(t *testing.T) {
+	jwt := mountPSAT(t)
+	c, err := CreateClient("https://localhost:9091", bootstrapJWT(t), instanceId, taskId, instanceType, DefaultNvctClientTimeout, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !c.delegatedToken {
+		t.Error("delegatedToken should be true with a mounted JWT")
+	}
+	tok, err := c.NvctTokenProvider.Token()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok.AccessToken != jwt {
+		t.Errorf("expected mounted JWT, got %q", tok.AccessToken)
+	}
+}
+
+func TestCreateClient_MountedJWT_UnreadableIsAnError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can read mode 0000 files")
+	}
+	mountPSAT(t)
+	if err := os.Chmod(os.Getenv(token.MountedTokenPathEnvKey), 0000); err != nil {
+		t.Fatal(err)
+	}
+	_, err := CreateClient("https://localhost:9091", bootstrapJWT(t), instanceId, taskId, instanceType, DefaultNvctClientTimeout, t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error for an unreadable mounted JWT")
+	}
+}
+
+func TestStartWorkerTokenRefresher_DelegatedTokenIsNoop(t *testing.T) {
+	jwt := mountPSAT(t)
+	c, err := CreateClient("https://localhost:9091", bootstrapJWT(t), instanceId, taskId, instanceType, DefaultNvctClientTimeout, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c.StartWorkerTokenRefresher(ctx, false)
+	time.Sleep(500 * time.Millisecond)
+
+	tok, err := c.NvctTokenProvider.Token()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok.AccessToken != jwt {
+		t.Errorf("refresher must not replace the mounted JWT; got %q", tok.AccessToken)
+	}
+	if _, statErr := os.Stat(filepath.Join(c.sharedConfigDir, cachedNvctTokenFilename)); !os.IsNotExist(statErr) {
+		t.Error("no token may be persisted on the delegated path")
+	}
+}

--- a/src/libraries/go/worker/nvct/result.go
+++ b/src/libraries/go/worker/nvct/result.go
@@ -39,6 +39,7 @@ type StreamingClient struct {
 	streamer        pb.Worker_SendResultMetadataClient
 	nvctClient      pb.WorkerClient
 	tokenSource     oauth2.TokenSource
+	requireTLS      bool
 }
 
 // ------------------------------------------------------------------------
@@ -50,7 +51,8 @@ type Flusher interface {
 // ------------------------------------------------------------------------
 
 // Constructor
-func NewStreamingClient(ctx context.Context, nvctClient pb.WorkerClient, ts oauth2.TokenSource) *StreamingClient {
+// requireTLS must be true when ts serves a mounted projected ServiceAccount token.
+func NewStreamingClient(ctx context.Context, nvctClient pb.WorkerClient, ts oauth2.TokenSource, requireTLS bool) *StreamingClient {
 	// For gracefully shut down the streaming client in case the parent context is cancelled
 	ctx = context.WithoutCancel(ctx)
 
@@ -58,6 +60,7 @@ func NewStreamingClient(ctx context.Context, nvctClient pb.WorkerClient, ts oaut
 		globalCtx:   ctx,
 		nvctClient:  nvctClient,
 		tokenSource: ts,
+		requireTLS:  requireTLS,
 	}
 }
 
@@ -104,7 +107,7 @@ func (c *StreamingClient) getStreamer(ctx context.Context) (pb.Worker_SendResult
 		return c.streamer, nil
 	}
 
-	streamer, err := c.nvctClient.SendResultMetadata(ctx, auth.GrpcTokenFromSource(c.tokenSource))
+	streamer, err := c.nvctClient.SendResultMetadata(ctx, auth.GrpcTokenFromSource(c.tokenSource, c.requireTLS))
 	if err != nil {
 		zap.L().Error("failed to create streaming request for sending results", zap.Error(err))
 		return nil, err

--- a/src/libraries/go/worker/nvct/worker_token.go
+++ b/src/libraries/go/worker/nvct/worker_token.go
@@ -40,6 +40,11 @@ const (
 
 // Schedule a periodical token refresher.
 func (c *Client) StartWorkerTokenRefresher(ctx context.Context, enableJitter bool) {
+	if c.delegatedToken {
+		// The mounted JWT is rotated by the kubelet; NVCT issues no replacement token.
+		zap.L().Info("mounted JWT in use; worker token refresher disabled")
+		return
+	}
 	token.StartTokenRefresher(
 		ctx,
 		"worker token",
@@ -64,7 +69,7 @@ func (c *Client) getWorkerToken(ctx context.Context) (token.Token, error) {
 		var err error
 		resp, err = c.Client.RefreshToken(ctx, &pb.RefreshTokenRequest{
 			TaskId: c.taskId,
-		}, auth.GrpcTokenFromSource(c.NvctTokenProvider))
+		}, auth.GrpcTokenFromSource(c.NvctTokenProvider, c.delegatedToken))
 		return err
 	}, backoff.WithContext(backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 10), ctx))
 

--- a/src/libraries/go/worker/token/psat_select.go
+++ b/src/libraries/go/worker/token/psat_select.go
@@ -1,0 +1,58 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package token
+
+import (
+	"errors"
+	"fmt"
+
+	"go.uber.org/zap"
+	"golang.org/x/oauth2"
+
+	"github.com/NVIDIA/nvcf/src/libraries/go/worker/utils"
+)
+
+// TokenSourceSetter is satisfied by auth.SettableTokenSource.
+type TokenSourceSetter interface {
+	SetTokenSource(oauth2.TokenSource)
+}
+
+// SelectMountedToken installs a mounted projected ServiceAccount token on provider when one
+// is present and reports whether it did. Only ErrNoMountedToken falls back to the bootstrap
+// credential already held by provider; any other error is returned. Because the mounted
+// token is a bearer credential, it may only be presented to an https endpoint.
+func SelectMountedToken(provider TokenSourceSetter, apiFqdn string, service string) (bool, error) {
+	mountedSrc, err := NewMountedJWTSource()
+	if err != nil {
+		if errors.Is(err, ErrNoMountedToken) {
+			zap.L().Info("no mounted JWT; using legacy bootstrap credential (deprecated)", zap.String("service", service))
+			return false, nil
+		}
+		return false, fmt.Errorf("mounted JWT unavailable: %w", err)
+	}
+	apiUrl, err := utils.PortSafeUrl(apiFqdn)
+	if err != nil {
+		return false, err
+	}
+	if apiUrl.Scheme != "https" {
+		return false, fmt.Errorf("mounted JWT requires TLS but %s endpoint %q is not https", service, apiFqdn)
+	}
+	zap.L().Info("mounted JWT found; using projected ServiceAccount token as credential", zap.String("service", service))
+	provider.SetTokenSource(mountedSrc)
+	return true, nil
+}

--- a/src/libraries/go/worker/token/psat_source.go
+++ b/src/libraries/go/worker/token/psat_source.go
@@ -24,18 +24,31 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 )
 
-// ErrNoMountedToken is returned by NewMountedJWTSource when NVCF_TOKEN_FILE_PATH
-// is unset or the file does not exist. Callers should fall back to the bootstrap token.
+// MountedTokenPathEnvKey is the environment variable that may override the mounted JWT path.
+const MountedTokenPathEnvKey = "NVCF_TOKEN_FILE_PATH"
+
+// DefaultMountedTokenPath is where the cluster agent projects the worker ServiceAccount token.
+const DefaultMountedTokenPath = "/var/run/secrets/tokens/token"
+
+// MountedTokenRoot is the only directory a mounted JWT may be read from. An override of
+// MountedTokenPathEnvKey that resolves outside this directory is ignored. Tests may replace it.
+var MountedTokenRoot = "/var/run/secrets/tokens/"
+
+// ErrNoMountedToken is returned by NewMountedJWTSource when no usable mounted JWT exists:
+// the file is missing, is not a regular file under MountedTokenRoot, or does not contain a JWS.
+// Callers should fall back to the bootstrap token.
 var ErrNoMountedToken = errors.New("no mounted JWT token available")
 
-// MountedJWTTokenSource reads a projected ServiceAccount Token (PSAT) from the path
-// given by the NVCF_TOKEN_FILE_PATH environment variable. It implements oauth2.TokenSource.
+// MountedJWTTokenSource reads a projected ServiceAccount Token (PSAT) from a fixed mount
+// path. It implements oauth2.TokenSource.
 //
 // The file is re-read on every Token() call so that kubelet token rotation is
 // picked up automatically without a process restart.
@@ -43,12 +56,13 @@ type MountedJWTTokenSource struct {
 	path string
 }
 
-// NewMountedJWTSource returns a MountedJWTTokenSource for the file at NVCF_TOKEN_FILE_PATH,
-// or ErrNoMountedToken if the env var is unset or the file does not exist.
+// NewMountedJWTSource returns a MountedJWTTokenSource for the mounted JWT, or
+// ErrNoMountedToken when none is usable. Any other error is an I/O failure on an
+// otherwise valid path and should not be treated as "no token mounted".
 func NewMountedJWTSource() (*MountedJWTTokenSource, error) {
-	path := os.Getenv("NVCF_TOKEN_FILE_PATH")
-	if path == "" {
-		return nil, ErrNoMountedToken
+	path, err := resolveMountedTokenPath(os.Getenv(MountedTokenPathEnvKey))
+	if err != nil {
+		return nil, err
 	}
 	info, err := os.Stat(path)
 	if err != nil {
@@ -60,12 +74,47 @@ func NewMountedJWTSource() (*MountedJWTTokenSource, error) {
 	if !info.Mode().IsRegular() {
 		return nil, ErrNoMountedToken
 	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read mounted JWT: %w", err)
+	}
+	if _, err := parseJWTExpiry(strings.TrimSpace(string(raw))); err != nil {
+		zap.L().Warn("mounted token file does not contain a JWT; treating as not mounted",
+			zap.String("path", path), zap.Error(err))
+		return nil, ErrNoMountedToken
+	}
 	return &MountedJWTTokenSource{path: path}, nil
+}
+
+// resolveMountedTokenPath returns the path to read, enforcing that any override stays
+// within MountedTokenRoot after symlink resolution.
+func resolveMountedTokenPath(override string) (string, error) {
+	if override == "" {
+		return DefaultMountedTokenPath, nil
+	}
+	cleaned := filepath.Clean(override)
+	resolved, err := filepath.EvalSymlinks(cleaned)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", ErrNoMountedToken
+		}
+		return "", fmt.Errorf("resolve mounted JWT path: %w", err)
+	}
+	root, err := filepath.EvalSymlinks(filepath.Clean(MountedTokenRoot))
+	if err != nil {
+		root = filepath.Clean(MountedTokenRoot)
+	}
+	if !strings.HasPrefix(resolved, strings.TrimSuffix(root, "/")+"/") {
+		zap.L().Warn("ignoring mounted token path outside the allowed directory",
+			zap.String("path", override), zap.String("allowedRoot", MountedTokenRoot))
+		return "", ErrNoMountedToken
+	}
+	return resolved, nil
 }
 
 // Token reads the mounted JWT and returns it as an oauth2.Token.
 // The expiry is parsed from the JWT exp claim so the token source signals
-// rotation at the right time.
+// rotation at the right time. Content that is not a JWT is an error.
 func (s *MountedJWTTokenSource) Token() (*oauth2.Token, error) {
 	raw, err := os.ReadFile(s.path)
 	if err != nil {
@@ -75,9 +124,7 @@ func (s *MountedJWTTokenSource) Token() (*oauth2.Token, error) {
 
 	expiry, err := parseJWTExpiry(jwtStr)
 	if err != nil {
-		// Non-fatal: return the token without a meaningful expiry.
-		// The NVCF API verifies the JWT independently.
-		expiry = time.Now().Add(15 * time.Minute)
+		return nil, fmt.Errorf("mounted JWT is not a valid token: %w", err)
 	}
 
 	return &oauth2.Token{

--- a/src/libraries/go/worker/token/psat_source.go
+++ b/src/libraries/go/worker/token/psat_source.go
@@ -50,7 +50,14 @@ func NewMountedJWTSource() (*MountedJWTTokenSource, error) {
 	if path == "" {
 		return nil, ErrNoMountedToken
 	}
-	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrNoMountedToken
+		}
+		return nil, fmt.Errorf("stat mounted JWT: %w", err)
+	}
+	if !info.Mode().IsRegular() {
 		return nil, ErrNoMountedToken
 	}
 	return &MountedJWTTokenSource{path: path}, nil

--- a/src/libraries/go/worker/token/psat_source.go
+++ b/src/libraries/go/worker/token/psat_source.go
@@ -1,0 +1,102 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package token provides token caching and refresh utilities for worker clients.
+package token
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// ErrNoMountedToken is returned by NewMountedJWTSource when NVCF_TOKEN_FILE_PATH
+// is unset or the file does not exist. Callers should fall back to the bootstrap token.
+var ErrNoMountedToken = errors.New("no mounted JWT token available")
+
+// MountedJWTTokenSource reads a projected ServiceAccount Token (PSAT) from the path
+// given by the NVCF_TOKEN_FILE_PATH environment variable. It implements oauth2.TokenSource.
+//
+// The file is re-read on every Token() call so that kubelet token rotation is
+// picked up automatically without a process restart.
+type MountedJWTTokenSource struct {
+	path string
+}
+
+// NewMountedJWTSource returns a MountedJWTTokenSource for the file at NVCF_TOKEN_FILE_PATH,
+// or ErrNoMountedToken if the env var is unset or the file does not exist.
+func NewMountedJWTSource() (*MountedJWTTokenSource, error) {
+	path := os.Getenv("NVCF_TOKEN_FILE_PATH")
+	if path == "" {
+		return nil, ErrNoMountedToken
+	}
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		return nil, ErrNoMountedToken
+	}
+	return &MountedJWTTokenSource{path: path}, nil
+}
+
+// Token reads the mounted JWT and returns it as an oauth2.Token.
+// The expiry is parsed from the JWT exp claim so the token source signals
+// rotation at the right time.
+func (s *MountedJWTTokenSource) Token() (*oauth2.Token, error) {
+	raw, err := os.ReadFile(s.path)
+	if err != nil {
+		return nil, fmt.Errorf("read mounted JWT: %w", err)
+	}
+	jwtStr := strings.TrimSpace(string(raw))
+
+	expiry, err := parseJWTExpiry(jwtStr)
+	if err != nil {
+		// Non-fatal: return the token without a meaningful expiry.
+		// The NVCF API verifies the JWT independently.
+		expiry = time.Now().Add(15 * time.Minute)
+	}
+
+	return &oauth2.Token{
+		AccessToken: jwtStr,
+		Expiry:      expiry,
+	}, nil
+}
+
+// parseJWTExpiry extracts the exp claim from a JWT without verifying the signature.
+func parseJWTExpiry(jwtStr string) (time.Time, error) {
+	parts := strings.Split(jwtStr, ".")
+	if len(parts) != 3 {
+		return time.Time{}, fmt.Errorf("not a JWT: expected 3 parts, got %d", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return time.Time{}, fmt.Errorf("decode JWT payload: %w", err)
+	}
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return time.Time{}, fmt.Errorf("unmarshal JWT claims: %w", err)
+	}
+	if claims.Exp == 0 {
+		return time.Time{}, fmt.Errorf("JWT has no exp claim")
+	}
+	return time.Unix(claims.Exp, 0), nil
+}

--- a/src/libraries/go/worker/token/psat_source_test.go
+++ b/src/libraries/go/worker/token/psat_source_test.go
@@ -20,8 +20,10 @@ package token
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -31,44 +33,147 @@ import (
 func buildFakeJWT(exp int64) string {
 	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
 	payload := base64.RawURLEncoding.EncodeToString(
-		[]byte(fmt.Sprintf(`{"sub":"system:serviceaccount:ns:sa","exp":%d}`, exp)),
+		[]byte(fmt.Sprintf(`{"sub":"system:serviceaccount:ns:nvcf-worker","exp":%d}`, exp)),
 	)
 	return header + "." + payload + ".fakesig"
 }
 
-func TestNewMountedJWTSource_NoEnvVar(t *testing.T) {
-	t.Setenv("NVCF_TOKEN_FILE_PATH", "")
-	_, err := NewMountedJWTSource()
-	if err != ErrNoMountedToken {
-		t.Errorf("expected ErrNoMountedToken, got %v", err)
+// useTempMountRoot points MountedTokenRoot at a fresh temp directory for the test and
+// returns its symlink-resolved path.
+func useTempMountRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := MountedTokenRoot
+	MountedTokenRoot = dir + "/"
+	t.Cleanup(func() { MountedTokenRoot = old })
+	return dir
+}
+
+// writeMountedJWT writes a valid fake JWT under root and points the env var at it.
+func writeMountedJWT(t *testing.T, root string, exp int64) string {
+	t.Helper()
+	path := filepath.Join(root, "token")
+	if err := os.WriteFile(path, []byte(buildFakeJWT(exp)), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(MountedTokenPathEnvKey, path)
+	return path
+}
+
+func TestNewMountedJWTSource_NoEnvVar_UsesDefaultPath(t *testing.T) {
+	t.Setenv(MountedTokenPathEnvKey, "")
+	path, err := resolveMountedTokenPath("")
+	if err != nil {
+		t.Fatalf("resolveMountedTokenPath: %v", err)
+	}
+	if path != DefaultMountedTokenPath {
+		t.Errorf("default path = %q, want %q", path, DefaultMountedTokenPath)
+	}
+	if _, statErr := os.Stat(DefaultMountedTokenPath); statErr == nil {
+		t.Skip("default mount path exists on this host")
+	}
+	_, err = NewMountedJWTSource()
+	if !errors.Is(err, ErrNoMountedToken) {
+		t.Errorf("expected ErrNoMountedToken when the default path is absent, got %v", err)
 	}
 }
 
 func TestNewMountedJWTSource_FileMissing(t *testing.T) {
-	t.Setenv("NVCF_TOKEN_FILE_PATH", "/nonexistent/path/token")
+	root := useTempMountRoot(t)
+	t.Setenv(MountedTokenPathEnvKey, filepath.Join(root, "missing"))
 	_, err := NewMountedJWTSource()
-	if err != ErrNoMountedToken {
+	if !errors.Is(err, ErrNoMountedToken) {
 		t.Errorf("expected ErrNoMountedToken, got %v", err)
 	}
 }
 
 func TestNewMountedJWTSource_NonRegularFile(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("NVCF_TOKEN_FILE_PATH", dir)
+	root := useTempMountRoot(t)
+	t.Setenv(MountedTokenPathEnvKey, root)
 	_, err := NewMountedJWTSource()
-	if err != ErrNoMountedToken {
+	if !errors.Is(err, ErrNoMountedToken) {
 		t.Errorf("expected ErrNoMountedToken for directory path, got %v", err)
 	}
 }
 
-func TestNewMountedJWTSource_FileExists(t *testing.T) {
-	f, err := os.CreateTemp("", "psat-*.jwt")
-	if err != nil {
+func TestNewMountedJWTSource_PathOutsideAllowedRoot(t *testing.T) {
+	useTempMountRoot(t)
+	outside := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(outside, []byte(buildFakeJWT(time.Now().Add(time.Hour).Unix())), 0600); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(f.Name())
-	t.Setenv("NVCF_TOKEN_FILE_PATH", f.Name())
+	t.Setenv(MountedTokenPathEnvKey, outside)
+	_, err := NewMountedJWTSource()
+	if !errors.Is(err, ErrNoMountedToken) {
+		t.Errorf("expected ErrNoMountedToken for a path outside %s, got %v", MountedTokenRoot, err)
+	}
+}
 
+func TestNewMountedJWTSource_SymlinkEscapeRejected(t *testing.T) {
+	root := useTempMountRoot(t)
+	outside := filepath.Join(t.TempDir(), "real-token")
+	if err := os.WriteFile(outside, []byte(buildFakeJWT(time.Now().Add(time.Hour).Unix())), 0600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "token")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(MountedTokenPathEnvKey, link)
+	_, err := NewMountedJWTSource()
+	if !errors.Is(err, ErrNoMountedToken) {
+		t.Errorf("expected ErrNoMountedToken for a symlink escaping the root, got %v", err)
+	}
+}
+
+func TestNewMountedJWTSource_TraversalRejected(t *testing.T) {
+	root := useTempMountRoot(t)
+	outside := filepath.Join(filepath.Dir(root), "escaped-token")
+	if err := os.WriteFile(outside, []byte(buildFakeJWT(time.Now().Add(time.Hour).Unix())), 0600); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(outside)
+	t.Setenv(MountedTokenPathEnvKey, filepath.Join(root, "..", "escaped-token"))
+	_, err := NewMountedJWTSource()
+	if !errors.Is(err, ErrNoMountedToken) {
+		t.Errorf("expected ErrNoMountedToken for a traversal path, got %v", err)
+	}
+}
+
+func TestNewMountedJWTSource_NonJWTContent(t *testing.T) {
+	root := useTempMountRoot(t)
+	path := filepath.Join(root, "token")
+	if err := os.WriteFile(path, []byte("not a jwt"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(MountedTokenPathEnvKey, path)
+	_, err := NewMountedJWTSource()
+	if !errors.Is(err, ErrNoMountedToken) {
+		t.Errorf("expected ErrNoMountedToken for non-JWT content, got %v", err)
+	}
+}
+
+func TestNewMountedJWTSource_UnreadableFileIsNotNoToken(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can read mode 0000 files")
+	}
+	root := useTempMountRoot(t)
+	path := writeMountedJWT(t, root, time.Now().Add(time.Hour).Unix())
+	if err := os.Chmod(path, 0000); err != nil {
+		t.Fatal(err)
+	}
+	_, err := NewMountedJWTSource()
+	if err == nil || errors.Is(err, ErrNoMountedToken) {
+		t.Errorf("expected a read error distinct from ErrNoMountedToken, got %v", err)
+	}
+}
+
+func TestNewMountedJWTSource_FileExists(t *testing.T) {
+	root := useTempMountRoot(t)
+	writeMountedJWT(t, root, time.Now().Add(time.Hour).Unix())
 	src, err := NewMountedJWTSource()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -79,19 +184,9 @@ func TestNewMountedJWTSource_FileExists(t *testing.T) {
 }
 
 func TestMountedJWTTokenSource_Token_ReadsFile(t *testing.T) {
+	root := useTempMountRoot(t)
 	exp := time.Now().Add(15 * time.Minute).Unix()
-	jwtStr := buildFakeJWT(exp)
-
-	f, err := os.CreateTemp("", "psat-*.jwt")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(f.Name())
-	if _, err := f.WriteString(jwtStr); err != nil {
-		t.Fatal(err)
-	}
-	f.Close()
-	t.Setenv("NVCF_TOKEN_FILE_PATH", f.Name())
+	writeMountedJWT(t, root, exp)
 
 	src, err := NewMountedJWTSource()
 	if err != nil {
@@ -101,8 +196,8 @@ func TestMountedJWTTokenSource_Token_ReadsFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Token() error: %v", err)
 	}
-	if tok.AccessToken != jwtStr {
-		t.Errorf("AccessToken = %q, want %q", tok.AccessToken, jwtStr)
+	if tok.AccessToken != buildFakeJWT(exp) {
+		t.Errorf("AccessToken = %q, want %q", tok.AccessToken, buildFakeJWT(exp))
 	}
 	if tok.Expiry.Unix() != exp {
 		t.Errorf("Expiry = %v, want %v", tok.Expiry, time.Unix(exp, 0))
@@ -110,29 +205,46 @@ func TestMountedJWTTokenSource_Token_ReadsFile(t *testing.T) {
 }
 
 func TestMountedJWTTokenSource_Token_ReReadsOnRotation(t *testing.T) {
-	f, err := os.CreateTemp("", "psat-*.jwt")
+	root := useTempMountRoot(t)
+	path := writeMountedJWT(t, root, time.Now().Add(10*time.Minute).Unix())
+
+	src, err := NewMountedJWTSource()
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(f.Name())
-	t.Setenv("NVCF_TOKEN_FILE_PATH", f.Name())
-
-	src, _ := NewMountedJWTSource()
-
-	// Write first token
-	tok1 := buildFakeJWT(time.Now().Add(10 * time.Minute).Unix())
-	os.WriteFile(f.Name(), []byte(tok1), 0600)
-	r1, _ := src.Token()
-	if r1.AccessToken != tok1 {
-		t.Errorf("first read: got %q, want %q", r1.AccessToken, tok1)
+	r1, err := src.Token()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// Rotate: write second token
 	tok2 := buildFakeJWT(time.Now().Add(15 * time.Minute).Unix())
-	os.WriteFile(f.Name(), []byte(tok2), 0600)
-	r2, _ := src.Token()
-	if r2.AccessToken != tok2 {
+	if err := os.WriteFile(path, []byte(tok2), 0600); err != nil {
+		t.Fatal(err)
+	}
+	r2, err := src.Token()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r2.AccessToken != tok2 || r2.AccessToken == r1.AccessToken {
 		t.Errorf("second read after rotation: got %q, want %q", r2.AccessToken, tok2)
+	}
+}
+
+func TestMountedJWTTokenSource_Token_ErrorsOnRotatedGarbage(t *testing.T) {
+	root := useTempMountRoot(t)
+	path := writeMountedJWT(t, root, time.Now().Add(10*time.Minute).Unix())
+
+	src, err := NewMountedJWTSource()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("garbage"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	tok, err := src.Token()
+	if err == nil {
+		t.Fatalf("expected error for non-JWT content, got token %q", tok.AccessToken)
 	}
 }
 

--- a/src/libraries/go/worker/token/psat_source_test.go
+++ b/src/libraries/go/worker/token/psat_source_test.go
@@ -1,0 +1,171 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package token
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// buildFakeJWT builds a minimal unsigned JWT with the given exp claim.
+func buildFakeJWT(exp int64) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString(
+		[]byte(fmt.Sprintf(`{"sub":"system:serviceaccount:ns:sa","exp":%d}`, exp)),
+	)
+	return header + "." + payload + ".fakesig"
+}
+
+func TestNewMountedJWTSource_NoEnvVar(t *testing.T) {
+	t.Setenv("NVCF_TOKEN_FILE_PATH", "")
+	_, err := NewMountedJWTSource()
+	if err != ErrNoMountedToken {
+		t.Errorf("expected ErrNoMountedToken, got %v", err)
+	}
+}
+
+func TestNewMountedJWTSource_FileMissing(t *testing.T) {
+	t.Setenv("NVCF_TOKEN_FILE_PATH", "/nonexistent/path/token")
+	_, err := NewMountedJWTSource()
+	if err != ErrNoMountedToken {
+		t.Errorf("expected ErrNoMountedToken, got %v", err)
+	}
+}
+
+func TestNewMountedJWTSource_FileExists(t *testing.T) {
+	f, err := os.CreateTemp("", "psat-*.jwt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	t.Setenv("NVCF_TOKEN_FILE_PATH", f.Name())
+
+	src, err := NewMountedJWTSource()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src == nil {
+		t.Fatal("expected non-nil source")
+	}
+}
+
+func TestMountedJWTTokenSource_Token_ReadsFile(t *testing.T) {
+	exp := time.Now().Add(15 * time.Minute).Unix()
+	jwtStr := buildFakeJWT(exp)
+
+	f, err := os.CreateTemp("", "psat-*.jwt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString(jwtStr); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	t.Setenv("NVCF_TOKEN_FILE_PATH", f.Name())
+
+	src, err := NewMountedJWTSource()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tok, err := src.Token()
+	if err != nil {
+		t.Fatalf("Token() error: %v", err)
+	}
+	if tok.AccessToken != jwtStr {
+		t.Errorf("AccessToken = %q, want %q", tok.AccessToken, jwtStr)
+	}
+	if tok.Expiry.Unix() != exp {
+		t.Errorf("Expiry = %v, want %v", tok.Expiry, time.Unix(exp, 0))
+	}
+}
+
+func TestMountedJWTTokenSource_Token_ReReadsOnRotation(t *testing.T) {
+	f, err := os.CreateTemp("", "psat-*.jwt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	t.Setenv("NVCF_TOKEN_FILE_PATH", f.Name())
+
+	src, _ := NewMountedJWTSource()
+
+	// Write first token
+	tok1 := buildFakeJWT(time.Now().Add(10 * time.Minute).Unix())
+	os.WriteFile(f.Name(), []byte(tok1), 0600)
+	r1, _ := src.Token()
+	if r1.AccessToken != tok1 {
+		t.Errorf("first read: got %q, want %q", r1.AccessToken, tok1)
+	}
+
+	// Rotate: write second token
+	tok2 := buildFakeJWT(time.Now().Add(15 * time.Minute).Unix())
+	os.WriteFile(f.Name(), []byte(tok2), 0600)
+	r2, _ := src.Token()
+	if r2.AccessToken != tok2 {
+		t.Errorf("second read after rotation: got %q, want %q", r2.AccessToken, tok2)
+	}
+}
+
+func TestParseJWTExpiry_Valid(t *testing.T) {
+	exp := time.Now().Add(10 * time.Minute).Unix()
+	jwtStr := buildFakeJWT(exp)
+	got, err := parseJWTExpiry(jwtStr)
+	if err != nil {
+		t.Fatalf("parseJWTExpiry: %v", err)
+	}
+	if got.Unix() != exp {
+		t.Errorf("got expiry %v, want %v", got.Unix(), exp)
+	}
+}
+
+func TestParseJWTExpiry_NoExpClaim(t *testing.T) {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"test"}`))
+	jwtStr := header + "." + payload + ".sig"
+	_, err := parseJWTExpiry(jwtStr)
+	if err == nil {
+		t.Error("expected error for missing exp claim")
+	}
+}
+
+func TestParseJWTExpiry_BadFormat(t *testing.T) {
+	_, err := parseJWTExpiry("not.a.jwt.with.too.many.parts")
+	if err == nil {
+		t.Error("expected error for malformed JWT")
+	}
+}
+
+// Exercise that the JSON payload round-trips cleanly (regression for padding issues).
+func TestParseJWTExpiry_PaddingVariants(t *testing.T) {
+	for _, pad := range []string{"", "a", "ab", "abc"} {
+		claims := map[string]int64{"exp": time.Now().Add(time.Hour).Unix()}
+		b, _ := json.Marshal(claims)
+		payload := base64.RawURLEncoding.EncodeToString(b)
+		jwt := "hdr." + payload + ".sig"
+		// Inject a suffix to vary the base64 padding
+		jwt = strings.Replace(jwt, ".sig", pad+".sig", 1)
+		// This should not panic; errors are acceptable for malformed input
+		_ = jwt
+	}
+}

--- a/src/libraries/go/worker/token/psat_source_test.go
+++ b/src/libraries/go/worker/token/psat_source_test.go
@@ -52,6 +52,15 @@ func TestNewMountedJWTSource_FileMissing(t *testing.T) {
 	}
 }
 
+func TestNewMountedJWTSource_NonRegularFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("NVCF_TOKEN_FILE_PATH", dir)
+	_, err := NewMountedJWTSource()
+	if err != ErrNoMountedToken {
+		t.Errorf("expected ErrNoMountedToken for directory path, got %v", err)
+	}
+}
+
 func TestNewMountedJWTSource_FileExists(t *testing.T) {
 	f, err := os.CreateTemp("", "psat-*.jwt")
 	if err != nil {
@@ -158,14 +167,17 @@ func TestParseJWTExpiry_BadFormat(t *testing.T) {
 
 // Exercise that the JSON payload round-trips cleanly (regression for padding issues).
 func TestParseJWTExpiry_PaddingVariants(t *testing.T) {
+	exp := time.Now().Add(time.Hour).Unix()
 	for _, pad := range []string{"", "a", "ab", "abc"} {
-		claims := map[string]int64{"exp": time.Now().Add(time.Hour).Unix()}
-		b, _ := json.Marshal(claims)
-		payload := base64.RawURLEncoding.EncodeToString(b)
-		jwt := "hdr." + payload + ".sig"
-		// Inject a suffix to vary the base64 padding
-		jwt = strings.Replace(jwt, ".sig", pad+".sig", 1)
-		// This should not panic; errors are acceptable for malformed input
-		_ = jwt
+		t.Run("pad="+pad, func(t *testing.T) {
+			claims := map[string]int64{"exp": exp}
+			b, _ := json.Marshal(claims)
+			payload := base64.RawURLEncoding.EncodeToString(b)
+			jwtStr := "hdr." + payload + ".sig"
+			// Inject a suffix to vary the part count (exercises structural validation).
+			jwtStr = strings.Replace(jwtStr, ".sig", pad+".sig", 1)
+			// Must not panic; errors are acceptable for structurally invalid input.
+			_, _ = parseJWTExpiry(jwtStr)
+		})
 	}
 }


### PR DESCRIPTION
## Why

Part of the delegated worker token feature (issue #840). Workers on self-hosted NVCF clusters receive a projected Kubernetes ServiceAccount Token (PSAT) mounted at a well-known path. This PR makes NVCF workers, NVCT task workers, and LLM credential managers use that token as their bearer credential instead of the static bootstrap token, enabling ICMS-backed token introspection on the server side.

## What changed

- **`src/libraries/go/worker/token/psat_source.go`** (new): `MountedJWTTokenSource` implements `oauth2.TokenSource`. Re-reads `NVCF_TOKEN_FILE_PATH` on every `Token()` call so kubelet rotation is transparent. Parses the `exp` claim so the token source can signal rotation at the right time. Returns `ErrNoMountedToken` when the env var is unset or the file is absent, so callers fall back gracefully.

- **`src/libraries/go/worker/nvcf/client.go`**: After constructing `tokenProvider` from the bootstrap token, check for a mounted JWT and prefer it when present.

- **`src/libraries/go/worker/nvct/client.go`**: Same mounted-JWT preference pattern for the NVCT token provider.

LLM workers (`src/compute-plane-services/worker-llm-credentials/`) call `nvcf.CreateClient()` and automatically inherit the change; no code changes needed in that service. The dependency update to pick up the new worker library version will be in the deploy PR.

## Customer Release Notes

Not customer visible — self-hosted infrastructure change.

## Plan Summary

Not applicable.

## Usage

Workers on self-hosted clusters: set `NVCF_TOKEN_FILE_PATH=/var/run/secrets/tokens/token` (done by NVCA in PR #846). All worker types then use the projected SAT automatically.

Workers in managed NVCF or local dev: `NVCF_TOKEN_FILE_PATH` is unset, so the bootstrap token path is unchanged.

## Testing

- `go test ./token/...` passes (new unit tests cover file reads, rotation, expiry parsing, and missing-file fallback).
- `go build ./...` in the worker library passes.
- End-to-end validation requires all PRs deployed to a self-hosted cluster; see the test plan in issue #840.

## Notes

The existing 5-minute exponential backoff in `ConnectIndefinitely` covers the ~2-minute ICMS propagation window after NVCA registers the worker identity. No additional retry layer is needed.

## References

Relates to #840

## Related Pull Requests

- ICMS: #839
- NVCA: #846
- NVCF API server: feat/nvcf-api-delegated-worker-tokens (pending)
- NVCT API server: feat/nvct-api-delegated-worker-tokens (pending)
- Deploy manifests: feat/deploy-delegated-worker-tokens (pending)

## Dependencies

None — no new third-party dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for projected ServiceAccount tokens, including automatic token rotation.
  * Mounted tokens are preferred over bootstrap credentials when available.
  * Delegated-token connections now preserve the mounted token without replacing or persisting it.

* **Bug Fixes**
  * Invalid, unreadable, malformed, or unsafe token paths now return clear errors.
  * Missing mounted tokens continue to use bootstrap credentials.
  * Transport security is enforced for projected tokens while supporting legacy plaintext credentials where applicable.

* **Tests**
  * Expanded coverage for token selection, validation, rotation, fallback, TLS enforcement, and delegated connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->