### PR TITLE
feat(nvcf): accept delegated projected ServiceAccount tokens for worker auth

### DIFF
--- a/src/control-plane-services/cloud-functions/nvcf-core/BUILD.bazel
+++ b/src/control-plane-services/cloud-functions/nvcf-core/BUILD.bazel
@@ -73,6 +73,7 @@ nvct_library(
         "@nv_third_party_deps//:com_github_ben_manes_caffeine_guava",
         "@nv_third_party_deps//:com_google_guava_guava",
         "@nv_third_party_deps//:com_google_protobuf_protobuf_java",
+        "@nv_third_party_deps//:com_nimbusds_nimbus_jose_jwt",
         "@nv_third_party_deps//:com_nimbusds_oauth2_oidc_sdk",
         "//src/libraries/java/nv-boot-parent/nv-boot-starter-audit:nv_boot_starter_audit",
         "//src/libraries/java/nv-boot-parent/nv-boot-starter-cassandra:nv_boot_starter_cassandra",

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/grpc/GrpcWorkerService.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/grpc/GrpcWorkerService.java
@@ -33,6 +33,7 @@ import com.nvidia.nvcf.configuration.AwsConfiguration.AwsProperties;
 import com.nvidia.nvcf.configuration.nats.NatsConfiguration.NatsProperties;
 import com.nvidia.nvcf.icms.client.IcmsClient;
 import com.nvidia.nvcf.persistence.function.entity.FunctionType;
+import com.nvidia.nvcf.service.token.WorkerTokenIntrospectionService;
 import com.nvidia.nvcf.proto.ArtifactsRequest;
 import com.nvidia.nvcf.proto.ArtifactsResponse;
 import com.nvidia.nvcf.proto.ArtifactsResponse.ArtifactResponse;
@@ -103,6 +104,7 @@ public class GrpcWorkerService extends WorkerImplBase {
     private final RegistryArtifactService artifactService;
     private final WorkerUrlGeneratorService workerUrlGeneratorService;
     private final IcmsClient icmsClient;
+    private final WorkerTokenIntrospectionService workerTokenIntrospectionService;
 
     @Override
     public void connectOnce(
@@ -238,12 +240,30 @@ public class GrpcWorkerService extends WorkerImplBase {
 
     private NvcfIssuedToken validateWorkerToken(UUID functionId, UUID functionVersionId) {
         var token = getToken();
-        var nvcfIssuedToken = grpcTokenService.validateToken(token, TokenType.WORKER);
-        if (nvcfIssuedToken.functionId().equals(functionId)
-                && nvcfIssuedToken.functionVersionId().equals(functionVersionId)) {
-            return nvcfIssuedToken;
+        try {
+            var nvcfIssuedToken = grpcTokenService.validateToken(token, TokenType.WORKER);
+            if (nvcfIssuedToken.functionId().equals(functionId)
+                    && nvcfIssuedToken.functionVersionId().equals(functionVersionId)) {
+                return nvcfIssuedToken;
+            }
+            throw new ForbiddenException("invalid worker token");
+        } catch (ForbiddenException e) {
+            if (!workerTokenIntrospectionService.isEnabled()) {
+                throw e;
+            }
+            // Delegated token path: the bearer token is a projected ServiceAccount Token (PSAT).
+            // ICMS verifies cluster OIDC and worker identity; active=true means authorized.
+            var result = workerTokenIntrospectionService.introspect(token);
+            if (!result.isActive()) {
+                log.warn("worker token introspection returned active=false: {}", result.getError());
+                throw new ForbiddenException("worker token not active");
+            }
+            log.debug("worker authorized via delegated token, instance_id={}", result.getInstanceId());
+            // Construct a synthetic token representing this worker's claimed function identity.
+            // The function lookup below independently verifies the function is active.
+            return new NvcfIssuedToken(functionId, functionVersionId, Instant.now(),
+                                       TokenType.WORKER);
         }
-        throw new ForbiddenException("invalid worker token");
     }
 
     private static String getToken() {

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/grpc/GrpcWorkerService.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/grpc/GrpcWorkerService.java
@@ -116,7 +116,8 @@ public class GrpcWorkerService extends WorkerImplBase {
                 SPAN_TAG_INSTANCE_ID, request.getInstanceId()));
         var functionId = UUID.fromString(request.getFunctionId());
         var functionVersionId = UUID.fromString(request.getFunctionVersionId());
-        var workerToken = validateWorkerToken(functionId, functionVersionId);
+        var validated = validateWorkerToken(functionId, functionVersionId);
+        var workerToken = validated.token();
         NvcfUtils.addTagsToCurrentSpan(tracer, Map.of(
                 SPAN_TAG_ISSUED_AT, workerToken.issuedAt().toString()));
         var otherRegions =
@@ -138,15 +139,18 @@ public class GrpcWorkerService extends WorkerImplBase {
                             region, functionVersionId));
         }
 
-        // return response
-        responseObserver.onNext(WorkerConnectOnceResponse.newBuilder()
-                                        .setConnectedRegion(natsProperties.getRegion())
-                                        .addAllOtherRegions(otherRegions)
-                                        .setNvcfWorkerToken(grpcTokenService.issueToken(
-                                                functionId, functionVersionId,
-                                                TokenType.WORKER))
-                                        .setExpiration(toTimestamp(Instant.now().plus(VALIDITY)))
-                                        .build());
+        var response = WorkerConnectOnceResponse.newBuilder()
+                .setConnectedRegion(natsProperties.getRegion())
+                .addAllOtherRegions(otherRegions);
+        if (validated.delegated()) {
+            // The mounted PSAT stays the worker's credential; no NVCF-issued token replaces it.
+            response.setExpiration(toTimestamp(validated.expiresAt()));
+        } else {
+            response.setNvcfWorkerToken(grpcTokenService.issueToken(
+                            functionId, functionVersionId, TokenType.WORKER))
+                    .setExpiration(toTimestamp(Instant.now().plus(VALIDITY)));
+        }
+        responseObserver.onNext(response.build());
         responseObserver.onCompleted();
     }
 
@@ -238,32 +242,71 @@ public class GrpcWorkerService extends WorkerImplBase {
                 functionId, functionVersionId);
     }
 
-    private NvcfIssuedToken validateWorkerToken(UUID functionId, UUID functionVersionId) {
-        var token = getToken();
-        try {
+    /**
+     * A worker identity accepted for the requested function version.
+     *
+     * @param token     the function-bound identity; for delegated tokens it is built from the
+     *                  ICMS-resolved binding, never from the request
+     * @param delegated true when the worker authenticated with a mounted PSAT
+     * @param expiresAt expiry of the presented credential
+     */
+    record ValidatedWorker(NvcfIssuedToken token, boolean delegated, Instant expiresAt) {
+    }
+
+    private ValidatedWorker validateWorkerToken(UUID functionId, UUID functionVersionId) {
+        return validateWorkerToken(getToken(), functionId, functionVersionId);
+    }
+
+    /**
+     * Selects the legacy or delegated path by token shape. A legacy JWE that does not match the
+     * requested function is rejected outright and is never retried through introspection; a
+     * delegated PSAT is accepted only when ICMS reports it active and bound to exactly the
+     * requested function version.
+     */
+    ValidatedWorker validateWorkerToken(String token, UUID functionId, UUID functionVersionId) {
+        if (!WorkerTokenIntrospectionService.isDelegatedToken(token)) {
             var nvcfIssuedToken = grpcTokenService.validateToken(token, TokenType.WORKER);
             if (nvcfIssuedToken.functionId().equals(functionId)
                     && nvcfIssuedToken.functionVersionId().equals(functionVersionId)) {
-                return nvcfIssuedToken;
+                return new ValidatedWorker(nvcfIssuedToken, false,
+                                           nvcfIssuedToken.issuedAt().plus(VALIDITY));
             }
             throw new ForbiddenException("invalid worker token");
-        } catch (ForbiddenException e) {
-            if (!workerTokenIntrospectionService.isEnabled()) {
-                throw e;
-            }
-            // Delegated token path: the bearer token is a projected ServiceAccount Token (PSAT).
-            // ICMS verifies cluster OIDC and worker identity; active=true means authorized.
-            var result = workerTokenIntrospectionService.introspect(token);
-            if (!result.isActive()) {
-                log.warn("worker token introspection returned active=false: {}", result.getError());
-                throw new ForbiddenException("worker token not active");
-            }
-            log.debug("worker authorized via delegated token, instance_id={}", result.getInstanceId());
-            // Construct a synthetic token representing this worker's claimed function identity.
-            // The function lookup below independently verifies the function is active.
-            return new NvcfIssuedToken(functionId, functionVersionId, Instant.now(),
-                                       TokenType.WORKER);
         }
+
+        if (!workerTokenIntrospectionService.isEnabled()) {
+            throw new ForbiddenException("delegated worker tokens are not enabled");
+        }
+        var result = workerTokenIntrospectionService.introspect(token);
+        if (!result.isActive()) {
+            log.warn("worker token introspection returned active=false: {}", result.getError());
+            throw new ForbiddenException("worker token not active");
+        }
+        UUID boundFunctionId;
+        UUID boundFunctionVersionId;
+        try {
+            boundFunctionId = UUID.fromString(result.getFunctionId());
+            boundFunctionVersionId = UUID.fromString(result.getFunctionVersionId());
+        } catch (IllegalArgumentException | NullPointerException e) {
+            log.warn("worker token introspection returned malformed binding, instance_id={}",
+                     result.getInstanceId());
+            throw new ForbiddenException("worker token not active");
+        }
+        if (!boundFunctionId.equals(functionId)
+                || !boundFunctionVersionId.equals(functionVersionId)) {
+            log.warn("delegated worker token bound to function {} version {} used for function {} "
+                             + "version {}, instance_id={}", boundFunctionId,
+                     boundFunctionVersionId, functionId, functionVersionId,
+                     result.getInstanceId());
+            throw new ForbiddenException("worker token not bound to requested workload");
+        }
+        log.debug("worker authorized via delegated token, instance_id={} cluster_id={}",
+                  result.getInstanceId(), result.getClientId());
+        var expiresAt = Instant.ofEpochSecond(result.getExp());
+        return new ValidatedWorker(
+                new NvcfIssuedToken(boundFunctionId, boundFunctionVersionId, Instant.now(),
+                                    TokenType.WORKER),
+                true, expiresAt);
     }
 
     private static String getToken() {
@@ -301,11 +344,21 @@ public class GrpcWorkerService extends WorkerImplBase {
     @Override
     public StreamObserver<RefreshAssetDownloadCredentialsRequest> refreshAssetDownloadCredentials(
             StreamObserver<RefreshAssetDownloadCredentialsResponse> responseObserver) {
-        var nvcfIssuedToken = grpcTokenService.validateToken(getToken(), TokenType.WORKER);
-        return new RefreshAssetDownloadCredentialsRequestStreamObserver(nvcfIssuedToken,
-                                                                        responseObserver,
-                                                                        workerNatsService,
-                                                                        workerUrlGeneratorService);
+        // The function binding arrives with the first streamed message, so capture the bearer
+        // token now (the security context is not available on the stream thread) and validate
+        // it against that binding on first use. Both legacy and delegated tokens take this path.
+        var token = getToken();
+        return new RefreshAssetDownloadCredentialsRequestStreamObserver(
+                (functionId, functionVersionId) ->
+                        validateWorkerToken(token, functionId, functionVersionId).token(),
+                responseObserver,
+                workerNatsService,
+                workerUrlGeneratorService);
+    }
+
+    @FunctionalInterface
+    interface WorkerTokenValidator {
+        NvcfIssuedToken validate(UUID functionId, UUID functionVersionId);
     }
 
     @RequiredArgsConstructor
@@ -313,7 +366,7 @@ public class GrpcWorkerService extends WorkerImplBase {
             StreamObserver<RefreshAssetDownloadCredentialsRequest> {
 
         private String ncaId;
-        private final NvcfIssuedToken nvcfIssuedToken;
+        private final WorkerTokenValidator tokenValidator;
         private final StreamObserver<RefreshAssetDownloadCredentialsResponse> responseObserver;
         private final WorkerNatsService workerNatsService;
         private final WorkerUrlGeneratorService workerUrlGeneratorService;
@@ -324,12 +377,7 @@ public class GrpcWorkerService extends WorkerImplBase {
                 var firstRequestId = UUID.fromString(request.getRequestId());
                 var functionId = UUID.fromString(request.getFunctionId());
                 var functionVersionId = UUID.fromString(request.getFunctionVersionId());
-                var requestId = UUID.fromString(request.getRequestId());
-                if (!nvcfIssuedToken.functionId().equals(functionId)
-                        || !nvcfIssuedToken.functionVersionId().equals(functionVersionId)
-                        || !firstRequestId.equals(requestId)) {
-                    throw new ForbiddenException("invalid worker token");
-                }
+                tokenValidator.validate(functionId, functionVersionId);
                 var invocationRequest = workerNatsService.lookupFunctionInvocationRequest(
                         UUID.fromString(request.getFunctionVersionId()), firstRequestId);
 

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/icms/client/IcmsClient.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/icms/client/IcmsClient.java
@@ -671,6 +671,11 @@ public class IcmsClient {
         return clusterGroupCache.get(new IcmsCacheKey(ncaId, instanceUsage));
     }
 
+    public IcmsStubService.WorkerTokenIntrospectResult introspectWorkerToken(
+            IcmsStubService.WorkerTokenIntrospectRequest request) {
+        return service.introspectWorkerToken(request);
+    }
+
     public DescribeInstancesResponse.Instance getInstanceById(String instanceId) {
         var response = service.describeInstances(List.of(instanceId));
         return Optional.ofNullable(response)

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/icms/client/IcmsStubService.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/icms/client/IcmsStubService.java
@@ -415,14 +415,28 @@ public interface IcmsStubService {
         @Nullable String sub;
         @Nullable String aud;
         @Nullable String iss;
+        /** RFC 7662 section 2.2: epoch-seconds at which the token expires. */
+        @Nullable Long exp;
+        /** Cluster id resolved by ICMS from the signed audience. */
+        @JsonProperty("client_id")
+        @Nullable String clientId;
         @JsonProperty("instance_id")
         @Nullable String instanceId;
         @JsonProperty("worker_id")
         @Nullable String workerId;
+        /** Workload binding resolved by ICMS from the instance's request record. */
+        @JsonProperty("request_id")
+        @Nullable String requestId;
+        @JsonProperty("function_id")
+        @Nullable String functionId;
+        @JsonProperty("function_version_id")
+        @Nullable String functionVersionId;
+        @JsonProperty("task_id")
+        @Nullable String taskId;
+        @JsonProperty("nca_id")
+        @Nullable String ncaId;
         @JsonProperty("token_type")
         @Nullable String tokenType;
-        /** RFC 7662 §2.2: epoch-seconds at which the token expires. Null when unknown. */
-        @Nullable Long exp;
         @Nullable String error;
     }
 

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/icms/client/IcmsStubService.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/icms/client/IcmsStubService.java
@@ -421,10 +421,12 @@ public interface IcmsStubService {
         @Nullable String workerId;
         @JsonProperty("token_type")
         @Nullable String tokenType;
+        /** RFC 7662 §2.2: epoch-seconds at which the token expires. Null when unknown. */
+        @Nullable Long exp;
         @Nullable String error;
     }
 
-    @PostExchange(url = "/v1/workers/tokens/introspect",
+    @PostExchange(url = "/v1/icms/workers/tokens/introspect",
                   accept = APPLICATION_JSON_VALUE,
                   contentType = APPLICATION_JSON_VALUE)
     WorkerTokenIntrospectResult introspectWorkerToken(

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/icms/client/IcmsStubService.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/icms/client/IcmsStubService.java
@@ -398,4 +398,35 @@ public interface IcmsStubService {
     void deleteInstancesByDeploymentId(
             @PathVariable("ncaId") String ncaId,
             @PathVariable("workloadId") UUID deploymentId);
+
+    @Value
+    @Jacksonized
+    @Builder
+    class WorkerTokenIntrospectRequest {
+        @JsonProperty("token")
+        String token;
+    }
+
+    @Value
+    @Jacksonized
+    @Builder
+    class WorkerTokenIntrospectResult {
+        boolean active;
+        @Nullable String sub;
+        @Nullable String aud;
+        @Nullable String iss;
+        @JsonProperty("instance_id")
+        @Nullable String instanceId;
+        @JsonProperty("worker_id")
+        @Nullable String workerId;
+        @JsonProperty("token_type")
+        @Nullable String tokenType;
+        @Nullable String error;
+    }
+
+    @PostExchange(url = "/v1/workers/tokens/introspect",
+                  accept = APPLICATION_JSON_VALUE,
+                  contentType = APPLICATION_JSON_VALUE)
+    WorkerTokenIntrospectResult introspectWorkerToken(
+            @org.springframework.web.bind.annotation.RequestBody WorkerTokenIntrospectRequest request);
 }

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/service/token/WorkerTokenIntrospectionService.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/service/token/WorkerTokenIntrospectionService.java
@@ -18,12 +18,15 @@ package com.nvidia.nvcf.service.token;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
 import com.nvidia.nvcf.icms.client.IcmsClient;
 import com.nvidia.nvcf.icms.client.IcmsStubService;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -46,13 +49,40 @@ public class WorkerTokenIntrospectionService {
 
     public WorkerTokenIntrospectionService(
             IcmsClient icmsClient,
-            @Value("${nvcf.worker.delegated-token-enabled:false}") boolean enabled) {
+            @Value("${nvcf.worker.delegated-token.enabled:false}") boolean enabled) {
         this.icmsClient = icmsClient;
         this.enabled = enabled;
         this.cache = Caffeine.newBuilder()
                 .maximumSize(10_000)
-                .expireAfterWrite(CACHE_TTL)
-                .<String, IcmsStubService.WorkerTokenIntrospectResult>build();
+                .expireAfter(new Expiry<String, IcmsStubService.WorkerTokenIntrospectResult>() {
+                    @Override
+                    public long expireAfterCreate(
+                            String key, IcmsStubService.WorkerTokenIntrospectResult value,
+                            long currentTime) {
+                        if (value.getExp() != null) {
+                            long remainingMs =
+                                    value.getExp() * 1000L - Instant.now().toEpochMilli();
+                            long cappedMs = Math.max(0, Math.min(CACHE_TTL.toMillis(), remainingMs));
+                            return TimeUnit.MILLISECONDS.toNanos(cappedMs);
+                        }
+                        return CACHE_TTL.toNanos();
+                    }
+
+                    @Override
+                    public long expireAfterUpdate(
+                            String key, IcmsStubService.WorkerTokenIntrospectResult value,
+                            long currentTime, long currentDuration) {
+                        return currentDuration;
+                    }
+
+                    @Override
+                    public long expireAfterRead(
+                            String key, IcmsStubService.WorkerTokenIntrospectResult value,
+                            long currentTime, long currentDuration) {
+                        return currentDuration;
+                    }
+                })
+                .build();
     }
 
     public boolean isEnabled() {

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/service/token/WorkerTokenIntrospectionService.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/service/token/WorkerTokenIntrospectionService.java
@@ -19,29 +19,36 @@ package com.nvidia.nvcf.service.token;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Expiry;
+import com.nimbusds.jwt.JWTParser;
+import com.nimbusds.jwt.SignedJWT;
 import com.nvidia.nvcf.icms.client.IcmsClient;
 import com.nvidia.nvcf.icms.client.IcmsStubService;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.text.ParseException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /**
  * Calls the ICMS worker token introspection endpoint (RFC 7662) and caches
- * active results keyed on a SHA-256 digest of the raw token.  Results are
- * evicted after at most the PSAT TTL (15 minutes).  Inactive results are never
- * cached so clock-skew and nbf windows are handled on the next retry.
+ * active results keyed on a SHA-256 digest of the raw token. Active results are
+ * evicted after min(token exp, 15 minutes). Inactive results, and active results
+ * that lack the token expiry or the workload binding, are never cached.
  */
 @Slf4j
 @Service
 public class WorkerTokenIntrospectionService {
 
-    private static final Duration CACHE_TTL = Duration.ofMinutes(14);
+    static final Duration CACHE_TTL = Duration.ofMinutes(15);
+    static final String ERROR_MISSING_BINDING = "introspection response missing binding";
+    private static final String DELEGATED_AUDIENCE_PREFIX = "nvcf-icms:";
 
     private final IcmsClient icmsClient;
     private final boolean enabled;
@@ -59,13 +66,12 @@ public class WorkerTokenIntrospectionService {
                     public long expireAfterCreate(
                             String key, IcmsStubService.WorkerTokenIntrospectResult value,
                             long currentTime) {
-                        if (value.getExp() != null) {
-                            long remainingMs =
-                                    value.getExp() * 1000L - Instant.now().toEpochMilli();
-                            long cappedMs = Math.max(0, Math.min(CACHE_TTL.toMillis(), remainingMs));
-                            return TimeUnit.MILLISECONDS.toNanos(cappedMs);
+                        if (value.getExp() == null) {
+                            return 0;
                         }
-                        return CACHE_TTL.toNanos();
+                        long remainingMs = value.getExp() * 1000L - Instant.now().toEpochMilli();
+                        long cappedMs = Math.max(0, Math.min(CACHE_TTL.toMillis(), remainingMs));
+                        return TimeUnit.MILLISECONDS.toNanos(cappedMs);
                     }
 
                     @Override
@@ -90,9 +96,33 @@ public class WorkerTokenIntrospectionService {
     }
 
     /**
-     * Introspects a worker token against ICMS.  Returns the result with
-     * {@code active=true} when the token is valid; {@code active=false} otherwise.
-     * Active results are cached; inactive results are not.
+     * Returns true when the bearer token has the shape of a delegated worker token: a
+     * compact JWS whose audience carries the cluster-scoped ICMS prefix. Legacy NVCF
+     * worker tokens are JWE blobs and never match. The signature is not verified here;
+     * ICMS verifies it during introspection.
+     */
+    public static boolean isDelegatedToken(String token) {
+        if (StringUtils.isBlank(token)) {
+            return false;
+        }
+        try {
+            var jwt = JWTParser.parse(token);
+            if (!(jwt instanceof SignedJWT)) {
+                return false;
+            }
+            List<String> audience = jwt.getJWTClaimsSet().getAudience();
+            return audience != null
+                    && audience.stream().anyMatch(a -> a.startsWith(DELEGATED_AUDIENCE_PREFIX));
+        } catch (ParseException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Introspects a worker token against ICMS. Returns the result with
+     * {@code active=true} only when ICMS accepted the token and returned its expiry
+     * and function binding; otherwise {@code active=false}. Only active results are
+     * cached.
      */
     public IcmsStubService.WorkerTokenIntrospectResult introspect(String rawToken) {
         var cacheKey = sha256Hex(rawToken);
@@ -106,9 +136,20 @@ public class WorkerTokenIntrospectionService {
         var result = icmsClient.introspectWorkerToken(
                 IcmsStubService.WorkerTokenIntrospectRequest.builder().token(rawToken).build());
 
-        if (result.isActive()) {
-            cache.put(cacheKey, result);
+        if (!result.isActive()) {
+            return result;
         }
+        if (result.getExp() == null
+                || StringUtils.isBlank(result.getFunctionId())
+                || StringUtils.isBlank(result.getFunctionVersionId())) {
+            log.warn("worker token introspection active but missing exp or function binding, "
+                             + "instance_id={}", result.getInstanceId());
+            return IcmsStubService.WorkerTokenIntrospectResult.builder()
+                    .active(false)
+                    .error(ERROR_MISSING_BINDING)
+                    .build();
+        }
+        cache.put(cacheKey, result);
         return result;
     }
 

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/service/token/WorkerTokenIntrospectionService.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/service/token/WorkerTokenIntrospectionService.java
@@ -1,0 +1,98 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.nvcf.service.token;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.nvidia.nvcf.icms.client.IcmsClient;
+import com.nvidia.nvcf.icms.client.IcmsStubService;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * Calls the ICMS worker token introspection endpoint (RFC 7662) and caches
+ * active results keyed on a SHA-256 digest of the raw token.  Results are
+ * evicted after at most the PSAT TTL (15 minutes).  Inactive results are never
+ * cached so clock-skew and nbf windows are handled on the next retry.
+ */
+@Slf4j
+@Service
+public class WorkerTokenIntrospectionService {
+
+    private static final Duration CACHE_TTL = Duration.ofMinutes(14);
+
+    private final IcmsClient icmsClient;
+    private final boolean enabled;
+    private final Cache<String, IcmsStubService.WorkerTokenIntrospectResult> cache;
+
+    public WorkerTokenIntrospectionService(
+            IcmsClient icmsClient,
+            @Value("${nvcf.worker.delegated-token-enabled:false}") boolean enabled) {
+        this.icmsClient = icmsClient;
+        this.enabled = enabled;
+        this.cache = Caffeine.newBuilder()
+                .maximumSize(10_000)
+                .expireAfterWrite(CACHE_TTL)
+                .<String, IcmsStubService.WorkerTokenIntrospectResult>build();
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Introspects a worker token against ICMS.  Returns the result with
+     * {@code active=true} when the token is valid; {@code active=false} otherwise.
+     * Active results are cached; inactive results are not.
+     */
+    public IcmsStubService.WorkerTokenIntrospectResult introspect(String rawToken) {
+        var cacheKey = sha256Hex(rawToken);
+        var cached = cache.getIfPresent(cacheKey);
+        if (cached != null) {
+            log.debug("worker token introspection cache hit");
+            return cached;
+        }
+
+        log.debug("calling ICMS to introspect worker token");
+        var result = icmsClient.introspectWorkerToken(
+                IcmsStubService.WorkerTokenIntrospectRequest.builder().token(rawToken).build());
+
+        if (result.isActive()) {
+            cache.put(cacheKey, result);
+        }
+        return result;
+    }
+
+    private static String sha256Hex(String input) {
+        try {
+            var digest = MessageDigest.getInstance("SHA-256");
+            var hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            var sb = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+}

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/grpc/GrpcWorkerServiceValidateWorkerTokenTest.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/grpc/GrpcWorkerServiceValidateWorkerTokenTest.java
@@ -1,0 +1,225 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.nvcf.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nvidia.boot.exceptions.ForbiddenException;
+import com.nvidia.nvcf.configuration.AwsConfiguration.AwsProperties;
+import com.nvidia.nvcf.configuration.nats.NatsConfiguration.NatsProperties;
+import com.nvidia.nvcf.icms.client.IcmsClient;
+import com.nvidia.nvcf.icms.client.IcmsStubService;
+import com.nvidia.nvcf.s3.MultipartUploadService;
+import com.nvidia.nvcf.s3.S3PreSignedUrlGenerator;
+import com.nvidia.nvcf.service.function.FunctionLookupService;
+import com.nvidia.nvcf.service.function.invocation.WorkerUrlGeneratorService;
+import com.nvidia.nvcf.service.registry.RegistryArtifactService;
+import com.nvidia.nvcf.service.token.GrpcTokenService;
+import com.nvidia.nvcf.service.token.GrpcTokenService.NvcfIssuedToken;
+import com.nvidia.nvcf.service.token.GrpcTokenService.NvcfIssuedToken.TokenType;
+import com.nvidia.nvcf.service.token.WorkerTokenIntrospectionService;
+import com.nvidia.nvcf.service.worker.WorkerNatsService;
+import com.nvidia.nvcf.service.worker.WorkerNotaryService;
+import io.micrometer.tracing.Tracer;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GrpcWorkerServiceValidateWorkerTokenTest {
+
+    private static final UUID FUNCTION_ID = UUID.randomUUID();
+    private static final UUID VERSION_ID = UUID.randomUUID();
+    private static final UUID OTHER_FUNCTION_ID = UUID.randomUUID();
+    private static final UUID OTHER_VERSION_ID = UUID.randomUUID();
+    private static final String LEGACY_TOKEN = "opaque-jwe-blob";
+
+    @Mock private Tracer tracer;
+    @Mock private GrpcTokenService grpcTokenService;
+    @Mock private MultipartUploadService multipartUploadService;
+    @Mock private NatsProperties natsProperties;
+    @Mock private WorkerNotaryService workerNotaryService;
+    @Mock private AwsProperties awsProperties;
+    @Mock private S3PreSignedUrlGenerator preSignedUrlGenerator;
+    @Mock private FunctionLookupService functionLookupService;
+    @Mock private WorkerNatsService workerNatsService;
+    @Mock private RegistryArtifactService artifactService;
+    @Mock private WorkerUrlGeneratorService workerUrlGeneratorService;
+    @Mock private IcmsClient icmsClient;
+    @Mock private WorkerTokenIntrospectionService introspectionService;
+
+    private GrpcWorkerService service;
+    private String psat;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        service = new GrpcWorkerService(tracer, grpcTokenService, multipartUploadService,
+                                        natsProperties, workerNotaryService, awsProperties,
+                                        preSignedUrlGenerator, functionLookupService,
+                                        workerNatsService, artifactService,
+                                        workerUrlGeneratorService, icmsClient,
+                                        introspectionService);
+        var claims = new JWTClaimsSet.Builder()
+                .subject("system:serviceaccount:inst-789:nvcf-worker")
+                .audience(List.of("nvcf-icms:cl-abc123"))
+                .expirationTime(Date.from(Instant.now().plusSeconds(900)))
+                .build();
+        var jwt = new SignedJWT(new JWSHeader(JWSAlgorithm.HS256), claims);
+        jwt.sign(new MACSigner(new byte[32]));
+        psat = jwt.serialize();
+    }
+
+    private static IcmsStubService.WorkerTokenIntrospectResult active(UUID functionId,
+                                                                        UUID versionId) {
+        return IcmsStubService.WorkerTokenIntrospectResult.builder()
+                .active(true)
+                .clientId("cl-abc123")
+                .instanceId("inst-789")
+                .workerId("utils")
+                .requestId("sr-1")
+                .functionId(functionId.toString())
+                .functionVersionId(versionId.toString())
+                .exp(Instant.now().plusSeconds(600).getEpochSecond())
+                .tokenType("psat")
+                .build();
+    }
+
+    @Test
+    void delegated_activeAndBound_isAcceptedWithIcmsIdentity() {
+        when(introspectionService.isEnabled()).thenReturn(true);
+        when(introspectionService.introspect(psat)).thenReturn(active(FUNCTION_ID, VERSION_ID));
+
+        var validated = service.validateWorkerToken(psat, FUNCTION_ID, VERSION_ID);
+
+        assertThat(validated.delegated()).isTrue();
+        assertThat(validated.token().functionId()).isEqualTo(FUNCTION_ID);
+        assertThat(validated.token().functionVersionId()).isEqualTo(VERSION_ID);
+        assertThat(validated.token().type()).isEqualTo(TokenType.WORKER);
+        assertThat(validated.expiresAt()).isAfter(Instant.now());
+        verify(grpcTokenService, never()).validateToken(anyString(), any());
+    }
+
+    @Test
+    void delegated_boundToOtherFunction_isRejected() {
+        when(introspectionService.isEnabled()).thenReturn(true);
+        when(introspectionService.introspect(psat))
+                .thenReturn(active(OTHER_FUNCTION_ID, OTHER_VERSION_ID));
+
+        assertThatThrownBy(() -> service.validateWorkerToken(psat, FUNCTION_ID, VERSION_ID))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("not bound to requested workload");
+    }
+
+    @Test
+    void delegated_boundToOtherVersion_isRejected() {
+        when(introspectionService.isEnabled()).thenReturn(true);
+        when(introspectionService.introspect(psat))
+                .thenReturn(active(FUNCTION_ID, OTHER_VERSION_ID));
+
+        assertThatThrownBy(() -> service.validateWorkerToken(psat, FUNCTION_ID, VERSION_ID))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("not bound to requested workload");
+    }
+
+    @Test
+    void delegated_inactive_isRejected() {
+        when(introspectionService.isEnabled()).thenReturn(true);
+        when(introspectionService.introspect(psat)).thenReturn(
+                IcmsStubService.WorkerTokenIntrospectResult.builder()
+                        .active(false).error("JWT verification failed").build());
+
+        assertThatThrownBy(() -> service.validateWorkerToken(psat, FUNCTION_ID, VERSION_ID))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("not active");
+    }
+
+    @Test
+    void delegated_malformedBinding_isRejected() {
+        when(introspectionService.isEnabled()).thenReturn(true);
+        when(introspectionService.introspect(psat)).thenReturn(
+                IcmsStubService.WorkerTokenIntrospectResult.builder()
+                        .active(true).functionId("not-a-uuid")
+                        .functionVersionId(VERSION_ID.toString())
+                        .exp(Instant.now().plusSeconds(60).getEpochSecond()).build());
+
+        assertThatThrownBy(() -> service.validateWorkerToken(psat, FUNCTION_ID, VERSION_ID))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    void delegated_featureDisabled_isRejectedWithoutIntrospection() {
+        when(introspectionService.isEnabled()).thenReturn(false);
+
+        assertThatThrownBy(() -> service.validateWorkerToken(psat, FUNCTION_ID, VERSION_ID))
+                .isInstanceOf(ForbiddenException.class);
+        verify(introspectionService, never()).introspect(anyString());
+        verify(grpcTokenService, never()).validateToken(anyString(), any());
+    }
+
+    @Test
+    void legacy_matchingFunction_isAccepted() {
+        when(grpcTokenService.validateToken(LEGACY_TOKEN, TokenType.WORKER))
+                .thenReturn(new NvcfIssuedToken(FUNCTION_ID, VERSION_ID, Instant.now(),
+                                                TokenType.WORKER));
+
+        var validated = service.validateWorkerToken(LEGACY_TOKEN, FUNCTION_ID, VERSION_ID);
+
+        assertThat(validated.delegated()).isFalse();
+        assertThat(validated.token().functionId()).isEqualTo(FUNCTION_ID);
+        verify(introspectionService, never()).introspect(anyString());
+    }
+
+    @Test
+    void legacy_mismatchedFunction_isRejectedWithoutFallbackToIntrospection() {
+        when(grpcTokenService.validateToken(LEGACY_TOKEN, TokenType.WORKER))
+                .thenReturn(new NvcfIssuedToken(OTHER_FUNCTION_ID, VERSION_ID, Instant.now(),
+                                                TokenType.WORKER));
+
+        assertThatThrownBy(() -> service.validateWorkerToken(LEGACY_TOKEN, FUNCTION_ID, VERSION_ID))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("invalid worker token");
+        verify(introspectionService, never()).isEnabled();
+        verify(introspectionService, never()).introspect(anyString());
+    }
+
+    @Test
+    void legacy_undecryptable_isRejectedWithoutFallbackToIntrospection() {
+        when(grpcTokenService.validateToken(LEGACY_TOKEN, TokenType.WORKER))
+                .thenThrow(new ForbiddenException("invalid token"));
+
+        assertThatThrownBy(() -> service.validateWorkerToken(LEGACY_TOKEN, FUNCTION_ID, VERSION_ID))
+                .isInstanceOf(ForbiddenException.class);
+        verify(introspectionService, never()).introspect(anyString());
+    }
+}

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/service/token/WorkerTokenIntrospectionServiceTest.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/service/token/WorkerTokenIntrospectionServiceTest.java
@@ -1,0 +1,118 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.nvcf.service.token;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.nvidia.nvcf.icms.client.IcmsClient;
+import com.nvidia.nvcf.icms.client.IcmsStubService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WorkerTokenIntrospectionServiceTest {
+
+    @Mock
+    private IcmsClient icmsClient;
+
+    private WorkerTokenIntrospectionService service;
+    private WorkerTokenIntrospectionService disabledService;
+
+    @BeforeEach
+    void setUp() {
+        service = new WorkerTokenIntrospectionService(icmsClient, true);
+        disabledService = new WorkerTokenIntrospectionService(icmsClient, false);
+    }
+
+    @Test
+    void isEnabled_returnsTrue_whenFlagSet() {
+        assertThat(service.isEnabled()).isTrue();
+    }
+
+    @Test
+    void isEnabled_returnsFalse_whenFlagNotSet() {
+        assertThat(disabledService.isEnabled()).isFalse();
+    }
+
+    @Test
+    void introspect_returnsActiveResult_andCaches() {
+        var activeResult = IcmsStubService.WorkerTokenIntrospectResult.builder()
+                .active(true)
+                .instanceId("inst-1")
+                .workerId("pod-1")
+                .tokenType("psat")
+                .build();
+        when(icmsClient.introspectWorkerToken(any())).thenReturn(activeResult);
+
+        var result1 = service.introspect("token.val.ue");
+        var result2 = service.introspect("token.val.ue");
+
+        assertThat(result1.isActive()).isTrue();
+        assertThat(result2.isActive()).isTrue();
+        // Second call should hit cache — ICMS called only once.
+        verify(icmsClient, times(1)).introspectWorkerToken(any());
+    }
+
+    @Test
+    void introspect_doesNotCache_whenInactive() {
+        var inactiveResult = IcmsStubService.WorkerTokenIntrospectResult.builder()
+                .active(false)
+                .error("JWT verification failed")
+                .build();
+        when(icmsClient.introspectWorkerToken(any())).thenReturn(inactiveResult);
+
+        service.introspect("bad.token.here");
+        service.introspect("bad.token.here");
+
+        // Both calls hit ICMS because inactive results are not cached.
+        verify(icmsClient, times(2)).introspectWorkerToken(any());
+    }
+
+    @Test
+    void introspect_differentTokens_callIcmsSeparately() {
+        var result = IcmsStubService.WorkerTokenIntrospectResult.builder()
+                .active(true)
+                .instanceId("inst-2")
+                .build();
+        when(icmsClient.introspectWorkerToken(any())).thenReturn(result);
+
+        service.introspect("token.a.1");
+        service.introspect("token.b.2");
+
+        verify(icmsClient, times(2)).introspectWorkerToken(any());
+    }
+
+    @Test
+    void introspect_passesTokenToIcms() {
+        var result = IcmsStubService.WorkerTokenIntrospectResult.builder()
+                .active(false)
+                .build();
+        when(icmsClient.introspectWorkerToken(any())).thenReturn(result);
+
+        service.introspect("my.raw.token");
+
+        verify(icmsClient).introspectWorkerToken(
+                IcmsStubService.WorkerTokenIntrospectRequest.builder().token("my.raw.token").build());
+    }
+}

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/service/token/WorkerTokenIntrospectionServiceTest.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/service/token/WorkerTokenIntrospectionServiceTest.java
@@ -22,8 +22,17 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.PlainJWT;
+import com.nimbusds.jwt.SignedJWT;
 import com.nvidia.nvcf.icms.client.IcmsClient;
 import com.nvidia.nvcf.icms.client.IcmsStubService;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +41,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class WorkerTokenIntrospectionServiceTest {
+
+    private static final String FUNCTION_ID = "b28e2fd6-6d35-4f38-a0a7-a2ddae81f310";
+    private static final String VERSION_ID = "f2619229-35a7-4361-acca-2c4f1f4d609f";
+    private static final byte[] HMAC_KEY = new byte[32];
 
     @Mock
     private IcmsClient icmsClient;
@@ -45,6 +58,31 @@ class WorkerTokenIntrospectionServiceTest {
         disabledService = new WorkerTokenIntrospectionService(icmsClient, false);
     }
 
+    static String signedJwt(List<String> audience) throws Exception {
+        var claims = new JWTClaimsSet.Builder()
+                .subject("system:serviceaccount:inst-789:nvcf-worker")
+                .audience(audience)
+                .expirationTime(Date.from(Instant.now().plusSeconds(900)))
+                .build();
+        var jwt = new SignedJWT(new JWSHeader(JWSAlgorithm.HS256), claims);
+        jwt.sign(new MACSigner(HMAC_KEY));
+        return jwt.serialize();
+    }
+
+    private static IcmsStubService.WorkerTokenIntrospectResult.WorkerTokenIntrospectResultBuilder
+    boundActive() {
+        return IcmsStubService.WorkerTokenIntrospectResult.builder()
+                .active(true)
+                .instanceId("inst-1")
+                .workerId("utils")
+                .tokenType("psat")
+                .clientId("cl-1")
+                .requestId("sr-1")
+                .functionId(FUNCTION_ID)
+                .functionVersionId(VERSION_ID)
+                .exp(Instant.now().plusSeconds(900).getEpochSecond());
+    }
+
     @Test
     void isEnabled_returnsTrue_whenFlagSet() {
         assertThat(service.isEnabled()).isTrue();
@@ -56,21 +94,42 @@ class WorkerTokenIntrospectionServiceTest {
     }
 
     @Test
+    void isDelegatedToken_true_forSignedJwtWithIcmsAudience() throws Exception {
+        assertThat(WorkerTokenIntrospectionService.isDelegatedToken(
+                signedJwt(List.of("nvcf-icms:cl-abc123")))).isTrue();
+    }
+
+    @Test
+    void isDelegatedToken_false_forSignedJwtWithoutIcmsAudience() throws Exception {
+        assertThat(WorkerTokenIntrospectionService.isDelegatedToken(
+                signedJwt(List.of("https://kubernetes.default.svc")))).isFalse();
+    }
+
+    @Test
+    void isDelegatedToken_false_forUnsignedJwt() throws Exception {
+        var plain = new PlainJWT(new JWTClaimsSet.Builder()
+                                         .audience("nvcf-icms:cl-abc123").build());
+        assertThat(WorkerTokenIntrospectionService.isDelegatedToken(plain.serialize())).isFalse();
+    }
+
+    @Test
+    void isDelegatedToken_false_forOpaqueOrBlankTokens() {
+        assertThat(WorkerTokenIntrospectionService.isDelegatedToken("not-a-jwt")).isFalse();
+        assertThat(WorkerTokenIntrospectionService.isDelegatedToken("a.b.c.d.e")).isFalse();
+        assertThat(WorkerTokenIntrospectionService.isDelegatedToken("")).isFalse();
+        assertThat(WorkerTokenIntrospectionService.isDelegatedToken(null)).isFalse();
+    }
+
+    @Test
     void introspect_returnsActiveResult_andCaches() {
-        var activeResult = IcmsStubService.WorkerTokenIntrospectResult.builder()
-                .active(true)
-                .instanceId("inst-1")
-                .workerId("pod-1")
-                .tokenType("psat")
-                .build();
-        when(icmsClient.introspectWorkerToken(any())).thenReturn(activeResult);
+        when(icmsClient.introspectWorkerToken(any())).thenReturn(boundActive().build());
 
         var result1 = service.introspect("token.val.ue");
         var result2 = service.introspect("token.val.ue");
 
         assertThat(result1.isActive()).isTrue();
         assertThat(result2.isActive()).isTrue();
-        // Second call should hit cache — ICMS called only once.
+        assertThat(result2.getFunctionId()).isEqualTo(FUNCTION_ID);
         verify(icmsClient, times(1)).introspectWorkerToken(any());
     }
 
@@ -85,17 +144,55 @@ class WorkerTokenIntrospectionServiceTest {
         service.introspect("bad.token.here");
         service.introspect("bad.token.here");
 
-        // Both calls hit ICMS because inactive results are not cached.
         verify(icmsClient, times(2)).introspectWorkerToken(any());
     }
 
     @Test
+    void introspect_activeWithoutExp_becomesInactive_andIsNotCached() {
+        when(icmsClient.introspectWorkerToken(any())).thenReturn(boundActive().exp(null).build());
+
+        var first = service.introspect("token.no.exp");
+        var second = service.introspect("token.no.exp");
+
+        assertThat(first.isActive()).isFalse();
+        assertThat(first.getError())
+                .isEqualTo(WorkerTokenIntrospectionService.ERROR_MISSING_BINDING);
+        assertThat(second.isActive()).isFalse();
+        verify(icmsClient, times(2)).introspectWorkerToken(any());
+    }
+
+    @Test
+    void introspect_activeWithoutFunctionBinding_becomesInactive_andIsNotCached() {
+        when(icmsClient.introspectWorkerToken(any()))
+                .thenReturn(boundActive().functionId(null).build())
+                .thenReturn(boundActive().functionVersionId("").build());
+
+        assertThat(service.introspect("token.no.fn").isActive()).isFalse();
+        assertThat(service.introspect("token.no.fn").isActive()).isFalse();
+        verify(icmsClient, times(2)).introspectWorkerToken(any());
+    }
+
+    @Test
+    void introspect_activeAlreadyExpired_isNotServedFromCache() {
+        when(icmsClient.introspectWorkerToken(any()))
+                .thenReturn(boundActive().exp(Instant.now().minusSeconds(5).getEpochSecond())
+                                    .build());
+
+        service.introspect("token.expired");
+        service.introspect("token.expired");
+
+        // A zero remaining lifetime yields a zero cache TTL, so the second call reaches ICMS.
+        verify(icmsClient, times(2)).introspectWorkerToken(any());
+    }
+
+    @Test
+    void cacheTtl_isCappedAtFifteenMinutes() {
+        assertThat(WorkerTokenIntrospectionService.CACHE_TTL.toMinutes()).isEqualTo(15);
+    }
+
+    @Test
     void introspect_differentTokens_callIcmsSeparately() {
-        var result = IcmsStubService.WorkerTokenIntrospectResult.builder()
-                .active(true)
-                .instanceId("inst-2")
-                .build();
-        when(icmsClient.introspectWorkerToken(any())).thenReturn(result);
+        when(icmsClient.introspectWorkerToken(any())).thenReturn(boundActive().build());
 
         service.introspect("token.a.1");
         service.introspect("token.b.2");
@@ -105,10 +202,9 @@ class WorkerTokenIntrospectionServiceTest {
 
     @Test
     void introspect_passesTokenToIcms() {
-        var result = IcmsStubService.WorkerTokenIntrospectResult.builder()
-                .active(false)
-                .build();
-        when(icmsClient.introspectWorkerToken(any())).thenReturn(result);
+        when(icmsClient.introspectWorkerToken(any()))
+                .thenReturn(IcmsStubService.WorkerTokenIntrospectResult.builder()
+                                    .active(false).build());
 
         service.introspect("my.raw.token");
 

--- a/src/control-plane-services/cloud-functions/nvcf-service/src/main/resources/application.yaml
+++ b/src/control-plane-services/cloud-functions/nvcf-service/src/main/resources/application.yaml
@@ -307,6 +307,8 @@ nvcf:
   icms:
     allocator:
       maximum-target-latency: PT10S
+  worker:
+    delegated-token-enabled: false
   notary:
     jwt:
       issuer-uri: ${nvcf.notary.base-url}

--- a/src/control-plane-services/cloud-functions/nvcf-service/src/main/resources/application.yaml
+++ b/src/control-plane-services/cloud-functions/nvcf-service/src/main/resources/application.yaml
@@ -308,7 +308,8 @@ nvcf:
     allocator:
       maximum-target-latency: PT10S
   worker:
-    delegated-token-enabled: false
+    delegated-token:
+      enabled: false
   notary:
     jwt:
       issuer-uri: ${nvcf.notary.base-url}


### PR DESCRIPTION
## Why

Part of the delegated worker token feature (issue #840). On self-hosted NVCF clusters, workers receive a projected Kubernetes ServiceAccount Token (PSAT) mounted into their pods. The legacy token validation path decrypts an NVCF-issued JWE, which the PSAT is not. This PR adds a fallback so the gRPC worker service calls ICMS token introspection when the decrypt fails, enabling workers to authenticate via cluster OIDC instead of the static bootstrap token.

## What changed

- **`IcmsStubService`**: Added `WorkerTokenIntrospectRequest`/`WorkerTokenIntrospectResult` DTOs and the `introspectWorkerToken` HTTP exchange method targeting `POST /v1/workers/tokens/introspect`.

- **`IcmsClient`**: Delegating wrapper for `introspectWorkerToken`.

- **`WorkerTokenIntrospectionService`** (new): Caffeine-backed cache keyed on SHA-256(token), evicted after 14 minutes. Inactive results are never cached so clock-skew and `nbf` edge cases are retried. Gated on `nvcf.worker.delegated-token-enabled`.

- **`GrpcWorkerService.validateWorkerToken`**: When legacy decrypt throws `ForbiddenException` and the delegated-token flag is on, falls through to ICMS introspection. `active=true` → synthesize a `NvcfIssuedToken` with the claimed function IDs (independently verified by the function lookup in `connectOnce`). `active=false` → re-throw forbidden.

- **`application.yaml`**: Added `nvcf.worker.delegated-token-enabled: false` (default). Self-hosted Helmfile overlay sets it to `true`.

## Customer Release Notes

Not customer visible — self-hosted infrastructure change.

## Plan Summary

Not applicable.

## Usage

Enable on self-hosted clusters by setting `nvcf.worker.delegated-token-enabled: true` in the Helmfile values overlay (done in the deploy manifests PR). No changes needed for managed NVCF.

## Testing

- `WorkerTokenIntrospectionServiceTest`: cache-hit, cache-miss, no-cache-on-inactive, distinct-tokens, token-forwarded-to-ICMS.
- Unit tests run cleanly with Mockito + AssertJ.
- End-to-end validation requires all PRs deployed together; see test plan in issue #840.

## Notes

Only `connectOnce` needs the delegated-token path. After `connectOnce` returns the NVCF-issued `nvcfWorkerToken`, subsequent gRPC calls (artifacts, credentials) use that token and hit the existing legacy path.

## References

Relates to #840

## Related Pull Requests

- ICMS: #839
- NVCA: #846
- Worker clients: #847
- NVCT API server: feat/nvct-api-delegated-worker-tokens (pending)
- Deploy manifests: feat/deploy-delegated-worker-tokens (pending)

## Dependencies

No new third-party dependencies. Caffeine is already used in `IcmsClient`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional delegated worker-token validation through token introspection.
  * Active delegated tokens can be associated with the appropriate worker identity and retain their expiration details.
  * Added secure caching for active introspection results, with automatic expiration.
  * Streaming asset credentials are now validated against the requested function.

* **Configuration**
  * Added a setting to enable delegated-token support, disabled by default.

* **Bug Fixes**
  * Inactive, expired, malformed, or incorrectly bound delegated tokens are rejected.
  * Existing local token validation remains unchanged when delegated-token support is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->