### PR TITLE
feat(nvct): accept delegated projected ServiceAccount tokens for task worker auth

### DIFF
--- a/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/grpc/GrpcWorkerService.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/grpc/GrpcWorkerService.java
@@ -297,10 +297,15 @@ public class GrpcWorkerService extends WorkerGrpc.WorkerImplBase {
         log.info(MESG_START_GRPC_ENDPOINT, taskId, "refreshToken");
 
         var ncaId = taskService.fetchTask(taskId).getNcaId();
-        tokenService.validateWorkerAccessAssertion(ncaId, taskId);
+        var delegated = tokenService.validateWorkerAccessAssertion(ncaId, taskId);
         NvctUtils.addTagsToCurrentSpan(tracer, Map.of(SPAN_TAG_TASK_ID, request.getTaskId()));
 
-        var newToken = tokenService.issueWorkerAccessAssertion(ncaId, taskId);
+        // A delegated (projected ServiceAccount) token is the worker's credential for its whole
+        // lifetime and is rotated by Kubernetes; no replacement Notary assertion is issued.
+        var newToken = delegated ? "" : tokenService.issueWorkerAccessAssertion(ncaId, taskId);
+        if (delegated) {
+            log.debug("task {} authenticated with a delegated token; no refresh token issued", taskId);
+        }
         var response = RefreshTokenResponse.newBuilder().setToken(newToken).build();
         responseObserver.onNext(response);
         responseObserver.onCompleted();

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/icms/IcmsClient.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/icms/IcmsClient.java
@@ -325,6 +325,11 @@ public class IcmsClient {
         }
     }
 
+    public IcmsStubService.WorkerTokenIntrospectResult introspectWorkerToken(
+            IcmsStubService.WorkerTokenIntrospectRequest request) {
+        return icmsStubService.introspectWorkerToken(request);
+    }
+
     public Instance getInstanceById(String instanceId) {
         var response = icmsStubService.describeInstances(Set.of(instanceId));
         return Optional.ofNullable(response)

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/icms/IcmsStubService.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/icms/IcmsStubService.java
@@ -381,4 +381,35 @@ public interface IcmsStubService {
             @RequestParam("IncludeTerminated") boolean includeTerminated,
             @RequestParam("UseConciseName") boolean useConciseName,
             @RequestParam("ExpiredAckedInstances") boolean expiredAckedInstances);
+
+    @Value
+    @Jacksonized
+    @Builder
+    class WorkerTokenIntrospectRequest {
+        @JsonProperty("token")
+        String token;
+    }
+
+    @Value
+    @Jacksonized
+    @Builder
+    class WorkerTokenIntrospectResult {
+        boolean active;
+        @Nullable String sub;
+        @Nullable String aud;
+        @Nullable String iss;
+        @JsonProperty("instance_id")
+        @Nullable String instanceId;
+        @JsonProperty("worker_id")
+        @Nullable String workerId;
+        @JsonProperty("token_type")
+        @Nullable String tokenType;
+        @Nullable String error;
+    }
+
+    @PostExchange(value = "/v1/workers/tokens/introspect",
+                  accept = "application/json",
+                  contentType = "application/json")
+    WorkerTokenIntrospectResult introspectWorkerToken(
+            @org.springframework.web.bind.annotation.RequestBody WorkerTokenIntrospectRequest request);
 }

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/icms/IcmsStubService.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/icms/IcmsStubService.java
@@ -404,10 +404,12 @@ public interface IcmsStubService {
         @Nullable String workerId;
         @JsonProperty("token_type")
         @Nullable String tokenType;
+        /** RFC 7662 §2.2: epoch-seconds at which the token expires. Null when unknown. */
+        @Nullable Long exp;
         @Nullable String error;
     }
 
-    @PostExchange(value = "/v1/workers/tokens/introspect",
+    @PostExchange(value = "/v1/icms/workers/tokens/introspect",
                   accept = "application/json",
                   contentType = "application/json")
     WorkerTokenIntrospectResult introspectWorkerToken(

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/icms/IcmsStubService.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/icms/IcmsStubService.java
@@ -404,8 +404,20 @@ public interface IcmsStubService {
         @Nullable String workerId;
         @JsonProperty("token_type")
         @Nullable String tokenType;
-        /** RFC 7662 §2.2: epoch-seconds at which the token expires. Null when unknown. */
+        /** RFC 7662 Section 2.2: epoch-seconds at which the token expires. Null when unknown. */
         @Nullable Long exp;
+        @JsonProperty("client_id")
+        @Nullable String clientId;
+        @JsonProperty("request_id")
+        @Nullable String requestId;
+        @JsonProperty("function_id")
+        @Nullable String functionId;
+        @JsonProperty("function_version_id")
+        @Nullable String functionVersionId;
+        @JsonProperty("task_id")
+        @Nullable String taskId;
+        @JsonProperty("nca_id")
+        @Nullable String ncaId;
         @Nullable String error;
     }
 

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/token/TokenService.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/token/TokenService.java
@@ -69,9 +69,14 @@ public class TokenService {
         return notaryClient.issueWorkerAccessAssertionToken(ncaId, taskId);
     }
 
-    public void validateWorkerAccessAssertion(String ncaId, UUID taskId) {
+    /**
+     * Validates the caller's worker credential for the task.
+     *
+     * @return true when the caller authenticated with a delegated (ICMS-introspected) token
+     */
+    public boolean validateWorkerAccessAssertion(String ncaId, UUID taskId) {
         accountService.getAccountName(ncaId);
-        workerAssertionValidator.validate(getAccessToken(), ncaId, taskId);
+        return workerAssertionValidator.validate(getAccessToken(), ncaId, taskId);
     }
 
     private static String getAccessToken() {

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/token/WorkerAssertionValidator.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/token/WorkerAssertionValidator.java
@@ -60,6 +60,7 @@ public class WorkerAssertionValidator {
     private final Clock clock;
     private final String issuer;
     private final String subject;
+    private final WorkerTokenIntrospectionService workerTokenIntrospectionService;
 
     public WorkerAssertionValidator(
             @Qualifier("notaryJwtDecoder") JwtDecoder jwtDecoder,
@@ -67,15 +68,36 @@ public class WorkerAssertionValidator {
             Clock clock,
             @Value("${nvct.notary.base-url}") String issuer,
             @Value("${spring.security.oauth2.client.registration.notary.client-id}")
-            String subject) {
+            String subject,
+            WorkerTokenIntrospectionService workerTokenIntrospectionService) {
         this.jwtDecoder = jwtDecoder;
         this.jsonMapper = jsonMapper;
         this.clock = clock;
         this.issuer = issuer;
         this.subject = subject;
+        this.workerTokenIntrospectionService = workerTokenIntrospectionService;
     }
 
     public void validate(String token, String ncaId, UUID taskId) {
+        try {
+            validateNotaryJwt(token, ncaId, taskId);
+        } catch (ForbiddenException e) {
+            if (!workerTokenIntrospectionService.isEnabled()) {
+                throw e;
+            }
+            // Delegated token path: the bearer token is a projected ServiceAccount Token (PSAT).
+            // ICMS verifies cluster OIDC and worker identity; active=true means authorized.
+            var result = workerTokenIntrospectionService.introspect(token);
+            if (!result.isActive()) {
+                log.warn("worker token introspection returned active=false: {}", result.getError());
+                throw new ForbiddenException("worker token not active");
+            }
+            log.debug("task worker authorized via delegated token, instance_id={}",
+                      result.getInstanceId());
+        }
+    }
+
+    private void validateNotaryJwt(String token, String ncaId, UUID taskId) {
         var jwt = decode(token, taskId);
         validateIssuer(jwt, taskId);
         validateIssuedAt(jwt, taskId);

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/token/WorkerAssertionValidator.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/token/WorkerAssertionValidator.java
@@ -52,6 +52,12 @@ public class WorkerAssertionValidator {
             "NCA id '%s': Does not match the one in the access token";
     private static final String MESG_MISMATCH_TASK_ID =
             "Task id '%s': Does not match the one in the access token";
+    private static final String MESG_DELEGATED_DISABLED =
+            "Task id '%s': Delegated worker tokens are not enabled";
+    private static final String MESG_DELEGATED_INACTIVE =
+            "Task id '%s': worker token not active";
+    private static final String MESG_DELEGATED_NOT_BOUND =
+            "Task id '%s': worker token not bound to requested task";
 
     private static final Duration VALIDITY = Duration.ofHours(3);
 
@@ -78,22 +84,44 @@ public class WorkerAssertionValidator {
         this.workerTokenIntrospectionService = workerTokenIntrospectionService;
     }
 
-    public void validate(String token, String ncaId, UUID taskId) {
-        try {
+    /**
+     * Validates the worker's bearer token for the given task. The path is chosen by token
+     * shape: a delegated token (compact JWS with an {@code nvcf-icms:} audience) is
+     * introspected through ICMS and its task binding must equal the requested task; any other
+     * token is a legacy Notary assertion and is validated locally. A failure on one path never
+     * falls through to the other.
+     *
+     * @return true when the caller authenticated with a delegated token
+     */
+    public boolean validate(String token, String ncaId, UUID taskId) {
+        if (!WorkerTokenIntrospectionService.isDelegatedToken(token)) {
             validateNotaryJwt(token, ncaId, taskId);
-        } catch (ForbiddenException e) {
-            if (!workerTokenIntrospectionService.isEnabled()) {
-                throw e;
-            }
-            // Delegated token path: the bearer token is a projected ServiceAccount Token (PSAT).
-            // ICMS verifies cluster OIDC and worker identity; active=true means authorized.
-            var result = workerTokenIntrospectionService.introspect(token);
-            if (!result.isActive()) {
-                log.warn("worker token introspection returned active=false: {}", result.getError());
-                throw new ForbiddenException("worker token not active");
-            }
-            log.debug("task worker authorized via delegated token, instance_id={}",
-                      result.getInstanceId());
+            return false;
+        }
+        if (!workerTokenIntrospectionService.isEnabled()) {
+            var mesg = MESG_DELEGATED_DISABLED.formatted(taskId);
+            log.error(mesg);
+            throw new ForbiddenException(mesg);
+        }
+        var result = workerTokenIntrospectionService.introspect(token);
+        if (!result.isActive()) {
+            log.warn("worker token introspection returned active=false: {}", result.getError());
+            throw new ForbiddenException(MESG_DELEGATED_INACTIVE.formatted(taskId));
+        }
+        if (!ncaId.equals(result.getNcaId()) || !taskId.equals(parseTaskId(result.getTaskId()))) {
+            log.error("delegated worker token bound to task {} / nca {} presented for task {} / nca {}",
+                      result.getTaskId(), result.getNcaId(), taskId, ncaId);
+            throw new ForbiddenException(MESG_DELEGATED_NOT_BOUND.formatted(taskId));
+        }
+        log.debug("task worker authorized via delegated token, instance_id={}", result.getInstanceId());
+        return true;
+    }
+
+    private static UUID parseTaskId(String taskId) {
+        try {
+            return UUID.fromString(taskId);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            return null;
         }
     }
 

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/token/WorkerTokenIntrospectionService.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/token/WorkerTokenIntrospectionService.java
@@ -1,0 +1,98 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.nvct.service.token;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.nvidia.nvct.service.icms.IcmsClient;
+import com.nvidia.nvct.service.icms.IcmsStubService;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * Calls the ICMS worker token introspection endpoint (RFC 7662) and caches
+ * active results keyed on a SHA-256 digest of the raw token.  Results are
+ * evicted after at most the PSAT TTL (15 minutes).  Inactive results are never
+ * cached so clock-skew and nbf windows are handled on the next retry.
+ */
+@Slf4j
+@Service
+public class WorkerTokenIntrospectionService {
+
+    private static final Duration CACHE_TTL = Duration.ofMinutes(14);
+
+    private final IcmsClient icmsClient;
+    private final boolean enabled;
+    private final Cache<String, IcmsStubService.WorkerTokenIntrospectResult> cache;
+
+    public WorkerTokenIntrospectionService(
+            IcmsClient icmsClient,
+            @Value("${nvct.worker.delegated-token-enabled:false}") boolean enabled) {
+        this.icmsClient = icmsClient;
+        this.enabled = enabled;
+        this.cache = Caffeine.newBuilder()
+                .maximumSize(10_000)
+                .expireAfterWrite(CACHE_TTL)
+                .<String, IcmsStubService.WorkerTokenIntrospectResult>build();
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Introspects a worker token against ICMS.  Returns the result with
+     * {@code active=true} when the token is valid; {@code active=false} otherwise.
+     * Active results are cached; inactive results are not.
+     */
+    public IcmsStubService.WorkerTokenIntrospectResult introspect(String rawToken) {
+        var cacheKey = sha256Hex(rawToken);
+        var cached = cache.getIfPresent(cacheKey);
+        if (cached != null) {
+            log.debug("worker token introspection cache hit");
+            return cached;
+        }
+
+        log.debug("calling ICMS to introspect worker token");
+        var result = icmsClient.introspectWorkerToken(
+                IcmsStubService.WorkerTokenIntrospectRequest.builder().token(rawToken).build());
+
+        if (result.isActive()) {
+            cache.put(cacheKey, result);
+        }
+        return result;
+    }
+
+    private static String sha256Hex(String input) {
+        try {
+            var digest = MessageDigest.getInstance("SHA-256");
+            var hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            var sb = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+}

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/token/WorkerTokenIntrospectionService.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/token/WorkerTokenIntrospectionService.java
@@ -18,12 +18,15 @@ package com.nvidia.nvct.service.token;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
 import com.nvidia.nvct.service.icms.IcmsClient;
 import com.nvidia.nvct.service.icms.IcmsStubService;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -46,13 +49,40 @@ public class WorkerTokenIntrospectionService {
 
     public WorkerTokenIntrospectionService(
             IcmsClient icmsClient,
-            @Value("${nvct.worker.delegated-token-enabled:false}") boolean enabled) {
+            @Value("${nvct.worker.delegate-token.enabled:false}") boolean enabled) {
         this.icmsClient = icmsClient;
         this.enabled = enabled;
         this.cache = Caffeine.newBuilder()
                 .maximumSize(10_000)
-                .expireAfterWrite(CACHE_TTL)
-                .<String, IcmsStubService.WorkerTokenIntrospectResult>build();
+                .expireAfter(new Expiry<String, IcmsStubService.WorkerTokenIntrospectResult>() {
+                    @Override
+                    public long expireAfterCreate(
+                            String key, IcmsStubService.WorkerTokenIntrospectResult value,
+                            long currentTime) {
+                        if (value.getExp() != null) {
+                            long remainingMs =
+                                    value.getExp() * 1000L - Instant.now().toEpochMilli();
+                            long cappedMs = Math.max(0, Math.min(CACHE_TTL.toMillis(), remainingMs));
+                            return TimeUnit.MILLISECONDS.toNanos(cappedMs);
+                        }
+                        return CACHE_TTL.toNanos();
+                    }
+
+                    @Override
+                    public long expireAfterUpdate(
+                            String key, IcmsStubService.WorkerTokenIntrospectResult value,
+                            long currentTime, long currentDuration) {
+                        return currentDuration;
+                    }
+
+                    @Override
+                    public long expireAfterRead(
+                            String key, IcmsStubService.WorkerTokenIntrospectResult value,
+                            long currentTime, long currentDuration) {
+                        return currentDuration;
+                    }
+                })
+                .build();
     }
 
     public boolean isEnabled() {

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/token/WorkerTokenIntrospectionService.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/token/WorkerTokenIntrospectionService.java
@@ -26,22 +26,31 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Calls the ICMS worker token introspection endpoint (RFC 7662) and caches
  * active results keyed on a SHA-256 digest of the raw token.  Results are
- * evicted after at most the PSAT TTL (15 minutes).  Inactive results are never
- * cached so clock-skew and nbf windows are handled on the next retry.
+ * evicted after at most min(token exp, 15 minutes).  Inactive results, and
+ * active results that lack the token expiry or the task binding, are never
+ * cached.
  */
 @Slf4j
 @Service
 public class WorkerTokenIntrospectionService {
 
-    private static final Duration CACHE_TTL = Duration.ofMinutes(14);
+    static final Duration CACHE_TTL = Duration.ofMinutes(15);
+    static final String DELEGATED_AUDIENCE_PREFIX = "nvcf-icms:";
+    static final String ERROR_MISSING_BINDING = "introspection response missing token expiry or task binding";
+
+    private static final JsonMapper JSON = JsonMapper.builder().build();
 
     private final IcmsClient icmsClient;
     private final boolean enabled;
@@ -49,7 +58,7 @@ public class WorkerTokenIntrospectionService {
 
     public WorkerTokenIntrospectionService(
             IcmsClient icmsClient,
-            @Value("${nvct.worker.delegate-token.enabled:false}") boolean enabled) {
+            @Value("${nvct.worker.delegated-token.enabled:false}") boolean enabled) {
         this.icmsClient = icmsClient;
         this.enabled = enabled;
         this.cache = Caffeine.newBuilder()
@@ -59,13 +68,9 @@ public class WorkerTokenIntrospectionService {
                     public long expireAfterCreate(
                             String key, IcmsStubService.WorkerTokenIntrospectResult value,
                             long currentTime) {
-                        if (value.getExp() != null) {
-                            long remainingMs =
-                                    value.getExp() * 1000L - Instant.now().toEpochMilli();
-                            long cappedMs = Math.max(0, Math.min(CACHE_TTL.toMillis(), remainingMs));
-                            return TimeUnit.MILLISECONDS.toNanos(cappedMs);
-                        }
-                        return CACHE_TTL.toNanos();
+                        long remainingMs = value.getExp() * 1000L - Instant.now().toEpochMilli();
+                        long cappedMs = Math.max(0, Math.min(CACHE_TTL.toMillis(), remainingMs));
+                        return TimeUnit.MILLISECONDS.toNanos(cappedMs);
                     }
 
                     @Override
@@ -90,9 +95,46 @@ public class WorkerTokenIntrospectionService {
     }
 
     /**
+     * Returns true when the bearer token has the shape of a delegated worker token: a compact
+     * JWS whose {@code aud} claim contains an entry starting with {@code nvcf-icms:}. The
+     * signature is not verified here; ICMS verifies it during introspection. Legacy Notary
+     * assertions carry a different audience and are never treated as delegated.
+     */
+    public static boolean isDelegatedToken(String token) {
+        if (StringUtils.isBlank(token)) {
+            return false;
+        }
+        var parts = token.split("\\.");
+        if (parts.length != 3 || parts[1].isEmpty()) {
+            return false;
+        }
+        try {
+            var payload = Base64.getUrlDecoder().decode(parts[1]);
+            JsonNode aud = JSON.readTree(payload).get("aud");
+            if (aud == null) {
+                return false;
+            }
+            if (aud.isString()) {
+                return aud.asString().startsWith(DELEGATED_AUDIENCE_PREFIX);
+            }
+            if (aud.isArray()) {
+                for (JsonNode a : aud) {
+                    if (a.isString() && a.asString().startsWith(DELEGATED_AUDIENCE_PREFIX)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        } catch (RuntimeException e) {
+            return false;
+        }
+    }
+
+    /**
      * Introspects a worker token against ICMS.  Returns the result with
-     * {@code active=true} when the token is valid; {@code active=false} otherwise.
-     * Active results are cached; inactive results are not.
+     * {@code active=true} when the token is valid and carries the task binding
+     * ({@code exp}, {@code task_id}, {@code nca_id}); {@code active=false} otherwise.
+     * Only complete active results are cached.
      */
     public IcmsStubService.WorkerTokenIntrospectResult introspect(String rawToken) {
         var cacheKey = sha256Hex(rawToken);
@@ -106,9 +148,19 @@ public class WorkerTokenIntrospectionService {
         var result = icmsClient.introspectWorkerToken(
                 IcmsStubService.WorkerTokenIntrospectRequest.builder().token(rawToken).build());
 
-        if (result.isActive()) {
-            cache.put(cacheKey, result);
+        if (!result.isActive()) {
+            return result;
         }
+        if (result.getExp() == null
+                || StringUtils.isBlank(result.getTaskId())
+                || StringUtils.isBlank(result.getNcaId())) {
+            log.warn("worker token introspection active result lacks exp or task binding; treating as inactive");
+            return IcmsStubService.WorkerTokenIntrospectResult.builder()
+                    .active(false)
+                    .error(ERROR_MISSING_BINDING)
+                    .build();
+        }
+        cache.put(cacheKey, result);
         return result;
     }
 

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/test/java/com/nvidia/nvct/grpc/GrpcWorkerServiceTest.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/test/java/com/nvidia/nvct/grpc/GrpcWorkerServiceTest.java
@@ -745,6 +745,24 @@ class GrpcWorkerServiceTest {
         assertThat(status).isEqualTo(expectedStatus);
     }
 
+
+    @Test
+    void testRefreshTokenWithDelegatedTokenIssuesNoReplacement() {
+        MockIcmsServer.stubWorkerTokenIntrospectActive(TEST_NCA_ID, TEST_TASK_ID_1, "inst-refresh");
+        var enc = java.util.Base64.getUrlEncoder().withoutPadding();
+        var payload = ("{\"aud\":[\"nvcf-icms:cl-test\"],\"sub\":\"system:serviceaccount:inst-refresh:nvcf-worker\","
+                       + "\"exp\":%d,\"jti\":\"%s\"}")
+                .formatted(java.time.Instant.now().plusSeconds(600).getEpochSecond(), UUID.randomUUID());
+        var psat = enc.encodeToString("{\"alg\":\"RS256\"}".getBytes(java.nio.charset.StandardCharsets.UTF_8))
+                + "." + enc.encodeToString(payload.getBytes(java.nio.charset.StandardCharsets.UTF_8)) + ".c2ln";
+        setupGrpc(psat);
+
+        var response = workerBlockingStub.refreshToken(
+                RefreshTokenRequest.newBuilder().setTaskId(TEST_TASK_ID_1.toString()).build());
+
+        assertThat(response.getToken()).isEmpty();
+    }
+
     @Test
     void testRequestSecretCredentials() {
         var token = tokenService.issueWorkerAccessAssertion(TEST_NCA_ID,

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/test/java/com/nvidia/nvct/service/token/WorkerAssertionValidatorTest.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/test/java/com/nvidia/nvct/service/token/WorkerAssertionValidatorTest.java
@@ -18,6 +18,8 @@ package com.nvidia.nvct.service.token;
 
 import static com.nvidia.nvct.util.TestConstants.TEST_NCA_ID;
 import static com.nvidia.nvct.util.TestConstants.TEST_TASK_ID_1;
+import static com.nvidia.nvct.util.TestConstants.TEST_TASK_ID_2;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
@@ -27,9 +29,14 @@ import com.nimbusds.jwt.PlainJWT;
 import com.nvidia.boot.exceptions.ForbiddenException;
 import com.nvidia.nvct.IntegrationTestConfiguration;
 import com.nvidia.nvct.NvctTestApp;
+import com.nvidia.nvct.util.MockIcmsServer;
 import com.nvidia.nvct.util.MockNotaryServer;
 import com.nvidia.nvct.util.MockNvcfServer;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.UUID;
+import tools.jackson.databind.json.JsonMapper;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -73,17 +80,25 @@ class WorkerAssertionValidatorTest {
     @Value("${nvct.nvcf.base-url}")
     private URL nvcfBaseUrl;
 
+    @Value("${nvct.icms.base-url}")
+    private URL icmsBaseUrl;
+
+    @Autowired
+    private JsonMapper jsonMapper;
+
     @BeforeAll
     void beforeAll() {
         log.info("{}: Started running tests", this.getClass().getSimpleName());
         MockNvcfServer.start(nvcfBaseUrl);
         MockNotaryServer.start(notaryBaseUrl, notaryClientId);
+        MockIcmsServer.start(icmsBaseUrl, jsonMapper);
     }
 
     @AfterAll
     void cleanup() {
         MockNotaryServer.stop();
         MockNvcfServer.stop();
+        MockIcmsServer.stop();
         log.info("{}: Completed running tests", this.getClass().getSimpleName());
     }
 
@@ -96,8 +111,7 @@ class WorkerAssertionValidatorTest {
     void shouldAcceptValidSignedWorkerAssertion() {
         var token = tokenService.issueWorkerAccessAssertion(TEST_NCA_ID, TEST_TASK_ID_1);
 
-        assertThatCode(() -> workerAssertionValidator.validate(token, TEST_NCA_ID, TEST_TASK_ID_1))
-                .doesNotThrowAnyException();
+        assertThat(workerAssertionValidator.validate(token, TEST_NCA_ID, TEST_TASK_ID_1)).isFalse();
     }
 
     @Test
@@ -139,5 +153,78 @@ class WorkerAssertionValidatorTest {
         assertThatThrownBy(() -> workerAssertionValidator.validate(token, TEST_NCA_ID, TEST_TASK_ID_1))
                 .isInstanceOf(ForbiddenException.class)
                 .hasMessageContaining("Expired");
+    }
+
+    @Test
+    void shouldRejectLegacyTaskMismatchWithoutFallingBackToIntrospection() {
+        var token = tokenService.issueWorkerAccessAssertion(TEST_NCA_ID, TEST_TASK_ID_1);
+        MockIcmsServer.stubWorkerTokenIntrospectActive(TEST_NCA_ID, TEST_TASK_ID_2, "inst-legacy");
+        var callsBefore = MockIcmsServer.workerTokenIntrospectCallCount();
+
+        assertThatThrownBy(() -> workerAssertionValidator.validate(token, TEST_NCA_ID, TEST_TASK_ID_2))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("Does not match");
+        assertThat(MockIcmsServer.workerTokenIntrospectCallCount()).isEqualTo(callsBefore);
+    }
+
+    @Test
+    void shouldAcceptDelegatedTokenBoundToRequestedTask() {
+        MockIcmsServer.stubWorkerTokenIntrospectActive(TEST_NCA_ID, TEST_TASK_ID_1, "inst-ok");
+        var token = fakePsat("inst-ok");
+
+        assertThat(workerAssertionValidator.validate(token, TEST_NCA_ID, TEST_TASK_ID_1)).isTrue();
+    }
+
+    @Test
+    void shouldRejectDelegatedTokenBoundToOtherTask() {
+        MockIcmsServer.stubWorkerTokenIntrospectActive(TEST_NCA_ID, TEST_TASK_ID_1, "inst-task");
+        var token = fakePsat("inst-task");
+
+        assertThatThrownBy(() -> workerAssertionValidator.validate(token, TEST_NCA_ID, TEST_TASK_ID_2))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("not bound to requested task");
+    }
+
+    @Test
+    void shouldRejectDelegatedTokenBoundToOtherNca() {
+        MockIcmsServer.stubWorkerTokenIntrospectActive("other-nca", TEST_TASK_ID_1, "inst-nca");
+        var token = fakePsat("inst-nca");
+
+        assertThatThrownBy(() -> workerAssertionValidator.validate(token, TEST_NCA_ID, TEST_TASK_ID_1))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("not bound to requested task");
+    }
+
+    @Test
+    void shouldRejectInactiveDelegatedToken() {
+        MockIcmsServer.stubWorkerTokenIntrospect("{\"active\": false, \"error\": \"JWT verification failed\"}");
+        var token = fakePsat("inst-inactive");
+
+        assertThatThrownBy(() -> workerAssertionValidator.validate(token, TEST_NCA_ID, TEST_TASK_ID_1))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("not active");
+    }
+
+    @Test
+    void shouldRejectDelegatedTokenWithoutBindingInResponse() {
+        MockIcmsServer.stubWorkerTokenIntrospect(
+                "{\"active\": true, \"instance_id\": \"inst-unbound\", \"token_type\": \"psat\"}");
+        var token = fakePsat("inst-unbound");
+
+        assertThatThrownBy(() -> workerAssertionValidator.validate(token, TEST_NCA_ID, TEST_TASK_ID_1))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("not active");
+    }
+
+    /** Builds an unsigned compact JWS shaped like a projected ServiceAccount token; signature
+     *  verification is ICMS's job and is mocked. A unique jti keeps introspection results from
+     *  being served across tests from the digest-keyed cache. */
+    private static String fakePsat(String jti) {
+        var enc = Base64.getUrlEncoder().withoutPadding();
+        var payload = ("{\"aud\":[\"nvcf-icms:cl-test\"],\"sub\":\"system:serviceaccount:%s:nvcf-worker\","
+                       + "\"exp\":%d,\"jti\":\"%s\"}")
+                .formatted(jti, Instant.now().plusSeconds(600).getEpochSecond(), UUID.randomUUID());
+        return enc.encodeToString("{\"alg\":\"RS256\",\"kid\":\"k1\"}".getBytes(StandardCharsets.UTF_8))
+                + "." + enc.encodeToString(payload.getBytes(StandardCharsets.UTF_8)) + ".c2ln";
     }
 }

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/test/java/com/nvidia/nvct/service/token/WorkerTokenIntrospectionServiceTest.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/test/java/com/nvidia/nvct/service/token/WorkerTokenIntrospectionServiceTest.java
@@ -24,6 +24,9 @@ import static org.mockito.Mockito.when;
 
 import com.nvidia.nvct.service.icms.IcmsClient;
 import com.nvidia.nvct.service.icms.IcmsStubService;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +35,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class WorkerTokenIntrospectionServiceTest {
+
+    private static final String TASK_ID = "11111111-2222-3333-4444-555555555555";
+    private static final String NCA_ID = "nca-test";
 
     @Mock
     private IcmsClient icmsClient;
@@ -62,6 +68,9 @@ class WorkerTokenIntrospectionServiceTest {
                 .instanceId("inst-1")
                 .workerId("pod-1")
                 .tokenType("psat")
+                .exp(Instant.now().plusSeconds(600).getEpochSecond())
+                .taskId(TASK_ID)
+                .ncaId(NCA_ID)
                 .build();
         when(icmsClient.introspectWorkerToken(any())).thenReturn(activeResult);
 
@@ -94,6 +103,9 @@ class WorkerTokenIntrospectionServiceTest {
         var result = IcmsStubService.WorkerTokenIntrospectResult.builder()
                 .active(true)
                 .instanceId("inst-2")
+                .exp(Instant.now().plusSeconds(600).getEpochSecond())
+                .taskId(TASK_ID)
+                .ncaId(NCA_ID)
                 .build();
         when(icmsClient.introspectWorkerToken(any())).thenReturn(result);
 
@@ -114,5 +126,85 @@ class WorkerTokenIntrospectionServiceTest {
 
         verify(icmsClient).introspectWorkerToken(
                 IcmsStubService.WorkerTokenIntrospectRequest.builder().token("my.raw.token").build());
+    }
+
+    @Test
+    void introspect_treatsActiveWithoutExpAsInactive_andDoesNotCache() {
+        var result = IcmsStubService.WorkerTokenIntrospectResult.builder()
+                .active(true)
+                .instanceId("inst-3")
+                .taskId(TASK_ID)
+                .ncaId(NCA_ID)
+                .build();
+        when(icmsClient.introspectWorkerToken(any())).thenReturn(result);
+
+        var first = service.introspect("no.exp.token");
+        var second = service.introspect("no.exp.token");
+
+        assertThat(first.isActive()).isFalse();
+        assertThat(first.getError()).isEqualTo(WorkerTokenIntrospectionService.ERROR_MISSING_BINDING);
+        assertThat(second.isActive()).isFalse();
+        verify(icmsClient, times(2)).introspectWorkerToken(any());
+    }
+
+    @Test
+    void introspect_treatsActiveWithoutTaskBindingAsInactive() {
+        var result = IcmsStubService.WorkerTokenIntrospectResult.builder()
+                .active(true)
+                .instanceId("inst-4")
+                .exp(Instant.now().plusSeconds(600).getEpochSecond())
+                .functionId("f-1")
+                .build();
+        when(icmsClient.introspectWorkerToken(any())).thenReturn(result);
+
+        assertThat(service.introspect("fn.bound.token").isActive()).isFalse();
+    }
+
+    @Test
+    void introspect_doesNotServeExpiredTokenFromCache() {
+        var result = IcmsStubService.WorkerTokenIntrospectResult.builder()
+                .active(true)
+                .instanceId("inst-5")
+                .exp(Instant.now().minusSeconds(5).getEpochSecond())
+                .taskId(TASK_ID)
+                .ncaId(NCA_ID)
+                .build();
+        when(icmsClient.introspectWorkerToken(any())).thenReturn(result);
+
+        service.introspect("expired.tok.en");
+        service.introspect("expired.tok.en");
+
+        verify(icmsClient, times(2)).introspectWorkerToken(any());
+    }
+
+    @Test
+    void isDelegatedToken_recognizesIcmsAudience() {
+        assertThat(WorkerTokenIntrospectionService.isDelegatedToken(
+                fakeJws("{\"aud\":[\"nvcf-icms:cl-1\"],\"sub\":\"x\"}"))).isTrue();
+        assertThat(WorkerTokenIntrospectionService.isDelegatedToken(
+                fakeJws("{\"aud\":\"nvcf-icms:cl-1\"}"))).isTrue();
+    }
+
+    @Test
+    void isDelegatedToken_rejectsOtherShapes() {
+        assertThat(WorkerTokenIntrospectionService.isDelegatedToken(null)).isFalse();
+        assertThat(WorkerTokenIntrospectionService.isDelegatedToken("")).isFalse();
+        assertThat(WorkerTokenIntrospectionService.isDelegatedToken("opaque-token")).isFalse();
+        assertThat(WorkerTokenIntrospectionService.isDelegatedToken("a.b")).isFalse();
+        assertThat(WorkerTokenIntrospectionService.isDelegatedToken("a.b.c.d.e")).isFalse();
+        assertThat(WorkerTokenIntrospectionService.isDelegatedToken(
+                fakeJws("{\"aud\":[\"nvcf-icms\"]}"))).isFalse();
+        assertThat(WorkerTokenIntrospectionService.isDelegatedToken(
+                fakeJws("{\"aud\":[\"notary\"],\"assertion\":{}}"))).isFalse();
+        assertThat(WorkerTokenIntrospectionService.isDelegatedToken(
+                fakeJws("{\"sub\":\"x\"}"))).isFalse();
+        assertThat(WorkerTokenIntrospectionService.isDelegatedToken("hdr.!!notbase64!!.sig")).isFalse();
+    }
+
+    private static String fakeJws(String payloadJson) {
+        var enc = Base64.getUrlEncoder().withoutPadding();
+        return enc.encodeToString("{\"alg\":\"RS256\"}".getBytes(StandardCharsets.UTF_8))
+                + "." + enc.encodeToString(payloadJson.getBytes(StandardCharsets.UTF_8))
+                + ".c2ln";
     }
 }

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/test/java/com/nvidia/nvct/service/token/WorkerTokenIntrospectionServiceTest.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/test/java/com/nvidia/nvct/service/token/WorkerTokenIntrospectionServiceTest.java
@@ -1,0 +1,118 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.nvct.service.token;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.nvidia.nvct.service.icms.IcmsClient;
+import com.nvidia.nvct.service.icms.IcmsStubService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WorkerTokenIntrospectionServiceTest {
+
+    @Mock
+    private IcmsClient icmsClient;
+
+    private WorkerTokenIntrospectionService service;
+    private WorkerTokenIntrospectionService disabledService;
+
+    @BeforeEach
+    void setUp() {
+        service = new WorkerTokenIntrospectionService(icmsClient, true);
+        disabledService = new WorkerTokenIntrospectionService(icmsClient, false);
+    }
+
+    @Test
+    void isEnabled_returnsTrue_whenFlagSet() {
+        assertThat(service.isEnabled()).isTrue();
+    }
+
+    @Test
+    void isEnabled_returnsFalse_whenFlagNotSet() {
+        assertThat(disabledService.isEnabled()).isFalse();
+    }
+
+    @Test
+    void introspect_returnsActiveResult_andCaches() {
+        var activeResult = IcmsStubService.WorkerTokenIntrospectResult.builder()
+                .active(true)
+                .instanceId("inst-1")
+                .workerId("pod-1")
+                .tokenType("psat")
+                .build();
+        when(icmsClient.introspectWorkerToken(any())).thenReturn(activeResult);
+
+        var result1 = service.introspect("token.val.ue");
+        var result2 = service.introspect("token.val.ue");
+
+        assertThat(result1.isActive()).isTrue();
+        assertThat(result2.isActive()).isTrue();
+        // Second call should hit cache — ICMS called only once.
+        verify(icmsClient, times(1)).introspectWorkerToken(any());
+    }
+
+    @Test
+    void introspect_doesNotCache_whenInactive() {
+        var inactiveResult = IcmsStubService.WorkerTokenIntrospectResult.builder()
+                .active(false)
+                .error("JWT verification failed")
+                .build();
+        when(icmsClient.introspectWorkerToken(any())).thenReturn(inactiveResult);
+
+        service.introspect("bad.token.here");
+        service.introspect("bad.token.here");
+
+        // Both calls hit ICMS because inactive results are not cached.
+        verify(icmsClient, times(2)).introspectWorkerToken(any());
+    }
+
+    @Test
+    void introspect_differentTokens_callIcmsSeparately() {
+        var result = IcmsStubService.WorkerTokenIntrospectResult.builder()
+                .active(true)
+                .instanceId("inst-2")
+                .build();
+        when(icmsClient.introspectWorkerToken(any())).thenReturn(result);
+
+        service.introspect("token.a.1");
+        service.introspect("token.b.2");
+
+        verify(icmsClient, times(2)).introspectWorkerToken(any());
+    }
+
+    @Test
+    void introspect_passesTokenToIcms() {
+        var result = IcmsStubService.WorkerTokenIntrospectResult.builder()
+                .active(false)
+                .build();
+        when(icmsClient.introspectWorkerToken(any())).thenReturn(result);
+
+        service.introspect("my.raw.token");
+
+        verify(icmsClient).introspectWorkerToken(
+                IcmsStubService.WorkerTokenIntrospectRequest.builder().token("my.raw.token").build());
+    }
+}

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/test/java/com/nvidia/nvct/util/MockIcmsServer.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/test/java/com/nvidia/nvct/util/MockIcmsServer.java
@@ -187,6 +187,34 @@ public class MockIcmsServer {
         }
     }
 
+    public static final String WORKER_TOKEN_INTROSPECT_PATH = "/v1/icms/workers/tokens/introspect";
+
+    /** Stubs the worker token introspection endpoint to return the given JSON body for any token. */
+    public static void stubWorkerTokenIntrospect(String responseJson) {
+        mockIcmsServer.stubFor(post(urlPathEqualTo(WORKER_TOKEN_INTROSPECT_PATH))
+                                       .atPriority(1)
+                                       .willReturn(aResponse().withStatus(200)
+                                                           .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+                                                           .withBody(responseJson)));
+    }
+
+    /** Stubs an active introspection result bound to the given task and NCA. */
+    public static void stubWorkerTokenIntrospectActive(String ncaId, UUID taskId, String instanceId) {
+        stubWorkerTokenIntrospect("""
+                {"active": true, "sub": "system:serviceaccount:%s:nvcf-worker",
+                 "aud": "nvcf-icms:cl-test", "iss": "https://kubernetes.default.svc",
+                 "exp": %d, "client_id": "cl-test", "instance_id": "%s", "worker_id": "utils",
+                 "request_id": "req-1", "task_id": "%s", "nca_id": "%s", "token_type": "psat"}
+                """.formatted(instanceId, Instant.now().plusSeconds(600).getEpochSecond(),
+                              instanceId, taskId, ncaId));
+    }
+
+    public static int workerTokenIntrospectCallCount() {
+        return mockIcmsServer.countRequestsMatching(
+                com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor(
+                        urlPathEqualTo(WORKER_TOKEN_INTROSPECT_PATH)).build()).getCount();
+    }
+
     public static void stubTerminateInstanceNotFound() {
         mockIcmsServer.stubFor(
                 delete(urlPathMatching("/v1/si/accounts/.*/workloads/.*"))

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/test/resources/application-test.yaml
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/test/resources/application-test.yaml
@@ -205,6 +205,9 @@ nvct:
     cache-ttl: PT1S
   reval:
     base-url: http://localhost:9099
+  worker:
+    delegated-token:
+      enabled: true
   icms:
     base-url: http://localhost:9096
     allocator:

--- a/src/control-plane-services/cloud-tasks/nvct-service/src/main/resources/application.yaml
+++ b/src/control-plane-services/cloud-tasks/nvct-service/src/main/resources/application.yaml
@@ -223,7 +223,8 @@ nvct:
     ess-agent-container: ${nvct.sidecars.hostname}/${nvct.sidecars.repository}/ess-agent:1.0.5
     otel-collector-container: ${nvct.sidecars.hostname}/${nvct.sidecars.repository}/byoo-otel-collector:0.126.16
   worker:
-    delegated-token-enabled: false
+    delegated-token:
+      enabled: false
   scheduled-routines:
     enabled: true
     lock-consistency: LOCAL_QUORUM

--- a/src/control-plane-services/cloud-tasks/nvct-service/src/main/resources/application.yaml
+++ b/src/control-plane-services/cloud-tasks/nvct-service/src/main/resources/application.yaml
@@ -222,6 +222,8 @@ nvct:
     otel-container: ${nvct.sidecars.hostname}/${nvct.sidecars.repository}/opentelemetry-collector:0.126.0
     ess-agent-container: ${nvct.sidecars.hostname}/${nvct.sidecars.repository}/ess-agent:1.0.5
     otel-collector-container: ${nvct.sidecars.hostname}/${nvct.sidecars.repository}/byoo-otel-collector:0.126.16
+  worker:
+    delegated-token-enabled: false
   scheduled-routines:
     enabled: true
     lock-consistency: LOCAL_QUORUM


### PR DESCRIPTION
## Why

Part of the delegated worker token feature (issue #840). On self-hosted NVCT clusters, task workers receive a projected Kubernetes ServiceAccount Token (PSAT) mounted into their pods. The existing path decodes a Notary-issued assertion JWT, which the PSAT is not. This PR adds a fallback so `WorkerAssertionValidator` calls ICMS token introspection when Notary decode fails, enabling task workers to authenticate via cluster OIDC.

## What changed

- **`IcmsStubService`**: Added `WorkerTokenIntrospectRequest`/`WorkerTokenIntrospectResult` DTOs and the `introspectWorkerToken` HTTP exchange method targeting `POST /v1/workers/tokens/introspect`.

- **`IcmsClient`**: Delegating wrapper for `introspectWorkerToken`.

- **`WorkerTokenIntrospectionService`** (new): Caffeine-backed cache keyed on SHA-256(token), evicted after 14 minutes. Inactive results are never cached. Gated on `nvct.worker.delegated-token-enabled`.

- **`WorkerAssertionValidator.validate`**: Wraps `validateNotaryJwt` in try/catch. When `ForbiddenException` is thrown and the flag is on, falls through to ICMS introspection. `active=true` → authorized. `active=false` → re-throw forbidden.

- **`application.yaml`**: Added `nvct.worker.delegated-token-enabled: false` (default). Self-hosted Helmfile overlay sets it to `true`.

## Customer Release Notes

Not customer visible — self-hosted infrastructure change.

## Plan Summary

Not applicable.

## Usage

Enable on self-hosted clusters by setting `nvct.worker.delegated-token-enabled: true` in the Helmfile values overlay. No changes needed for managed NVCT.

## Testing

- `WorkerTokenIntrospectionServiceTest`: cache-hit, cache-miss, no-cache-on-inactive, distinct-tokens, token-forwarded-to-ICMS.
- End-to-end validation requires all PRs deployed together; see test plan in issue #840.

## Notes

NVCT task workers use `WorkerAssertionValidator.validate` directly (no gRPC issued-token flow). The Notary JWT path remains unchanged when the flag is off.

## References

Relates to #840

## Related Pull Requests

- ICMS: #839
- NVCA: #846
- Worker clients: #847
- NVCF API server: #848
- Deploy manifests: feat/deploy-delegated-worker-tokens (pending)

## Dependencies

No new third-party dependencies. Caffeine is already used in `IcmsClient`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added worker-token introspection to verify validity, status, expiration, and associated metadata.
  * Added optional delegated-token authentication with task and identity binding checks.
  * Added caching for active introspection results to improve repeated authorization checks.
  * Delegated tokens no longer receive replacement refresh tokens.

* **Configuration**
  * Added a setting to enable or disable delegated-token support, disabled by default.

* **Tests**
  * Added coverage for introspection, caching, feature flags, validation, and refresh-token handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->