### PR TITLE
feat(deploy): enable delegated worker token auth in self-managed stack

### DIFF
--- a/deploy/stacks/self-managed/Makefile
+++ b/deploy/stacks/self-managed/Makefile
@@ -4,3 +4,4 @@ include Makefile.dist
 .PHONY: test
 test:
 	@tests/llm-router-worker-address.sh
+	@tests/delegated-worker-tokens.sh

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -306,6 +306,15 @@ addons:
   nvcfUi:
     enabled: false
 
+# Control-plane security toggles.
+security:
+  # Delegated worker tokens: NVCF API and NVCT API accept Helm-worker projected
+  # ServiceAccount tokens verified through ICMS introspection. Enable together
+  # with NVCA cluster OIDC identity. The NVCF and NVCT service credentials must
+  # carry the worker-token-introspect scope for ICMS to serve introspection.
+  delegatedWorkerTokens:
+    enabled: false
+
 stateMetrics:
   enabled: true
   # Disable ServiceMonitor for environments without Prometheus Operator

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -263,6 +263,7 @@ natsAuthCalloutService:
 {{- $llmRequestRouterDefaultAddress := printf "llm-request-router.nvcf.svc.cluster.local:%v" $llmRequestRouterGrpcPort }}
 {{- $llmRequestRouterWorkerAddress := dig "llmRequestRouterAddress" "" $workerEndpoints | trim | default $llmRequestRouterDefaultAddress }}
 {{- $llmEnabled := dig "addons" "llm" "enabled" false .Values }}
+{{- $delegatedWorkerTokensEnabled := dig "security" "delegatedWorkerTokens" "enabled" false .Values }}
 {{- if $llmEnabled }}
 {{- $llmRequestRouterWorkerAddressError := "global.workerEndpoints.llmRequestRouterAddress must use DNS-or-IPv4:port or [IPv6]:port with port 1-65535" }}
 {{- $llmRequestRouterDNSAddressPattern := `^([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)(\.([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?))*:[0-9]{1,5}$` }}
@@ -344,7 +345,8 @@ api:
     configData:
       nvcf:
         worker:
-          delegated-token-enabled: true
+          delegated-token:
+            enabled: {{ $delegatedWorkerTokensEnabled }}
         {{- if $llmEnabled }}
         llm-request-router:
           worker-address: {{ $llmRequestRouterWorkerAddress | quote }}
@@ -485,7 +487,7 @@ nvctApi:
     NVCT_ESS_BASE_URL: {{ . | quote }}
     NVCT_ESS_WORKER_BASE_URL: {{ . | quote }}
     {{- end }}
-    NVCT_WORKER_DELEGATED_TOKEN_ENABLED: "true"
+    NVCT_WORKER_DELEGATEDTOKEN_ENABLED: {{ $delegatedWorkerTokensEnabled | toString | quote }}
     {{- with dig "nvctApi" "icmsBaseUrl" nil .Values }}
     NVCT_ICMS_BASE_URL: {{ . | quote }}
     {{- end }}

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -340,13 +340,15 @@ api:
   {{- with include "nvcf.tolerations" (dict "type" "controlplane" "tolerations" .Values.global.tolerations) }}
   {{- . | nindent 2 }}
   {{- end }}
-  {{- if $llmEnabled }}
   remoteConfig:
     configData:
       nvcf:
+        worker:
+          delegated-token-enabled: true
+        {{- if $llmEnabled }}
         llm-request-router:
           worker-address: {{ $llmRequestRouterWorkerAddress | quote }}
-  {{- end }}
+        {{- end }}
   accountBootstrap:
     image:
       registry: {{ .Values.global.image.registry }}
@@ -483,6 +485,7 @@ nvctApi:
     NVCT_ESS_BASE_URL: {{ . | quote }}
     NVCT_ESS_WORKER_BASE_URL: {{ . | quote }}
     {{- end }}
+    NVCT_WORKER_DELEGATED_TOKEN_ENABLED: "true"
     {{- with dig "nvctApi" "icmsBaseUrl" nil .Values }}
     NVCT_ICMS_BASE_URL: {{ . | quote }}
     {{- end }}

--- a/deploy/stacks/self-managed/tests/delegated-worker-tokens.sh
+++ b/deploy/stacks/self-managed/tests/delegated-worker-tokens.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+work_dir="$(mktemp -d)"
+test_stack_dir="$work_dir/self-managed"
+environment_name="delegated-worker-tokens-test"
+environment_file="$test_stack_dir/environments/$environment_name.yaml"
+secrets_file="$test_stack_dir/secrets/$environment_name-secrets.yaml"
+trap 'rm -rf "$work_dir"' EXIT
+
+fail() {
+  echo "delegated-worker-tokens: $*" >&2
+  exit 1
+}
+
+mkdir -p "$test_stack_dir"
+cp -R "$stack_dir"/. "$test_stack_dir"
+printf '{}\n' >"$secrets_file"
+
+write_environment() {
+  local enabled="$1"
+
+  if [ -z "$enabled" ]; then
+    printf '{}\n' >"$environment_file"
+    return
+  fi
+  printf '%s\n' \
+    'security:' \
+    '  delegatedWorkerTokens:' \
+    "    enabled: $enabled" \
+    >"$environment_file"
+}
+
+render_values() {
+  local release_name="$1"
+  local output_file="$2"
+
+  HELMFILE_ENV="$environment_name" \
+    HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" \
+    helmfile \
+      --file "$test_stack_dir/helmfile.d/02-core.yaml.gotmpl" \
+      --environment default \
+      --state-values-set ingress.gatewayApi.controllerNamespace=envoy-gateway-system \
+      --state-values-set ingress.gatewayApi.gateways.shared.name=shared-gw \
+      --state-values-set ingress.gatewayApi.gateways.shared.namespace=envoy-gateway-system \
+      --state-values-set ingress.gatewayApi.gateways.grpc.name=grpc-gw \
+      --state-values-set ingress.gatewayApi.gateways.grpc.namespace=envoy-gateway-system \
+      --selector "name=$release_name" \
+      write-values \
+      --output-file-template "$output_file"
+}
+
+# Walks api.remoteConfig.configData.nvcf.worker.delegated-token.enabled by
+# indentation so a key rendered under another release or path is not accepted.
+read_nvcf_delegated_token_enabled() {
+  local values_file="$1"
+
+  awk '
+    /^[[:space:]]*($|#)/ { next }
+
+    /^[^[:space:]]/ {
+      in_api = ($0 == "api:")
+      in_remote_config = in_config_data = in_nvcf = in_worker = in_delegated = 0
+      next
+    }
+    in_api && /^  [^[:space:]]/ {
+      in_remote_config = ($0 == "  remoteConfig:")
+      in_config_data = in_nvcf = in_worker = in_delegated = 0
+      next
+    }
+    in_remote_config && /^    [^[:space:]]/ {
+      in_config_data = ($0 == "    configData:")
+      in_nvcf = in_worker = in_delegated = 0
+      next
+    }
+    in_config_data && /^      [^[:space:]]/ {
+      in_nvcf = ($0 == "      nvcf:")
+      in_worker = in_delegated = 0
+      next
+    }
+    in_nvcf && /^        [^[:space:]]/ {
+      in_worker = ($0 == "        worker:")
+      in_delegated = 0
+      next
+    }
+    in_worker && /^          [^[:space:]]/ {
+      in_delegated = ($0 == "          delegated-token:")
+      next
+    }
+    in_delegated && /^            [^[:space:]]/ {
+      if ($0 ~ /^            enabled:[[:space:]]*/) {
+        value = $0
+        sub(/^            enabled:[[:space:]]*/, "", value)
+        print value
+        found = 1
+        exit
+      }
+      next
+    }
+
+    END { if (!found) exit 1 }
+  ' "$values_file"
+}
+
+# Walks nvctApi.env.NVCT_WORKER_DELEGATEDTOKEN_ENABLED by indentation.
+read_nvct_delegated_token_enabled() {
+  local values_file="$1"
+
+  awk '
+    /^[[:space:]]*($|#)/ { next }
+
+    /^[^[:space:]]/ {
+      in_nvct = ($0 == "nvctApi:")
+      in_env = 0
+      next
+    }
+    in_nvct && /^  [^[:space:]]/ {
+      in_env = ($0 == "  env:")
+      next
+    }
+    in_env && /^    [^[:space:]]/ {
+      if ($0 ~ /^    NVCT_WORKER_DELEGATEDTOKEN_ENABLED:[[:space:]]*/) {
+        value = $0
+        sub(/^    NVCT_WORKER_DELEGATEDTOKEN_ENABLED:[[:space:]]*/, "", value)
+        first = substr(value, 1, 1)
+        last = substr(value, length(value), 1)
+        if ((first == "\"" && last == "\"") ||
+            (first == sprintf("%c", 39) && last == sprintf("%c", 39))) {
+          value = substr(value, 2, length(value) - 2)
+        }
+        print value
+        found = 1
+        exit
+      }
+      next
+    }
+
+    END { if (!found) exit 1 }
+  ' "$values_file"
+}
+
+assert_rendered() {
+  local case_name="$1"
+  local expected="$2"
+  local api_values="$work_dir/$case_name-api-values.yaml"
+  local nvct_values="$work_dir/$case_name-nvct-values.yaml"
+  local actual
+
+  render_values api "$api_values" >/dev/null
+  render_values nvct-api "$nvct_values" >/dev/null
+
+  actual="$(read_nvcf_delegated_token_enabled "$api_values")" ||
+    fail "$case_name: nvcf.worker.delegated-token.enabled was not rendered in API remote config"
+  test "$actual" = "$expected" ||
+    fail "$case_name: expected nvcf.worker.delegated-token.enabled=$expected, got $actual"
+
+  actual="$(read_nvct_delegated_token_enabled "$nvct_values")" ||
+    fail "$case_name: NVCT_WORKER_DELEGATEDTOKEN_ENABLED was not rendered in nvctApi.env"
+  test "$actual" = "$expected" ||
+    fail "$case_name: expected NVCT_WORKER_DELEGATEDTOKEN_ENABLED=$expected, got $actual"
+
+  # The service-side property keys are nvcf.worker.delegated-token.enabled and
+  # nvct.worker.delegated-token.enabled; the previous spellings did not bind.
+  if grep -Eq 'delegated-token-enabled|NVCT_WORKER_DELEGATED_TOKEN_ENABLED' \
+    "$api_values" "$nvct_values"; then
+    fail "$case_name: a stale delegated-token key spelling was rendered"
+  fi
+}
+
+write_environment ''
+assert_rendered default false
+
+write_environment false
+assert_rendered disabled false
+
+write_environment true
+assert_rendered enabled true
+
+echo "delegated-worker-tokens: all checks passed"

--- a/deploy/stacks/self-managed/tests/llm-router-worker-address.sh
+++ b/deploy/stacks/self-managed/tests/llm-router-worker-address.sh
@@ -346,4 +346,13 @@ if grep -Fq "$staged_worker_address" "$work_dir/disabled-api-values.yaml"; then
   fail "disabled LLM supplied a staged worker address to the API chart"
 fi
 
+invalid_disabled_worker_address='not-valid:99999'
+write_environment false "$invalid_disabled_worker_address"
+if ! render_api_values "$work_dir/disabled-invalid-api-values.yaml" >/dev/null 2>&1; then
+  fail "disabled LLM rejected render with an invalid worker address (validation must not run when disabled)"
+fi
+if grep -Fq "$invalid_disabled_worker_address" "$work_dir/disabled-invalid-api-values.yaml"; then
+  fail "disabled LLM passed an invalid worker address through to the API chart"
+fi
+
 echo "llm-router-worker-address: all checks passed"


### PR DESCRIPTION
## Why

Projected ServiceAccount Token (PSAT) based worker authentication (issue #840) requires the NVCF API and NVCT API services to have the delegated-token feature flag enabled in the self-managed deployment. Without this, both services fall back to Notary JWT validation only and reject PSAT-based workers even when all other pieces (NVCA token injection, ICMS introspection endpoint, worker library) are in place.

## What changed

`deploy/stacks/self-managed/global.yaml.gotmpl`:

- **NVCF API**: Restructured the `remoteConfig.configData.nvcf` block so `worker.delegated-token-enabled: true` is always emitted. The LLM request router address remains conditional on `$llmEnabled` within the same block. Previously the entire `remoteConfig` stanza was guarded by `$llmEnabled`, which would have left the feature flag absent on deployments without LLM support.

- **NVCT API**: Added `NVCT_WORKER_DELEGATED_TOKEN_ENABLED: "true"` to the `nvctApi.env` map. Spring Boot's relaxed env var binding maps this to `nvct.worker.delegated-token-enabled` in the service's application properties.

No RBAC changes are needed: the NVCA operator ClusterRole already grants full CRUD on `serviceaccounts`, so NVCA can create per-instance worker ServiceAccounts and the kubelet can issue projected tokens for those SAs.

## Customer Release Notes

Self-managed NVCF deployments now accept projected Kubernetes ServiceAccount Tokens (PSAT) as worker credentials, enabling keyless worker authentication on self-hosted clusters without pre-distributed bootstrap secrets.

## Plan Summary

Single-file Helmfile overlay change; no new Helm chart values, no new Kubernetes resources. The `remoteConfig` mechanism for NVCF API injects config via a ConfigMap; the `env` mechanism for NVCT API injects Spring Boot properties as environment variables.

## Usage

No operator action required. After upgrading, both services automatically prefer PSAT-based auth for workers that present a valid projected token, while falling back to the existing Notary JWT path for workers that do not.

## Testing

This change depends on the NVCF API (PR #848) and NVCT API (PR #849) service changes being deployed. End-to-end validation requires a self-hosted cluster with NVCA injecting PSATs and ICMS introspection enabled.

## Notes

The defaults in the services' `application.yaml` remain `false` for non-self-managed environments; these overlay values override them only in the self-managed Helmfile stack.

## References

Closes #840

## Related Pull Requests

- PR #847 — Worker client library: MountedJWTTokenSource + NVCF/NVCT client opt-in
- PR #848 — NVCF API: WorkerTokenIntrospectionService + GrpcWorkerService fallback
- PR #849 — NVCT API: WorkerTokenIntrospectionService + WorkerAssertionValidator fallback

## Dependencies

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to enable delegated worker-token authentication for self-managed deployments. It is disabled by default.
  * Delegated worker-token settings are now applied consistently to the API and worker services when enabled.

* **Bug Fixes**
  * Worker-router addresses are no longer passed to the API when LLM features are disabled, including invalid configured addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->