### PR TITLE
fix(charts): consume latest llm-api-gateway and llm-request-router …

### DIFF
--- a/deploy/helm/cassandra/helm/values.yaml
+++ b/deploy/helm/cassandra/helm/values.yaml
@@ -196,7 +196,7 @@ cassandra:
       # repository: must be supplied in additional values
       registry: ""
       repository: ""
-      tag: 0.11.0
+      tag: 0.15.0
       pullPolicy: Always
 
   dbUser:

--- a/deploy/helm/llm-api-gateway/llm-api-gateway/Chart.yaml
+++ b/deploy/helm/llm-api-gateway/llm-api-gateway/Chart.yaml
@@ -18,4 +18,4 @@ name: helm-nvcf-llm-api-gateway
 description: Helm chart for the NVCF LLM API Gateway
 type: application
 version: 0.0.0 # managed by semantic-release
-appVersion: "1.0.1" # bumped manually to match the published llm-api-gateway image tag
+appVersion: "0.13.0" # bumped manually to match the published llm-api-gateway image tag

--- a/deploy/helm/llm-api-gateway/llm-api-gateway/values.yaml
+++ b/deploy/helm/llm-api-gateway/llm-api-gateway/values.yaml
@@ -26,7 +26,7 @@ llmApiGateway:
   image:
     registry: ""
     repository: ""
-    tag: "1.0.1"
+    tag: "0.13.0"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/deploy/helm/llm-request-router/llm-request-router/Chart.yaml
+++ b/deploy/helm/llm-request-router/llm-request-router/Chart.yaml
@@ -18,4 +18,4 @@ name: helm-nvcf-llm-request-router
 description: Helm chart for the NVCF LLM Request Router backed by Stargate
 type: application
 version: 0.0.0 # managed by semantic-release
-appVersion: "0.3.2" # match the versioned stargate image tag
+appVersion: "0.9.0" # match the versioned stargate image tag

--- a/deploy/helm/llm-request-router/llm-request-router/values.yaml
+++ b/deploy/helm/llm-request-router/llm-request-router/values.yaml
@@ -29,7 +29,7 @@ llmRequestRouter:
   image:
     registry: ""
     repository: ""
-    tag: "0.3.2"
+    tag: "0.9.0"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []


### PR DESCRIPTION
## TL;DR

Bump the default image tags in the llm-api-gateway, llm-request-router, and cassandra charts: llm-api-gateway 0.13.0, llm-request-router (stargate) 0.9.0, and cassandra migrations 0.15.0. Chart appVersions move with the tags where they track the image.

## Additional Details

- for llm function request priority QA test for self-installed

## For QA

- `helm lint` passes for all three charts.
- `helm template` renders `llm-request-router:0.9.0`, `llm-api-gateway:0.13.0`, and `nvcf-cassandra-migrations:0.15.0` with registry and repository supplied, matching the documented install flow.

## Issues
https://github.com/NVIDIA/nvcf/issues/852

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

- Updated the LLM API Gateway deployment to release version 0.13.0.
- Updated the LLM Request Router deployment to release version 0.9.0.
- Updated the Cassandra migrations image to version 0.15.0.
- Aligned deployment metadata and container images with the latest releases for improved deployment consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->