### PR TITLE
fix(stacks): point the ess image at the repository the service publishes to

### DIFF
--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -561,7 +561,7 @@ ess:
   {{- end }}
   image:
     registry: {{ .Values.global.image.registry }}
-    repository: {{ .Values.global.image.repository }}/ess-api
+    repository: {{ .Values.global.image.repository }}/nvcf-ess
   {{- with include "nvcf.nodeSelector" (dict "type" "controlplane" "selectors" .Values.global.nodeSelectors) }}
   {{- . | nindent 2 }}
   {{- end }}


### PR DESCRIPTION
## Why

The self-managed stack release package fails resolving digests, blocking every stack release since `dev.116`:

```
failed to request manifest head .../ncp-dev/ess-api:0.4.13: not found [http 404]
```

`global.yaml.gotmpl` composes the ess image repository as `<global repo>/ess-api`, but the encrypted-secret-store service publishes to `nvcf-ess`:

| repository | tags |
|---|---|
| `ess-api` | `0.2.5`, `v0.47.0`, `v0.48.0` … `v0.58.5` |
| `nvcf-ess` | `0.2.0`, `0.4.9` … `0.4.13` |

`0.4.13` exists only in `nvcf-ess`. `ess-api` is the lineage the service left. The reference pairs the old repository with a tag from the new one, so it has never existed anywhere and no retry can succeed.

## What changed

One line: the ess image repository becomes `nvcf-ess`.

## Plan Summary

Changes which repository the ess image is pulled from in the self-managed stack. The image content is the one the service publishes today, so this corrects a broken reference rather than switching to a different build.

## Testing

`nvcf-ess:0.4.13` was confirmed to resolve to a manifest (`sha256:701af145…`) before making the change.

I also swept every hand-composed image repository in `global.yaml.gotmpl` — 23 of them — against the registry, and cross-referenced each against the services' actual publish destinations.

## Notes

Two siblings are composed the same way and are also names their services no longer publish to:

| composed | service publishes to | resolves today |
|---|---|---|
| `notary-service` | `nvcf-notary` | yes, `1.8.1` still in the old repo |
| `nvct-service-oss` | `nvcf-cloud-tasks` | yes, `1.6.2` still in the old repo |

They are deliberately **not** changed here. The versions their charts pin still exist in the old repositories, so repointing them now would break two working services. They fail the same way as ess the moment their charts move to the new lineage, which is worth fixing before that happens rather than after.

The underlying issue is that these coordinates are strings built in a stack template, in a different repository from the config that records where each service publishes. Nothing checks the two agree until a release runs. A merge-time check that resolves every reference in the rendered stack against the registry would have caught this on the pull request instead of blocking eight stack releases; that is worth doing separately.

## References

Failing job: `publish-self-managed-stack-release-package`, stack `v0.8.0-dev.116` through `dev.118`.

## Related Merge Requests/Pull Requests

NVIDIA/nvcf#833 fixed the templated chart version that masked this failure.

## Dependencies

None.

Github commit:
fix(stacks): point the ess image at the repository the service publishes to

The stack paired the repository the service left with a tag from the one
it moved to, producing a reference that never existed.

Co-authored-by: Balaji Ganesan <bganesan@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the ESS image repository reference to ensure deployments use the correct image source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->