### PR TITLE
fix(nvca): require HTTPS for Helm-managed Vault

### DIFF
--- a/deploy/helm/nvca-operator/nvca-operator/README.md
+++ b/deploy/helm/nvca-operator/nvca-operator/README.md
@@ -107,7 +107,7 @@ used in Kubernetes Clusters to run NVCF Workloads.
 
 | Name                                       | Description                                                                                                                                             | Value |
 | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| `vaultConfig.address`                      | Vault server URL for Helm-managed clusters. Required when `helmManaged.oAuthClientID` is set; must be HTTP(S), without credentials, query, or fragment. | `""`  |
+| `vaultConfig.address`                      | Vault server URL for Helm-managed clusters. Required when `helmManaged.oAuthClientID` is set; must use HTTPS without credentials, query, or fragment. | `""`  |
 | `vaultConfig.oAuthClientMountPathTemplate` | Template for constructing the OAuth client mount path in Vault. Use %s as placeholder for clientID. Example: "nvidia/services/oauth/clients/%s/kv/secret" | `""`  |
 | `vaultConfig.oAuthClientMountPath`         | (Optional) Full OAuth client mount path. If set, overrides the computed path from template.                                                             | `""`  |
 

--- a/deploy/helm/nvca-operator/nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
@@ -39,7 +39,7 @@ data:
     {{- end }}
     {{- if $clientID }}
     {{- if or (ne $vaultAddress (trim $vaultAddress)) (contains "@" $vaultAddress) (contains "?" $vaultAddress) (contains "#" $vaultAddress) }}
-    {{- fail "vaultConfig.address must be an absolute HTTP(S) URL with no credentials, query, or fragment when helmManaged.oAuthClientID is set" }}
+    {{- fail "vaultConfig.address must be an absolute HTTPS URL with no credentials, query, or fragment when helmManaged.oAuthClientID is set" }}
     {{- end }}
     {{- $parsedVaultAddress := urlParse $vaultAddress }}
     {{- $vaultScheme := $parsedVaultAddress.scheme | default "" }}
@@ -47,8 +47,8 @@ data:
     {{- $vaultUserInfo := $parsedVaultAddress.userinfo | default "" }}
     {{- $vaultQuery := $parsedVaultAddress.query | default "" }}
     {{- $vaultFragment := $parsedVaultAddress.fragment | default "" }}
-    {{- if or (not (has $vaultScheme (list "http" "https"))) (not (regexMatch `^(\[[^]]+\]|[^:[:space:]]+)(:[0-9]+)?$` $vaultHost)) $vaultUserInfo $vaultQuery $vaultFragment }}
-    {{- fail "vaultConfig.address must be an absolute HTTP(S) URL with no credentials, query, or fragment when helmManaged.oAuthClientID is set" }}
+    {{- if or (ne $vaultScheme "https") (not (regexMatch `^(\[[^]]+\]|[^:[:space:]]+)(:[0-9]+)?$` $vaultHost)) $vaultUserInfo $vaultQuery $vaultFragment }}
+    {{- fail "vaultConfig.address must be an absolute HTTPS URL with no credentials, query, or fragment when helmManaged.oAuthClientID is set" }}
     {{- end }}
     {{- end }}
     clusterDescription: {{ .clusterDescription | default $.Values.clusterName | quote }}

--- a/deploy/helm/nvca-operator/nvca-operator/values.schema.json
+++ b/deploy/helm/nvca-operator/nvca-operator/values.schema.json
@@ -587,7 +587,7 @@
             "properties": {
                 "address": {
                     "type": "string",
-                    "description": "Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set; must be HTTP(S), without credentials, query, or fragment.",
+                    "description": "Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set; must use HTTPS without credentials, query, or fragment.",
                     "default": ""
                 },
                 "oAuthClientMountPathTemplate": {

--- a/deploy/helm/nvca-operator/nvca-operator/values.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/values.yaml
@@ -269,7 +269,7 @@ ngcConfig:
   apiURL: https://api.ngc.nvidia.com
   clusterSource: ngc-managed
 ## @section Vault Configuration
-## @param vaultConfig.address Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set; must be HTTP(S), without credentials, query, or fragment.
+## @param vaultConfig.address Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set; must use HTTPS without credentials, query, or fragment.
 ## @param vaultConfig.oAuthClientMountPathTemplate Template for constructing the OAuth client mount path in Vault. Use %s as placeholder for clientID. Example: "nvidia/services/oauth/clients/%s/kv/secret"
 ## @param vaultConfig.oAuthClientMountPath (Optional) Full OAuth client mount path. If set, overrides the computed path from template.
 vaultConfig:

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/README.md
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/README.md
@@ -107,7 +107,7 @@ used in Kubernetes Clusters to run NVCF Workloads.
 
 | Name                                       | Description                                                                                                                                             | Value |
 | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| `vaultConfig.address`                      | Vault server URL for Helm-managed clusters. Required when `helmManaged.oAuthClientID` is set; must be HTTP(S), without credentials, query, or fragment. | `""`  |
+| `vaultConfig.address`                      | Vault server URL for Helm-managed clusters. Required when `helmManaged.oAuthClientID` is set; must use HTTPS without credentials, query, or fragment. | `""`  |
 | `vaultConfig.oAuthClientMountPathTemplate` | Template for constructing the OAuth client mount path in Vault. Use %s as placeholder for clientID. Example: "nvidia/services/oauth/clients/%s/kv/secret" | `""`  |
 | `vaultConfig.oAuthClientMountPath`         | (Optional) Full OAuth client mount path. If set, overrides the computed path from template.                                                             | `""`  |
 

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
@@ -39,7 +39,7 @@ data:
     {{- end }}
     {{- if $clientID }}
     {{- if or (ne $vaultAddress (trim $vaultAddress)) (contains "@" $vaultAddress) (contains "?" $vaultAddress) (contains "#" $vaultAddress) }}
-    {{- fail "vaultConfig.address must be an absolute HTTP(S) URL with no credentials, query, or fragment when helmManaged.oAuthClientID is set" }}
+    {{- fail "vaultConfig.address must be an absolute HTTPS URL with no credentials, query, or fragment when helmManaged.oAuthClientID is set" }}
     {{- end }}
     {{- $parsedVaultAddress := urlParse $vaultAddress }}
     {{- $vaultScheme := $parsedVaultAddress.scheme | default "" }}
@@ -47,8 +47,8 @@ data:
     {{- $vaultUserInfo := $parsedVaultAddress.userinfo | default "" }}
     {{- $vaultQuery := $parsedVaultAddress.query | default "" }}
     {{- $vaultFragment := $parsedVaultAddress.fragment | default "" }}
-    {{- if or (not (has $vaultScheme (list "http" "https"))) (not (regexMatch `^(\[[^]]+\]|[^:[:space:]]+)(:[0-9]+)?$` $vaultHost)) $vaultUserInfo $vaultQuery $vaultFragment }}
-    {{- fail "vaultConfig.address must be an absolute HTTP(S) URL with no credentials, query, or fragment when helmManaged.oAuthClientID is set" }}
+    {{- if or (ne $vaultScheme "https") (not (regexMatch `^(\[[^]]+\]|[^:[:space:]]+)(:[0-9]+)?$` $vaultHost)) $vaultUserInfo $vaultQuery $vaultFragment }}
+    {{- fail "vaultConfig.address must be an absolute HTTPS URL with no credentials, query, or fragment when helmManaged.oAuthClientID is set" }}
     {{- end }}
     {{- end }}
     clusterDescription: {{ .clusterDescription | default $.Values.clusterName | quote }}

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/values.schema.json
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/values.schema.json
@@ -587,7 +587,7 @@
             "properties": {
                 "address": {
                     "type": "string",
-                    "description": "Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set; must be HTTP(S), without credentials, query, or fragment.",
+                    "description": "Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set; must use HTTPS without credentials, query, or fragment.",
                     "default": ""
                 },
                 "oAuthClientMountPathTemplate": {

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/values.yaml
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/values.yaml
@@ -290,7 +290,7 @@ ngcConfig:
 
 
 ## @section Vault Configuration
-## @param vaultConfig.address Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set; must be HTTP(S), without credentials, query, or fragment.
+## @param vaultConfig.address Vault server URL for Helm-managed clusters. Required when helmManaged.oAuthClientID is set; must use HTTPS without credentials, query, or fragment.
 ## @param vaultConfig.oAuthClientMountPathTemplate Template for constructing the OAuth client mount path in Vault. Use %s as placeholder for clientID. Example: "nvidia/services/oauth/clients/%s/kv/secret"
 ## @param vaultConfig.oAuthClientMountPath (Optional) Full OAuth client mount path. If set, overrides the computed path from template.
 vaultConfig:

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient.go
@@ -65,12 +65,12 @@ func withRequiredHelmManagedVaultAddress() clusterMapper {
 		parsed, err := url.Parse(address)
 		if err != nil ||
 			address != strings.TrimSpace(address) ||
-			(parsed.Scheme != "http" && parsed.Scheme != "https") ||
+			parsed.Scheme != "https" ||
 			parsed.Hostname() == "" ||
 			parsed.User != nil ||
 			parsed.RawQuery != "" ||
 			parsed.Fragment != "" {
-			return errors.New("vaultConfig.address must be an absolute HTTP(S) URL with no credentials, query, or fragment when OAuth is enabled")
+			return errors.New("vaultConfig.address must be an absolute HTTPS URL with no credentials, query, or fragment when OAuth is enabled")
 		}
 
 		return nil

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient.go
@@ -68,8 +68,7 @@ func withRequiredHelmManagedVaultAddress() clusterMapper {
 			parsed.Scheme != "https" ||
 			parsed.Hostname() == "" ||
 			parsed.User != nil ||
-			parsed.RawQuery != "" ||
-			parsed.Fragment != "" {
+			strings.ContainsAny(address, "?#") {
 			return errors.New("vaultConfig.address must be an absolute HTTPS URL with no credentials, query, or fragment when OAuth is enabled")
 		}
 

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient_test.go
@@ -145,7 +145,9 @@ func TestHelmManagedClient_GetCluster_RequiresValidVaultAddress(t *testing.T) {
 		"plain HTTP":             "http://vault.example.test:8200",
 		"surrounding whitespace": " https://vault.example.test:443 ",
 		"credentials":            "https://user@vault.example.test:443",
+		"empty query":            "https://vault.example.test:443?",
 		"query":                  "https://vault.example.test:443?namespace=test",
+		"empty fragment":         "https://vault.example.test:443#",
 		"fragment":               "https://vault.example.test:443#test",
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt/helmclient_test.go
@@ -142,6 +142,7 @@ func TestHelmManagedClient_GetCluster_RequiresValidVaultAddress(t *testing.T) {
 	for name, address := range map[string]string{
 		"missing address":        "",
 		"address without host":   "https://:443",
+		"plain HTTP":             "http://vault.example.test:8200",
 		"surrounding whitespace": " https://vault.example.test:443 ",
 		"credentials":            "https://user@vault.example.test:443",
 		"query":                  "https://vault.example.test:443?namespace=test",

--- a/src/compute-plane-services/nvca/scripts/lint_helm.sh
+++ b/src/compute-plane-services/nvca/scripts/lint_helm.sh
@@ -217,6 +217,7 @@ assert_helm_managed_vault_address() {
   for invalid_address in \
     "" \
     "https://:443" \
+    "http://vault.example.test:8200" \
     " https://vault.example.test:443 " \
     "https://user@vault.example.test:443" \
     "https://vault.example.test:443?namespace=test" \

--- a/src/compute-plane-services/nvca/scripts/lint_helm.sh
+++ b/src/compute-plane-services/nvca/scripts/lint_helm.sh
@@ -220,7 +220,9 @@ assert_helm_managed_vault_address() {
     "http://vault.example.test:8200" \
     " https://vault.example.test:443 " \
     "https://user@vault.example.test:443" \
+    "https://vault.example.test:443?" \
     "https://vault.example.test:443?namespace=test" \
+    "https://vault.example.test:443#" \
     "https://vault.example.test:443#test"; do
     if helm template test-release "${chart_dir}" \
       --set "ngcConfig.serviceKey=fakekey" \


### PR DESCRIPTION
## TL;DR
Require HTTPS for the Helm-managed Vault address so the projected service-account JWT and retrieved OAuth client secret cannot be exposed over plaintext transport.

## What changed
- Reject plain HTTP in both the Helm template and NVCA cluster mapper.
- Add plain-HTTP negative coverage to Go and Helm tests.
- Update source and generated chart documentation.

## Context for reviewers
This is a focused follow-up to #843 prompted by review feedback on the 3.2 backport (#845). No supported Helm-managed deployment uses a plain-HTTP Vault endpoint.

## QA
- go test -count=1 -ldflags '-X github.com/NVIDIA/k8s-dra-driver-gpu/internal/info.version=v25.8.0' ./pkg/operator/reconcile/clustermgmt
- ./scripts/lint_helm.sh
- golangci-lint run --allow-parallel-runners -c .golangci.yml ./pkg/operator/reconcile/clustermgmt/...
- bazel test //src/compute-plane-services/nvca/pkg/operator/reconcile/clustermgmt:clustermgmt_test

Relates to #842

## Checklist
- [x] Source and generated charts are synchronized.
- [x] Validation and negative tests cover plain HTTP.
- [x] Go, Helm, lint, and Bazel checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Vault connections now require HTTPS exclusively; plain HTTP addresses are rejected.
  * OAuth-based Vault integrations enforce secure HTTPS URLs.

* **Bug Fixes**
  * Improved validation messages clarify the HTTPS requirement.
  * Added coverage to ensure insecure Vault addresses are rejected.

* **Documentation**
  * Updated configuration guidance and schema descriptions to specify HTTPS-only Vault addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->