### PR TITLE
feat(charts): port nvcf api helm chart

### DIFF
--- a/deploy/helm/cloud-functions/.gitignore
+++ b/deploy/helm/cloud-functions/.gitignore
@@ -1,0 +1,5 @@
+vault-secrets.json
+nvcr.io.txt
+
+bin/
+packaged-charts/

--- a/deploy/helm/cloud-functions/AGENTS.md
+++ b/deploy/helm/cloud-functions/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md - NVCF API Helm chart
+
+Scope: `deploy/helm/cloud-functions`, the Helm chart for the NVCF API service.
+
+The chart publishes as `helm-nvcf-api`. Its `Chart.yaml` name is the published
+OCI name and must not be renamed to match the directory or the service. The
+release lane is registered as `cloud-functions-helm` in
+`tools/ci/github-release-subprojects.json`.
+
+## Commands
+
+Run these from this directory.
+
+```sh
+make lint       # helm lint with the shared CI values
+make template   # render to bin/manifest.yaml
+make validate   # template, then kubeconform
+make test       # tests/sidecar_release_artifacts_test.sh
+```
+
+`lint`, `template`, and `validate` read
+`tools/ci/helm-validate-values/cloud-functions.yaml`. The chart leaves
+`api.image.registry`, `api.image.repository`, and the matching
+`api.accountBootstrap.image` fields empty on purpose, so it does not render
+without those values.
+
+`make install`, `make uninstall`, and `make status` default to release `api` in
+namespace `nvcf`.
+
+## Conventions
+
+`Chart.yaml` keeps `version: 0.0.0`. The release pipeline sets the real version
+from the `deploy/helm/cloud-functions/v*` tag. `appVersion` tracks the API
+service image and is bumped by hand.
+
+Match the conventional commit type to the intended version bump, because the tag
+generation pipeline reads it:
+
+- `fix(<scope>):` for a patch bump
+- `feat(<scope>):` for a minor bump
+- `feat(<scope>)!:` or a `BREAKING CHANGE:` footer for a major bump
+
+A `chore` commit skips tag creation entirely.
+
+## Adjacent subtrees
+
+- `src/control-plane-services/cloud-functions` builds the image this chart deploys.
+- Sidecar image references in `api.remoteConfig.configData.nvcf.sidecars` use
+  Spring placeholders resolved at runtime. `tests/sidecar_release_artifacts_test.sh`
+  guards the `release-artifact-*-image` annotations that surface them to stack
+  release tooling, so run it after changing any sidecar entry.

--- a/deploy/helm/cloud-functions/CLAUDE.md
+++ b/deploy/helm/cloud-functions/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/deploy/helm/cloud-functions/Makefile
+++ b/deploy/helm/cloud-functions/Makefile
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Variables
+release ?= api
+namespace ?= nvcf
+helm_dir ?= ./nvcf-api
+values := $(helm_dir)/values.yaml
+# CI-only values for lint/template, shared with the chart validation job.
+validation_values ?= ../../../tools/ci/helm-validate-values/cloud-functions.yaml
+
+# OPTIONAL for deploy target: Path to an additional Helm values file.
+# Example: make deploy values=my-values.yaml additional_values=override.yaml
+additional_values ?= 
+
+# OCI Registry details
+OCI_REGISTRY_HOST ?= nvcr.io
+OCI_REGISTRY_NAMESPACE ?= 0651155215864979/ncp-dev
+
+# Automatically determine chart name and version from Chart.yaml
+# IMPORTANT: For this setup, CHART_NAME is expected to include any desired OCI prefix (e.g., "helm-yourchart")
+# as defined in helm/Chart.yaml's 'name' field.
+CHART_NAME := $(shell yq -r .name $(helm_dir)/Chart.yaml)
+CHART_VERSION := $(shell yq -r .version $(helm_dir)/Chart.yaml)
+
+.PHONY: install uninstall status lint template validate test clean package push-oci
+
+install:
+ifndef values
+	$(error "values" variable is not set. Please specify with 'make deploy values=<path-to-your-values.yaml>')
+endif
+	@echo "Deploying $(release) to namespace $(namespace) using values file '$(values)'..."
+	@echo "Additional values file: '$(if $(additional_values),$(additional_values),N/A)'"
+	helm install $(release) $(helm_dir) \
+		--namespace $(namespace) \
+		--values $(values) \
+		$(if $(additional_values),--values $(additional_values),) \
+		--atomic \
+		--create-namespace \
+		--wait \
+		--wait-for-jobs \
+		--timeout 20m
+
+uninstall:
+	@echo "Deleting $(release) from namespace $(namespace)..."
+	helm uninstall $(release) --namespace $(namespace)
+
+status:
+	@echo "Checking status of $(release) in namespace $(namespace)..."
+	helm status $(release) --namespace $(namespace)
+
+lint:
+	@echo "Linting chart $(helm_dir)..."
+	helm lint $(helm_dir) \
+		$(if $(validation_values),--values $(validation_values),) \
+		$(if $(additional_values),--values $(additional_values),)
+
+template:
+	@echo "Templating chart $(helm_dir)..."
+	@mkdir -p bin
+	helm template $(release) $(helm_dir) \
+		--namespace $(namespace) \
+		$(if $(validation_values),--values $(validation_values),) \
+		$(if $(additional_values),--values $(additional_values),) \
+		> bin/manifest.yaml
+	@echo "Rendered manifest to bin/manifest.yaml"
+
+validate: template
+	@echo "Validating manifest with kubeconform..."
+	@kubeconform -strict -summary -output pretty -kubernetes-version 1.31.5 bin/manifest.yaml
+
+test:
+	@echo "Running chart tests..."
+	@./tests/sidecar_release_artifacts_test.sh
+
+# Publish Chart
+# NOTE: this is manual until the CI pipeline is updated to push the chart to the NVCR OCI registry
+clean:
+	rm -rf ./bin
+	rm -rf ./packaged-charts
+
+package: clean lint
+	@echo "[package] Packaging Helm chart $(CHART_NAME) version $(CHART_VERSION)..."
+	@mkdir -p ./packaged-charts
+	@helm package $(helm_dir) -d ./packaged-charts/
+	@echo "[package] Packaged chart to ./packaged-charts/$(CHART_NAME)-$(CHART_VERSION).tgz"
+
+push-oci:
+	@echo "[push-oci] Pushing chart $(CHART_NAME) version $(CHART_VERSION) to oci://$(OCI_REGISTRY_HOST)/$(OCI_REGISTRY_NAMESPACE)/$(CHART_NAME):$(CHART_VERSION)"
+	@echo "[push-oci] Note: You must be logged into oci://$(OCI_REGISTRY_HOST) for the push to succeed."
+	@if [ ! -f ./packaged-charts/$(CHART_NAME)-$(CHART_VERSION).tgz ]; then \
+		echo "[push-oci] Error: Packaged chart ./packaged-charts/$(CHART_NAME)-$(CHART_VERSION).tgz not found. Run 'make package' first."; \
+		exit 1; \
+	fi
+	@helm push ./packaged-charts/$(CHART_NAME)-$(CHART_VERSION).tgz oci://$(OCI_REGISTRY_HOST)/$(OCI_REGISTRY_NAMESPACE)
+	@echo "[push-oci] Successfully pushed chart to OCI registry."
+	@echo "[push-oci] Cleaning up temporary package directory..."
+	@rm -rf ./packaged-charts
+	@echo "[push-oci] Cleanup complete."

--- a/deploy/helm/cloud-functions/README.md
+++ b/deploy/helm/cloud-functions/README.md
@@ -1,0 +1,125 @@
+# NVCF API Helm Chart
+
+This directory contains the Helm chart for deploying the NVCF API service on Kubernetes.
+
+## Overview
+
+The chart packages the NVCF API deployment together with a post-install account bootstrap hook.
+
+The default chart values do not set the required image registries and repositories for the API or the account bootstrap job. They must be supplied through an additional values file at install time, and access to those images must be arranged separately.
+
+Example:
+
+```yaml
+api:
+  image:
+    registry: <your-registry>
+    repository: <your-org>/nvcf-api
+    tag: <appVersion>
+  accountBootstrap:
+    image:
+      registry: <your-registry>
+      repository: <your-org>/nvcf-account-bootstrap
+      tag: <version>
+```
+
+## Prerequisites
+
+- Kubernetes cluster
+- Helm 3.x
+- `kubectl`
+
+## Getting Started
+
+Install the chart with the default values plus your own overrides:
+
+```bash
+helm install api nvcf-api \
+  --namespace nvcf \
+  --create-namespace \
+  --values nvcf-api/values.yaml \
+  --values path/to/values.yaml \
+  --wait \
+  --wait-for-jobs \
+  --timeout 20m
+```
+
+Upgrade an existing release:
+
+```bash
+helm upgrade api nvcf-api \
+  --namespace nvcf \
+  --values nvcf-api/values.yaml \
+  --values path/to/values.yaml \
+  --wait \
+  --wait-for-jobs \
+  --timeout 20m
+```
+
+Uninstall the release:
+
+```bash
+helm uninstall api --namespace nvcf
+```
+
+The `Makefile` wraps these with the same defaults (`release=api`, `namespace=nvcf`):
+
+```bash
+make install additional_values=path/to/values.yaml
+make status
+make uninstall
+```
+
+## Configuration
+
+The default chart configuration lives in `nvcf-api/values.yaml`.
+
+Important settings to review before deployment:
+
+- `api.image.*` for the API container image
+- `api.accountBootstrap.image.*` for the post-install bootstrap job image
+- `api.imagePullSecrets` for private registry access
+- `api.replicaCount`, resource requests, and HPA settings for your environment
+- `api.accountBootstrap.accountName`, `api.accountBootstrap.adminClientId`, and `api.accountBootstrap.registryCredentials` for initial account configuration. Use `registryCredentials: []` to create the account without system-provisioned registry credentials.
+- `api.accountBootstrap.limits.*` for per-account quotas
+
+The default values include development-oriented placeholders. Override them before using the chart in any shared or production environment.
+
+## Remote Config RBAC
+
+`spring-cloud-kubernetes` (v3.3.0, shipped in nvcf-service `1.3.x`) calls `listNamespacedConfigMap` without a `fieldSelector=metadata.name` filter and matches the target name in memory. Because the API request is unfiltered, the Role must grant `list`/`watch` on the configmaps collection itself, with no `resourceNames` scoping for those verbs, so the `nvcf-api` SA can read every ConfigMap in the namespace. Chart assumes none are sensitive; clusters that block broad namespace reads need a policy exception.
+
+Set `api.remoteConfig.enabled: false` to opt out: the chart no longer renders the broad RBAC, and the service runs on JAR sidecar defaults in `application-ncp.yaml`. The SA keeps default-token automount on (the K8s default) so the vault-k8s injector's fallback service-account discovery continues to find a mount. Hot reload is unavailable.
+
+## Sidecar release-artifact annotations
+
+The `api.remoteConfig.configData.nvcf.sidecars` worker images reference the
+registry via Spring placeholders (`${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}`)
+that resolve at runtime from `NVCF_SIDECARS_HOSTNAME` / `NVCF_SIDECARS_REPOSITORY`.
+Stack release-artifact tooling scans rendered manifests for concrete image
+references and skips any value containing `${...}`, so those worker images would
+otherwise be excluded from stack release artifacts.
+
+To surface them, the remote-config ConfigMap renders a
+`release-artifact-<sidecar>-image` annotation for every sidecar entry that carries
+the placeholder prefix, with the prefix resolved to
+`<NVCF_SIDECARS_HOSTNAME>/<NVCF_SIDECARS_REPOSITORY>/<image>:<tag>`. This mirrors
+the `release-artifact-*-image` annotations rendered by nvca-operator's
+`self-managed-nvcfbackend-cm.yaml`. Annotations are emitted only when both sidecar
+registry env vars are set, so partially resolved references are never produced.
+
+## Account bootstrap
+
+The chart installs a Helm `post-install` hook Job that calls the API to create an initial NVCF account. The Job waits for the API readiness probe to pass, authenticates to the configured secret store, and issues a single `POST /v2/nvcf/accounts/{ncaId}` request.
+
+Key points to be noted:
+
+- The Job is rendered from `nvcf-api/templates/account-bootstrap-hook-job.yaml` and configured by `api.accountBootstrap.*` in `values.yaml`.
+- The bootstrap script lives at `nvcf-api/scripts/account-bootstrap.sh`.
+- `registryCredentials: []` is valid and omits the `registryCredentials` field from the account payload.
+- Non-empty `registryCredentials` may include `CONTAINER` and `HELM` entries. `MODEL` and `RESOURCE` entries are ignored if supplied.
+- Set `DEBUG=true` in the Job environment to enable verbose logging.
+
+## Notes
+
+- If you publish or mirror the required images into another registry, set the image registry, repository, tag, and pull secret values explicitly in your override file.

--- a/deploy/helm/cloud-functions/nvcf-api/.helmignore
+++ b/deploy/helm/cloud-functions/nvcf-api/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/helm/cloud-functions/nvcf-api/Chart.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/Chart.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: helm-nvcf-api
+description: A Helm chart for NVCF API deployment
+
+type: application
+version: 0.0.0 # autoversioning enabled via release pipeline
+appVersion: "1.12.6"

--- a/deploy/helm/cloud-functions/nvcf-api/scripts/account-bootstrap.sh
+++ b/deploy/helm/cloud-functions/nvcf-api/scripts/account-bootstrap.sh
@@ -1,0 +1,452 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env bash
+
+# =============================================================================
+# NVCF NCA Bootstrap Script
+# =============================================================================
+# Purpose: Creates a default NCA account for NVCF API during Helm installation
+# Dependencies: curl, jq, base64 (all available in curlimages/curl)
+# =============================================================================
+
+set -euo pipefail  # Exit on error, undefined vars, pipe failures
+IFS=$'\n\t'       # Secure internal field separator
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+readonly SCRIPT_VERSION="2.0.0"
+readonly SCRIPT_NAME="account-bootstrap"
+
+# Kubernetes-style readiness probe settings
+readonly API_READINESS_PERIOD_SECONDS="${API_READINESS_PERIOD_SECONDS:-10}"     # periodSeconds
+readonly API_READINESS_FAILURE_THRESHOLD="${API_READINESS_FAILURE_THRESHOLD:-60}"  # failureThreshold (period * threshold = total timeout)
+
+# Service endpoints
+readonly OPENBAO_SERVICE_ADDR="openbao-server.vault-system.svc.cluster.local:8200"
+# Vault JWT Auth configuration
+# Role used for the /v1/auth/jwt/login endpoint (overridable via env var)
+readonly OPENBAO_JWT_AUTH_ROLE="${OPENBAO_JWT_AUTH_ROLE:-nvcf-api-account-bootstrap}"
+# Name of the JWT role used for signing (overridable)
+readonly OPENBAO_JWT_SIGNING_ROLE="${OPENBAO_JWT_SIGNING_ROLE:-nvcf-api-admin}"
+
+# API paths
+readonly HEALTH_PATH="/health"
+readonly ACCOUNTS_ENDPOINT="/v2/nvcf/accounts"
+
+# Exit codes
+readonly EXIT_SUCCESS=0
+readonly EXIT_CONFIG_ERROR=1
+readonly EXIT_API_TIMEOUT=2
+readonly EXIT_OPENBAO_ERROR=3
+readonly EXIT_AUTH_ERROR=4
+readonly EXIT_ACCOUNT_ERROR=5
+
+# =============================================================================
+# LOGGING FUNCTIONS
+# =============================================================================
+
+log() {
+    local level="$1"
+    shift
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [$level] $*" >&2
+}
+
+log_info() { log "INFO" "$@"; }
+log_step() { log "STEP" "$@"; }
+log_success() { log "SUCCESS" "$@"; }
+log_warning() { log "WARNING" "$@"; }
+log_error() { log "ERROR" "$@"; }
+log_debug() {
+    if [[ "${DEBUG:-true}" == "true" ]]; then
+        log "DEBUG" "$@"
+    fi
+}
+
+# =============================================================================
+# ERROR HANDLING
+# =============================================================================
+
+cleanup() {
+    log_debug "Cleaning up sensitive variables..."
+    unset vault_token bearer_token 2>/dev/null || true
+}
+
+error_exit() {
+    local exit_code="${1:-$EXIT_CONFIG_ERROR}"
+    local message="${2:-Unknown error occurred}"
+    log_error "$message"
+    cleanup
+    exit "$exit_code"
+}
+
+# Trap to ensure cleanup on exit
+trap cleanup EXIT
+
+# =============================================================================
+# VALIDATION FUNCTIONS
+# =============================================================================
+
+validate_environment() {
+    log_step "Validating environment variables..."
+
+    local required_vars=(
+        "API_SERVICE_NAME"
+        "API_NAMESPACE"
+        "NVCF_ACCOUNT_NAME"
+        "NVCF_ADMIN_CLIENT_ID"
+        "NVCF_REGISTRY_CREDENTIALS_JSON"
+        "NVCF_MAX_FUNCTIONS_ALLOWED"
+        "NVCF_MAX_TASKS_ALLOWED"
+        "NVCF_MAX_TELEMETRIES_ALLOWED"
+        "NVCF_MAX_REGISTRY_CREDENTIALS_ALLOWED"
+    )
+
+    local missing_vars=()
+    for var in "${required_vars[@]}"; do
+        if [[ -z "${!var:-}" ]]; then
+            missing_vars+=("$var")
+        fi
+    done
+
+    if [[ ${#missing_vars[@]} -gt 0 ]]; then
+        error_exit "$EXIT_CONFIG_ERROR" "Missing required environment variables: ${missing_vars[*]}"
+    fi
+
+    if ! echo "$NVCF_REGISTRY_CREDENTIALS_JSON" | jq -e 'type == "array"' >/dev/null 2>&1; then
+        error_exit "$EXIT_CONFIG_ERROR" "NVCF_REGISTRY_CREDENTIALS_JSON must be a JSON array"
+    fi
+
+    if [[ "$(echo "$NVCF_REGISTRY_CREDENTIALS_JSON" | jq 'length')" == "0" ]]; then
+        log_info "No registry credentials configured; account payload will omit registryCredentials"
+    fi
+
+    log_success "Environment validation completed"
+}
+
+validate_dependencies() {
+    log_step "Validating dependencies..."
+
+    local deps=("curl" "jq" "base64")
+    for dep in "${deps[@]}"; do
+        if ! command -v "$dep" >/dev/null 2>&1; then
+            error_exit "$EXIT_CONFIG_ERROR" "Required dependency not found: $dep"
+        fi
+    done
+
+    log_success "Dependencies validated"
+}
+
+# =============================================================================
+# KUBERNETES API FUNCTIONS
+# =============================================================================
+
+get_k8s_service_account_token() {
+    local sa_path="/var/run/secrets/kubernetes.io/serviceaccount"
+
+    if [[ ! -f "$sa_path/token" ]]; then
+        error_exit "$EXIT_CONFIG_ERROR" "Kubernetes service account token not found"
+    fi
+
+    cat "$sa_path/token"
+}
+
+# =============================================================================
+# API HEALTH CHECK FUNCTIONS
+# =============================================================================
+
+wait_for_api_ready() {
+    log_step "Probing NVCF API readiness (Kubernetes probe semantics)..."
+
+    local api_url="http://${API_SERVICE_NAME}.${API_NAMESPACE}.svc.cluster.local:8080"
+    local health_url="${api_url}${HEALTH_PATH}"
+
+    log_info "Health check URL: $health_url"
+    log_info "periodSeconds: ${API_READINESS_PERIOD_SECONDS}s, failureThreshold: ${API_READINESS_FAILURE_THRESHOLD}"
+
+
+    local failure_count=0
+    while true; do
+        if curl -sf "$health_url" >/dev/null 2>&1; then
+            log_success "NVCF API is ready at $api_url"
+            return 0
+        fi
+
+        failure_count=$((failure_count + 1))
+        if [[ $failure_count -ge $API_READINESS_FAILURE_THRESHOLD ]]; then
+            error_exit "$EXIT_API_TIMEOUT" "API did not become ready after $((API_READINESS_PERIOD_SECONDS * API_READINESS_FAILURE_THRESHOLD))s (failureThreshold reached)"
+        fi
+
+        log_info "API not ready (failure #$failure_count/$API_READINESS_FAILURE_THRESHOLD), retrying in ${API_READINESS_PERIOD_SECONDS}s..."
+        sleep "$API_READINESS_PERIOD_SECONDS"
+    done
+}
+
+# =============================================================================
+# OPENBAO FUNCTIONS
+# ------------------
+# The bootstrap script authenticates to OpenBao using the built-in **JWT Auth**
+# method. It sends the Pod's service-account token to the
+# `/v1/auth/jwt/login` endpoint (role: `${OPENBAO_JWT_AUTH_ROLE}`) and receives a
+# short-lived client token. That token is subsequently used to call the
+# signing endpoint `/v1/services/nvcf-api/jwt/sign/${OPENBAO_JWT_SIGNING_ROLE}`.
+# No cluster-wide root token or Secret lookup is required.
+# ------------------------------------
+# Authenticate to OpenBao via JWT Auth
+# ------------------------------------
+
+login_to_openbao() {
+    log_step "Authenticating to OpenBao via JWT auth (role: ${OPENBAO_JWT_AUTH_ROLE})..."
+
+    local sa_token openbao_url login_url login_payload login_response vault_token
+
+    sa_token=$(get_k8s_service_account_token)
+    openbao_url="http://${OPENBAO_SERVICE_ADDR}"
+    login_url="${openbao_url}/v1/auth/jwt/login"
+
+    login_payload=$(jq -n --arg role "${OPENBAO_JWT_AUTH_ROLE}" --arg jwt "${sa_token}" '{role:$role, jwt:$jwt}')
+
+    login_response=$(curl -s -X POST -H "Content-Type: application/json" -d "${login_payload}" "${login_url}")
+
+    if echo "$login_response" | jq -e '.errors' >/dev/null 2>&1; then
+        log_error "JWT auth login failed"
+        log_debug "Login response: $(echo "$login_response" | jq -c 'if .auth.client_token then .auth.client_token = "[REDACTED]" else . end' 2>/dev/null || echo "$login_response")"
+        error_exit "$EXIT_OPENBAO_ERROR" "Failed to authenticate to OpenBao via JWT auth"
+    fi
+
+    vault_token=$(echo "$login_response" | jq -r '.auth.client_token // empty')
+
+    if [[ -z "$vault_token" ]]; then
+        log_error "client_token not found in login response"
+        log_debug "Login response: $(echo "$login_response" | jq '.' -c 2>/dev/null || echo "$login_response")"
+        error_exit "$EXIT_OPENBAO_ERROR" "Failed to obtain Vault client token"
+    fi
+
+    log_success "Authenticated to OpenBao (token length: ${#vault_token} chars)"
+    echo "$vault_token"
+}
+
+test_openbao_connection() {
+    local vault_token="$1"
+    log_step "Testing OpenBao connection..."
+
+    local openbao_url="http://${OPENBAO_SERVICE_ADDR}"
+    local status_url="${openbao_url}/v1/sys/seal-status"
+
+    if ! curl -sf -H "X-Vault-Token: $vault_token" "$status_url" >/dev/null 2>&1; then
+        error_exit "$EXIT_OPENBAO_ERROR" "Cannot connect to OpenBao at $openbao_url"
+    fi
+
+    log_success "OpenBao connection verified"
+}
+
+generate_jwt_token() {
+    local vault_token="$1"
+    log_step "Generating JWT token..."
+
+    local openbao_url="http://${OPENBAO_SERVICE_ADDR}"
+    local sign_url="${openbao_url}/v1/services/nvcf-api/jwt/sign/${OPENBAO_JWT_SIGNING_ROLE}"
+
+    local jwt_output
+    jwt_output=$(curl -s -X PUT -H "X-Vault-Token: $vault_token" -d '{}' "$sign_url")
+
+    if echo "$jwt_output" | jq -e '.errors' >/dev/null 2>&1; then
+        log_error "Failed to generate JWT token"
+        log_debug "JWT response: $(echo "$jwt_output" | jq -c 'if .data.token then .data.token = "[REDACTED]" else . end' 2>/dev/null || echo "$jwt_output")"
+        error_exit "$EXIT_AUTH_ERROR" "JWT token generation failed"
+    fi
+
+    local bearer_token
+    bearer_token=$(echo "$jwt_output" | jq -r '.data.token // empty')
+
+    if [[ -z "$bearer_token" ]]; then
+        log_error "Could not extract bearer token from response"
+        log_debug "JWT output: $(echo "$jwt_output" | jq '.' 2>/dev/null || echo "$jwt_output")"
+        error_exit "$EXIT_AUTH_ERROR" "Bearer token extraction failed"
+    fi
+
+    log_success "JWT token generated successfully"
+    echo "$bearer_token"
+}
+
+# =============================================================================
+# REGISTRY CREDENTIALS PROCESSING
+# =============================================================================
+# MODEL and RESOURCE artifact types are not supported in self-hosted deployments.
+# Any user-provided credentials with these types are dropped.
+# =============================================================================
+
+build_registry_credentials() {
+    log_debug "Processing registry credentials (filtering unsupported MODEL/RESOURCE types)..."
+
+    local input_creds="$NVCF_REGISTRY_CREDENTIALS_JSON"
+    local filtered_creds
+
+    filtered_creds=$(echo "$input_creds" | jq '[.[] | select(
+        (.artifactTypes | map(ascii_upcase) | index("MODEL") | not) and
+        (.artifactTypes | map(ascii_upcase) | index("RESOURCE") | not)
+    )]')
+
+    local original_count filtered_count removed_count
+    original_count=$(echo "$input_creds" | jq 'length')
+    filtered_count=$(echo "$filtered_creds" | jq 'length')
+    removed_count=$((original_count - filtered_count))
+
+    if [[ $removed_count -gt 0 ]]; then
+        log_warning "Dropped $removed_count credential(s) with MODEL/RESOURCE types (not supported in self-hosted)"
+    fi
+
+    log_debug "Registry credentials: $filtered_count total"
+    echo "$filtered_creds"
+}
+
+# =============================================================================
+# ACCOUNT CREATION FUNCTIONS
+# =============================================================================
+
+create_account_payload() {
+    log_debug "Creating account payload (new schema)..."
+
+    local registry_creds
+    registry_creds=$(build_registry_credentials)
+
+    local payload
+    payload=$(jq -n \
+        --arg name "$NVCF_ACCOUNT_NAME" \
+        --arg adminClientId "$NVCF_ADMIN_CLIENT_ID" \
+        --argjson registryCredentials "$registry_creds" \
+        --argjson maxFunctionsAllowed "$NVCF_MAX_FUNCTIONS_ALLOWED" \
+        --argjson maxTasksAllowed "$NVCF_MAX_TASKS_ALLOWED" \
+        --argjson maxTelemetriesAllowed "$NVCF_MAX_TELEMETRIES_ALLOWED" \
+        --argjson maxRegistryCredentialsAllowed "$NVCF_MAX_REGISTRY_CREDENTIALS_ALLOWED" \
+        '{
+            name: $name,
+            adminClientId: $adminClientId,
+            maxFunctionsAllowed: $maxFunctionsAllowed,
+            maxTasksAllowed: $maxTasksAllowed,
+            maxTelemetriesAllowed: $maxTelemetriesAllowed,
+            maxRegistryCredentialsAllowed: $maxRegistryCredentialsAllowed
+        } + if ($registryCredentials | length) > 0 then {
+            registryCredentials: $registryCredentials
+        } else {} end')
+
+    log_debug "Account payload content: $(echo "$payload" | jq -c 'if .registryCredentials? then .registryCredentials |= map(if .secret.value? then .secret.value = "[REDACTED]" else . end) else . end')"
+    log_debug "Payload created (${#payload} bytes)"
+    echo "$payload"
+}
+
+create_nvcf_account() {
+    local bearer_token="$1"
+    log_step "Creating NVCF account..."
+
+    local api_url="http://${API_SERVICE_NAME}.${API_NAMESPACE}.svc.cluster.local:8080"
+    local accounts_url="${api_url}${ACCOUNTS_ENDPOINT}/${NVCF_ACCOUNT_NAME}"
+
+    log_info "Account endpoint: $accounts_url"
+
+    local payload
+    payload=$(create_account_payload)
+
+    local response
+    response=$(curl -s -w "\n%{http_code}" \
+        --location "$accounts_url" \
+        --header "Content-Type: application/json" \
+        --header "Authorization: Bearer $bearer_token" \
+        --data "$payload")
+
+    local response_body status_code
+    response_body=$(echo "$response" | head -n -1)
+    status_code=$(echo "$response" | tail -n 1)
+
+    log_info "HTTP Status: $status_code"
+
+    # Validate status code format
+    if ! [[ "$status_code" =~ ^[0-9]+$ ]]; then
+        log_error "Invalid HTTP status code: '$status_code'"
+        log_debug "Full response: $response"
+        error_exit "$EXIT_ACCOUNT_ERROR" "Invalid HTTP response"
+    fi
+
+    # Log response (safely)
+    if echo "$response_body" | jq '.' >/dev/null 2>&1; then
+        log_debug "Response: $(echo "$response_body" | jq -c '.')"
+    else
+        log_debug "Response: $response_body"
+    fi
+
+    # Handle response codes
+    case "$status_code" in
+        2[0-9][0-9])
+            log_success "NVCF account created successfully!"
+            log_info "Account '$NVCF_ACCOUNT_NAME' is ready"
+            return 0
+            ;;
+        409)
+            log_warning "Account already exists (HTTP 409)"
+            log_info "Treating as success since the account is available"
+            return 0
+            ;;
+        401|403)
+            log_error "Authentication/authorization failed (HTTP $status_code)"
+            log_warning "Check JWT token validity and API permissions"
+            error_exit "$EXIT_AUTH_ERROR" "Authentication failed"
+            ;;
+        *)
+            log_error "Failed to create account (HTTP $status_code)"
+            error_exit "$EXIT_ACCOUNT_ERROR" "Account creation failed"
+            ;;
+    esac
+}
+
+# =============================================================================
+# MAIN EXECUTION FLOW
+# =============================================================================
+
+main() {
+    log_info "Starting $SCRIPT_NAME v$SCRIPT_VERSION"
+    log_info "Target account: $NVCF_ACCOUNT_NAME"
+
+    # Validation phase
+    validate_dependencies
+    validate_environment
+
+    # API readiness phase
+    wait_for_api_ready
+
+    # OpenBao authentication phase (JWT auth)
+    local vault_token
+    vault_token=$(login_to_openbao)
+    test_openbao_connection "$vault_token"
+
+    # JWT token generation phase
+    local bearer_token
+    bearer_token=$(generate_jwt_token "$vault_token")
+
+    # Account creation phase
+    create_nvcf_account "$bearer_token"
+
+    log_success "NCA bootstrap completed successfully!"
+}
+
+# =============================================================================
+# SCRIPT ENTRY POINT
+# =============================================================================
+
+# Only run main if script is executed directly (not sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/deploy/helm/cloud-functions/nvcf-api/templates/NOTES.txt
+++ b/deploy/helm/cloud-functions/nvcf-api/templates/NOTES.txt
@@ -1,0 +1,10 @@
+1. Get the application URL by running these commands:
+  export POD_NAME=$(kubectl get pods --namespace {{ include "nvcf-api.namespace" . }} -l "app.kubernetes.io/name={{ include "nvcf-api.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  
+  HTTP Port: {{ (index .Values.api.service.ports 0).port }}
+  gRPC Port: {{ (index .Values.api.service.ports 1).port }}
+  
+  Service Name: {{ include "nvcf-api.fullname" . }}.{{ include "nvcf-api.namespace" . }}.svc.cluster.local
+
+2. View the logs:
+  kubectl --namespace {{ include "nvcf-api.namespace" . }} logs $POD_NAME

--- a/deploy/helm/cloud-functions/nvcf-api/templates/_helpers.tpl
+++ b/deploy/helm/cloud-functions/nvcf-api/templates/_helpers.tpl
@@ -1,0 +1,158 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nvcf-api.name" -}}
+{{- default .Chart.Name .Values.api.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nvcf-api.fullname" -}}
+{{- if .Values.api.fullnameOverride }}
+{{- .Values.api.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.api.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nvcf-api.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Allow the release namespace to be overridden
+*/}}
+{{- define "nvcf-api.namespace" -}}
+{{- default .Release.Namespace .Values.api.namespace -}}
+{{- end -}}
+
+{{/*
+Derive the full image value
+*/}}
+{{- define "nvcf-api.image" -}}
+{{- $registry := required "A valid image registry (.Values.api.image.registry) is required!" .Values.api.image.registry -}}
+{{- $repository := required "A valid image repository (.Values.api.image.repository) is required!" .Values.api.image.repository -}}
+{{- $tag := .Values.api.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- end -}}
+
+{{/*
+Derive the full image value
+*/}}
+{{- define "nvcf-api.accountBootstrapImage" -}}
+{{- $registry := required "A valid image registry (.Values.api.accountBootstrap.image.registry) is required!" .Values.api.accountBootstrap.image.registry -}}
+{{- $repository := required "A valid image repository (.Values.api.accountBootstrap.image.repository) is required!" .Values.api.accountBootstrap.image.repository -}}
+{{- $tag := .Values.api.accountBootstrap.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "nvcf-api.labels" -}}
+helm.sh/chart: {{ include "nvcf-api.chart" . }}
+{{ include "nvcf-api.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "nvcf-api.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nvcf-api.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the Docker config JSON for image pull secret
+*/}}
+{{- define "imagePullSecret" }}
+{{- with .Values.api.registry }}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .server .username .password .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
+{{- end }}
+{{- end }}
+
+{{/*
+Remote config ConfigMap name. Default: <fullname>-remote-config (release-scoped
+to avoid collisions across installs in the same namespace). Override via
+.Values.api.remoteConfig.configMapName when a fixed external name is required.
+*/}}
+{{- define "nvcf-api.remoteConfigName" -}}
+{{- .Values.api.remoteConfig.configMapName | default (printf "%s-remote-config" (include "nvcf-api.fullname" .)) -}}
+{{- end -}}
+
+{{/*
+Remote config Role/RoleBinding name. Release-scoped via the fullname helper.
+*/}}
+{{- define "nvcf-api.remoteConfigReaderName" -}}
+{{- printf "%s-remote-config-reader" (include "nvcf-api.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Release-artifact annotations for worker sidecar images.
+
+The remote-config sidecar image references embed Spring placeholders
+(${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}) that are resolved at
+runtime from the NVCF_SIDECARS_HOSTNAME / NVCF_SIDECARS_REPOSITORY env vars.
+Stack release-artifact tooling scans rendered manifests for concrete image
+references and skips any value containing "${", so those worker images would
+otherwise be omitted from stack release artifacts. This helper emits a fully
+resolved "<hostname>/<repository>/<image>:<tag>" reference for every sidecar
+entry that carries the placeholder prefix, mirroring the release-artifact-*-image
+annotations rendered by nvca-operator's self-managed-nvcfbackend-cm.yaml.
+
+Nothing is emitted unless both NVCF_SIDECARS_HOSTNAME and NVCF_SIDECARS_REPOSITORY
+are set, so partially-resolved (and therefore invalid) references are never
+produced.
+*/}}
+{{- define "nvcf-api.sidecarReleaseArtifacts" -}}
+{{- $env := .Values.api.env | default dict -}}
+{{- $hostname := $env.NVCF_SIDECARS_HOSTNAME | default "" -}}
+{{- $repository := $env.NVCF_SIDECARS_REPOSITORY | default "" -}}
+{{- $remoteConfig := .Values.api.remoteConfig | default dict -}}
+{{- $configData := $remoteConfig.configData | default dict -}}
+{{- $nvcf := $configData.nvcf | default dict -}}
+{{- $sidecars := $nvcf.sidecars | default dict -}}
+{{- if and $hostname $repository -}}
+{{- range $key, $value := $sidecars }}
+{{- if kindIs "map" $value }}
+{{- range $subKey, $subValue := $value }}
+{{- if and (kindIs "string" $subValue) (contains "${nvcf.sidecars." $subValue) }}
+{{- $name := printf "%s-%s" $key $subKey }}
+release-artifact-{{ $name }}{{ if not (hasSuffix "-image" $name) }}-image{{ end }}: {{ $subValue | replace "${nvcf.sidecars.hostname}" $hostname | replace "${nvcf.sidecars.repository}" $repository | quote }}
+{{- end }}
+{{- end }}
+{{- else if and (kindIs "string" $value) (contains "${nvcf.sidecars." $value) }}
+release-artifact-{{ $key }}{{ if not (hasSuffix "-image" $key) }}-image{{ end }}: {{ $value | replace "${nvcf.sidecars.hostname}" $hostname | replace "${nvcf.sidecars.repository}" $repository | quote }}
+{{- end }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Vault Agent Injector Annotations for JWT Auth
+*/}}
+{{- define "nvcf-api.vaultAnnotations" -}}
+vault.hashicorp.com/agent-inject: "true"
+vault.hashicorp.com/role: "nvcf-api"
+vault.hashicorp.com/auth-path: "auth/jwt"
+vault.hashicorp.com/auth-config-token-path: "/var/run/secrets/openbao/token"
+vault.hashicorp.com/agent-copy-volume-mounts: {{ .Chart.Name }}
+vault.hashicorp.com/agent-run-as-same-user: "true"
+vault.hashicorp.com/agent-inject-template-file-secrets.json: "/vault/config/templates/secrets.json.tmpl"
+vault.hashicorp.com/secret-volume-path: "/home/app/vault"
+{{- end }}

--- a/deploy/helm/cloud-functions/nvcf-api/templates/account-bootstrap-configmap.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/templates/account-bootstrap-configmap.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ConfigMap for NVCF API NCA bootstrap script
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nvcf-api.fullname" . }}-account-bootstrap-script
+  namespace: {{ include "nvcf-api.namespace" . }}
+  labels:
+    {{- include "nvcf-api.labels" . | nindent 4 }}
+    app.kubernetes.io/component: account-bootstrap
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation
+data:
+  account-bootstrap.sh: |-
+    {{- tpl (.Files.Get "scripts/account-bootstrap.sh") . | nindent 4 }}

--- a/deploy/helm/cloud-functions/nvcf-api/templates/account-bootstrap-hook-job.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/templates/account-bootstrap-hook-job.yaml
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "nvcf-api.fullname" . }}-account-bootstrap
+  namespace: {{ include "nvcf-api.namespace" . }}
+  labels:
+    {{- include "nvcf-api.labels" . | nindent 4 }}
+    app.kubernetes.io/component: account-bootstrap
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "2"
+    # don't delete the job on success, it will be deleted by the ttl
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      {{- with .Values.api.accountBootstrap.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "nvcf-api.labels" . | nindent 8 }}
+        app.kubernetes.io/component: account-bootstrap
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: nvcf-api-account-bootstrap
+      {{- with .Values.api.accountBootstrap.schedulingGates }}
+      schedulingGates:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: token
+              expirationSeconds: 3600
+              audience: http://openbao-server.vault-system.svc.cluster.local:8200
+      - name: account-bootstrap-script
+        configMap:
+          name: {{ include "nvcf-api.fullname" . }}-account-bootstrap-script
+          defaultMode: 0755
+      {{- with .Values.api.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: account-bootstrap-creator
+        image: "{{ include "nvcf-api.accountBootstrapImage" . }}"
+        imagePullPolicy: {{ .Values.api.accountBootstrap.image.pullPolicy }}
+        command: ["/bin/bash"]
+        args: ["/scripts/account-bootstrap.sh"]
+        volumeMounts:
+        - name: token
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          readOnly: true
+        - name: account-bootstrap-script
+          mountPath: /scripts
+          readOnly: true
+        envFrom:
+        - secretRef:
+            name: {{ include "nvcf-api.fullname" . }}-account-bootstrap-secret
+        env:
+          - name: API_SERVICE_NAME
+            value: api
+          - name: API_NAMESPACE
+            value: {{ include "nvcf-api.namespace" . | quote }}
+          - name: API_READINESS_PERIOD_SECONDS
+            value: "{{ .Values.api.accountBootstrap.readiness.periodSeconds }}"
+          - name: API_READINESS_FAILURE_THRESHOLD
+            value: "{{ .Values.api.accountBootstrap.readiness.failureThreshold }}"
+        resources:
+          {{- toYaml .Values.api.accountBootstrap.resources | nindent 10 }}

--- a/deploy/helm/cloud-functions/nvcf-api/templates/account-bootstrap-secret.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/templates/account-bootstrap-secret.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "nvcf-api.fullname" . }}-account-bootstrap-secret
+  namespace: {{ include "nvcf-api.namespace" . }}
+  labels:
+    {{- include "nvcf-api.labels" . | nindent 4 }}
+    app.kubernetes.io/component: account-bootstrap
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+type: Opaque
+stringData:
+  NVCF_ACCOUNT_NAME: {{ .Values.api.accountBootstrap.accountName | quote }}
+  NVCF_ADMIN_CLIENT_ID: {{ .Values.api.accountBootstrap.adminClientId | quote }}
+  {{- $creds := .Values.api.accountBootstrap.registryCredentials | default (list) }}
+  NVCF_REGISTRY_CREDENTIALS_JSON: |
+    {{ $creds | toJson | indent 4 }}
+  NVCF_MAX_FUNCTIONS_ALLOWED: "{{ .Values.api.accountBootstrap.limits.maxFunctions }}"
+  NVCF_MAX_TASKS_ALLOWED: "{{ .Values.api.accountBootstrap.limits.maxTasks }}"
+  NVCF_MAX_TELEMETRIES_ALLOWED: "{{ .Values.api.accountBootstrap.limits.maxTelemetries }}"
+  NVCF_MAX_REGISTRY_CREDENTIALS_ALLOWED: "{{ .Values.api.accountBootstrap.limits.maxRegistryCreds }}"

--- a/deploy/helm/cloud-functions/nvcf-api/templates/account-bootstrap-serviceaccount.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/templates/account-bootstrap-serviceaccount.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  # hardcoded to match the service account configured in the OpenBao JWT auth role
+  name: nvcf-api-account-bootstrap
+  namespace: {{ include "nvcf-api.namespace" . }}
+  labels:
+    {{- include "nvcf-api.labels" . | nindent 4 }}
+    app.kubernetes.io/component: account-bootstrap
+automountServiceAccountToken: true

--- a/deploy/helm/cloud-functions/nvcf-api/templates/configmap-env.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/templates/configmap-env.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.api.env }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nvcf-api.fullname" . }}-env
+  namespace: {{ include "nvcf-api.namespace" . }}
+  labels:
+    {{- include "nvcf-api.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.api.env }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/cloud-functions/nvcf-api/templates/configmap-remote-config.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/templates/configmap-remote-config.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.api.remoteConfig.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nvcf-api.remoteConfigName" . }}
+  namespace: {{ include "nvcf-api.namespace" . }}
+  {{- $sidecarReleaseArtifacts := include "nvcf-api.sidecarReleaseArtifacts" . | trim }}
+  {{- if $sidecarReleaseArtifacts }}
+  annotations:
+    {{- $sidecarReleaseArtifacts | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "nvcf-api.labels" . | nindent 4 }}
+data:
+  nvcf-api.yaml: |-
+{{ toYaml .Values.api.remoteConfig.configData | indent 4 }}
+{{- end }}

--- a/deploy/helm/cloud-functions/nvcf-api/templates/configmap-vault-agent-template.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/templates/configmap-vault-agent-template.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nvcf-api.fullname" . }}-vault-agent-tpl
+  namespace: {{ include "nvcf-api.namespace" . }}
+  labels:
+    {{- include "nvcf-api.labels" . | nindent 4 }}
+data:
+  secrets.json.tmpl: |-
+{{ .Files.Get "vault-agent-templates/secrets.json.tmpl" | indent 4 }} 

--- a/deploy/helm/cloud-functions/nvcf-api/templates/deployment.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/templates/deployment.yaml
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "nvcf-api.fullname" . }}
+  namespace: {{ include "nvcf-api.namespace" . }}
+  labels:
+    {{- include "nvcf-api.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.api.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "nvcf-api.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- include "nvcf-api.vaultAnnotations" . | nindent 8 }}
+        {{- with .Values.api.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.api.env }}
+        checksum/config-env: {{ toYaml .Values.api.env | sha256sum }}
+        {{- end }}
+        checksum/vault-agent-template: {{ .Files.Get "vault-agent-templates/secrets.json.tmpl" | sha256sum }}
+      labels:
+        {{- include "nvcf-api.selectorLabels" . | nindent 8 }}
+    spec:
+      terminationGracePeriodSeconds: {{ .Values.api.terminationGracePeriodSeconds }}
+      {{- with .Values.api.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: nvcf-api
+      securityContext:
+        {{- toYaml .Values.api.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- if .Values.api.debugHost }}
+          args: ["java","-agentlib:jdwp=transport=dt_socket,server=n,address={{ .Values.api.debugHost }},suspend=y", "-jar", "/usr/share/app.jar"]
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.api.securityContext | nindent 12 }}
+          image: "{{ include "nvcf-api.image" . }}"
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          lifecycle:
+            {{- toYaml .Values.api.lifecycle | nindent 12 }}
+          volumeMounts:
+            {{- with .Values.api.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            - name: vault-config-templates
+              mountPath: /vault/config/templates
+              readOnly: true
+          {{- with .Values.api.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.api.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.api.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: AWS_REGION
+              value: "ncp"
+            - name: SPRING_PROFILES_ACTIVE
+              value: "ncp"
+            {{- if .Values.api.remoteConfig.enabled }}
+            - name: REMOTE_CONFIG_ENABLED
+              value: "true"
+            - name: REMOTE_CONFIG_NAME
+              value: {{ include "nvcf-api.remoteConfigName" . | quote }}
+            {{- end }}
+          {{- if .Values.api.env }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "nvcf-api.fullname" . }}-env
+          {{- end }}
+          ports:
+            {{- range .Values.api.ports }}
+            - name: {{ .name }}
+              containerPort: {{ .containerPort }}
+              protocol: {{ .protocol }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+      volumes:
+        {{- with .Values.api.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        - name: vault-config-templates
+          configMap:
+            name: {{ include "nvcf-api.fullname" . }}-vault-agent-tpl
+            items:
+              - key: secrets.json.tmpl
+                path: secrets.json.tmpl
+      {{- with .Values.api.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.api.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.api.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/cloud-functions/nvcf-api/templates/hpa.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/templates/hpa.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.api.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "nvcf-api.fullname" . }}
+  namespace: {{ include "nvcf-api.namespace" . }}
+  labels:
+    {{- include "nvcf-api.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "nvcf-api.fullname" . }}
+  minReplicas: {{ .Values.api.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.api.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.api.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.api.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.api.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.api.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/cloud-functions/nvcf-api/templates/rbac-config-reader.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/templates/rbac-config-reader.yaml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.api.remoteConfig.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "nvcf-api.remoteConfigReaderName" . }}
+  namespace: {{ include "nvcf-api.namespace" . }}
+  labels:
+    {{- include "nvcf-api.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "nvcf-api.remoteConfigReaderName" . }}
+  namespace: {{ include "nvcf-api.namespace" . }}
+  labels:
+    {{- include "nvcf-api.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: nvcf-api
+    namespace: {{ include "nvcf-api.namespace" . }}
+roleRef:
+  kind: Role
+  name: {{ include "nvcf-api.remoteConfigReaderName" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/deploy/helm/cloud-functions/nvcf-api/templates/service.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/templates/service.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  namespace: {{ include "nvcf-api.namespace" . }}
+  labels:
+    {{- include "nvcf-api.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    {{- range .Values.api.service.ports }}
+    - port: {{ .port }}
+      targetPort: {{ .targetPort }}
+      protocol: {{ .protocol }}
+      name: {{ .name }}
+    {{- end }}
+  selector:
+    {{- include "nvcf-api.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/cloud-functions/nvcf-api/templates/serviceaccount.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/templates/serviceaccount.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nvcf-api
+  namespace: {{ include "nvcf-api.namespace" . }}
+  labels:
+    {{- include "nvcf-api.labels" . | nindent 4 }}

--- a/deploy/helm/cloud-functions/nvcf-api/values.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/values.yaml
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# nest everything under api:
+api:
+
+  # Namespace to deploy the resources. Default is the release namespace.
+  namespace: ""
+
+  # This is to override the chart name.
+  nameOverride: ""
+  fullnameOverride: ""
+
+  # This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+  replicaCount: 1
+
+  # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+  image:
+    registry: "" # must be supplied
+    repository: "" # must be supplied
+    # This sets the pull policy for images.
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "1.12.6"
+
+  # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  # imagePullSecrets:
+  #   - name: frank-image-pull-secret
+
+  # Post-install hook job for creating NVCF account
+  accountBootstrap:
+    image:
+      registry: ""
+      repository: ""
+      tag: ""
+      pullPolicy: IfNotPresent
+
+    # Readiness probe tuning for bootstrap script
+    readiness:
+      periodSeconds: 3
+      failureThreshold: 600
+
+    podAnnotations: {}
+    schedulingGates: []
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 250m
+        memory: 256Mi
+
+    # NCA ID for the NVCF account
+    accountName: nvcf-default
+    adminClientId: "ncp"
+
+    # Registry credentials array for the Account API.
+    # An empty list is valid and omits registryCredentials from the bootstrap
+    # account payload. Non-empty lists may include CONTAINER and HELM entries.
+    # MODEL and RESOURCE entries are ignored by the bootstrap script.
+    # Example:
+    # registryCredentials:
+    #   - registryHostname: "nvcr.io"
+    #     secret:
+    #       name: "secret-name"
+    #       value: "secret-value"
+    #     artifactTypes:
+    #       - "CONTAINER"
+    #       - "HELM"
+    #     tags:
+    #       - "tag1"
+    #     description: "optional description"
+    registryCredentials: []
+
+    # Quota limits for new Account API
+    # Minimum 1, even if unused
+    limits:
+      maxFunctions: 5
+      maxTasks: 1
+      maxTelemetries: 1
+      maxRegistryCreds: 5
+
+  # This is for setting Kubernetes Annotations to a Pod.
+  # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  podAnnotations: {}
+  # This is for setting Kubernetes Labels to a Pod.
+  # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    runAsUser: 1000
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+
+  service:
+    ports:
+      - name: http
+        port: 8080
+        targetPort: http
+        protocol: TCP
+      - name: grpc
+        port: 9090
+        targetPort: grpc
+        protocol: TCP
+      - name: metrics
+        port: 9464
+        targetPort: metrics
+        protocol: TCP
+
+  # This will set the terminationGracePeriodSeconds for the pod
+  terminationGracePeriodSeconds: 60
+
+  resources:
+    limits:
+      cpu: 2
+      memory: 4Gi
+    requests:
+      cpu: 2
+      memory: 4Gi
+
+  # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  readinessProbe:
+    httpGet:
+      path: /actuator/health/readiness
+      port: management-port
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    failureThreshold: 1
+    successThreshold: 3
+    timeoutSeconds: 1
+
+  livenessProbe:
+    httpGet:
+      path: /actuator/health/liveness
+      port: management-port
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 6
+
+  startupProbe:
+    httpGet:
+      path: /actuator/health/readiness
+      port: management-port
+    failureThreshold: 180
+    periodSeconds: 5
+    initialDelaySeconds: 10
+
+  # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  volumes:
+    - name: token
+      projected:
+        sources:
+        - serviceAccountToken:
+            path: token
+            expirationSeconds: 3600
+            audience: http://openbao-server.vault-system.svc.cluster.local:8200
+
+  # Additional volumeMounts on the output Deployment definition.
+  volumeMounts:
+    - name: token
+      mountPath: /var/run/secrets/openbao
+      readOnly: true
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+  ports:
+    - name: http
+      containerPort: 8080
+      protocol: TCP
+    - name: grpc
+      containerPort: 9090
+      protocol: TCP
+    - name: management-port
+      containerPort: 8181
+      protocol: TCP
+    - name: metrics
+      containerPort: 9464
+      protocol: TCP
+
+  env: {}
+
+  # Remote configuration via spring-cloud-kubernetes-client-config. When enabled,
+  # the chart renders the ConfigMap + Role/RoleBinding + REMOTE_CONFIG_* env vars,
+  # giving a hot-reloadable override layer over the baked-in ncp profile.
+  # Set to false to opt out; the service then falls back to JAR defaults in
+  # application-ncp.yaml. See README "Remote Config RBAC".
+  remoteConfig:
+    enabled: true
+    # ConfigMap metadata.name. Empty -> defaults to <fullname>-remote-config
+    # (release-scoped, collision-safe across installs in the same namespace).
+    # Override with a fixed string only when an external contract pins the name.
+    configMapName: ""
+    # Can be used for remote configuration by adding NVCF-specific properties here. 
+    # Add only the keys you need to override.
+    # Placeholders like ${nvcf.sidecars.hostname} resolve from environment variables,
+    # (NVCF_SIDECARS_HOSTNAME / NVCF_SIDECARS_REPOSITORY).
+    # Example:
+    #   configData:
+    #     nvcf:
+    #       sidecars:
+    #         init-container: "${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/nvcf_worker_init:2.103.0"
+    #       scheduled-tasks:
+    #         migration-job-1: # use specific migration job name here
+    #           enabled: false
+    configData:
+      nvcf:
+        sidecars:
+          inference-container: nvcr.io/nvidia/tritonserver:23.04-py3
+          init-container: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/nvcf-worker-init-oss:1.0.9
+          utils-container-image:
+            go: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/nvcf-worker-utils-oss:1.0.4
+          otel-container: dummy
+          niclls-container: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/nvcf_worker_niclls:2.109.4
+          ess-agent-container: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/ess-agent:1.3.1
+          otel-collector-container: dummy
+          llm-credential-manager-image: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/nvcf-worker-llm-credentials-oss:1.0.4
+          llm-router-client-image: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/pylon:0.3.2
+        notary:
+          turn:
+            enabled: true
+        llm-request-router:
+          # Worker-facing endpoint advertised to LLM worker containers as
+          # LLM_REQUEST_ROUTER_ADDRESS. Deployment overlays must provide a
+          # routable address for their topology.
+          worker-address: ""

--- a/deploy/helm/cloud-functions/nvcf-api/vault-agent-templates/secrets.json.tmpl
+++ b/deploy/helm/cloud-functions/nvcf-api/vault-agent-templates/secrets.json.tmpl
@@ -1,0 +1,42 @@
+{
+  "kv": {
+    "cassandra": {
+      {{ with secret "/services/nvcf-api/kv/data/cassandra/creds" }}
+      "username": "{{ .Data.data.username }}",
+      "password": "{{ .Data.data.password }}"
+      {{ end }}
+    },
+    "tokens": {
+    {{- with secret `services/nvcf-api/jwt/sign/nvcf-api` }}
+      "notary": "{{ .Data.token }}",
+    {{- end }}
+    {{- with secret `services/sis-api/jwt/sign/nvcf-api` }}
+      "icms": "{{ .Data.token }}",
+    {{- end }}
+    {{- with secret `services/ess-api/jwt/sign/nvcf-api` }}
+      "ess": "{{ .Data.token }}",
+    {{- end }}
+    {{- with secret `services/api-keys-api/jwt/sign/nvcf-api` }}
+      "api-keys": "{{ .Data.token }}",
+    {{- end }}
+    {{- with secret `services/reval/jwt/sign/nvcf-api` }}
+      "reval": "{{ .Data.token }}"
+    {{- end }}
+  },
+    "jwks": "{{ with secret "services/all/kv/data/encryption/keys/stored_data" }}{{ .Data.data.keys }}{{ end }}",
+    "kid": "{{ with secret "services/all/kv/data/encryption/keys/stored_data"  }}{{ .Data.data.current_kid }}{{ end }}",
+    "nats": {
+      {{ with secret "/services/all/kv/data/nats/creds" }}
+      "api-auth": {
+        "user": "{{ .Data.data.public_key }}",
+        "user-seed": "{{ .Data.data.key }}"
+      }
+      {{ end }}
+    },
+    "worker-nkey-seed": "{{ with secret "/services/all/kv/data/nats/creds" }}{{ .Data.data.key }}{{ end }}",
+    "worker-tracing": "dummy-worker-tracing",
+    "sidecars": {
+      "image-pull-secret": "{{ with secret "/services/nvcf-api/kv/data/sidecars/image-pull-secret" }}{{ .Data.data.secret }}{{ end }}"
+    }
+  }
+} 

--- a/deploy/helm/cloud-functions/tests/sidecar_release_artifacts_test.sh
+++ b/deploy/helm/cloud-functions/tests/sidecar_release_artifacts_test.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -12,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/deploy/helm/cloud-functions/tests/sidecar_release_artifacts_test.sh
+++ b/deploy/helm/cloud-functions/tests/sidecar_release_artifacts_test.sh
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+chart_root="$(cd "$(dirname "$0")/.." && pwd)"
+chart_dir="${chart_root}/nvcf-api"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+
+hostname="nvcr.io"
+repository="0651155215864979/ncp-dev"
+
+manifest="${tmp_dir}/manifest.yaml"
+manifest_without_sidecar_env="${tmp_dir}/manifest-without-sidecar-env.yaml"
+
+helm template nvcf-api "${chart_dir}" \
+  --namespace nvcf \
+  --values "${chart_dir}/values.yaml" \
+  --set-string api.image.registry=example.com \
+  --set-string api.image.repository=foo/bar/strap \
+  --set-string api.accountBootstrap.image.registry=example.com \
+  --set-string api.accountBootstrap.image.repository=foo/bar/alpine-k8s \
+  --set-string api.accountBootstrap.image.tag=0.0.0 \
+  --set-string "api.env.NVCF_SIDECARS_HOSTNAME=${hostname}" \
+  --set-string "api.env.NVCF_SIDECARS_REPOSITORY=${repository}" \
+  --show-only templates/configmap-remote-config.yaml \
+  > "${manifest}"
+
+# Every sidecar entry carrying the ${nvcf.sidecars.*} placeholder must surface a
+# concrete, placeholder-free release-artifact-*-image annotation resolved from
+# NVCF_SIDECARS_HOSTNAME / NVCF_SIDECARS_REPOSITORY.
+expected_annotations=(
+  "release-artifact-init-container-image: \"${hostname}/${repository}/nvcf-worker-init-oss:1.0.9\""
+  "release-artifact-utils-container-image-go-image: \"${hostname}/${repository}/nvcf-worker-utils-oss:1.0.4\""
+  "release-artifact-niclls-container-image: \"${hostname}/${repository}/nvcf_worker_niclls:2.109.4\""
+  "release-artifact-ess-agent-container-image: \"${hostname}/${repository}/ess-agent:1.3.1\""
+  "release-artifact-llm-credential-manager-image: \"${hostname}/${repository}/nvcf-worker-llm-credentials-oss:1.0.4\""
+  "release-artifact-llm-router-client-image: \"${hostname}/${repository}/pylon:0.3.2\""
+)
+
+for annotation in "${expected_annotations[@]}"; do
+  if ! grep -Fq "${annotation}" "${manifest}"; then
+    echo "expected rendered remote-config ConfigMap to include annotation: ${annotation}" >&2
+    exit 1
+  fi
+done
+
+# Sidecar values without the placeholder prefix are pinned by digest/tag elsewhere
+# and must not be duplicated as release-artifact annotations.
+for absent in \
+  "release-artifact-inference-container" \
+  "release-artifact-otel-container" \
+  "release-artifact-otel-collector-container"; do
+  if grep -Fq "${absent}" "${manifest}"; then
+    echo "did not expect release-artifact annotation for non-placeholder sidecar: ${absent}" >&2
+    exit 1
+  fi
+done
+
+# No annotation may leak an unresolved placeholder into the release artifacts.
+if grep -E 'release-artifact-.*\$\{' "${manifest}"; then
+  echo "release-artifact annotations must not contain unresolved \${...} placeholders" >&2
+  exit 1
+fi
+
+# Without the sidecar registry env vars the annotations must be omitted entirely
+# rather than emitting partially-resolved (invalid) references.
+helm template nvcf-api "${chart_dir}" \
+  --namespace nvcf \
+  --values "${chart_dir}/values.yaml" \
+  --set-string api.image.registry=example.com \
+  --set-string api.image.repository=foo/bar/strap \
+  --set-string api.accountBootstrap.image.registry=example.com \
+  --set-string api.accountBootstrap.image.repository=foo/bar/alpine-k8s \
+  --set-string api.accountBootstrap.image.tag=0.0.0 \
+  --show-only templates/configmap-remote-config.yaml \
+  > "${manifest_without_sidecar_env}"
+
+if grep -Fq "release-artifact-" "${manifest_without_sidecar_env}"; then
+  echo "expected no release-artifact annotations when NVCF_SIDECARS_* env is unset" >&2
+  exit 1
+fi
+
+echo "remote-config ConfigMap surfaces resolved release-artifact image references for placeholder sidecars"

--- a/deploy/helm/cloud-functions/values.local.yaml
+++ b/deploy/helm/cloud-functions/values.local.yaml
@@ -1,0 +1,58 @@
+api:
+  image:
+    registry: nvcr.io
+    repository: 0651155215864979/ncp-dev/strap
+    tag: "1.9.0"
+  
+  accountBootstrap:
+    image:
+      registry: nvcr.io
+      repository: 0651155215864979/ncp-dev/alpine-k8s
+      tag: 1.30.12
+      pullPolicy: IfNotPresent
+    
+    # Keep local account bootstrap credential provisioning disabled unless valid
+    # base64 username:password secrets are available. Empty placeholder secrets
+    # are rejected by the API.
+    registryCredentials: []
+    # To provision NGC registry credentials during bootstrap, change the value
+    # above to `registryCredentials:` and uncomment entries like these:
+    #   - registryHostname: "nvcr.io"
+    #     secret:
+    #       name: "nvcf-registry-credentials"
+    #       value: "" # must be base64 encoded username:password format
+    #     artifactTypes:
+    #       - "CONTAINER"
+    #     description: "NVCF Registry Credentials - 0651155215864979/ncp-dev"
+    #   - registryHostname: "helm.ngc.nvidia.com"
+    #     secret:
+    #       name: "nvcf-registry-credentials"
+    #       value: "" # must be base64 encoded username:password format
+    #     artifactTypes:
+    #       - "HELM"
+    #     description: "NVCF Registry Credentials - 0651155215864979/ncp-dev"
+    #   - registryHostname: "api.ngc.nvidia.com"
+    #     secret:
+    #       name: "nvcf-registry-credentials"
+    #       value: "" # must be base64 encoded username:password format
+    #     artifactTypes:
+    #       - "MODEL"
+    #       - "RESOURCE"
+    #     description: "NGC Registry Credentials - 0651155215864979/ncp-dev"
+
+  env:
+    # Ensure stacktraces are expanded
+    LOGGING_EXCEPTION_CONVERSION_WORD: "%wEx"
+
+    NVCF_REVAL_ENABLED: "false"
+    
+    # Matches the NATS config
+    NVCF_NATS_REGION_PLACEMENT_TAG: "dc"
+
+  remoteConfig:
+    configData:
+      nvcf:
+        llm-request-router:
+          # Local worker-facing LLM request router endpoint. Split control/compute-plane
+          # environments should override this with a routable external host:port.
+          worker-address: "llm-request-router.nvcf.svc.cluster.local:50071"

--- a/tools/ci/github-release-subprojects.json
+++ b/tools/ci/github-release-subprojects.json
@@ -296,7 +296,7 @@
       "id": "cloud-functions-helm",
       "path": "deploy/helm/cloud-functions",
       "service_name": "helm-nvcf-api",
-      "initial_version": "0.4.2"
+      "initial_version": "1.23.11"
     },
     {
       "id": "instance-cluster-management",

--- a/tools/ci/github-release-subprojects.json
+++ b/tools/ci/github-release-subprojects.json
@@ -293,6 +293,12 @@
       "initial_version": "1.4.2"
     },
     {
+      "id": "cloud-functions-helm",
+      "path": "deploy/helm/cloud-functions",
+      "service_name": "helm-nvcf-api",
+      "initial_version": "0.4.2"
+    },
+    {
       "id": "instance-cluster-management",
       "path": "src/control-plane-services/instance-cluster-management",
       "service_name": "nvcf-instance-cluster-management"

--- a/tools/ci/helm-validate-values/cloud-functions.yaml
+++ b/tools/ci/helm-validate-values/cloud-functions.yaml
@@ -1,0 +1,10 @@
+# CI-only values for helm lint/template validation.
+api:
+  image:
+    registry: example.com
+    repository: foo/bar/baz
+  accountBootstrap:
+    image:
+      registry: example.com
+      repository: foo/bar/bop
+      tag: "0.0.0"


### PR DESCRIPTION
## Why

The chart lived in its own colocated-deploy repo, publishing as helm-nvcf-api. Porting it here puts it on the same tag-driven release lane as the other charts under deploy/helm, so releases are cut from the monorepo instead of the external repo.

## What changed

- deploy/helm/cloud-functions/ - the chart, ported from that repo's main. The chart itself is unchanged: the inner nvcf-api/ directory is byte-identical to the source, and helm template renders identical manifests.
- tools/ci/helm-validate-values/cloud-functions.yaml - CI-only values, matching the other charts. The chart leaves image.registry and image.repository empty on purpose and does not render without them.
- tools/ci/github-release-subprojects.json - registers cloud-functions-helm.

The release entry is the part worth reviewing:

```json
{
  "id": "cloud-functions-helm",
  "path": "deploy/helm/cloud-functions",
  "service_name": "helm-nvcf-api",
  "initial_version": "1.23.11"
}
```

service_name is the chart's own published name from Chart.yaml, not one derived from the service. A service-shaped name would publish into a new empty chart repository and strand the existing versions while the pipeline still reported success.

initial_version anchors at 1.23.11, the newest published version. The registry holds two series: three early manual pushes ending at 0.4.2 on the classic chart registry, and the CI-released OCI series up to 1.23.11, matching the source repo's newest tag. 1.23.11 was verified by pulling it from the OCI registry. The first release cut here computes 1.23.12 or 1.24.0.

Dropped on the way in, all repo-level files that do not belong in a chart directory: .gitlab-ci.yml, the license-header scripts, CODEOWNERS, SECURITY.md, .oss-allowlist, .security-triage.yaml, and debug-pod.yaml.

Two defects fixed in the wrapper: the Makefile's clean target used an undefined variable and expanded to `rm -rf /*.tgz`, and the chart test's shebang sat below the license header, so on Linux runners the script fell back to a shell that rejects `set -o pipefail`.

## Plan Summary

One new chart directory and one new release registration. Nothing publishes until a deploy/helm/cloud-functions/v* tag exists, and that requires the companion config in the internal repo.

## Usage

```
make -C deploy/helm/cloud-functions lint
make -C deploy/helm/cloud-functions template
make -C deploy/helm/cloud-functions test
```

## Testing

helm lint passes and helm template renders 11 resources with the CI values, validated with kubeconform against Kubernetes 1.31.5. make test passes, and was verified to run under a POSIX shell after the shebang fix. The rendered manifests were diffed against the source repo's chart under the same values: identical.

## Notes

appVersion stays 1.12.6, from the source repo's main. The previously published charts carry appVersion equal to the chart version because the old release job overwrote it. That drift is deliberate here: it keeps the chart identical to the source, and the pin can move in its own change.

## Issues

https://github.com/NVIDIA/nvcf/issues/876

## References

None.

## Related Pull Requests

Companion publish config in the internal repo, to follow.

## Dependencies

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Helm chart for deploying the NVCF API on Kubernetes.
  * Supports configurable images, services, ports, health checks, resources, autoscaling, scheduling, and environment settings.
  * Added optional remote configuration, Vault-managed secrets, and sidecar release-artifact configuration.
  * Added automated account initialization during installation and upgrades.
  * Added deployment commands for installation, validation, testing, packaging, and publishing.
* **Documentation**
  * Added deployment instructions, configuration guidance, prerequisites, and post-install usage notes.
* **Tests**
  * Added validation for sidecar release-artifact annotations and Helm-rendered configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->