### PR TITLE
fix(function-autoscaler): use metric-specific environment labels

### DIFF
--- a/src/control-plane-services/function-autoscaler/crates/server/src/work/discovery.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/work/discovery.rs
@@ -32,6 +32,8 @@ use tokio::time::Instant;
 use tracing;
 use uuid::Uuid;
 
+use super::MetricEnvironments;
+
 pub const LOCK_NAME_FUNCTION_DISCOVERY: &str = "function_discovery";
 
 /// Lookback window (minutes) for "recently invoked" in discovery. Functions with no invocations
@@ -165,7 +167,8 @@ fn get_timeseries_db_query(
 ) -> String {
     let mut matchers = Vec::new();
     if !ignore_env {
-        matchers.push(format!(r#"aws_env="{}""#, env));
+        let metric_env = MetricEnvironments::from_config(env);
+        matchers.push(format!(r#"aws_env="{}""#, metric_env.aws));
     }
     if let Some(function_version_id) = function_version_filter {
         matchers.push(format!(r#"function_version_id="{}""#, function_version_id));
@@ -694,19 +697,7 @@ pub async fn get_functions_with_workers(
     // Query for functions with workers OR functions with active instances (for BYOC)
     // This ensures both normal functions and BYOC functions are discovered
     // Note: nvcf_function_instances_current query does NOT filter by state to match get_byoc_instance_count
-    let query = if timeseries_db_ignore_env {
-        r#"count by(function_id, function_version_id, nca_id) (nvcf_worker_service_worker_thread_count_total) > 0
-or
-avg by(function_id, function_version_id, nca_id) (nvcf_function_instances_current) > 0"#.to_string()
-    } else {
-        let environment = if env == "stg" { "stage" } else { "prod" };
-        format!(
-            r#"count by(function_id, function_version_id, nca_id) (nvcf_worker_service_worker_thread_count_total{{environment="{}"}}) > 0
-or
-avg by(function_id, function_version_id, nca_id) (nvcf_function_instances_current{{environment="{}"}}) > 0"#,
-            environment, environment
-        )
-    };
+    let query = functions_with_workers_query(env, timeseries_db_ignore_env);
 
     tracing::info!(
         "Executing PromQL query for functions with workers (ignore_env={}): {}",
@@ -804,6 +795,22 @@ avg by(function_id, function_version_id, nca_id) (nvcf_function_instances_curren
     Ok(functions_with_workers)
 }
 
+fn functions_with_workers_query(env: &str, ignore_env: bool) -> String {
+    if ignore_env {
+        r#"count by(function_id, function_version_id, nca_id) (nvcf_worker_service_worker_thread_count_total) > 0
+or
+avg by(function_id, function_version_id, nca_id) (nvcf_function_instances_current) > 0"#.to_string()
+    } else {
+        let metric_env = MetricEnvironments::from_config(env);
+        format!(
+            r#"count by(function_id, function_version_id, nca_id) (nvcf_worker_service_worker_thread_count_total{{environment="{}"}}) > 0
+or
+avg by(function_id, function_version_id, nca_id) (nvcf_function_instances_current{{environment="{}"}}) > 0"#,
+            metric_env.worker, metric_env.control_plane
+        )
+    }
+}
+
 /// Get functions with active instances from TimeseriesDb (for BYOC functions that don't emit worker metrics)
 /// This uses the nvcf_function_instances_current metric which tracks actual running instances
 pub async fn get_functions_with_active_instances(
@@ -820,15 +827,7 @@ pub async fn get_functions_with_active_instances(
     let start_time = end_time - Duration::minutes(5); // 5 minute window
     let step = StdDuration::from_secs(STEP_SECS as u64);
 
-    let query = if timeseries_db_ignore_env {
-        r#"nvcf_function_instances_current{state="active"} > 0"#.to_string()
-    } else {
-        let environment = if env == "stg" { "stage" } else { "prod" };
-        format!(
-            r#"nvcf_function_instances_current{{state="active", environment="{}"}} > 0"#,
-            environment
-        )
-    };
+    let query = active_instances_query(env, timeseries_db_ignore_env);
 
     tracing::info!(
         "Executing PromQL query for functions with active instances (ignore_env={}): {}",
@@ -918,6 +917,18 @@ pub async fn get_functions_with_active_instances(
     Ok(functions_with_active_instances)
 }
 
+fn active_instances_query(env: &str, ignore_env: bool) -> String {
+    if ignore_env {
+        "nvcf_function_instances_current > 0".to_string()
+    } else {
+        let metric_env = MetricEnvironments::from_config(env);
+        format!(
+            r#"nvcf_function_instances_current{{environment="{}"}} > 0"#,
+            metric_env.control_plane
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -987,6 +998,35 @@ mod tests {
                 4
             );
         }
+    }
+
+    #[test]
+    fn running_function_query_uses_each_metric_familys_environment_labels() {
+        let prod_query = functions_with_workers_query("prd", false);
+        assert!(prod_query
+            .contains(r#"nvcf_worker_service_worker_thread_count_total{environment="prod"}"#));
+        assert!(prod_query.contains(r#"nvcf_function_instances_current{environment="production"}"#));
+
+        let stage_query = functions_with_workers_query("stg", false);
+        assert!(stage_query
+            .contains(r#"nvcf_worker_service_worker_thread_count_total{environment="stage"}"#));
+        assert!(stage_query.contains(r#"nvcf_function_instances_current{environment="staging"}"#));
+    }
+
+    #[test]
+    fn active_instance_query_uses_control_plane_environment_without_state() {
+        assert_eq!(
+            active_instances_query("prd", false),
+            r#"nvcf_function_instances_current{environment="production"} > 0"#
+        );
+        assert_eq!(
+            active_instances_query("stg", false),
+            r#"nvcf_function_instances_current{environment="staging"} > 0"#
+        );
+        assert_eq!(
+            active_instances_query("prd", true),
+            "nvcf_function_instances_current > 0"
+        );
     }
 
     #[tokio::test]

--- a/src/control-plane-services/function-autoscaler/crates/server/src/work/mod.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/work/mod.rs
@@ -62,6 +62,31 @@ use discovery::get_recently_invoked_functions;
 const TIMESERIES_DB_QUERY_STEP: StdDuration = StdDuration::from_secs(60); // 1 minute step for TimeseriesDb queries
 pub const CALCULATE_UTILIZATION_LOCK_PREFIX: &str = "util_lock";
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct MetricEnvironments {
+    aws: &'static str,
+    worker: &'static str,
+    control_plane: &'static str,
+}
+
+impl MetricEnvironments {
+    fn from_config(env: &str) -> Self {
+        if env == "stg" {
+            Self {
+                aws: "stg",
+                worker: "stage",
+                control_plane: "staging",
+            }
+        } else {
+            Self {
+                aws: "prd",
+                worker: "prod",
+                control_plane: "production",
+            }
+        }
+    }
+}
+
 /// Get historical utilization data for a specific function
 #[allow(clippy::too_many_arguments)]
 async fn get_function_utilization_history(
@@ -78,11 +103,13 @@ async fn get_function_utilization_history(
     let start_time = end_time - Duration::minutes(lookback_minutes);
     let step = TIMESERIES_DB_QUERY_STEP;
 
+    let metric_env = MetricEnvironments::from_config(env);
     let env_suffix = if ignore_env {
         String::new()
+    } else if use_control_plane_metrics {
+        format!(r#", aws_env="{}""#, metric_env.aws)
     } else {
-        let env_val = if env == "stg" { "stage" } else { "prod" };
-        format!(", environment=\"{}\"", env_val)
+        format!(r#", environment="{}""#, metric_env.worker)
     };
 
     let query = if use_control_plane_metrics {
@@ -173,12 +200,8 @@ async fn get_byoc_instance_count(
     let env_suffix = if ignore_env {
         String::new()
     } else {
-        let env_val = if env == "stg" {
-            "staging"
-        } else {
-            "production"
-        };
-        format!(r#", environment="{}""#, env_val)
+        let metric_env = MetricEnvironments::from_config(env);
+        format!(r#", environment="{}""#, metric_env.control_plane)
     };
 
     let query = format!(
@@ -280,8 +303,8 @@ async fn get_current_worker_count_from_timeseries_db(
     let env_filter = if ignore_env {
         String::new()
     } else {
-        let environment = if env == "stg" { "stage" } else { "prod" };
-        format!(r#", environment="{}""#, environment)
+        let metric_env = MetricEnvironments::from_config(env);
+        format!(r#", environment="{}""#, metric_env.worker)
     };
     let query = format!(
         r#"count by(function_id, function_version_id) (nvcf_worker_service_worker_thread_count_total{{function_id="{}", function_version_id="{}"{}}})"#,
@@ -861,6 +884,30 @@ mod tests {
         r#"{"status":"success","data":{"resultType":"matrix","result":[]}}"#.to_string()
     }
 
+    #[test]
+    fn metric_environments_use_metric_family_label_values() {
+        assert_eq!(
+            MetricEnvironments::from_config("stg"),
+            MetricEnvironments {
+                aws: "stg",
+                worker: "stage",
+                control_plane: "staging",
+            }
+        );
+        assert_eq!(
+            MetricEnvironments::from_config("prd"),
+            MetricEnvironments {
+                aws: "prd",
+                worker: "prod",
+                control_plane: "production",
+            }
+        );
+        assert_eq!(
+            MetricEnvironments::from_config("prod"),
+            MetricEnvironments::from_config("prd")
+        );
+    }
+
     #[tokio::test]
     async fn test_control_plane_utilization_query_aggregates_shared_function_pool() {
         let fid = Uuid::new_v4();
@@ -898,6 +945,50 @@ mod tests {
         .expect("control-plane utilization");
 
         assert_eq!(utilization, vec![(1_700_000_000, "42".to_string())]);
+    }
+
+    #[tokio::test]
+    async fn test_control_plane_utilization_query_uses_aws_environment_labels() {
+        let fid = Uuid::new_v4();
+        let fvid = Uuid::new_v4();
+        let mut server = mockito::Server::new_async().await;
+
+        for (configured_env, aws_env) in [("prd", "prd"), ("stg", "stg")] {
+            let expected_query = format!(
+                r#"100 * sum by(function_id, function_version_id) (rate(function_request_latency_sum{{function_id="{fid}", function_version_id="{fvid}", aws_env="{aws_env}"}}[2m])) /
+            (avg by(function_id, function_version_id) (nvcf_function_instances_current{{function_id="{fid}", function_version_id="{fvid}", aws_env="{aws_env}"}}) * avg by(function_id, function_version_id) (nvcf_function_concurrency{{function_id="{fid}", function_version_id="{fvid}", aws_env="{aws_env}"}})) or vector(0)"#
+            );
+            let query_mock = server
+                .mock("GET", "/api/v1/query_range")
+                .match_query(mockito::Matcher::UrlEncoded(
+                    "query".to_string(),
+                    expected_query,
+                ))
+                .with_status(200)
+                .with_body(vm_series(
+                    &format!(r#""function_id":"{fid}","function_version_id":"{fvid}""#),
+                    "42",
+                ))
+                .expect(1)
+                .create_async()
+                .await;
+
+            let utilization = get_function_utilization_history(
+                &ts_client(server.url()),
+                &fid,
+                &fvid,
+                configured_env,
+                true,
+                false,
+                5,
+                60,
+            )
+            .await
+            .expect("control-plane utilization");
+
+            assert_eq!(utilization, vec![(1_700_000_000, "42".to_string())]);
+            query_mock.assert_async().await;
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## TL;DR

Use the environment labels emitted by each autoscaler metric family: `aws_env` for invocation/control-plane utilization, worker `environment` labels for worker metrics, and control-plane `environment` labels for instance-only queries.

## Additional Details

- Centralizes production and staging label mappings.
- Fixes BYOC discovery and control-plane utilization selectors.
- Removes the nonexistent `state="active"` matcher.
- Preserves the behavior introduced by #501, #652, and #769.

## For the Reviewer

Please focus on the query construction in `work/mod.rs` and `work/discovery.rs`.

## For QA

- Formatting and Clippy passed.
- All nonignored tests passed.
- Corrected queries returned labeled data in production verification.

## Issues

NO-REF

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autoscaling metric discovery across staging and production environments.
  * Corrected environment labeling for worker, instance, utilization, and cloud-provider metrics.
  * Active-instance metrics now accurately reflect available instances without relying on an “active” state filter.
  * Added validation to ensure scaling decisions use the appropriate environment-specific metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->