### PR TITLE
test(bdd): simplify rendered manifest content steps

### DIFF
--- a/tests/bdd/AGENTS.md
+++ b/tests/bdd/AGENTS.md
@@ -4,7 +4,7 @@ Scope: everything under `tests/bdd/`.
 
 This directory is the strict-DSL replacement for the legacy `tests/bdd`
 runner. The whole point is a Gherkin vocabulary that an AI can extend
-without inventing domain helpers. Read `PLAN.md` before touching code.
+without inventing opaque domain helpers. Read `PLAN.md` before touching code.
 
 ## The strict-DSL contract
 
@@ -15,9 +15,10 @@ output. Step handlers in `steps/` are thin wrappers around helpers in
 Gherkin via `When I run command` plus an output assertion, never inside
 a handler.
 
-If a scenario asks for behavior the catalog cannot express, the right
-move is almost always another `When I run command` plus an assertion,
-not a new step.
+Use a shared step when a repeated operator action or observable keeps every
+meaningful target, value, context, and timeout visible while hiding only
+command or output-format mechanics. Keep `When I run command` plus an
+assertion as the escape hatch for uncommon or command-specific behavior.
 
 ## Layering
 
@@ -235,8 +236,9 @@ multi-cluster feature:
 
 ## Adding a step
 
-Adding a step is rare. The DSL should not grow domain-shaped
-primitives.
+Adding a step is deliberate. Add one only for a repeated action or observable
+that keeps meaningful inputs visible and has no hidden workflow branching.
+Do not add opaque composite steps such as `Given the stack is installed`.
 
 1. Add the row to `PLAN.md` first: regex, table/docstring shape, one
    sentence of behavior.

--- a/tests/bdd/PLAN.md
+++ b/tests/bdd/PLAN.md
@@ -1,9 +1,10 @@
 # Strict Infrastructure-Level Gherkin DSL
 
 This is the complete set of step definitions for `tests/bdd`. Every
-new step must reuse one of these patterns. Step handlers do not contain
-domain-specific validation logic; that lives in Gherkin via CLI invocations
-and output assertions.
+new step must reuse one of these patterns. Shared steps may hide repeated
+command and output-format mechanics, but their Gherkin must keep meaningful
+targets, values, contexts, and timeouts visible. Step handlers do not contain
+domain-specific validation logic.
 
 ## Vocabulary
 
@@ -130,6 +131,8 @@ refactor in every consumer; that is a feature.
 | `Then yaml file {string} should contain:` (docstring) | Subset variant: every key in expected must exist in actual with the same value; extra keys in actual are allowed. Use this when the file has dynamic or future-additive fields. `${VAR}` expansion applies. |
 | `Then yaml file {string} key {string} should contain:` (docstring) | Subset semantics scoped to the subtree at the dotted key path. |
 | `Then the json output should contain rows:` (table) | Parses the last command's stdout as JSON (expected: array of objects). For each table row, asserts an object matching every column value exists in the array. Extra objects are allowed; ordering is not asserted. |
+| `Then the rendered manifests in {string} should contain:` (table) | Requires a `text` header and one or more fixed strings. Recursively inspects regular files under the repo-relative directory and fails if any listed string is absent. `${VAR}` expansion applies to the path and table values. |
+| `Then the rendered manifests in {string} under directories matching {string} should contain:` (table) | Positive rendered-manifest assertion scoped to files below a directory whose name matches the supplied shell pattern, such as `*-nats`. The render directory, directory-name pattern, and table values support `${VAR}` expansion. |
 | `Then the rendered manifests in {string} should not contain:` (table) | Requires a `text` header and one or more fixed strings. Recursively inspects regular files under the repo-relative directory and fails if any listed string appears. `${VAR}` expansion applies to the path and table values. |
 | `Then these ServiceMonitors should exist in namespace {string} using context {string}:` (table) | Requires a `name` header and one or more names. Runs one `kubectl get` with every named ServiceMonitor; exit code 0 proves every listed resource exists. |
 
@@ -227,10 +230,10 @@ do so via another `When I run command "rm ..."`.
 
 ## Why this list
 
-The promise of the DSL is that any future feature file can be written
-using only these steps. If a new scenario needs something the catalog
-doesn't cover, the right move is almost always to express it as a
-`When I run command` + an output assertion, not to add a new step.
+The promise of the DSL is that any future feature file can be written using
+only these steps. Add a shared step when a repeated action or observable keeps
+its meaningful inputs visible and hides only command or output-format
+mechanics. Otherwise use `When I run command` plus an output assertion.
 
 The infrastructure-bootstrap Givens (cluster up, image pull secret) and
 the single `Given command has succeeded:` carry-over are the only places
@@ -448,6 +451,11 @@ func JSONContainsRows(raw string, rows []map[string]string) error
 // FilesDoNotContain recursively inspects regular files under root and
 // fails if any interpolated fixed string appears.
 func FilesDoNotContain(root string, needles []string) error
+
+// FilesContain recursively inspects regular files under root and fails if any
+// fixed string is absent. A non-empty directoryNamePattern limits the search
+// to files below a directory whose name matches the shell pattern.
+func FilesContain(root, directoryNamePattern string, needles []string) error
 
 // ServiceMonitorExistenceCommand builds one kubectl get command whose
 // successful exit proves every named ServiceMonitor exists.

--- a/tests/bdd/dsl/textsearch.go
+++ b/tests/bdd/dsl/textsearch.go
@@ -22,9 +22,121 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 )
+
+// FilesContain recursively inspects regular files under root and fails if any
+// required fixed string is absent. A non-empty directoryNamePattern limits the
+// search to files below a directory whose name matches the shell
+// pattern.
+func FilesContain(root, directoryNamePattern string, needles []string) error {
+	root = strings.TrimSpace(Interpolate(root))
+	if root == "" {
+		return fmt.Errorf("rendered manifests directory is empty")
+	}
+	if len(needles) == 0 {
+		return fmt.Errorf("required text list is empty")
+	}
+
+	resolvedNeedles := make([]string, 0, len(needles))
+	for _, rawNeedle := range needles {
+		needle := Interpolate(rawNeedle)
+		if needle == "" {
+			return fmt.Errorf("required text is empty")
+		}
+		resolvedNeedles = append(resolvedNeedles, needle)
+	}
+
+	directoryNamePattern = strings.TrimSpace(Interpolate(directoryNamePattern))
+	if strings.Contains(directoryNamePattern, "/") {
+		return fmt.Errorf("rendered manifest directory name pattern %q must not contain a slash", directoryNamePattern)
+	}
+	if directoryNamePattern != "" {
+		if _, err := path.Match(directoryNamePattern, "candidate"); err != nil {
+			return fmt.Errorf("invalid rendered manifest directory name pattern %q: %w", directoryNamePattern, err)
+		}
+	}
+
+	info, err := os.Stat(root)
+	if err != nil {
+		return fmt.Errorf("inspect rendered manifests directory %q: %w", root, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("rendered manifests path %q is not a directory", root)
+	}
+
+	found := make([]bool, len(resolvedNeedles))
+	filesInspected := 0
+	if err := filepath.WalkDir(root, func(filePath string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("inspect rendered manifest %q: %w", filePath, walkErr)
+		}
+		if !entry.Type().IsRegular() {
+			return nil
+		}
+		matches, err := matchesDirectoryName(root, filePath, directoryNamePattern)
+		if err != nil {
+			return err
+		}
+		if !matches {
+			return nil
+		}
+		filesInspected++
+		body, err := os.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("read rendered manifest %q: %w", filePath, err)
+		}
+		for index, needle := range resolvedNeedles {
+			if !found[index] && bytes.Contains(body, []byte(needle)) {
+				found[index] = true
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	if filesInspected == 0 {
+		if directoryNamePattern != "" {
+			return fmt.Errorf("rendered manifests directory %q contains no regular files under directories matching %q", root, directoryNamePattern)
+		}
+		return fmt.Errorf("rendered manifests directory %q contains no regular files", root)
+	}
+	for index, matched := range found {
+		if !matched {
+			if directoryNamePattern != "" {
+				return fmt.Errorf("rendered manifests in %q under directories matching %q do not contain required text %q", root, directoryNamePattern, resolvedNeedles[index])
+			}
+			return fmt.Errorf("rendered manifests in %q do not contain required text %q", root, resolvedNeedles[index])
+		}
+	}
+	return nil
+}
+
+func matchesDirectoryName(root, filePath, pattern string) (bool, error) {
+	if pattern == "" {
+		return true, nil
+	}
+	relative, err := filepath.Rel(root, filePath)
+	if err != nil {
+		return false, fmt.Errorf("resolve rendered manifest path %q relative to %q: %w", filePath, root, err)
+	}
+	directory := filepath.Dir(relative)
+	if directory == "." {
+		return false, nil
+	}
+	for _, segment := range strings.Split(filepath.ToSlash(directory), "/") {
+		matched, err := path.Match(pattern, segment)
+		if err != nil {
+			return false, fmt.Errorf("match rendered manifest directory name %q against %q: %w", segment, pattern, err)
+		}
+		if matched {
+			return true, nil
+		}
+	}
+	return false, nil
+}
 
 // FilesDoNotContain recursively inspects regular files under root and
 // fails if any interpolated fixed string appears.

--- a/tests/bdd/dsl/textsearch_test.go
+++ b/tests/bdd/dsl/textsearch_test.go
@@ -24,6 +24,45 @@ import (
 	"testing"
 )
 
+func TestFilesContainFindsFixedTextUnderMatchingDirectories(t *testing.T) {
+	root := t.TempDir()
+	writeRenderedManifest(t, root, "01-nats/templates/statefulset.yaml", "image: docker.io/natsio/reloader:0.23.0\n")
+	writeRenderedManifest(t, root, "01-nats/templates/secret.yaml", "# Source: helm-nvcf-nats/templates/nkey-secret.yaml\n")
+	writeRenderedManifest(t, root, "02-api/templates/deployment.yaml", "image: docker.io/alpine/k8s:1.36.1\n")
+
+	err := FilesContain(root, "*-nats", []string{
+		"docker.io/natsio/reloader:0.23.0",
+		"# Source: helm-nvcf-nats/templates/nkey-secret.yaml",
+	})
+	if err != nil {
+		t.Fatalf("find required rendered text: %v", err)
+	}
+}
+
+func TestFilesContainRestrictsSearchToMatchingDirectories(t *testing.T) {
+	root := t.TempDir()
+	writeRenderedManifest(t, root, "01-nats/templates/statefulset.yaml", "kind: StatefulSet\n")
+	writeRenderedManifest(t, root, "02-api/templates/deployment.yaml", "image: docker.io/alpine/k8s:1.36.1\n")
+
+	err := FilesContain(root, "*-nats", []string{"docker.io/alpine/k8s:1.36.1"})
+	if err == nil {
+		t.Fatal("expected missing required text error")
+	}
+	if !strings.Contains(err.Error(), `under directories matching "*-nats"`) ||
+		!strings.Contains(err.Error(), "docker.io/alpine/k8s:1.36.1") {
+		t.Fatalf("error = %q, want filter and missing text", err)
+	}
+}
+
+func TestFilesContainSearchesAllFilesWithoutPathFilter(t *testing.T) {
+	root := t.TempDir()
+	writeRenderedManifest(t, root, "collector.yaml", "kind: OpenTelemetryCollector\n")
+
+	if err := FilesContain(root, "", []string{"kind: OpenTelemetryCollector"}); err != nil {
+		t.Fatalf("find required rendered text: %v", err)
+	}
+}
+
 func TestFilesDoNotContainRejectsMatchedText(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "control-plane", "collector.yaml")
@@ -51,5 +90,16 @@ func TestFilesDoNotContainRejectsEmptyDirectory(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "contains no regular files") {
 		t.Fatalf("error = %q, want empty render directory detail", err)
+	}
+}
+
+func writeRenderedManifest(t *testing.T, root, relativePath, body string) {
+	t.Helper()
+	filePath := filepath.Join(root, filepath.FromSlash(relativePath))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		t.Fatalf("create render directory: %v", err)
+	}
+	if err := os.WriteFile(filePath, []byte(body), 0o644); err != nil {
+		t.Fatalf("write rendered manifest: %v", err)
 	}
 }

--- a/tests/bdd/features/single-cluster-helmfile-upstream-images.feature
+++ b/tests/bdd/features/single-cluster-helmfile-upstream-images.feature
@@ -23,6 +23,7 @@ Feature: Install a local single-cluster stack with upstream supporting images
       | global.imagePullSecrets[0].name | nvcr-pull-secret                     |
       | global.helm.sources.repository  | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM} |
       | global.image.repository         | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM} |
+      | observability.profile           | disabled                             |
     And I copy the file "deploy/stacks/self-managed/secrets/secrets.yaml.template" to "deploy/stacks/self-managed/secrets/local-bdd-secrets.yaml"
     # Only ${VAR} is interpolated; bare $oauthtoken stays literal.
     And I substitute "REPLACE_WITH_BASE64_DOCKER_CREDENTIAL" in file "deploy/stacks/self-managed/secrets/local-bdd-secrets.yaml" with base64 of "$oauthtoken:${NGC_API_KEY}"

--- a/tests/bdd/features/single-cluster-helmfile-upstream-images.feature
+++ b/tests/bdd/features/single-cluster-helmfile-upstream-images.feature
@@ -73,37 +73,23 @@ Feature: Install a local single-cluster stack with upstream supporting images
     Then the command exit code should be 0
     And the command output should not contain "Error:"
 
-    When I run command:
-      """
-      rg --fixed-strings 'docker.io/natsio/nats-server-config-reloader:0.23.0' deploy/stacks/self-managed/out -g '**/*-nats/**'
-      """
-    Then the command exit code should be 0
-    And the command output should contain "docker.io/natsio/nats-server-config-reloader:0.23.0"
+    # The current NATS chart renders NKey Secrets directly and has no nkey job
+    # image to override. Check it beside the supporting image override owned by
+    # the same rendered release.
+    Then the rendered manifests in "deploy/stacks/self-managed/out" under directories matching "*-nats" should contain:
+      | text                                                               |
+      | docker.io/natsio/nats-server-config-reloader:0.23.0                |
+      | # Source: helm-nvcf-nats/templates/nkey-secret.yaml                |
 
     # Cassandra initialization currently uses its migrations image. Selecting
     # alpine-k8s for this hook requires chart support.
-    When I run command:
-      """
-      rg --fixed-strings 'nvcf-cassandra-migrations:' deploy/stacks/self-managed/out -g '**/*-cassandra/**'
-      """
-    Then the command exit code should be 0
-    And the command output should contain "nvcf-cassandra-migrations:"
+    And the rendered manifests in "deploy/stacks/self-managed/out" under directories matching "*-cassandra" should contain:
+      | text                       |
+      | nvcf-cassandra-migrations: |
 
-    # The current NATS chart renders NKey Secrets directly and has no nkey job
-    # image to override.
-    When I run command:
-      """
-      rg --fixed-strings '# Source: helm-nvcf-nats/templates/nkey-secret.yaml' deploy/stacks/self-managed/out -g '**/*-nats/**'
-      """
-    Then the command exit code should be 0
-    And the command output should contain "nkey-secret.yaml"
-
-    When I run command:
-      """
-      rg --fixed-strings 'docker.io/alpine/k8s:1.36.1' deploy/stacks/self-managed/out -g '**/*-api/**'
-      """
-    Then the command exit code should be 0
-    And the command output should contain "docker.io/alpine/k8s:1.36.1"
+    And the rendered manifests in "deploy/stacks/self-managed/out" under directories matching "*-api" should contain:
+      | text                             |
+      | docker.io/alpine/k8s:1.36.1      |
 
     # Keep this focused on the releases that own or exercise the overrides.
     # A full local stack install also starts unrelated service images that may

--- a/tests/bdd/godog_test.go
+++ b/tests/bdd/godog_test.go
@@ -927,25 +927,8 @@ func TestSingleClusterHelmfileUpstreamImagesFeatureFileWiresToSteps(t *testing.T
 	t.Setenv("SAMPLE_NGC_TEAM", "test-team")
 	t.Setenv("REPO_ROOT", "/repo-root-placeholder")
 	upstreamReloader := "docker.io/natsio/nats-server-config-reloader:0.23.0"
-	upstreamAlpine := "docker.io/alpine/k8s:1.36.1"
 	suite := newWiringSuite(t, newFakeRunner(map[string]harness.Result{
 		"k3d cluster get ncp-local-cp": {ExitCode: 1},
-		"rg --fixed-strings 'docker.io/natsio/nats-server-config-reloader:0.23.0' deploy/stacks/self-managed/out -g '**/*-nats/**'": {
-			ExitCode: 0,
-			Stdout:   upstreamReloader,
-		},
-		"rg --fixed-strings 'nvcf-cassandra-migrations:' deploy/stacks/self-managed/out -g '**/*-cassandra/**'": {
-			ExitCode: 0,
-			Stdout:   "nvcf-cassandra-migrations:",
-		},
-		"rg --fixed-strings '# Source: helm-nvcf-nats/templates/nkey-secret.yaml' deploy/stacks/self-managed/out -g '**/*-nats/**'": {
-			ExitCode: 0,
-			Stdout:   "nkey-secret.yaml",
-		},
-		"rg --fixed-strings 'docker.io/alpine/k8s:1.36.1' deploy/stacks/self-managed/out -g '**/*-api/**'": {
-			ExitCode: 0,
-			Stdout:   upstreamAlpine,
-		},
 		"helm list --all-namespaces -o json": {
 			ExitCode: 0,
 			Stdout:   helmListAllNamespacesJSON(),
@@ -958,6 +941,7 @@ func TestSingleClusterHelmfileUpstreamImagesFeatureFileWiresToSteps(t *testing.T
 	seedHelmfileLocalBDDFixture(t, suite.Config.RepoRoot)
 	seedStackSecretsTemplate(t, suite.Config.RepoRoot)
 	seedUpstreamImageStackInputs(t, suite.Config.RepoRoot)
+	seedUpstreamImageRenderOutput(t, suite.Config.RepoRoot)
 
 	sc := steps.NewScenarioContext(suite)
 	featurePath := mustResolveFeaturePath(t, "single-cluster-helmfile-upstream-images.feature")
@@ -990,6 +974,9 @@ func TestSingleClusterHelmfileUpstreamImagesFeatureFileWiresToSteps(t *testing.T
 		if !commandRanThatContains(runs, "install HELMFILE_ENV=local-bdd "+selector) {
 			t.Fatalf("helmfile install selector %q was never invoked", selector)
 		}
+	}
+	if commandRanThatContains(runs, "rg --fixed-strings") {
+		t.Fatal("rendered manifest assertions should not invoke rg")
 	}
 }
 
@@ -1149,6 +1136,29 @@ api:
 `
 	if err := os.WriteFile(filepath.Join(stackDir, "global.yaml.gotmpl"), []byte(global), 0o644); err != nil {
 		t.Fatalf("write global template: %v", err)
+	}
+}
+
+// seedUpstreamImageRenderOutput writes representative render directories for
+// the positive fixed-string assertions in the upstream-image feature.
+func seedUpstreamImageRenderOutput(t *testing.T, repoRoot string) {
+	t.Helper()
+	manifests := map[string]string{
+		"01-nats/templates/nats.yaml": `# Source: helm-nvcf-nats/templates/nkey-secret.yaml
+image: docker.io/natsio/nats-server-config-reloader:0.23.0
+`,
+		"02-cassandra/templates/cassandra.yaml": "image: nvcf-cassandra-migrations:latest\n",
+		"03-api/templates/api.yaml":             "image: docker.io/alpine/k8s:1.36.1\n",
+	}
+	root := filepath.Join(repoRoot, "deploy", "stacks", "self-managed", "out")
+	for relativePath, body := range manifests {
+		filePath := filepath.Join(root, filepath.FromSlash(relativePath))
+		if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+			t.Fatalf("mkdir rendered manifest dir: %v", err)
+		}
+		if err := os.WriteFile(filePath, []byte(body), 0o644); err != nil {
+			t.Fatalf("write rendered manifest: %v", err)
+		}
 	}
 }
 

--- a/tests/bdd/steps/assertion_steps.go
+++ b/tests/bdd/steps/assertion_steps.go
@@ -42,6 +42,8 @@ func registerAssertionSteps(ctx *godog.ScenarioContext, sc *ScenarioContext) {
 	ctx.Step(`^yaml file "([^"]*)" should contain:$`, sc.yamlFileShouldContain)
 	ctx.Step(`^yaml file "([^"]*)" key "([^"]*)" should contain:$`, sc.yamlFileKeyShouldContain)
 	ctx.Step(`^the json output should contain rows:$`, sc.jsonOutputShouldContainRows)
+	ctx.Step(`^the rendered manifests in "([^"]*)" should contain:$`, sc.renderedManifestsShouldContain)
+	ctx.Step(`^the rendered manifests in "([^"]*)" under directories matching "([^"]*)" should contain:$`, sc.renderedManifestsUnderMatchingDirectoriesShouldContain)
 	ctx.Step(`^the rendered manifests in "([^"]*)" should not contain:$`, sc.renderedManifestsShouldNotContain)
 	ctx.Step(`^these ServiceMonitors should exist in namespace "([^"]*)" using context "([^"]*)":$`, sc.serviceMonitorsShouldExist)
 }
@@ -155,6 +157,22 @@ func (sc *ScenarioContext) renderedManifestsShouldNotContain(path string, table 
 		return err
 	}
 	return dsl.FilesDoNotContain(sc.resolvePath(dsl.Interpolate(path)), needles)
+}
+
+func (sc *ScenarioContext) renderedManifestsShouldContain(path string, table *godog.Table) error {
+	needles, err := tableToSingleColumn(table, "text")
+	if err != nil {
+		return err
+	}
+	return dsl.FilesContain(sc.resolvePath(dsl.Interpolate(path)), "", needles)
+}
+
+func (sc *ScenarioContext) renderedManifestsUnderMatchingDirectoriesShouldContain(path, pattern string, table *godog.Table) error {
+	needles, err := tableToSingleColumn(table, "text")
+	if err != nil {
+		return err
+	}
+	return dsl.FilesContain(sc.resolvePath(dsl.Interpolate(path)), pattern, needles)
 }
 
 func tableToSingleColumn(table *godog.Table, header string) ([]string, error) {

--- a/tests/bdd/steps/steps_test.go
+++ b/tests/bdd/steps/steps_test.go
@@ -648,6 +648,50 @@ func TestRenderedManifestsShouldNotContainAcceptsExplicitMarkers(t *testing.T) {
 	}
 }
 
+func TestRenderedManifestsShouldContainAcceptsExplicitMarkers(t *testing.T) {
+	sc, fake := newScenarioContext(t)
+	renderDir := filepath.Join(sc.Suite.Config.RepoRoot, "out", "rendered")
+	if err := os.MkdirAll(renderDir, 0o755); err != nil {
+		t.Fatalf("create render directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(renderDir, "collector.yaml"), []byte("kind: OpenTelemetryCollector\n"), 0o644); err != nil {
+		t.Fatalf("write rendered manifest: %v", err)
+	}
+	table := docTable(t, [][]string{
+		{"text"},
+		{"kind: OpenTelemetryCollector"},
+	})
+
+	if err := sc.renderedManifestsShouldContain("out/rendered", table); err != nil {
+		t.Fatalf("assert rendered manifests: %v", err)
+	}
+	if len(fake.runs) != 0 {
+		t.Fatalf("runs = %d, want 0", len(fake.runs))
+	}
+}
+
+func TestRenderedManifestsUnderMatchingDirectoriesShouldContainAcceptsExplicitMarkers(t *testing.T) {
+	sc, fake := newScenarioContext(t)
+	renderDir := filepath.Join(sc.Suite.Config.RepoRoot, "out", "rendered", "01-nats", "templates")
+	if err := os.MkdirAll(renderDir, 0o755); err != nil {
+		t.Fatalf("create render directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(renderDir, "nats.yaml"), []byte("image: docker.io/natsio/reloader:0.23.0\n"), 0o644); err != nil {
+		t.Fatalf("write rendered manifest: %v", err)
+	}
+	table := docTable(t, [][]string{
+		{"text"},
+		{"docker.io/natsio/reloader:0.23.0"},
+	})
+
+	if err := sc.renderedManifestsUnderMatchingDirectoriesShouldContain("out/rendered", "*-nats", table); err != nil {
+		t.Fatalf("assert rendered manifests: %v", err)
+	}
+	if len(fake.runs) != 0 {
+		t.Fatalf("runs = %d, want 0", len(fake.runs))
+	}
+}
+
 // docTable builds a godog.Table from a slice of rows. The Picker rows
 // type matches what godog hands to step handlers at runtime.
 func docTable(t *testing.T, rows [][]string) *godog.Table {


### PR DESCRIPTION
## TL;DR

Adds table-driven positive rendered-manifest assertions and replaces repeated `rg` command blocks in the upstream supporting-images feature. The render directory, release-directory filter, and expected fixed strings remain visible in Gherkin.

## Additional Details

- Adds fixed-string search across rendered files with an optional directory-name pattern such as `*-nats`.
- Reports the missing string and searched scope without printing manifest contents.
- Revises the BDD guidance to allow repeated common operations while rejecting opaque composite steps.
- Migrates all positive render searches in the upstream-images feature.
- Disables the unrelated observability profile so the focused render/install scenario remains self-contained with current defaults.

Customer release notes: Not customer visible.

Plan summary: Not applicable.

Dependencies: None. No license or NOTICE changes.

## For the Reviewer

Please focus on the directory-filter semantics in `dsl/textsearch.go` and whether the Gherkin keeps enough render scope visible.

## For QA

Passed:

- `go test -short ./...` from `tests/bdd`
- `tests/bdd/scripts/lint.sh`
- `TestSingleClusterHelmfileUpstreamImagesFeatureFileWiresToSteps`
- `BDD_CLEANUP_MODE=stack-single go test -run '^TestSingleClusterHelmfileUpstreamImages$' -count=1 -v .` against `ncp-local` (`1` scenario and `35` steps passed)

QA needed: No separate QA.

## Issues

Closes #865

Relates to #858

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added BDD assertions for verifying expected text in rendered manifests, including optional directory-pattern filtering.
  - Added recursive fixed-text checks for rendered files.

- **Bug Fixes**
  - Updated upstream-image validation to inspect rendered manifests directly, improving coverage for NATS, Cassandra, and API images.

- **Documentation**
  - Clarified BDD step design, visible inputs, timeout handling, and DSL extension guidance.

- **Tests**
  - Added coverage for filtered and unfiltered manifest searches and confirmed assertions run without shell commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->