### PR TITLE
test(bdd): add successful command step

### DIFF
--- a/tests/bdd/PLAN.md
+++ b/tests/bdd/PLAN.md
@@ -113,6 +113,8 @@ refactor in every consumer; that is a feature.
 |------|-------|
 | `When I run command {string}` | Single-line command. `${VAR}` expansion applies. Captures exit code + stdout + stderr in scenario state. The most recent run is the one assertions reference. |
 | `When I run command:` (docstring) | Multi-line form for commands that don't fit on one line. Same recording semantics. |
+| `When I successfully run command {string}` | Single-line command that must exit 0. Preserves the command result for later output assertions and records the resolved command in the successful-command cache. |
+| `When I successfully run command:` (docstring) | Multi-line form for commands that must exit 0. Uses the same result recording, interpolation, logging, and cache semantics as the single-line form. |
 | `When I run command with a terminal:` (docstring) | Same as the docstring form, but stdin is attached to a pseudo-terminal so the child sees a TTY on fd 0. For commands that gate interactive-only behavior on a TTY, such as `nvcf-cli self-hosted up` (its auth-gate mints the admin token only when stdin is a terminal). No input is written; stdout and stderr are captured separately as usual. |
 | `When I export command output to environment variable {string}` | Exports the previous command's trimmed stdout under the named env var. Fails the step unless the prior command exited 0 and produced non-empty stdout. Snapshotted by the env Ledger; restored at suite teardown. |
 

--- a/tests/bdd/features/observability-control.feature
+++ b/tests/bdd/features/observability-control.feature
@@ -50,8 +50,7 @@ Feature: Install local Helmfile observability with the control profile
       | monitoring       |
 
   Scenario: Control profile installs shared infrastructure and control monitors
-    When I run command "make -C deploy/stacks/self-managed install HELMFILE_ENV=local-bdd-observability-control"
-    Then the command exit code should be 0
+    When I successfully run command "make -C deploy/stacks/self-managed install HELMFILE_ENV=local-bdd-observability-control"
 
     When I run command "helm list --all-namespaces --kube-context k3d-ncp-local -o json"
     Then the json output should contain rows:
@@ -62,8 +61,7 @@ Feature: Install local Helmfile observability with the control profile
       | otel-collector           | monitoring | deployed |
       | default-monitors         | monitoring | deployed |
 
-    When I run command "kubectl get opentelemetrycollector nvcf-observability -n monitoring --context k3d-ncp-local -o jsonpath='{.spec.targetAllocator.enabled}'"
-    Then the command exit code should be 0
+    When I successfully run command "kubectl get opentelemetrycollector nvcf-observability -n monitoring --context k3d-ncp-local -o jsonpath='{.spec.targetAllocator.enabled}'"
     And the command output should contain "true"
 
     Then these ServiceMonitors should exist in namespace "monitoring" using context "k3d-ncp-local":

--- a/tests/bdd/steps/command_steps.go
+++ b/tests/bdd/steps/command_steps.go
@@ -35,6 +35,8 @@ import (
 func registerCommandSteps(ctx *godog.ScenarioContext, sc *ScenarioContext) {
 	ctx.Step(`^I run command "([^"]*)"$`, sc.iRunCommandLine)
 	ctx.Step(`^I run command:$`, sc.iRunCommandDoc)
+	ctx.Step(`^I successfully run command "([^"]*)"$`, sc.iSuccessfullyRunCommandLine)
+	ctx.Step(`^I successfully run command:$`, sc.iSuccessfullyRunCommandDoc)
 	ctx.Step(`^I run command with a terminal:$`, sc.iRunCommandWithTTYDoc)
 	ctx.Step(`^command has succeeded:$`, sc.commandHasSucceededDoc)
 	ctx.Step(`^I export command output to environment variable "([^"]*)"$`, sc.iExportCommandOutputToEnv)
@@ -46,6 +48,14 @@ func (sc *ScenarioContext) iRunCommandLine(ctx context.Context, commandText stri
 
 func (sc *ScenarioContext) iRunCommandDoc(ctx context.Context, doc *godog.DocString) error {
 	return sc.runAndRecord(ctx, doc.Content)
+}
+
+func (sc *ScenarioContext) iSuccessfullyRunCommandLine(ctx context.Context, commandText string) error {
+	return sc.runSuccessfully(ctx, commandText)
+}
+
+func (sc *ScenarioContext) iSuccessfullyRunCommandDoc(ctx context.Context, doc *godog.DocString) error {
+	return sc.runSuccessfully(ctx, doc.Content)
 }
 
 // iRunCommandWithTTYDoc runs the docstring command with stdin attached to
@@ -85,6 +95,15 @@ func (sc *ScenarioContext) runAndRecord(ctx context.Context, commandText string)
 	return sc.runAndRecordWith(ctx, commandText, sc.Suite.Runner.Run)
 }
 
+// runSuccessfully records the command result, requires exit code 0, and uses
+// the existing exit-zero assertion path to seed the successful-command cache.
+func (sc *ScenarioContext) runSuccessfully(ctx context.Context, commandText string) error {
+	if err := sc.runAndRecord(ctx, commandText); err != nil {
+		return err
+	}
+	return sc.commandExitCodeShouldBe(0)
+}
+
 // runAndRecordWith interpolates, executes via the supplied runner method
 // (Run or RunWithTTY), and stores the Result on the ScenarioContext so
 // later assertions can read it. The non-zero-exit-is-not-a-failure
@@ -112,11 +131,10 @@ func combinedOutput(r harness.Result) string {
 // iExportCommandOutputToEnv records the previous command's trimmed
 // stdout under the named env var. Strict gates:
 //
-//   - LastResult.ExitCode must be 0. A non-zero exit on the prior step
-//     should already have failed an explicit "Then the command exit code
-//     should be 0" assertion, so reaching this step with a non-zero
-//     exit means the feature author forgot to assert success; surface
-//     it rather than exporting garbage.
+//   - LastResult.ExitCode must be 0. A non-zero exit on the prior step should
+//     already have failed an explicit exit-code assertion or a successful-run
+//     step. Reaching this step with a non-zero exit means the feature author
+//     forgot to assert success, so surface it rather than exporting garbage.
 //   - The trimmed stdout must be non-empty. Exporting an empty string
 //     would silently allow downstream "${VAR}" interpolation to expand
 //     to "" and produce malformed kubectl URLs (-n -o instead of

--- a/tests/bdd/steps/context.go
+++ b/tests/bdd/steps/context.go
@@ -39,11 +39,11 @@ import (
 // suite (so the Ledger and CommandCache persist); LastResult,
 // LastErr, and LastCommand are reset per scenario inside the Before
 // hook installed by RegisterAll. LastCommand tracks the resolved text
-// of the most recent command executed in this scenario; a successful
-// "the command exit code should be 0" assertion uses it to seed the
-// suite-level CommandCache so a subsequent "Given command has
-// succeeded:" for the same resolved text hits the cache instead of
-// rerunning a destructive command.
+// of the most recent command executed in this scenario. A successful-run step
+// or an explicit "the command exit code should be 0" assertion uses it to seed
+// the suite-level CommandCache so a subsequent "Given command has succeeded:"
+// for the same resolved text hits the cache instead of rerunning a destructive
+// command.
 type ScenarioContext struct {
 	Suite       *harness.Suite
 	LastResult  harness.Result

--- a/tests/bdd/steps/steps_test.go
+++ b/tests/bdd/steps/steps_test.go
@@ -202,6 +202,52 @@ func TestIRunCommandRecordsResult(t *testing.T) {
 	}
 }
 
+func TestISuccessfullyRunCommandLineRecordsResultAndCaches(t *testing.T) {
+	sc, fake := newScenarioContext(t)
+	t.Setenv("EXAMPLE_VAR", "value")
+	fake.result = harness.Result{ExitCode: 0, Stdout: "ok"}
+	if err := sc.iSuccessfullyRunCommandLine(context.Background(), "echo ${EXAMPLE_VAR}"); err != nil {
+		t.Fatalf("run successfully: %v", err)
+	}
+	if sc.LastResult.Stdout != "ok" {
+		t.Fatalf("last stdout = %q", sc.LastResult.Stdout)
+	}
+	if sc.LastCommand != "echo value" {
+		t.Fatalf("last command = %q, want resolved command", sc.LastCommand)
+	}
+	if !sc.Suite.Cache.Has("echo value") {
+		t.Fatal("successful command was not recorded in cache")
+	}
+}
+
+func TestISuccessfullyRunCommandDocPreservesOutput(t *testing.T) {
+	sc, fake := newScenarioContext(t)
+	fake.result = harness.Result{ExitCode: 0, Stdout: "rendered output"}
+	doc := &godog.DocString{Content: "make template"}
+	if err := sc.iSuccessfullyRunCommandDoc(context.Background(), doc); err != nil {
+		t.Fatalf("run successfully: %v", err)
+	}
+	if err := sc.commandOutputShouldContain("rendered output"); err != nil {
+		t.Fatalf("assert preserved output: %v", err)
+	}
+}
+
+func TestISuccessfullyRunCommandRejectsNonZeroExit(t *testing.T) {
+	sc, fake := newScenarioContext(t)
+	fake.result = harness.Result{ExitCode: 2, Stderr: "failed"}
+	fake.err = errors.New("command failed: exit status 2")
+	err := sc.iSuccessfullyRunCommandLine(context.Background(), "make install")
+	if err == nil {
+		t.Fatal("expected non-zero command to fail the step")
+	}
+	if sc.LastResult.ExitCode != 2 {
+		t.Fatalf("last exit code = %d, want 2", sc.LastResult.ExitCode)
+	}
+	if sc.Suite.Cache.Has("make install") {
+		t.Fatal("failed command was recorded in cache")
+	}
+}
+
 // TestIRunCommandWithTTYDocRecordsResult verifies the pty-backed run form
 // wires through RunWithTTY and records the result like the plain docstring
 // form. The fake runner ignores the TTY and resolves identically.
@@ -484,12 +530,16 @@ func TestRegisterAllRunsAFeatureFile(t *testing.T) {
 	feature := `Feature: Smoke
   Scenario: register-all smoke
     Given environment variable "BDD_TMP_SMOKE" is set
-    When I run command "echo smoke"
-    Then the command exit code should be 0
+    When I successfully run command "echo smoke"
+    And I successfully run command:
+      """
+      echo documented
+      """
+    Then the command output should contain "documented"
 `
 	t.Setenv("BDD_TMP_SMOKE", "ready")
 	sc, fake := newScenarioContext(t)
-	fake.result = harness.Result{ExitCode: 0, Stdout: "smoke\n"}
+	fake.result = harness.Result{ExitCode: 0, Stdout: "smoke documented\n"}
 
 	suite := godog.TestSuite{
 		Name: "smoke",


### PR DESCRIPTION
## TL;DR

Adds line and docstring forms of `When I successfully run command`, removing mechanical exit-zero assertions while keeping the command and its meaningful inputs visible.

## Additional Details

- Preserves the resolved command, exit result, stdout, stderr, interpolation, and command logging.
- Seeds the existing successful-command cache only after exit code 0.
- Migrates the control observability install and collector readback. Negative resource checks keep their explicit exit-code assertions.
- Updates the BDD guidance and DSL catalog with the common-operation abstraction criteria.

Customer release notes: Not customer visible.

Plan summary: Not applicable.

Dependencies: None. No license or NOTICE changes.

Related Pull Request: #866

## For the Reviewer

Please focus on the cache and result-preservation behavior in `steps/command_steps.go` and whether the migrated Gherkin keeps the operator action clear.

## For QA

Passed:

- `go test -short ./...` from `tests/bdd`
- `tests/bdd/scripts/lint.sh`
- `BDD_CLEANUP_MODE=stack-single go test -timeout 30m -run '^TestObservabilityControl$' -count=1 -v .` against an isolated `k3d-ncp-local` kubeconfig (`1` scenario and `29` steps passed in `11m18s`)

The first live attempt encountered a transient NGC 403 for one chart. A direct authenticated pull succeeded, and the final clean-stack rerun passed.

QA needed: No separate QA.

## Issues

Closes #859

Relates to #858

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added single-line and multiline steps for running commands that must complete successfully.
  * Command output and resolved values are retained for subsequent assertions.
  * Successful commands can be reused through caching, while failed commands are rejected.

* **Tests**
  * Added coverage for variable substitution, output preservation, caching, failure handling, and combined command execution.

* **Documentation**
  * Clarified how successful command execution and recorded results support later checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->