### PR TITLE
fix(cli): use JWT ahead of API key for Admin Accounts requests

### DIFF
--- a/src/clis/nvcf-cli/internal/client/multi_token_transport.go
+++ b/src/clis/nvcf-cli/internal/client/multi_token_transport.go
@@ -26,6 +26,7 @@ import (
 const (
 	deploymentPathSegment     = "/deployments/"
 	functionVersionPathPrefix = "/v2/nvcf/functions/"
+	accountsPathPrefix        = "/v2/nvcf/accounts"
 )
 
 // multiTokenTransport is an HTTP transport that uses different tokens for different operations
@@ -58,14 +59,19 @@ func (m *multiTokenTransport) RoundTrip(req *http.Request) (*http.Response, erro
 	var token string
 	var expectedScope string
 	clusterManagementOperation := m.isClusterManagementOperation(req)
+	accountManagementOperation := isAccountManagementOperation(req.Method, req.URL.Path)
 	isAdminOperation := m.isAdminOperation(req)
 
 	if isAdminOperation && m.functionToken != "" {
 		token = m.functionToken
-		if clusterManagementOperation {
+		switch {
+		case clusterManagementOperation:
 			expectedScope = "cluster-management"
 			log.Printf("DEBUG: Using ADMIN JWT (cluster-management operation) for %s %s - expects scope: %s", req.Method, req.URL.Path, expectedScope)
-		} else {
+		case accountManagementOperation:
+			expectedScope = "account_setup"
+			log.Printf("DEBUG: Using ADMIN JWT (account management operation) for %s %s - expects scope: %s", req.Method, req.URL.Path, expectedScope)
+		default:
 			expectedScope = "register_function, deploy_function, delete_function, update_function, etc."
 			log.Printf("DEBUG: Using FUNCTION TOKEN (function operation) for %s %s - expects scope: %s", req.Method, req.URL.Path, expectedScope)
 		}
@@ -101,6 +107,7 @@ func (m *multiTokenTransport) isAdminOperation(req *http.Request) bool {
 		isRegistryCredentialManagement(path) ||
 		isSecretUpdate(method, path) ||
 		isTelemetryManagement(path) ||
+		isAccountManagementOperation(method, path) ||
 		m.isClusterManagementOperation(req)
 }
 
@@ -156,6 +163,23 @@ func (m *multiTokenTransport) isClusterManagementOperation(req *http.Request) bo
 		return true
 	}
 	return strings.Contains(path, "/v1/nvca/clusters")
+}
+
+// isAccountManagementOperation checks if this request is an Admin Accounts
+// operation (list or update NVIDIA Cloud Accounts). These are scoped
+// `account_setup`, which currently lives only in the JWT (NVCF_TOKEN);
+// NVCF_API_KEY support is temporary and must not be selected ahead of it.
+// Sub-resources such as .../secrets/... and .../queues/... have their own
+// scopes and are matched separately, so they are excluded here.
+func isAccountManagementOperation(method, path string) bool {
+	if method == "GET" && path == accountsPathPrefix {
+		return true
+	}
+	if method != "PATCH" || !strings.HasPrefix(path, accountsPathPrefix+"/") {
+		return false
+	}
+	rest := strings.TrimPrefix(path, accountsPathPrefix+"/")
+	return rest != "" && !strings.Contains(rest, "/")
 }
 
 // getExpectedUserScope returns the expected scope for user operations (for debugging)

--- a/src/clis/nvcf-cli/internal/client/multi_token_transport_test.go
+++ b/src/clis/nvcf-cli/internal/client/multi_token_transport_test.go
@@ -131,6 +131,37 @@ func TestMultiTokenTransportIsAdminOperation(t *testing.T) {
 			reason:   "Delete is cluster-management scope",
 		},
 
+		// Admin Accounts — must use JWT (account_setup scope) even when an
+		// API key is present; API-key support for account_setup is temporary.
+		{
+			name:     "Admin accounts list",
+			method:   "GET",
+			path:     "/v2/nvcf/accounts",
+			expected: true,
+			reason:   "List accounts requires account_setup scope (JWT)",
+		},
+		{
+			name:     "Admin accounts update",
+			method:   "PATCH",
+			path:     "/v2/nvcf/accounts/nvcf-default",
+			expected: true,
+			reason:   "Update account requires account_setup scope (JWT)",
+		},
+		{
+			name:     "Admin accounts secrets sub-resource",
+			method:   "PUT",
+			path:     "/v2/nvcf/accounts/nvcf-default/secrets/functions/id/versions/vid",
+			expected: true,
+			reason:   "Already covered by isSecretUpdate (update_secrets scope), not account_setup",
+		},
+		{
+			name:     "Admin accounts queues sub-resource",
+			method:   "GET",
+			path:     "/v2/nvcf/accounts/nvcf-default/queues/functions/id",
+			expected: false,
+			reason:   "Queue details are not account_setup scoped and are unaffected by this check",
+		},
+
 		// USER OPERATIONS - Should use API KEY
 		{
 			name:     "Get function details",
@@ -395,6 +426,33 @@ func TestTokenSelectionPriority(t *testing.T) {
 			expectedToken: "Bearer jwt-token",
 			description:   "Per-spec deployment update is admin; must use function token even when API key present",
 		},
+		{
+			name:          "Admin accounts list with both tokens - use JWT",
+			apiKey:        "api-key",
+			functionToken: "jwt-token",
+			requestMethod: "GET",
+			requestPath:   "/v2/nvcf/accounts",
+			expectedToken: "Bearer jwt-token",
+			description:   "account_setup is JWT-only; API key must not be picked ahead of it",
+		},
+		{
+			name:          "Admin accounts update with both tokens - use JWT",
+			apiKey:        "api-key",
+			functionToken: "jwt-token",
+			requestMethod: "PATCH",
+			requestPath:   "/v2/nvcf/accounts/nvcf-default",
+			expectedToken: "Bearer jwt-token",
+			description:   "account_setup is JWT-only; API key must not be picked ahead of it",
+		},
+		{
+			name:          "Admin accounts list without JWT - fall back to API key",
+			apiKey:        "api-key",
+			functionToken: "",
+			requestMethod: "GET",
+			requestPath:   "/v2/nvcf/accounts",
+			expectedToken: "Bearer api-key",
+			description:   "API-key support for account_setup is temporary; still used when no JWT is configured",
+		},
 	}
 
 	for _, tt := range tests {
@@ -471,5 +529,44 @@ func TestMultiTokenTransportLogsClusterManagementForSISDelete(t *testing.T) {
 	}
 	if strings.Contains(got, "function operation") {
 		t.Fatalf("ICMS delete must not be logged as a function operation: %q", got)
+	}
+}
+
+func TestMultiTokenTransportLogsAccountManagementForAccountsList(t *testing.T) {
+	var logs bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(prev) })
+
+	mockBase := &mockRoundTripper{}
+	transport := &multiTokenTransport{
+		apiKey:        "api-key",
+		functionToken: "jwt-token",
+		base:          mockBase,
+	}
+	reqURL, err := url.Parse("https://api.nvcf.example.test/v2/nvcf/accounts")
+	if err != nil {
+		t.Fatalf("Failed to parse URL: %v", err)
+	}
+	req := &http.Request{
+		Method: http.MethodGet,
+		URL:    reqURL,
+		Header: make(http.Header),
+	}
+
+	_, err = transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip failed: %v", err)
+	}
+
+	if mockBase.capturedAuth != "Bearer jwt-token" {
+		t.Fatalf("expected admin accounts list to use admin JWT even with an API key present, got %q", mockBase.capturedAuth)
+	}
+	got := logs.String()
+	if !strings.Contains(got, "account_setup") {
+		t.Fatalf("expected account_setup auth log, got %q", got)
+	}
+	if strings.Contains(got, "fallback") {
+		t.Fatalf("admin accounts list must not be logged as a fallback: %q", got)
 	}
 }


### PR DESCRIPTION
## TL;DR
Fixes `nvcf-cli admin accounts` commands (`list`, `update`) picking `NVCF_API_KEY` ahead of `NVCF_TOKEN`, even though `account_setup` scope is only meant to live in the JWT.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
`multiTokenTransport.RoundTrip` selects a credential per-request based on `isAdminOperation`, a set of path/method predicates covering function create/deploy/delete/update, registry-credentials, secret-update, telemetry-management, and cluster-management. `GET /v2/nvcf/accounts` and `PATCH /v2/nvcf/accounts/{ncaId}` (the Admin Accounts endpoints, scoped `account_setup`) weren't in that set, so they fell through to the API-key-first branch and only used `NVCF_TOKEN` as a last-resort fallback when no API key was configured. With `--debug`, this showed as `Using FUNCTION TOKEN (fallback) ... - API key not available` instead of an explicit admin-JWT selection.

Added `isAccountManagementOperation(method, path)`, matching only the accounts collection/resource endpoints (not sub-resources like `.../secrets/...` or `.../queues/...`, which already have their own scope handling), and wired it into `isAdminOperation` so Admin Accounts requests take the JWT-first branch like cluster-management requests do. Gave it a dedicated debug-log branch (`Using ADMIN JWT (account management operation) ... - expects scope: account_setup`) instead of the generic function-operation message. The API-key fallback is preserved for when no JWT is configured, since API-key support for `account_setup` is described as temporary rather than to be removed outright.

## For the Reviewer
Main change is in `src/clis/nvcf-cli/internal/client/multi_token_transport.go` (`isAccountManagementOperation`, `isAdminOperation`, `RoundTrip`'s debug-log switch). Tests added in `multi_token_transport_test.go`.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
- New unit tests covering: `isAdminOperation` classification for accounts list/update (true) vs. secrets/queues sub-resources (secrets already true via existing scope, queues correctly false), token-selection priority (JWT wins over API key for accounts list/update; API key still used as fallback when no JWT is configured), and a log-content test asserting the `account_setup` label appears and `fallback` does not.
- `go build ./...` and `go test ./internal/client/... ./cmd/...` pass.
- Verified live against a local self-managed k3d cluster: reproduced the original bug on the pre-fix binary (`admin accounts list --debug` with only `NVCF_TOKEN` set showed `Using FUNCTION TOKEN (fallback)`), then confirmed the fixed binary logs `Using ADMIN JWT (account management operation)` in that same scenario, and that with both `NVCF_TOKEN` and a fake `NVCF_API_KEY` set, the fixed binary still prefers the JWT (and the fake API key is never sent) for both `admin accounts list` and `admin accounts update`.

## Issues
NO-REF

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes. (no user-facing docs changes needed; behavior now matches documented scope requirements)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account-management request handling for account listings and individual account updates.
  * Ensured these operations use the appropriate administrative authentication when available, with API-key fallback support.
  * Preserved separate authentication behavior for account secrets and queue operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->