### PR TITLE
perf(http-invocation): reduce function_request_latency histogram buckets

### DIFF
--- a/src/invocation-plane-services/http-invocation/crates/server/src/metrics/mod.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/src/metrics/mod.rs
@@ -62,8 +62,9 @@ const SECONDS_DURATION_BUCKETS: &[f64; 15] = &[
     0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 1000.0,
 ];
 
-// Buckets tuned for AI inference latency: coarser resolution reduces series count
-// while preserving visibility at p50/p95/p99 thresholds that matter operationally.
+// Reduces each (function_id, function_version_id) histogram from 18 to 12 series
+// (15 to 9 finite buckets, plus +Inf, sum, and count), a 33.3% reduction, while
+// preserving useful resolution for AI inference latency.
 const FUNCTION_REQUEST_LATENCY_BUCKETS_IN_SECONDS: &[f64; 9] = &[
     0.5, 1.0, 5.0, 10.0, 30.0, 60.0, 300.0, 600.0, 1800.0,
 ];
@@ -354,6 +355,14 @@ mod tests {
     use super::*;
     use metrics_util::debugging::{DebugValue, DebuggingRecorder};
     use metrics_util::MetricKind;
+
+    #[test]
+    fn function_request_latency_uses_expected_buckets() {
+        assert_eq!(
+            FUNCTION_REQUEST_LATENCY_BUCKETS_IN_SECONDS,
+            &[0.5, 1.0, 5.0, 10.0, 30.0, 60.0, 300.0, 600.0, 1800.0]
+        );
+    }
 
     #[test]
     fn invocation_latency_omits_nca_id() {

--- a/src/invocation-plane-services/http-invocation/crates/server/src/metrics/mod.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/src/metrics/mod.rs
@@ -62,9 +62,10 @@ const SECONDS_DURATION_BUCKETS: &[f64; 15] = &[
     0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 1000.0,
 ];
 
-// define time bucket for FUNCTION_REQUEST_LATENCY in the same way we're doing in the Java code
-const FUNCTION_REQUEST_LATENCY_BUCKETS_IN_SECONDS: &[f64; 15] = &[
-    0.1, 0.25, 0.5, 1.0, 1.5, 2.0, 3.0, 6.0, 20.0, 60.0, 120.0, 300.0, 600.0, 1200.0, 1800.0,
+// Buckets tuned for AI inference latency: coarser resolution reduces series count
+// while preserving visibility at p50/p95/p99 thresholds that matter operationally.
+const FUNCTION_REQUEST_LATENCY_BUCKETS_IN_SECONDS: &[f64; 9] = &[
+    0.5, 1.0, 5.0, 10.0, 30.0, 60.0, 300.0, 600.0, 1800.0,
 ];
 
 const FUNCTION_REQUEST_LATENCY: Metric = Metric {


### PR DESCRIPTION
## Why

The `function_request_latency_bucket` histogram had 15 finite buckets. Each
unique `(function_id, function_version_id)` combination produces
`num_buckets + 3` Prometheus series: the finite buckets, the mandatory `+Inf`
bucket, `_sum`, and `_count`. At scale with many active function versions, this
generates unnecessary series volume. The sub-second buckets (0.1s and 0.25s)
are not actionable for AI inference workloads, and there was no bucket between
6s and 20s.

## What changed

- Reduced `FUNCTION_REQUEST_LATENCY_BUCKETS_IN_SECONDS` from 15 to 9 finite buckets
- New set: `0.5, 1.0, 5.0, 10.0, 30.0, 60.0, 300.0, 600.0, 1800.0`
- Covers the full inference latency range at operationally meaningful thresholds
- Reduces Prometheus series per function version from 18 to 12, a 33.3% reduction

## Testing

`bazel test //src/invocation-plane-services/http-invocation/crates/server:nvcf_invocation_service_test --flaky_test_attempts=3`

## References

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI inference request latency metrics with nine broader measurement ranges spanning 0.5 to 1,800 seconds.
  * These updated ranges make latency trends easier to interpret and reduce unnecessary detail in monitoring data.
  * Added validation to ensure the reported latency measurements consistently use the intended ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
