### PR TITLE
fix(ci): keep fork content away from the Fern docs token

### DIFF
--- a/.github/workflows/fern-docs-preview-comment.yml
+++ b/.github/workflows/fern-docs-preview-comment.yml
@@ -88,22 +88,42 @@ jobs:
             # should not be pulled into memory.
             value=$(head -c 512 "$path")
             value=${value%$'\n'}
-            if printf '%s' "$value" | LC_ALL=C grep -q '[[:cntrl:]]'; then
-              echo "::error::$path contains control characters" >&2
-              return 1
-            fi
+            # Match with bash, not grep. grep splits its input on LF, so a
+            # bracket expression can never match one, and an anchored pattern
+            # matches if any single line matches. LF is precisely the
+            # $GITHUB_OUTPUT injection character, so a grep-based guard passes
+            # the one input it most needs to reject. Bash patterns have no
+            # concept of a line and test the whole string.
+            case $value in
+              *[[:cntrl:]]*)
+                echo "::error::$path contains control characters" >&2
+                return 1
+                ;;
+            esac
             printf '%s' "$value"
           }
 
           pr_number=$(read_one_line preview-metadata/pr_number)
           head_ref=$(read_one_line preview-metadata/head_ref)
 
-          if ! printf '%s' "$pr_number" | grep -Eq '^[0-9]{1,10}$'; then
+          # Same reason as above: bash =~ anchors against the whole string,
+          # where grep -E '^...$' would anchor per line.
+          if ! [[ $pr_number =~ ^[0-9]{1,10}$ ]]; then
             echo "::error::pr_number from the artifact is not a plain number"
             exit 1
           fi
           # git decides what a valid ref is. A character-class pattern accepted
           # ../evil, foo//bar, /foo, foo/ and -x, all of which git rejects.
+          # Reject a leading dash before git sees it. check-ref-format has no
+          # -- separator, so it would parse the value as an option and exit on
+          # a usage error: the right verdict reached by accident, and one that
+          # would silently change if git ever grew a matching option.
+          case $head_ref in
+            -*)
+              echo "::error::head_ref from the artifact starts with a dash"
+              exit 1
+              ;;
+          esac
           if ! git check-ref-format --allow-onelevel "$head_ref"; then
             echo "::error::head_ref from the artifact is not a valid git ref"
             exit 1

--- a/.github/workflows/fern-docs-preview-comment.yml
+++ b/.github/workflows/fern-docs-preview-comment.yml
@@ -72,17 +72,43 @@ jobs:
           # to $GITHUB_OUTPUT unchecked, a value containing a newline injects
           # further outputs: a crafted head_ref could set preview_url, and
           # pr_number is interpolated into a gh api path, so it could redirect the
-          # comment elsewhere. Read one line and require a known-safe shape.
-          pr_number=$(head -n1 preview-metadata/pr_number | tr -d '\r')
-          head_ref=$(head -n1 preview-metadata/head_ref | tr -d '\r')
-          if ! printf '%s' "$pr_number" | grep -Eq '^[0-9]+$'; then
-            echo "::error::pr_number from the artifact is not a number"
+          # comment elsewhere.
+          #
+          # Reject, do not normalise. Stripping carriage returns turns
+          # "123\r456" into "123456", which is a different pull request that
+          # still passes a digits check, so the sanitiser would launder the input
+          # rather than refuse it. Anything but a single clean line is an error.
+          read_one_line() {
+            path="$1"
+            if [ ! -f "$path" ]; then
+              echo "::error::missing $path in the artifact" >&2
+              return 1
+            fi
+            # Read a bounded amount: the artifact is untrusted, so a huge file
+            # should not be pulled into memory.
+            value=$(head -c 512 "$path")
+            value=${value%$'\n'}
+            if printf '%s' "$value" | LC_ALL=C grep -q '[[:cntrl:]]'; then
+              echo "::error::$path contains control characters" >&2
+              return 1
+            fi
+            printf '%s' "$value"
+          }
+
+          pr_number=$(read_one_line preview-metadata/pr_number)
+          head_ref=$(read_one_line preview-metadata/head_ref)
+
+          if ! printf '%s' "$pr_number" | grep -Eq '^[0-9]{1,10}$'; then
+            echo "::error::pr_number from the artifact is not a plain number"
             exit 1
           fi
-          if ! printf '%s' "$head_ref" | grep -Eq '^[A-Za-z0-9._/-]{1,255}$'; then
-            echo "::error::head_ref from the artifact is not a plain git ref"
+          # git decides what a valid ref is. A character-class pattern accepted
+          # ../evil, foo//bar, /foo, foo/ and -x, all of which git rejects.
+          if ! git check-ref-format --allow-onelevel "$head_ref"; then
+            echo "::error::head_ref from the artifact is not a valid git ref"
             exit 1
           fi
+
           echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
           echo "head_ref=$head_ref" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/fern-docs-preview-comment.yml
+++ b/.github/workflows/fern-docs-preview-comment.yml
@@ -17,8 +17,14 @@
 #
 # Triggered by workflow_run after "Preview Fern Docs: Build" completes.
 # Downloads the fern/ artifact, builds a preview with DOCS_FERN_TOKEN, and
-# posts a stable :herb: comment on the PR. This workflow never checks out the
-# PR branch directly, keeping secrets isolated from untrusted code.
+# posts a stable :herb: comment on the PR.
+#
+# Not checking out the PR branch is not by itself sufficient. The artifact IS
+# the PR branch content, and `fern generate` processes it with DOCS_FERN_TOKEN
+# in the environment, so a fork could have its docs.yml and API specs handled
+# by a privileged process holding the token. The job is therefore restricted to
+# pull requests from this repository; a fork gets no preview rather than a
+# preview built with a secret.
 #
 # Required configuration:
 # - Organization secret: DOCS_FERN_TOKEN (from `fern token` for the nvidia Fern org)
@@ -42,7 +48,14 @@ jobs:
   preview:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # A fork must never reach DOCS_FERN_TOKEN. workflow_run runs privileged with
+    # repository secrets, and the artifact it consumes is built from the PR
+    # branch, so this is the boundary that keeps untrusted content away from the
+    # token. head_repository is the repository the PR branch lives in.
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success'
+          && github.event.workflow_run.event == 'pull_request'
+          && github.event.workflow_run.head_repository.full_name == github.repository }}
     steps:
       - name: Download fern sources and metadata
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -54,8 +67,24 @@ jobs:
       - name: Read PR metadata
         id: metadata
         run: |
-          echo "pr_number=$(cat preview-metadata/pr_number)" >> "$GITHUB_OUTPUT"
-          echo "head_ref=$(cat preview-metadata/head_ref)" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          # These files come from the artifact, which is PR branch content. Written
+          # to $GITHUB_OUTPUT unchecked, a value containing a newline injects
+          # further outputs: a crafted head_ref could set preview_url, and
+          # pr_number is interpolated into a gh api path, so it could redirect the
+          # comment elsewhere. Read one line and require a known-safe shape.
+          pr_number=$(head -n1 preview-metadata/pr_number | tr -d '\r')
+          head_ref=$(head -n1 preview-metadata/head_ref | tr -d '\r')
+          if ! printf '%s' "$pr_number" | grep -Eq '^[0-9]+$'; then
+            echo "::error::pr_number from the artifact is not a number"
+            exit 1
+          fi
+          if ! printf '%s' "$head_ref" | grep -Eq '^[A-Za-z0-9._/-]{1,255}$'; then
+            echo "::error::head_ref from the artifact is not a plain git ref"
+            exit 1
+          fi
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$head_ref" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
## Why

Jackalope SAST finding `db4abaeb-7aa8-4540-88f9-e2f289a0e1a8`, `.github/workflows/fern-docs-preview-comment.yml:78`, exploitability medium.

`fern-docs-preview-build.yml` triggers on `pull_request`, so it runs for forks, and uploads the PR branch's `fern/` and `docs/` as an artifact. `fern-docs-preview-comment.yml` triggers on `workflow_run`, which is privileged and holds repository secrets, downloads that artifact, and runs `fern generate --docs --preview` with `DOCS_FERN_TOKEN` in the environment. It then sends the same token as a header to a URL derived from that run's output.

The workflow's own header claimed it "never checks out the PR branch directly, keeping secrets isolated from untrusted code". The finding is right that this does not hold: the artifact **is** the PR branch content. The `npm install -g fern-api@${VERSION}` is semver-validated, but the config the Fern CLI then processes is not.

## What changed

The preview job is restricted to pull requests opened from this repository:

```yaml
github.event.workflow_run.conclusion == 'success'
  && github.event.workflow_run.event == 'pull_request'
  && github.event.workflow_run.head_repository.full_name == github.repository
```

A fork now gets no preview rather than a preview built with a secret. The misleading header comment is corrected rather than left for the next reader to trust.

**A second issue not in the report.** The metadata step read `pr_number` and `head_ref` straight from the artifact into `$GITHUB_OUTPUT`:

```
echo "pr_number=$(cat preview-metadata/pr_number)" >> "$GITHUB_OUTPUT"
```

Those files are attacker-controlled. A value containing a newline injects further step outputs — a crafted `head_ref` could set `preview_url`, which is later used to build the comment and as the target of the token-bearing `curl`. `pr_number` is interpolated into `gh api repos/.../issues/${PR_NUMBER}/comments`, so a crafted value could direct the comment elsewhere. Both are now read as a single line and required to match a known-safe shape, failing loudly otherwise.

## Plan Summary

No change to what the preview does for internal pull requests. Fork pull requests stop receiving a docs preview comment.

## Testing

The workflow parses as YAML and the job keys are unchanged. The validation was exercised against a plain number, a newline-injection payload, and a path-traversal value; only the first is accepted.

The fork restriction cannot be exercised without opening a fork pull request. It is a standard `workflow_run` guard and is the mitigation the finding recommends.

## Notes

This trades a feature for the token: contributors working from forks lose the preview comment. That is the intended outcome — a fork cannot be given a secret safely, and the alternative of sandboxing the Fern CLI is far more work for a docs preview.

Worth a follow-up beyond this finding: `fern-docs-ci.yml` and `publish-fern-docs.yml` were not reviewed here and may have the same shape.

## References

Jackalope finding `db4abaeb-7aa8-4540-88f9-e2f289a0e1a8`.

## Dependencies

None.

Github commit:
fix(ci): keep fork content away from the Fern docs token

Restrict the privileged preview job to pull requests from this
repository, and validate artifact-supplied metadata before it becomes a
step output.

Co-authored-by: Balaji Ganesan <bganesan@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation preview workflow security by restricting execution to successful pull requests from the same repository.
  * Added validation for pull request metadata to prevent malformed, oversized, multiline, or unsafe values from being processed.
  * Invalid or missing metadata now causes the workflow to fail safely, preventing unreliable preview comments and protecting documentation preview credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->