### PR TITLE
fix(llm-gateway): stop returning gRPC auth errors to callers

### DIFF
--- a/src/invocation-plane-services/llm-api-gateway/api/auth_middleware.go
+++ b/src/invocation-plane-services/llm-api-gateway/api/auth_middleware.go
@@ -146,23 +146,38 @@ func rateLimitSubjectKey(rateLimitKey string, projectID string, routingKey strin
 	return fmt.Sprintf("nvcf:%s:routing_key:%s", rateLimitKey, routingKey)
 }
 
+// nvcfAuthHTTPError maps an auth gRPC error onto an HTTP response.
+//
+// The messages are deliberately generic. A gRPC error stringifies to something
+// like:
+//
+//	rpc error: code = Unavailable desc = connection error: desc = "transport:
+//	Error while dialing dial tcp 10.0.0.5:9090: connect: connection refused"
+//
+// so returning err.Error() handed every caller the auth service's address, port
+// and dial state. This path is reachable before authentication succeeds, so
+// that was available to anyone who could reach the gateway.
+//
+// The status code still carries what a caller can act on. The detail is not
+// lost: the call site records the original error on the span before calling
+// this, so it stays in traces for debugging.
 func nvcfAuthHTTPError(err error) error {
 	switch status.Code(err) {
 	case codes.OK:
 		return nil
 	case codes.InvalidArgument:
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
 	case codes.Unauthenticated:
-		return echo.NewHTTPError(http.StatusUnauthorized, err.Error())
+		return echo.NewHTTPError(http.StatusUnauthorized, "authentication failed")
 	case codes.PermissionDenied:
-		return echo.NewHTTPError(http.StatusForbidden, err.Error())
+		return echo.NewHTTPError(http.StatusForbidden, "permission denied")
 	case codes.NotFound:
-		return echo.NewHTTPError(http.StatusNotFound, err.Error())
+		return echo.NewHTTPError(http.StatusNotFound, "not found")
 	case codes.DeadlineExceeded:
-		return echo.NewHTTPError(http.StatusGatewayTimeout, err.Error())
+		return echo.NewHTTPError(http.StatusGatewayTimeout, "authentication timed out")
 	case codes.Unavailable:
-		return echo.NewHTTPError(http.StatusServiceUnavailable, err.Error())
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "authentication service unavailable")
 	default:
-		return echo.NewHTTPError(http.StatusBadGateway, err.Error())
+		return echo.NewHTTPError(http.StatusBadGateway, "authentication failed")
 	}
 }

--- a/src/invocation-plane-services/llm-api-gateway/api/auth_middleware_test.go
+++ b/src/invocation-plane-services/llm-api-gateway/api/auth_middleware_test.go
@@ -425,3 +425,29 @@ func (s *stubInvocationAuthClient) AuthorizeInvocation(
 	s.authorizeRoutingKey = routingKey
 	return s.authResponse, nil
 }
+
+func TestNVCFAuthHTTPErrorDoesNotLeakTransportDetail(t *testing.T) {
+	t.Parallel()
+
+	// The shape a real dial failure takes. Returned verbatim, it handed callers
+	// the auth service's address and port on a pre-authentication path.
+	transportErr := status.Error(codes.Unavailable,
+		`connection error: desc = "transport: Error while dialing dial tcp 10.0.0.5:9090: connect: connection refused"`)
+
+	for _, err := range []error{
+		transportErr,
+		status.Error(codes.Internal, "panic in authorize: /opt/nvcf/internal/auth.go:412"),
+		status.Error(codes.DeadlineExceeded, "context deadline exceeded talking to auth.nvcf.svc.cluster.local:9090"),
+	} {
+		he, ok := nvcfAuthHTTPError(err).(*echo.HTTPError)
+		if !ok {
+			t.Fatalf("want *echo.HTTPError, got %T", nvcfAuthHTTPError(err))
+		}
+		msg, _ := he.Message.(string)
+		for _, leak := range []string{"10.0.0.5", "9090", "rpc error", "svc.cluster.local", "/opt/nvcf", "dial tcp"} {
+			if strings.Contains(msg, leak) {
+				t.Errorf("response message leaks %q: %s", leak, msg)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Why

Jackalope SAST finding `665d0beb-206a-4d57-80ca-c7f5735774f5`, `auth_middleware.go:139`, exploitability high.

`nvcfAuthHTTPError` returned `err.Error()` as the HTTP response message for every gRPC code. A gRPC error stringifies to:

```
rpc error: code = Unavailable desc = connection error: desc = "transport:
Error while dialing dial tcp 10.0.0.5:9090: connect: connection refused"
```

so a caller received the auth service's address, port and dial state. This path runs before authentication succeeds, so it was reachable by anyone who could reach the gateway. That is what makes it worse than a typical verbose-error finding: no credential is needed to collect the information.

## What changed

The messages are now generic; the status codes are untouched, since the code is what a caller can act on.

| code | status | message |
|---|---|---|
| InvalidArgument | 400 | invalid request |
| Unauthenticated | 401 | authentication failed |
| PermissionDenied | 403 | permission denied |
| NotFound | 404 | not found |
| DeadlineExceeded | 504 | authentication timed out |
| Unavailable | 503 | authentication service unavailable |
| other | 502 | authentication failed |

Nothing is lost for debugging. The call site already does `span.RecordError(err)` before calling this, so the original error stays in traces.

## Plan Summary

No behaviour change beyond response text. Callers keyed on status codes are unaffected; a caller parsing the message body for detail would see less, which is the intent.

## Testing

`go build ./...` and `go test ./...` pass for the service.

The existing `TestNVCFAuthHTTPErrorMapsCodes` only asserted status codes, so it passed against the leak and would have kept passing. Added `TestNVCFAuthHTTPErrorDoesNotLeakTransportDetail`, which feeds realistic transport, panic and deadline errors and asserts the response carries no address, port, internal path, cluster DNS name or `rpc error` framing.

Confirmed the new test fails against the previous handler:

```
response message leaks "10.0.0.5": rpc error: code = Unavailable desc = ...
response message leaks "9090": ...
response message leaks "rpc error": ...
```

## Notes

Worth checking whether other services map upstream errors the same way; this pattern is easy to repeat and the existing test shape (status codes only) does not catch it.

## References

Jackalope finding `665d0beb-206a-4d57-80ca-c7f5735774f5`.

## Dependencies

None.

Github commit:
fix(llm-gateway): stop returning gRPC auth errors to callers

Return generic messages from the auth middleware; the gRPC error string
carried the auth service's address and port to unauthenticated callers.

Co-authored-by: Balaji Ganesan <bganesan@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication error responses by showing generic, status-specific messages instead of exposing internal technical details.
  - Preserved existing HTTP status code mappings.
  - Sensitive network addresses, service hostnames, filesystem paths, and connection details are no longer revealed in responses.
  - Detailed diagnostic information remains available through tracing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->