### PR TITLE
feat(stargate): configure cluster comparators

### DIFF
--- a/src/libraries/rust/stargate/crates/stargate/src/http_proxy/run.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/http_proxy/run.rs
@@ -171,14 +171,7 @@ impl<'a> ProxyRequestRun<'a> {
             self.app.metrics.as_ref(),
             &self.request.request_inputs.target,
         );
-        let comparator_trace = {
-            let request = self.load_balancer_request();
-            self.request
-                .lb_resolution
-                .config()
-                .comparator()
-                .map(|comparator| comparator.trace(&request, selected_cluster.cluster.snapshot()))
-        };
+        let comparator = self.request.lb_resolution.config().comparator();
 
         loop {
             self.record_routing_selection(RoutingTraceFields {
@@ -190,7 +183,7 @@ impl<'a> ProxyRequestRun<'a> {
                     .selection
                     .choice
                     .selected_after_kv_free_tokens_skip,
-                comparator: comparator_trace.as_ref(),
+                comparator,
                 cluster: selected_cluster.cluster.snapshot(),
                 chosen: &chosen,
             });

--- a/src/libraries/rust/stargate/crates/stargate/src/http_proxy/run.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/http_proxy/run.rs
@@ -182,6 +182,7 @@ impl<'a> ProxyRequestRun<'a> {
                     .selection
                     .choice
                     .selected_after_kv_free_tokens_skip,
+                comparator: selected_cluster.selection.comparator.as_ref(),
                 cluster: selected_cluster.cluster.snapshot(),
                 chosen: &chosen,
             });
@@ -442,6 +443,7 @@ mod tests {
             num_candidates: 1,
             rank_depth: 0,
             selected_after_kv_free_tokens_skip: false,
+            comparator: None,
             cluster: &cluster,
             chosen: &chosen,
         });
@@ -467,6 +469,7 @@ mod tests {
             },
             effective_algorithm: LoadBalancerAlgorithm::PowerOfN,
             requested_algorithm: None,
+            comparator: None,
         };
         let selected_cluster = SelectedClusterRun::new(
             RoutingTargetSnapshot::for_test(vec![cluster_candidate("cluster-a")]),

--- a/src/libraries/rust/stargate/crates/stargate/src/http_proxy/run.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/http_proxy/run.rs
@@ -171,6 +171,14 @@ impl<'a> ProxyRequestRun<'a> {
             self.app.metrics.as_ref(),
             &self.request.request_inputs.target,
         );
+        let comparator_trace = {
+            let request = self.load_balancer_request();
+            self.request
+                .lb_resolution
+                .config()
+                .comparator()
+                .map(|comparator| comparator.trace(&request, selected_cluster.cluster.snapshot()))
+        };
 
         loop {
             self.record_routing_selection(RoutingTraceFields {
@@ -182,7 +190,7 @@ impl<'a> ProxyRequestRun<'a> {
                     .selection
                     .choice
                     .selected_after_kv_free_tokens_skip,
-                comparator: selected_cluster.selection.comparator.as_ref(),
+                comparator: comparator_trace.as_ref(),
                 cluster: selected_cluster.cluster.snapshot(),
                 chosen: &chosen,
             });
@@ -469,7 +477,6 @@ mod tests {
             },
             effective_algorithm: LoadBalancerAlgorithm::PowerOfN,
             requested_algorithm: None,
-            comparator: None,
         };
         let selected_cluster = SelectedClusterRun::new(
             RoutingTargetSnapshot::for_test(vec![cluster_candidate("cluster-a")]),

--- a/src/libraries/rust/stargate/crates/stargate/src/http_proxy/trace.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/http_proxy/trace.rs
@@ -17,6 +17,7 @@ use axum::http::HeaderMap;
 use tracing::{Span, field};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
+use crate::load_balancer::ClusterComparatorTrace;
 use crate::routing_state::{RoutedClusterSnapshot, RoutedInferenceServerSnapshot};
 use crate::telemetry::parent_context_from_headers;
 
@@ -59,6 +60,11 @@ pub(super) fn proxy_openai_request_span(headers: &HeaderMap) -> Span {
         routing.num_candidates = field::Empty,
         routing.sample_count_configured = field::Empty,
         routing.sample_count_effective = field::Empty,
+        routing.comparator = field::Empty,
+        routing.comparator.score = field::Empty,
+        routing.comparator.queue_ms = field::Empty,
+        routing.comparator.prefill_ms = field::Empty,
+        routing.comparator.rtt_ms = field::Empty,
         routing.rank_depth = field::Empty,
         routing.selected_after_kv_free_tokens_skip = field::Empty,
         routing.retry_attempts = field::Empty,
@@ -107,6 +113,7 @@ pub(super) struct RoutingTraceFields<'a> {
     pub(super) num_candidates: usize,
     pub(super) rank_depth: usize,
     pub(super) selected_after_kv_free_tokens_skip: bool,
+    pub(super) comparator: Option<&'a ClusterComparatorTrace>,
     pub(super) cluster: &'a RoutedClusterSnapshot,
     pub(super) chosen: &'a RoutedInferenceServerSnapshot,
 }
@@ -135,6 +142,22 @@ pub(super) fn record_routing_to_span(span: &Span, routing: RoutingTraceFields<'_
         "selected_inst.rtt_ms" = routing.cluster.rtt.as_secs_f64() * 1000.0,
         "selected_inst.snapshot_age_ms" = routing.cluster.snapshot_updated_at.elapsed().as_secs_f64() * 1000.0,
     );
+
+    if let Some(comparator) = routing.comparator {
+        record_fields!(span;
+            "routing.comparator" = comparator.comparator.as_str(),
+            "routing.comparator.score" = comparator.score,
+        );
+        if let Some(queue_ms) = comparator.queue_ms {
+            span.record("routing.comparator.queue_ms", queue_ms);
+        }
+        if let Some(prefill_ms) = comparator.prefill_ms {
+            span.record("routing.comparator.prefill_ms", prefill_ms);
+        }
+        if let Some(rtt_ms) = comparator.rtt_ms {
+            span.record("routing.comparator.rtt_ms", rtt_ms);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -169,7 +192,7 @@ mod tests {
     }
 
     #[test]
-    fn proxy_span_declares_load_balancer_sample_count_fields() {
+    fn proxy_span_declares_load_balancer_fields() {
         let span = proxy_openai_request_span(&HeaderMap::new());
         let fields = span
             .metadata()
@@ -178,5 +201,10 @@ mod tests {
 
         assert!(fields.field("routing.sample_count_configured").is_some());
         assert!(fields.field("routing.sample_count_effective").is_some());
+        assert!(fields.field("routing.comparator").is_some());
+        assert!(fields.field("routing.comparator.score").is_some());
+        assert!(fields.field("routing.comparator.queue_ms").is_some());
+        assert!(fields.field("routing.comparator.prefill_ms").is_some());
+        assert!(fields.field("routing.comparator.rtt_ms").is_some());
     }
 }

--- a/src/libraries/rust/stargate/crates/stargate/src/http_proxy/trace.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/http_proxy/trace.rs
@@ -17,7 +17,7 @@ use axum::http::HeaderMap;
 use tracing::{Span, field};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-use crate::load_balancer::ClusterComparatorTrace;
+use crate::load_balancer::ClusterComparator;
 use crate::routing_state::{RoutedClusterSnapshot, RoutedInferenceServerSnapshot};
 use crate::telemetry::parent_context_from_headers;
 
@@ -61,10 +61,6 @@ pub(super) fn proxy_openai_request_span(headers: &HeaderMap) -> Span {
         routing.sample_count_configured = field::Empty,
         routing.sample_count_effective = field::Empty,
         routing.comparator = field::Empty,
-        routing.comparator.score = field::Empty,
-        routing.comparator.queue_ms = field::Empty,
-        routing.comparator.prefill_ms = field::Empty,
-        routing.comparator.rtt_ms = field::Empty,
         routing.rank_depth = field::Empty,
         routing.selected_after_kv_free_tokens_skip = field::Empty,
         routing.retry_attempts = field::Empty,
@@ -113,7 +109,7 @@ pub(super) struct RoutingTraceFields<'a> {
     pub(super) num_candidates: usize,
     pub(super) rank_depth: usize,
     pub(super) selected_after_kv_free_tokens_skip: bool,
-    pub(super) comparator: Option<&'a ClusterComparatorTrace>,
+    pub(super) comparator: Option<ClusterComparator>,
     pub(super) cluster: &'a RoutedClusterSnapshot,
     pub(super) chosen: &'a RoutedInferenceServerSnapshot,
 }
@@ -144,19 +140,7 @@ pub(super) fn record_routing_to_span(span: &Span, routing: RoutingTraceFields<'_
     );
 
     if let Some(comparator) = routing.comparator {
-        record_fields!(span;
-            "routing.comparator" = comparator.comparator.as_str(),
-            "routing.comparator.score" = comparator.score,
-        );
-        if let Some(queue_ms) = comparator.queue_ms {
-            span.record("routing.comparator.queue_ms", queue_ms);
-        }
-        if let Some(prefill_ms) = comparator.prefill_ms {
-            span.record("routing.comparator.prefill_ms", prefill_ms);
-        }
-        if let Some(rtt_ms) = comparator.rtt_ms {
-            span.record("routing.comparator.rtt_ms", rtt_ms);
-        }
+        span.record("routing.comparator", comparator.as_str());
     }
 }
 
@@ -202,9 +186,5 @@ mod tests {
         assert!(fields.field("routing.sample_count_configured").is_some());
         assert!(fields.field("routing.sample_count_effective").is_some());
         assert!(fields.field("routing.comparator").is_some());
-        assert!(fields.field("routing.comparator.score").is_some());
-        assert!(fields.field("routing.comparator.queue_ms").is_some());
-        assert!(fields.field("routing.comparator.prefill_ms").is_some());
-        assert!(fields.field("routing.comparator.rtt_ms").is_some());
     }
 }

--- a/src/libraries/rust/stargate/crates/stargate/src/lib.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/lib.rs
@@ -41,12 +41,15 @@ pub(crate) mod queue_estimate {
         stats: &ModelStats,
         priority: u32,
     ) -> Option<u64> {
-        stats
-            .queue_time_estimate_ms_by_priority
-            .iter()
-            .filter(|(candidate_priority, _)| **candidate_priority <= priority)
-            .max_by_key(|(candidate_priority, _)| **candidate_priority)
-            .map(|(_, queue_time_ms)| *queue_time_ms)
+        let mut best = None;
+        for (&candidate_priority, &queue_time_ms) in &stats.queue_time_estimate_ms_by_priority {
+            if candidate_priority <= priority
+                && best.is_none_or(|(best_priority, _)| candidate_priority > best_priority)
+            {
+                best = Some((candidate_priority, queue_time_ms));
+            }
+        }
+        best.map(|(_, queue_time_ms)| queue_time_ms)
     }
 
     pub(crate) fn aggregate_queue_time_estimate_ms(stats: &ModelStats) -> Option<u64> {

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/cluster_comparator.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/cluster_comparator.rs
@@ -73,19 +73,19 @@ impl ClusterComparator {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct TtftEstimate {
+pub(crate) struct Ttft {
     pub(crate) queue_ms: f64,
     pub(crate) ttft_ms: f64,
 }
 
 #[inline]
-pub(crate) fn estimate_ttft(
+pub(crate) fn ttft(
     candidate: &RoutedClusterSnapshot,
     input_tokens: Option<u64>,
     priority: u32,
     ignore_queue_time: bool,
     ignore_input_processing_time: bool,
-) -> TtftEstimate {
+) -> Ttft {
     let input_tps = input_tps(candidate);
     let queue_ms = queue_delay_ms_with_tps(candidate, priority, input_tps);
     let prefill_ms = processing_delay_ms(input_tokens.unwrap_or_default() as f64, input_tps);
@@ -97,7 +97,7 @@ pub(crate) fn estimate_ttft(
             prefill_ms
         };
 
-    TtftEstimate { queue_ms, ttft_ms }
+    Ttft { queue_ms, ttft_ms }
 }
 
 #[inline]
@@ -111,7 +111,7 @@ pub(crate) fn rtt_ms(candidate: &RoutedClusterSnapshot) -> f64 {
 }
 
 fn ttft_ms(candidate: &RoutedClusterSnapshot, request: &LoadBalancerRequest<'_>) -> f64 {
-    estimate_ttft(
+    ttft(
         candidate,
         request.input_tokens,
         request.priority,

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/cluster_comparator.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/cluster_comparator.rs
@@ -1,0 +1,248 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp::Ordering;
+use std::fmt;
+
+use serde::Deserialize;
+use stargate_protocol::common::valid_last_mean_input_tps;
+
+use super::{LoadBalancerRequest, input_work_units};
+use crate::routing_state::RoutedClusterSnapshot;
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ClusterComparator {
+    #[default]
+    EstimatedTtft,
+    QueueTime,
+    InputWorkSeconds,
+    Utilization,
+    NumRequestsQueued,
+}
+
+impl fmt::Display for ClusterComparator {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl ClusterComparator {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::EstimatedTtft => "estimated-ttft",
+            Self::QueueTime => "queue-time",
+            Self::InputWorkSeconds => "input-work-seconds",
+            Self::Utilization => "utilization",
+            Self::NumRequestsQueued => "num-requests-queued",
+        }
+    }
+
+    #[inline]
+    pub(crate) fn compare(
+        self,
+        request: &LoadBalancerRequest<'_>,
+        candidate_a: &RoutedClusterSnapshot,
+        candidate_b: &RoutedClusterSnapshot,
+    ) -> Ordering {
+        match self {
+            Self::EstimatedTtft => full_ttft(candidate_a, request)
+                .ttft_ms
+                .total_cmp(&full_ttft(candidate_b, request).ttft_ms),
+            Self::QueueTime => queue_delay_ms(candidate_a, request.priority)
+                .total_cmp(&queue_delay_ms(candidate_b, request.priority)),
+            Self::InputWorkSeconds => input_work_seconds(candidate_a, request.input_tokens)
+                .total_cmp(&input_work_seconds(candidate_b, request.input_tokens)),
+            Self::Utilization => utilization(candidate_a).total_cmp(&utilization(candidate_b)),
+            Self::NumRequestsQueued => candidate_a
+                .stats
+                .queue_size
+                .cmp(&candidate_b.stats.queue_size),
+        }
+    }
+
+    pub(crate) fn trace(
+        self,
+        request: &LoadBalancerRequest<'_>,
+        candidate: &RoutedClusterSnapshot,
+    ) -> ClusterComparatorTrace {
+        match self {
+            Self::EstimatedTtft => {
+                let (queue_ms, prefill_ms, rtt_ms) = ttft_components(
+                    candidate,
+                    request.input_tokens.unwrap_or_default() as f64,
+                    request.priority,
+                );
+                ClusterComparatorTrace {
+                    comparator: self,
+                    score: rtt_ms + queue_ms + prefill_ms,
+                    queue_ms: Some(queue_ms),
+                    prefill_ms: Some(prefill_ms),
+                    rtt_ms: Some(rtt_ms),
+                }
+            }
+            Self::QueueTime => {
+                let queue_ms = queue_delay_ms(candidate, request.priority);
+                ClusterComparatorTrace {
+                    comparator: self,
+                    score: queue_ms,
+                    queue_ms: Some(queue_ms),
+                    prefill_ms: None,
+                    rtt_ms: None,
+                }
+            }
+            Self::InputWorkSeconds => ClusterComparatorTrace {
+                comparator: self,
+                score: input_work_seconds(candidate, request.input_tokens),
+                queue_ms: None,
+                prefill_ms: None,
+                rtt_ms: None,
+            },
+            Self::Utilization => ClusterComparatorTrace {
+                comparator: self,
+                score: utilization(candidate),
+                queue_ms: None,
+                prefill_ms: None,
+                rtt_ms: None,
+            },
+            Self::NumRequestsQueued => ClusterComparatorTrace {
+                comparator: self,
+                score: candidate.stats.queue_size as f64,
+                queue_ms: None,
+                prefill_ms: None,
+                rtt_ms: None,
+            },
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ClusterComparatorTrace {
+    pub comparator: ClusterComparator,
+    pub score: f64,
+    pub queue_ms: Option<f64>,
+    pub prefill_ms: Option<f64>,
+    pub rtt_ms: Option<f64>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct TtftEstimate {
+    pub(crate) queue_ms: f64,
+    pub(crate) ttft_ms: f64,
+}
+
+#[inline]
+pub(crate) fn estimate_ttft(
+    candidate: &RoutedClusterSnapshot,
+    input_tokens: Option<u64>,
+    priority: u32,
+    ignore_queue_time: bool,
+    ignore_input_processing_time: bool,
+) -> TtftEstimate {
+    let (queue_ms, prefill_ms, rtt_ms) =
+        ttft_components(candidate, input_tokens.unwrap_or_default() as f64, priority);
+    let ttft_ms = rtt_ms
+        + if ignore_queue_time { 0.0 } else { queue_ms }
+        + if ignore_input_processing_time {
+            0.0
+        } else {
+            prefill_ms
+        };
+
+    TtftEstimate { queue_ms, ttft_ms }
+}
+
+#[inline]
+pub(crate) fn queue_ignored_ttft_ms(candidate: &RoutedClusterSnapshot, input_tokens: f64) -> f64 {
+    rtt_ms(candidate) + processing_delay_ms(input_tokens, input_tps(candidate))
+}
+
+#[inline]
+pub(crate) fn rtt_ms(candidate: &RoutedClusterSnapshot) -> f64 {
+    candidate.rtt.as_secs_f64() * 1000.0
+}
+
+fn full_ttft(candidate: &RoutedClusterSnapshot, request: &LoadBalancerRequest<'_>) -> TtftEstimate {
+    estimate_ttft(
+        candidate,
+        request.input_tokens,
+        request.priority,
+        false,
+        false,
+    )
+}
+
+fn queue_delay_ms(candidate: &RoutedClusterSnapshot, priority: u32) -> f64 {
+    queue_delay_ms_with_tps(candidate, priority, input_tps(candidate))
+}
+
+fn ttft_components(
+    candidate: &RoutedClusterSnapshot,
+    input_tokens: f64,
+    priority: u32,
+) -> (f64, f64, f64) {
+    let input_tps = input_tps(candidate);
+    (
+        queue_delay_ms_with_tps(candidate, priority, input_tps),
+        processing_delay_ms(input_tokens, input_tps),
+        rtt_ms(candidate),
+    )
+}
+
+fn queue_delay_ms_with_tps(
+    candidate: &RoutedClusterSnapshot,
+    priority: u32,
+    input_tps: f64,
+) -> f64 {
+    crate::queue_estimate::queue_time_estimate_ms_for_priority(&candidate.stats, priority)
+        .map_or_else(
+            || processing_delay_ms(input_work_units(candidate), input_tps),
+            |queue_time_ms| queue_time_ms as f64,
+        )
+}
+
+fn input_work_seconds(candidate: &RoutedClusterSnapshot, request_input_tokens: Option<u64>) -> f64 {
+    processing_delay_seconds(
+        input_work_units(candidate) + request_input_tokens.unwrap_or_default() as f64,
+        input_tps(candidate),
+    )
+}
+
+fn utilization(candidate: &RoutedClusterSnapshot) -> f64 {
+    candidate.stats.num_running_queries as f64
+        / candidate.stats.max_engine_concurrency.max(1) as f64
+}
+
+fn input_tps(candidate: &RoutedClusterSnapshot) -> f64 {
+    if valid_last_mean_input_tps(candidate.stats.last_mean_input_tps) {
+        candidate.stats.last_mean_input_tps
+    } else {
+        0.0
+    }
+}
+
+fn processing_delay_ms(work: f64, rate: f64) -> f64 {
+    processing_delay_seconds(work, rate) * 1000.0
+}
+
+fn processing_delay_seconds(work: f64, rate: f64) -> f64 {
+    if work == 0.0 {
+        return 0.0;
+    }
+    if rate <= 0.0 {
+        return f64::INFINITY;
+    }
+    work / rate
+}

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/cluster_comparator.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/cluster_comparator.rs
@@ -58,9 +58,8 @@ impl ClusterComparator {
         candidate_b: &RoutedClusterSnapshot,
     ) -> Ordering {
         match self {
-            Self::EstimatedTtft => full_ttft(candidate_a, request)
-                .ttft_ms
-                .total_cmp(&full_ttft(candidate_b, request).ttft_ms),
+            Self::EstimatedTtft => estimated_ttft_ms(candidate_a, request)
+                .total_cmp(&estimated_ttft_ms(candidate_b, request)),
             Self::QueueTime => queue_delay_ms(candidate_a, request.priority)
                 .total_cmp(&queue_delay_ms(candidate_b, request.priority)),
             Self::InputWorkSeconds => input_work_seconds(candidate_a, request.input_tokens)
@@ -88,9 +87,10 @@ pub(crate) fn estimate_ttft(
     ignore_queue_time: bool,
     ignore_input_processing_time: bool,
 ) -> TtftEstimate {
-    let (queue_ms, prefill_ms, rtt_ms) =
-        ttft_components(candidate, input_tokens.unwrap_or_default() as f64, priority);
-    let ttft_ms = rtt_ms
+    let input_tps = input_tps(candidate);
+    let queue_ms = queue_delay_ms_with_tps(candidate, priority, input_tps);
+    let prefill_ms = processing_delay_ms(input_tokens.unwrap_or_default() as f64, input_tps);
+    let ttft_ms = rtt_ms(candidate)
         + if ignore_queue_time { 0.0 } else { queue_ms }
         + if ignore_input_processing_time {
             0.0
@@ -111,7 +111,7 @@ pub(crate) fn rtt_ms(candidate: &RoutedClusterSnapshot) -> f64 {
     candidate.rtt.as_secs_f64() * 1000.0
 }
 
-fn full_ttft(candidate: &RoutedClusterSnapshot, request: &LoadBalancerRequest<'_>) -> TtftEstimate {
+fn estimated_ttft_ms(candidate: &RoutedClusterSnapshot, request: &LoadBalancerRequest<'_>) -> f64 {
     estimate_ttft(
         candidate,
         request.input_tokens,
@@ -119,23 +119,11 @@ fn full_ttft(candidate: &RoutedClusterSnapshot, request: &LoadBalancerRequest<'_
         false,
         false,
     )
+    .ttft_ms
 }
 
 fn queue_delay_ms(candidate: &RoutedClusterSnapshot, priority: u32) -> f64 {
     queue_delay_ms_with_tps(candidate, priority, input_tps(candidate))
-}
-
-fn ttft_components(
-    candidate: &RoutedClusterSnapshot,
-    input_tokens: f64,
-    priority: u32,
-) -> (f64, f64, f64) {
-    let input_tps = input_tps(candidate);
-    (
-        queue_delay_ms_with_tps(candidate, priority, input_tps),
-        processing_delay_ms(input_tokens, input_tps),
-        rtt_ms(candidate),
-    )
 }
 
 fn queue_delay_ms_with_tps(

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/cluster_comparator.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/cluster_comparator.rs
@@ -129,12 +129,12 @@ impl ClusterComparator {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct ClusterComparatorTrace {
-    pub comparator: ClusterComparator,
-    pub score: f64,
-    pub queue_ms: Option<f64>,
-    pub prefill_ms: Option<f64>,
-    pub rtt_ms: Option<f64>,
+pub(crate) struct ClusterComparatorTrace {
+    pub(crate) comparator: ClusterComparator,
+    pub(crate) score: f64,
+    pub(crate) queue_ms: Option<f64>,
+    pub(crate) prefill_ms: Option<f64>,
+    pub(crate) rtt_ms: Option<f64>,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/cluster_comparator.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/cluster_comparator.rs
@@ -26,7 +26,7 @@ use crate::routing_state::RoutedClusterSnapshot;
 #[serde(rename_all = "kebab-case")]
 pub enum ClusterComparator {
     #[default]
-    EstimatedTtft,
+    Ttft,
     QueueTime,
     InputWorkSeconds,
     Utilization,
@@ -42,7 +42,7 @@ impl fmt::Display for ClusterComparator {
 impl ClusterComparator {
     pub(crate) const fn as_str(self) -> &'static str {
         match self {
-            Self::EstimatedTtft => "estimated-ttft",
+            Self::Ttft => "ttft",
             Self::QueueTime => "queue-time",
             Self::InputWorkSeconds => "input-work-seconds",
             Self::Utilization => "utilization",
@@ -58,8 +58,7 @@ impl ClusterComparator {
         candidate_b: &RoutedClusterSnapshot,
     ) -> Ordering {
         match self {
-            Self::EstimatedTtft => estimated_ttft_ms(candidate_a, request)
-                .total_cmp(&estimated_ttft_ms(candidate_b, request)),
+            Self::Ttft => ttft_ms(candidate_a, request).total_cmp(&ttft_ms(candidate_b, request)),
             Self::QueueTime => queue_delay_ms(candidate_a, request.priority)
                 .total_cmp(&queue_delay_ms(candidate_b, request.priority)),
             Self::InputWorkSeconds => input_work_seconds(candidate_a, request.input_tokens)
@@ -111,7 +110,7 @@ pub(crate) fn rtt_ms(candidate: &RoutedClusterSnapshot) -> f64 {
     candidate.rtt.as_secs_f64() * 1000.0
 }
 
-fn estimated_ttft_ms(candidate: &RoutedClusterSnapshot, request: &LoadBalancerRequest<'_>) -> f64 {
+fn ttft_ms(candidate: &RoutedClusterSnapshot, request: &LoadBalancerRequest<'_>) -> f64 {
     estimate_ttft(
         candidate,
         request.input_tokens,

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/cluster_comparator.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/cluster_comparator.rs
@@ -72,69 +72,6 @@ impl ClusterComparator {
                 .cmp(&candidate_b.stats.queue_size),
         }
     }
-
-    pub(crate) fn trace(
-        self,
-        request: &LoadBalancerRequest<'_>,
-        candidate: &RoutedClusterSnapshot,
-    ) -> ClusterComparatorTrace {
-        match self {
-            Self::EstimatedTtft => {
-                let (queue_ms, prefill_ms, rtt_ms) = ttft_components(
-                    candidate,
-                    request.input_tokens.unwrap_or_default() as f64,
-                    request.priority,
-                );
-                ClusterComparatorTrace {
-                    comparator: self,
-                    score: rtt_ms + queue_ms + prefill_ms,
-                    queue_ms: Some(queue_ms),
-                    prefill_ms: Some(prefill_ms),
-                    rtt_ms: Some(rtt_ms),
-                }
-            }
-            Self::QueueTime => {
-                let queue_ms = queue_delay_ms(candidate, request.priority);
-                ClusterComparatorTrace {
-                    comparator: self,
-                    score: queue_ms,
-                    queue_ms: Some(queue_ms),
-                    prefill_ms: None,
-                    rtt_ms: None,
-                }
-            }
-            Self::InputWorkSeconds => ClusterComparatorTrace {
-                comparator: self,
-                score: input_work_seconds(candidate, request.input_tokens),
-                queue_ms: None,
-                prefill_ms: None,
-                rtt_ms: None,
-            },
-            Self::Utilization => ClusterComparatorTrace {
-                comparator: self,
-                score: utilization(candidate),
-                queue_ms: None,
-                prefill_ms: None,
-                rtt_ms: None,
-            },
-            Self::NumRequestsQueued => ClusterComparatorTrace {
-                comparator: self,
-                score: candidate.stats.queue_size as f64,
-                queue_ms: None,
-                prefill_ms: None,
-                rtt_ms: None,
-            },
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub(crate) struct ClusterComparatorTrace {
-    pub(crate) comparator: ClusterComparator,
-    pub(crate) score: f64,
-    pub(crate) queue_ms: Option<f64>,
-    pub(crate) prefill_ms: Option<f64>,
-    pub(crate) rtt_ms: Option<f64>,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/config.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/config.rs
@@ -19,6 +19,8 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Deserializer};
 
+use super::ClusterComparator;
+
 #[derive(Clone, Debug)]
 pub enum LoadBalancerModelConfig {
     Name(LoadBalancerAlgorithm),
@@ -189,6 +191,7 @@ pub struct LoadBalancerRequestPolicy {
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 pub struct WaitAndWidenAlgorithmConfig {
     pub seed: Option<String>,
+    pub comparator: Option<ClusterComparator>,
     pub cache_affinity_virtual_nodes: Option<usize>,
     pub cache_affinity_backend_selection_count: Option<usize>,
     pub max_queue_time_floor_ms: Option<u64>,
@@ -208,12 +211,14 @@ pub const MAX_POWER_OF_N_SAMPLE_COUNT: usize = 64;
 #[serde(default)]
 pub struct PowerOfNAlgorithmConfig {
     pub sample_count: usize,
+    pub comparator: Option<ClusterComparator>,
 }
 
 impl Default for PowerOfNAlgorithmConfig {
     fn default() -> Self {
         Self {
             sample_count: DEFAULT_POWER_OF_N_SAMPLE_COUNT,
+            comparator: None,
         }
     }
 }
@@ -282,6 +287,21 @@ impl LoadBalancerAlgorithmConfig {
 
     pub fn considers_kv_free_tokens(&self) -> bool {
         self.request_policy.consider_kv_free_tokens
+    }
+
+    pub fn comparator(&self) -> Option<ClusterComparator> {
+        match &self.settings {
+            LoadBalancerAlgorithmSettings::PowerOfN(config) => {
+                Some(config.comparator.unwrap_or_default())
+            }
+            LoadBalancerAlgorithmSettings::WaitAndWiden(config) => {
+                Some(config.comparator.unwrap_or_default())
+            }
+            LoadBalancerAlgorithmSettings::RoundRobin
+            | LoadBalancerAlgorithmSettings::Random
+            | LoadBalancerAlgorithmSettings::Pulsar(_)
+            | LoadBalancerAlgorithmSettings::PulsarWaitAndWiden(_) => None,
+        }
     }
 
     pub fn request_policy_mut(&mut self) -> &mut LoadBalancerRequestPolicy {

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/config.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/config.rs
@@ -191,6 +191,7 @@ pub struct LoadBalancerRequestPolicy {
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 pub struct WaitAndWidenAlgorithmConfig {
     pub seed: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_present_comparator")]
     pub comparator: Option<ClusterComparator>,
     pub cache_affinity_virtual_nodes: Option<usize>,
     pub cache_affinity_backend_selection_count: Option<usize>,
@@ -204,6 +205,15 @@ pub struct WaitAndWidenAlgorithmConfig {
     pub ignore_input_processing_time: Option<bool>,
 }
 
+fn deserialize_present_comparator<'de, D>(
+    deserializer: D,
+) -> Result<Option<ClusterComparator>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    ClusterComparator::deserialize(deserializer).map(Some)
+}
+
 const DEFAULT_POWER_OF_N_SAMPLE_COUNT: usize = 2;
 pub const MAX_POWER_OF_N_SAMPLE_COUNT: usize = 64;
 
@@ -211,14 +221,14 @@ pub const MAX_POWER_OF_N_SAMPLE_COUNT: usize = 64;
 #[serde(default)]
 pub struct PowerOfNAlgorithmConfig {
     pub sample_count: usize,
-    pub comparator: Option<ClusterComparator>,
+    pub comparator: ClusterComparator,
 }
 
 impl Default for PowerOfNAlgorithmConfig {
     fn default() -> Self {
         Self {
             sample_count: DEFAULT_POWER_OF_N_SAMPLE_COUNT,
-            comparator: None,
+            comparator: ClusterComparator::default(),
         }
     }
 }
@@ -291,9 +301,7 @@ impl LoadBalancerAlgorithmConfig {
 
     pub(crate) fn comparator(&self) -> Option<ClusterComparator> {
         match &self.settings {
-            LoadBalancerAlgorithmSettings::PowerOfN(config) => {
-                Some(config.comparator.unwrap_or_default())
-            }
+            LoadBalancerAlgorithmSettings::PowerOfN(config) => Some(config.comparator),
             LoadBalancerAlgorithmSettings::WaitAndWiden(config) => {
                 Some(config.comparator.unwrap_or_default())
             }

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/config.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/config.rs
@@ -289,7 +289,7 @@ impl LoadBalancerAlgorithmConfig {
         self.request_policy.consider_kv_free_tokens
     }
 
-    pub fn comparator(&self) -> Option<ClusterComparator> {
+    pub(crate) fn comparator(&self) -> Option<ClusterComparator> {
         match &self.settings {
             LoadBalancerAlgorithmSettings::PowerOfN(config) => {
                 Some(config.comparator.unwrap_or_default())

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/factory.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/factory.rs
@@ -26,6 +26,14 @@ use super::{LoadBalancer, LoadBalancerAlgorithm, LoadBalancerAlgorithmConfig};
 pub fn create_load_balancer_with_config(
     config: &LoadBalancerAlgorithmConfig,
 ) -> anyhow::Result<Arc<dyn LoadBalancer>> {
+    if config.algorithm() == LoadBalancerAlgorithm::PulsarWaitAndWiden
+        && config
+            .wait_and_widen_settings()
+            .is_some_and(|settings| settings.comparator.is_some())
+    {
+        anyhow::bail!("comparator is not supported for pulsar-wait-and-widen");
+    }
+
     if config.considers_kv_free_tokens()
         && !matches!(
             config.algorithm(),

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/mod.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/mod.rs
@@ -24,6 +24,7 @@ macro_rules! impl_display {
 }
 
 mod algorithm;
+mod cluster_comparator;
 mod config;
 mod factory;
 mod power_of_n;
@@ -41,6 +42,8 @@ mod wait_and_widen;
 pub use algorithm::LoadBalancer;
 pub(crate) use algorithm::input_work_seconds_for_request;
 pub(super) use algorithm::{HashInputBuilder, cache_affinity_key_is_cacheable, input_work_units};
+pub use cluster_comparator::{ClusterComparator, ClusterComparatorTrace};
+pub(super) use cluster_comparator::{TtftEstimate, estimate_ttft};
 pub use config::{
     LoadBalancerAlgorithm, LoadBalancerAlgorithmConfig, LoadBalancerAlgorithmOverride,
     LoadBalancerAlgorithmSettings, LoadBalancerConfig, LoadBalancerModelConfig,

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/mod.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/mod.rs
@@ -42,7 +42,8 @@ mod wait_and_widen;
 pub use algorithm::LoadBalancer;
 pub(crate) use algorithm::input_work_seconds_for_request;
 pub(super) use algorithm::{HashInputBuilder, cache_affinity_key_is_cacheable, input_work_units};
-pub use cluster_comparator::{ClusterComparator, ClusterComparatorTrace};
+pub use cluster_comparator::ClusterComparator;
+pub(crate) use cluster_comparator::ClusterComparatorTrace;
 pub(super) use cluster_comparator::{TtftEstimate, estimate_ttft};
 pub use config::{
     LoadBalancerAlgorithm, LoadBalancerAlgorithmConfig, LoadBalancerAlgorithmOverride,

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/mod.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/mod.rs
@@ -43,7 +43,7 @@ pub use algorithm::LoadBalancer;
 pub(crate) use algorithm::input_work_seconds_for_request;
 pub(super) use algorithm::{HashInputBuilder, cache_affinity_key_is_cacheable, input_work_units};
 pub use cluster_comparator::ClusterComparator;
-pub(super) use cluster_comparator::{TtftEstimate, estimate_ttft};
+pub(super) use cluster_comparator::{Ttft, ttft};
 pub use config::{
     LoadBalancerAlgorithm, LoadBalancerAlgorithmConfig, LoadBalancerAlgorithmOverride,
     LoadBalancerAlgorithmSettings, LoadBalancerConfig, LoadBalancerModelConfig,

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/mod.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/mod.rs
@@ -43,7 +43,6 @@ pub use algorithm::LoadBalancer;
 pub(crate) use algorithm::input_work_seconds_for_request;
 pub(super) use algorithm::{HashInputBuilder, cache_affinity_key_is_cacheable, input_work_units};
 pub use cluster_comparator::ClusterComparator;
-pub(crate) use cluster_comparator::ClusterComparatorTrace;
 pub(super) use cluster_comparator::{TtftEstimate, estimate_ttft};
 pub use config::{
     LoadBalancerAlgorithm, LoadBalancerAlgorithmConfig, LoadBalancerAlgorithmOverride,

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/power_of_n.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/power_of_n.rs
@@ -42,9 +42,7 @@ impl PowerOfNLoadBalancer {
             .map_err(anyhow::Error::msg)?;
         Ok(Self {
             sample_count,
-            comparator: config
-                .comparator()
-                .expect("power-of-n should have a comparator"),
+            comparator: settings.comparator,
         })
     }
 

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/power_of_n.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/power_of_n.rs
@@ -15,19 +15,19 @@
 
 use rand::Rng;
 use rand::seq::IteratorRandom;
-use stargate_protocol::common::valid_last_mean_input_tps;
 use tracing::{Span, debug};
 
 #[cfg(test)]
 use super::tests::LoadBalancerTestChoiceExt;
 use super::{
-    LoadBalancer, LoadBalancerAlgorithmConfig, LoadBalancerCandidateChoice, LoadBalancerRequest,
-    MAX_POWER_OF_N_SAMPLE_COUNT,
+    ClusterComparator, LoadBalancer, LoadBalancerAlgorithmConfig, LoadBalancerCandidateChoice,
+    LoadBalancerRequest, MAX_POWER_OF_N_SAMPLE_COUNT,
 };
 use crate::routing_state::RoutedClusterSnapshot;
 
 pub(super) struct PowerOfNLoadBalancer {
     sample_count: usize,
+    comparator: ClusterComparator,
 }
 
 impl PowerOfNLoadBalancer {
@@ -40,7 +40,12 @@ impl PowerOfNLoadBalancer {
         let sample_count = settings
             .validated_sample_count()
             .map_err(anyhow::Error::msg)?;
-        Ok(Self { sample_count })
+        Ok(Self {
+            sample_count,
+            comparator: config
+                .comparator()
+                .expect("power-of-n should have a comparator"),
+        })
     }
 
     fn choose_candidate_with_rng<R: Rng + ?Sized>(
@@ -54,7 +59,13 @@ impl PowerOfNLoadBalancer {
         span.record("routing.sample_count_configured", self.sample_count);
         span.record("routing.sample_count_effective", sampled.len());
 
-        choose_least_loaded(candidates, sampled.as_slice(), request.input_tokens, rng)
+        choose_least_loaded(
+            candidates,
+            sampled.as_slice(),
+            request,
+            self.comparator,
+            rng,
+        )
     }
 }
 
@@ -148,47 +159,43 @@ fn sample_distinct_pair<R: Rng + ?Sized>(len: usize, rng: &mut R) -> (usize, usi
 fn choose_least_loaded<R: Rng + ?Sized>(
     candidates: &[RoutedClusterSnapshot],
     sampled_indices: &[usize],
-    input_tokens: Option<u64>,
+    request: &LoadBalancerRequest<'_>,
+    comparator: ClusterComparator,
     rng: &mut R,
 ) -> Option<LoadBalancerCandidateChoice> {
     let (&first_index, remaining_indices) = sampled_indices.split_first()?;
     let mut selected_index = first_index;
-    let mut selected_score = load_score(&candidates[first_index], input_tokens);
     let mut tied_best_count = 1u32;
 
     for &candidate_index in remaining_indices {
-        let score = load_score(&candidates[candidate_index], input_tokens);
-        if score < selected_score {
-            selected_index = candidate_index;
-            selected_score = score;
-            tied_best_count = 1;
-        } else if score == selected_score {
-            tied_best_count += 1;
-            if rng.random_ratio(1, tied_best_count) {
+        match comparator.compare(
+            request,
+            &candidates[candidate_index],
+            &candidates[selected_index],
+        ) {
+            std::cmp::Ordering::Less => {
                 selected_index = candidate_index;
+                tied_best_count = 1;
             }
+            std::cmp::Ordering::Equal => {
+                tied_best_count += 1;
+                if rng.random_ratio(1, tied_best_count) {
+                    selected_index = candidate_index;
+                }
+            }
+            std::cmp::Ordering::Greater => {}
         }
     }
 
     debug!(
         effective_sample_count = sampled_indices.len(),
         selected_candidate_index = selected_index,
-        selected_load_score = selected_score,
+        comparator = %comparator,
         "sampled clusters"
     );
     Some(LoadBalancerCandidateChoice::with_rank_depth_1(
         selected_index,
     ))
-}
-
-fn load_score(candidate: &RoutedClusterSnapshot, input_tokens: Option<u64>) -> f64 {
-    let last_mean_input_tps = candidate.stats.last_mean_input_tps;
-    if valid_last_mean_input_tps(last_mean_input_tps) {
-        (super::input_work_units(candidate) + input_tokens.unwrap_or_default() as f64)
-            / last_mean_input_tps
-    } else {
-        f64::INFINITY
-    }
 }
 
 #[cfg(test)]
@@ -236,9 +243,12 @@ mod tests {
             request_slo: None,
             excluded_cluster_ids: Some(excluded_cluster_ids),
         };
-        PowerOfNLoadBalancer { sample_count }
-            .choose_for_test(&request, candidates)
-            .map(|choice| choice.candidate.cluster_id)
+        PowerOfNLoadBalancer {
+            sample_count,
+            comparator: ClusterComparator::default(),
+        }
+        .choose_for_test(&request, candidates)
+        .map(|choice| choice.candidate.cluster_id)
     }
 
     fn sampled_indices(
@@ -260,29 +270,6 @@ mod tests {
         sample_candidates(&request, candidates, sample_count, rng)
             .as_slice()
             .to_vec()
-    }
-
-    #[test]
-    fn load_score_prefers_faster_empty_backend_for_incoming_prefill() {
-        let fast = candidate("fast", 200.0, 0);
-        let slow = candidate("slow", 100.0, 0);
-
-        assert!(load_score(&fast, Some(1000)) < load_score(&slow, Some(1000)));
-    }
-
-    #[test]
-    fn load_score_accounts_for_queued_prefill_work() {
-        let busy_fast = candidate("busy-fast", 200.0, 10_000);
-        let empty_slow = candidate("empty-slow", 100.0, 0);
-
-        assert!(load_score(&empty_slow, Some(1000)) < load_score(&busy_fast, Some(1000)));
-    }
-
-    #[test]
-    fn load_score_rejects_invalid_input_throughput() {
-        for input_tps in [0.0, -1.0, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
-            assert!(load_score(&candidate("invalid", input_tps, 0), Some(100)).is_infinite());
-        }
     }
 
     #[test]
@@ -450,7 +437,10 @@ mod tests {
             request_slo: None,
             excluded_cluster_ids: None,
         };
-        let load_balancer = PowerOfNLoadBalancer { sample_count: 3 };
+        let load_balancer = PowerOfNLoadBalancer {
+            sample_count: 3,
+            comparator: ClusterComparator::default(),
+        };
         let mut rng = StdRng::seed_from_u64(11);
         let mut selected = HashSet::new();
 

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/router.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/router.rs
@@ -19,10 +19,9 @@ use crate::routing_state::RoutedClusterSnapshot;
 
 use super::target_state::LoadBalancerDefinition;
 use super::{
-    ClusterComparatorTrace, LoadBalancerAlgorithm, LoadBalancerAlgorithmConfig,
-    LoadBalancerAlgorithmOverride, LoadBalancerCandidateChoice, LoadBalancerConfig,
-    LoadBalancerModelConfig, LoadBalancerRequest, LoadBalancerRoutingAlgorithmError,
-    LoadBalancerTargetState,
+    LoadBalancerAlgorithm, LoadBalancerAlgorithmConfig, LoadBalancerAlgorithmOverride,
+    LoadBalancerCandidateChoice, LoadBalancerConfig, LoadBalancerModelConfig, LoadBalancerRequest,
+    LoadBalancerRoutingAlgorithmError, LoadBalancerTargetState,
 };
 
 #[cfg(test)]
@@ -43,7 +42,6 @@ pub struct LoadBalancerCandidateSelection {
     pub choice: LoadBalancerCandidateChoice,
     pub effective_algorithm: LoadBalancerAlgorithm,
     pub requested_algorithm: Option<String>,
-    pub comparator: Option<ClusterComparatorTrace>,
 }
 
 #[derive(Clone, Debug)]
@@ -190,13 +188,9 @@ impl LoadBalancerRouter {
         let lb = target_state.load_balancer(&resolution.definition);
         let effective_algorithm = resolution.config().algorithm();
         let requested_algorithm = resolution.requested_algorithm.clone();
-        let comparator = resolution.config().comparator();
 
         lb.choose_candidate(request, candidates)
             .map(|choice| LoadBalancerCandidateSelection {
-                comparator: comparator.map(|comparator| {
-                    comparator.trace(request, &candidates[choice.candidate_index])
-                }),
                 choice,
                 effective_algorithm,
                 requested_algorithm,

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/router.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/router.rs
@@ -19,9 +19,10 @@ use crate::routing_state::RoutedClusterSnapshot;
 
 use super::target_state::LoadBalancerDefinition;
 use super::{
-    LoadBalancerAlgorithm, LoadBalancerAlgorithmConfig, LoadBalancerAlgorithmOverride,
-    LoadBalancerCandidateChoice, LoadBalancerConfig, LoadBalancerModelConfig, LoadBalancerRequest,
-    LoadBalancerRoutingAlgorithmError, LoadBalancerTargetState,
+    ClusterComparatorTrace, LoadBalancerAlgorithm, LoadBalancerAlgorithmConfig,
+    LoadBalancerAlgorithmOverride, LoadBalancerCandidateChoice, LoadBalancerConfig,
+    LoadBalancerModelConfig, LoadBalancerRequest, LoadBalancerRoutingAlgorithmError,
+    LoadBalancerTargetState,
 };
 
 #[cfg(test)]
@@ -42,6 +43,7 @@ pub struct LoadBalancerCandidateSelection {
     pub choice: LoadBalancerCandidateChoice,
     pub effective_algorithm: LoadBalancerAlgorithm,
     pub requested_algorithm: Option<String>,
+    pub comparator: Option<ClusterComparatorTrace>,
 }
 
 #[derive(Clone, Debug)]
@@ -188,9 +190,13 @@ impl LoadBalancerRouter {
         let lb = target_state.load_balancer(&resolution.definition);
         let effective_algorithm = resolution.config().algorithm();
         let requested_algorithm = resolution.requested_algorithm.clone();
+        let comparator = resolution.config().comparator();
 
         lb.choose_candidate(request, candidates)
             .map(|choice| LoadBalancerCandidateSelection {
+                comparator: comparator.map(|comparator| {
+                    comparator.trace(request, &candidates[choice.candidate_index])
+                }),
                 choice,
                 effective_algorithm,
                 requested_algorithm,

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/tests.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/tests.rs
@@ -716,7 +716,7 @@ fn algorithm_specific_load_balancer_fields_are_rejected_for_other_algorithms() {
         ),
         (r#"{"algorithm":"random","sample_count":4}"#, "sample_count"),
         (
-            r#"{"algorithm":"random","comparator":"estimated-ttft"}"#,
+            r#"{"algorithm":"random","comparator":"ttft"}"#,
             "comparator",
         ),
     ] {
@@ -735,14 +735,14 @@ fn power_of_n_sample_count_defaults_to_two() {
 }
 
 #[test]
-fn comparator_defaults_to_estimated_ttft_only_for_supported_algorithms() {
+fn comparator_defaults_to_ttft_only_for_supported_algorithms() {
     for algorithm in [
         LoadBalancerAlgorithm::PowerOfN,
         LoadBalancerAlgorithm::WaitAndWiden,
     ] {
         assert_eq!(
             LoadBalancerAlgorithmConfig::from(algorithm).comparator(),
-            Some(ClusterComparator::EstimatedTtft)
+            Some(ClusterComparator::Ttft)
         );
     }
 
@@ -799,7 +799,7 @@ fn configured_comparators_resolve_for_models_and_request_overrides() {
 #[test]
 fn pulsar_wait_and_widen_rejects_explicit_comparator() {
     let config: LoadBalancerConfig = parse_json(
-        r#"{"models":{"model-a":{"algorithm":"pulsar-wait-and-widen","comparator":"estimated-ttft"}}}"#,
+        r#"{"models":{"model-a":{"algorithm":"pulsar-wait-and-widen","comparator":"ttft"}}}"#,
     );
     let error = match LoadBalancerRouter::from_config(&config) {
         Ok(_) => panic!("pulsar-wait-and-widen comparator should be rejected"),
@@ -1688,7 +1688,7 @@ fn request_excluded_clusters_are_not_selected() {
 fn power_of_n_uses_each_configured_comparator() {
     let cases = [
         (
-            ClusterComparator::EstimatedTtft,
+            ClusterComparator::Ttft,
             [
                 candidate("preferred", 1024).with_rtt_ms(1),
                 candidate("other", 1024).with_rtt_ms(100),
@@ -1746,7 +1746,7 @@ fn power_of_n_uses_each_configured_comparator() {
 }
 
 #[test]
-fn wait_and_widen_uses_comparator_with_and_without_affinity() {
+fn wait_and_widen_uses_comparator_in_every_selection_path() {
     let candidates = [
         candidate("lower-ttft-higher-queue", 1024)
             .with_rtt_ms(5)
@@ -1757,11 +1757,14 @@ fn wait_and_widen_uses_comparator_with_and_without_affinity() {
     ];
     let target = target();
 
-    for cache_affinity_key in [None, Some("prefix-a")] {
+    for (cache_affinity_key, ignore_queue_time) in
+        [(None, false), (None, true), (Some("prefix-a"), false)]
+    {
         let load_balancer = wait_and_widen_load_balancer(|settings| {
             settings.comparator = Some(ClusterComparator::NumRequestsQueued);
             settings.ttft_bucket_size_ms = Some(100);
             settings.n = Some(2);
+            settings.ignore_queue_time = ignore_queue_time.then_some(true);
             if cache_affinity_key.is_some() {
                 settings.seed = Some("seed-1".to_string());
                 settings.cache_affinity_virtual_nodes = Some(8);
@@ -1781,7 +1784,7 @@ fn wait_and_widen_uses_comparator_with_and_without_affinity() {
 }
 
 wait_and_widen_choice_tests! {
-    wait_and_widen_prefers_lower_estimated_ttft:
+    wait_and_widen_prefers_lower_ttft:
     |_| {};
     |target| request(target, None, Some(10));
     [

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/tests.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/tests.rs
@@ -715,6 +715,10 @@ fn algorithm_specific_load_balancer_fields_are_rejected_for_other_algorithms() {
             "consider_kv_free_tokens",
         ),
         (r#"{"algorithm":"random","sample_count":4}"#, "sample_count"),
+        (
+            r#"{"algorithm":"random","comparator":"estimated-ttft"}"#,
+            "comparator",
+        ),
     ] {
         assert_json_rejected::<LoadBalancerAlgorithmConfig>(raw, expected_field);
     }
@@ -728,6 +732,84 @@ fn power_of_n_sample_count_defaults_to_two() {
         .expect("power-of-n config should expose settings");
 
     assert_eq!(settings.sample_count, 2);
+}
+
+#[test]
+fn comparator_defaults_to_estimated_ttft_only_for_supported_algorithms() {
+    for algorithm in [
+        LoadBalancerAlgorithm::PowerOfN,
+        LoadBalancerAlgorithm::WaitAndWiden,
+    ] {
+        assert_eq!(
+            LoadBalancerAlgorithmConfig::from(algorithm).comparator(),
+            Some(ClusterComparator::EstimatedTtft)
+        );
+    }
+
+    for algorithm in [
+        LoadBalancerAlgorithm::RoundRobin,
+        LoadBalancerAlgorithm::Random,
+        LoadBalancerAlgorithm::Pulsar,
+        LoadBalancerAlgorithm::PulsarWaitAndWiden,
+    ] {
+        assert_eq!(
+            LoadBalancerAlgorithmConfig::from(algorithm).comparator(),
+            None
+        );
+    }
+}
+
+#[test]
+fn configured_comparators_resolve_for_models_and_request_overrides() {
+    let direct: LoadBalancerAlgorithmConfig =
+        parse_json(r#"{"algorithm":"power-of-n","comparator":"input-work-seconds"}"#);
+    assert_eq!(
+        direct.comparator(),
+        Some(ClusterComparator::InputWorkSeconds)
+    );
+
+    let router = router_from_json(
+        r#"{"default":"random","request_algorithms":{"power-of-n":{"algorithm":"power-of-n","comparator":"queue-time"}},"models":{"model-a":{"algorithm":"wait-and-widen","comparator":"utilization","request_algorithms":{"power-of-n":{"algorithm":"power-of-n","comparator":"num-requests-queued"}}}}}"#,
+    );
+    assert_eq!(
+        router.algorithm_config("model-a").comparator(),
+        Some(ClusterComparator::Utilization)
+    );
+
+    let override_header = LoadBalancerAlgorithmOverride::parse("power-of-n")
+        .expect("power-of-n override should parse");
+    assert_eq!(
+        router
+            .resolve_algorithm_override("model-a", Some(&override_header))
+            .expect("model request override should resolve")
+            .config()
+            .comparator(),
+        Some(ClusterComparator::NumRequestsQueued)
+    );
+    assert_eq!(
+        router
+            .resolve_algorithm_override("model-b", Some(&override_header))
+            .expect("top-level request override should resolve")
+            .config()
+            .comparator(),
+        Some(ClusterComparator::QueueTime)
+    );
+}
+
+#[test]
+fn pulsar_wait_and_widen_rejects_explicit_comparator() {
+    let config: LoadBalancerConfig = parse_json(
+        r#"{"models":{"model-a":{"algorithm":"pulsar-wait-and-widen","comparator":"estimated-ttft"}}}"#,
+    );
+    let error = match LoadBalancerRouter::from_config(&config) {
+        Ok(_) => panic!("pulsar-wait-and-widen comparator should be rejected"),
+        Err(error) => error,
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("comparator is not supported for pulsar-wait-and-widen")
+    );
 }
 
 #[test]
@@ -1596,6 +1678,140 @@ fn request_excluded_clusters_are_not_selected() {
     let chosen = choose_from_router(&router, &target_state, &request, &candidates);
 
     assert_eq!(chosen.candidate.cluster_id, "cluster-1");
+}
+
+#[test]
+fn power_of_n_uses_each_configured_comparator() {
+    let cases = [
+        (
+            ClusterComparator::EstimatedTtft,
+            [
+                candidate("preferred", 1024).with_rtt_ms(1),
+                candidate("other", 1024).with_rtt_ms(100),
+            ],
+        ),
+        (
+            ClusterComparator::QueueTime,
+            [
+                priority_candidate("preferred", 0, 1).with_rtt_ms(100),
+                priority_candidate("other", 0, 50).with_rtt_ms(1),
+            ],
+        ),
+        (
+            ClusterComparator::InputWorkSeconds,
+            [
+                work_candidate("preferred", 100, 1000.0, 100),
+                work_candidate("other", 100, 10.0, 100),
+            ],
+        ),
+        (
+            ClusterComparator::Utilization,
+            [
+                concurrency_candidate("preferred", 100, 10, 1),
+                concurrency_candidate("other", 1, 10, 9),
+            ],
+        ),
+        (
+            ClusterComparator::NumRequestsQueued,
+            [
+                candidate("preferred", 1024)
+                    .with_rtt_ms(100)
+                    .with_stats(|stats| stats.queue_size = 1),
+                candidate("other", 1024)
+                    .with_rtt_ms(1)
+                    .with_stats(|stats| stats.queue_size = 10),
+            ],
+        ),
+    ];
+    let target = target();
+    let request = request(&target, None, Some(100));
+
+    for (comparator, candidates) in cases {
+        let mut config = LoadBalancerAlgorithmConfig::from(LoadBalancerAlgorithm::PowerOfN);
+        let settings = config
+            .power_of_n_settings_mut()
+            .expect("power-of-n config should expose settings");
+        settings.sample_count = 2;
+        settings.comparator = Some(comparator);
+        let load_balancer =
+            create_load_balancer_with_config(&config).expect("comparator config should be valid");
+
+        let chosen = choose(load_balancer.as_ref(), &request, &candidates);
+        assert_eq!(chosen.candidate.cluster_id, "preferred", "{comparator}");
+    }
+}
+
+#[test]
+fn wait_and_widen_uses_comparator_with_and_without_affinity() {
+    let candidates = [
+        candidate("lower-ttft-higher-queue", 1024)
+            .with_rtt_ms(5)
+            .with_stats(|stats| stats.queue_size = 10),
+        candidate("higher-ttft-lower-queue", 1024)
+            .with_rtt_ms(50)
+            .with_stats(|stats| stats.queue_size = 1),
+    ];
+    let target = target();
+
+    for cache_affinity_key in [None, Some("prefix-a")] {
+        let load_balancer = wait_and_widen_load_balancer(|settings| {
+            settings.comparator = Some(ClusterComparator::NumRequestsQueued);
+            settings.ttft_bucket_size_ms = Some(100);
+            settings.n = Some(2);
+            if cache_affinity_key.is_some() {
+                settings.seed = Some("seed-1".to_string());
+                settings.cache_affinity_virtual_nodes = Some(8);
+                settings.cache_affinity_backend_selection_count = Some(2);
+            }
+        });
+        let request = request(&target, cache_affinity_key, Some(1));
+
+        assert_repeated_choice(
+            load_balancer.as_ref(),
+            &request,
+            &candidates,
+            8,
+            "higher-ttft-lower-queue",
+        );
+    }
+}
+
+#[test]
+fn routing_selection_reports_effective_comparator_and_selected_score() {
+    let router =
+        router_from_json(r#"{"models":{"model-a":{"algorithm":"power-of-n","sample_count":2}}}"#);
+    let target = target();
+    let request = request(&target, None, Some(100));
+    let candidates = [
+        priority_candidate("selected", 0, 20).with_rtt_ms(5),
+        priority_candidate("slower", 0, 50).with_rtt_ms(100),
+    ];
+    let target_state = LoadBalancerTargetState::default();
+    let resolution = router
+        .resolve_algorithm_override(&target.model_id, None)
+        .expect("configured algorithm should resolve");
+
+    let selection = router
+        .choose_candidate_with_algorithm_resolution(
+            &target_state,
+            &request,
+            &candidates,
+            &resolution,
+        )
+        .expect("candidate should be selected");
+    let comparator = selection
+        .comparator
+        .expect("power-of-n selection should report its comparator");
+
+    assert_eq!(
+        candidates[selection.choice.candidate_index].cluster_id,
+        "selected"
+    );
+    assert_eq!(comparator.comparator, ClusterComparator::EstimatedTtft);
+    assert_eq!(comparator.score, 1025.0);
+    assert_eq!(comparator.queue_ms, Some(20.0));
+    assert_eq!(comparator.prefill_ms, Some(1000.0));
+    assert_eq!(comparator.rtt_ms, Some(5.0));
 }
 
 wait_and_widen_choice_tests! {

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/tests.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/tests.rs
@@ -1777,41 +1777,22 @@ fn wait_and_widen_uses_comparator_with_and_without_affinity() {
 }
 
 #[test]
-fn routing_selection_reports_effective_comparator_and_selected_score() {
-    let router =
-        router_from_json(r#"{"models":{"model-a":{"algorithm":"power-of-n","sample_count":2}}}"#);
+fn default_comparator_trace_reports_score_components() {
+    let config = LoadBalancerAlgorithmConfig::from(LoadBalancerAlgorithm::PowerOfN);
+    let comparator = config
+        .comparator()
+        .expect("power-of-n should have an effective comparator");
     let target = target();
     let request = request(&target, None, Some(100));
-    let candidates = [
-        priority_candidate("selected", 0, 20).with_rtt_ms(5),
-        priority_candidate("slower", 0, 50).with_rtt_ms(100),
-    ];
-    let target_state = LoadBalancerTargetState::default();
-    let resolution = router
-        .resolve_algorithm_override(&target.model_id, None)
-        .expect("configured algorithm should resolve");
+    let selected = priority_candidate("selected", 0, 20).with_rtt_ms(5);
 
-    let selection = router
-        .choose_candidate_with_algorithm_resolution(
-            &target_state,
-            &request,
-            &candidates,
-            &resolution,
-        )
-        .expect("candidate should be selected");
-    let comparator = selection
-        .comparator
-        .expect("power-of-n selection should report its comparator");
+    let trace = comparator.trace(&request, &selected);
 
-    assert_eq!(
-        candidates[selection.choice.candidate_index].cluster_id,
-        "selected"
-    );
-    assert_eq!(comparator.comparator, ClusterComparator::EstimatedTtft);
-    assert_eq!(comparator.score, 1025.0);
-    assert_eq!(comparator.queue_ms, Some(20.0));
-    assert_eq!(comparator.prefill_ms, Some(1000.0));
-    assert_eq!(comparator.rtt_ms, Some(5.0));
+    assert_eq!(trace.comparator, ClusterComparator::EstimatedTtft);
+    assert_eq!(trace.score, 1025.0);
+    assert_eq!(trace.queue_ms, Some(20.0));
+    assert_eq!(trace.prefill_ms, Some(1000.0));
+    assert_eq!(trace.rtt_ms, Some(5.0));
 }
 
 wait_and_widen_choice_tests! {

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/tests.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/tests.rs
@@ -810,6 +810,10 @@ fn pulsar_wait_and_widen_rejects_explicit_comparator() {
             .to_string()
             .contains("comparator is not supported for pulsar-wait-and-widen")
     );
+    assert_json_rejected::<LoadBalancerAlgorithmConfig>(
+        r#"{"algorithm":"pulsar-wait-and-widen","comparator":null}"#,
+        "invalid type: null",
+    );
 }
 
 #[test]
@@ -1732,7 +1736,7 @@ fn power_of_n_uses_each_configured_comparator() {
             .power_of_n_settings_mut()
             .expect("power-of-n config should expose settings");
         settings.sample_count = 2;
-        settings.comparator = Some(comparator);
+        settings.comparator = comparator;
         let load_balancer =
             create_load_balancer_with_config(&config).expect("comparator config should be valid");
 

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/tests.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/tests.rs
@@ -2027,7 +2027,7 @@ fn wait_and_widen_cache_affinity_is_skipped_without_header() {
 }
 
 wait_and_widen_choice_tests! {
-    wait_and_widen_uses_input_tokens_in_ttft_estimate:
+    wait_and_widen_uses_input_tokens_in_ttft:
     |_| {};
     |target| request(target, None, Some(100));
     [
@@ -2036,7 +2036,7 @@ wait_and_widen_choice_tests! {
     ];
     1 => "higher-rtt-higher-cap";
 
-    wait_and_widen_can_ignore_input_processing_time_in_ttft_estimate:
+    wait_and_widen_can_ignore_input_processing_time_in_ttft:
     |settings| settings.ignore_input_processing_time = Some(true);
     |target| request(target, None, Some(100));
     [
@@ -2064,7 +2064,7 @@ fn wait_and_widen_limits_selection_to_first_ttft_bucket() {
 }
 
 wait_and_widen_choice_tests! {
-    wait_and_widen_can_ignore_queue_time_in_ttft_estimate:
+    wait_and_widen_can_ignore_queue_time_in_ttft:
     |settings| settings.ignore_queue_time = Some(true);
     |target| request(target, None, Some(0));
     [
@@ -2321,7 +2321,7 @@ wait_and_widen_choice_tests! {
 }
 
 #[test]
-fn wait_and_widen_ttft_estimator_uses_priority_queue_and_ignore_flags() {
+fn wait_and_widen_ttft_uses_priority_queue_and_ignore_flags() {
     let mut candidate = work_candidate("estimated", 7, 100.0, 999);
     candidate.stats.queue_time_estimate_ms_by_priority = HashMap::from([(4, 25)]);
 

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/tests.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/tests.rs
@@ -1776,25 +1776,6 @@ fn wait_and_widen_uses_comparator_with_and_without_affinity() {
     }
 }
 
-#[test]
-fn default_comparator_trace_reports_score_components() {
-    let config = LoadBalancerAlgorithmConfig::from(LoadBalancerAlgorithm::PowerOfN);
-    let comparator = config
-        .comparator()
-        .expect("power-of-n should have an effective comparator");
-    let target = target();
-    let request = request(&target, None, Some(100));
-    let selected = priority_candidate("selected", 0, 20).with_rtt_ms(5);
-
-    let trace = comparator.trace(&request, &selected);
-
-    assert_eq!(trace.comparator, ClusterComparator::EstimatedTtft);
-    assert_eq!(trace.score, 1025.0);
-    assert_eq!(trace.queue_ms, Some(20.0));
-    assert_eq!(trace.prefill_ms, Some(1000.0));
-    assert_eq!(trace.rtt_ms, Some(5.0));
-}
-
 wait_and_widen_choice_tests! {
     wait_and_widen_prefers_lower_estimated_ttft:
     |_| {};

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen.rs
@@ -111,7 +111,7 @@ impl WaitAndWidenConfig {
     }
 
     #[inline]
-    fn compare_configured_candidates(
+    fn compare_sampled_candidates(
         &self,
         request: &LoadBalancerRequest<'_>,
         candidate_a: &RoutedClusterSnapshot,
@@ -123,7 +123,7 @@ impl WaitAndWidenConfig {
     }
 
     #[inline]
-    fn compare_candidates_with_estimates(
+    fn compare_sampled_candidates_with_estimates(
         &self,
         request: &LoadBalancerRequest<'_>,
         candidate_a: &RoutedClusterSnapshot,
@@ -133,7 +133,7 @@ impl WaitAndWidenConfig {
     ) -> Ordering {
         match self.comparator {
             None => compare_least_queue_time(candidate_a, estimate_a, candidate_b, estimate_b),
-            Some(ClusterComparator::EstimatedTtft)
+            Some(ClusterComparator::Ttft)
                 if !self.ignore_queue_time && !self.ignore_input_processing_time =>
             {
                 estimate_a.ttft_ms.total_cmp(&estimate_b.ttft_ms)
@@ -284,6 +284,8 @@ impl WaitAndWidenLoadBalancer {
         candidates: impl ExactSizeIterator<Item = &'a RoutedClusterSnapshot>,
         candidate_index_source: &[RoutedClusterSnapshot],
     ) -> Option<LoadBalancerCandidateChoice> {
+        // TTFT determines bucket eligibility and unlock timing. The configured
+        // comparator is applied after the unlocked candidates are sampled.
         let mut estimates =
             CandidateEstimateAccumulator::new(&self.config, request, candidates.len());
         if let RequestExclusions::One(excluded_cluster_id) = RequestExclusions::from(request) {
@@ -375,7 +377,7 @@ impl WaitAndWidenLoadBalancer {
             .into_iter()
             .take(sampled_count)
             .min_by(|(candidate_a, estimate_a), (candidate_b, estimate_b)| {
-                self.config.compare_candidates_with_estimates(
+                self.config.compare_sampled_candidates_with_estimates(
                     request,
                     candidate_a,
                     estimate_a,
@@ -424,7 +426,7 @@ fn choose_preferred_candidate<'a>(
     estimate_b: &TtftEstimate,
     rng: &mut impl Rng,
 ) -> &'a RoutedClusterSnapshot {
-    match config.compare_candidates_with_estimates(
+    match config.compare_sampled_candidates_with_estimates(
         request,
         candidate_a,
         estimate_a,

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen.rs
@@ -24,22 +24,19 @@ use std::time::Duration;
 use rand::Rng;
 
 use super::{
-    LoadBalancer, LoadBalancerAlgorithmConfig, LoadBalancerCandidateChoice, LoadBalancerRequest,
-    WaitAndWidenAlgorithmConfig,
+    ClusterComparator, LoadBalancer, LoadBalancerAlgorithmConfig, LoadBalancerCandidateChoice,
+    LoadBalancerRequest, TtftEstimate, estimate_ttft,
 };
 use crate::routing_state::RoutedClusterSnapshot;
 use cache_affinity::CacheAffinitySelector;
-use estimates::{
-    CandidateEstimateAccumulator, TtftEstimate, compare_least_queue_time, estimate_ttft_ms,
-    has_capacity,
-};
+use estimates::{CandidateEstimateAccumulator, compare_least_queue_time, has_capacity};
 
+#[cfg(test)]
+pub(super) use super::estimate_ttft as wait_and_widen_ttft_components;
 #[cfg(test)]
 pub(super) use cache_affinity::{
     cache_affinity_candidate_indices, cache_affinity_candidates, cache_affinity_virtual_node_hash,
 };
-#[cfg(test)]
-pub(super) use estimates::estimate_ttft_ms as wait_and_widen_ttft_components;
 
 // Parity notes vs lpu-router WaitAndWiden:
 // - Stargate uses only the sticky last_mean_input_tps capacity signal for
@@ -55,6 +52,7 @@ pub(super) struct WaitAndWidenLoadBalancer {
 
 #[derive(Clone, Debug)]
 pub(super) struct WaitAndWidenConfig {
+    comparator: Option<ClusterComparator>,
     pub(super) seed: Option<String>,
     pub(super) cache_affinity_virtual_nodes: usize,
     pub(super) cache_affinity_backend_selection_count: Option<usize>,
@@ -69,14 +67,12 @@ pub(super) struct WaitAndWidenConfig {
 
 impl WaitAndWidenConfig {
     pub(super) fn from_algorithm_config(config: &LoadBalancerAlgorithmConfig) -> Self {
+        let comparator = config.comparator();
         let config = config
             .wait_and_widen_settings()
             .expect("wait_and_widen settings should match load-balancer algorithm");
-        Self::from_settings(config)
-    }
-
-    pub(super) fn from_settings(config: &WaitAndWidenAlgorithmConfig) -> Self {
         Self {
+            comparator,
             seed: config.seed.clone(),
             // Zero virtual nodes would make affinity routing degenerate; keep the historical minimum.
             cache_affinity_virtual_nodes: config.cache_affinity_virtual_nodes.unwrap_or(150).max(1),
@@ -112,6 +108,41 @@ impl WaitAndWidenConfig {
         };
         let max_queue_time_ms = floor_ms + (ceil_ms - floor_ms) * slo_elapsed_percentage;
         Some(Duration::from_secs_f64(max_queue_time_ms / 1000.0))
+    }
+
+    #[inline]
+    fn compare_configured_candidates(
+        &self,
+        request: &LoadBalancerRequest<'_>,
+        candidate_a: &RoutedClusterSnapshot,
+        candidate_b: &RoutedClusterSnapshot,
+    ) -> Ordering {
+        self.comparator
+            .expect("wait-and-widen fast path should have a configured comparator")
+            .compare(request, candidate_a, candidate_b)
+    }
+
+    #[inline]
+    fn compare_candidates_with_estimates(
+        &self,
+        request: &LoadBalancerRequest<'_>,
+        candidate_a: &RoutedClusterSnapshot,
+        estimate_a: &TtftEstimate,
+        candidate_b: &RoutedClusterSnapshot,
+        estimate_b: &TtftEstimate,
+    ) -> Ordering {
+        match self.comparator {
+            None => compare_least_queue_time(candidate_a, estimate_a, candidate_b, estimate_b),
+            Some(ClusterComparator::EstimatedTtft)
+                if !self.ignore_queue_time && !self.ignore_input_processing_time =>
+            {
+                estimate_a.ttft_ms.total_cmp(&estimate_b.ttft_ms)
+            }
+            Some(ClusterComparator::QueueTime) => {
+                estimate_a.queue_ms.total_cmp(&estimate_b.queue_ms)
+            }
+            Some(comparator) => comparator.compare(request, candidate_a, candidate_b),
+        }
     }
 }
 
@@ -206,7 +237,7 @@ impl WaitAndWidenLoadBalancer {
         }
 
         let estimate = |candidate| {
-            estimate_ttft_ms(
+            estimate_ttft(
                 candidate,
                 request.input_tokens,
                 request.priority,
@@ -229,7 +260,9 @@ impl WaitAndWidenLoadBalancer {
         // by the shuffled order, so keep that random tie-break explicitly while
         // avoiding the allocation and prefix-shuffle overhead on cache hits.
         let mut rng = rand::rng();
-        let candidate = choose_less_queued_candidate(
+        let candidate = choose_preferred_candidate(
+            &self.config,
+            request,
             candidate_a,
             &estimate_a,
             candidate_b,
@@ -278,6 +311,7 @@ impl WaitAndWidenLoadBalancer {
         let bucket_size_ms = self.config.ttft_bucket_size.as_secs_f64() * 1000.0;
         if estimates.all_estimates_in_first_bucket(bucket_size_ms) {
             return self.choose_from_unlocked_candidates(
+                request,
                 estimates.into_estimates(),
                 candidate_index_source,
             );
@@ -315,11 +349,12 @@ impl WaitAndWidenLoadBalancer {
         }
 
         estimated.truncate(unlocked_count);
-        self.choose_from_unlocked_candidates(estimated, candidate_index_source)
+        self.choose_from_unlocked_candidates(request, estimated, candidate_index_source)
     }
 
     fn choose_from_unlocked_candidates(
         &self,
+        request: &LoadBalancerRequest<'_>,
         mut unlocked_with_capacity: Vec<(&RoutedClusterSnapshot, TtftEstimate)>,
         candidates: &[RoutedClusterSnapshot],
     ) -> Option<LoadBalancerCandidateChoice> {
@@ -340,7 +375,13 @@ impl WaitAndWidenLoadBalancer {
             .into_iter()
             .take(sampled_count)
             .min_by(|(candidate_a, estimate_a), (candidate_b, estimate_b)| {
-                compare_least_queue_time(candidate_a, estimate_a, candidate_b, estimate_b)
+                self.config.compare_candidates_with_estimates(
+                    request,
+                    candidate_a,
+                    estimate_a,
+                    candidate_b,
+                    estimate_b,
+                )
             })
             .map(|(candidate, _)| choice_for_candidate(candidates, candidate, 1))
     }
@@ -374,14 +415,22 @@ fn choice_for_candidate(
     }
 }
 
-fn choose_less_queued_candidate<'a>(
+fn choose_preferred_candidate<'a>(
+    config: &WaitAndWidenConfig,
+    request: &LoadBalancerRequest<'_>,
     candidate_a: &'a RoutedClusterSnapshot,
     estimate_a: &TtftEstimate,
     candidate_b: &'a RoutedClusterSnapshot,
     estimate_b: &TtftEstimate,
     rng: &mut impl Rng,
 ) -> &'a RoutedClusterSnapshot {
-    match compare_least_queue_time(candidate_a, estimate_a, candidate_b, estimate_b) {
+    match config.compare_candidates_with_estimates(
+        request,
+        candidate_a,
+        estimate_a,
+        candidate_b,
+        estimate_b,
+    ) {
         Ordering::Less => candidate_a,
         Ordering::Equal if rng.random_bool(0.5) => candidate_a,
         Ordering::Equal | Ordering::Greater => candidate_b,

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen.rs
@@ -25,14 +25,14 @@ use rand::Rng;
 
 use super::{
     ClusterComparator, LoadBalancer, LoadBalancerAlgorithmConfig, LoadBalancerCandidateChoice,
-    LoadBalancerRequest, TtftEstimate, estimate_ttft,
+    LoadBalancerRequest, Ttft, ttft,
 };
 use crate::routing_state::RoutedClusterSnapshot;
 use cache_affinity::CacheAffinitySelector;
-use estimates::{CandidateEstimateAccumulator, compare_least_queue_time, has_capacity};
+use estimates::{CandidateTtftAccumulator, compare_least_queue_time, has_capacity};
 
 #[cfg(test)]
-pub(super) use super::estimate_ttft as wait_and_widen_ttft_components;
+pub(super) use super::ttft as wait_and_widen_ttft_components;
 #[cfg(test)]
 pub(super) use cache_affinity::{
     cache_affinity_candidate_indices, cache_affinity_candidates, cache_affinity_virtual_node_hash,
@@ -123,24 +123,22 @@ impl WaitAndWidenConfig {
     }
 
     #[inline]
-    fn compare_sampled_candidates_with_estimates(
+    fn compare_sampled_candidates_with_ttft(
         &self,
         request: &LoadBalancerRequest<'_>,
         candidate_a: &RoutedClusterSnapshot,
-        estimate_a: &TtftEstimate,
+        ttft_a: &Ttft,
         candidate_b: &RoutedClusterSnapshot,
-        estimate_b: &TtftEstimate,
+        ttft_b: &Ttft,
     ) -> Ordering {
         match self.comparator {
-            None => compare_least_queue_time(candidate_a, estimate_a, candidate_b, estimate_b),
+            None => compare_least_queue_time(candidate_a, ttft_a, candidate_b, ttft_b),
             Some(ClusterComparator::Ttft)
                 if !self.ignore_queue_time && !self.ignore_input_processing_time =>
             {
-                estimate_a.ttft_ms.total_cmp(&estimate_b.ttft_ms)
+                ttft_a.ttft_ms.total_cmp(&ttft_b.ttft_ms)
             }
-            Some(ClusterComparator::QueueTime) => {
-                estimate_a.queue_ms.total_cmp(&estimate_b.queue_ms)
-            }
+            Some(ClusterComparator::QueueTime) => ttft_a.queue_ms.total_cmp(&ttft_b.queue_ms),
             Some(comparator) => comparator.compare(request, candidate_a, candidate_b),
         }
     }
@@ -236,8 +234,8 @@ impl WaitAndWidenLoadBalancer {
             return None;
         }
 
-        let estimate = |candidate| {
-            estimate_ttft(
+        let candidate_ttft = |candidate| {
+            ttft(
                 candidate,
                 request.input_tokens,
                 request.priority,
@@ -245,11 +243,11 @@ impl WaitAndWidenLoadBalancer {
                 self.config.ignore_input_processing_time,
             )
         };
-        let estimate_a = estimate(candidate_a);
-        let estimate_b = estimate(candidate_b);
-        if !estimate_a.ttft_ms.is_finite()
-            || !estimate_b.ttft_ms.is_finite()
-            || (estimate_a.ttft_ms - estimate_b.ttft_ms).abs()
+        let ttft_a = candidate_ttft(candidate_a);
+        let ttft_b = candidate_ttft(candidate_b);
+        if !ttft_a.ttft_ms.is_finite()
+            || !ttft_b.ttft_ms.is_finite()
+            || (ttft_a.ttft_ms - ttft_b.ttft_ms).abs()
                 > self.config.ttft_bucket_size.as_secs_f64() * 1000.0
         {
             return None;
@@ -264,9 +262,9 @@ impl WaitAndWidenLoadBalancer {
             &self.config,
             request,
             candidate_a,
-            &estimate_a,
+            &ttft_a,
             candidate_b,
-            &estimate_b,
+            &ttft_b,
             &mut rng,
         );
         Some(LoadBalancerCandidateChoice::with_rank_depth_1(
@@ -286,44 +284,43 @@ impl WaitAndWidenLoadBalancer {
     ) -> Option<LoadBalancerCandidateChoice> {
         // TTFT determines bucket eligibility and unlock timing. The configured
         // comparator is applied after the unlocked candidates are sampled.
-        let mut estimates =
-            CandidateEstimateAccumulator::new(&self.config, request, candidates.len());
+        let mut ttfts = CandidateTtftAccumulator::new(&self.config, request, candidates.len());
         if let RequestExclusions::One(excluded_cluster_id) = RequestExclusions::from(request) {
             for candidate in candidates {
                 if candidate.cluster_id != excluded_cluster_id {
-                    estimates.push_estimate(candidate);
+                    ttfts.push_ttft(candidate);
                 }
             }
-        } else if request.has_excluded_clusters() || estimates.filters_by_queue_slo() {
+        } else if request.has_excluded_clusters() || ttfts.filters_by_queue_slo() {
             for candidate in candidates {
                 if !request.excludes_cluster(&candidate.cluster_id) {
-                    estimates.push_estimate(candidate);
+                    ttfts.push_ttft(candidate);
                 }
             }
         } else {
             for candidate in candidates {
-                estimates.push_estimate(candidate);
+                ttfts.push_ttft(candidate);
             }
         }
 
-        if estimates.is_empty() || !estimates.has_finite_fastest_ttft() {
+        if ttfts.is_empty() || !ttfts.has_finite_fastest_ttft() {
             return None;
         }
 
         let bucket_size_ms = self.config.ttft_bucket_size.as_secs_f64() * 1000.0;
-        if estimates.all_estimates_in_first_bucket(bucket_size_ms) {
+        if ttfts.all_in_first_bucket(bucket_size_ms) {
             return self.choose_from_unlocked_candidates(
                 request,
-                estimates.into_estimates(),
+                ttfts.into_ttfts(),
                 candidate_index_source,
             );
         }
 
-        let mut estimated = estimates.into_estimates();
-        estimated.sort_unstable_by(|(candidate_a, estimate_a), (candidate_b, estimate_b)| {
-            estimate_a
+        let mut ttfts = ttfts.into_ttfts();
+        ttfts.sort_unstable_by(|(candidate_a, ttft_a), (candidate_b, ttft_b)| {
+            ttft_a
                 .ttft_ms
-                .total_cmp(&estimate_b.ttft_ms)
+                .total_cmp(&ttft_b.ttft_ms)
                 .then_with(|| candidate_a.cluster_id.cmp(&candidate_b.cluster_id))
         });
 
@@ -331,33 +328,33 @@ impl WaitAndWidenLoadBalancer {
         let mut prev_bucket_start_ttft = None;
         let mut unlocked_count = 0;
 
-        for (_, estimate) in &estimated {
-            if !estimate.ttft_ms.is_finite() {
+        for (_, ttft) in &ttfts {
+            if !ttft.ttft_ms.is_finite() {
                 break;
             }
 
-            let bucket_start_ttft = prev_bucket_start_ttft.get_or_insert(estimate.ttft_ms);
-            let gap_ms = estimate.ttft_ms - *bucket_start_ttft;
+            let bucket_start_ttft = prev_bucket_start_ttft.get_or_insert(ttft.ttft_ms);
+            let gap_ms = ttft.ttft_ms - *bucket_start_ttft;
             if gap_ms > bucket_size_ms {
                 let sleep_for_at_least_ms = gap_ms * self.config.next_bucket_unlock_factor;
                 if slept_for_ms < sleep_for_at_least_ms {
                     break;
                 }
                 slept_for_ms -= sleep_for_at_least_ms;
-                *bucket_start_ttft = estimate.ttft_ms;
+                *bucket_start_ttft = ttft.ttft_ms;
             }
 
             unlocked_count += 1;
         }
 
-        estimated.truncate(unlocked_count);
-        self.choose_from_unlocked_candidates(request, estimated, candidate_index_source)
+        ttfts.truncate(unlocked_count);
+        self.choose_from_unlocked_candidates(request, ttfts, candidate_index_source)
     }
 
     fn choose_from_unlocked_candidates(
         &self,
         request: &LoadBalancerRequest<'_>,
-        mut unlocked_with_capacity: Vec<(&RoutedClusterSnapshot, TtftEstimate)>,
+        mut unlocked_with_capacity: Vec<(&RoutedClusterSnapshot, Ttft)>,
         candidates: &[RoutedClusterSnapshot],
     ) -> Option<LoadBalancerCandidateChoice> {
         // The caller already owns this candidate buffer. Retaining in place
@@ -376,13 +373,13 @@ impl WaitAndWidenLoadBalancer {
         unlocked_with_capacity
             .into_iter()
             .take(sampled_count)
-            .min_by(|(candidate_a, estimate_a), (candidate_b, estimate_b)| {
-                self.config.compare_sampled_candidates_with_estimates(
+            .min_by(|(candidate_a, ttft_a), (candidate_b, ttft_b)| {
+                self.config.compare_sampled_candidates_with_ttft(
                     request,
                     candidate_a,
-                    estimate_a,
+                    ttft_a,
                     candidate_b,
-                    estimate_b,
+                    ttft_b,
                 )
             })
             .map(|(candidate, _)| choice_for_candidate(candidates, candidate, 1))
@@ -421,17 +418,17 @@ fn choose_preferred_candidate<'a>(
     config: &WaitAndWidenConfig,
     request: &LoadBalancerRequest<'_>,
     candidate_a: &'a RoutedClusterSnapshot,
-    estimate_a: &TtftEstimate,
+    ttft_a: &Ttft,
     candidate_b: &'a RoutedClusterSnapshot,
-    estimate_b: &TtftEstimate,
+    ttft_b: &Ttft,
     rng: &mut impl Rng,
 ) -> &'a RoutedClusterSnapshot {
-    match config.compare_sampled_candidates_with_estimates(
+    match config.compare_sampled_candidates_with_ttft(
         request,
         candidate_a,
-        estimate_a,
+        ttft_a,
         candidate_b,
-        estimate_b,
+        ttft_b,
     ) {
         Ordering::Less => candidate_a,
         Ordering::Equal if rng.random_bool(0.5) => candidate_a,

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen/estimates.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen/estimates.rs
@@ -15,17 +15,10 @@
 
 use std::cmp::Ordering;
 
-use crate::load_balancer::{LoadBalancerRequest, input_work_units};
+use crate::load_balancer::{LoadBalancerRequest, TtftEstimate, estimate_ttft};
 use crate::routing_state::RoutedClusterSnapshot;
-use stargate_protocol::common::valid_last_mean_input_tps;
 
 use super::WaitAndWidenConfig;
-
-#[derive(Clone, Copy, Debug)]
-pub(in crate::load_balancer) struct TtftEstimate {
-    pub(in crate::load_balancer) queue_ms: f64,
-    pub(in crate::load_balancer) ttft_ms: f64,
-}
 
 pub(super) struct CandidateEstimateAccumulator<'a> {
     estimates: Vec<(&'a RoutedClusterSnapshot, TtftEstimate)>,
@@ -67,7 +60,7 @@ impl<'a> CandidateEstimateAccumulator<'a> {
     }
 
     pub(super) fn push_estimate(&mut self, candidate: &'a RoutedClusterSnapshot) {
-        let estimate = estimate_ttft_ms(
+        let estimate = estimate_ttft(
             candidate,
             self.input_tokens,
             self.priority,
@@ -143,79 +136,4 @@ pub(super) fn has_capacity(candidate: &RoutedClusterSnapshot, max_queued: u64) -
 
 fn within_queue_slo(estimate: &TtftEstimate, max_queue_time_ms: Option<f64>) -> bool {
     max_queue_time_ms.is_none_or(|max_queue_time_ms| estimate.queue_ms <= max_queue_time_ms)
-}
-
-pub(in crate::load_balancer) fn estimate_ttft_ms(
-    candidate: &RoutedClusterSnapshot,
-    input_tokens: Option<u64>,
-    priority: u32,
-    ignore_queue_time: bool,
-    ignore_input_processing_time: bool,
-) -> TtftEstimate {
-    let input_tokens = input_tokens.unwrap_or(0) as f64;
-    let effective_input_tps = effective_input_tps(candidate);
-    let queue_ms = estimate_queue_delay_ms(candidate, priority, effective_input_tps);
-    let prefill_ms = estimate_processing_delay_ms(input_tokens, effective_input_tps);
-    let rtt_ms = rtt_ms(candidate);
-    let ttft_ms = rtt_ms
-        + if ignore_queue_time { 0.0 } else { queue_ms }
-        + if ignore_input_processing_time {
-            0.0
-        } else {
-            prefill_ms
-        };
-
-    TtftEstimate { queue_ms, ttft_ms }
-}
-
-pub(super) fn estimate_queue_comparison(
-    candidate: &RoutedClusterSnapshot,
-    priority: u32,
-) -> TtftEstimate {
-    let effective_input_tps = effective_input_tps(candidate);
-    TtftEstimate {
-        queue_ms: estimate_queue_delay_ms(candidate, priority, effective_input_tps),
-        ttft_ms: rtt_ms(candidate),
-    }
-}
-
-pub(super) fn queue_ignored_ttft_ms(candidate: &RoutedClusterSnapshot, input_tokens: f64) -> f64 {
-    rtt_ms(candidate) + estimate_processing_delay_ms(input_tokens, effective_input_tps(candidate))
-}
-
-pub(super) fn rtt_ms(candidate: &RoutedClusterSnapshot) -> f64 {
-    candidate.rtt.as_secs_f64() * 1000.0
-}
-
-fn estimate_queue_delay_ms(
-    candidate: &RoutedClusterSnapshot,
-    priority: u32,
-    effective_input_tps: f64,
-) -> f64 {
-    if let Some(queue_time_ms) =
-        crate::queue_estimate::queue_time_estimate_ms_for_priority(&candidate.stats, priority)
-    {
-        return queue_time_ms as f64;
-    }
-
-    estimate_processing_delay_ms(input_work_units(candidate), effective_input_tps)
-}
-
-fn effective_input_tps(candidate: &RoutedClusterSnapshot) -> f64 {
-    if valid_last_mean_input_tps(candidate.stats.last_mean_input_tps) {
-        candidate.stats.last_mean_input_tps
-    } else {
-        0.0
-    }
-}
-
-fn estimate_processing_delay_ms(work_units: f64, rate: f64) -> f64 {
-    if work_units == 0.0 {
-        return 0.0;
-    }
-    if rate <= 0.0 {
-        return f64::INFINITY;
-    }
-
-    (work_units / rate) * 1000.0
 }

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen/estimates.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen/estimates.rs
@@ -15,13 +15,13 @@
 
 use std::cmp::Ordering;
 
-use crate::load_balancer::{LoadBalancerRequest, TtftEstimate, estimate_ttft};
+use crate::load_balancer::{LoadBalancerRequest, Ttft, ttft};
 use crate::routing_state::RoutedClusterSnapshot;
 
 use super::WaitAndWidenConfig;
 
-pub(super) struct CandidateEstimateAccumulator<'a> {
-    estimates: Vec<(&'a RoutedClusterSnapshot, TtftEstimate)>,
+pub(super) struct CandidateTtftAccumulator<'a> {
+    ttfts: Vec<(&'a RoutedClusterSnapshot, Ttft)>,
     input_tokens: Option<u64>,
     priority: u32,
     max_queue_time_ms: Option<f64>,
@@ -29,10 +29,10 @@ pub(super) struct CandidateEstimateAccumulator<'a> {
     ignore_input_processing_time: bool,
     fastest_ttft: f64,
     slowest_ttft: f64,
-    all_estimates_finite: bool,
+    all_ttfts_finite: bool,
 }
 
-impl<'a> CandidateEstimateAccumulator<'a> {
+impl<'a> CandidateTtftAccumulator<'a> {
     pub(super) fn new(
         config: &WaitAndWidenConfig,
         request: &LoadBalancerRequest<'_>,
@@ -43,7 +43,7 @@ impl<'a> CandidateEstimateAccumulator<'a> {
             .map(|duration| duration.as_secs_f64() * 1000.0);
 
         Self {
-            estimates: Vec::with_capacity(candidate_capacity),
+            ttfts: Vec::with_capacity(candidate_capacity),
             input_tokens: request.input_tokens,
             priority: request.priority,
             max_queue_time_ms,
@@ -51,7 +51,7 @@ impl<'a> CandidateEstimateAccumulator<'a> {
             ignore_input_processing_time: config.ignore_input_processing_time,
             fastest_ttft: f64::INFINITY,
             slowest_ttft: f64::NEG_INFINITY,
-            all_estimates_finite: true,
+            all_ttfts_finite: true,
         }
     }
 
@@ -59,51 +59,51 @@ impl<'a> CandidateEstimateAccumulator<'a> {
         self.max_queue_time_ms.is_some()
     }
 
-    pub(super) fn push_estimate(&mut self, candidate: &'a RoutedClusterSnapshot) {
-        let estimate = estimate_ttft(
+    pub(super) fn push_ttft(&mut self, candidate: &'a RoutedClusterSnapshot) {
+        let ttft = ttft(
             candidate,
             self.input_tokens,
             self.priority,
             self.ignore_queue_time,
             self.ignore_input_processing_time,
         );
-        if !within_queue_slo(&estimate, self.max_queue_time_ms) {
+        if !within_queue_slo(&ttft, self.max_queue_time_ms) {
             return;
         }
 
-        if estimate.ttft_ms.is_finite() {
-            self.fastest_ttft = self.fastest_ttft.min(estimate.ttft_ms);
-            self.slowest_ttft = self.slowest_ttft.max(estimate.ttft_ms);
+        if ttft.ttft_ms.is_finite() {
+            self.fastest_ttft = self.fastest_ttft.min(ttft.ttft_ms);
+            self.slowest_ttft = self.slowest_ttft.max(ttft.ttft_ms);
         } else {
-            self.all_estimates_finite = false;
+            self.all_ttfts_finite = false;
         }
-        self.estimates.push((candidate, estimate));
+        self.ttfts.push((candidate, ttft));
     }
 
     pub(super) fn is_empty(&self) -> bool {
-        self.estimates.is_empty()
+        self.ttfts.is_empty()
     }
 
     pub(super) fn has_finite_fastest_ttft(&self) -> bool {
         self.fastest_ttft.is_finite()
     }
 
-    pub(super) fn all_estimates_in_first_bucket(&self, bucket_size_ms: f64) -> bool {
-        self.all_estimates_finite && self.slowest_ttft - self.fastest_ttft <= bucket_size_ms
+    pub(super) fn all_in_first_bucket(&self, bucket_size_ms: f64) -> bool {
+        self.all_ttfts_finite && self.slowest_ttft - self.fastest_ttft <= bucket_size_ms
     }
 
-    pub(super) fn into_estimates(self) -> Vec<(&'a RoutedClusterSnapshot, TtftEstimate)> {
-        self.estimates
+    pub(super) fn into_ttfts(self) -> Vec<(&'a RoutedClusterSnapshot, Ttft)> {
+        self.ttfts
     }
 }
 
 pub(super) fn compare_least_queue_time(
     candidate_a: &RoutedClusterSnapshot,
-    estimate_a: &TtftEstimate,
+    ttft_a: &Ttft,
     candidate_b: &RoutedClusterSnapshot,
-    estimate_b: &TtftEstimate,
+    ttft_b: &Ttft,
 ) -> Ordering {
-    match estimate_a.queue_ms.total_cmp(&estimate_b.queue_ms) {
+    match ttft_a.queue_ms.total_cmp(&ttft_b.queue_ms) {
         Ordering::Equal => compare_least_percent_used(candidate_a, candidate_b),
         other => other,
     }
@@ -134,6 +134,6 @@ pub(super) fn has_capacity(candidate: &RoutedClusterSnapshot, max_queued: u64) -
     candidate.stats.num_running_queries < candidate.stats.max_engine_concurrency + max_queued
 }
 
-fn within_queue_slo(estimate: &TtftEstimate, max_queue_time_ms: Option<f64>) -> bool {
-    max_queue_time_ms.is_none_or(|max_queue_time_ms| estimate.queue_ms <= max_queue_time_ms)
+fn within_queue_slo(ttft: &Ttft, max_queue_time_ms: Option<f64>) -> bool {
+    max_queue_time_ms.is_none_or(|max_queue_time_ms| ttft.queue_ms <= max_queue_time_ms)
 }

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen/fast_path.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen/fast_path.rs
@@ -150,7 +150,7 @@ fn choose_from_unlocked_candidate_refs(
         .into_iter()
         .take(sampled_count)
         .min_by(|candidate_a, candidate_b| {
-            config.compare_configured_candidates(request, candidate_a, candidate_b)
+            config.compare_sampled_candidates(request, candidate_a, candidate_b)
         })
         .map(|candidate| choice_for_candidate(candidates, candidate, 1))
 }
@@ -182,7 +182,7 @@ fn choose_two_candidates(
 
     let candidate_a = unlocked_with_capacity[candidate_a_index];
     let candidate_b = unlocked_with_capacity[candidate_b_index];
-    let candidate = match config.compare_configured_candidates(request, candidate_a, candidate_b) {
+    let candidate = match config.compare_sampled_candidates(request, candidate_a, candidate_b) {
         std::cmp::Ordering::Less => candidate_a,
         std::cmp::Ordering::Equal if rng.random_bool(0.5) => candidate_a,
         std::cmp::Ordering::Equal | std::cmp::Ordering::Greater => candidate_b,

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen/fast_path.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen/fast_path.rs
@@ -15,17 +15,14 @@
 
 use rand::Rng;
 
-use crate::load_balancer::{LoadBalancerCandidateChoice, LoadBalancerRequest};
+use crate::load_balancer::{
+    LoadBalancerCandidateChoice, LoadBalancerRequest, cluster_comparator::queue_ignored_ttft_ms,
+    cluster_comparator::rtt_ms,
+};
 use crate::routing_state::RoutedClusterSnapshot;
 
-use super::estimates::{
-    compare_least_queue_time, estimate_queue_comparison, has_capacity, queue_ignored_ttft_ms,
-    rtt_ms,
-};
-use super::{
-    RequestExclusions, WaitAndWidenConfig, choice_for_candidate, choose_less_queued_candidate,
-    shuffle_prefix,
-};
+use super::estimates::has_capacity;
+use super::{RequestExclusions, WaitAndWidenConfig, choice_for_candidate, shuffle_prefix};
 
 macro_rules! choose_with_fast_path_exclusions {
     ($config:expr, $request:expr, $candidates:expr, $ttft_ms:expr) => {
@@ -144,11 +141,7 @@ fn choose_from_unlocked_candidate_refs(
         ));
     }
     if sample_count == 2 {
-        return choose_two_rtt_only_candidates(
-            &unlocked_with_capacity,
-            request.priority,
-            candidates,
-        );
+        return choose_two_candidates(config, request, &unlocked_with_capacity, candidates);
     }
 
     let sampled_count = sample_count.min(unlocked_with_capacity.len());
@@ -156,21 +149,16 @@ fn choose_from_unlocked_candidate_refs(
     unlocked_with_capacity
         .into_iter()
         .take(sampled_count)
-        .map(|candidate| {
-            (
-                candidate,
-                estimate_queue_comparison(candidate, request.priority),
-            )
+        .min_by(|candidate_a, candidate_b| {
+            config.compare_configured_candidates(request, candidate_a, candidate_b)
         })
-        .min_by(|(candidate_a, estimate_a), (candidate_b, estimate_b)| {
-            compare_least_queue_time(candidate_a, estimate_a, candidate_b, estimate_b)
-        })
-        .map(|(candidate, _)| choice_for_candidate(candidates, candidate, 1))
+        .map(|candidate| choice_for_candidate(candidates, candidate, 1))
 }
 
-fn choose_two_rtt_only_candidates(
+fn choose_two_candidates(
+    config: &WaitAndWidenConfig,
+    request: &LoadBalancerRequest<'_>,
     unlocked_with_capacity: &[&RoutedClusterSnapshot],
-    priority: u32,
     candidates: &[RoutedClusterSnapshot],
 ) -> Option<LoadBalancerCandidateChoice> {
     if unlocked_with_capacity.len() < 2 {
@@ -194,9 +182,10 @@ fn choose_two_rtt_only_candidates(
 
     let candidate_a = unlocked_with_capacity[candidate_a_index];
     let candidate_b = unlocked_with_capacity[candidate_b_index];
-    let estimate_a = estimate_queue_comparison(candidate_a, priority);
-    let estimate_b = estimate_queue_comparison(candidate_b, priority);
-    let candidate =
-        choose_less_queued_candidate(candidate_a, &estimate_a, candidate_b, &estimate_b, &mut rng);
+    let candidate = match config.compare_configured_candidates(request, candidate_a, candidate_b) {
+        std::cmp::Ordering::Less => candidate_a,
+        std::cmp::Ordering::Equal if rng.random_bool(0.5) => candidate_a,
+        std::cmp::Ordering::Equal | std::cmp::Ordering::Greater => candidate_b,
+    };
     Some(choice_for_candidate(candidates, candidate, 1))
 }

--- a/src/libraries/rust/stargate/crates/stargate/tests/suite/load_balancing.rs
+++ b/src/libraries/rust/stargate/crates/stargate/tests/suite/load_balancing.rs
@@ -403,7 +403,7 @@ fn float_eq(actual: f64, expected: f64) -> bool {
 }
 
 #[tokio::test]
-async fn power_of_n_prefers_lower_estimated_ttft() {
+async fn power_of_n_prefers_lower_ttft() {
     let stargate = RunningStargate::start("test-sg-p2c", None).await;
     let mut low =
         RegisteredBackend::active(stargate.grpc_addr, "p2c-model", "inst-low-headroom").await;
@@ -426,7 +426,7 @@ async fn power_of_n_prefers_lower_estimated_ttft() {
         ..CurrentModelStats::default()
     });
 
-    // Less pending prompt work should have the lower estimated TTFT.
+    // Less pending prompt work should have the lower TTFT.
     high.set_stats(CurrentModelStats {
         output_tps: 50.0,
         last_mean_input_tps: 1000.0,
@@ -848,7 +848,7 @@ async fn power_of_n_uses_cluster_aggregated_metrics_and_backend_round_robin() {
 }
 
 #[tokio::test]
-async fn wait_and_widen_load_balancing_prefers_lower_estimated_ttft() {
+async fn wait_and_widen_load_balancing_prefers_lower_ttft() {
     let stargate = RunningStargate::start(
         "test-sg-wait-and-widen",
         Some(r#"{"default": "power-of-n", "models": {"wait-and-widen-model": "wait-and-widen"}}"#),
@@ -908,10 +908,7 @@ async fn wait_and_widen_load_balancing_prefers_lower_estimated_ttft() {
         poll.tick().await;
     }
 
-    assert!(
-        stable_fast,
-        "expected wait-and-widen to prefer lower estimated TTFT"
-    );
+    assert!(stable_fast, "expected wait-and-widen to prefer lower TTFT");
 
     stop_backends(&mut backends);
     stargate.shutdown().await;

--- a/src/libraries/rust/stargate/crates/stargate/tests/suite/load_balancing.rs
+++ b/src/libraries/rust/stargate/crates/stargate/tests/suite/load_balancing.rs
@@ -403,7 +403,7 @@ fn float_eq(actual: f64, expected: f64) -> bool {
 }
 
 #[tokio::test]
-async fn power_of_n_prefers_less_input_work() {
+async fn power_of_n_prefers_lower_estimated_ttft() {
     let stargate = RunningStargate::start("test-sg-p2c", None).await;
     let mut low =
         RegisteredBackend::active(stargate.grpc_addr, "p2c-model", "inst-low-headroom").await;
@@ -412,7 +412,8 @@ async fn power_of_n_prefers_less_input_work() {
 
     wait_for_routing(stargate.http_addr, "p2c-model", Duration::from_secs(5)).await;
 
-    // More pending prompt work should lose when both clusters report the same service rate.
+    // More pending prompt work increases estimated queue delay and TTFT when both clusters
+    // report the same service rate.
     low.set_stats(CurrentModelStats {
         output_tps: 50.0,
         last_mean_input_tps: 1000.0,
@@ -425,7 +426,7 @@ async fn power_of_n_prefers_less_input_work() {
         ..CurrentModelStats::default()
     });
 
-    // Less pending prompt work should win.
+    // Less pending prompt work should have the lower estimated TTFT.
     high.set_stats(CurrentModelStats {
         output_tps: 50.0,
         last_mean_input_tps: 1000.0,
@@ -456,7 +457,7 @@ async fn power_of_n_prefers_less_input_work() {
     )
     .await;
 
-    // With exactly 2 candidates, p2c samples both and picks the lower work-time candidate.
+    // With exactly 2 candidates, power-of-n samples both and picks the lower TTFT candidate.
     assert_all_probes_routed_to(
         stargate.http_addr,
         "p2c-model",
@@ -1206,6 +1207,7 @@ async fn wait_and_widen_priority_header_uses_matching_queue_estimate() {
             "models": {
                 "wait-and-widen-priority-model": {
                     "algorithm": "wait-and-widen",
+                    "comparator": "queue-time",
                     "n": 2
                 }
             }
@@ -1218,12 +1220,12 @@ async fn wait_and_widen_priority_header_uses_matching_queue_estimate() {
         (
             "wait-and-widen-priority-specific-low",
             100_u64,
-            HashMap::from([(4_u32, 5_u64)]),
+            HashMap::from([(0_u32, 1000_u64), (4_u32, 5_u64)]),
         ),
         (
             "wait-and-widen-priority-specific-high",
             0_u64,
-            HashMap::from([(4_u32, 500_u64)]),
+            HashMap::from([(0_u32, 0_u64), (4_u32, 500_u64)]),
         ),
     ];
     let mut backends = Vec::new();

--- a/src/libraries/rust/stargate/docs/load-balancer-configuration.md
+++ b/src/libraries/rust/stargate/docs/load-balancer-configuration.md
@@ -108,20 +108,20 @@ Choose based on the routing goal and available backend statistics:
 
 | Goal | Algorithm | Required backend signals |
 | --- | --- | --- |
-| Minimize estimated time to first token across heterogeneous or remote clusters. | `wait-and-widen` | Forwarded health RTT and model statistics. Valid `last_mean_input_tps` is needed when queued or request input work is nonzero. |
+| Compare a small random sample using estimated TTFT or another load signal. | `power-of-n` | Signals required by the configured comparator. |
+| Minimize estimated time to first token across heterogeneous or remote clusters while controlling which TTFT bands are eligible. | `wait-and-widen` | Forwarded health RTT and model statistics. Valid `last_mean_input_tps` is needed when queued or request input work is nonzero. |
 | Keep the same prefix on a stable, capacity-weighted cluster. | `pulsar` | Positive finite `last_mean_input_tps` for every participating cluster. |
 | Keep Pulsar affinity when possible, but escape to lower-latency capacity when the primary cannot meet queue policy. | `pulsar-wait-and-widen` | Pulsar capacity plus the RTT and queue statistics used by `wait-and-widen`. |
 
-Use `power-of-n` when these statistics or affinity requirements are not
-available. Use `round-robin` for deterministic cycling and `random` for uniform
-random selection.
+Use `round-robin` for deterministic cycling and `random` for uniform random
+selection when routing should not depend on backend load statistics.
 
 ## `power-of-n`
 
 `power-of-n` uniformly samples distinct eligible clusters and selects the
-cluster with the lowest sum of queued and request input tokens divided by its
-last mean input TPS. It breaks equal scores randomly. Retried clusters are
-excluded before sampling.
+cluster with the lowest configured comparator score. The default comparator is
+`estimated-ttft`. It breaks equal scores randomly. Retried clusters are excluded
+before sampling.
 
 The default sample count is `2`. A larger sample can improve routing decisions
 in a heterogeneous pool, but it compares more clusters on every request. Valid
@@ -134,7 +134,8 @@ compares every eligible cluster once.
   "models": {
     "model-a": {
       "algorithm": "power-of-n",
-      "sample_count": 4
+      "sample_count": 4,
+      "comparator": "num-requests-queued"
     }
   }
 }
@@ -153,9 +154,10 @@ Otherwise it divides queued input tokens by `last_mean_input_tps`. Prefill time
 divides `x-input-tokens` by the same capacity signal.
 
 The algorithm groups close TTFT estimates into buckets. It samples `n`
-candidates from unlocked buckets and chooses the candidate with the least
-queue time, then the lowest engine utilization. A later bucket becomes
-available after the request has waited for a fraction of the TTFT gap.
+candidates from unlocked buckets and chooses the candidate with the lowest
+configured comparator score. The default comparator is `estimated-ttft`. A
+later bucket becomes available after the request has waited for a fraction of
+the TTFT gap.
 
 When `cache_affinity_backend_selection_count` is enabled and the request has
 `x-cache-affinity-key`, a consistent hash ring first limits selection to a
@@ -234,6 +236,31 @@ Minimal configuration:
 
 ## Algorithm fields
 
+`power-of-n` and `wait-and-widen` support this field:
+
+| Field | Type | Default | Constraint and effect |
+| --- | --- | --- | --- |
+| `comparator` | string | `estimated-ttft` | Signal used to choose among sampled candidates. See the supported values below. |
+
+Supported comparator values are:
+
+| Value | Score |
+| --- | --- |
+| `estimated-ttft` | Forwarded health RTT plus priority-aware queue delay plus request prefill time. |
+| `queue-time` | Priority-aware queue delay. Uses queued input tokens divided by `last_mean_input_tps` when no published priority estimate is available. |
+| `input-work-seconds` | Queued input tokens plus request input tokens, divided by `last_mean_input_tps`. |
+| `utilization` | Running queries divided by `max_engine_concurrency`, using `1` as the denominator when the reported maximum is `0`. |
+| `num-requests-queued` | Reported `queue_size`, including pending local routing reservations applied to the snapshot. |
+
+Comparators use the latest eligible routing snapshot without a second age
+filter. Registration stream timeout and cleanup determine snapshot eligibility.
+A nonpositive or non-finite `last_mean_input_tps` is unavailable capacity: zero
+work scores zero, while nonzero work scores infinity. Equal scores use the
+algorithm's existing tie behavior.
+
+`pulsar-wait-and-widen` does not support `comparator`. An explicit comparator in
+that algorithm's detailed configuration prevents startup.
+
 `power-of-n` supports this field:
 
 | Field | Type | Default | Constraint and effect |
@@ -261,8 +288,8 @@ selection. Pulsar ranking supplies that algorithm's affinity.
 | `next_bucket_unlock_factor` | number | `0.25` | Fraction of the TTFT gap to wait before the next bucket unlocks. |
 | `n` | unsigned integer | `2` | Number of unlocked candidates sampled. `0` is normalized to `1`. |
 | `max_queued` | unsigned integer | `0` | Additional queued requests allowed above `max_engine_concurrency`. A reported concurrency of `0` disables this capacity check. |
-| `ignore_queue_time` | boolean | `false` | Removes queue delay from TTFT ranking. Queue-SLO filtering still uses the queue estimate. |
-| `ignore_input_processing_time` | boolean | `false` | Removes request prefill time from TTFT ranking. |
+| `ignore_queue_time` | boolean | `false` | Removes queue delay from TTFT bucket formation. Queue-SLO filtering and the configured comparator are unchanged. |
+| `ignore_input_processing_time` | boolean | `false` | Removes request prefill time from TTFT bucket formation. The configured comparator is unchanged. |
 
 Stargate does not range-check `next_bucket_unlock_factor`. Values from `0` to
 `1` unlock a later bucket between no wait and the full TTFT gap. Values outside
@@ -280,8 +307,8 @@ bounds, so set the floor less than or equal to the ceiling.
 | `seed` | string | empty | Changes the rendezvous ranking. Keep it stable across replicas. |
 | `consider_kv_free_tokens` | boolean | `false` | Requires KV-cache values to be reported and skips candidates with fewer free tokens than the request input-token estimate. |
 
-`pulsar-wait-and-widen` supports both wait-and-widen fields and
-`consider_kv_free_tokens`.
+`pulsar-wait-and-widen` supports the wait-and-widen fields except `comparator`,
+plus `consider_kv_free_tokens`.
 
 ## Request algorithm overrides
 
@@ -367,6 +394,10 @@ admission rejections, upstream latency, and active backend counts. The prefix
 is configurable with `--metrics-prefix`. See the
 [NVCF request-router metrics reference](../../../../../docs/user/metrics/llm-request-router/metrics.md)
 for metric names, labels, and descriptions.
+
+The proxy request span records the effective comparator and selected score in
+`routing.comparator` and `routing.comparator.score`. It also records queue,
+prefill, and RTT score components when they apply.
 
 ## Validation checklist
 

--- a/src/libraries/rust/stargate/docs/load-balancer-configuration.md
+++ b/src/libraries/rust/stargate/docs/load-balancer-configuration.md
@@ -395,9 +395,7 @@ is configurable with `--metrics-prefix`. See the
 [NVCF request-router metrics reference](../../../../../docs/user/metrics/llm-request-router/metrics.md)
 for metric names, labels, and descriptions.
 
-The proxy request span records the effective comparator and selected score in
-`routing.comparator` and `routing.comparator.score`. It also records queue,
-prefill, and RTT score components when they apply.
+The proxy request span records the effective comparator in `routing.comparator`.
 
 ## Validation checklist
 

--- a/src/libraries/rust/stargate/docs/load-balancer-configuration.md
+++ b/src/libraries/rust/stargate/docs/load-balancer-configuration.md
@@ -153,7 +153,7 @@ The queue delay uses the backend's priority-aware queue estimate when present.
 Otherwise it divides queued input tokens by `last_mean_input_tps`. Prefill time
 divides `x-input-tokens` by the same capacity signal.
 
-The algorithm groups close TTFT estimates into buckets. It samples `n`
+The algorithm groups close TTFT values into buckets. It samples `n`
 candidates from unlocked buckets and chooses the candidate with the lowest
 configured comparator score. The default comparator is `ttft`. A
 later bucket becomes available after the request has waited for a fraction of

--- a/src/libraries/rust/stargate/docs/load-balancer-configuration.md
+++ b/src/libraries/rust/stargate/docs/load-balancer-configuration.md
@@ -108,7 +108,7 @@ Choose based on the routing goal and available backend statistics:
 
 | Goal | Algorithm | Required backend signals |
 | --- | --- | --- |
-| Compare a small random sample using estimated TTFT or another load signal. | `power-of-n` | Signals required by the configured comparator. |
+| Compare a small random sample using TTFT or another load signal. | `power-of-n` | Signals required by the configured comparator. |
 | Minimize estimated time to first token across heterogeneous or remote clusters while controlling which TTFT bands are eligible. | `wait-and-widen` | Forwarded health RTT and model statistics. Valid `last_mean_input_tps` is needed when queued or request input work is nonzero. |
 | Keep the same prefix on a stable, capacity-weighted cluster. | `pulsar` | Positive finite `last_mean_input_tps` for every participating cluster. |
 | Keep Pulsar affinity when possible, but escape to lower-latency capacity when the primary cannot meet queue policy. | `pulsar-wait-and-widen` | Pulsar capacity plus the RTT and queue statistics used by `wait-and-widen`. |
@@ -120,7 +120,7 @@ selection when routing should not depend on backend load statistics.
 
 `power-of-n` uniformly samples distinct eligible clusters and selects the
 cluster with the lowest configured comparator score. The default comparator is
-`estimated-ttft`. It breaks equal scores randomly. Retried clusters are excluded
+`ttft`. It breaks equal scores randomly. Retried clusters are excluded
 before sampling.
 
 The default sample count is `2`. A larger sample can improve routing decisions
@@ -155,7 +155,7 @@ divides `x-input-tokens` by the same capacity signal.
 
 The algorithm groups close TTFT estimates into buckets. It samples `n`
 candidates from unlocked buckets and chooses the candidate with the lowest
-configured comparator score. The default comparator is `estimated-ttft`. A
+configured comparator score. The default comparator is `ttft`. A
 later bucket becomes available after the request has waited for a fraction of
 the TTFT gap.
 
@@ -240,13 +240,13 @@ Minimal configuration:
 
 | Field | Type | Default | Constraint and effect |
 | --- | --- | --- | --- |
-| `comparator` | string | `estimated-ttft` | Signal used to choose among sampled candidates. See the supported values below. |
+| `comparator` | string | `ttft` | Signal used to choose among sampled candidates. See the supported values below. |
 
 Supported comparator values are:
 
 | Value | Score |
 | --- | --- |
-| `estimated-ttft` | Forwarded health RTT plus priority-aware queue delay plus request prefill time. |
+| `ttft` | Forwarded health RTT plus priority-aware queue delay plus request prefill time. |
 | `queue-time` | Priority-aware queue delay. Uses queued input tokens divided by `last_mean_input_tps` when no published priority estimate is available. |
 | `input-work-seconds` | Queued input tokens plus request input tokens, divided by `last_mean_input_tps`. |
 | `utilization` | Running queries divided by `max_engine_concurrency`, using `1` as the denominator when the reported maximum is `0`. |


### PR DESCRIPTION
## Why
Stargate hard-codes how load-balancer algorithms compare cluster candidates. Operators need to select the comparison signal that matches their workload while retaining each algorithm's existing sampling, bucketing, capacity, affinity, and tie behavior.

## What changed
- Added TTFT, queue time, input work seconds, utilization, and queued request count comparators.
- Made TTFT the default for Power-of-N and Wait-and-Widen.
- Applied the selected comparator to final candidate selection across Power-of-N and every Wait-and-Widen path, including fast and cache-affinity paths. Wait-and-Widen continues to use TTFT for bucket eligibility.
- Rejected comparator configuration for Pulsar-Wait-and-Widen because its primary path bypasses Wait-and-Widen comparison.
- Added the effective comparator to request traces.
- Updated load-balancer configuration documentation and routing coverage.
- Replaced the priority queue estimate iterator chain with an equivalent direct loop to avoid a measured hot-path code generation regression.

## Customer Release Notes
Stargate now supports configurable cluster comparison signals for Power-of-N and Wait-and-Widen load balancing.

## Plan Summary
Not applicable.

## Usage
Set `comparator` in a detailed `power-of-n` or `wait-and-widen` configuration. Supported values are `ttft`, `queue-time`, `input-work-seconds`, `utilization`, and `num-requests-queued`. Omitting the field uses `ttft`.

## Testing
- `rustup run stable cargo fmt --all -- --check`
- `rustup run stable cargo clippy --workspace --all-targets -- -D warnings`
- `rustup run stable cargo test --workspace`
- `rustup run stable cargo test -p stargate` on final head
- Bazel `//src/libraries/rust/stargate/crates/stargate:stargate_test`
- Repeated merge-base load-balancer microbenchmarks through the comparator-configuration simplification revision

No additional QA is required. Wait-and-Widen and affinity paths showed no regression. Same-comparator Power-of-N dispatch overhead measured 0.1 percent.

## Notes
Power-of-N performs additional work under its new TTFT default because it now includes queue delay and RTT. The comparator dispatch itself does not add material overhead.

## References
Closes #877

## Related Pull Requests
None.

## Dependencies
None. No license review or NOTICE update is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable cluster-selection comparators for Power-of-N and Wait-and-Widen, including TTFT, queue time, input work, utilization, and queued-request count.
  - Added comparator-aware candidate selection with capacity safeguards and randomized tie handling.
  - Routing traces now record the effective comparator.

- **Bug Fixes**
  - Unsupported comparator configurations are now rejected with a clear validation error.

- **Documentation**
  - Expanded load-balancer configuration guidance, examples, and comparator-selection recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





