### PR TITLE
fix(icms): Throw 503 on config reload failure

### DIFF
--- a/src/control-plane-services/instance-cluster-management/icms-core/BUILD.bazel
+++ b/src/control-plane-services/instance-cluster-management/icms-core/BUILD.bazel
@@ -86,6 +86,7 @@ ICMS_CORE_DEPS = [
     "@nv_third_party_deps//:org_springframework_boot_spring_boot_starter_webmvc",
     "@nv_third_party_deps//:org_springframework_boot_spring_boot_webclient",
     "@nv_third_party_deps//:org_springframework_cloud_spring_cloud_context",
+    "@nv_third_party_deps//:org_springframework_cloud_spring_cloud_kubernetes_commons",
     "@nv_third_party_deps//:org_springframework_cloud_spring_cloud_starter_bootstrap",
     "@nv_third_party_deps//:org_springframework_cloud_spring_cloud_starter_kubernetes_client_config",
     "@nv_third_party_deps//:org_springframework_data_spring_data_cassandra",

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/configuration/refresh/ConfigRefreshConfiguration.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/configuration/refresh/ConfigRefreshConfiguration.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.icms.configuration.refresh;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.availability.ApplicationAvailability;
+import org.springframework.boot.availability.AvailabilityChangeEvent;
+import org.springframework.boot.availability.ReadinessState;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.context.refresh.ContextRefresher;
+import org.springframework.cloud.kubernetes.commons.config.reload.ConfigurationUpdateStrategy;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configures the Spring Cloud Kubernetes refresh strategy to reflect configuration validity in
+ * Spring Boot readiness.
+ *
+ * <p>{@link RefreshScopeBeanValidator} eagerly re-creates refresh-scoped beans before the refresh
+ * completes. If binding or bean construction fails, the refresh throws and this strategy publishes
+ * {@link ReadinessState#REFUSING_TRAFFIC}. A later successful refresh restores
+ * {@link ReadinessState#ACCEPTING_TRAFFIC} when this strategy owns the current readiness refusal.
+ */
+@Configuration(proxyBeanMethods = false)
+@Slf4j
+public class ConfigRefreshConfiguration {
+
+    static final String STRATEGY_NAME = "refresh";
+
+    @Bean
+    @ConditionalOnProperty(
+            prefix = "spring.cloud.kubernetes.reload",
+            name = "strategy",
+            havingValue = STRATEGY_NAME,
+            matchIfMissing = true)
+    ConfigurationUpdateStrategy icmsConfigurationUpdateStrategy(
+            ContextRefresher contextRefresher,
+            ApplicationAvailability availability,
+            ApplicationEventPublisher eventPublisher) {
+        return new ConfigurationUpdateStrategy(
+                STRATEGY_NAME,
+                () -> refresh(contextRefresher, availability, eventPublisher));
+    }
+
+    private void refresh(
+            ContextRefresher contextRefresher,
+            ApplicationAvailability availability,
+            ApplicationEventPublisher eventPublisher) {
+        try {
+            contextRefresher.refresh();
+        } catch (RuntimeException failure) {
+            log.error(
+                    "Configuration refresh failed; refusing traffic until a subsequent refresh "
+                            + "succeeds",
+                    failure);
+            AvailabilityChangeEvent.publish(
+                    eventPublisher, this, ReadinessState.REFUSING_TRAFFIC);
+            return;
+        }
+
+        var lastReadinessEvent = availability.getLastChangeEvent(ReadinessState.class);
+        if (lastReadinessEvent != null
+                && lastReadinessEvent.getSource() == this
+                && lastReadinessEvent.getState() == ReadinessState.REFUSING_TRAFFIC) {
+            log.info("Configuration refresh succeeded; accepting traffic again");
+            AvailabilityChangeEvent.publish(
+                    eventPublisher, this, ReadinessState.ACCEPTING_TRAFFIC);
+        }
+    }
+}

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/configuration/refresh/RefreshScopeBeanValidator.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/configuration/refresh/RefreshScopeBeanValidator.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.icms.configuration.refresh;
+
+import org.springframework.beans.BeansException;
+import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
+import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Eagerly re-creates every refresh-scoped bean after a context refresh and fails loudly when
+ * one of them no longer binds.
+ *
+ * <p>{@code RefreshScope.refreshAll()} destroys all refresh-scoped beans without checking that
+ * they can be rebuilt from the new environment. A bad value (for example a misspelled enum in
+ * a {@code @ConfigurationProperties} bean) therefore stays latent until some request happens
+ * to touch the affected bean, at which point bean creation fails mid-request. Worse, requests
+ * that never touch the broken bean keep succeeding, so the service looks healthy while parts
+ * of it are dead.
+ *
+ * <p>This listener runs inside {@code ContextRefresher.refresh()} (it is invoked synchronously
+ * from {@code refreshAll()}), forces re-creation of every refresh-scoped bean while the caller
+ * is still in the refresh path, and throws on failure. Throwing makes the refresh itself fail,
+ * so the triggering component can report the real cause. The Kubernetes update strategy then
+ * publishes a readiness refusal until a fixed configuration is applied. Any refresh-scoped bean
+ * construction failure is treated as an invalid refreshed context because the service cannot
+ * safely accept traffic when one of those beans is unavailable.
+ */
+@Component
+public class RefreshScopeBeanValidator {
+
+    private final ConfigurableApplicationContext context;
+
+    public RefreshScopeBeanValidator(ConfigurableApplicationContext context) {
+        this.context = context;
+    }
+
+    @EventListener(RefreshScopeRefreshedEvent.class)
+    public void validateRefreshScopeBeans() {
+        var beanFactory = context.getBeanFactory();
+        for (String beanName : beanFactory.getBeanDefinitionNames()) {
+            var definition = beanFactory.getBeanDefinition(beanName);
+            if (!RefreshAutoConfiguration.REFRESH_SCOPE_NAME.equals(definition.getScope())) {
+                continue;
+            }
+            try {
+                beanFactory.getBean(beanName);
+            } catch (BeansException failure) {
+                throw new IllegalStateException(
+                        "Configuration refresh left the context broken; refresh-scoped bean '"
+                                + beanName + "' could not be re-created",
+                        failure);
+            }
+        }
+    }
+}

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/configuration/refresh/ConfigRefreshConfigurationTest.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/configuration/refresh/ConfigRefreshConfigurationTest.java
@@ -1,0 +1,157 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.icms.configuration.refresh;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.boot.availability.ApplicationAvailability;
+import org.springframework.boot.availability.ApplicationAvailabilityBean;
+import org.springframework.boot.availability.AvailabilityChangeEvent;
+import org.springframework.boot.availability.ReadinessState;
+import org.springframework.cloud.context.refresh.ContextRefresher;
+import org.springframework.cloud.kubernetes.commons.config.reload.ConfigurationUpdateStrategy;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+
+class ConfigRefreshConfigurationTest {
+
+    private final ConfigRefreshConfiguration configuration =
+            new ConfigRefreshConfiguration();
+
+    private final ContextRefresher contextRefresher = mock(ContextRefresher.class);
+
+    private final ApplicationAvailability availability = mock(ApplicationAvailability.class);
+
+    private final ApplicationEventPublisher eventPublisher =
+            mock(ApplicationEventPublisher.class);
+
+    @Test
+    void failedRefreshRefusesTrafficWithoutStoppingTheUpdateStrategy() {
+        when(contextRefresher.refresh()).thenThrow(new IllegalStateException("rebind failed"));
+        var strategy = configuration.icmsConfigurationUpdateStrategy(
+                contextRefresher, availability, eventPublisher);
+
+        strategy.reloadProcedure().run();
+
+        assertThat(strategy.name()).isEqualTo(ConfigRefreshConfiguration.STRATEGY_NAME);
+        assertPublishedState(ReadinessState.REFUSING_TRAFFIC);
+    }
+
+    @Test
+    void healthyRefreshLeavesAvailabilityUnchanged() {
+        when(contextRefresher.refresh()).thenReturn(Set.of("icms.setting"));
+        var strategy = configuration.icmsConfigurationUpdateStrategy(
+                contextRefresher, availability, eventPublisher);
+
+        strategy.reloadProcedure().run();
+
+        verifyNoInteractions(eventPublisher);
+    }
+
+    @Test
+    void successfulRefreshRecoversTrafficWhenStrategyOwnsReadinessRefusal() {
+        when(contextRefresher.refresh()).thenReturn(Set.of());
+        when(availability.getLastChangeEvent(ReadinessState.class))
+                .thenReturn(new AvailabilityChangeEvent<>(
+                        configuration, ReadinessState.REFUSING_TRAFFIC));
+        var strategy = configuration.icmsConfigurationUpdateStrategy(
+                contextRefresher, availability, eventPublisher);
+
+        strategy.reloadProcedure().run();
+
+        assertPublishedState(ReadinessState.ACCEPTING_TRAFFIC);
+    }
+
+    @Test
+    void successfulRefreshDoesNotOverrideAnotherReadinessRefusal() {
+        when(contextRefresher.refresh()).thenReturn(Set.of());
+        when(availability.getLastChangeEvent(ReadinessState.class))
+                .thenReturn(new AvailabilityChangeEvent<>(
+                        new Object(), ReadinessState.REFUSING_TRAFFIC));
+        var strategy = configuration.icmsConfigurationUpdateStrategy(
+                contextRefresher, availability, eventPublisher);
+
+        strategy.reloadProcedure().run();
+
+        verifyNoInteractions(eventPublisher);
+    }
+
+    @Test
+    void springContextMovesReadinessDownAndBackUpThroughTheCustomStrategy() {
+        var refreshFailure = new AtomicReference<RuntimeException>();
+        var refresher = mock(ContextRefresher.class);
+        when(refresher.refresh()).thenAnswer(invocation -> {
+            var failure = refreshFailure.get();
+            if (failure != null) {
+                throw failure;
+            }
+            return Set.of();
+        });
+
+        try (var context = new AnnotationConfigApplicationContext()) {
+            context.registerBean(ContextRefresher.class, () -> refresher);
+            context.registerBean(ApplicationAvailability.class, ApplicationAvailabilityBean::new);
+            context.register(ConfigRefreshConfiguration.class);
+            context.refresh();
+
+            var strategy = context.getBean(ConfigurationUpdateStrategy.class);
+            var applicationAvailability = context.getBean(ApplicationAvailability.class);
+
+            refreshFailure.set(new IllegalStateException("rebind failed"));
+            strategy.reloadProcedure().run();
+            assertThat(applicationAvailability.getReadinessState())
+                    .isEqualTo(ReadinessState.REFUSING_TRAFFIC);
+
+            refreshFailure.set(null);
+            strategy.reloadProcedure().run();
+            assertThat(applicationAvailability.getReadinessState())
+                    .isEqualTo(ReadinessState.ACCEPTING_TRAFFIC);
+        }
+    }
+
+    @Test
+    void customStrategyBacksOffWhenReloadIsNotConfiguredForRefresh() {
+        try (var context = new AnnotationConfigApplicationContext()) {
+            context.getEnvironment()
+                    .getPropertySources()
+                    .addFirst(new MapPropertySource(
+                            "test", Map.of("spring.cloud.kubernetes.reload.strategy", "shutdown")));
+            context.register(ConfigRefreshConfiguration.class);
+            context.refresh();
+
+            assertThat(context.getBeansOfType(ConfigurationUpdateStrategy.class)).isEmpty();
+        }
+    }
+
+    private void assertPublishedState(ReadinessState expected) {
+        var eventCaptor = ArgumentCaptor.forClass(AvailabilityChangeEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        var event = eventCaptor.getValue();
+        assertThat(event.getSource()).isSameAs(configuration);
+        assertThat(event.getState()).isEqualTo(expected);
+    }
+}

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/configuration/refresh/RefreshScopeBeanValidatorTest.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/configuration/refresh/RefreshScopeBeanValidatorTest.java
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.icms.configuration.refresh;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.context.ConfigurableApplicationContext;
+
+class RefreshScopeBeanValidatorTest {
+
+    private final ConfigurableApplicationContext context =
+            mock(ConfigurableApplicationContext.class);
+
+    private final ConfigurableListableBeanFactory beanFactory =
+            mock(ConfigurableListableBeanFactory.class);
+
+    private final RefreshScopeBeanValidator validator =
+            new RefreshScopeBeanValidator(context);
+
+    @Test
+    void passesWhenEveryRefreshScopedBeanCanBeRecreated() {
+        when(context.getBeanFactory()).thenReturn(beanFactory);
+        var singleton = new RootBeanDefinition();
+        var scoped = new RootBeanDefinition();
+        scoped.setScope("refresh");
+        when(beanFactory.getBeanDefinitionNames())
+                .thenReturn(new String[] {"singletonBean", "scopedTarget.configBean"});
+        when(beanFactory.getBeanDefinition("singletonBean")).thenReturn(singleton);
+        when(beanFactory.getBeanDefinition("scopedTarget.configBean")).thenReturn(scoped);
+        when(beanFactory.getBean("scopedTarget.configBean")).thenReturn(new Object());
+
+        validator.validateRefreshScopeBeans();
+    }
+
+    @Test
+    void throwsWhenARefreshScopedBeanCannotBeRecreated() {
+        when(context.getBeanFactory()).thenReturn(beanFactory);
+        var scoped = new RootBeanDefinition();
+        scoped.setScope("refresh");
+        when(beanFactory.getBeanDefinitionNames())
+                .thenReturn(new String[] {"scopedTarget.configBean"});
+        when(beanFactory.getBeanDefinition("scopedTarget.configBean")).thenReturn(scoped);
+        when(beanFactory.getBean("scopedTarget.configBean"))
+                .thenThrow(new BeanCreationException("Could not bind properties"));
+
+        assertThatThrownBy(validator::validateRefreshScopeBeans)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("scopedTarget.configBean")
+                .hasCauseInstanceOf(BeanCreationException.class)
+                .hasRootCauseMessage("Could not bind properties");
+    }
+
+    @Test
+    void ignoresNonRefreshScopedBeansEvenIfTheyWouldFail() {
+        when(context.getBeanFactory()).thenReturn(beanFactory);
+        BeanDefinition singleton = new RootBeanDefinition();
+        when(beanFactory.getBeanDefinitionNames()).thenReturn(new String[] {"singletonBean"});
+        when(beanFactory.getBeanDefinition("singletonBean")).thenReturn(singleton);
+
+        validator.validateRefreshScopeBeans();
+    }
+}

--- a/src/control-plane-services/instance-cluster-management/icms-service/BUILD.bazel
+++ b/src/control-plane-services/instance-cluster-management/icms-service/BUILD.bazel
@@ -51,6 +51,8 @@ nv_boot_library_test(
     srcs = ICMS_SERVICE_TEST_SRCS,
     deps = ICMS_SERVICE_DEPS + [
         ":app_classes",
+        "@nv_third_party_deps//:org_awaitility_awaitility",
+        "@nv_third_party_deps//:org_springframework_cloud_spring_cloud_kubernetes_commons",
         "@nv_third_party_deps//:org_springframework_spring_web",
         "@nv_third_party_deps//:org_springframework_spring_core",
         "@nv_third_party_deps//:org_springframework_spring_beans",

--- a/src/control-plane-services/instance-cluster-management/icms-service/src/test/java/com/nvidia/icms/ConfigRefreshFailureIntegrationTest.java
+++ b/src/control-plane-services/instance-cluster-management/icms-service/src/test/java/com/nvidia/icms/ConfigRefreshFailureIntegrationTest.java
@@ -1,0 +1,166 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.icms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import com.nvidia.icms.integration.IntegrationTest;
+import com.nvidia.icms.util.CassandraTestConfiguration;
+import java.net.URI;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalManagementPort;
+import org.springframework.cloud.kubernetes.commons.config.reload.ConfigurationUpdateStrategy;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.RequestEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Replays the production incident in which a live ConfigMap update carried a misspelled enum
+ * value ({@code icms.telemetry.oauth2.auth-method}). The update is soaked into the running
+ * context through the Spring Cloud Kubernetes {@link ConfigurationUpdateStrategy} used by the
+ * event reload watcher.
+ *
+ * <p>Before the custom update strategy, this refresh returned normally while leaving the
+ * context poisoned: refresh-scoped beans such as {@code telemetryProperties} could no longer
+ * be re-created, so requests failed downstream with confusing status codes (HTTP 400 in
+ * production) and Kubernetes probes stayed green. The update strategy must instead report
+ * readiness DOWN until a fixed configuration is refreshed.
+ */
+@SpringBootTest(
+        classes = App.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+                "management.server.port=0",
+                "spring.profiles.active=test",
+                // Production runs with telemetry enabled. The validator materializes its
+                // refresh-scoped properties after a config refresh.
+                "icms.telemetry.enabled=true"})
+@ContextConfiguration(initializers = IntegrationTest.Initializer.class)
+@ActiveProfiles("test")
+@Import(CassandraTestConfiguration.class)
+class ConfigRefreshFailureIntegrationTest {
+
+    private static final String TEST_SOURCE = "test-remote-config";
+
+    private static final String ENUM_PROPERTY = "icms.telemetry.oauth2.auth-method";
+
+    /** Enum value with a typo; valid values are CLIENT_SECRET_POST and CLIENT_SECRET_BASIC. */
+    private static final String MISSPELLED_ENUM = "CLIENT_SECRET_BASICS";
+
+    @Autowired
+    private ConfigurableApplicationContext context;
+
+    @Autowired
+    private ConfigurationUpdateStrategy configurationUpdateStrategy;
+
+    @LocalManagementPort
+    private int managementPort;
+
+    @Test
+    void invalidEnumInLiveConfigUpdate_flipsReadinessUntilFixedConfigRefreshes() {
+        // LegacyContextRefresher rebuilds the bootstrap environment retaining only standard
+        // sources; in production the profile comes from the SPRING_PROFILES_ACTIVE env var,
+        // here the test profile is exposed through the (retained) system properties source.
+        var previousProfiles = System.getProperty("spring.profiles.active");
+        System.setProperty("spring.profiles.active", "test");
+        try {
+            // Baseline: readiness and liveness answer normally.
+            assertHealth("/actuator/health/readiness", HttpStatus.OK, "UP");
+            assertHealth("/actuator/health/liveness", HttpStatus.OK, "UP");
+
+            // The ConfigMap update with the misspelled enum arrives; the reload watcher
+            // runs the configured update strategy.
+            overrideRemoteConfigValue(MISSPELLED_ENUM);
+            configurationUpdateStrategy.reloadProcedure().run();
+
+            // The poisoned bean can no longer be created from the broken environment.
+            assertThatThrownBy(() -> context.getBean("scopedTarget.telemetryProperties"))
+                    .hasMessageContaining("TelemetryProperties");
+
+            // Readiness reports DOWN so Kubernetes takes the pod out of service; liveness
+            // stays UP so the pod is not restarted and can self-heal.
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertHealth(
+                    "/actuator/health/readiness", HttpStatus.SERVICE_UNAVAILABLE, "DOWN"));
+            assertHealth("/actuator/health/liveness", HttpStatus.OK, "UP");
+
+            // The ConfigMap is fixed and another refresh is triggered: the pod recovers
+            // without a restart.
+            overrideRemoteConfigValue("CLIENT_SECRET_BASIC");
+            configurationUpdateStrategy.reloadProcedure().run();
+
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
+                    assertHealth("/actuator/health/readiness", HttpStatus.OK, "UP"));
+        } finally {
+            // Restore a pristine environment for any other test sharing this context.
+            var sources = ((ConfigurableEnvironment) context.getEnvironment())
+                    .getPropertySources();
+            if (sources.contains(TEST_SOURCE)) {
+                sources.remove(TEST_SOURCE);
+            }
+            configurationUpdateStrategy.reloadProcedure().run();
+            if (previousProfiles == null) {
+                System.clearProperty("spring.profiles.active");
+            } else {
+                System.setProperty("spring.profiles.active", previousProfiles);
+            }
+        }
+    }
+
+    private void overrideRemoteConfigValue(String authMethod) {
+        var sources = ((ConfigurableEnvironment) context.getEnvironment()).getPropertySources();
+        var source = new MapPropertySource(TEST_SOURCE, Map.of(ENUM_PROPERTY, authMethod));
+        if (sources.contains(TEST_SOURCE)) {
+            sources.replace(TEST_SOURCE, source);
+        } else {
+            sources.addFirst(source);
+        }
+    }
+
+    private void assertHealth(String path, HttpStatus status, String healthStatus) {
+        var response = getManagementHealth(path);
+        assertThat(response.status()).isEqualTo(status);
+        assertThat(response.body()).contains("\"status\":\"" + healthStatus + "\"");
+    }
+
+    private HealthResponse getManagementHealth(String path) {
+        var endpoint = URI.create("http://localhost:" + managementPort + path);
+        try {
+            var response = new RestTemplate().exchange(
+                    RequestEntity.get(endpoint).build(), String.class);
+            return new HealthResponse(
+                    HttpStatus.valueOf(response.getStatusCode().value()), response.getBody());
+        } catch (HttpStatusCodeException e) {
+            return new HealthResponse(
+                    HttpStatus.valueOf(e.getStatusCode().value()), e.getResponseBodyAsString());
+        }
+    }
+
+    private record HealthResponse(HttpStatus status, String body) {}
+}


### PR DESCRIPTION
## Problem

  A live configuration update can introduce an invalid value, such as a misspelled enum. Spring Cloud applies the new environment and destroys refresh-scoped beans, but normally recreates those beans lazily.

  As a result, the refresh can appear successful while the application context is unusable. Requests later fail with misleading responses, while Kubernetes readiness remains healthy and continues routing traffic to the affected pod.

  ## What changed

 - Added src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/configuration/refresh/ConfigRefreshConfiguration.java:
      - Provides a Spring Cloud Kubernetes ConfigurationUpdateStrategy.
      - Runs ContextRefresher.refresh().
      - Publishes REFUSING_TRAFFIC when refresh fails.
      - Publishes ACCEPTING_TRAFFIC after a subsequent successful refresh.
      - Does not override readiness refusals published by another component.
      - Backs off when the configured reload strategy is not refresh.

  - Added src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/configuration/refresh/RefreshScopeBeanValidator.java:
      - Recreates refresh-scoped beans immediately after refresh.
      - Converts latent property-binding failures, such as an invalid enum, into refresh failures.

  - Added unit tests covering failed refreshes, recovery, readiness ownership, Spring event wiring, and non-refresh strategy behavior.
  - Added src/control-plane-services/instance-cluster-management/icms-service/src/test/java/com/nvidia/icms/ConfigRefreshFailureIntegrationTest.java:
      - Replays the invalid telemetry enum scenario.
      - Verifies readiness becomes unavailable while liveness remains healthy.
      - Verifies readiness recovers after fixing the configuration.

  - Updated Bazel dependencies for Spring Cloud Kubernetes commons and Awaitility.

@sanjay-saxena I have a feeling this should go to parent lib.

Closes NVCF-11367