### PR TITLE
feat(invocation): forward configured region to function containers

### DIFF
--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -355,6 +355,8 @@ ess:
     maxUnavailable: 1
 
 invocation:
+  env:
+    NATS_PROPERTIES__REGION: local
   podDisruptionBudget:
     enabled: false
     maxUnavailable: 1

--- a/docs/user/container-functions.md
+++ b/docs/user/container-functions.md
@@ -28,6 +28,10 @@ Any server can be implemented within the container, as long as it implements the
 
 These endpoints are expected to be served on the same port, defined as the `inferencePort`.
 
+## Invocation Metadata Headers
+
+Cloud Functions adds `NVCF-INVOCATION-REGION` to HTTP requests sent to a function container. Its value is the configured region of the invocation service that accepted the request. Client-supplied values are replaced. Cloud Functions does not add this header to client responses.
+
 <Warning>
 Cloud Functions reserves the following ports on your container for internal monitoring and metrics:
 

--- a/docs/user/function-creation.md
+++ b/docs/user/function-creation.md
@@ -64,6 +64,7 @@ For examples of how to extract and use some of these variables, see [NVCF Contai
 | NVCF-BACKEND                 | Backend or "Cluster Group" the function is deployed on. |
 | NVCF-INSTANCETYPE            | Instance type the function is deployed on.              |
 | NVCF-REGION                  | Region or zone the function is deployed in.             |
+| NVCF-INVOCATION-REGION       | Region of the invocation service that accepted the request. Client values are replaced. |
 | NVCF-ENV                     | Spot environment if deployed on spot instances.         |
 
 #### Environment Variables

--- a/src/compute-plane-services/worker-utils/worker/httpstream/request_stream_test.go
+++ b/src/compute-plane-services/worker-utils/worker/httpstream/request_stream_test.go
@@ -58,6 +58,7 @@ func TestNewRequestStreamHandler_Success(t *testing.T) {
 			fullRequest := "POST /test/path?query=value HTTP/1.1\r\n" +
 				"Host: example.com\r\n" +
 				"Content-Type: application/json\r\n" +
+				"NVCF-INVOCATION-REGION: invocation-region\r\n" +
 				"Content-Length: 15\r\n" +
 				"\r\n" +
 				`{"test":"data"}`
@@ -129,6 +130,7 @@ func TestNewRequestStreamHandler_Success(t *testing.T) {
 	assert.NotEmpty(t, requestDataWritable.RequestHeaders)
 	assert.Contains(t, requestDataWritable.RequestHeaders, &pb.StringKV{Key: "Content-Type", Value: "application/json"})
 	assert.Contains(t, requestDataWritable.RequestHeaders, &pb.StringKV{Key: "Content-Length", Value: "15"})
+	assert.Contains(t, requestDataWritable.RequestHeaders, &pb.StringKV{Key: "Nvcf-Invocation-Region", Value: "invocation-region"})
 
 	// Verify we can get the request body
 	body, err := handler.GetClientRequestBody()

--- a/src/compute-plane-services/worker-utils/worker/work.go
+++ b/src/compute-plane-services/worker-utils/worker/work.go
@@ -68,6 +68,24 @@ const (
 	invocationRegionHeader            = "NVCF-INVOCATION-REGION"
 )
 
+var workerOwnedHeaders = map[string]struct{}{
+	"nvcf-reqid":                   {},
+	"nvcf-sub":                     {},
+	"nvcf-ncaid":                   {},
+	"nvcf-function-name":           {},
+	"nvcf-function-id":             {},
+	"nvcf-function-version-id":     {},
+	"nvcf-asset-dir":               {},
+	"nvcf-large-output-dir":        {},
+	"nvcf-max-response-size-bytes": {},
+	"nvcf-nspectid":                {},
+	"nvcf-backend":                 {},
+	"nvcf-instancetype":            {},
+	"nvcf-region":                  {},
+	"nvcf-env":                     {},
+	"nvcf-function-asset-ids":      {},
+}
+
 func (w *NVCFWorker) handleWorkRequest(ctx context.Context, work *consumer.WorkRequest) error {
 	// setup metrics
 	requestTracker := nvcfMetrics.NewRequestTracker(
@@ -506,6 +524,9 @@ func (w *NVCFWorker) createInferenceRequest(ctx context.Context, work *pb.Worker
 	for _, header := range work.RequestHeaders {
 		if strings.EqualFold(header.Key, invocationRegionHeader) {
 			req.Header[invocationRegionHeader] = []string{header.Value}
+			continue
+		}
+		if _, workerOwned := workerOwnedHeaders[strings.ToLower(header.Key)]; workerOwned {
 			continue
 		}
 		req.Header.Add(header.Key, header.Value)

--- a/src/compute-plane-services/worker-utils/worker/work.go
+++ b/src/compute-plane-services/worker-utils/worker/work.go
@@ -65,6 +65,7 @@ const (
 	inferenceConnErrorResponse string = "inference-connection"
 	successResponseCode        int    = 0
 	internalErrorResponseCode  int    = 500
+	invocationRegionHeader            = "NVCF-INVOCATION-REGION"
 )
 
 func (w *NVCFWorker) handleWorkRequest(ctx context.Context, work *consumer.WorkRequest) error {
@@ -503,6 +504,10 @@ func (w *NVCFWorker) createInferenceRequest(ctx context.Context, work *pb.Worker
 		"NVCF-ENV":                     {w.meteringConfig.ICMSEnvironment},
 	}
 	for _, header := range work.RequestHeaders {
+		if strings.EqualFold(header.Key, invocationRegionHeader) {
+			req.Header[invocationRegionHeader] = []string{header.Value}
+			continue
+		}
 		req.Header.Add(header.Key, header.Value)
 	}
 	if !w.config.V3BackwardsCompatibilityDisabled && req.Header.Get("Content-Type") == "" {

--- a/src/compute-plane-services/worker-utils/worker/work_test.go
+++ b/src/compute-plane-services/worker-utils/worker/work_test.go
@@ -96,6 +96,7 @@ func TestCreateInferenceRequest(t *testing.T) {
 			RequestHeaders: []*pb.StringKV{
 				{Key: "nvcf-poll-seconds", Value: "45"},
 				{Key: "Content-Length", Value: "123"},
+				{Key: "Nvcf-Invocation-Region", Value: "invocation-region"},
 			},
 			InputAssetReference: []*pb.InputAssetReference{
 				{AssetId: "a1"}, {AssetId: "a2"},
@@ -107,6 +108,9 @@ func TestCreateInferenceRequest(t *testing.T) {
 		// preserve case, so they must be read via direct map indexing.
 		assert.Equal(t, "req-1", req.Header["NVCF-REQID"][0])
 		assert.Equal(t, "fn-name", req.Header["NVCF-FUNCTION-NAME"][0])
+		assert.Equal(t, "z1", req.Header["NVCF-REGION"][0])
+		assert.Equal(t, "invocation-region", req.Header["NVCF-INVOCATION-REGION"][0])
+		assert.NotContains(t, req.Header, "Nvcf-Invocation-Region")
 		assert.Equal(t, "a1,a2", req.Header["NVCF-FUNCTION-ASSET-IDS"][0])
 		assert.Equal(t, "application/json", req.Header.Get("Content-Type")) // defaulted
 		assert.Equal(t, int64(123), req.ContentLength)

--- a/src/compute-plane-services/worker-utils/worker/work_test.go
+++ b/src/compute-plane-services/worker-utils/worker/work_test.go
@@ -116,6 +116,7 @@ func TestCreateInferenceRequest(t *testing.T) {
 		//nolint:staticcheck // The public container contract requires this literal uppercase key.
 		assert.Equal(t, []string{"invocation-region"}, req.Header["NVCF-INVOCATION-REGION"])
 		assert.NotContains(t, req.Header, "Nvcf-Invocation-Region")
+		//nolint:staticcheck // The worker intentionally stores this contract key in uppercase.
 		assert.Equal(t, "a1,a2", req.Header["NVCF-FUNCTION-ASSET-IDS"][0])
 		var serializedHeaders bytes.Buffer
 		require.NoError(t, req.Header.Write(&serializedHeaders))

--- a/src/compute-plane-services/worker-utils/worker/work_test.go
+++ b/src/compute-plane-services/worker-utils/worker/work_test.go
@@ -21,11 +21,13 @@ limitations under the License.
 package worker
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -96,6 +98,7 @@ func TestCreateInferenceRequest(t *testing.T) {
 			RequestHeaders: []*pb.StringKV{
 				{Key: "nvcf-poll-seconds", Value: "45"},
 				{Key: "Content-Length", Value: "123"},
+				{Key: "Nvcf-Region", Value: "client-region"},
 				{Key: "Nvcf-Invocation-Region", Value: "invocation-region"},
 			},
 			InputAssetReference: []*pb.InputAssetReference{
@@ -108,10 +111,16 @@ func TestCreateInferenceRequest(t *testing.T) {
 		// preserve case, so they must be read via direct map indexing.
 		assert.Equal(t, "req-1", req.Header["NVCF-REQID"][0])
 		assert.Equal(t, "fn-name", req.Header["NVCF-FUNCTION-NAME"][0])
-		assert.Equal(t, "z1", req.Header["NVCF-REGION"][0])
-		assert.Equal(t, "invocation-region", req.Header["NVCF-INVOCATION-REGION"][0])
+		//nolint:staticcheck // The worker intentionally stores this server-owned key in uppercase.
+		assert.Equal(t, []string{"z1"}, req.Header["NVCF-REGION"])
+		//nolint:staticcheck // The public container contract requires this literal uppercase key.
+		assert.Equal(t, []string{"invocation-region"}, req.Header["NVCF-INVOCATION-REGION"])
 		assert.NotContains(t, req.Header, "Nvcf-Invocation-Region")
 		assert.Equal(t, "a1,a2", req.Header["NVCF-FUNCTION-ASSET-IDS"][0])
+		var serializedHeaders bytes.Buffer
+		require.NoError(t, req.Header.Write(&serializedHeaders))
+		assert.Equal(t, 1, strings.Count(serializedHeaders.String(), "NVCF-REGION: z1\r\n"))
+		assert.NotContains(t, serializedHeaders.String(), "Nvcf-Region")
 		assert.Equal(t, "application/json", req.Header.Get("Content-Type")) // defaulted
 		assert.Equal(t, int64(123), req.ContentLength)
 		assert.Equal(t, 45*time.Second, target)

--- a/src/invocation-plane-services/http-invocation/crates/server/src/nats/mod.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/src/nats/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     request_id::RequestId,
     secrets::secret_provider::SecretFileWatcher,
 };
-use anyhow::anyhow;
+use anyhow::{anyhow, Context as _};
 use async_nats::{
     connection::State,
     jetstream::{
@@ -45,11 +45,13 @@ use async_nats::{
 };
 use bytes::Bytes;
 use futures::{FutureExt, StreamExt, TryFutureExt};
+use http::HeaderValue;
 use oauth2::Scope;
 use opentelemetry::propagation::Injector;
 use prost::Message;
 use rand;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::pin::pin;
 use std::sync::Arc;
@@ -68,6 +70,7 @@ pub struct NatsService {
     client: Client,
     jetstream: Context,
     nats_properties: NatsProperties,
+    invocation_region_headers: HashMap<String, HeaderValue>,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
@@ -199,8 +202,14 @@ pub enum WorkerPollingResponse {
 }
 
 impl NatsService {
-    pub(crate) fn region(&self) -> &str {
-        &self.nats_properties.region
+    pub(crate) fn invocation_region_header(&self) -> &HeaderValue {
+        self.invocation_region_header_for_region(&self.nats_properties.region)
+    }
+
+    pub(crate) fn invocation_region_header_for_region(&self, region: &str) -> &HeaderValue {
+        self.invocation_region_headers
+            .get(region)
+            .expect("request mapping region must be configured")
     }
 
     pub async fn new(
@@ -209,6 +218,7 @@ impl NatsService {
         secrets_provider: Option<Arc<SecretFileWatcher>>,
         grpc_config: &crate::settings::GrpcClientConfig,
     ) -> anyhow::Result<Self> {
+        let invocation_region_headers = Self::invocation_region_headers(nats_properties)?;
         tracing::info!("connecting to nats {}", nats_properties.nats_address);
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
 
@@ -267,6 +277,7 @@ impl NatsService {
             client: client.clone(),
             jetstream,
             nats_properties: nats_properties.clone(),
+            invocation_region_headers,
         };
         // NATS will time out instead of returning a 404 if the stream does not exist and we do a direct get.
         // create the stream eagerly to prevent timeouts.
@@ -277,6 +288,19 @@ impl NatsService {
                 record_nats_error_total();
             })?;
         Ok(nats_service)
+    }
+
+    fn invocation_region_headers(
+        nats_properties: &NatsProperties,
+    ) -> anyhow::Result<HashMap<String, HeaderValue>> {
+        std::iter::once(&nats_properties.region)
+            .chain(nats_properties.other_regions.iter())
+            .map(|region| {
+                HeaderValue::from_str(region)
+                    .with_context(|| format!("invalid configured invocation region: {region:?}"))
+                    .map(|header| (region.clone(), header))
+            })
+            .collect()
     }
 
     fn create_auth_callback(
@@ -977,6 +1001,20 @@ mod tests {
     use tempfile::NamedTempFile;
     use tokio::io::AsyncWriteExt;
     use tokio::net::TcpListener;
+
+    #[test]
+    fn invocation_region_headers_reject_invalid_config() {
+        let nats_properties = NatsProperties {
+            region: "invalid\nregion".into(),
+            ..Default::default()
+        };
+
+        let error = NatsService::invocation_region_headers(&nats_properties).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("invalid configured invocation region"));
+    }
 
     #[derive(Serialize)]
     struct TokenResponse {

--- a/src/invocation-plane-services/http-invocation/crates/server/src/nats/mod.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/src/nats/mod.rs
@@ -199,6 +199,10 @@ pub enum WorkerPollingResponse {
 }
 
 impl NatsService {
+    pub(crate) fn region(&self) -> &str {
+        &self.nats_properties.region
+    }
+
     pub async fn new(
         nats_properties: &NatsProperties,
         oauth2_token_endpoint: &str,

--- a/src/invocation-plane-services/http-invocation/crates/server/src/routes/get_pexec.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/src/routes/get_pexec.rs
@@ -30,7 +30,7 @@ use crate::nvcf_api::{
 };
 use crate::request_id::RequestId;
 use crate::routes::app_error::AppError;
-use crate::routes::http_headers::remove_hop_by_hop_headers;
+use crate::routes::http_headers::{inject_invocation_region_header, remove_hop_by_hop_headers};
 use crate::settings::AppConfig;
 use crate::worker_streams::WorkerStreamService;
 use anyhow::Context;
@@ -91,7 +91,6 @@ pub async fn pexec_status(
     let span = Span::current();
     span.record("request_id", request_id_string.clone());
     remove_hop_by_hop_headers(headers);
-    crate::routes::post_pexec::inject_invocation_region_header(headers, nats_service.region())?;
 
     let poll_duration = super::post_pexec::poll_duration(headers, false)
         .context("failed to parse poll duration")
@@ -116,6 +115,10 @@ pub async fn pexec_status(
         }
     };
     let existing_region = existing_request.region;
+    inject_invocation_region_header(
+        headers,
+        nats_service.invocation_region_header_for_region(&existing_region),
+    );
     let existing_request = existing_request.worker_result_tracking;
 
     let function_id: Uuid = existing_request.function_id.parse()?;

--- a/src/invocation-plane-services/http-invocation/crates/server/src/routes/get_pexec.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/src/routes/get_pexec.rs
@@ -91,6 +91,7 @@ pub async fn pexec_status(
     let span = Span::current();
     span.record("request_id", request_id_string.clone());
     remove_hop_by_hop_headers(headers);
+    crate::routes::post_pexec::inject_invocation_region_header(headers, nats_service.region())?;
 
     let poll_duration = super::post_pexec::poll_duration(headers, false)
         .context("failed to parse poll duration")

--- a/src/invocation-plane-services/http-invocation/crates/server/src/routes/http_headers.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/src/routes/http_headers.rs
@@ -33,6 +33,16 @@ const HOP_HEADERS: [http::header::HeaderName; 9] = [
     http::header::UPGRADE,
 ];
 
+pub(crate) const NVCF_INVOCATION_REGION: http::header::HeaderName =
+    http::header::HeaderName::from_static("nvcf-invocation-region");
+
+pub(crate) fn inject_invocation_region_header(
+    headers: &mut http::HeaderMap,
+    region: &http::HeaderValue,
+) {
+    headers.insert(NVCF_INVOCATION_REGION, region.clone());
+}
+
 /// Removes hop-by-hop headers from the given header map.
 /// Copied from httputil.ReverseProxy because it's private.
 pub fn remove_hop_by_hop_headers(headers: &mut http::HeaderMap) {
@@ -215,6 +225,38 @@ mod tests {
 
         // Headers not mentioned should remain
         assert_eq!(headers.get("x-header-4").unwrap(), "value4");
+    }
+
+    #[test]
+    fn invocation_region_header_replaces_client_value() {
+        let mut headers = HeaderMap::new();
+        headers.append(
+            NVCF_INVOCATION_REGION,
+            HeaderValue::from_static("client-region-1"),
+        );
+        headers.append(
+            "NVCF-INVOCATION-REGION",
+            HeaderValue::from_static("client-region-2"),
+        );
+        headers.insert("x-user-header", HeaderValue::from_static("user-value"));
+
+        inject_invocation_region_header(&mut headers, &HeaderValue::from_static("server-region"));
+
+        let values = headers.get_all(NVCF_INVOCATION_REGION);
+        assert_eq!(values.iter().count(), 1);
+        assert_eq!(values.iter().next().unwrap(), "server-region");
+        assert_eq!(headers.get("x-user-header").unwrap(), "user-value");
+    }
+
+    #[test]
+    fn invocation_region_header_is_added_when_absent() {
+        let mut headers = HeaderMap::new();
+
+        inject_invocation_region_header(&mut headers, &HeaderValue::from_static("server-region"));
+
+        let values = headers.get_all(NVCF_INVOCATION_REGION);
+        assert_eq!(values.iter().count(), 1);
+        assert_eq!(values.iter().next().unwrap(), "server-region");
     }
 
     #[test]

--- a/src/invocation-plane-services/http-invocation/crates/server/src/routes/post_pexec.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/src/routes/post_pexec.rs
@@ -63,6 +63,8 @@ use uom::si::information;
 use uom::si::usize::Information;
 use uuid::Uuid;
 
+const NVCF_INVOCATION_REGION: &str = "nvcf-invocation-region";
+
 #[derive(Clone, Deserialize)]
 pub struct FunctionRouting {
     pub function_id: Uuid,
@@ -217,6 +219,7 @@ pub async fn pexec(
 
     let (mut parts, request_body) = req.into_parts();
     remove_hop_by_hop_headers(&mut parts.headers);
+    inject_invocation_region_header(&mut parts.headers, nats_service.region())?;
     let stream_full_request = app_config.worker_stream_properties.stream_full_request
         || is_only_stream_full_request_opt_in(&parts.headers);
     let headers = if stream_full_request {
@@ -624,6 +627,17 @@ pub fn to_nvcf_request_headers(map: &HeaderMap) -> anyhow::Result<Vec<StringKv>>
         .collect()
 }
 
+pub(crate) fn inject_invocation_region_header(
+    headers: &mut HeaderMap,
+    region: &str,
+) -> anyhow::Result<()> {
+    headers.insert(
+        NVCF_INVOCATION_REGION,
+        HeaderValue::from_str(region).context("invalid nats_properties.region header value")?,
+    );
+    Ok(())
+}
+
 fn select_version(routing: &AllowedFunctionInvocations) -> anyhow::Result<AllowedFunctionVersion> {
     let version = if routing.function_version_ids.len() == 1 {
         routing.function_version_ids[0].clone()
@@ -657,6 +671,29 @@ mod tests {
     use testcontainers_modules::nats::Nats;
     use testcontainers_modules::testcontainers::core::Mount;
     use testcontainers_modules::testcontainers::{runners::AsyncRunner, ContainerAsync, ImageExt};
+
+    #[test]
+    fn invocation_region_header_replaces_client_value() {
+        let mut headers = HeaderMap::new();
+        headers.append(
+            NVCF_INVOCATION_REGION,
+            HeaderValue::from_static("client-region-1"),
+        );
+        headers.append(
+            "NVCF-INVOCATION-REGION",
+            HeaderValue::from_static("client-region-2"),
+        );
+        headers.insert("x-user-header", HeaderValue::from_static("user-value"));
+        headers.insert("nvcf-region", HeaderValue::from_static("worker-region"));
+
+        inject_invocation_region_header(&mut headers, "server-region").unwrap();
+
+        let values = headers.get_all(NVCF_INVOCATION_REGION);
+        assert_eq!(values.iter().count(), 1);
+        assert_eq!(values.iter().next().unwrap(), "server-region");
+        assert_eq!(headers.get("x-user-header").unwrap(), "user-value");
+        assert_eq!(headers.get("nvcf-region").unwrap(), "worker-region");
+    }
 
     #[test]
     fn gateway_timeout_response_records_function_error_metric() {

--- a/src/invocation-plane-services/http-invocation/crates/server/src/routes/post_pexec.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/src/routes/post_pexec.rs
@@ -31,8 +31,12 @@ use crate::nvcf_api::{
 use crate::rate_limit::{LimitResult, RateLimitService};
 use crate::request_id::RequestId;
 use crate::routes::{
-    app_error::AppError, body_stream, http_headers::remove_hop_by_hop_headers,
-    input_asset_header::InputAssetHeader, nvcf_status_header::NVCFStatusHeader, tlb::FunctionId,
+    app_error::AppError,
+    body_stream,
+    http_headers::{inject_invocation_region_header, remove_hop_by_hop_headers},
+    input_asset_header::InputAssetHeader,
+    nvcf_status_header::NVCFStatusHeader,
+    tlb::FunctionId,
 };
 use crate::s3::{Error, S3Service};
 use crate::settings::AppConfig;
@@ -62,8 +66,6 @@ use tracing::{Instrument, Level, Span};
 use uom::si::information;
 use uom::si::usize::Information;
 use uuid::Uuid;
-
-const NVCF_INVOCATION_REGION: &str = "nvcf-invocation-region";
 
 #[derive(Clone, Deserialize)]
 pub struct FunctionRouting {
@@ -219,7 +221,7 @@ pub async fn pexec(
 
     let (mut parts, request_body) = req.into_parts();
     remove_hop_by_hop_headers(&mut parts.headers);
-    inject_invocation_region_header(&mut parts.headers, nats_service.region())?;
+    inject_invocation_region_header(&mut parts.headers, nats_service.invocation_region_header());
     let stream_full_request = app_config.worker_stream_properties.stream_full_request
         || is_only_stream_full_request_opt_in(&parts.headers);
     let headers = if stream_full_request {
@@ -627,17 +629,6 @@ pub fn to_nvcf_request_headers(map: &HeaderMap) -> anyhow::Result<Vec<StringKv>>
         .collect()
 }
 
-pub(crate) fn inject_invocation_region_header(
-    headers: &mut HeaderMap,
-    region: &str,
-) -> anyhow::Result<()> {
-    headers.insert(
-        NVCF_INVOCATION_REGION,
-        HeaderValue::from_str(region).context("invalid nats_properties.region header value")?,
-    );
-    Ok(())
-}
-
 fn select_version(routing: &AllowedFunctionInvocations) -> anyhow::Result<AllowedFunctionVersion> {
     let version = if routing.function_version_ids.len() == 1 {
         routing.function_version_ids[0].clone()
@@ -671,29 +662,6 @@ mod tests {
     use testcontainers_modules::nats::Nats;
     use testcontainers_modules::testcontainers::core::Mount;
     use testcontainers_modules::testcontainers::{runners::AsyncRunner, ContainerAsync, ImageExt};
-
-    #[test]
-    fn invocation_region_header_replaces_client_value() {
-        let mut headers = HeaderMap::new();
-        headers.append(
-            NVCF_INVOCATION_REGION,
-            HeaderValue::from_static("client-region-1"),
-        );
-        headers.append(
-            "NVCF-INVOCATION-REGION",
-            HeaderValue::from_static("client-region-2"),
-        );
-        headers.insert("x-user-header", HeaderValue::from_static("user-value"));
-        headers.insert("nvcf-region", HeaderValue::from_static("worker-region"));
-
-        inject_invocation_region_header(&mut headers, "server-region").unwrap();
-
-        let values = headers.get_all(NVCF_INVOCATION_REGION);
-        assert_eq!(values.iter().count(), 1);
-        assert_eq!(values.iter().next().unwrap(), "server-region");
-        assert_eq!(headers.get("x-user-header").unwrap(), "user-value");
-        assert_eq!(headers.get("nvcf-region").unwrap(), "worker-region");
-    }
 
     #[test]
     fn gateway_timeout_response_records_function_error_metric() {

--- a/src/invocation-plane-services/http-invocation/crates/server/tests/mocks/nvcf_worker_mock.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/tests/mocks/nvcf_worker_mock.rs
@@ -639,7 +639,7 @@ pub struct JsonHttpRequest {
     pub method: String,
     pub path: String,
     pub body: Option<String>,
-    pub headers: HashMap<String, String>,
+    pub headers: Vec<(String, String)>,
 }
 
 #[async_trait]

--- a/src/invocation-plane-services/http-invocation/crates/server/tests/mocks/nvcf_worker_mock.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/tests/mocks/nvcf_worker_mock.rs
@@ -529,6 +529,7 @@ impl WorkHandler for FnWorkHandler {
 pub struct PollAwareHandler {
     pub sleep_time: Duration,
     pub enable_echo_request: bool,
+    pub echo_polling_request_headers: bool,
 }
 
 #[async_trait]
@@ -561,14 +562,11 @@ impl WorkHandler for PollAwareHandler {
         } else {
             "a response".into()
         };
-        let response_headers = if self.enable_echo_request {
-            request.request_headers.clone()
-        } else {
-            vec![StringKv {
-                key: CONTENT_TYPE.to_string(),
-                value: "text/plain".into(),
-            }]
-        };
+        let default_response_headers = vec![StringKv {
+            key: CONTENT_TYPE.to_string(),
+            value: "text/plain".into(),
+        }];
+        let echo_polling_request_headers = self.echo_polling_request_headers;
 
         let send_responses = async move {
             let finished = tokio::time::sleep(self.sleep_time);
@@ -579,7 +577,12 @@ impl WorkHandler for PollAwareHandler {
                     () = &mut finished => {
                         tracing::debug!("producing finished response");
                         let mut builder = http::Response::builder().status(StatusCode::OK);
-                        for header in &response_headers {
+                        let response_headers = if echo_polling_request_headers {
+                            &polling_request.request_headers
+                        } else {
+                            &default_response_headers
+                        };
+                        for header in response_headers {
                             builder = builder.header(header.key.clone(), header.value.clone());
                         }
                         let response = builder.body(response_body.into())?;
@@ -631,6 +634,7 @@ pub struct JsonHttpRequest {
     pub method: String,
     pub path: String,
     pub body: Option<String>,
+    pub headers: HashMap<String, String>,
 }
 
 #[async_trait]
@@ -640,9 +644,32 @@ impl WorkHandler for ReturnRequestHandler {
         worker: &Worker,
         request: &WorkerInvokeFunctionRequest,
     ) -> anyhow::Result<()> {
-        let body_stream = match worker.get_request_body(request).await? {
-            AttachedRequest::BodyOnly(body) => body,
-            AttachedRequest::FullRequest(request) => request.into_body(),
+        let (body_stream, method, path, headers) = match worker.get_request_body(request).await? {
+            AttachedRequest::BodyOnly(body) => (
+                body,
+                request.request_method.clone(),
+                request.request_path.clone(),
+                HashMap::new(),
+            ),
+            AttachedRequest::FullRequest(request) => {
+                let (parts, body) = request.into_parts();
+                let headers = parts
+                    .headers
+                    .iter()
+                    .filter_map(|(key, value)| {
+                        value
+                            .to_str()
+                            .ok()
+                            .map(|value| (key.to_string(), value.to_string()))
+                    })
+                    .collect();
+                (
+                    body,
+                    parts.method.to_string(),
+                    parts.uri.to_string(),
+                    headers,
+                )
+            }
         };
         let body = body_stream.collect().await?.to_bytes();
         let body = if body.is_empty() {
@@ -651,9 +678,10 @@ impl WorkHandler for ReturnRequestHandler {
             Some(String::from_utf8(body.to_vec())?)
         };
         let json_http_request = JsonHttpRequest {
-            method: request.request_method.clone(),
-            path: request.request_path.clone(),
+            method,
+            path,
             body,
+            headers,
         };
         let body = serde_json::to_vec(&json_http_request)?;
         let response = http::Response::builder()

--- a/src/invocation-plane-services/http-invocation/crates/server/tests/mocks/nvcf_worker_mock.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/tests/mocks/nvcf_worker_mock.rs
@@ -566,6 +566,9 @@ impl WorkHandler for PollAwareHandler {
             key: CONTENT_TYPE.to_string(),
             value: "text/plain".into(),
         }];
+        let echo_request_headers = self
+            .enable_echo_request
+            .then(|| request.request_headers.clone());
         let echo_polling_request_headers = self.echo_polling_request_headers;
 
         let send_responses = async move {
@@ -579,6 +582,8 @@ impl WorkHandler for PollAwareHandler {
                         let mut builder = http::Response::builder().status(StatusCode::OK);
                         let response_headers = if echo_polling_request_headers {
                             &polling_request.request_headers
+                        } else if let Some(headers) = &echo_request_headers {
+                            headers
                         } else {
                             &default_response_headers
                         };
@@ -649,7 +654,11 @@ impl WorkHandler for ReturnRequestHandler {
                 body,
                 request.request_method.clone(),
                 request.request_path.clone(),
-                HashMap::new(),
+                request
+                    .request_headers
+                    .iter()
+                    .map(|header| (header.key.clone(), header.value.clone()))
+                    .collect(),
             ),
             AttachedRequest::FullRequest(request) => {
                 let (parts, body) = request.into_parts();

--- a/src/invocation-plane-services/http-invocation/crates/server/tests/test_exec.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/tests/test_exec.rs
@@ -95,6 +95,7 @@ async fn test_exec_poll() -> anyhow::Result<()> {
         Box::new(PollAwareHandler {
             sleep_time: Duration::from_secs(2),
             enable_echo_request: true,
+            echo_polling_request_headers: false,
         }),
         PublishMode::Attach(app.clone()),
     )

--- a/src/invocation-plane-services/http-invocation/crates/server/tests/test_pexec.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/tests/test_pexec.rs
@@ -27,7 +27,8 @@ use mime::TEXT_EVENT_STREAM;
 use mocks::{
     fixtures,
     nvcf_worker_mock::{
-        DefaultWorkHandler, FnWorkHandler, SseWorkHandler, Worker, WorkerProperties,
+        DefaultWorkHandler, EchoWorkHandler, FnWorkHandler, SseWorkHandler, Worker,
+        WorkerProperties,
     },
     rate_limit_mock, API_KEY, FUNCTION_ID, FUNCTION_ID_2_RATELIMIT_SYNC,
     FUNCTION_ID_3_RATELIMIT_ASYNC, INSTANCE_ID, VERSION_ID_1, VERSION_ID_3, VERSION_ID_4,
@@ -102,6 +103,41 @@ async fn test_pexec() -> anyhow::Result<()> {
         assert_eq!(response_body, "a response");
         tracing::info!("completed request {i}");
     }
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_pexec_forwards_invocation_region() -> anyhow::Result<()> {
+    let (_localstack, _nats, _mock_nvcf_api, mut config) = fixtures().await;
+    config.nats_properties.region = "server-region".into();
+    let mut app = app(config.clone(), None).await?;
+    let app = ServiceExt::<http::Request<Body>>::ready(&mut app).await?;
+    let _worker = Worker::new(
+        config.nats_properties.clone(),
+        WorkerProperties {
+            function_id: FUNCTION_ID,
+            function_version_id: VERSION_ID_1,
+            instance_id: INSTANCE_ID.into(),
+        },
+        Box::new(EchoWorkHandler {}),
+        PublishMode::Attach(app.clone()),
+    )
+    .await?
+    .into_background_task();
+
+    let request = axum::http::Request::builder()
+        .method(Method::POST)
+        .uri(format!(
+            "/v2/nvcf/pexec/functions/{FUNCTION_ID}/versions/{VERSION_ID_1}"
+        ))
+        .header(AUTHORIZATION, format!("Bearer {API_KEY}"))
+        .header("NVCF-INVOCATION-REGION", "client-region")
+        .body(Body::from("a body"))?;
+    let response = app.call(request).await?;
+
+    let regions = response.headers().get_all("nvcf-invocation-region");
+    assert_eq!(regions.iter().count(), 1);
+    assert_eq!(regions.iter().next().unwrap(), "server-region");
     Ok(())
 }
 

--- a/src/invocation-plane-services/http-invocation/crates/server/tests/test_pexec.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/tests/test_pexec.rs
@@ -132,6 +132,7 @@ async fn test_pexec_forwards_invocation_region() -> anyhow::Result<()> {
         ))
         .header(AUTHORIZATION, format!("Bearer {API_KEY}"))
         .header("x-user-header", "user-value")
+        .header("NVCF-INVOCATION-REGION", "client-region")
         .body(Body::from("a body"))?;
     let response = app.call(request).await?;
     assert_eq!(response.status(), StatusCode::OK);
@@ -143,17 +144,19 @@ async fn test_pexec_forwards_invocation_region() -> anyhow::Result<()> {
         .is_none());
     let response_body = response.into_body().collect().await?.to_bytes();
     let parsed_request: JsonHttpRequest = serde_json::from_slice(&response_body)?;
-    let region = parsed_request
+    let regions: Vec<_> = parsed_request
         .headers
         .iter()
-        .find(|(key, _)| key.eq_ignore_ascii_case("nvcf-invocation-region"))
-        .map(|(_, value)| value);
-    assert_eq!(region.map(String::as_str), Some("server-region"));
+        .filter(|(key, _)| key.eq_ignore_ascii_case("nvcf-invocation-region"))
+        .map(|(_, value)| value.as_str())
+        .collect();
+    assert_eq!(regions, ["server-region"]);
     assert_eq!(
         parsed_request
             .headers
-            .get("x-user-header")
-            .map(String::as_str),
+            .iter()
+            .find(|(key, _)| key == "x-user-header")
+            .map(|(_, value)| value.as_str()),
         Some("user-value")
     );
     Ok(())

--- a/src/invocation-plane-services/http-invocation/crates/server/tests/test_pexec.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/tests/test_pexec.rs
@@ -27,8 +27,8 @@ use mime::TEXT_EVENT_STREAM;
 use mocks::{
     fixtures,
     nvcf_worker_mock::{
-        DefaultWorkHandler, EchoWorkHandler, FnWorkHandler, SseWorkHandler, Worker,
-        WorkerProperties,
+        DefaultWorkHandler, FnWorkHandler, JsonHttpRequest, ReturnRequestHandler, SseWorkHandler,
+        Worker, WorkerProperties,
     },
     rate_limit_mock, API_KEY, FUNCTION_ID, FUNCTION_ID_2_RATELIMIT_SYNC,
     FUNCTION_ID_3_RATELIMIT_ASYNC, INSTANCE_ID, VERSION_ID_1, VERSION_ID_3, VERSION_ID_4,
@@ -119,7 +119,7 @@ async fn test_pexec_forwards_invocation_region() -> anyhow::Result<()> {
             function_version_id: VERSION_ID_1,
             instance_id: INSTANCE_ID.into(),
         },
-        Box::new(EchoWorkHandler {}),
+        Box::new(ReturnRequestHandler {}),
         PublishMode::Attach(app.clone()),
     )
     .await?
@@ -131,13 +131,31 @@ async fn test_pexec_forwards_invocation_region() -> anyhow::Result<()> {
             "/v2/nvcf/pexec/functions/{FUNCTION_ID}/versions/{VERSION_ID_1}"
         ))
         .header(AUTHORIZATION, format!("Bearer {API_KEY}"))
-        .header("NVCF-INVOCATION-REGION", "client-region")
+        .header("x-user-header", "user-value")
         .body(Body::from("a body"))?;
     let response = app.call(request).await?;
-
-    let regions = response.headers().get_all("nvcf-invocation-region");
-    assert_eq!(regions.iter().count(), 1);
-    assert_eq!(regions.iter().next().unwrap(), "server-region");
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(response
+        .headers()
+        .get_all("nvcf-invocation-region")
+        .iter()
+        .next()
+        .is_none());
+    let response_body = response.into_body().collect().await?.to_bytes();
+    let parsed_request: JsonHttpRequest = serde_json::from_slice(&response_body)?;
+    let region = parsed_request
+        .headers
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case("nvcf-invocation-region"))
+        .map(|(_, value)| value);
+    assert_eq!(region.map(String::as_str), Some("server-region"));
+    assert_eq!(
+        parsed_request
+            .headers
+            .get("x-user-header")
+            .map(String::as_str),
+        Some("user-value")
+    );
     Ok(())
 }
 

--- a/src/invocation-plane-services/http-invocation/crates/server/tests/test_polling.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/tests/test_polling.rs
@@ -34,7 +34,8 @@ use tower::{Service, ServiceExt};
 
 #[tokio::test]
 async fn test_poll() -> anyhow::Result<()> {
-    let (_localstack, _nats, _mock_nvcf_api, config) = fixtures().await;
+    let (_localstack, _nats, _mock_nvcf_api, mut config) = fixtures().await;
+    config.nats_properties.region = "server-region".into();
     let mut app = app(config.clone(), None).await?;
     let app = ServiceExt::<http::Request<Body>>::ready(&mut app).await?;
     let _worker = Worker::new(
@@ -47,6 +48,7 @@ async fn test_poll() -> anyhow::Result<()> {
         Box::new(PollAwareHandler {
             sleep_time: Duration::from_secs(2),
             enable_echo_request: false,
+            echo_polling_request_headers: true,
         }),
         PublishMode::Attach(app.clone()),
     )
@@ -56,6 +58,7 @@ async fn test_poll() -> anyhow::Result<()> {
     let request = axum::http::Request::builder()
         .method(Method::POST)
         .header("nvcf-poll-seconds", "1")
+        .header("NVCF-INVOCATION-REGION", "client-initial-region")
         .uri(format!(
             "/v2/nvcf/pexec/functions/{FUNCTION_ID}/versions/{VERSION_ID_1}"
         ))
@@ -85,6 +88,8 @@ async fn test_poll() -> anyhow::Result<()> {
         .method(Method::GET)
         .uri(format!("/v2/nvcf/pexec/status/{request_id}"))
         .header(AUTHORIZATION, format!("Bearer {API_KEY}"))
+        .header(CONTENT_TYPE, "text/plain")
+        .header("NVCF-INVOCATION-REGION", "client-poll-region")
         .body(Body::empty())?;
     let response = app.call(request).await?;
     assert_eq!(response.status(), StatusCode::OK);
@@ -100,6 +105,9 @@ async fn test_poll() -> anyhow::Result<()> {
         response.headers().get("nvcf-status"),
         Some(&HeaderValue::from_static("fulfilled"))
     );
+    let regions = response.headers().get_all("nvcf-invocation-region");
+    assert_eq!(regions.iter().count(), 1);
+    assert_eq!(regions.iter().next().unwrap(), "server-region");
     let response_body = response.into_body().collect().await?.to_bytes();
     let response_body = String::from_utf8(response_body.into())?;
     assert_eq!(response_body, "a response");
@@ -121,6 +129,7 @@ async fn test_worker_responds_while_client_is_not_polling() -> anyhow::Result<()
         Box::new(PollAwareHandler {
             sleep_time: Duration::from_secs(2),
             enable_echo_request: false,
+            echo_polling_request_headers: false,
         }),
         PublishMode::Attach(app.clone()),
     )
@@ -216,6 +225,7 @@ async fn test_cross_region_poll() -> anyhow::Result<()> {
         Box::new(PollAwareHandler {
             sleep_time: Duration::from_secs(2),
             enable_echo_request: false,
+            echo_polling_request_headers: false,
         }),
         PublishMode::AttachMultiRegion(HashMap::from([
             (
@@ -334,6 +344,7 @@ async fn test_cross_region_poll_response_returned_while_client_not_present() -> 
         Box::new(PollAwareHandler {
             sleep_time: Duration::from_secs(2),
             enable_echo_request: false,
+            echo_polling_request_headers: false,
         }),
         PublishMode::AttachMultiRegion(HashMap::from([
             (

--- a/src/invocation-plane-services/http-invocation/crates/server/tests/test_polling.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/tests/test_polling.rs
@@ -48,7 +48,7 @@ async fn test_poll() -> anyhow::Result<()> {
         Box::new(PollAwareHandler {
             sleep_time: Duration::from_secs(2),
             enable_echo_request: false,
-            echo_polling_request_headers: true,
+            echo_polling_request_headers: false,
         }),
         PublishMode::Attach(app.clone()),
     )
@@ -58,7 +58,6 @@ async fn test_poll() -> anyhow::Result<()> {
     let request = axum::http::Request::builder()
         .method(Method::POST)
         .header("nvcf-poll-seconds", "1")
-        .header("NVCF-INVOCATION-REGION", "client-initial-region")
         .uri(format!(
             "/v2/nvcf/pexec/functions/{FUNCTION_ID}/versions/{VERSION_ID_1}"
         ))
@@ -88,8 +87,6 @@ async fn test_poll() -> anyhow::Result<()> {
         .method(Method::GET)
         .uri(format!("/v2/nvcf/pexec/status/{request_id}"))
         .header(AUTHORIZATION, format!("Bearer {API_KEY}"))
-        .header(CONTENT_TYPE, "text/plain")
-        .header("NVCF-INVOCATION-REGION", "client-poll-region")
         .body(Body::empty())?;
     let response = app.call(request).await?;
     assert_eq!(response.status(), StatusCode::OK);
@@ -105,9 +102,6 @@ async fn test_poll() -> anyhow::Result<()> {
         response.headers().get("nvcf-status"),
         Some(&HeaderValue::from_static("fulfilled"))
     );
-    let regions = response.headers().get_all("nvcf-invocation-region");
-    assert_eq!(regions.iter().count(), 1);
-    assert_eq!(regions.iter().next().unwrap(), "server-region");
     let response_body = response.into_body().collect().await?.to_bytes();
     let response_body = String::from_utf8(response_body.into())?;
     assert_eq!(response_body, "a response");
@@ -225,7 +219,7 @@ async fn test_cross_region_poll() -> anyhow::Result<()> {
         Box::new(PollAwareHandler {
             sleep_time: Duration::from_secs(2),
             enable_echo_request: false,
-            echo_polling_request_headers: false,
+            echo_polling_request_headers: true,
         }),
         PublishMode::AttachMultiRegion(HashMap::from([
             (
@@ -277,6 +271,7 @@ async fn test_cross_region_poll() -> anyhow::Result<()> {
         .method(Method::GET)
         .uri(format!("/v2/nvcf/pexec/status/{request_id}"))
         .header(AUTHORIZATION, format!("Bearer {API_KEY}"))
+        .header(CONTENT_TYPE, "text/plain")
         .header("nvcf-poll-seconds", "3")
         .body(Body::empty())?;
 
@@ -294,6 +289,9 @@ async fn test_cross_region_poll() -> anyhow::Result<()> {
         response.headers().get("nvcf-status"),
         Some(&HeaderValue::from_static("fulfilled"))
     );
+    let regions = response.headers().get_all("nvcf-invocation-region");
+    assert_eq!(regions.iter().count(), 1);
+    assert_eq!(regions.iter().next().unwrap(), "region_1");
     let response_body = response.into_body().collect().await?.to_bytes();
     let response_body = String::from_utf8(response_body.into())?;
     assert_eq!(response_body, "a response");

--- a/src/invocation-plane-services/http-invocation/crates/server/tests/test_polling.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/tests/test_polling.rs
@@ -273,6 +273,7 @@ async fn test_cross_region_poll() -> anyhow::Result<()> {
         .header(AUTHORIZATION, format!("Bearer {API_KEY}"))
         .header(CONTENT_TYPE, "text/plain")
         .header("nvcf-poll-seconds", "3")
+        .header("NVCF-INVOCATION-REGION", "client-region")
         .body(Body::empty())?;
 
     let response = app_region_2.call(request).await?;

--- a/src/invocation-plane-services/http-invocation/crates/server/tests/test_tlb.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/tests/test_tlb.rs
@@ -272,12 +272,13 @@ async fn test_fully_streamed_pexec_forwards_invocation_region() -> anyhow::Resul
     assert_eq!(response.status(), StatusCode::OK);
     let response_body = response.into_body().collect().await?.to_bytes();
     let parsed_request: JsonHttpRequest = serde_json::from_slice(&response_body)?;
-    let region = parsed_request
+    let regions: Vec<_> = parsed_request
         .headers
         .iter()
-        .find(|(key, _)| key.eq_ignore_ascii_case("nvcf-invocation-region"))
-        .map(|(_, value)| value);
-    assert_eq!(region.map(String::as_str), Some("server-region"));
+        .filter(|(key, _)| key.eq_ignore_ascii_case("nvcf-invocation-region"))
+        .map(|(_, value)| value.as_str())
+        .collect();
+    assert_eq!(regions, ["server-region"]);
     Ok(())
 }
 

--- a/src/invocation-plane-services/http-invocation/crates/server/tests/test_tlb.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/tests/test_tlb.rs
@@ -240,6 +240,47 @@ async fn test_bidi_streaming_fully_streamed() -> anyhow::Result<()> {
     bidi_streaming_test(config).await
 }
 
+#[tokio::test]
+async fn test_fully_streamed_pexec_forwards_invocation_region() -> anyhow::Result<()> {
+    let (_localstack, _nats, _mock_nvcf_api, mut config) = fixtures().await;
+    config.nats_properties.region = "server-region".into();
+    config.worker_stream_properties.stream_full_request = true;
+    let mut app = app(config.clone(), None).await?;
+    let app = ServiceExt::<http::Request<Body>>::ready(&mut app).await?;
+    let _worker = Worker::new(
+        config.nats_properties.clone(),
+        WorkerProperties {
+            function_id: FUNCTION_ID,
+            function_version_id: VERSION_ID_1,
+            instance_id: INSTANCE_ID.into(),
+        },
+        Box::new(ReturnRequestHandler {}),
+        PublishMode::Attach(app.clone()),
+    )
+    .await?
+    .into_background_task();
+
+    let request = axum::http::Request::builder()
+        .method(Method::POST)
+        .uri(format!(
+            "/v2/nvcf/pexec/functions/{FUNCTION_ID}/versions/{VERSION_ID_1}"
+        ))
+        .header(header::AUTHORIZATION, format!("Bearer {API_KEY}"))
+        .header("NVCF-INVOCATION-REGION", "client-region")
+        .body(Body::from("a body"))?;
+    let response = app.call(request).await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let response_body = response.into_body().collect().await?.to_bytes();
+    let parsed_request: JsonHttpRequest = serde_json::from_slice(&response_body)?;
+    let region = parsed_request
+        .headers
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case("nvcf-invocation-region"))
+        .map(|(_, value)| value);
+    assert_eq!(region.map(String::as_str), Some("server-region"));
+    Ok(())
+}
+
 async fn bidi_streaming_test(config: AppConfig) -> Result<(), Error> {
     let mut app = app(config.clone(), None).await?;
     let app = ServiceExt::<http::Request<Body>>::ready(&mut app).await?;


### PR DESCRIPTION
## Why

Function containers need the region of the invocation service that accepted an invocation. The existing `NVCF-REGION` header is worker-owned worker-zone metadata and cannot provide this contract.

## What changed

- Validate configured invocation regions once when `NatsService` starts and retain the parsed values for infallible request-header injection.
- Set exactly one server-derived `NVCF-INVOCATION-REGION` header on initial POST, fully streamed, and polling requests. Cross-region polling uses the region recorded for the original invocation.
- Preserve the documented uppercase header name when the Go worker reconstructs the container request, including after full-request streaming canonicalizes incoming HTTP headers.
- Ignore client headers that collide case-insensitively with worker-owned metadata, preventing duplicate container headers after Go header canonicalization.
- Restore polling mock echo semantics and expose normal request headers in the request-returning test handler.
- Document the header in the canonical container request-header table and configure the self-managed stack with `local`.

## Customer Release Notes

Function containers can read the accepting invocation service's deployment region from the `NVCF-INVOCATION-REGION` request header.

## Plan Summary

Not applicable.

## Usage

Read `NVCF-INVOCATION-REGION` from the incoming function-container request. Cloud Functions supplies the configured accepting-region value, replaces a client-supplied value, and does not automatically add the header to client responses.

## Testing

- Passed `cargo test invocation_region`.
- Passed targeted normal POST, cross-region polling GET, and fully streamed pexec tests.
- Passed `cargo test --test test_exec`.
- Passed targeted Go worker request-construction and full-request-stream tests.
- Passed `./tools/ci/check-docs`, targeted `rustfmt --check`, Helm rendering of the self-managed values, and `git diff --check`.
- `bazel test //... --flaky_test_attempts=3` cannot analyze the suite because the unrelated BYOO collector generation rule requires `GO_BIN` on the host.

## Notes

No protobuf change. The worker preserves the public header spelling and ignores client headers that collide case-insensitively with worker-owned metadata. Broader client `NVCF-*` reserved-prefix sanitization is intentionally separate because it would change unrelated client-header behavior. Hosted deployment overrides are outside this checkout; the self-managed environment is explicitly configured as `local`.

## References

Fixes #881

## Related Merge Requests/Pull Requests

None.

## Dependencies

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added invocation-region metadata to forwarded inference, polling, and streamed requests.
  - Server-configured regions now override client-provided values.
  - Region metadata is preserved across cross-region requests.
  - Self-managed deployments now default to the local invocation region.

- **Bug Fixes**
  - Prevented invocation-region metadata from appearing in client responses.
  - Standardized region-header handling regardless of capitalization or duplication.
  - Added validation for invalid configured region values.

- **Documentation**
  - Documented the invocation-region header and its behavior for container functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
