### PR TITLE
feat(cloud-functions): expose legacy registry credential key type

### DIFF
--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/registry/RegistryCredentialManagementFacade.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/registry/RegistryCredentialManagementFacade.java
@@ -51,6 +51,7 @@ public class RegistryCredentialManagementFacade {
     private final RegistryCredentialLookupService registryCredentialLookupService;
     private final RegistryCredentialService registryCredentialService;
     private final RegistryLookupService registryLookupService;
+    private final RegistryFunctionMapperService registryFunctionMapperService;
 
     public RegistryCredentialDetailsResponse addRegistryCredential(
             String ncaId,
@@ -66,7 +67,7 @@ public class RegistryCredentialManagementFacade {
                                                                        payloadBuilder);
         return RegistryCredentialDetailsResponse.builder()
                 .registryCredential(
-                        RegistryFunctionMapperService.toRegistryCredentialDetailsDto(registry))
+                        registryFunctionMapperService.toRegistryCredentialDetailsDto(registry))
                 .build();
     }
 
@@ -87,7 +88,7 @@ public class RegistryCredentialManagementFacade {
         var entity = registryCredentialLookupService
                 .lookupRegistryCredentialByAccountAndIdOrThrow(ncaId, registryCredentialId);
         return RegistryCredentialDetailsResponse.builder()
-                .registryCredential(RegistryFunctionMapperService
+                .registryCredential(registryFunctionMapperService
                                             .toRegistryCredentialDetailsDto(entity))
                 .build();
     }

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/registry/dto/RegistryCredentialDetailsDto.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/registry/dto/RegistryCredentialDetailsDto.java
@@ -57,6 +57,9 @@ public record RegistryCredentialDetailsDto(
         @Schema(description = "Registry credential provisioned by system or user")
         @NotNull ProvisionedByEnum provisionedBy,
 
+        @Schema(description = "Optional registry credential key type")
+        @Nullable String keyType,
+
         @Schema(description = "Timestamp for last registry credential update")
         @NotNull Instant lastUpdatedAt,
 

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/service/registry/RegistryCredentialLookupService.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/service/registry/RegistryCredentialLookupService.java
@@ -49,6 +49,7 @@ public class RegistryCredentialLookupService {
 
     private final RegistryCredentialsByAccountRepository registryCredentialsByAccountRepository;
     private final RegistryMapperService registryMapperService;
+    private final RegistryFunctionMapperService registryFunctionMapperService;
     private final LoadingCache<String, List<RegistryCredentialByAccountEntity>>
             registryCredentialsByAccountCache = Caffeine.newBuilder()
                 .maximumSize(1024)   // Approximate number of accounts in Prod env.
@@ -96,7 +97,7 @@ public class RegistryCredentialLookupService {
         }
 
         return registryCredentials.stream()
-                .map(RegistryFunctionMapperService::toRegistryCredentialDetailsDto)
+                .map(registryFunctionMapperService::toRegistryCredentialDetailsDto)
                 .toList();
     }
 
@@ -114,7 +115,7 @@ public class RegistryCredentialLookupService {
                 .filter(regCred -> !Sets
                         .intersection(regCred.getArtifactTypes(), artifactTypes)
                         .isEmpty())
-                .map(RegistryFunctionMapperService::toRegistryCredentialDetailsDto)
+                .map(registryFunctionMapperService::toRegistryCredentialDetailsDto)
                 .toList();
     }
 
@@ -137,7 +138,7 @@ public class RegistryCredentialLookupService {
                         .intersection(regCred.getArtifactTypes(), artifactTypes)
                         .isEmpty())
                 .filter(regCred -> provisionedBys.contains(regCred.getProvisionedBy()))
-                .map(RegistryFunctionMapperService::toRegistryCredentialDetailsDto)
+                .map(registryFunctionMapperService::toRegistryCredentialDetailsDto)
                 .toList();
     }
 
@@ -156,7 +157,7 @@ public class RegistryCredentialLookupService {
                 .stream()
                 .filter(rc -> rc.getArtifactTypes().contains(artifactType)
                         && rc.getRegistryHostname().equals(normalizedHostname))
-                .map(RegistryFunctionMapperService::toRegistryCredentialDetailsDto)
+                .map(registryFunctionMapperService::toRegistryCredentialDetailsDto)
                 .toList();
     }
 

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/service/registry/RegistryCredentialService.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/service/registry/RegistryCredentialService.java
@@ -16,8 +16,6 @@
  */
 package com.nvidia.nvcf.service.registry;
 
-import static com.nvidia.nvcf.service.registry.RegistryFunctionMapperService.toRegistryCredentialDetailsDto;
-
 import com.nvidia.boot.audit.event.AuditEventPayload;
 import com.nvidia.boot.exceptions.BadRequestException;
 import com.nvidia.boot.exceptions.BootResponseException;
@@ -102,6 +100,7 @@ public class RegistryCredentialService {
     private final RegistryCredentialFunctionService registryCredentialFunctionService;
     private final RegistryCredentialEssService registryCredentialEssService;
     private final RegistryCredentialValidationService registryCredentialValidationService;
+    private final RegistryFunctionMapperService registryFunctionMapperService;
     private final JsonMapper jsonMapper;
 
     public RegistryCredentialService(
@@ -112,6 +111,7 @@ public class RegistryCredentialService {
             RegistryCredentialFunctionService registryCredentialFunctionService,
             RegistryCredentialEssService registryCredentialEssService,
             RegistryCredentialValidationService registryCredentialValidationService,
+            RegistryFunctionMapperService registryFunctionMapperService,
             JsonMapper jsonMapper) {
         this.registryCredentialAuditService = registryCredentialAuditService;
         this.registryLookupService = registryLookupService;
@@ -120,6 +120,7 @@ public class RegistryCredentialService {
         this.registryCredentialFunctionService = registryCredentialFunctionService;
         this.registryCredentialEssService = registryCredentialEssService;
         this.registryCredentialValidationService = registryCredentialValidationService;
+        this.registryFunctionMapperService = registryFunctionMapperService;
         this.jsonMapper = jsonMapper;
     }
 
@@ -198,7 +199,7 @@ public class RegistryCredentialService {
         registryCredentialLookupService.saveRegistryCredential(ncaId, entity);
 
         var hostname = entity.getRegistryHostname();
-        var dto = toRegistryCredentialDetailsDto(entity);
+        var dto = registryFunctionMapperService.toRegistryCredentialDetailsDto(entity);
         registryCredentialAuditService
                 .auditRegistryCredentialUpdate(payloadBuilder, jsonBefore, entity);
         log.info(MESG_REGISTRY_CREDENTIAL_OPER, ncaId, registryCredentialId, "Updated", hostname);

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/service/registry/RegistryFunctionMapperService.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/service/registry/RegistryFunctionMapperService.java
@@ -23,22 +23,31 @@ import com.nvidia.nvcf.persistence.registry.entity.ArtifactType;
 import com.nvidia.nvcf.persistence.registry.entity.ProvisionedBy;
 import com.nvidia.nvcf.persistence.registry.entity.RegistryCredentialByAccountEntity;
 import com.nvidia.nvcf.persistence.registry.entity.RegistryCredentialByAccountKey;
+import com.nvidia.nvcf.rest.function.management.dto.SecretDto;
 import com.nvidia.nvcf.rest.registry.dto.AddRegistryCredentialRequest;
 import com.nvidia.nvcf.rest.registry.dto.ProvisionedByEnum;
 import com.nvidia.nvcf.rest.registry.dto.RegistryCredentialDetailsDto;
 import com.nvidia.nvcf.rest.registry.dto.RegistryCredentialDto;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.Base64;
+import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.JsonNode;
 
 @Slf4j
 @Service
 @AllArgsConstructor
 public class RegistryFunctionMapperService {
+    private static final String API_KEY_PREFIX = "nvapi-";
+    private static final String LEGACY_KEY_TYPE = "LEGACY";
+    private static final String OAUTH_TOKEN_PREFIX = "$oauthtoken:";
     private static final String MESG_MISSING_REGISTRY_SECRET =
             "Account '%s', Registry Credential '%s': Missing secret in ESS (likely db replication" +
                     " delay), returning null";
@@ -84,7 +93,7 @@ public class RegistryFunctionMapperService {
                 });
     }
 
-    public static RegistryCredentialDetailsDto toRegistryCredentialDetailsDto(
+    public RegistryCredentialDetailsDto toRegistryCredentialDetailsDto(
             RegistryCredentialByAccountEntity entity) {
         return RegistryCredentialDetailsDto.builder()
                 .registryCredentialId(entity.getKey().getRegistryCredentialId())
@@ -96,9 +105,52 @@ public class RegistryFunctionMapperService {
                 .description(entity.getDescription())
                 .tags(entity.getTags())
                 .provisionedBy(toProvisionedByEnum(entity.getProvisionedBy()))
+                .keyType(toKeyType(entity))   // Temporary to help NGC with key migration
                 .lastUpdatedAt(entity.getLastUpdatedAt())
                 .createdAt(entity.getCreatedAt())
                 .build();
+    }
+
+    private String toKeyType(RegistryCredentialByAccountEntity entity) {
+        if (!isNgcRegistryHostname(entity.getRegistryHostname())) {
+            return null;
+        }
+
+        return registryCredentialEssService
+                .getRegistryCredentialSecret(
+                        entity.getKey().getNcaId(), entity.getKey().getRegistryCredentialId())
+                .map(SecretDto::value)
+                .filter(JsonNode::isString)
+                .map(JsonNode::stringValue)
+                .flatMap(this::decodeSecret)
+                .flatMap(this::extractApiKey)
+                .filter(apiKey -> !apiKey.startsWith(API_KEY_PREFIX))
+                .map(apiKey -> LEGACY_KEY_TYPE)
+                .orElse(null);
+    }
+
+    private static boolean isNgcRegistryHostname(String hostname) {
+        var normalizedHostname = hostname.toLowerCase(Locale.ROOT);
+        return normalizedHostname.endsWith("nvcr.io")
+                || normalizedHostname.endsWith("ngc.nvidia.com");
+    }
+
+    private Optional<String> decodeSecret(String encodedSecret) {
+        try {
+            return Optional.of(new String(
+                    Base64.getDecoder().decode(encodedSecret), StandardCharsets.UTF_8));
+        } catch (IllegalArgumentException ex) {
+            return Optional.empty();
+        }
+    }
+
+    private Optional<String> extractApiKey(String decodedSecret) {
+        if (!decodedSecret.startsWith(OAUTH_TOKEN_PREFIX)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(decodedSecret.substring(OAUTH_TOKEN_PREFIX.length()))
+                .filter(apiKey -> !apiKey.isEmpty());
     }
 
     public static RegistryCredentialByAccountEntity toRegistryCredentialByAccountEntity(

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/rest/registry/TestRegistryCredentialService.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/rest/registry/TestRegistryCredentialService.java
@@ -16,7 +16,6 @@
  */
 package com.nvidia.nvcf.rest.registry;
 
-import static com.nvidia.nvcf.service.registry.RegistryFunctionMapperService.toRegistryCredentialDetailsDto;
 import static com.nvidia.nvcf.util.TestConstants.TEST_CONTAINER_REGISTRY_CRED;
 import static com.nvidia.nvcf.util.TestConstants.TEST_HELM_REGISTRY_CRED;
 import static com.nvidia.nvcf.util.TestConstants.TEST_MODEL_REGISTRY_CRED;
@@ -27,6 +26,7 @@ import com.nvidia.nvcf.rest.registry.dto.RegistryCredentialDetailsDto;
 import com.nvidia.nvcf.service.account.AccountService;
 import com.nvidia.nvcf.service.registry.RegistryCredentialEssService;
 import com.nvidia.nvcf.service.registry.RegistryCredentialLookupService;
+import com.nvidia.nvcf.service.registry.RegistryFunctionMapperService;
 import java.util.Base64;
 import java.util.List;
 import java.util.Set;
@@ -44,6 +44,9 @@ public class TestRegistryCredentialService {
 
     @Autowired
     private AccountService accountService;
+
+    @Autowired
+    private RegistryFunctionMapperService registryFunctionMapperService;
 
     public void validateRegistryCredentials(String ncaId) {
         validateRegistryCredential(
@@ -73,7 +76,7 @@ public class TestRegistryCredentialService {
                                                                      UUID registryCredentialId) {
         var entity = registryCredentialLookupService
                 .lookupRegistryCredentialByAccountAndIdOrThrow(ncaId, registryCredentialId);
-        return toRegistryCredentialDetailsDto(entity);
+        return registryFunctionMapperService.toRegistryCredentialDetailsDto(entity);
     }
 
     private void validateRegistryCredential(

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/service/registry/RegistryFunctionMapperServiceTest.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/service/registry/RegistryFunctionMapperServiceTest.java
@@ -1,0 +1,125 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.nvcf.service.registry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.nvidia.boot.registries.service.registry.RegistryMapperService;
+import com.nvidia.nvcf.persistence.registry.RegistryCredentialsByAccountRepository;
+import com.nvidia.nvcf.persistence.registry.entity.ArtifactType;
+import com.nvidia.nvcf.persistence.registry.entity.ProvisionedBy;
+import com.nvidia.nvcf.persistence.registry.entity.RegistryCredentialByAccountEntity;
+import com.nvidia.nvcf.persistence.registry.entity.RegistryCredentialByAccountKey;
+import com.nvidia.nvcf.rest.function.management.dto.SecretDto;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.node.StringNode;
+
+@ExtendWith(MockitoExtension.class)
+class RegistryFunctionMapperServiceTest {
+
+    @Mock
+    private RegistryCredentialEssService registryCredentialEssService;
+
+    @Mock
+    private RegistryMapperService registryMapperService;
+
+    @Mock
+    private RegistryCredentialsByAccountRepository registryCredentialsByAccountRepository;
+
+    @ParameterizedTest
+    @MethodSource("keyTypeArguments")
+    void shouldSetKeyTypeOnlyForLegacyNgcCredentials(
+            String hostname,
+            String decodedSecret,
+        String expectedKeyType) {
+        var entity = registryCredential(hostname);
+        if (hostname.endsWith("nvcr.io") || hostname.endsWith("ngc.nvidia.com")) {
+            when(registryCredentialEssService.getRegistryCredentialSecret(
+                    entity.getKey().getNcaId(), entity.getKey().getRegistryCredentialId()))
+                    .thenReturn(Optional.of(secret(decodedSecret)));
+        }
+
+        var result = mapper().toRegistryCredentialDetailsDto(entity);
+
+        assertThat(result.keyType()).isEqualTo(expectedKeyType);
+    }
+
+    @Test
+    void shouldLeaveKeyTypeNullWhenEssSecretIsUnavailable() {
+        var entity = registryCredential("helm.ngc.nvidia.com");
+        when(registryCredentialEssService.getRegistryCredentialSecret(
+                entity.getKey().getNcaId(), entity.getKey().getRegistryCredentialId()))
+                .thenReturn(Optional.empty());
+
+        var result = mapper().toRegistryCredentialDetailsDto(entity);
+
+        assertThat(result.keyType()).isNull();
+    }
+
+    private static java.util.stream.Stream<Arguments> keyTypeArguments() {
+        return java.util.stream.Stream.of(
+                Arguments.of("nvcr.io", "$oauthtoken:legacy-key", "LEGACY"),
+                Arguments.of("helm.ngc.nvidia.com", "$oauthtoken:legacy-key", "LEGACY"),
+                Arguments.of("api.ngc.nvidia.com", "$oauthtoken:legacy-key", "LEGACY"),
+                Arguments.of("helm.ngc.nvidia.com", "$oauthtoken:nvapi-key", null),
+                Arguments.of("api.ngc.nvidia.com", "$oauthtoken:nvapi-key", null),
+                Arguments.of("docker.io", "$oauthtoken:legacy-key", null),
+                Arguments.of("helm.ngc.nvidia.com", "invalid-secret", null));
+    }
+
+    private RegistryFunctionMapperService mapper() {
+        return new RegistryFunctionMapperService(
+                registryCredentialEssService,
+                registryMapperService,
+                registryCredentialsByAccountRepository);
+    }
+
+    private static RegistryCredentialByAccountEntity registryCredential(String hostname) {
+        return RegistryCredentialByAccountEntity.builder()
+                .key(RegistryCredentialByAccountKey.builder()
+                        .ncaId("account-id")
+                        .registryCredentialId(UUID.randomUUID())
+                        .build())
+                .registryName("ngc")
+                .registryHostname(hostname)
+                .registryCredentialName("registry-credential")
+                .artifactTypes(Set.of(ArtifactType.HELM))
+                .provisionedBy(ProvisionedBy.USER)
+                .build();
+    }
+
+    private static SecretDto secret(String decodedSecret) {
+        var encodedSecret = Base64.getEncoder()
+                .encodeToString(decodedSecret.getBytes(StandardCharsets.UTF_8));
+        return SecretDto.builder()
+                .name("registry-credential")
+                .value(new StringNode(encodedSecret))
+                .build();
+    }
+}


### PR DESCRIPTION
## TL;DR

Adds an optional `keyType` discriminator to registry credential detail responses so clients can identify legacy NGC registry keys.

## Additional Details

`keyType` is `LEGACY` only when the registry hostname ends in `nvcr.io` or `ngc.nvidia.com` and the decoded `$oauthtoken:` API key does not start with `nvapi-`. The field is derived from the existing ESS secret, is not persisted, and never exposes the secret value.

The property is nullable and remains part of the response contract after the detection logic is retired.

## For the Reviewer

Review the centralized registry credential detail mapping and the ESS-backed discriminator conditions.

## For QA

The full `nvcf-core` test target was run. It reported one Mockito unnecessary-stubbing failure in the new mapper test. The test now stubs ESS only for hostnames that query ESS.

## Issues

Closes #886

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registry credential details now include the detected key type for supported NGC registries.
  * Legacy and OAuth-token credential formats are identified when valid secret information is available.

* **Bug Fixes**
  * Improved credential mapping reliability when secrets are missing, invalid, empty, or use unsupported formats.
  * Key type remains unset for non-NGC registries and unrecognized credential data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->