### PR TITLE
fix(registry-credentials): read registry credential secrets from ESS in cloud tasks

### DIFF
--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/registry/dto/RegistryCredentialDto.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/registry/dto/RegistryCredentialDto.java
@@ -33,12 +33,18 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.util.Set;
+import java.util.UUID;
 import lombok.Builder;
 import org.hibernate.validator.constraints.Length;
 
 @Builder
 @Schema(description = "DTO of a registry credential")
 public record RegistryCredentialDto(
+        @Nullable
+        @Schema(description = "Registry credential id. Populated on the internal account "
+                + "details response so downstream services can read the secret from ESS.")
+        UUID registryCredentialId,
+
         @Schema(description = "Registry hostname")
         @Pattern(regexp = HOSTNAME_REGEX,
                 message = "Invalid hostname: Must conform to regex " + HOSTNAME_REGEX)

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/registry/dto/RegistryCredentialDto.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/registry/dto/RegistryCredentialDto.java
@@ -52,8 +52,10 @@ public record RegistryCredentialDto(
                 message = "Invalid hostname: Must be 1 - " + MAX_HOSTNAME_LENGTH + " chars long")
         @NotBlank String registryHostname,
 
-        @Schema(description = "Registry credential - secret value must be base64 encoded " +
-                "string in username:password format")
+        @Schema(description = "Registry credential - secret value must be base64 encoded "
+                + "string in username:password format. Required on requests. Omitted from the "
+                + "internal account details response: Cloud Tasks reads the value from ESS by "
+                + "registry credential id.")
         @NotNull SecretDto secret,
 
         @Schema(description = "Artifact types")

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/service/account/AccountMapperService.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/service/account/AccountMapperService.java
@@ -52,7 +52,6 @@ public class AccountMapperService {
     private static final String MESG_MISSING_REGISTRY_CREDENTIALS =
             "Account '%s': Missing registry credentials";
 
-    private final RegistryFunctionMapperService registryFunctionMapperService;
     private final TelemetryMapperService telemetryMapperService;
     private final FunctionsRepository functionsRepository;
 
@@ -144,7 +143,7 @@ public class AccountMapperService {
     private List<RegistryCredentialDto> toRegistryCredentialDtos(
             List<RegistryCredentialDetailsDto> registryCredentialDetailsDtos) {
         var registryCredentials = registryCredentialDetailsDtos.stream()
-                .map(registryFunctionMapperService::toRegistryCredentialDto)
+                .map(RegistryFunctionMapperService::toRegistryCredentialDtoWithoutSecret)
                 .filter(Objects::nonNull)
                 .toList();
 

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/service/registry/RegistryFunctionMapperService.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/service/registry/RegistryFunctionMapperService.java
@@ -56,7 +56,7 @@ public class RegistryFunctionMapperService {
         var hostname = registryCredentialDetailsDto.registryHostname();
         var ncaId = registryCredentialDetailsDto.ncaId();
         var artifactTypes = registryCredentialDetailsDto.artifactTypes();
-        
+
         return registryCredentialEssService
                 .getRegistryCredentialSecret(ncaId, registryCredentialId)
                 .map(secret -> RegistryCredentialDto.builder()
@@ -82,6 +82,21 @@ public class RegistryFunctionMapperService {
                     }
                     return null;
                 });
+    }
+
+    // Maps a registry credential to the DTO returned in the internal account details response
+    // consumed by Cloud Tasks. The secret value is intentionally omitted: it is stored in ESS by
+    // NVCF and read directly from ESS by Cloud Tasks using the registry credential id. This
+    // mirrors how telemetry secrets are handled.
+    public static RegistryCredentialDto toRegistryCredentialDtoWithoutSecret(
+            RegistryCredentialDetailsDto registryCredentialDetailsDto) {
+        return RegistryCredentialDto.builder()
+                .registryCredentialId(registryCredentialDetailsDto.registryCredentialId())
+                .registryHostname(registryCredentialDetailsDto.registryHostname())
+                .artifactTypes(registryCredentialDetailsDto.artifactTypes())
+                .tags(registryCredentialDetailsDto.tags())
+                .description(registryCredentialDetailsDto.description())
+                .build();
     }
 
     public static RegistryCredentialDetailsDto toRegistryCredentialDetailsDto(

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/account/dto/RegistryCredentialDto.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/account/dto/RegistryCredentialDto.java
@@ -33,12 +33,17 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.util.Set;
+import java.util.UUID;
 import lombok.Builder;
 import org.hibernate.validator.constraints.Length;
 
 @Builder(toBuilder = true)
 @Schema(description = "DTO of a registry credential")
 public record RegistryCredentialDto(
+        @Nullable
+        @Schema(description = "Registry credential id used to read the secret directly from ESS")
+        UUID registryCredentialId,
+
         @Schema(description = "Registry hostname")
         @Pattern(regexp = HOSTNAME_REGEX,
                 message = "Invalid hostname: Must conform to regex " + HOSTNAME_REGEX)
@@ -46,9 +51,10 @@ public record RegistryCredentialDto(
                 message = "Invalid hostname: Must be 1 - " + MAX_HOSTNAME_LENGTH + " chars long")
         @NotBlank String registryHostname,
 
-        @Schema(description = "Registry credential - secret value must be base64 encoded " +
-                "string in username:password format")
-        @NotNull SecretDto secret,
+        @Nullable
+        @Schema(description = "Registry credential secret. Not populated on the account details "
+                + "response: the value is read directly from ESS by registry credential id.")
+        SecretDto secret,
 
         @Schema(description = "Artifact types")
         @NotNull @NotEmpty Set<ArtifactTypeEnum> artifactTypes,

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/ess/EssClient.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/ess/EssClient.java
@@ -209,4 +209,30 @@ public class EssClient {
         }
     }
 
+    public Optional<Map<String, JsonNode>> fetchRegistryCredentialSecret(
+            String ncaId,
+            UUID registryCredentialId) {
+        if (!enabled) {
+            log.debug(MESG_ESS_DISABLED);
+            return Optional.empty();
+        }
+
+        try {
+            var response = essStubService.fetchRegistryCredentialSecret(
+                    ncaId, registryCredentialId.toString(), "fetch_secret", ESS_NAMESPACE);
+            return Optional.ofNullable(response)
+                    .map(body -> Optional.ofNullable(body.getData().getData()))
+                    .orElseThrow(() -> {
+                        var path = "accounts/%s/registry-credentials/%s"
+                                .formatted(ncaId, registryCredentialId);
+                        var mesg = MESG_MISSING_FETCH_SECRETS_RESPONSE_BODY
+                                .formatted(path, "Fetch Secrets");
+                        log.error(mesg);
+                        return new UpstreamException(mesg);
+                    });
+        } catch (NotFoundException ex) {
+            return Optional.empty();
+        }
+    }
+
 }

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/ess/EssStubService.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/ess/EssStubService.java
@@ -52,6 +52,13 @@ public interface EssStubService {
                                               @RequestParam("query_type") String queryType,
                                               @RequestHeader("X-ESS-NAMESPACE") String namespace);
 
+    @GetExchange("v1/accounts/{ncaId}/registry-credentials/{registryCredentialId}")
+    FetchSecretsResponse fetchRegistryCredentialSecret(
+            @PathVariable String ncaId,
+            @PathVariable String registryCredentialId,
+            @RequestParam("query_type") String queryType,
+            @RequestHeader("X-ESS-NAMESPACE") String namespace);
+
     @DeleteExchange("v1/tasks/{taskId}/secrets")
     void deleteSecrets(@PathVariable String taskId,
                        @RequestHeader("X-ESS-NAMESPACE") String namespace);

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/registry/RegistryCredentialEssService.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/registry/RegistryCredentialEssService.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.nvct.service.registry;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Scheduler;
+import com.google.common.annotations.VisibleForTesting;
+import com.nvidia.nvct.rest.task.dto.SecretDto;
+import com.nvidia.nvct.service.ess.EssClient;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+// Reads a registry credential secret directly from ESS by registry credential id. NVCF stores the
+// secret in ESS and no longer returns it inline in the account details response, mirroring how
+// telemetry secrets are handled. Results are cached briefly to bound ESS load during task launch.
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RegistryCredentialEssService {
+
+    private record RegistryCredentialKey(String ncaId, UUID registryCredentialId) {}
+
+    private final EssClient essClient;
+    private final LoadingCache<RegistryCredentialKey, SecretDto> registryCredentialSecretsCache =
+            Caffeine.newBuilder()
+                    .maximumSize(3 * 1024)
+                    .expireAfterWrite(Duration.ofMinutes(5))
+                    .scheduler(Scheduler.systemScheduler())
+                    .build(this::fetchRegistryCredentialSecret);
+
+    public Optional<SecretDto> getRegistryCredentialSecret(
+            String ncaId,
+            UUID registryCredentialId) {
+        var key = new RegistryCredentialKey(ncaId, registryCredentialId);
+        return Optional.ofNullable(registryCredentialSecretsCache.get(key));
+    }
+
+    @VisibleForTesting
+    public void invalidateCache() {
+        registryCredentialSecretsCache.invalidateAll();
+    }
+
+    private SecretDto fetchRegistryCredentialSecret(RegistryCredentialKey key) {
+        return essClient
+                .fetchRegistryCredentialSecret(key.ncaId(), key.registryCredentialId())
+                .flatMap(secretMap -> secretMap.entrySet()
+                        .stream()
+                        .findFirst()
+                        .map(entry -> SecretDto.builder()
+                                .name(entry.getKey())
+                                .value(entry.getValue())
+                                .build()))
+                .orElse(null);
+    }
+}

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/registry/RegistryCredentialService.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/registry/RegistryCredentialService.java
@@ -21,6 +21,7 @@ import static com.nvidia.boot.registries.service.registry.dto.ArtifactTypeEnum.C
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.json.JsonMapper;
 import com.google.common.collect.Sets;
+import com.nvidia.boot.exceptions.NotFoundException;
 import com.nvidia.boot.registries.service.registry.RegistryMapperService;
 import com.nvidia.boot.registries.service.registry.dto.ArtifactTypeEnum;
 import com.nvidia.nvct.persistence.task.entity.TaskEntity;
@@ -55,10 +56,13 @@ public class RegistryCredentialService {
     private static final String MESG_FAIL_TO_ENCODE_SECRETS =
             MESG_COMMON_ERROR_PREFIX + "Failed to encode secrets";
     private static final String MESG_INVALID_REGISTRY_URL = "Invalid registry URL: %s";
+    private static final String MESG_MISSING_REGISTRY_SECRET =
+            "Account '%s', Registry Credential '%s': Secret not found in ESS";
 
     private final AccountService accountService;
     private final RegistryMapperService registryMapperService;
     private final RegistryTaskMapperService registryTaskMapperService;
+    private final RegistryCredentialEssService registryCredentialEssService;
     private final JsonMapper jsonMapper;
     private final String sidecarImagePullSecret;
     private final String sidecarRegistryHostname;
@@ -67,6 +71,7 @@ public class RegistryCredentialService {
             AccountService accountService,
             RegistryMapperService registryMapperService,
             RegistryTaskMapperService registryTaskMapperService,
+            RegistryCredentialEssService registryCredentialEssService,
             JsonMapper jsonMapper,
             @Value("${nvct.sidecars.image-pull-secret}")
             String sidecarImagePullSecret,
@@ -75,6 +80,7 @@ public class RegistryCredentialService {
         this.accountService = accountService;
         this.registryTaskMapperService = registryTaskMapperService;
         this.registryMapperService = registryMapperService;
+        this.registryCredentialEssService = registryCredentialEssService;
         this.jsonMapper = jsonMapper;
         this.sidecarImagePullSecret = sidecarImagePullSecret;
         this.sidecarRegistryHostname = sidecarRegistryHostname;
@@ -169,12 +175,33 @@ public class RegistryCredentialService {
                 .toList();
     }
 
+    // Reads the registry credential secret value directly from ESS by registry credential id.
+    // NVCF no longer returns the secret inline in the account details response. As a rollout
+    // safeguard, if an older NVCF still returns the secret inline (and no id), that value is used.
+    private String getRegistryCredentialSecretValue(
+            String ncaId,
+            RegistryCredentialDto registryCredential) {
+        if (registryCredential.secret() != null) {
+            return registryCredential.secret().value().asString();
+        }
+        return registryCredentialEssService
+                .getRegistryCredentialSecret(ncaId, registryCredential.registryCredentialId())
+                .map(secret -> secret.value().asString())
+                .orElseThrow(() -> {
+                    var mesg = MESG_MISSING_REGISTRY_SECRET
+                            .formatted(ncaId, registryCredential.registryCredentialId());
+                    log.error(mesg);
+                    return new NotFoundException(mesg);
+                });
+    }
+
     private K8sSecretsDto getRegistryImagePullSecrets(
+            String ncaId,
             List<RegistryCredentialDto> registryCredentials) {
         K8sSecretsDto k8SSecretsDto = K8sSecretsDto.builder().k8sSecrets(new ArrayList<>()).build();
         registryCredentials.forEach(registry -> {
             var hostname = registry.registryHostname();
-            var secret = registry.secret().value().asString();
+            var secret = getRegistryCredentialSecretValue(ncaId, registry);
             var dockerConfigJsonRegistryCredentialDto = DockerConfigJsonAuthDto
                     .builder()
                     .auth(secret)
@@ -213,13 +240,14 @@ public class RegistryCredentialService {
 
     public List<String> getContainerRegistryCredentialsValue(TaskEntity taskEntity) {
         return getContainerRegistryCredentials(taskEntity)
-                .stream().map(x -> x.secret().value().asString())
+                .stream()
+                .map(x -> getRegistryCredentialSecretValue(taskEntity.getNcaId(), x))
                 .toList();
     }
 
     public K8sSecretsDto getContainerRegistryImagePullSecrets(TaskEntity task) {
         var containerRegistryCredentials = getContainerRegistryCredentials(task);
-        return getRegistryImagePullSecrets(containerRegistryCredentials);
+        return getRegistryImagePullSecrets(task.getNcaId(), containerRegistryCredentials);
     }
 
     public List<RegistryCredentialDto> getHelmRegistryCredentials(TaskEntity task) {
@@ -243,13 +271,14 @@ public class RegistryCredentialService {
 
     public List<String> getHelmRegistryCredentialsValue(TaskEntity taskEntity) {
         return getHelmRegistryCredentials(taskEntity)
-                .stream().map(x -> x.secret().value().asString())
+                .stream()
+                .map(x -> getRegistryCredentialSecretValue(taskEntity.getNcaId(), x))
                 .toList();
     }
 
     public K8sSecretsDto getHelmRegistryImagePullSecrets(TaskEntity task) {
         var helmRegistryCredentials = getHelmRegistryCredentials(task);
-        return getRegistryImagePullSecrets(helmRegistryCredentials);
+        return getRegistryImagePullSecrets(task.getNcaId(), helmRegistryCredentials);
     }
 
     public Map<String, List<RegistryCredentialDto>> getModelRegistryCredentials(TaskEntity task) {
@@ -287,8 +316,8 @@ public class RegistryCredentialService {
                         Map.Entry::getKey,
                         x -> x.getValue().stream()
                                 .map(registryCredentialDto ->
-                                             registryCredentialDto
-                                                     .secret().value().asString())
+                                             getRegistryCredentialSecretValue(
+                                                     taskEntity.getNcaId(), registryCredentialDto))
                                 .toList()));
     }
 
@@ -329,8 +358,8 @@ public class RegistryCredentialService {
                         Map.Entry::getKey,
                         x -> x.getValue().stream()
                                 .map(registryCredentialDto ->
-                                             registryCredentialDto
-                                                     .secret().value().asString())
+                                             getRegistryCredentialSecretValue(
+                                                     taskEntity.getNcaId(), registryCredentialDto))
                                 .toList()));
     }
 

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/test/java/com/nvidia/nvct/service/registry/RegistryCredentialEssServiceTest.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/test/java/com/nvidia/nvct/service/registry/RegistryCredentialEssServiceTest.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.nvct.service.registry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.StringNode;
+import com.nvidia.nvct.service.ess.EssClient;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RegistryCredentialEssServiceTest {
+
+    private static final String NCA_ID = "test-nca-id";
+    private static final UUID REGISTRY_CREDENTIAL_ID =
+            UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final String SECRET_NAME = "docker-container-registry-credential";
+    private static final String SECRET_VALUE = "dXNlcm5hbWU6ZG9ja2VyLXBhdC1wYXNzd29yZA==";
+
+    @Mock
+    private EssClient essClient;
+
+    @InjectMocks
+    private RegistryCredentialEssService registryCredentialEssService;
+
+    @Test
+    void shouldReturnSecretFromEss() {
+        when(essClient.fetchRegistryCredentialSecret(NCA_ID, REGISTRY_CREDENTIAL_ID))
+                .thenReturn(Optional.of(Map.<String, JsonNode>of(
+                        SECRET_NAME, new StringNode(SECRET_VALUE))));
+
+        var secret = registryCredentialEssService
+                .getRegistryCredentialSecret(NCA_ID, REGISTRY_CREDENTIAL_ID);
+
+        assertThat(secret).isPresent();
+        assertThat(secret.get().name()).isEqualTo(SECRET_NAME);
+        assertThat(secret.get().value().asString()).isEqualTo(SECRET_VALUE);
+    }
+
+    @Test
+    void shouldReturnEmptyWhenEssHasNoSecret() {
+        when(essClient.fetchRegistryCredentialSecret(NCA_ID, REGISTRY_CREDENTIAL_ID))
+                .thenReturn(Optional.empty());
+
+        var secret = registryCredentialEssService
+                .getRegistryCredentialSecret(NCA_ID, REGISTRY_CREDENTIAL_ID);
+
+        assertThat(secret).isEmpty();
+    }
+
+    @Test
+    void shouldCacheSecretAndNotCallEssAgain() {
+        when(essClient.fetchRegistryCredentialSecret(NCA_ID, REGISTRY_CREDENTIAL_ID))
+                .thenReturn(Optional.of(Map.<String, JsonNode>of(
+                        SECRET_NAME, new StringNode(SECRET_VALUE))));
+
+        registryCredentialEssService.getRegistryCredentialSecret(NCA_ID, REGISTRY_CREDENTIAL_ID);
+        registryCredentialEssService.getRegistryCredentialSecret(NCA_ID, REGISTRY_CREDENTIAL_ID);
+
+        verify(essClient, times(1))
+                .fetchRegistryCredentialSecret(eq(NCA_ID), eq(REGISTRY_CREDENTIAL_ID));
+    }
+}

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/test/java/com/nvidia/nvct/service/registry/RegistryCredentialServiceTest.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/test/java/com/nvidia/nvct/service/registry/RegistryCredentialServiceTest.java
@@ -1,0 +1,163 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.nvct.service.registry;
+
+import static com.nvidia.boot.registries.service.registry.dto.ArtifactTypeEnum.CONTAINER;
+import static com.nvidia.nvct.util.TestConstants.TEST_GFN_GPU_SPEC;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.StringNode;
+import com.nvidia.boot.exceptions.NotFoundException;
+import com.nvidia.boot.registries.service.registry.RegistryMapperService;
+import com.nvidia.nvct.persistence.task.entity.TaskEntity;
+import com.nvidia.nvct.persistence.task.entity.TaskStatus;
+import com.nvidia.nvct.rest.task.dto.SecretDto;
+import com.nvidia.nvct.service.account.AccountService;
+import com.nvidia.nvct.service.account.dto.AccountDto;
+import com.nvidia.nvct.service.account.dto.RegistryCredentialDto;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RegistryCredentialServiceTest {
+
+    private static final String NCA_ID = "test-nca-id";
+    private static final String CONTAINER_IMAGE = "docker.io/library/nginx:latest";
+    private static final String CONTAINER_HOSTNAME = "docker.io";
+    private static final UUID REGISTRY_CREDENTIAL_ID =
+            UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final String ESS_SECRET_VALUE = "ess-base64-secret";
+    private static final String INLINE_SECRET_VALUE = "inline-base64-secret";
+
+    @Mock
+    private AccountService accountService;
+
+    @Mock
+    private RegistryCredentialEssService registryCredentialEssService;
+
+    private RegistryCredentialService createService() {
+        var registryMapperService = new RegistryMapperService(
+                "stg.nvcr.io", "api.stg.ngc.nvidia.com", "helm.stg.ngc.nvidia.com");
+        var registryTaskMapperService = new RegistryTaskMapperService(registryMapperService);
+        return new RegistryCredentialService(
+                accountService,
+                registryMapperService,
+                registryTaskMapperService,
+                registryCredentialEssService,
+                JsonMapper.builder().build(),
+                "sidecar-image-pull-secret",
+                "sidecar.registry.example.com");
+    }
+
+    private static TaskEntity containerTask() {
+        return TaskEntity.builder()
+                .taskId(UUID.randomUUID())
+                .ncaId(NCA_ID)
+                .name("test-task")
+                .status(TaskStatus.QUEUED)
+                .gpuSpec(TEST_GFN_GPU_SPEC)
+                .maxQueuedDuration(Duration.ofHours(1))
+                .terminalGracePeriodDuration(Duration.ofHours(1))
+                .containerImage(CONTAINER_IMAGE)
+                .build();
+    }
+
+    private void mockAccountWith(RegistryCredentialDto credential) {
+        var account = AccountDto.builder()
+                .ncaId(NCA_ID)
+                .name("test-account")
+                .registryCredentials(List.of(credential))
+                .lastUpdatedAt(Instant.now())
+                .maxTasksAllowed(1)
+                .build();
+        when(accountService.getAccount(NCA_ID)).thenReturn(account);
+    }
+
+    @Test
+    void shouldResolveSecretFromEssWhenInlineSecretAbsent() {
+        var service = createService();
+        var credential = RegistryCredentialDto.builder()
+                .registryCredentialId(REGISTRY_CREDENTIAL_ID)
+                .registryHostname(CONTAINER_HOSTNAME)
+                .artifactTypes(Set.of(CONTAINER))
+                .build();
+        mockAccountWith(credential);
+        when(registryCredentialEssService.getRegistryCredentialSecret(NCA_ID, REGISTRY_CREDENTIAL_ID))
+                .thenReturn(Optional.of(SecretDto.builder()
+                        .name("docker-container-registry-credential")
+                        .value(new StringNode(ESS_SECRET_VALUE))
+                        .build()));
+
+        var values = service.getContainerRegistryCredentialsValue(containerTask());
+
+        assertThat(values).containsExactly(ESS_SECRET_VALUE);
+        verify(registryCredentialEssService)
+                .getRegistryCredentialSecret(NCA_ID, REGISTRY_CREDENTIAL_ID);
+    }
+
+    @Test
+    void shouldUseInlineSecretWhenPresentAndNotCallEss() {
+        var service = createService();
+        var credential = RegistryCredentialDto.builder()
+                .registryHostname(CONTAINER_HOSTNAME)
+                .secret(SecretDto.builder()
+                        .name("docker-container-registry-credential")
+                        .value(new StringNode(INLINE_SECRET_VALUE))
+                        .build())
+                .artifactTypes(Set.of(CONTAINER))
+                .build();
+        mockAccountWith(credential);
+
+        var values = service.getContainerRegistryCredentialsValue(containerTask());
+
+        assertThat(values).containsExactly(INLINE_SECRET_VALUE);
+        verify(registryCredentialEssService, never())
+                .getRegistryCredentialSecret(any(), any());
+    }
+
+    @Test
+    void shouldThrowWhenSecretMissingFromEss() {
+        var service = createService();
+        var credential = RegistryCredentialDto.builder()
+                .registryCredentialId(REGISTRY_CREDENTIAL_ID)
+                .registryHostname(CONTAINER_HOSTNAME)
+                .artifactTypes(Set.of(CONTAINER))
+                .build();
+        mockAccountWith(credential);
+        when(registryCredentialEssService.getRegistryCredentialSecret(NCA_ID, REGISTRY_CREDENTIAL_ID))
+                .thenReturn(Optional.empty());
+
+        var task = containerTask();
+        assertThatThrownBy(() -> service.getContainerRegistryCredentialsValue(task))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("Secret not found in ESS");
+    }
+}

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/test/java/com/nvidia/nvct/service/reval/RevalClientIntegrationTest.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/test/java/com/nvidia/nvct/service/reval/RevalClientIntegrationTest.java
@@ -42,6 +42,7 @@ import com.nvidia.nvct.rest.task.dto.GpuSpecificationDto;
 import com.nvidia.nvct.service.account.AccountService;
 import com.nvidia.nvct.service.account.dto.AccountDto;
 import com.nvidia.nvct.service.registry.RegistryArtifactValidationService;
+import com.nvidia.nvct.service.registry.RegistryCredentialEssService;
 import com.nvidia.nvct.service.registry.RegistryCredentialService;
 import com.nvidia.nvct.service.registry.RegistryTaskMapperService;
 import com.nvidia.nvct.util.MockRevalServer;
@@ -126,9 +127,12 @@ class RevalClientIntegrationTest {
                                           TEST_HELM_REGISTRY);
         RegistryTaskMapperService registryTaskMapperService =
                 new RegistryTaskMapperService(registryMapperService);
+        RegistryCredentialEssService registryCredentialEssService =
+                mock(RegistryCredentialEssService.class);
         registryCredentialService = new RegistryCredentialService(accountService,
                                                                   registryMapperService,
                                                                   registryTaskMapperService,
+                                                                  registryCredentialEssService,
                                                                   jsonMapper,
                                                                   sidecarImagePullSecret,
                                                                   sidecarRegistryHostname);


### PR DESCRIPTION
## Why

NVCF API stores registry credential secrets in the External Secret Store (ESS), but it also fetched them back and returned the secret values inline in the internal account details response consumed by Cloud Tasks. Sending secrets inline in a service to service response is unnecessary now that the value already lives in ESS. Telemetry secrets already follow the pattern where NVCF populates ESS and the downstream reads directly from ESS. This change applies the same pattern to registry credentials.

## What changed

- NVCF: the account details registry credentials now carry `registryCredentialId` and omit the secret value. A dedicated mapper builds the response DTO without the secret. The request and function deployment paths are unchanged.
- Cloud Tasks: added an ESS registry-credential fetch (stub method, client method) and a cached `RegistryCredentialEssService`. `RegistryCredentialService` now resolves the secret at task launch by id instead of reading it from the account response.
- Rollout safeguard: if an older NVCF still returns the inline secret and no id, Cloud Tasks uses the inline value. This makes NVCF and Cloud Tasks deploy order independent.
- Shared DTOs gained a nullable `registryCredentialId`; the secret is nullable on the account response.

No database schema change is required.

## Customer Release Notes

Not customer visible. Internal control-plane secret handling only.

## Plan Summary

Not applicable.

## Usage

Not applicable.

## Testing

- bazel test //src/control-plane-services/cloud-tasks/nvct-core:tests: PASSED
- bazel test //src/control-plane-services/cloud-functions/nvcf-core:tests: PASSED
- Added unit tests: RegistryCredentialEssServiceTest (ESS fetch mapping, empty result, caching) and RegistryCredentialServiceTest (resolve from ESS, inline fallback without calling ESS, not-found path). Updated RevalClientIntegrationTest for the new constructor.

## Notes

Deployment note: NVCF and Cloud Tasks can ship in either order. Cloud Tasks keeps using the inline secret until NVCF stops sending it and provides the id, after which Cloud Tasks reads from ESS.

## References

Fixes NVIDIA/nvcf#889

## Related Pull Requests

None. No change needed for src/clis/nvcf-cli: the affected account details response is an internal service to service contract, not a public API surface.

## Dependencies

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Registry credentials can reference secrets securely by credential ID.
  * Secrets can be retrieved on demand from the secure secret store for container, Helm, model, and resource workflows.
  * Registry credential details can be returned without exposing secret values.

* **Bug Fixes**
  * Existing inline secrets remain supported as a fallback.
  * Missing credential secrets now produce a clear not-found response.
  * Secret lookups are cached briefly to reduce repeated retrievals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->