### PR TITLE
feat(nvcf-api): add api.accountBootstrap.enabled flag to gate account-bootstrap hook

### DIFF
--- a/deploy/helm/cloud-functions/nvcf-api/templates/account-bootstrap-configmap.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/templates/account-bootstrap-configmap.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+{{- if .Values.api.accountBootstrap.enabled }}
 # ConfigMap for NVCF API NCA bootstrap script
 apiVersion: v1
 kind: ConfigMap
@@ -29,3 +29,4 @@ metadata:
 data:
   account-bootstrap.sh: |-
     {{- tpl (.Files.Get "scripts/account-bootstrap.sh") . | nindent 4 }}
+{{- end }}

--- a/deploy/helm/cloud-functions/nvcf-api/templates/account-bootstrap-hook-job.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/templates/account-bootstrap-hook-job.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+{{- if .Values.api.accountBootstrap.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -87,3 +87,4 @@ spec:
             value: "{{ .Values.api.accountBootstrap.readiness.failureThreshold }}"
         resources:
           {{- toYaml .Values.api.accountBootstrap.resources | nindent 10 }}
+{{- end }}

--- a/deploy/helm/cloud-functions/nvcf-api/templates/account-bootstrap-secret.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/templates/account-bootstrap-secret.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+{{- if .Values.api.accountBootstrap.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -36,3 +36,4 @@ stringData:
   NVCF_MAX_TASKS_ALLOWED: "{{ .Values.api.accountBootstrap.limits.maxTasks }}"
   NVCF_MAX_TELEMETRIES_ALLOWED: "{{ .Values.api.accountBootstrap.limits.maxTelemetries }}"
   NVCF_MAX_REGISTRY_CREDENTIALS_ALLOWED: "{{ .Values.api.accountBootstrap.limits.maxRegistryCreds }}"
+{{- end }}

--- a/deploy/helm/cloud-functions/nvcf-api/templates/account-bootstrap-serviceaccount.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/templates/account-bootstrap-serviceaccount.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+{{- if .Values.api.accountBootstrap.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -23,3 +23,4 @@ metadata:
     {{- include "nvcf-api.labels" . | nindent 4 }}
     app.kubernetes.io/component: account-bootstrap
 automountServiceAccountToken: true
+{{- end }}

--- a/deploy/helm/cloud-functions/nvcf-api/values.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/values.yaml
@@ -41,6 +41,8 @@ api:
 
   # Post-install hook job for creating NVCF account
   accountBootstrap:
+    # Set false to skip the post-install account-bootstrap hook (e.g. when accounts are provisioned via the API).
+    enabled: true
     image:
       registry: ""
       repository: ""

--- a/deploy/helm/cloud-functions/nvcf-api/values.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/values.yaml
@@ -41,7 +41,7 @@ api:
 
   # Post-install hook job for creating NVCF account
   accountBootstrap:
-    # Set false to skip the post-install account-bootstrap hook (e.g. when accounts are provisioned via the API).
+    # Set false to skip the account-bootstrap hook (runs on post-install and post-upgrade; e.g. when accounts are provisioned via the API).
     enabled: true
     image:
       registry: ""


### PR DESCRIPTION
## Summary
Add an `api.accountBootstrap.enabled` value to the `nvcf-api` chart that gates the
account-bootstrap `post-install,post-upgrade` hook Job and its companion resources.
Defaults to `true`, so existing deployments are unchanged. Setting it to `false`
lets operators who provision the NVCF account externally (e.g. via the API) skip the hook and its required bootstrap image + OpenBao JWT role.

## Additional Details
The account-bootstrap hook previously rendered unconditionally. This change wraps
the four account-bootstrap templates in `{{- if .Values.api.accountBootstrap.enabled }}`
and adds the default to `values.yaml`:

- `deploy/helm/cloud-functions/nvcf-api/templates/account-bootstrap-hook-job.yaml`
- `deploy/helm/cloud-functions/nvcf-api/templates/account-bootstrap-secret.yaml`
- `deploy/helm/cloud-functions/nvcf-api/templates/account-bootstrap-configmap.yaml`
- `deploy/helm/cloud-functions/nvcf-api/templates/account-bootstrap-serviceaccount.yaml`
- `deploy/helm/cloud-functions/nvcf-api/values.yaml` (`api.accountBootstrap.enabled: true`)

This follows the existing hook-gating convention used by `llm-request-router`
(`{{- if .Values.llmRequestRouter.pki.enabled }}` in `templates/hook-llm-migrations.yaml`).

Example:
```yaml
api:
  accountBootstrap:
    enabled: false   # accounts provisioned externally (e.g. via the API / GFN-managed)
```

## For the Reviewer
- Backward-compatible: defaults to `true`, so the hook still runs unless explicitly disabled.
- The gate wraps all four account-bootstrap resources so nothing is templated when disabled.
- Note on Helm hook semantics: on a fresh install with `enabled=false`, none of the four
  resources are created. On an *existing* release that flips to `false`, the ServiceAccount
  is pruned and the Secret/Job self-clean (hook-delete-policy + `ttlSecondsAfterFinished`),
  but the account-bootstrap `ConfigMap` (a Helm hook) may linger until removed, since Helm
  does not prune hook resources that stop rendering.

## For QA
Verified end-to-end on a live cluster(k3d locally) — the new value is optional and defaults to
`enabled: true` (hook runs) when unset, so existing deployments are unchanged.

**Setup**
- Deployed the self-managed `api` release on a local k3d cluster (`ncp-local`), with the
  control-plane images sourced from the public `nvcr.io/nvidia/nvcf` catalog (entitled NGC
  API key) and the account-bootstrap image from `docker.io/alpine/k8s:1.36.1`.
- Ported this change into the `nvcf-api` chart and deployed via `helmfile apply`
  (helm v3.16.4 + helmfile v1.1.3), then waited for `nvcf-api` to reach 2/2 Ready before
  checking any resources.
- Verified at two layers: (1) chart render (`helm lint` + `helm template` for both states),
  and (2) live cluster resources plus the hook Job pod's status and startup logs.

**Case A — enabled (default / key unset)**
- All four account-bootstrap resources are created: the hook `Job`, `Secret`, `ConfigMap`,
  and `ServiceAccount`.
- The hook Job pulls `docker.io/alpine/k8s:1.36.1` (no ImagePullBackOff) and Completes 1/1;
  its log shows the expected `HTTP 409 → treated as success` (account already existed).
  `nvcf-api` stays 2/2 Ready.

**Case B — override set (`enabled=false`)**
- None of the four account-bootstrap resources are templated;
  `kubectl get job,secret,cm,sa | rg account-bootstrap` → empty.
- `nvcf-api` still installs and stays 2/2 Ready, confirming the hook is skippable without
  affecting the control-plane deployment.

## Issues
Fixes #894

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for DCO compliance.
- [ ] New or existing tests cover these changes. <!-- template-only render change; validated via helm lint/template + live k3d -->
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a configuration option to enable or disable account bootstrapping during deployment.
  - Account bootstrapping remains enabled by default.

- **Bug Fixes**
  - Prevented account-bootstrap deployment resources from being created when the feature is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->