### PR TITLE
fix(nvca): inject transport trust into Helm LLM workers

### DIFF
--- a/src/compute-plane-services/nvca/internal/miniservice/BUILD.bazel
+++ b/src/compute-plane-services/nvca/internal/miniservice/BUILD.bazel
@@ -161,6 +161,7 @@ go_test(
         "//src/compute-plane-services/nvca/internal/metrics",
         "//src/compute-plane-services/nvca/internal/miniservice/chartcache",
         "//src/compute-plane-services/nvca/internal/otel",
+        "//src/compute-plane-services/nvca/internal/transporttls",
         "//src/compute-plane-services/nvca/internal/util/k8sutil",
         "//src/compute-plane-services/nvca/internal/util/k8sutil/mock",
         "//src/compute-plane-services/nvca/pkg/apis/nvca/v1:nvca",

--- a/src/compute-plane-services/nvca/internal/miniservice/BUILD.bazel
+++ b/src/compute-plane-services/nvca/internal/miniservice/BUILD.bazel
@@ -220,6 +220,7 @@ go_test(
         "//src/compute-plane-services/nvca/vendor/sigs.k8s.io/controller-runtime/pkg/client",
         "//src/compute-plane-services/nvca/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake",
         "//src/compute-plane-services/nvca/vendor/sigs.k8s.io/controller-runtime/pkg/client/interceptor",
+        "//src/compute-plane-services/nvca/vendor/sigs.k8s.io/controller-runtime/pkg/config",
         "//src/compute-plane-services/nvca/vendor/sigs.k8s.io/controller-runtime/pkg/log",
         "//src/compute-plane-services/nvca/vendor/sigs.k8s.io/controller-runtime/pkg/manager",
         "//src/compute-plane-services/nvca/vendor/sigs.k8s.io/controller-runtime/pkg/reconcile",

--- a/src/compute-plane-services/nvca/internal/miniservice/controller_test.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/controller_test.go
@@ -49,6 +49,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	nvcaenvtest "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/envtest"
@@ -73,7 +74,38 @@ func init() {
 	utilruntime.Must(SchemeBuilder.AddToScheme(mgrScheme))
 }
 
+type controllerTestCase struct {
+	functionType   string
+	configure      func(*nvcaconfig.Config, *featureflagmock.Fetcher)
+	additionalEnvs []corev1.EnvVar
+	assertUtilsPod func(*testing.T, context.Context, client.Client, *v1alpha1.MiniService, *corev1.Pod)
+}
+
 func TestController(t *testing.T) {
+	testController(t, controllerTestCase{functionType: "DEFAULT"})
+}
+
+func TestControllerHelmLLMTransportTLS(t *testing.T) {
+	testController(t, controllerTestCase{
+		functionType: function.FunctionTypeLLM,
+		configure: func(cfg *nvcaconfig.Config, fff *featureflagmock.Fetcher) {
+			fff.EnabledFFs = append(fff.EnabledFFs, featureflag.EnforceHelmFunctionResourceLimits)
+			cfg.Workload.TransportTLS = &nvcaconfig.TransportTLSConfig{
+				TrustMode:                nvcaconfig.TrustModeBundle,
+				TrustBundleConfigMapName: "nvcf-transport-trust-bundle",
+				TrustBundleKey:           "nvcf-ca-bundle.pem",
+				TrustBundleFingerprint:   testTransportTLSRootFingerprint,
+				TrustBundlePEM:           testTransportTLSRootCertPEM,
+			}
+		},
+		additionalEnvs: []corev1.EnvVar{
+			{Name: "LLM_REQUEST_ROUTER_ADDRESS", Value: "llm-router.example.test:443"},
+		},
+		assertUtilsPod: assertHelmLLMTransportTLS,
+	})
+}
+
+func testController(t *testing.T, tc controllerTestCase) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -81,12 +113,16 @@ func TestController(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(cleanup)
 
+	skipControllerNameValidation := true
 	mgr, err := ctrl.NewManager(restConfig, manager.Options{
 		Scheme:                  mgrScheme,
 		GracefulShutdownTimeout: new(time.Duration),
 		BaseContext:             func() context.Context { return ctx },
 		WebhookServer:           nvcaenvtest.NewFakeWebhookServer(),
 		Metrics:                 nvcaenvtest.NewFakeMetricsOptions(),
+		Controller: ctrlconfig.Controller{
+			SkipNameValidation: &skipControllerNameValidation,
+		},
 	})
 	require.NoError(t, err)
 
@@ -119,7 +155,6 @@ func TestController(t *testing.T) {
 
 	fff := &featureflagmock.Fetcher{
 		EnabledFFs: []*featureflag.FeatureFlag{
-			featureflag.EnforceHelmFunctionResourceLimits,
 			featureflag.HelmRBACEnforcement,
 		},
 		EnabledAttrs: []*featureflag.Attribute{
@@ -193,8 +228,14 @@ func TestController(t *testing.T) {
 		FeatureFlagFetcher:   fff,
 		ClusterName:          "local",
 		ClusterRegion:        "us-west-1",
-		Metrics:              metrics.NewDefaultMetrics("nca-cluster", "cluster-foo", "cluster-group-foo", "1.2.3"),
-		cacheDir:             t.TempDir(),
+		Metrics: metrics.NewDefaultMetrics(
+			"nca-cluster",
+			"cluster-foo",
+			"cluster-group-foo",
+			"1.2.3",
+			metrics.WithRegisterer(prometheus.NewRegistry()),
+		),
+		cacheDir: t.TempDir(),
 	}
 
 	cfg := nvcaconfig.Config{
@@ -211,15 +252,9 @@ func TestController(t *testing.T) {
 				},
 			},
 		},
-		Workload: nvcaconfig.WorkloadConfig{
-			TransportTLS: &nvcaconfig.TransportTLSConfig{
-				TrustMode:                nvcaconfig.TrustModeBundle,
-				TrustBundleConfigMapName: "nvcf-transport-trust-bundle",
-				TrustBundleKey:           "nvcf-ca-bundle.pem",
-				TrustBundleFingerprint:   testTransportTLSRootFingerprint,
-				TrustBundlePEM:           testTransportTLSRootCertPEM,
-			},
-		},
+	}
+	if tc.configure != nil {
+		tc.configure(&cfg, fff)
 	}
 	err = k8sutil.SetConfigDefaultResources(&cfg)
 	require.NoError(t, err)
@@ -249,7 +284,6 @@ func TestController(t *testing.T) {
 		{Name: "INFERENCE_PROTOCOL", Value: "GRPC"},
 		{Name: "INFERENCE_URL", Value: "/grpc"},
 		{Name: "INIT_CONTAINER", Value: "registry.example.test/nvcf-core/nvcf_worker_init:0.24.10"},
-		{Name: "LLM_REQUEST_ROUTER_ADDRESS", Value: "llm-router.example.test:443"},
 		{Name: "MAX_REQUEST_CONCURRENCY", Value: "1"},
 		{Name: "NVCF_FQDN", Value: "https://api.example.test"},
 		{Name: "NVCF_FQDN_GRPC", Value: "https://grpc.example.test"},
@@ -262,6 +296,7 @@ func TestController(t *testing.T) {
 		{Name: "TRACING_ACCESS_TOKEN", Value: "trace-tok-1"},
 		{Name: "UTILS_CONTAINER", Value: "registry.example.test/nvcf-core/nvcf_worker_utils:2.21.4"},
 	}
+	envs = append(envs, tc.additionalEnvs...)
 
 	sr := &nvcav2beta1.ICMSRequest{}
 	sr.Name = "sr-7788caf9-cac0-42a4-820d-36bde3ced020"
@@ -270,7 +305,7 @@ func TestController(t *testing.T) {
 		FunctionDetails: function.Details{
 			FunctionID:        "funcid-1",
 			FunctionVersionID: "funcverid-1",
-			FunctionType:      function.FunctionTypeLLM,
+			FunctionType:      tc.functionType,
 		},
 		Action:         common.FunctionCreationAction,
 		NCAId:          "ncaid-1",
@@ -409,25 +444,9 @@ rules:
 		assert.NoError(collect, err)
 	}, 2*time.Second, 100*time.Millisecond)
 
-	llmWorker := findWorkloadContainer(utilsPod.Spec, function.LLMWorkerContainerName)
-	require.NotNil(t, llmWorker)
-	installContainer := findWorkloadInitContainer(utilsPod.Spec, transporttls.InstallContainerName)
-	require.NotNil(t, installContainer)
-	assert.Equal(t, llmWorker.Resources, installContainer.Resources)
-	assert.NotNil(t, findWorkloadVolume(utilsPod.Spec, transporttls.TrustBundleVolumeName))
-	assert.NotNil(t, findWorkloadVolume(utilsPod.Spec, transporttls.MergedCertsVolumeName))
-	assert.Equal(t, transporttls.SystemCertFile,
-		findWorkloadEnvValue(llmWorker, transporttls.CertPathEnv))
-	assert.NotNil(t, findWorkloadVolumeMount(llmWorker, transporttls.MergedCertsVolumeName))
-
-	trustConfigMap := &corev1.ConfigMap{}
-	require.NoError(t, crclient.Get(ctx, client.ObjectKey{
-		Name:      "nvcf-transport-trust-bundle",
-		Namespace: ms.Spec.Namespace,
-	}, trustConfigMap))
-	assert.Equal(t, testTransportTLSRootCertPEM, trustConfigMap.Data["nvcf-ca-bundle.pem"])
-	assert.Equal(t, testTransportTLSRootFingerprint,
-		trustConfigMap.Data[transporttls.TrustBundleFingerprintKey])
+	if tc.assertUtilsPod != nil {
+		tc.assertUtilsPod(t, ctx, crclient, ms, utilsPod)
+	}
 
 	utilsPod.Status.Phase = corev1.PodRunning
 	utilsPod.Status.Conditions = []corev1.PodCondition{
@@ -474,6 +493,34 @@ rules:
 
 	cancel()
 	<-mgrErrCh
+}
+
+func assertHelmLLMTransportTLS(
+	t *testing.T,
+	ctx context.Context,
+	crclient client.Client,
+	ms *v1alpha1.MiniService,
+	utilsPod *corev1.Pod,
+) {
+	llmWorker := findWorkloadContainer(utilsPod.Spec, function.LLMWorkerContainerName)
+	require.NotNil(t, llmWorker)
+	installContainer := findWorkloadInitContainer(utilsPod.Spec, transporttls.InstallContainerName)
+	require.NotNil(t, installContainer)
+	assert.Equal(t, llmWorker.Resources, installContainer.Resources)
+	assert.NotNil(t, findWorkloadVolume(utilsPod.Spec, transporttls.TrustBundleVolumeName))
+	assert.NotNil(t, findWorkloadVolume(utilsPod.Spec, transporttls.MergedCertsVolumeName))
+	assert.Equal(t, transporttls.SystemCertFile,
+		findWorkloadEnvValue(llmWorker, transporttls.CertPathEnv))
+	assert.NotNil(t, findWorkloadVolumeMount(llmWorker, transporttls.MergedCertsVolumeName))
+
+	trustConfigMap := &corev1.ConfigMap{}
+	require.NoError(t, crclient.Get(ctx, client.ObjectKey{
+		Name:      "nvcf-transport-trust-bundle",
+		Namespace: ms.Spec.Namespace,
+	}, trustConfigMap))
+	assert.Equal(t, testTransportTLSRootCertPEM, trustConfigMap.Data["nvcf-ca-bundle.pem"])
+	assert.Equal(t, testTransportTLSRootFingerprint,
+		trustConfigMap.Data[transporttls.TrustBundleFingerprintKey])
 }
 
 func TestNVLinkOptMetricsRunnable(t *testing.T) {

--- a/src/compute-plane-services/nvca/internal/miniservice/controller_test.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/controller_test.go
@@ -54,6 +54,7 @@ import (
 	nvcaenvtest "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/envtest"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/icms"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/metrics"
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/transporttls"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/util/k8sutil"
 	k8smock "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/util/k8sutil/mock"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/v1alpha1"
@@ -118,6 +119,7 @@ func TestController(t *testing.T) {
 
 	fff := &featureflagmock.Fetcher{
 		EnabledFFs: []*featureflag.FeatureFlag{
+			featureflag.EnforceHelmFunctionResourceLimits,
 			featureflag.HelmRBACEnforcement,
 		},
 		EnabledAttrs: []*featureflag.Attribute{
@@ -209,6 +211,15 @@ func TestController(t *testing.T) {
 				},
 			},
 		},
+		Workload: nvcaconfig.WorkloadConfig{
+			TransportTLS: &nvcaconfig.TransportTLSConfig{
+				TrustMode:                nvcaconfig.TrustModeBundle,
+				TrustBundleConfigMapName: "nvcf-transport-trust-bundle",
+				TrustBundleKey:           "nvcf-ca-bundle.pem",
+				TrustBundleFingerprint:   testTransportTLSRootFingerprint,
+				TrustBundlePEM:           testTransportTLSRootCertPEM,
+			},
+		},
 	}
 	err = k8sutil.SetConfigDefaultResources(&cfg)
 	require.NoError(t, err)
@@ -238,6 +249,7 @@ func TestController(t *testing.T) {
 		{Name: "INFERENCE_PROTOCOL", Value: "GRPC"},
 		{Name: "INFERENCE_URL", Value: "/grpc"},
 		{Name: "INIT_CONTAINER", Value: "registry.example.test/nvcf-core/nvcf_worker_init:0.24.10"},
+		{Name: "LLM_REQUEST_ROUTER_ADDRESS", Value: "llm-router.example.test:443"},
 		{Name: "MAX_REQUEST_CONCURRENCY", Value: "1"},
 		{Name: "NVCF_FQDN", Value: "https://api.example.test"},
 		{Name: "NVCF_FQDN_GRPC", Value: "https://grpc.example.test"},
@@ -258,7 +270,7 @@ func TestController(t *testing.T) {
 		FunctionDetails: function.Details{
 			FunctionID:        "funcid-1",
 			FunctionVersionID: "funcverid-1",
-			FunctionType:      "DEFAULT",
+			FunctionType:      function.FunctionTypeLLM,
 		},
 		Action:         common.FunctionCreationAction,
 		NCAId:          "ncaid-1",
@@ -396,6 +408,26 @@ rules:
 		err = crclient.Get(ctx, client.ObjectKey{Name: "utils", Namespace: ms.Spec.Namespace}, utilsPod)
 		assert.NoError(collect, err)
 	}, 2*time.Second, 100*time.Millisecond)
+
+	llmWorker := findWorkloadContainer(utilsPod.Spec, function.LLMWorkerContainerName)
+	require.NotNil(t, llmWorker)
+	installContainer := findWorkloadInitContainer(utilsPod.Spec, transporttls.InstallContainerName)
+	require.NotNil(t, installContainer)
+	assert.Equal(t, llmWorker.Resources, installContainer.Resources)
+	assert.NotNil(t, findWorkloadVolume(utilsPod.Spec, transporttls.TrustBundleVolumeName))
+	assert.NotNil(t, findWorkloadVolume(utilsPod.Spec, transporttls.MergedCertsVolumeName))
+	assert.Equal(t, transporttls.SystemCertFile,
+		findWorkloadEnvValue(llmWorker, transporttls.CertPathEnv))
+	assert.NotNil(t, findWorkloadVolumeMount(llmWorker, transporttls.MergedCertsVolumeName))
+
+	trustConfigMap := &corev1.ConfigMap{}
+	require.NoError(t, crclient.Get(ctx, client.ObjectKey{
+		Name:      "nvcf-transport-trust-bundle",
+		Namespace: ms.Spec.Namespace,
+	}, trustConfigMap))
+	assert.Equal(t, testTransportTLSRootCertPEM, trustConfigMap.Data["nvcf-ca-bundle.pem"])
+	assert.Equal(t, testTransportTLSRootFingerprint,
+		trustConfigMap.Data[transporttls.TrustBundleFingerprintKey])
 
 	utilsPod.Status.Phase = corev1.PodRunning
 	utilsPod.Status.Conditions = []corev1.PodCondition{

--- a/src/compute-plane-services/nvca/internal/miniservice/reconcile.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/reconcile.go
@@ -663,7 +663,8 @@ func (r *Reconciler) doInstall(ctx context.Context,
 		return reconcile.Result{}, err
 	}
 
-	if err := r.prepareTransportTLSForWorkloads(ctx, ms, workloadObjs); err != nil {
+	transportTLSObjs := append([]client.Object{utilsPod}, workloadObjs...)
+	if err := r.prepareTransportTLSForWorkloads(ctx, ms, transportTLSObjs); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/src/compute-plane-services/nvca/internal/transporttls/BUILD.bazel
+++ b/src/compute-plane-services/nvca/internal/transporttls/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
         "//src/compute-plane-services/nvca/vendor/github.com/stretchr/testify/assert",
         "//src/compute-plane-services/nvca/vendor/github.com/stretchr/testify/require",
         "//src/compute-plane-services/nvca/vendor/k8s.io/api/core/v1:core",
+        "//src/compute-plane-services/nvca/vendor/k8s.io/apimachinery/pkg/api/resource",
         "//src/compute-plane-services/nvca/vendor/k8s.io/apimachinery/pkg/util/strategicpatch",
     ],
 )

--- a/src/compute-plane-services/nvca/internal/transporttls/transport_tls.go
+++ b/src/compute-plane-services/nvca/internal/transporttls/transport_tls.go
@@ -156,8 +156,9 @@ func InjectIntoPodSpec(podSpec *corev1.PodSpec, cfg nvcaconfig.TransportTLSConfi
 	if err := validateInstalledBundleMountConflict(&podSpec.Containers[llmWorkerIdx], cfg.InstalledBundleMountPath); err != nil {
 		return err
 	}
+	llmWorkerResources := *podSpec.Containers[llmWorkerIdx].Resources.DeepCopy()
 	upsertVolumes(podSpec, cfg)
-	upsertInstallContainer(podSpec, installImage, installImagePullPolicy, cfg)
+	upsertInstallContainer(podSpec, installImage, installImagePullPolicy, llmWorkerResources, cfg)
 
 	llmWorker := &podSpec.Containers[llmWorkerIdx]
 	upsertVolumeMount(&llmWorker.VolumeMounts, corev1.VolumeMount{
@@ -234,12 +235,14 @@ func upsertInstallContainer(
 	podSpec *corev1.PodSpec,
 	image string,
 	imagePullPolicy corev1.PullPolicy,
+	resources corev1.ResourceRequirements,
 	cfg nvcaconfig.TransportTLSConfig,
 ) {
 	upsertContainer(&podSpec.InitContainers, corev1.Container{
 		Name:            InstallContainerName,
 		Image:           image,
 		ImagePullPolicy: imagePullPolicy,
+		Resources:       resources,
 		Command:         []string{InstallCommandPath},
 		Args: []string{
 			"--system-bundle", SystemCertFile,

--- a/src/compute-plane-services/nvca/internal/transporttls/transport_tls_test.go
+++ b/src/compute-plane-services/nvca/internal/transporttls/transport_tls_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 )
 
@@ -181,10 +182,24 @@ func TestValidateConfigRejectsInvalidInstalledBundleMountPaths(t *testing.T) {
 }
 
 func TestInjectIntoPodSpecOnlyMutatesLLMWorker(t *testing.T) {
+	llmWorkerResources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
+		},
+	}
 	podSpec := &corev1.PodSpec{
 		InitContainers: []corev1.Container{testWorkerInitContainer()},
 		Containers: []corev1.Container{
-			{Name: function.LLMWorkerContainerName, Image: "nvcr.io/nvcf/llm-worker:test"},
+			{
+				Name:      function.LLMWorkerContainerName,
+				Image:     "nvcr.io/nvcf/llm-worker:test",
+				Resources: llmWorkerResources,
+			},
 			{Name: "inference", Image: "nvcr.io/customer/inference:test"},
 			{Name: "smb-server", Image: "nvcr.io/nvcf/smb-server:test"},
 		},
@@ -203,7 +218,9 @@ func TestInjectIntoPodSpecOnlyMutatesLLMWorker(t *testing.T) {
 	require.NotNil(t, trustBundleVolume.ConfigMap.Optional)
 	assert.False(t, *trustBundleVolume.ConfigMap.Optional)
 	assert.NotNil(t, findTestVolume(podSpec, MergedCertsVolumeName))
-	assert.NotNil(t, findTestInitContainer(podSpec, InstallContainerName))
+	installContainer := findTestInitContainer(podSpec, InstallContainerName)
+	require.NotNil(t, installContainer)
+	assert.Equal(t, llmWorkerResources, installContainer.Resources)
 
 	llmWorker := findTestContainer(podSpec, function.LLMWorkerContainerName)
 	require.NotNil(t, llmWorker)


### PR DESCRIPTION
## TL;DR

Inject configured transport trust into the utility pod generated for Helm-based LLM functions so the LLM worker can use the merged certificate bundle.

## Additional Details

Helm LLM translation places the `llm-worker` container in a utility pod that reconciliation separates from the normal workload object collection. Transport trust mutation previously ran only on that workload collection, so the utility pod was appended without the trust ConfigMap volume, merged-certificate volume, installer init container, certificate mount, or `STARGATE_TLS_CERT_PATH`.

This change:

- Includes the utility pod in transport trust preparation while preserving the existing `llm-worker` filter.
- Copies the LLM worker resource requirements to the injected installer init container so resource validation continues to pass.
- Adds controller-level regression coverage for the real Helm LLM lifecycle.
- Adds focused coverage for installer resource inheritance.

Dependencies: none. License and NOTICE impact: none.

## For the Reviewer

Please focus on the utility-pod inclusion in `internal/miniservice/reconcile.go` and resource inheritance in `internal/transporttls/transport_tls.go`.

## For QA

Verified with:

- Go tests for the transport TLS and MiniService packages.
- Bazel tests for the same packages.
- Scoped Go linting.
- A k3d API-server round trip confirming the installer resources, trust volumes, merged certificate mount, and certificate-path environment variable.

Additional QA is not required.

## Issues

Fixes #606

Relates to #19

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Transport TLS setup now applies to utility workloads as well as worker workloads.
  * TLS installation containers inherit the worker’s CPU and memory requests and limits.
  * Helm resource-limit enforcement is covered for LLM workloads, including generated workers and TLS initialization containers.

* **Tests**
  * Expanded integration coverage for TLS certificates, trust bundles, mounts, volumes, and resource settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->