### PR TITLE
fix(llm-gateway): stop rewriting the forwarded chat request body

### DIFF
--- a/src/invocation-plane-services/llm-api-gateway/api/proxy_body_test.go
+++ b/src/invocation-plane-services/llm-api-gateway/api/proxy_body_test.go
@@ -1,0 +1,91 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The proxy endpoints must forward the caller's body untouched apart from the
+// fields they deliberately override, so they cannot pick up the marshalling
+// defects that affect the bound chat completion model.
+func TestRewriteJSONModelPreservesEverythingElse(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"model":"caller-model","input":"hello","tool_choice":"auto","encoding_format":"float","unknown":{"a":[1,2]}}`)
+
+	rewritten, changed, err := rewriteJSONModel(body, "routed-model")
+	if err != nil {
+		t.Fatalf("rewriteJSONModel: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected the model field to be rewritten")
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(rewritten, &got); err != nil {
+		t.Fatalf("unmarshal rewritten body: %v", err)
+	}
+
+	if got["model"] != "routed-model" {
+		t.Errorf("model = %v, want routed-model", got["model"])
+	}
+	if got["input"] != "hello" {
+		t.Errorf("input = %v, want the original string", got["input"])
+	}
+	if got["tool_choice"] != "auto" {
+		t.Errorf("tool_choice = %v, want auto", got["tool_choice"])
+	}
+	if got["encoding_format"] != "float" {
+		t.Errorf("encoding_format = %v, want float", got["encoding_format"])
+	}
+	if _, ok := got["unknown"]; !ok {
+		t.Error("unknown passthrough field was dropped")
+	}
+}
+
+func TestRewriteResponsesProxyBodyPreservesEverythingElse(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"model":"caller-model","stream":false,"input":"hello","tools":[{"type":"function","name":"f"}]}`)
+
+	rewritten, err := rewriteResponsesProxyBody(body, "routed-model", true)
+	if err != nil {
+		t.Fatalf("rewriteResponsesProxyBody: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(rewritten, &got); err != nil {
+		t.Fatalf("unmarshal rewritten body: %v", err)
+	}
+
+	if got["model"] != "routed-model" {
+		t.Errorf("model = %v, want routed-model", got["model"])
+	}
+	if got["stream"] != true {
+		t.Errorf("stream = %v, want true", got["stream"])
+	}
+	if got["input"] != "hello" {
+		t.Errorf("input = %v, want the original string", got["input"])
+	}
+	tools, ok := got["tools"].([]any)
+	if !ok || len(tools) != 1 {
+		t.Fatalf("tools = %v, want the original single-element array", got["tools"])
+	}
+}

--- a/src/invocation-plane-services/llm-api-gateway/api/proxy_body_test.go
+++ b/src/invocation-plane-services/llm-api-gateway/api/proxy_body_test.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 )
 
@@ -55,8 +56,9 @@ func TestRewriteJSONModelPreservesEverythingElse(t *testing.T) {
 	if got["encoding_format"] != "float" {
 		t.Errorf("encoding_format = %v, want float", got["encoding_format"])
 	}
-	if _, ok := got["unknown"]; !ok {
-		t.Error("unknown passthrough field was dropped")
+	wantUnknown := map[string]any{"a": []any{float64(1), float64(2)}}
+	if !reflect.DeepEqual(got["unknown"], wantUnknown) {
+		t.Errorf("unknown = %v, want %v", got["unknown"], wantUnknown)
 	}
 }
 
@@ -84,8 +86,8 @@ func TestRewriteResponsesProxyBodyPreservesEverythingElse(t *testing.T) {
 	if got["input"] != "hello" {
 		t.Errorf("input = %v, want the original string", got["input"])
 	}
-	tools, ok := got["tools"].([]any)
-	if !ok || len(tools) != 1 {
-		t.Fatalf("tools = %v, want the original single-element array", got["tools"])
+	wantTools := []any{map[string]any{"type": "function", "name": "f"}}
+	if !reflect.DeepEqual(got["tools"], wantTools) {
+		t.Errorf("tools = %v, want %v", got["tools"], wantTools)
 	}
 }

--- a/src/invocation-plane-services/llm-api-gateway/models/openai.go
+++ b/src/invocation-plane-services/llm-api-gateway/models/openai.go
@@ -500,10 +500,16 @@ func (content ChatMessageContent) MarshalJSON() ([]byte, error) {
 		case ContentPartText:
 			parts = append(parts, outboundContentPart{Type: ContentPartTypeText, Text: string(typed)})
 		case *ContentPartImageURL:
+			if typed == nil {
+				return nil, errors.New("marshal content: nil image_url content part")
+			}
 			parts = append(parts, outboundContentPart{Type: ContentPartTypeImageURL, ImageURL: typed})
 		case ContentPartImageURL:
 			parts = append(parts, outboundContentPart{Type: ContentPartTypeImageURL, ImageURL: &typed})
 		case *ContentPartDocument:
+			if typed == nil {
+				return nil, errors.New("marshal content: nil document content part")
+			}
 			parts = append(parts, outboundContentPart{Type: ContentPartTypeDocument, Document: typed})
 		case ContentPartDocument:
 			parts = append(parts, outboundContentPart{Type: ContentPartTypeDocument, Document: &typed})

--- a/src/invocation-plane-services/llm-api-gateway/models/openai.go
+++ b/src/invocation-plane-services/llm-api-gateway/models/openai.go
@@ -211,7 +211,7 @@ func (t ContentPartText) String() string {
 
 type ContentPartImageURL struct {
 	URL    string `json:"url"`
-	Detail string `json:"detail"`
+	Detail string `json:"detail,omitempty"`
 	Image  []byte `json:"-"`
 }
 
@@ -300,7 +300,7 @@ type ChatCompletionFunctionChoiceField struct {
 type ChatCompletionRequest struct {
 	Messages            *[]ChatMessage                    `json:"messages"`
 	Model               string                            `json:"model"`
-	Debug               bool                              `json:"debug"`
+	Debug               bool                              `json:"-"`
 	ServiceTier         servicetier.Tier                  `json:"service_tier"`
 	FrequencyPenalty    *float32                          `json:"frequency_penalty"`
 	IncludeReasoning    *bool                             `json:"include_reasoning"`
@@ -319,8 +319,8 @@ type ChatCompletionRequest struct {
 	TopP                *float32                          `json:"top_p"`
 	Tools               *[]ChatTool                       `json:"tools"`
 	Functions           *[]ChatFunctionSpec               `json:"functions"`
-	ToolChoice          ChatCompletionToolChoiceField     `json:"tool_choice"`
-	FunctionChoice      ChatCompletionFunctionChoiceField `json:"function_call"`
+	ToolChoice          ChatCompletionToolChoiceField     `json:"tool_choice,omitzero"`
+	FunctionChoice      ChatCompletionFunctionChoiceField `json:"function_call,omitzero"`
 	ParallelToolCalls   *bool                             `json:"parallel_tool_calls"`
 	PromptCacheKey      *string                           `json:"prompt_cache_key"`
 	User                *string                           `json:"user"`
@@ -476,6 +476,45 @@ func (sf *ChatCompletionStopField) UnmarshalJSON(data []byte) error {
 	}
 }
 
+type outboundContentPart struct {
+	Type     ContentPartType      `json:"type"`
+	Text     string               `json:"text,omitempty"`
+	ImageURL *ContentPartImageURL `json:"image_url,omitempty"`
+	Document *ContentPartDocument `json:"document,omitempty"`
+}
+
+// Decoding always yields a part slice, so rebuild the union on the way out.
+func (content ChatMessageContent) MarshalJSON() ([]byte, error) {
+	if content == nil {
+		return []byte("null"), nil
+	}
+	if len(content) == 1 {
+		if text, ok := content[0].(ContentPartText); ok {
+			return json.Marshal(string(text))
+		}
+	}
+
+	parts := make([]outboundContentPart, 0, len(content))
+	for _, part := range content {
+		switch typed := part.(type) {
+		case ContentPartText:
+			parts = append(parts, outboundContentPart{Type: ContentPartTypeText, Text: string(typed)})
+		case *ContentPartImageURL:
+			parts = append(parts, outboundContentPart{Type: ContentPartTypeImageURL, ImageURL: typed})
+		case ContentPartImageURL:
+			parts = append(parts, outboundContentPart{Type: ContentPartTypeImageURL, ImageURL: &typed})
+		case *ContentPartDocument:
+			parts = append(parts, outboundContentPart{Type: ContentPartTypeDocument, Document: typed})
+		case ContentPartDocument:
+			parts = append(parts, outboundContentPart{Type: ContentPartTypeDocument, Document: &typed})
+		default:
+			return nil, fmt.Errorf("marshal content: unsupported content part %T", part)
+		}
+	}
+
+	return json.Marshal(parts)
+}
+
 func (content *ChatMessageContent) UnmarshalJSON(data []byte) error {
 	if len(data) == 0 {
 		return nil
@@ -569,6 +608,22 @@ func (content *ChatMessageContent) UnmarshalJSON(data []byte) error {
 	}
 }
 
+// Without this encoding/json writes the Go field names onto the wire.
+func (tcf ChatCompletionToolChoiceField) MarshalJSON() ([]byte, error) {
+	switch {
+	case tcf.String != nil:
+		return json.Marshal(tcf.String)
+	case tcf.ToolChoice != nil:
+		return json.Marshal(tcf.ToolChoice)
+	default:
+		return []byte("null"), nil
+	}
+}
+
+func (tcf ChatCompletionToolChoiceField) IsZero() bool {
+	return tcf.String == nil && tcf.ToolChoice == nil
+}
+
 func (tcf *ChatCompletionToolChoiceField) UnmarshalJSON(data []byte) error {
 	var selection string
 	if err := json.Unmarshal(data, &selection); err == nil {
@@ -586,6 +641,21 @@ func (tcf *ChatCompletionToolChoiceField) UnmarshalJSON(data []byte) error {
 		Field: "tool_choice",
 		Msg:   "Must be either a string or a tool_choice object",
 	}
+}
+
+func (fcf ChatCompletionFunctionChoiceField) MarshalJSON() ([]byte, error) {
+	switch {
+	case fcf.String != nil:
+		return json.Marshal(fcf.String)
+	case fcf.FunctionCall != nil:
+		return json.Marshal(fcf.FunctionCall)
+	default:
+		return []byte("null"), nil
+	}
+}
+
+func (fcf ChatCompletionFunctionChoiceField) IsZero() bool {
+	return fcf.String == nil && fcf.FunctionCall == nil
 }
 
 func (fcf *ChatCompletionFunctionChoiceField) UnmarshalJSON(data []byte) error {

--- a/src/invocation-plane-services/llm-api-gateway/models/openai_marshal_test.go
+++ b/src/invocation-plane-services/llm-api-gateway/models/openai_marshal_test.go
@@ -108,6 +108,22 @@ func TestChatMessageContentMarshalRejectsUnknownPart(t *testing.T) {
 	}
 }
 
+// A typed-nil part would otherwise serialize as a type with no member.
+func TestChatMessageContentMarshalRejectsNilParts(t *testing.T) {
+	tests := map[string]ChatMessageContent{
+		"nil image_url": {ContentPartText("a"), (*ContentPartImageURL)(nil)},
+		"nil document":  {ContentPartText("a"), (*ContentPartDocument)(nil)},
+	}
+
+	for name, content := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := json.Marshal(content); err == nil {
+				t.Fatal("expected error for nil content part")
+			}
+		})
+	}
+}
+
 type unknownContentPart struct{}
 
 func (unknownContentPart) ContentType() ContentPartType {

--- a/src/invocation-plane-services/llm-api-gateway/models/openai_marshal_test.go
+++ b/src/invocation-plane-services/llm-api-gateway/models/openai_marshal_test.go
@@ -1,0 +1,115 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// The gateway forwards a re-marshalled request, so marshaller output is wire output.
+func TestChatCompletionRequestRoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		request string
+		want    []string
+		notWant []string
+	}{
+		{
+			name:    "no tool choice sent",
+			request: `{"model":"m","messages":[{"role":"user","content":"What is 2+2?"}]}`,
+			want:    []string{`"content":"What is 2+2?"`},
+			notWant: []string{"tool_choice", "function_call", `"debug"`, "String", "ToolChoice", "FunctionCall"},
+		},
+		{
+			name:    "tool choice string",
+			request: `{"model":"m","messages":[{"role":"user","content":"hi"}],"tool_choice":"auto"}`,
+			want:    []string{`"tool_choice":"auto"`},
+			notWant: []string{"String", "ToolChoice"},
+		},
+		{
+			name:    "tool choice object",
+			request: `{"model":"m","messages":[{"role":"user","content":"hi"}],"tool_choice":{"type":"function","function":{"name":"f"}}}`,
+			want:    []string{`"tool_choice":{"type":"function","function":{"name":"f"}}`},
+		},
+		{
+			name:    "function call string",
+			request: `{"model":"m","messages":[{"role":"user","content":"hi"}],"function_call":"none"}`,
+			want:    []string{`"function_call":"none"`},
+			notWant: []string{"FunctionCall"},
+		},
+		{
+			name:    "function call object",
+			request: `{"model":"m","messages":[{"role":"user","content":"hi"}],"function_call":{"name":"f"}}`,
+			want:    []string{`"function_call":{"name":"f"}`},
+		},
+		{
+			name:    "content array of one string collapses",
+			request: `{"model":"m","messages":[{"role":"user","content":["hi"]}]}`,
+			want:    []string{`"content":"hi"`},
+		},
+		{
+			name:    "multimodal content keeps part types",
+			request: `{"model":"m","messages":[{"role":"user","content":[{"type":"text","text":"a"},{"type":"image_url","image_url":{"url":"http://x/y.png"}}]}]}`,
+			want: []string{
+				`{"type":"text","text":"a"}`,
+				`{"type":"image_url","image_url":{"url":"http://x/y.png"}}`,
+			},
+			notWant: []string{`"detail":""`},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var request ChatCompletionRequest
+			if err := json.Unmarshal([]byte(test.request), &request); err != nil {
+				t.Fatalf("unmarshal inbound request: %v", err)
+			}
+
+			outbound, err := json.Marshal(&request)
+			if err != nil {
+				t.Fatalf("marshal outbound request: %v", err)
+			}
+
+			for _, want := range test.want {
+				if !strings.Contains(string(outbound), want) {
+					t.Errorf("outbound body missing %s\ngot: %s", want, outbound)
+				}
+			}
+			for _, notWant := range test.notWant {
+				if strings.Contains(string(outbound), notWant) {
+					t.Errorf("outbound body must not contain %s\ngot: %s", notWant, outbound)
+				}
+			}
+		})
+	}
+}
+
+func TestChatMessageContentMarshalRejectsUnknownPart(t *testing.T) {
+	content := ChatMessageContent{unknownContentPart{}, unknownContentPart{}}
+	if _, err := json.Marshal(content); err == nil {
+		t.Fatal("expected error for unsupported content part")
+	}
+}
+
+type unknownContentPart struct{}
+
+func (unknownContentPart) ContentType() ContentPartType {
+	return ContentPartType("unknown")
+}


### PR DESCRIPTION
## TL;DR

The gateway does not proxy the caller's JSON. It binds into `models.ChatCompletionRequest` and re-marshals that struct to build the upstream body, and three types in that model have `UnmarshalJSON` but no `MarshalJSON`. A request that carried no `tool_choice` was forwarded as `"tool_choice":{"String":null,"ToolChoice":null}`, which any upstream that validates its request body rejects with HTTP 400 before the model is reached. Add the missing marshallers so the outbound body matches what the caller sent.

## Additional Details

`ChatCompletionToolChoiceField` and `ChatCompletionFunctionChoiceField` have no json tags on their fields, so `encoding/json` used the Go field names as keys. Both are embedded by value, so `omitempty` could not drop them: a struct value is never empty. With no `MarshalJSON`, both nil pointers were written as `null` under those Go names.

`ChatMessageContent` had the same gap, which rewrote a string `content` to a one-element array and dropped the `type` discriminator and `image_url` nesting from multimodal parts.

Changes:

- `MarshalJSON` on all three types, plus `IsZero` and `omitzero` on the two choice fields so an unset field is omitted rather than sent as `null`.
- `Debug` is no longer serialized. It has no readers in the gateway and was shipping `"debug":false` upstream.
- `ContentPartImageURL.Detail` gains `omitempty`, since `"detail":""` is not a valid OpenAI detail value.

Inbound parsing was already correct and is unchanged. Only the outbound path is affected.

The `models` package had no test files, which is why this shipped. This PR adds roundtrip coverage.

### Other OpenAI endpoints

Checked in response to review. `/v1/embeddings` and `/v1/responses` are not affected. Both capture the raw request body and forward it through `rewriteJSONModel` / `rewriteResponsesProxyBody`, which decode into `map[string]json.RawMessage` and replace only `model` (and `stream` for responses), so every other field survives byte-for-byte. Neither sends a re-marshalled struct upstream. `/v1/responses` does build a `ChatCompletionRequest`, but only to size tokens and rate limits, never to produce the outbound body.

`EmbeddingInputField` also has `UnmarshalJSON` and no `MarshalJSON`, but it is a `[]string`, so it cannot leak Go field names and it never reaches an outbound path. Both rewriters had no test coverage; this PR adds it.

`ChatCompletionStopField` is the one remaining asymmetry on the chat path. It is a `[]string`, so `"stop":"END"` is forwarded as `"stop":["END"]`. That is valid per the OpenAI schema and upstreams accept it, so it is left alone.

## For the Reviewer

Main file is `models/openai.go`. The judgment call worth checking is `ChatMessageContent.MarshalJSON`: decoding collapses string content, `["str"]`, and `[{"type":"text",...}]` into the same Go value, so a lone text part is re-emitted as a bare string. That is the form every OpenAI-compatible upstream accepts.

## For QA

- `go build ./...` and `go test ./...` pass across all 12 packages in the subtree.
- Added passthrough tests for the embeddings and responses body rewriters.
- Confirmed the marshal test is not vacuous: reverted `openai.go`, the test fails on the reported symptoms; restored, it passes.
- End-to-end verification against a validating upstream is still worth running, since the original report came from a real deployment.

## Issues

Closes #903

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved request formatting for chat messages, multimodal content, tool choices, and function calls.
  - Omits internal or empty fields from outgoing requests.
  - Rejects unsupported content types instead of producing invalid payloads.
  - Preserves caller-provided fields, including nested data and tool arrays, when rewriting requests.

- **Tests**
  - Added coverage for request serialization, field preservation, multimodal messages, and tool/function choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->