### PR TITLE
fix(pylon): probe /v1/health/ready when the upstream serves no /health

### DIFF
--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
@@ -19,6 +19,8 @@ package function
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -56,6 +58,24 @@ func normalizeLLMRequestRouterAddressEnvAliases(envSet map[string]string) {
 	if envSet[legacyStargateAddressEnv] == "" {
 		envSet[legacyStargateAddressEnv] = llmRequestRouterAddress
 	}
+}
+
+// pylon probes the upstream over HTTP on the inference port, so the function's
+// declared health endpoint only carries over when the function keeps both
+// aligned. Otherwise pylon falls back to its own candidate paths.
+func upstreamHealthPath(allEnvSet map[string]string) string {
+	path := strings.TrimSpace(allEnvSet["INFERENCE_HEALTH_ENDPOINT"])
+	if path == "" {
+		return ""
+	}
+	if strings.EqualFold(strings.TrimSpace(allEnvSet["INFERENCE_HEALTH_PROTOCOL"]), "grpc") {
+		return ""
+	}
+	healthPort, err := strconv.Atoi(strings.TrimSpace(allEnvSet["INFERENCE_HEALTH_PORT"]))
+	if err == nil && healthPort > 0 && strconv.Itoa(healthPort) != strings.TrimSpace(allEnvSet["INFERENCE_PORT"]) {
+		return ""
+	}
+	return path
 }
 
 func newLLMRouterClientContainer(
@@ -127,6 +147,9 @@ func newLLMRouterClientContainer(
 		fmt.Sprintf("--auth-token-file=%s", llmWorkerTokenPath),
 		"--backend-connectivity=reverse",
 		"--initial-input-tps=100",
+	}
+	if healthPath := upstreamHealthPath(allEnvSet); healthPath != "" {
+		args = append(args, fmt.Sprintf("--upstream-health-path=%s", healthPath))
 	}
 	if tcfg.StargateQUICInsecure {
 		args = append(args, "--quic-insecure")

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
@@ -19,6 +19,8 @@ package function
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -56,6 +58,24 @@ func normalizeLLMRequestRouterAddressEnvAliases(envSet map[string]string) {
 	if envSet[legacyStargateAddressEnv] == "" {
 		envSet[legacyStargateAddressEnv] = llmRequestRouterAddress
 	}
+}
+
+// pylon probes the upstream over HTTP on the inference port, so the function's
+// declared health endpoint only carries over when the function keeps both
+// aligned. Otherwise pylon falls back to its own candidate paths.
+func upstreamHealthPath(allEnvSet map[string]string) string {
+	path := strings.TrimSpace(allEnvSet["INFERENCE_HEALTH_ENDPOINT"])
+	if path == "" {
+		return ""
+	}
+	if strings.EqualFold(strings.TrimSpace(allEnvSet["INFERENCE_HEALTH_PROTOCOL"]), "grpc") {
+		return ""
+	}
+	healthPort, err := strconv.Atoi(strings.TrimSpace(allEnvSet["INFERENCE_HEALTH_PORT"]))
+	if err == nil && healthPort > 0 && strconv.Itoa(healthPort) != strings.TrimSpace(allEnvSet["INFERENCE_PORT"]) {
+		return ""
+	}
+	return path
 }
 
 func newLLMRouterClientContainer(
@@ -127,6 +147,9 @@ func newLLMRouterClientContainer(
 		fmt.Sprintf("--auth-token-file=%s", llmWorkerTokenPath),
 		"--backend-connectivity=reverse",
 		"--initial-input-tps=100",
+	}
+	if healthPath := upstreamHealthPath(allEnvSet); healthPath != "" {
+		args = append(args, fmt.Sprintf("--upstream-health-path=%s", healthPath))
 	}
 	if tcfg.StargateQUICInsecure {
 		args = append(args, "--quic-insecure")

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/llm_test.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/llm_test.go
@@ -47,6 +47,16 @@ func assertCanonicalPylonBootstrapArgs(t *testing.T, args []string) {
 	assert.Equal(t, []string{"--initial-input-tps=100"}, initialInputTPSArgs)
 }
 
+func healthPathArgs(args []string) []string {
+	var healthPaths []string
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "--upstream-health-path=") {
+			healthPaths = append(healthPaths, arg)
+		}
+	}
+	return healthPaths
+}
+
 func TestNewLLMRouterClientContainer(t *testing.T) {
 	type spec struct {
 		name       string
@@ -296,6 +306,69 @@ func TestNewLLMRouterClientContainer(t *testing.T) {
 				assert.Equal(t, "/var/run/llm/worker-token", envMap["WORKER_TOKEN_PATH"])
 				assert.Equal(t, "stargate.example.com:443", envMap["LLM_REQUEST_ROUTER_ADDRESS"])
 				assert.Equal(t, "stargate.example.com:443", envMap["STARGATE_ADDRESS"])
+			},
+		},
+		{
+			name: "declared health endpoint is passed to pylon",
+			ls:   &LaunchSpecification{},
+			allEnvSet: map[string]string{
+				"STARGATE_ADDRESS":          "stargate.example.com:443",
+				"INFERENCE_PORT":            "8080",
+				"INFERENCE_HEALTH_ENDPOINT": "/v1/health/ready",
+				"INFERENCE_HEALTH_PORT":     "8080",
+				"INFERENCE_HEALTH_PROTOCOL": "http",
+			},
+			tcfg:       TranslateConfig{},
+			instanceID: "inst-health",
+			isHelm:     false,
+			validate: func(t *testing.T, c corev1.Container) {
+				assert.Equal(t, []string{"--upstream-health-path=/v1/health/ready"}, healthPathArgs(c.Args))
+			},
+		},
+		{
+			name: "health endpoint on a port other than the inference port is skipped",
+			ls:   &LaunchSpecification{},
+			allEnvSet: map[string]string{
+				"STARGATE_ADDRESS":          "stargate.example.com:443",
+				"INFERENCE_PORT":            "8080",
+				"INFERENCE_HEALTH_ENDPOINT": "/custom/ready",
+				"INFERENCE_HEALTH_PORT":     "9090",
+			},
+			tcfg:       TranslateConfig{},
+			instanceID: "inst-health-port",
+			isHelm:     false,
+			validate: func(t *testing.T, c corev1.Container) {
+				assert.Empty(t, healthPathArgs(c.Args))
+			},
+		},
+		{
+			name: "gRPC health protocol is skipped",
+			ls:   &LaunchSpecification{},
+			allEnvSet: map[string]string{
+				"STARGATE_ADDRESS":          "stargate.example.com:443",
+				"INFERENCE_PORT":            "8080",
+				"INFERENCE_HEALTH_ENDPOINT": "/grpc.health.v1.Health/Check",
+				"INFERENCE_HEALTH_PROTOCOL": "gRPC",
+			},
+			tcfg:       TranslateConfig{},
+			instanceID: "inst-health-grpc",
+			isHelm:     false,
+			validate: func(t *testing.T, c corev1.Container) {
+				assert.Empty(t, healthPathArgs(c.Args))
+			},
+		},
+		{
+			name: "no declared health endpoint leaves the pylon defaults in place",
+			ls:   &LaunchSpecification{},
+			allEnvSet: map[string]string{
+				"STARGATE_ADDRESS": "stargate.example.com:443",
+				"INFERENCE_PORT":   "8080",
+			},
+			tcfg:       TranslateConfig{},
+			instanceID: "inst-health-absent",
+			isHelm:     false,
+			validate: func(t *testing.T, c corev1.Container) {
+				assert.Empty(t, healthPathArgs(c.Args))
 			},
 		},
 	}

--- a/src/libraries/go/lib/testdata/icms-translate/function/container/llm/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/container/llm/exp.yaml
@@ -187,6 +187,7 @@ spec:
     - --auth-token-file=/var/run/llm/worker-token
     - --backend-connectivity=reverse
     - --initial-input-tps=100
+    - --upstream-health-path=/v1/health/ready
     - --quic-insecure
     - --model-name=model-gamma
     - --model-name=model-epsilon

--- a/src/libraries/go/lib/testdata/icms-translate/function/helmchart/llm/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/helmchart/llm/exp.yaml
@@ -150,6 +150,7 @@ spec:
     - --auth-token-file=/var/run/llm/worker-token
     - --backend-connectivity=reverse
     - --initial-input-tps=100
+    - --upstream-health-path=/v2/health/ready
     - --quic-insecure
     - --model-name=model-gamma
     - --model-name=model-epsilon

--- a/src/libraries/rust/stargate/README.md
+++ b/src/libraries/rust/stargate/README.md
@@ -30,6 +30,14 @@ set. Every Pylon must also select exactly one local stats initialization source:
 [Pylon onboarding](docs/operations/pylon-onboarding.md) for the complete
 lifecycle and calibration contract.
 
+Pylon gates startup on an upstream health probe. It tries `/health` and then
+`/v1/health/ready`, reuses whichever path answers first, and forwards Stargate's
+`/health` RTT probe to that same path, so engines that serve only the
+OpenAI-style ready endpoint work without extra configuration. Override the
+candidate list with the repeatable `--upstream-health-path`, and bound how long
+startup retries the probe with `--upstream-health-wait-ms` (default 60000; `0`
+probes once and exits).
+
 Use [docs/README.md](docs/README.md) as the docs entrypoint.
 Use [local quickstart](docs/getting-started/local-quickstart.md) to run the local stack.
 

--- a/src/libraries/rust/stargate/README.md
+++ b/src/libraries/rust/stargate/README.md
@@ -33,10 +33,10 @@ lifecycle and calibration contract.
 Pylon gates startup on an upstream health probe. It tries `/health` and then
 `/v1/health/ready`, reuses whichever path answers first, and forwards Stargate's
 `/health` RTT probe to that same path, so engines that serve only the
-OpenAI-style ready endpoint work without extra configuration. Override the
-candidate list with the repeatable `--upstream-health-path`, and bound how long
-startup retries the probe with `--upstream-health-wait-ms` (default 60000; `0`
-probes once and exits).
+OpenAI-style ready endpoint work without extra configuration. The repeatable
+`--upstream-health-path` puts your own paths ahead of those defaults, which stay
+in place as a fallback, and `--upstream-health-wait-ms` bounds how long startup
+retries the probe (default 60000; `0` probes once and exits).
 
 Use [docs/README.md](docs/README.md) as the docs entrypoint.
 Use [local quickstart](docs/getting-started/local-quickstart.md) to run the local stack.

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/bringup.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/bringup.rs
@@ -252,7 +252,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn health_check_uses_configured_paths_instead_of_the_defaults() {
+    async fn health_check_prefers_a_configured_path() {
         let server =
             TestHttpServer::spawn(Router::new().route("/ping", get(|| async { "ok" }))).await;
         let paths = UpstreamHealthPaths::new(["ping"]);
@@ -267,6 +267,27 @@ mod tests {
             .await
         );
         assert_eq!(paths.resolved_path().as_deref(), Some("/ping"));
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn health_check_falls_back_to_the_defaults_when_a_configured_path_is_wrong() {
+        let server =
+            TestHttpServer::spawn(Router::new().route("/v1/health/ready", get(|| async { "ok" })))
+                .await;
+        let paths = UpstreamHealthPaths::new(["/typo"]);
+
+        assert!(
+            check_upstream_health(
+                &reqwest::Client::new(),
+                server.as_str(),
+                Duration::from_secs(1),
+                &paths,
+            )
+            .await
+        );
+        assert_eq!(paths.resolved_path().as_deref(), Some("/v1/health/ready"));
 
         server.shutdown().await;
     }

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/bringup.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/bringup.rs
@@ -15,6 +15,8 @@
 
 use std::time::Duration;
 
+use crate::upstream_health::UpstreamHealthPaths;
+
 mod calibration;
 mod lifecycle;
 mod upstream;
@@ -77,6 +79,7 @@ pub(crate) struct BringupTaskConfig {
     pub upstream_http_base_url: String,
     pub generation: crate::runtime_state::ModelGeneration,
     pub config: BringupConfig,
+    pub health_paths: UpstreamHealthPaths,
 }
 
 #[cfg(test)]
@@ -103,6 +106,7 @@ mod tests {
 
     use crate::runtime_state::PylonRuntimeState;
     use crate::test_support::TestHttpServer;
+    use crate::upstream_health::UpstreamHealthPaths;
     use crate::{StatsCollectorConfig, StatsCollectorHandle, start_stats_collector};
 
     async fn wait_for_bringup_ready(runtime_state: &PylonRuntimeState, expected: bool) {
@@ -156,7 +160,122 @@ mod tests {
             upstream_http_base_url,
             generation: crate::runtime_state::ModelGeneration::new("test-model", 0),
             config,
+            health_paths: UpstreamHealthPaths::default(),
         }
+    }
+
+    #[tokio::test]
+    async fn health_check_falls_back_to_the_openai_ready_path() {
+        let server =
+            TestHttpServer::spawn(Router::new().route("/v1/health/ready", get(|| async { "ok" })))
+                .await;
+        let paths = UpstreamHealthPaths::default();
+
+        assert!(
+            check_upstream_health(
+                &reqwest::Client::new(),
+                server.as_str(),
+                Duration::from_secs(1),
+                &paths,
+            )
+            .await
+        );
+        assert_eq!(paths.resolved_path().as_deref(), Some("/v1/health/ready"));
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn health_check_reuses_the_resolved_path() {
+        let health_requests = Arc::new(AtomicUsize::new(0));
+        let ready_requests = Arc::new(AtomicUsize::new(0));
+        let server_health_requests = health_requests.clone();
+        let server_ready_requests = ready_requests.clone();
+        let server = TestHttpServer::spawn(
+            Router::new()
+                .route(
+                    "/health",
+                    get(move || {
+                        let requests = server_health_requests.clone();
+                        async move {
+                            requests.fetch_add(1, Ordering::SeqCst);
+                            axum::http::StatusCode::NOT_FOUND
+                        }
+                    }),
+                )
+                .route(
+                    "/v1/health/ready",
+                    get(move || {
+                        let requests = server_ready_requests.clone();
+                        async move {
+                            requests.fetch_add(1, Ordering::SeqCst);
+                            "ok"
+                        }
+                    }),
+                ),
+        )
+        .await;
+        let client = reqwest::Client::new();
+        let paths = UpstreamHealthPaths::default();
+
+        for _ in 0..2 {
+            assert!(
+                check_upstream_health(&client, server.as_str(), Duration::from_secs(1), &paths)
+                    .await
+            );
+        }
+
+        assert_eq!(health_requests.load(Ordering::SeqCst), 1);
+        assert_eq!(ready_requests.load(Ordering::SeqCst), 2);
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn health_check_fails_when_no_candidate_path_is_served() {
+        let server =
+            TestHttpServer::spawn(Router::new().route("/v1/models", get(|| async { "ok" }))).await;
+        let paths = UpstreamHealthPaths::default();
+
+        assert!(
+            !check_upstream_health(
+                &reqwest::Client::new(),
+                server.as_str(),
+                Duration::from_secs(1),
+                &paths,
+            )
+            .await
+        );
+        assert_eq!(paths.resolved_path(), None);
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn health_check_uses_configured_paths_instead_of_the_defaults() {
+        let server =
+            TestHttpServer::spawn(Router::new().route("/ping", get(|| async { "ok" }))).await;
+        let paths = UpstreamHealthPaths::new(["ping"]);
+
+        assert!(
+            check_upstream_health(
+                &reqwest::Client::new(),
+                server.as_str(),
+                Duration::from_secs(1),
+                &paths,
+            )
+            .await
+        );
+        assert_eq!(paths.resolved_path().as_deref(), Some("/ping"));
+
+        server.shutdown().await;
+    }
+
+    #[test]
+    fn probe_path_is_the_first_candidate_until_a_probe_resolves() {
+        let paths = UpstreamHealthPaths::default();
+
+        assert_eq!(paths.probe_path(), "/health");
     }
 
     #[test]

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/bringup/lifecycle.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/bringup/lifecycle.rs
@@ -33,6 +33,7 @@ pub(crate) async fn run_bringup_task(
         upstream_http_base_url,
         generation,
         config,
+        health_paths,
     } = task_config;
     let http_client = reqwest::Client::new();
 
@@ -58,6 +59,7 @@ pub(crate) async fn run_bringup_task(
                     &http_client,
                     &upstream_http_base_url,
                     config.canary_timeout,
+                    &health_paths,
                 ))
                 .await
             else {

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/bringup/upstream.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/bringup/upstream.rs
@@ -20,6 +20,7 @@ use crate::request_observer::{
     RequestObservationEndpoint, RequiredTunnelHeaders, TunnelRequestObserver,
 };
 use crate::runtime_state::{ModelGeneration, PylonRuntimeState};
+use crate::upstream_health::UpstreamHealthPaths;
 use crate::upstream_url::upstream_endpoint;
 use reqwest::StatusCode;
 use serde::Deserialize;
@@ -29,12 +30,19 @@ pub(crate) async fn check_upstream_health(
     http_client: &reqwest::Client,
     upstream_http_base_url: &str,
     timeout: Duration,
+    health_paths: &UpstreamHealthPaths,
 ) -> bool {
-    let health_url = upstream_endpoint(upstream_http_base_url, "/health");
-    matches!(
-        http_client.get(health_url).timeout(timeout).send().await,
-        Ok(response) if response.status().is_success()
-    )
+    for (index, path) in health_paths.probe_order() {
+        let health_url = upstream_endpoint(upstream_http_base_url, path);
+        if matches!(
+            http_client.get(health_url).timeout(timeout).send().await,
+            Ok(response) if response.status().is_success()
+        ) {
+            health_paths.mark_resolved(index);
+            return true;
+        }
+    }
+    false
 }
 
 pub(super) async fn send_canary_request(

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/lib.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/lib.rs
@@ -32,6 +32,7 @@ mod sse_message_stream;
 mod stats;
 #[cfg(test)]
 mod test_support;
+mod upstream_health;
 mod upstream_url;
 
 pub use bringup::{BringupConfig, BringupError, CalibrationConfig};
@@ -65,3 +66,4 @@ pub use stats::{
     start_stats_collector, start_stats_collector_with_engine_stats,
     stats_aggregator_update_channel,
 };
+pub use upstream_health::{DEFAULT_UPSTREAM_HEALTH_PATHS, UpstreamHealthPaths};

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/model_lifecycle.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/model_lifecycle.rs
@@ -33,8 +33,10 @@ use crate::stats::{
     CalibrationOutcome, ModelStatsInitialization, PylonMetrics, StatsCollectorControl,
     StatsCollectorHandle,
 };
+use crate::upstream_health::UpstreamHealthPaths;
 
 const STATIC_RETRY_INTERVAL: Duration = Duration::from_secs(1);
+const STARTUP_HEALTH_RETRY_INTERVAL: Duration = Duration::from_millis(500);
 
 #[derive(Clone, Debug)]
 pub enum ModelSource {
@@ -54,6 +56,10 @@ pub struct ModelLifecycleConfig {
     pub source: ModelSource,
     pub initialization: ModelInitialization,
     pub bringup: BringupConfig,
+    pub health_paths: UpstreamHealthPaths,
+    /// How long startup retries the upstream health probe before failing. Zero
+    /// probes once and leaves recovery to the container restart.
+    pub startup_health_wait: Duration,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -126,6 +132,7 @@ pub async fn start_model_lifecycle(
 ) -> Result<ModelLifecycleHandle, ModelLifecycleError> {
     let http_client = reqwest::Client::new();
     Url::parse(&config.upstream_http_base_url).map_err(ModelDiscoveryError::from)?;
+    wait_for_upstream_health(&http_client, &config).await?;
     let desired = match &config.source {
         ModelSource::Static(model_ids) => model_ids.clone(),
         ModelSource::Discovered(discovery) => {
@@ -479,6 +486,7 @@ impl ModelLifecycleSupervisor {
                 upstream_http_base_url: self.config.upstream_http_base_url.clone(),
                 generation: generation.clone(),
                 config: self.config.bringup.clone(),
+                health_paths: self.config.health_paths.clone(),
             };
             let runtime_state = self.runtime_state.clone();
             OwnedTask::spawn_child("model canary", stop, move |model_stop| {
@@ -595,16 +603,14 @@ async fn initialization_attempt(
     generation: ModelGeneration,
     metrics: Option<Arc<PylonMetrics>>,
 ) -> Result<(), ModelLifecycleError> {
-    let health_timeout = match &config.initialization {
-        ModelInitialization::Calibration(calibration) => Some(calibration.health_timeout),
-        ModelInitialization::ConfiguredInputTps { .. } if config.bringup.enabled => {
-            Some(config.bringup.canary_timeout)
-        }
-        ModelInitialization::ConfiguredInputTps { .. } => None,
-    };
-    if let Some(health_timeout) = health_timeout
-        && !check_upstream_health(&http_client, &config.upstream_http_base_url, health_timeout)
-            .await
+    if let Some(health_timeout) = health_probe_timeout(&config)
+        && !check_upstream_health(
+            &http_client,
+            &config.upstream_http_base_url,
+            health_timeout,
+            &config.health_paths,
+        )
+        .await
     {
         return Err(BringupError::UnhealthyUpstream.into());
     }
@@ -623,6 +629,56 @@ async fn initialization_attempt(
         result?;
     }
     Ok(())
+}
+
+fn health_probe_timeout(config: &ModelLifecycleConfig) -> Option<Duration> {
+    match &config.initialization {
+        ModelInitialization::Calibration(calibration) => Some(calibration.health_timeout),
+        ModelInitialization::ConfiguredInputTps { .. } if config.bringup.enabled => {
+            Some(config.bringup.canary_timeout)
+        }
+        ModelInitialization::ConfiguredInputTps { .. } => None,
+    }
+}
+
+async fn wait_for_upstream_health(
+    http_client: &reqwest::Client,
+    config: &ModelLifecycleConfig,
+) -> Result<(), ModelLifecycleError> {
+    let Some(health_timeout) = health_probe_timeout(config) else {
+        return Ok(());
+    };
+    let deadline = Instant::now() + config.startup_health_wait;
+    let mut reported = false;
+    loop {
+        if check_upstream_health(
+            http_client,
+            &config.upstream_http_base_url,
+            health_timeout,
+            &config.health_paths,
+        )
+        .await
+        {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(BringupError::UnhealthyUpstream.into());
+        }
+        if reported {
+            tracing::debug!(
+                upstream = %config.upstream_http_base_url,
+                "upstream is still not healthy; retrying"
+            );
+        } else {
+            reported = true;
+            tracing::warn!(
+                upstream = %config.upstream_http_base_url,
+                paths = ?config.health_paths.probe_order(),
+                "waiting for the upstream to answer a health probe"
+            );
+        }
+        tokio::time::sleep(STARTUP_HEALTH_RETRY_INTERVAL).await;
+    }
 }
 
 async fn wait_until(deadline: Option<Instant>) {
@@ -668,15 +724,17 @@ mod tests {
     use tokio_util::sync::CancellationToken;
 
     use super::{
-        LiveModelGeneration, ModelInitialization, ModelLifecycleConfig, ModelLifecycleSupervisor,
-        ModelSource, start_model_lifecycle,
+        LiveModelGeneration, ModelInitialization, ModelLifecycleConfig, ModelLifecycleError,
+        ModelLifecycleSupervisor, ModelSource, start_model_lifecycle,
     };
     use crate::generated_request_id::generated_request_generation;
     use crate::runtime_state::ModelGeneration;
     use crate::test_support::TestHttpServer;
+    use crate::upstream_health::UpstreamHealthPaths;
     use crate::{
-        BringupConfig, CalibrationConfig, ModelDiscoveryConfig, ModelDiscoveryProvider,
-        PylonMetrics, PylonRuntimeState, StatsCollectorConfig, start_stats_collector,
+        BringupConfig, BringupError, CalibrationConfig, ModelDiscoveryConfig,
+        ModelDiscoveryProvider, PylonMetrics, PylonRuntimeState, StatsCollectorConfig,
+        start_stats_collector,
     };
 
     #[derive(Clone)]
@@ -955,6 +1013,8 @@ mod tests {
                 enabled: false,
                 ..BringupConfig::default()
             },
+            health_paths: UpstreamHealthPaths::default(),
+            startup_health_wait: Duration::ZERO,
         }
     }
 
@@ -1074,6 +1134,8 @@ mod tests {
                     enabled: false,
                     ..BringupConfig::default()
                 },
+                health_paths: UpstreamHealthPaths::default(),
+                startup_health_wait: Duration::ZERO,
             },
             runtime_state.clone(),
             &stats,
@@ -1095,6 +1157,107 @@ mod tests {
         }));
 
         lifecycle.shutdown().await;
+        stats.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn startup_waits_for_an_upstream_that_is_not_healthy_yet() {
+        let unhealthy_probes = Arc::new(AtomicUsize::new(2));
+        let server_unhealthy_probes = unhealthy_probes.clone();
+        let upstream = TestHttpServer::spawn(Router::new().route(
+            "/health",
+            get(move || {
+                let remaining = server_unhealthy_probes.clone();
+                async move {
+                    if remaining.load(Ordering::SeqCst) > 0 {
+                        remaining.fetch_sub(1, Ordering::SeqCst);
+                        axum::http::StatusCode::SERVICE_UNAVAILABLE
+                    } else {
+                        axum::http::StatusCode::OK
+                    }
+                }
+            }),
+        ))
+        .await;
+        let stats_config = StatsCollectorConfig::default();
+        let (runtime_state, observations) = PylonRuntimeState::observed(
+            InferenceServerStatus::Active,
+            &[],
+            stats_config.observation_channel_capacity,
+            None,
+        );
+        let stats = start_stats_collector(stats_config, observations, runtime_state.clone());
+
+        let lifecycle = start_model_lifecycle(
+            ModelLifecycleConfig {
+                upstream_http_base_url: upstream.to_string(),
+                source: ModelSource::Static(BTreeSet::from(["model-a".to_string()])),
+                initialization: ModelInitialization::ConfiguredInputTps {
+                    input_tps: 123.0,
+                    pin: false,
+                },
+                bringup: BringupConfig {
+                    active_canary_interval: Duration::ZERO,
+                    ..BringupConfig::default()
+                },
+                health_paths: UpstreamHealthPaths::default(),
+                startup_health_wait: Duration::from_secs(10),
+            },
+            runtime_state.clone(),
+            &stats,
+            None,
+        )
+        .await
+        .expect("startup should wait for the upstream to become healthy");
+
+        assert_eq!(unhealthy_probes.load(Ordering::SeqCst), 0);
+        assert_eq!(runtime_state.advertised_model_ids(), ["model-a"]);
+
+        lifecycle.shutdown().await;
+        stats.shutdown().await;
+        upstream.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn startup_fails_fast_when_no_health_wait_is_configured() {
+        let stats_config = StatsCollectorConfig::default();
+        let (runtime_state, observations) = PylonRuntimeState::observed(
+            InferenceServerStatus::Active,
+            &[],
+            stats_config.observation_channel_capacity,
+            None,
+        );
+        let stats = start_stats_collector(stats_config, observations, runtime_state.clone());
+
+        let result = start_model_lifecycle(
+            ModelLifecycleConfig {
+                upstream_http_base_url: "http://127.0.0.1:1".to_string(),
+                source: ModelSource::Static(BTreeSet::from(["model-a".to_string()])),
+                initialization: ModelInitialization::ConfiguredInputTps {
+                    input_tps: 123.0,
+                    pin: false,
+                },
+                bringup: BringupConfig {
+                    active_canary_interval: Duration::ZERO,
+                    ..BringupConfig::default()
+                },
+                health_paths: UpstreamHealthPaths::default(),
+                startup_health_wait: Duration::ZERO,
+            },
+            runtime_state.clone(),
+            &stats,
+            None,
+        )
+        .await;
+
+        let Err(error) = result else {
+            panic!("startup should not wait for an unreachable upstream");
+        };
+        assert!(matches!(
+            error,
+            ModelLifecycleError::Bringup(BringupError::UnhealthyUpstream)
+        ));
+
         stats.shutdown().await;
     }
 
@@ -1153,6 +1316,8 @@ mod tests {
                     enabled: false,
                     ..BringupConfig::default()
                 },
+                health_paths: UpstreamHealthPaths::default(),
+                startup_health_wait: Duration::ZERO,
             },
             runtime_state: runtime_state.clone(),
             stats: stats.control(),
@@ -1238,6 +1403,8 @@ mod tests {
                     enabled: false,
                     ..BringupConfig::default()
                 },
+                health_paths: UpstreamHealthPaths::default(),
+                startup_health_wait: Duration::ZERO,
             },
             runtime_state.clone(),
             &stats,
@@ -1327,6 +1494,8 @@ mod tests {
                     enabled: false,
                     ..BringupConfig::default()
                 },
+                health_paths: UpstreamHealthPaths::default(),
+                startup_health_wait: Duration::ZERO,
             },
             runtime_state.clone(),
             &stats,

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/quic_http_tunnel/core.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/quic_http_tunnel/core.rs
@@ -56,6 +56,7 @@ use crate::sse_message_stream::{
     upstream_sse_message_stream,
 };
 use crate::stats::PylonMetrics;
+use crate::upstream_health::UpstreamHealthPaths;
 
 pub(super) const DEFAULT_MAX_BODY_BYTES: usize = 64 * 1024 * 1024;
 // This bounds only one upstream SSE event waiting for its blank-line delimiter,
@@ -110,6 +111,9 @@ pub struct TunnelForwardingConfig {
     pub upstream_backend: UpstreamBackend,
     /// Priority band ceiling; see [`backend::dynamo::request_priority`].
     pub priority_ceiling: u32,
+    /// Shared with bringup so forwarded health probes reach the upstream path
+    /// that answered, not the literal path Stargate asked for.
+    pub upstream_health_paths: UpstreamHealthPaths,
     pub metrics: Option<Arc<PylonMetrics>>,
     #[cfg(test)]
     pub webtransport_stream_header_wait_tx: Option<flume::Sender<()>>,
@@ -128,6 +132,7 @@ impl Default for TunnelForwardingConfig {
             queue_mismatch_retry: PylonQueueMismatchRetryConfig::default(),
             upstream_backend: UpstreamBackend::default(),
             priority_ceiling: DEFAULT_PRIORITY_CEILING,
+            upstream_health_paths: UpstreamHealthPaths::default(),
             metrics: None,
             #[cfg(test)]
             webtransport_stream_header_wait_tx: None,
@@ -150,6 +155,7 @@ pub(super) struct TunnelServerApp {
     pub(super) queue_mismatch_retry: PylonQueueMismatchRetryConfig,
     pub(super) upstream_backend: UpstreamBackend,
     pub(super) priority_ceiling: u32,
+    pub(super) upstream_health_paths: UpstreamHealthPaths,
     pub(super) metrics: Option<Arc<PylonMetrics>>,
     #[cfg(test)]
     pub(super) webtransport_stream_header_wait_tx: Option<flume::Sender<()>>,
@@ -175,6 +181,7 @@ impl TunnelServerApp {
             queue_mismatch_retry: forwarding.queue_mismatch_retry,
             upstream_backend: forwarding.upstream_backend,
             priority_ceiling: forwarding.priority_ceiling,
+            upstream_health_paths: forwarding.upstream_health_paths,
             metrics: forwarding.metrics,
             #[cfg(test)]
             webtransport_stream_header_wait_tx: forwarding.webtransport_stream_header_wait_tx,
@@ -586,6 +593,11 @@ pub(super) async fn forward_tunnel_request(
     } = request;
     let health_request = is_health_request_path(&path_and_query);
     let observation_endpoint = request_observation_endpoint(&method, &path_and_query);
+    let path_and_query = if health_request {
+        health_probe_path_and_query(&app.upstream_health_paths, &path_and_query)
+    } else {
+        path_and_query
+    };
     let mut lifecycle = if health_request {
         None
     } else {
@@ -815,6 +827,17 @@ fn validate_request_body(
 
 pub(super) fn is_health_request_path(path_and_query: &str) -> bool {
     path_and_query.split('?').next() == Some("/health")
+}
+
+pub(super) fn health_probe_path_and_query(
+    health_paths: &UpstreamHealthPaths,
+    path_and_query: &str,
+) -> String {
+    let probe_path = health_paths.probe_path();
+    match path_and_query.split_once('?') {
+        Some((_, query)) => format!("{probe_path}?{query}"),
+        None => probe_path.to_string(),
+    }
 }
 
 fn request_observation_endpoint(

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/quic_http_tunnel/raw_quic.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/quic_http_tunnel/raw_quic.rs
@@ -173,6 +173,7 @@ mod tests {
             queue_mismatch_retry: PylonQueueMismatchRetryConfig::default(),
             upstream_backend: crate::quic_http_tunnel::UpstreamBackend::default(),
             priority_ceiling: crate::quic_http_tunnel::DEFAULT_PRIORITY_CEILING,
+            upstream_health_paths: crate::upstream_health::UpstreamHealthPaths::default(),
             metrics: None,
             #[cfg(test)]
             webtransport_stream_header_wait_tx: None,

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/quic_http_tunnel/tests.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/quic_http_tunnel/tests.rs
@@ -16,9 +16,9 @@
 use super::backend::{DEFAULT_PRIORITY_CEILING, UpstreamBackend, dynamo};
 use super::core::{
     MAX_SPECULATIVE_REQUEST_BODY_PREALLOC_BYTES, TunnelServerApp, extend_body_from_buf,
-    is_health_request_path, otel_parent_from_headers, pylon_upstream_parent_context,
-    request_body_buffer, request_body_capacity, should_forward_header,
-    should_forward_response_header,
+    health_probe_path_and_query, is_health_request_path, otel_parent_from_headers,
+    pylon_upstream_parent_context, request_body_buffer, request_body_capacity,
+    should_forward_header, should_forward_response_header,
 };
 use super::endpoint::{
     build_trusted_client_config, derive_sni, make_server_config, target_authority,
@@ -61,6 +61,7 @@ use crate::request_observer::{
 use crate::request_quality_monitor::RequestQualityMonitorConfig;
 use crate::runtime_state::ModelGeneration;
 use crate::stats::PylonMetrics;
+use crate::upstream_health::UpstreamHealthPaths;
 use crate::{PylonRuntimeState, StatsCollectorConfig, start_stats_collector};
 
 #[derive(Clone, Default)]
@@ -921,6 +922,21 @@ fn assert_queue_mismatch_response(response: &TunnelResponse, raw_quic: bool) {
         std::str::from_utf8(&response.body)
             .unwrap()
             .contains("queue_estimate_mismatch")
+    );
+}
+
+#[test]
+fn health_probe_path_keeps_the_query_string() {
+    let health_paths = UpstreamHealthPaths::default();
+    health_paths.mark_resolved(1);
+
+    assert_eq!(
+        health_probe_path_and_query(&health_paths, "/health?probe=1"),
+        "/v1/health/ready?probe=1"
+    );
+    assert_eq!(
+        health_probe_path_and_query(&health_paths, "/health"),
+        "/v1/health/ready"
     );
 }
 
@@ -1790,6 +1806,27 @@ async fn quic_tunnel_health_requests_carry_no_derived_priority() {
 
     let response_headers = tunnel.response_head(StatusCode::OK).await;
     assert_eq!(response_headers["x-echo-dynamo-priority"], "absent");
+
+    tunnel.shutdown().await;
+}
+
+#[tokio::test]
+async fn quic_tunnel_health_probes_follow_the_resolved_upstream_path() {
+    let (mut config, _metrics) = metered_test_tunnel_config_for(
+        Router::new().route("/v1/health/ready", axum::routing::get(|| async { "ok" })),
+    )
+    .await;
+    let health_paths = UpstreamHealthPaths::default();
+    health_paths.mark_resolved(1);
+    config.forwarding.upstream_health_paths = health_paths;
+    let mut tunnel = RawTunnelTest::start(config).await;
+
+    let mut headers = HeaderMap::new();
+    headers.insert("x-method", "GET".parse().unwrap());
+    headers.insert("x-path", "/health".parse().unwrap());
+    tunnel.send(headers, b"").await;
+
+    tunnel.response_head(StatusCode::OK).await;
 
     tunnel.shutdown().await;
 }

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/upstream_health.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/upstream_health.rs
@@ -35,23 +35,22 @@ impl Default for UpstreamHealthPaths {
 }
 
 impl UpstreamHealthPaths {
+    /// Configured paths are probed first; the defaults always stay as a
+    /// fallback so a wrong path cannot strand an otherwise healthy upstream.
     pub fn new<I, P>(paths: I) -> Self
     where
         I: IntoIterator<Item = P>,
         P: AsRef<str>,
     {
         let mut candidates = Vec::new();
-        for path in paths {
-            let path = normalize_path(path.as_ref());
+        let configured = paths.into_iter().map(|path| normalize_path(path.as_ref()));
+        let defaults = DEFAULT_UPSTREAM_HEALTH_PATHS
+            .iter()
+            .map(|path| (*path).to_string());
+        for path in configured.chain(defaults) {
             if !path.is_empty() && !candidates.contains(&path) {
                 candidates.push(path);
             }
-        }
-        if candidates.is_empty() {
-            candidates = DEFAULT_UPSTREAM_HEALTH_PATHS
-                .iter()
-                .map(|path| (*path).to_string())
-                .collect();
         }
         Self {
             candidates: Arc::new(candidates),
@@ -129,6 +128,17 @@ mod tests {
         let paths = UpstreamHealthPaths::new(Vec::<String>::new());
 
         assert_eq!(paths.probe_path(), "/health");
+    }
+
+    #[test]
+    fn configured_paths_are_probed_before_the_defaults() {
+        let paths = UpstreamHealthPaths::new(["/ping"]);
+
+        assert_eq!(
+            paths.probe_order(),
+            vec![(0, "/ping"), (1, "/health"), (2, "/v1/health/ready")]
+        );
+        assert_eq!(paths.probe_path(), "/ping");
     }
 
     #[test]

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/upstream_health.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/upstream_health.rs
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Upstream health paths probed in order. Dynamo-style engines serve `/health`;
+/// OpenAI-style NIM images serve `/v1/health/ready` and no `/health`.
+pub const DEFAULT_UPSTREAM_HEALTH_PATHS: [&str; 2] = ["/health", "/v1/health/ready"];
+
+const UNRESOLVED: usize = usize::MAX;
+
+#[derive(Clone, Debug)]
+pub struct UpstreamHealthPaths {
+    candidates: Arc<Vec<String>>,
+    resolved: Arc<AtomicUsize>,
+}
+
+impl Default for UpstreamHealthPaths {
+    fn default() -> Self {
+        Self::new(DEFAULT_UPSTREAM_HEALTH_PATHS)
+    }
+}
+
+impl UpstreamHealthPaths {
+    pub fn new<I, P>(paths: I) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: AsRef<str>,
+    {
+        let mut candidates = Vec::new();
+        for path in paths {
+            let path = normalize_path(path.as_ref());
+            if !path.is_empty() && !candidates.contains(&path) {
+                candidates.push(path);
+            }
+        }
+        if candidates.is_empty() {
+            candidates = DEFAULT_UPSTREAM_HEALTH_PATHS
+                .iter()
+                .map(|path| (*path).to_string())
+                .collect();
+        }
+        Self {
+            candidates: Arc::new(candidates),
+            resolved: Arc::new(AtomicUsize::new(UNRESOLVED)),
+        }
+    }
+
+    pub fn resolved_path(&self) -> Option<String> {
+        self.resolved_index()
+            .map(|index| self.candidates[index].clone())
+    }
+
+    /// Path a health probe should use right now: the resolved one, or the first
+    /// candidate before any probe has succeeded.
+    pub fn probe_path(&self) -> &str {
+        let index = self.resolved_index().unwrap_or(0);
+        &self.candidates[index]
+    }
+
+    pub(crate) fn probe_order(&self) -> Vec<(usize, &str)> {
+        let resolved = self.resolved_index();
+        let mut order: Vec<(usize, &str)> = resolved
+            .map(|index| vec![(index, self.candidates[index].as_str())])
+            .unwrap_or_default();
+        order.extend(
+            self.candidates
+                .iter()
+                .enumerate()
+                .filter(|(index, _)| Some(*index) != resolved)
+                .map(|(index, path)| (index, path.as_str())),
+        );
+        order
+    }
+
+    pub(crate) fn mark_resolved(&self, index: usize) {
+        self.resolved.store(index, Ordering::Relaxed);
+    }
+
+    fn resolved_index(&self) -> Option<usize> {
+        match self.resolved.load(Ordering::Relaxed) {
+            UNRESOLVED => None,
+            index => Some(index),
+        }
+    }
+}
+
+fn normalize_path(path: &str) -> String {
+    let path = path.trim();
+    if path.is_empty() {
+        return String::new();
+    }
+    if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{path}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_and_deduplicates_candidates() {
+        let paths = UpstreamHealthPaths::new([" health ", "/health", "v1/health/ready", ""]);
+
+        assert_eq!(
+            paths.probe_order(),
+            vec![(0, "/health"), (1, "/v1/health/ready")]
+        );
+    }
+
+    #[test]
+    fn falls_back_to_the_defaults_when_no_path_is_configured() {
+        let paths = UpstreamHealthPaths::new(Vec::<String>::new());
+
+        assert_eq!(paths.probe_path(), "/health");
+    }
+
+    #[test]
+    fn probes_the_resolved_path_first() {
+        let paths = UpstreamHealthPaths::default();
+        paths.mark_resolved(1);
+
+        assert_eq!(
+            paths.probe_order(),
+            vec![(1, "/v1/health/ready"), (0, "/health")]
+        );
+        assert_eq!(paths.probe_path(), "/v1/health/ready");
+    }
+}

--- a/src/libraries/rust/stargate/crates/pylon/src/main.rs
+++ b/src/libraries/rust/stargate/crates/pylon/src/main.rs
@@ -74,6 +74,12 @@ struct Args {
     /// Disable ongoing upstream health monitoring and active canaries
     #[arg(long, default_value_t = false)]
     disable_bringup: bool,
+    /// Upstream health path to probe; repeat to try several in order. The first path that answers is reused
+    #[arg(long = "upstream-health-path", value_name = "PATH")]
+    upstream_health_paths: Vec<String>,
+    /// How long startup retries the upstream health probe before exiting. `0` probes once
+    #[arg(long, default_value_t = 60000, value_name = "MS")]
+    upstream_health_wait_ms: u64,
     /// Run local input-TPS calibration before contacting Stargate. Use only when this is the cluster's sole Pylon
     #[arg(long, default_value_t = false)]
     do_calibration: bool,

--- a/src/libraries/rust/stargate/crates/pylon/src/main.rs
+++ b/src/libraries/rust/stargate/crates/pylon/src/main.rs
@@ -74,7 +74,7 @@ struct Args {
     /// Disable ongoing upstream health monitoring and active canaries
     #[arg(long, default_value_t = false)]
     disable_bringup: bool,
-    /// Upstream health path to probe; repeat to try several in order. The first path that answers is reused
+    /// Upstream health path probed ahead of the built-in defaults; repeat to try several in order
     #[arg(long = "upstream-health-path", value_name = "PATH")]
     upstream_health_paths: Vec<String>,
     /// How long startup retries the upstream health probe before exiting. `0` probes once

--- a/src/libraries/rust/stargate/crates/pylon/src/startup.rs
+++ b/src/libraries/rust/stargate/crates/pylon/src/startup.rs
@@ -28,9 +28,9 @@ use pylon_lib::{
     ModelInitialization, ModelLifecycleConfig, ModelLifecycleHandle, ModelSource, PylonMetrics,
     PylonQueueMismatchRetryConfig, PylonRetryConfig, PylonRuntimeState, QuicHttpTunnelConfig,
     QuicHttpTunnelHandle, RequestQualityMonitorConfig, StatsCollectorConfig, StatsCollectorHandle,
-    TunnelForwardingConfig, UpstreamBackend, start_engine_stats_stream, start_metrics_server,
-    start_model_lifecycle, start_quic_http_tunnel, start_stats_collector_with_engine_stats,
-    stats_aggregator_update_channel,
+    TunnelForwardingConfig, UpstreamBackend, UpstreamHealthPaths, start_engine_stats_stream,
+    start_metrics_server, start_model_lifecycle, start_quic_http_tunnel,
+    start_stats_collector_with_engine_stats, stats_aggregator_update_channel,
 };
 use reqwest::header::HeaderName;
 use stargate_proto::pb::InferenceServerStatus;
@@ -110,6 +110,8 @@ pub(crate) struct PylonStartupPlan {
     model_initialization: ModelInitialization,
     bringup: BringupConfig,
     request_quality_monitor: RequestQualityMonitorConfig,
+    health_paths: UpstreamHealthPaths,
+    startup_health_wait: Duration,
     metrics_addr: SocketAddr,
     auth_token_provider: Option<Arc<AuthTokenProvider>>,
     backend_tunnel: BackendTunnelStartup,
@@ -162,6 +164,8 @@ impl PylonStartupPlan {
                 canary_max_generation_threshold: args.canary_max_generation_threshold,
             },
             request_quality_monitor: request_quality_monitor_config_from_args(args),
+            health_paths: UpstreamHealthPaths::new(args.upstream_health_paths.clone()),
+            startup_health_wait: Duration::from_millis(args.upstream_health_wait_ms),
             metrics_addr: format!("{}:{}", args.metrics_host, args.metrics_port).parse()?,
             auth_token_provider: auth_token_provider_from_args(args),
             backend_tunnel: BackendTunnelStartup::from_args(args)?,
@@ -383,6 +387,8 @@ async fn start_pylon_runtime(args: &Args, plan: &PylonStartupPlan) -> Result<Run
             source: plan.model_source.clone(),
             initialization: plan.model_initialization.clone(),
             bringup: plan.bringup.clone(),
+            health_paths: plan.health_paths.clone(),
+            startup_health_wait: plan.startup_health_wait,
         },
         runtime_state.clone(),
         &stats_collector,
@@ -514,6 +520,7 @@ fn tunnel_forwarding_config_from_plan(
         queue_mismatch_retry: plan.queue_mismatch_retry.clone(),
         upstream_backend: plan.upstream_backend,
         priority_ceiling: plan.priority_ceiling,
+        upstream_health_paths: plan.health_paths.clone(),
         ..Default::default()
     }
 }
@@ -1015,6 +1022,8 @@ mod tests {
                     enabled: false,
                     ..BringupConfig::default()
                 },
+                health_paths: UpstreamHealthPaths::default(),
+                startup_health_wait: Duration::ZERO,
             },
             PylonRuntimeState::default(),
             &stats_collector,
@@ -1142,6 +1151,35 @@ mod tests {
         let forwarding = test_forwarding(&passthrough_plan);
         assert_eq!(forwarding.upstream_backend, UpstreamBackend::Passthrough);
         assert_eq!(forwarding.priority_ceiling, 600);
+    }
+
+    #[test]
+    fn upstream_health_paths_default_and_flow_to_the_forwarding_config() {
+        let (_, default_plan) = startup(&[]);
+        assert_eq!(
+            test_forwarding(&default_plan)
+                .upstream_health_paths
+                .probe_path(),
+            "/health"
+        );
+        assert_eq!(default_plan.startup_health_wait, Duration::from_secs(60));
+
+        let (_, configured_plan) = startup(&[
+            "--upstream-health-path",
+            "/v1/health/ready",
+            "--upstream-health-wait-ms",
+            "5000",
+        ]);
+        assert_eq!(
+            test_forwarding(&configured_plan)
+                .upstream_health_paths
+                .probe_path(),
+            "/v1/health/ready"
+        );
+        assert_eq!(
+            configured_plan.startup_health_wait,
+            Duration::from_millis(5000)
+        );
     }
 
     #[test]
@@ -1341,6 +1379,8 @@ mod tests {
                     enabled: false,
                     ..BringupConfig::default()
                 },
+                health_paths: UpstreamHealthPaths::default(),
+                startup_health_wait: Duration::ZERO,
             },
             runtime_state.clone(),
             &stats_collector,

--- a/src/libraries/rust/stargate/crates/stargate/tests/common/mod.rs
+++ b/src/libraries/rust/stargate/crates/stargate/tests/common/mod.rs
@@ -1274,6 +1274,8 @@ pub async fn start_and_register_backend_with_bringup(
                 pin: true,
             },
             bringup,
+            health_paths: pylon_lib::UpstreamHealthPaths::default(),
+            startup_health_wait: std::time::Duration::ZERO,
         },
         runtime_state.clone(),
         &stats_collector,

--- a/src/libraries/rust/stargate/crates/stargate/tests/suite/lifecycle.rs
+++ b/src/libraries/rust/stargate/crates/stargate/tests/suite/lifecycle.rs
@@ -1269,6 +1269,8 @@ impl LifecycleBackendOptions<'_> {
                     pin: true,
                 },
                 bringup,
+                health_paths: pylon_lib::UpstreamHealthPaths::default(),
+                startup_health_wait: std::time::Duration::ZERO,
             },
             runtime_state.clone(),
             &stats_collector,


### PR DESCRIPTION
## TL;DR

Pylon gated startup on a hardcoded `GET <upstream>/health` and exited when it did not answer, so engines that serve only `/v1/health/ready` crash-looped next to a healthy inference container. Pylon now probes an ordered candidate list, and `icms-translate` passes down the health endpoint the function already declares.

## Additional Details

Pylon side:

- `UpstreamHealthPaths` (new `crates/pylon-lib/src/upstream_health.rs`) holds the candidate list and the resolved index. Configured paths are probed first, followed by the built-in `/health` and `/v1/health/ready`, so a path that does not answer falls back instead of stranding a healthy upstream.
- `check_upstream_health` probes the resolved path first, falls back to the rest, and records the winner.
- Stargate's forwarded `/health` RTT probe is rewritten to the resolved upstream path inside pylon. The tunnel wire path stays `/health`, so mixed router/pylon versions need no lockstep rollout.
- Startup retries the probe every 500ms for `--upstream-health-wait-ms` (default 60s) before failing, which also removes the restarts seen while an engine is still loading. `0` keeps the old probe-once behavior.
- New flags: repeatable `--upstream-health-path` and `--upstream-health-wait-ms`. Both default to working behavior.

Translate side:

- The `llm-worker` container already receives `INFERENCE_HEALTH_ENDPOINT` from the function's health URI, but pylon takes CLI args only, so the value was never used. `newLLMRouterClientContainer` now forwards it as `--upstream-health-path`.
- It is skipped when the health check is gRPC or bound to a port other than the inference port, since pylon probes over HTTP against the inference port. Those cases fall back to the built-in candidates.
- Regenerated the two LLM `icms-translate` goldens and synced the vendored copy under `src/compute-plane-services/nvca/vendor`.

## Rollout order

`--upstream-health-path` is a new flag, and pylon rejects unknown arguments, so the pylon image must roll out with or before the translate change. A worker still pinned to an older pylon exits at startup with `unexpected argument '--upstream-health-path' found`. Only `functionType: LLM` workloads run this container.

## For the Reviewer

`crates/pylon-lib/src/quic_http_tunnel/core.rs` is the part worth close reading: the health rewrite happens before `send_upstream_request`, so only requests matched by `is_health_request_path` are affected.

## For QA

`cargo test --workspace`, `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `go test ./pkg/icms-translate/...` pass. Two pre-existing local failures reproduce unchanged on `main` in the same environment and are unrelated to this change: `stargate::tests::occupied_metrics_port_fails_before_runtime_construction`, and `cmd/icms-translate TestRun`, which compares generator output against goldens that carry an SPDX header the generator does not emit (39 subtests before and after).

New tests cover the fallback probe, resolved-path reuse, the no-candidate case, configured-path precedence, fallback when a configured path is wrong, the tunnel probe rewrite with and without a query string, the startup wait, the flag-to-config wiring, and the four translate cases (declared endpoint, divergent health port, gRPC protocol, absent endpoint).

QA needed: deploy an LLM function on an engine image that serves only `/v1/health/ready` and confirm the worker pod reaches full readiness.

## Issues

Closes #906

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable upstream health-probe paths with `/health` and `/v1/health/ready` fallbacks.
  * Successful health paths are reused for subsequent checks and tunnel health requests.
  * Added startup health verification with configurable retry duration, including fail-fast behavior.
  * Added support for forwarding custom health paths while preserving query parameters.
  * LLM router health endpoints are now forwarded only when compatible with the inference protocol and port.

* **Documentation**
  * Documented health-probe order, fallback behavior, path reuse, and startup wait settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
