### PR TITLE
fix(llm-request-router): validate certificate hostname coverage

### DIFF
--- a/deploy/helm/llm-request-router/README.md
+++ b/deploy/helm/llm-request-router/README.md
@@ -20,6 +20,8 @@ llmRequestRouter:
 
 Single-replica deployments may use self-only discovery with `llmRequestRouter.discovery.disableDnsDiscovery=true`. Multi-replica deployments require DNS discovery and stable per-pod identity, so the chart fails rendering if DNS discovery is disabled while `llmRequestRouter.replicaCount > 1`. For multi-replica deployments, the default advertised hostname template is `{pod_name}.<headless-service>.<namespace>.svc.cluster.local`; the StatefulSet and headless service provide the stable pod DNS names required for router replicas to discover each other and share backend registrations.
 
+`llmRequestRouter.kubernetes.advertisedHostnameTemplate` supports the Stargate placeholders `{pod_name}` and `{namespace}`. Stargate resolves both placeholders at runtime. For certificate validation, the chart substitutes the deployment namespace and a representative StatefulSet pod name. `{pod_name}` must stay within the leftmost DNS label when certificate coverage relies on a wildcard. When `llmRequestRouter.certificate.enabled=true`, `certificate.dnsNames` must cover the advertised hostname with either a case-insensitive exact name or a valid leftmost `*.` wildcard. A wildcard covers exactly one label and requires at least two suffix labels. For example, `*.nvcf.example.internal` covers `{pod_name}.nvcf.example.internal`, but `*.example.internal` does not cover `{pod_name}.nvcf.example.internal`.
+
 Upgrading from a chart version that rendered a Deployment can briefly run both the old Deployment and new StatefulSet during `helm upgrade` while Helm replaces the workload kind.
 
 ## Prerequisites

--- a/deploy/helm/llm-request-router/llm-request-router/templates/_helpers.tpl
+++ b/deploy/helm/llm-request-router/llm-request-router/templates/_helpers.tpl
@@ -53,6 +53,102 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- default .Release.Namespace .Values.llmRequestRouter.namespace -}}
 {{- end -}}
 
+{{- define "llm-request-router.advertisedHostnameTemplate" -}}
+{{- $configuredTemplate := .Values.llmRequestRouter.kubernetes.advertisedHostnameTemplate -}}
+{{- if $configuredTemplate -}}
+{{- $configuredTemplate -}}
+{{- else if eq (.Values.llmRequestRouter.replicaCount | int) 1 -}}
+{{- printf "%s.%s.svc.cluster.local" (include "llm-request-router.fullname" .) (include "llm-request-router.namespace" .) -}}
+{{- else -}}
+{{- printf "{pod_name}.%s.%s.svc.cluster.local" .Values.llmRequestRouter.service.headlessName (include "llm-request-router.namespace" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "llm-request-router.isValidDnsName" -}}
+{{- $name := .name | toString | lower -}}
+{{- $labels := splitList "." $name -}}
+{{- $valid := and
+      (gt (len $name) 0)
+      (le (len $name) 253)
+      (not (hasPrefix "." $name))
+      (not (hasSuffix "." $name)) -}}
+{{- range $label := $labels -}}
+{{- if not (regexMatch "^[a-z0-9_]([a-z0-9_-]{0,61}[a-z0-9_])?$" $label) -}}
+{{- $valid = false -}}
+{{- end -}}
+{{- end -}}
+{{- if regexMatch "^[0-9]+$" (last $labels) -}}
+{{- $valid = false -}}
+{{- end -}}
+{{- if $valid -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+Certificate wildcards follow rustls-webpki rules: only a complete leftmost
+label may be a wildcard, and it matches exactly one hostname label. Replace
+the runtime placeholder with a representative StatefulSet pod name before
+comparing suffixes.
+*/}}
+{{- define "llm-request-router.validateCertificateDnsNames" -}}
+{{- $certificate := .Values.llmRequestRouter.certificate | default dict -}}
+{{- if $certificate.enabled -}}
+{{- $dnsNames := $certificate.dnsNames | default (list) -}}
+{{- if eq (len $dnsNames) 0 -}}
+{{- fail "llmRequestRouter.certificate.dnsNames is required when certificate.enabled is true" -}}
+{{- end -}}
+{{- $advertisedHostnameTemplate := include "llm-request-router.advertisedHostnameTemplate" . -}}
+{{- $resolvedTemplate := replace "{namespace}" (include "llm-request-router.namespace" .) $advertisedHostnameTemplate -}}
+{{- $hasPodName := contains "{pod_name}" $resolvedTemplate -}}
+{{- $templateLabels := splitList "." $resolvedTemplate -}}
+{{- $podNameOutsideLeftmostLabel := false -}}
+{{- range $index, $label := $templateLabels -}}
+{{- if and (gt $index 0) (contains "{pod_name}" $label) -}}
+{{- $podNameOutsideLeftmostLabel = true -}}
+{{- end -}}
+{{- end -}}
+{{- $podNameInLeftmostLabel := and $hasPodName (contains "{pod_name}" (first $templateLabels)) -}}
+{{- $samplePodName := printf "%s-0" (include "llm-request-router.fullname" .) -}}
+{{- $rawHostname := replace "{pod_name}" $samplePodName $resolvedTemplate | lower -}}
+{{- $hostname := trimSuffix "." $rawHostname -}}
+{{- $hasUnsupportedPlaceholder := regexMatch "\\{[^{}]+\\}" $hostname -}}
+{{- $validHostname := and
+      (le (len $rawHostname) 253)
+      (eq (include "llm-request-router.isValidDnsName" (dict "name" $hostname)) "true") -}}
+{{- $hostnameLabels := splitList "." $hostname -}}
+{{- $covered := false -}}
+{{- if and (not $hasUnsupportedPlaceholder) $validHostname -}}
+{{- range $configuredDnsName := $dnsNames -}}
+{{- $dnsName := $configuredDnsName | toString | lower -}}
+{{- $validExactDnsName := eq (include "llm-request-router.isValidDnsName" (dict "name" $dnsName)) "true" -}}
+{{- if and (not $hasPodName) $validExactDnsName (eq $dnsName $hostname) -}}
+{{- $covered = true -}}
+{{- else if hasPrefix "*." $dnsName -}}
+{{- $wildcardSuffix := trimPrefix "*." $dnsName -}}
+{{- $wildcardSuffixLabels := splitList "." $wildcardSuffix -}}
+{{- $validWildcard := and
+      (le (len $dnsName) 253)
+      (ge (len $wildcardSuffixLabels) 2)
+      (eq (include "llm-request-router.isValidDnsName" (dict "name" $wildcardSuffix)) "true") -}}
+{{- $podTemplateCanUseWildcard := or
+      (not $hasPodName)
+      (and $podNameInLeftmostLabel (not $podNameOutsideLeftmostLabel)) -}}
+{{- if and
+      $validWildcard
+      $podTemplateCanUseWildcard
+      (eq (len $hostnameLabels) (add1 (len $wildcardSuffixLabels)))
+      (ne (first $hostnameLabels) "")
+      (hasSuffix (printf ".%s" $wildcardSuffix) $hostname) -}}
+{{- $covered = true -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if not $covered -}}
+{{- fail (printf "advertised hostname template %q is not covered by llmRequestRouter.certificate.dnsNames %s" $advertisedHostnameTemplate (toJson $dnsNames)) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "llm-request-router.serviceAccountName" -}}
 {{- if .Values.llmRequestRouter.serviceAccount.create }}
 {{- default (include "llm-request-router.fullname" .) .Values.llmRequestRouter.serviceAccount.name }}

--- a/deploy/helm/llm-request-router/llm-request-router/templates/certificate.yaml
+++ b/deploy/helm/llm-request-router/llm-request-router/templates/certificate.yaml
@@ -15,6 +15,7 @@
 
 {{ $certificate := .Values.llmRequestRouter.certificate | default dict -}}
 {{- if $certificate.enabled }}
+{{- include "llm-request-router.validateCertificateDnsNames" . }}
 {{- $issuerRef := $certificate.issuerRef | default dict -}}
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/deploy/helm/llm-request-router/llm-request-router/templates/deployment.yaml
+++ b/deploy/helm/llm-request-router/llm-request-router/templates/deployment.yaml
@@ -31,14 +31,7 @@ tunnel target.
 {{- if and $disableDnsDiscovery (gt $replicaCount 1) }}
 {{- fail "llmRequestRouter.discovery.disableDnsDiscovery cannot be true when llmRequestRouter.replicaCount is greater than 1; multi-replica routers require DNS discovery" }}
 {{- end }}
-{{- $advertisedHostnameTemplate := .Values.llmRequestRouter.kubernetes.advertisedHostnameTemplate }}
-{{- if not $advertisedHostnameTemplate }}
-{{- if eq $replicaCount 1 }}
-{{- $advertisedHostnameTemplate = printf "%s.%s.svc.cluster.local" (include "llm-request-router.fullname" .) (include "llm-request-router.namespace" .) }}
-{{- else }}
-{{- $advertisedHostnameTemplate = printf "{pod_name}.%s.%s.svc.cluster.local" .Values.llmRequestRouter.service.headlessName (include "llm-request-router.namespace" .) }}
-{{- end }}
-{{- end }}
+{{- $advertisedHostnameTemplate := include "llm-request-router.advertisedHostnameTemplate" . }}
 spec:
   serviceName: {{ .Values.llmRequestRouter.service.headlessName }}
   replicas: {{ $replicaCount }}

--- a/deploy/helm/llm-request-router/llm-request-router/values.yaml
+++ b/deploy/helm/llm-request-router/llm-request-router/values.yaml
@@ -84,6 +84,9 @@ llmRequestRouter:
   affinity: {}
 
   kubernetes:
+    # Supports {pod_name} and {namespace}. When certificate.enabled is true,
+    # certificate.dnsNames must cover the resolved hostname with an exact name
+    # or a valid leftmost wildcard that matches one DNS label.
     advertisedHostnameTemplate: ""
 
   certificate:
@@ -92,6 +95,7 @@ llmRequestRouter:
     issuerRef:
       kind: ClusterIssuer
       name: ""
+    # Wildcards use the form *.example.internal and cover one label only.
     dnsNames: []
     usages:
       - server auth

--- a/deploy/helm/llm-request-router/scripts/check-pki-render.sh
+++ b/deploy/helm/llm-request-router/scripts/check-pki-render.sh
@@ -16,11 +16,34 @@
 
 set -eu
 
-manifest="$(mktemp)"
-defaults_manifest="$(mktemp)"
-trap 'rm -f "${manifest}" "${defaults_manifest}"' EXIT
+tmp_dir="$(mktemp -d)"
+manifest="${tmp_dir}/enabled.yaml"
+defaults_manifest="${tmp_dir}/defaults.yaml"
+trap 'rm -rf "${tmp_dir}"' EXIT
 
-# Pass 1: defaults — pki/certificate/tls all off. Assert the chart does NOT
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+render_certificate_case() {
+  output="$1"
+  advertised_hostname_template="$2"
+  dns_name="$3"
+
+  helm template llm-request-router ./llm-request-router \
+    --namespace nvcf \
+    --values ./llm-request-router/values.yaml \
+    --set llmRequestRouter.image.repository=stargate \
+    --set llmRequestRouter.certificate.enabled=true \
+    --set llmRequestRouter.certificate.secretName=stargate-quic-tls \
+    --set llmRequestRouter.certificate.issuerRef.name=nvcf-openbao-pki \
+    --set-string "llmRequestRouter.kubernetes.advertisedHostnameTemplate=${advertised_hostname_template}" \
+    --set-string "llmRequestRouter.certificate.dnsNames[0]=${dns_name}" \
+    > "${output}"
+}
+
+# Pass 1: defaults. PKI, certificate, and TLS are all off. Assert the chart does not
 # emit any of the optional PKI resources so a regression that accidentally
 # turns them on (or fails to gate them properly) is caught.
 helm template llm-request-router ./llm-request-router \
@@ -58,7 +81,7 @@ default_tls_mount="$(yq -rN 'select(.kind == "StatefulSet" and .metadata.name ==
 default_tls_volume="$(yq -rN 'select(.kind == "StatefulSet" and .metadata.name == "llm-request-router") | .spec.template.spec.volumes[]? | select(.name == "stargate-tls") | .name' "${defaults_manifest}" | head -n1)"
 [ -z "${default_tls_volume}" ] || { echo "FAIL: stargate-tls volume rendered with default values" >&2; exit 1; }
 
-# Pass 2: fully enabled — pki + certificate + tls. Assert that every
+# Pass 2: PKI, certificate, and TLS are fully enabled. Assert that every
 # expected resource and wiring is in place.
 helm template llm-request-router ./llm-request-router \
   --namespace nvcf \
@@ -69,6 +92,7 @@ helm template llm-request-router ./llm-request-router \
   --set llmRequestRouter.certificate.issuerRef.kind=ClusterIssuer \
   --set llmRequestRouter.certificate.issuerRef.name=nvcf-openbao-pki \
   --set-string 'llmRequestRouter.certificate.dnsNames[0]=*.stargate.localhost' \
+  --set-string 'llmRequestRouter.kubernetes.advertisedHostnameTemplate=\{pod_name\}.stargate.localhost' \
   --set llmRequestRouter.tls.secretName=stargate-quic-tls \
   --set llmRequestRouter.tls.certPath=/etc/stargate/tls/tls.crt \
   --set llmRequestRouter.tls.keyPath=/etc/stargate/tls/tls.key \
@@ -76,7 +100,7 @@ helm template llm-request-router ./llm-request-router \
   --set llmRequestRouter.pki.enabled=true \
   --set-string 'llmRequestRouter.pki.allowedDomains=stargate.localhost\,cluster.local' \
   --set llmRequestRouter.pki.image.registry=nvcr.io \
-  --set llmRequestRouter.pki.image.repository=<your-org>/nvcf-openbao-migrations \
+  --set 'llmRequestRouter.pki.image.repository=<your-org>/nvcf-openbao-migrations' \
   --set llmRequestRouter.pki.image.tag=0.12.1 \
   > "${manifest}"
 
@@ -114,7 +138,135 @@ hook_allowed_domains="$(yq -rN 'select(.kind == "Job" and .metadata.name == "add
 
 [ "${hook_job_name}" = "addons-llm-migrations" ]
 [ "${hook_helm_hook}" = "pre-install,pre-upgrade" ]
-[ "${hook_image}" = "<your-registry>/<your-org>/nvcf-openbao-migrations:0.12.1" ]
+[ "${hook_image}" = "nvcr.io/<your-org>/nvcf-openbao-migrations:0.12.1" ]
 [ "${hook_addons_llm}" = "true" ]
 [ "${hook_core_off}" = "false" ]
 [ "${hook_allowed_domains}" = "stargate.localhost,cluster.local" ]
+
+# Exact and wildcard SANs cover a static advertised hostname.
+exact_manifest="${tmp_dir}/exact.yaml"
+render_certificate_case \
+  "${exact_manifest}" \
+  "Router.NVCF.Example.Internal" \
+  "router.nvcf.example.internal"
+
+wildcard_manifest="${tmp_dir}/wildcard.yaml"
+render_certificate_case \
+  "${wildcard_manifest}" \
+  "router.example.internal" \
+  "*.example.internal"
+
+default_template_manifest="${tmp_dir}/default-template.yaml"
+render_certificate_case \
+  "${default_template_manifest}" \
+  "" \
+  "*.llm-request-router-headless.nvcf.svc.cluster.local"
+
+# Certificate validation resolves both supported placeholders. The pod name
+# remains one DNS label, while the namespace is known at chart render time.
+placeholder_manifest="${tmp_dir}/placeholder.yaml"
+render_certificate_case \
+  "${placeholder_manifest}" \
+  "router-\{pod_name\}.\{namespace\}.stargate.internal" \
+  "*.nvcf.stargate.internal"
+
+# Preserve the existing empty-list rejection.
+empty_dns_error="${tmp_dir}/empty-dns.err"
+if helm template llm-request-router ./llm-request-router \
+  --namespace nvcf \
+  --values ./llm-request-router/values.yaml \
+  --set llmRequestRouter.image.repository=stargate \
+  --set llmRequestRouter.certificate.enabled=true \
+  --set llmRequestRouter.certificate.issuerRef.name=nvcf-openbao-pki \
+  > /dev/null 2> "${empty_dns_error}"; then
+  fail "certificate render with empty dnsNames unexpectedly succeeded"
+fi
+grep -Fq \
+  "llmRequestRouter.certificate.dnsNames is required when certificate.enabled is true" \
+  "${empty_dns_error}" || fail "empty dnsNames render did not return the expected guard message"
+
+uncovered_error="${tmp_dir}/uncovered.err"
+if render_certificate_case \
+  /dev/null \
+  "router.example.internal" \
+  "router.other.internal" \
+  2> "${uncovered_error}"; then
+  fail "uncovered advertised hostname unexpectedly rendered"
+fi
+grep -Fq \
+  'advertised hostname template "router.example.internal" is not covered by llmRequestRouter.certificate.dnsNames ["router.other.internal"]' \
+  "${uncovered_error}" || fail "uncovered hostname render did not return the expected guard message"
+
+invalid_wildcard_error="${tmp_dir}/invalid-wildcard.err"
+if render_certificate_case \
+  /dev/null \
+  "router.sub.example.internal" \
+  "*.example.internal" \
+  2> "${invalid_wildcard_error}"; then
+  fail "wildcard SAN covering more than one hostname label unexpectedly rendered"
+fi
+grep -Fq \
+  'advertised hostname template "router.sub.example.internal" is not covered by llmRequestRouter.certificate.dnsNames ["*.example.internal"]' \
+  "${invalid_wildcard_error}" || fail "invalid wildcard render did not return the expected guard message"
+
+misplaced_placeholder_error="${tmp_dir}/misplaced-placeholder.err"
+if render_certificate_case \
+  /dev/null \
+  "router.\{pod_name\}.example.internal" \
+  "*.llm-request-router-0.example.internal" \
+  2> "${misplaced_placeholder_error}"; then
+  fail "pod-name placeholder outside the wildcard label unexpectedly rendered"
+fi
+grep -Fq \
+  'advertised hostname template "router.{pod_name}.example.internal" is not covered by llmRequestRouter.certificate.dnsNames ["*.llm-request-router-0.example.internal"]' \
+  "${misplaced_placeholder_error}" || fail "misplaced placeholder render did not return the expected guard message"
+
+short_wildcard_error="${tmp_dir}/short-wildcard.err"
+if render_certificate_case \
+  /dev/null \
+  "router.internal" \
+  "*.internal" \
+  2> "${short_wildcard_error}"; then
+  fail "wildcard SAN with fewer than two suffix labels unexpectedly rendered"
+fi
+grep -Fq \
+  'advertised hostname template "router.internal" is not covered by llmRequestRouter.certificate.dnsNames ["*.internal"]' \
+  "${short_wildcard_error}" || fail "short wildcard render did not return the expected guard message"
+
+invalid_hostname_error="${tmp_dir}/invalid-hostname.err"
+if render_certificate_case \
+  /dev/null \
+  "router..example.internal" \
+  "router..example.internal" \
+  2> "${invalid_hostname_error}"; then
+  fail "advertised hostname with an empty DNS label unexpectedly rendered"
+fi
+
+literal_wildcard_hostname_error="${tmp_dir}/literal-wildcard-hostname.err"
+if render_certificate_case \
+  /dev/null \
+  "*.example.internal" \
+  "*.example.internal" \
+  2> "${literal_wildcard_hostname_error}"; then
+  fail "advertised hostname containing a literal wildcard unexpectedly rendered"
+fi
+
+malformed_san_error="${tmp_dir}/malformed-san.err"
+if render_certificate_case \
+  /dev/null \
+  "router.example-.internal" \
+  "*.example-.internal" \
+  2> "${malformed_san_error}"; then
+  fail "malformed wildcard SAN unexpectedly rendered"
+fi
+
+invalid_character_error="${tmp_dir}/invalid-character.err"
+if render_certificate_case \
+  /dev/null \
+  "router-{}.example.internal" \
+  "*.example.internal" \
+  2> "${invalid_character_error}"; then
+  fail "advertised hostname containing non-DNS braces unexpectedly rendered"
+fi
+
+echo "PKI render checks passed"


### PR DESCRIPTION
## TL;DR

Validate that the Stargate Certificate DNS names cover the llm-request-router advertised hostname before Helm renders deployable resources. This prevents reverse-QUIC TLS failures caused by a certificate/hostname mismatch.

## Additional Details

### Why

The chart previously required a non-empty Certificate DNS name list but did not verify that any configured name could authenticate the advertised hostname. A mismatched configuration rendered successfully and failed only when a worker attempted the reverse-QUIC TLS handshake.

### What changed

- Centralized advertised-hostname-template rendering so the StatefulSet and certificate validation use the same value.
- Added case-insensitive exact matching and standard leftmost wildcard matching for one DNS label.
- Resolved the supported `{namespace}` and `{pod_name}` placeholders for validation.
- Rejected invalid DNS identities, malformed wildcards, unsupported placeholder placement, uncovered hostnames, and empty DNS name lists with clear render-time errors.
- Expanded render tests and documented the matching rules.

### Customer Release Notes

The llm-request-router chart now rejects certificate DNS names that cannot authenticate its advertised reverse-QUIC hostname.

### Plan Summary

Valid chart configurations render the same Kubernetes resources. Invalid certificate/hostname combinations now fail during Helm rendering before an install or upgrade.

### Usage

Configure `llmRequestRouter.certificate.dnsNames` with an exact advertised hostname or a valid leftmost wildcard that covers exactly one DNS label.

### Dependencies

None. No license or NOTICE changes are required.

## For the Reviewer

Please focus on the DNS syntax and wildcard semantics in `templates/_helpers.tpl` and the positive and negative coverage in `scripts/check-pki-render.sh`.

## For QA

Validated with:

- `make lint`
- `make template`
- `make test`
- `make validate`
- `git diff --check`
- Linux Helm lint and positive/negative render cases
- Non-mutating server-side Helm upgrade dry run against an existing self-managed deployment
- Controlled in-place rollout using the deployment's installed chart revision with this validator applied; the Helm diff was limited to adding the missing wildcard SAN
- Post-rollout confirmation that the new router pod was Ready with zero restarts, the reverse-QUIC handshake authenticated, and the worker reconnected without certificate errors

No additional manual QA is required beyond CI.

## Issues

Closes #908

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
