### PR TITLE
fix(nvca): reject insecure bundle trust configuration

### DIFF
--- a/deploy/helm/nvca-operator/nvca-operator/templates/_helpers.tpl
+++ b/deploy/helm/nvca-operator/nvca-operator/templates/_helpers.tpl
@@ -98,6 +98,29 @@ Validate imagePullSecretName is specified when generateImagePullSecret is false
 {{- end -}}
 
 {{/*
+Reject transport trust settings that explicitly disable QUIC verification.
+*/}}
+{{- define "nvcaop.validateTransportTrust" -}}
+{{- $agentConfig := .Values.agentConfig | default dict -}}
+{{- $mergeConfigData := $agentConfig.mergeConfig | default "" -}}
+{{- $mergeConfig := dict -}}
+{{- if $mergeConfigData -}}
+{{- $mergeConfig = $mergeConfigData | fromYaml -}}
+{{- end -}}
+{{- $mergeWorkload := $mergeConfig.workload | default dict -}}
+{{- $mergeTransportTLS := $mergeWorkload.transportTLS | default dict -}}
+{{- $operatorConfig := .Values.operatorConfig | default dict -}}
+{{- $operatorWorkload := $operatorConfig.workload | default dict -}}
+{{- $operatorTransportTLS := $operatorWorkload.transportTLS | default dict -}}
+{{- $trustBundle := $operatorTransportTLS.trustBundle | default dict -}}
+{{- $secretKeyRef := $trustBundle.secretKeyRef | default dict -}}
+{{- $bundleConfigured := or (eq ($mergeTransportTLS.trustMode | default "") "bundle") (ne ($secretKeyRef.name | default "") "") -}}
+{{- if and ($mergeWorkload.stargateQUICInsecure | default false) $bundleConfigured -}}
+{{- fail "workload.stargateQUICInsecure=true cannot be used with workload.transportTLS.trustMode=bundle; set workload.stargateQUICInsecure=false or use trustMode=system" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 ImagePullSecret for images.
 */}}
 {{- define "nvcaop.generatedImagePullSecret" }}

--- a/deploy/helm/nvca-operator/nvca-operator/templates/operator-config-cm.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/templates/operator-config-cm.yaml
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+{{- include "nvcaop.validateTransportTrust" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/src/clis/nvcf-cli/cmd/self_hosted_compute_plane.go
+++ b/src/clis/nvcf-cli/cmd/self_hosted_compute_plane.go
@@ -159,10 +159,38 @@ func readNVCAValuesMetadata(path string) (nvcaValuesMetadata, error) {
 	if err := decoder.Decode(&values); err != nil {
 		return nvcaValuesMetadata{}, fmt.Errorf("parsing values file: %w", err)
 	}
+	if err := validateNVCAAgentConfig(values.AgentConfig); err != nil {
+		return nvcaValuesMetadata{}, fmt.Errorf("validating values file: %w", err)
+	}
 	return nvcaValuesMetadata{
 		ClusterName: values.ClusterName,
 		NCAID:       firstNonEmpty(values.NCAID, values.NCAIDLower),
 	}, nil
+}
+
+type nvcaAgentConfigValidation struct {
+	Workload struct {
+		StargateQUICInsecure bool `yaml:"stargateQUICInsecure"`
+		TransportTLS         *struct {
+			TrustMode string `yaml:"trustMode"`
+		} `yaml:"transportTLS"`
+	} `yaml:"workload"`
+}
+
+func validateNVCAAgentConfig(agentConfig *nvca.AgentConfigValues) error {
+	if agentConfig == nil || strings.TrimSpace(agentConfig.MergeConfig) == "" {
+		return nil
+	}
+
+	var cfg nvcaAgentConfigValidation
+	if err := yaml.Unmarshal([]byte(agentConfig.MergeConfig), &cfg); err != nil {
+		return fmt.Errorf("parsing agentConfig.mergeConfig: %w", err)
+	}
+	if cfg.Workload.StargateQUICInsecure && cfg.Workload.TransportTLS != nil &&
+		cfg.Workload.TransportTLS.TrustMode == controlplaneprofile.TrustModeBundle {
+		return fmt.Errorf("workload.stargateQUICInsecure=true cannot be used with workload.transportTLS.trustMode=bundle; set workload.stargateQUICInsecure=false or use trustMode=system")
+	}
+	return nil
 }
 
 // nvcaValuesMetadataDoc is the strict-decode shape for the nvca-operator

--- a/src/clis/nvcf-cli/cmd/self_hosted_compute_plane_test.go
+++ b/src/clis/nvcf-cli/cmd/self_hosted_compute_plane_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -838,6 +839,62 @@ func TestReadNVCAValuesMetadata(t *testing.T) {
 		assert.Equal(t, "-----BEGIN CERTIFICATE-----\nrendered\n-----END CERTIFICATE-----\n", transportTLS["trustBundlePem"])
 		assert.NotContains(t, transportTLS, "installerImage")
 	})
+
+	t.Run("bundle transport trust with QUIC insecure is rejected", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "insecure-nvca-values.yaml")
+		body := `clusterName: gpu-insecure
+agentConfig:
+  mergeConfig: |
+    workload:
+      stargateQUICInsecure: true
+      transportTLS:
+        trustMode: bundle
+`
+		require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+
+		_, err := readNVCAValuesMetadata(path)
+		require.ErrorContains(t, err, "workload.stargateQUICInsecure=true cannot be used with workload.transportTLS.trustMode=bundle")
+		require.ErrorContains(t, err, "set workload.stargateQUICInsecure=false or use trustMode=system")
+	})
+
+	for _, tc := range []struct {
+		name        string
+		mergeConfig string
+	}{
+		{
+			name: "system transport trust with QUIC insecure is accepted",
+			mergeConfig: `workload:
+  stargateQUICInsecure: true
+  transportTLS:
+    trustMode: system
+`,
+		},
+		{
+			name: "bundle transport trust with QUIC insecure false is accepted",
+			mergeConfig: `workload:
+  stargateQUICInsecure: false
+  transportTLS:
+    trustMode: bundle
+`,
+		},
+		{
+			name: "bundle transport trust with QUIC insecure unset is accepted",
+			mergeConfig: `workload:
+  transportTLS:
+    trustMode: bundle
+`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "compatible-nvca-values.yaml")
+			body := "clusterName: gpu-compatible\nagentConfig:\n  mergeConfig: |\n    " +
+				strings.ReplaceAll(tc.mergeConfig, "\n", "\n    ")
+			require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+
+			_, err := readNVCAValuesMetadata(path)
+			require.NoError(t, err)
+		})
+	}
 
 	t.Run("typo in known field surfaces a decode error", func(t *testing.T) {
 		dir := t.TempDir()

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/templates/_helpers.tpl
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/templates/_helpers.tpl
@@ -98,6 +98,29 @@ Validate imagePullSecretName is specified when generateImagePullSecret is false
 {{- end -}}
 
 {{/*
+Reject transport trust settings that explicitly disable QUIC verification.
+*/}}
+{{- define "nvcaop.validateTransportTrust" -}}
+{{- $agentConfig := .Values.agentConfig | default dict -}}
+{{- $mergeConfigData := $agentConfig.mergeConfig | default "" -}}
+{{- $mergeConfig := dict -}}
+{{- if $mergeConfigData -}}
+{{- $mergeConfig = $mergeConfigData | fromYaml -}}
+{{- end -}}
+{{- $mergeWorkload := $mergeConfig.workload | default dict -}}
+{{- $mergeTransportTLS := $mergeWorkload.transportTLS | default dict -}}
+{{- $operatorConfig := .Values.operatorConfig | default dict -}}
+{{- $operatorWorkload := $operatorConfig.workload | default dict -}}
+{{- $operatorTransportTLS := $operatorWorkload.transportTLS | default dict -}}
+{{- $trustBundle := $operatorTransportTLS.trustBundle | default dict -}}
+{{- $secretKeyRef := $trustBundle.secretKeyRef | default dict -}}
+{{- $bundleConfigured := or (eq ($mergeTransportTLS.trustMode | default "") "bundle") (ne ($secretKeyRef.name | default "") "") -}}
+{{- if and ($mergeWorkload.stargateQUICInsecure | default false) $bundleConfigured -}}
+{{- fail "workload.stargateQUICInsecure=true cannot be used with workload.transportTLS.trustMode=bundle; set workload.stargateQUICInsecure=false or use trustMode=system" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 ImagePullSecret for images.
 */}}
 {{- define "nvcaop.generatedImagePullSecret" }}

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/templates/operator-config-cm.yaml
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/templates/operator-config-cm.yaml
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+{{- include "nvcaop.validateTransportTrust" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/src/compute-plane-services/nvca/internal/miniservice/transport_tls.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/transport_tls.go
@@ -37,6 +37,9 @@ func (r *Reconciler) prepareTransportTLSForWorkloads(
 	ms *nvcav1alpha1.MiniService,
 	objs []client.Object,
 ) error {
+	if err := r.cfg.Workload.Validate(); err != nil {
+		return reconcile.TerminalError(err)
+	}
 	if r.cfg.Workload.TransportTLS == nil {
 		return nil
 	}

--- a/src/compute-plane-services/nvca/internal/miniservice/transport_tls_test.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/transport_tls_test.go
@@ -127,6 +127,7 @@ func TestPrepareTransportTLSForWorkloadsInjectsPodLLMWorker(t *testing.T) {
 	assert.Equal(t, corev1.PullAlways, installer.ImagePullPolicy)
 	llmWorker := findWorkloadContainer(podSpec, function.LLMWorkerContainerName)
 	require.NotNil(t, llmWorker)
+	assert.NotContains(t, llmWorker.Args, "--quic-insecure")
 	assert.Equal(t, "/nvcf/transport-tls/ca-certificates.crt",
 		findWorkloadEnvValue(llmWorker, "STARGATE_TLS_CERT_PATH"))
 	mount := findWorkloadVolumeMount(llmWorker, "nvcf-trust-merged-certs")
@@ -320,6 +321,39 @@ func TestPrepareTransportTLSForWorkloadsReturnsTerminalErrorForInvalidConfig(t *
 			assert.True(t, errors.Is(err, reconcile.TerminalError(nil)), "invalid static transport TLS config should fail terminally")
 		})
 	}
+}
+
+func TestPrepareTransportTLSForWorkloadsRejectsQUICInsecureTerminal(t *testing.T) {
+	ctx := newTestContext()
+	ms := &nvcav1alpha1.MiniService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "llm-miniservice",
+			Namespace: "worker-ns",
+			UID:       k8stypes.UID("llm-miniservice-uid"),
+		},
+		Spec: nvcav1alpha1.MiniServiceSpec{Namespace: "worker-ns"},
+	}
+	crClient, _ := newFakeClient(mgrScheme, ms)
+	r := newTransportTLSReconciler(crClient, nvcaconfig.TransportTLSConfig{
+		TrustMode:                nvcaconfig.TrustModeBundle,
+		TrustBundleConfigMapName: "nvcf-transport-trust-bundle",
+		TrustBundleKey:           "nvcf-ca-bundle.pem",
+		TrustBundleFingerprint:   testTransportTLSRootFingerprint,
+		TrustBundlePEM:           testTransportTLSRootCertPEM,
+	})
+	r.cfg.Workload.StargateQUICInsecure = true
+	pod := newTransportTLSPod()
+	pod.Spec.Containers[0].Args = []string{"--quic-insecure"}
+
+	err := r.prepareTransportTLSForWorkloads(ctx, ms, []client.Object{pod})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, reconcile.TerminalError(nil)), "invalid static workload configuration must not be retried")
+	assert.Contains(t, err.Error(), "workload.stargateQUICInsecure=true cannot be used with workload.transportTLS.trustMode=bundle")
+	assert.Contains(t, err.Error(), "set workload.stargateQUICInsecure=false or use trustMode=system")
+	cm := &corev1.ConfigMap{}
+	getErr := crClient.Get(ctx, client.ObjectKey{Namespace: "worker-ns", Name: "nvcf-transport-trust-bundle"}, cm)
+	assert.True(t, apierrors.IsNotFound(getErr))
 }
 
 func TestPrepareTransportTLSForWorkloadsReturnsTerminalErrorWithoutRegularInitImage(t *testing.T) {

--- a/src/compute-plane-services/nvca/internal/miniservice/transport_tls_test.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/transport_tls_test.go
@@ -127,7 +127,6 @@ func TestPrepareTransportTLSForWorkloadsInjectsPodLLMWorker(t *testing.T) {
 	assert.Equal(t, corev1.PullAlways, installer.ImagePullPolicy)
 	llmWorker := findWorkloadContainer(podSpec, function.LLMWorkerContainerName)
 	require.NotNil(t, llmWorker)
-	assert.NotContains(t, llmWorker.Args, "--quic-insecure")
 	assert.Equal(t, "/nvcf/transport-tls/ca-certificates.crt",
 		findWorkloadEnvValue(llmWorker, "STARGATE_TLS_CERT_PATH"))
 	mount := findWorkloadVolumeMount(llmWorker, "nvcf-trust-merged-certs")

--- a/src/compute-plane-services/nvca/pkg/nvca/transport_tls.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/transport_tls.go
@@ -30,6 +30,9 @@ import (
 )
 
 func (c K8sComputeBackend) prepareTransportTLSForPod(ctx context.Context, pod *corev1.Pod) error {
+	if err := c.bk8s.cfg.Workload.Validate(); err != nil {
+		return nvcaerrors.TerminalError(err)
+	}
 	if c.bk8s.cfg.Workload.TransportTLS == nil {
 		return nil
 	}

--- a/src/compute-plane-services/nvca/pkg/nvca/transport_tls_test.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/transport_tls_test.go
@@ -95,7 +95,6 @@ func TestCreatePodArtifactInstancesTransportTLSBundleInjectsOnlyLLMWorker(t *tes
 
 	llmWorker := findTransportTLSContainer(createdPod, function.LLMWorkerContainerName)
 	require.NotNil(t, llmWorker)
-	assert.NotContains(t, llmWorker.Args, "--quic-insecure")
 	assert.Equal(t, "/nvcf/transport-tls/ca-certificates.crt",
 		findTransportTLSEnvValue(llmWorker, "STARGATE_TLS_CERT_PATH"))
 	mount := findTransportTLSVolumeMount(llmWorker, "nvcf-trust-merged-certs")

--- a/src/compute-plane-services/nvca/pkg/nvca/transport_tls_test.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/transport_tls_test.go
@@ -95,6 +95,7 @@ func TestCreatePodArtifactInstancesTransportTLSBundleInjectsOnlyLLMWorker(t *tes
 
 	llmWorker := findTransportTLSContainer(createdPod, function.LLMWorkerContainerName)
 	require.NotNil(t, llmWorker)
+	assert.NotContains(t, llmWorker.Args, "--quic-insecure")
 	assert.Equal(t, "/nvcf/transport-tls/ca-certificates.crt",
 		findTransportTLSEnvValue(llmWorker, "STARGATE_TLS_CERT_PATH"))
 	mount := findTransportTLSVolumeMount(llmWorker, "nvcf-trust-merged-certs")
@@ -115,9 +116,12 @@ func TestCreatePodArtifactInstancesTransportTLSSystemDoesNotInjectBundle(t *test
 	kb := newTransportTLSTestBackend(clients, nvcaconfig.TransportTLSConfig{
 		TrustMode: nvcaconfig.TrustModeSystem,
 	})
+	kb.bk8s.cfg.Workload.StargateQUICInsecure = true
 	req := newTransportTLSTestRequest()
+	pod := newTransportTLSTestPod()
+	pod.Spec.Containers[0].Args = []string{"--quic-insecure"}
 
-	_, err := kb.CreatePodArtifactInstances(ctx, newTransportTLSTestPod(), req, transportTLSTestMutator)
+	_, err := kb.CreatePodArtifactInstances(ctx, pod, req, transportTLSTestMutator)
 
 	require.NoError(t, err)
 	_, err = clients.K8s.CoreV1().ConfigMaps(RequestsNamespace).Get(ctx, "nvcf-transport-trust-bundle", metav1.GetOptions{})
@@ -128,7 +132,36 @@ func TestCreatePodArtifactInstancesTransportTLSSystemDoesNotInjectBundle(t *test
 	assert.Nil(t, findTransportTLSInitContainer(createdPod, "nvcf-trust-bundle-install"))
 	llmWorker := findTransportTLSContainer(createdPod, function.LLMWorkerContainerName)
 	require.NotNil(t, llmWorker)
+	assert.Contains(t, llmWorker.Args, "--quic-insecure")
 	assert.Empty(t, findTransportTLSEnvValue(llmWorker, "STARGATE_TLS_CERT_PATH"))
+}
+
+func TestCreatePodArtifactInstancesTransportTLSBundleRejectsQUICInsecureTerminal(t *testing.T) {
+	ctx := newTestContext()
+	clients := makeMockKubeClients()
+	kb := newTransportTLSTestBackend(clients, nvcaconfig.TransportTLSConfig{
+		TrustMode:                nvcaconfig.TrustModeBundle,
+		TrustBundleConfigMapName: "nvcf-transport-trust-bundle",
+		TrustBundleKey:           "nvcf-ca-bundle.pem",
+		TrustBundleFingerprint:   testTransportRootFingerprint,
+		TrustBundlePEM:           testTransportRootCertPEM,
+	})
+	kb.bk8s.cfg.Workload.StargateQUICInsecure = true
+	pod := newTransportTLSTestPod()
+	pod.Spec.Containers[0].Args = []string{"--quic-insecure"}
+
+	_, err := kb.CreatePodArtifactInstances(ctx, pod, newTransportTLSTestRequest(), transportTLSTestMutator)
+
+	require.Error(t, err)
+	assert.True(t, nvcaerrors.IsTerminal(err), "invalid static workload configuration must not be retried")
+	assert.Contains(t, err.Error(), "workload.stargateQUICInsecure=true cannot be used with workload.transportTLS.trustMode=bundle")
+	assert.Contains(t, err.Error(), "set workload.stargateQUICInsecure=false or use trustMode=system")
+	pods, listErr := clients.K8s.CoreV1().Pods(RequestsNamespace).List(ctx, metav1.ListOptions{})
+	require.NoError(t, listErr)
+	assert.Empty(t, pods.Items)
+	_, getErr := clients.K8s.CoreV1().ConfigMaps(RequestsNamespace).Get(ctx, "nvcf-transport-trust-bundle",
+		metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(getErr))
 }
 
 func TestCreatePodArtifactInstancesTransportTLSBundleRejectsMismatchedFingerprint(t *testing.T) {

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/nvcaagent_reconcile.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/nvcaagent_reconcile.go
@@ -1450,6 +1450,10 @@ func (bc *BackendK8sCache) getAgentConfigToMerge(ctx context.Context) (nvcaconfi
 	}
 
 	mergeCfg.Workload.TransportTLS = operatorCfg.Workload.TransportTLS
+	if err := mergeCfg.Validate(); err != nil {
+		return nvcaconfig.Config{}, false,
+			nvcaoperatorerrors.FatalError(fmt.Errorf("invalid combined NVCA agent configuration: %w", err))
+	}
 	return mergeCfg, true, nil
 }
 
@@ -1469,7 +1473,11 @@ func (bc *BackendK8sCache) getRawAgentConfigToMerge(ctx context.Context) (nvcaco
 
 	data := cm.Data[agentConfigFile]
 	cfg, err := nvcaconfig.DecodeConfig([]byte(data))
-	return cfg, true, err
+	if err != nil {
+		return nvcaconfig.Config{}, false,
+			nvcaoperatorerrors.FatalError(fmt.Errorf("invalid %s: %w", agentConfigMergeConfigMapName, err))
+	}
+	return cfg, true, nil
 }
 
 func (bc *BackendK8sCache) getImageRegistryServerFromRepo(nb *nvidiaiov1.NVCFBackend) string {

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/transport_tls_config_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/transport_tls_config_test.go
@@ -25,6 +25,7 @@ import (
 	nvidiaiov1 "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvcf/v1"
 	nvcabelister "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/client/listers/nvcf/v1"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/operator/cleanup"
+	nvcaoperatorerrors "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/operator/internal/errors"
 	nvcaopotel "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/operator/otel"
 	nvcaoptypes "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/operator/types"
 	nvcaconfig "github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/types/nvca/config"
@@ -163,6 +164,71 @@ func TestGetAgentConfigToMerge_RejectsTransportTLSSourceConflict(t *testing.T) {
 	_, _, err = bc.getAgentConfigToMerge(ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "both configure workload.transportTLS")
+}
+
+func TestGetAgentConfigToMerge_RejectsBundleWithQUICInsecureAsFatal(t *testing.T) {
+	ctx := newTestContext()
+	clients := mockKubeClientsForIntegrationTests()
+	bc := &BackendK8sCache{clients: clients, operatorNamespace: NVCAOperatorNamespace}
+
+	_, err := clients.K8s.CoreV1().ConfigMaps(NVCAOperatorNamespace).Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: agentConfigMergeConfigMapName},
+		Data: map[string]string{agentConfigFile: `workload:
+  stargateQUICInsecure: true
+  transportTLS:
+    trustMode: bundle
+`},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, _, err = bc.getAgentConfigToMerge(ctx)
+	require.Error(t, err)
+	assert.True(t, nvcaoperatorerrors.IsFatal(err), "invalid static agent configuration must not be requeued")
+	assert.Contains(t, err.Error(), "workload.stargateQUICInsecure=true cannot be used with workload.transportTLS.trustMode=bundle")
+	assert.Contains(t, err.Error(), "set workload.stargateQUICInsecure=false or use trustMode=system")
+}
+
+func TestGetAgentConfigToMerge_RejectsSecretBundleWithQUICInsecureAsFatal(t *testing.T) {
+	ctx := newTestContext()
+	clients := mockKubeClientsForIntegrationTests()
+	bc := &BackendK8sCache{clients: clients, operatorNamespace: NVCAOperatorNamespace}
+
+	_, err := clients.K8s.CoreV1().ConfigMaps(NVCAOperatorNamespace).Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: agentConfigMergeConfigMapName},
+		Data: map[string]string{agentConfigFile: `workload:
+  stargateQUICInsecure: true
+`},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+	createTransportTrustSource(t, ctx, clients)
+
+	_, _, err = bc.getAgentConfigToMerge(ctx)
+	require.Error(t, err)
+	assert.True(t, nvcaoperatorerrors.IsFatal(err), "invalid combined operator configuration must not be requeued")
+	assert.Contains(t, err.Error(), "workload.stargateQUICInsecure=true cannot be used with workload.transportTLS.trustMode=bundle")
+}
+
+func TestGetAgentConfigToMerge_AllowsSystemWithQUICInsecure(t *testing.T) {
+	ctx := newTestContext()
+	clients := mockKubeClientsForIntegrationTests()
+	bc := &BackendK8sCache{clients: clients, operatorNamespace: NVCAOperatorNamespace}
+
+	_, err := clients.K8s.CoreV1().ConfigMaps(NVCAOperatorNamespace).Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: agentConfigMergeConfigMapName},
+		Data: map[string]string{agentConfigFile: `workload:
+  stargateQUICInsecure: true
+  transportTLS:
+    trustMode: system
+`},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	cfg, found, err := bc.getAgentConfigToMerge(ctx)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.True(t, cfg.Workload.StargateQUICInsecure)
+	require.NotNil(t, cfg.Workload.TransportTLS)
+	assert.Equal(t, nvcaconfig.TrustModeSystem, cfg.Workload.TransportTLS.TrustMode)
 }
 
 func TestSecretBackedTransportTLS_RotationUpdatesAgentConfigWithoutMutatingWorkers(t *testing.T) {

--- a/src/compute-plane-services/nvca/scripts/lint_helm.sh
+++ b/src/compute-plane-services/nvca/scripts/lint_helm.sh
@@ -304,6 +304,8 @@ assert_transport_trust_config "reuse-values upgrade simulation" "" "" "" \
   --values "${reuse_values_file}" \
   --set "operatorConfig=null"
 
+bash "${repo_root}/scripts/test_transport_trust_validation.sh"
+
 # Test secret mirroring feature
 # Test with only source namespace (should not add args)
 run_lint nvca-operator --set "agent.secretMirror.sourceNamespace=custom-ns" --set "ngcConfig.serviceKey=fakekey"

--- a/src/compute-plane-services/nvca/scripts/test_transport_trust_validation.sh
+++ b/src/compute-plane-services/nvca/scripts/test_transport_trust_validation.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+test_dir="$(mktemp -d)"
+trap 'rm -rf "${test_dir}"' EXIT
+
+cat > "${test_dir}/invalid-direct.yaml" <<'EOF'
+agentConfig:
+  mergeConfig: |
+    workload:
+      stargateQUICInsecure: true
+      transportTLS:
+        trustMode: bundle
+EOF
+
+cat > "${test_dir}/invalid-secret.yaml" <<'EOF'
+agentConfig:
+  mergeConfig: |
+    workload:
+      stargateQUICInsecure: true
+operatorConfig:
+  workload:
+    transportTLS:
+      trustBundle:
+        secretKeyRef:
+          name: nvcf-trust
+EOF
+
+cat > "${test_dir}/valid-system.yaml" <<'EOF'
+agentConfig:
+  mergeConfig: |
+    workload:
+      stargateQUICInsecure: true
+      transportTLS:
+        trustMode: system
+EOF
+
+cat > "${test_dir}/valid-bundle.yaml" <<'EOF'
+agentConfig:
+  mergeConfig: |
+    workload:
+      stargateQUICInsecure: false
+      transportTLS:
+        trustMode: bundle
+EOF
+
+cat > "${test_dir}/valid-bundle-unset.yaml" <<'EOF'
+agentConfig:
+  mergeConfig: |
+    workload:
+      transportTLS:
+        trustMode: bundle
+EOF
+
+validation_error="workload.stargateQUICInsecure=true cannot be used with workload.transportTLS.trustMode=bundle"
+
+assert_invalid() {
+  local chart_dir="$1"
+  local label="$2"
+  local values_file="$3"
+  local output_file="${test_dir}/output"
+
+  if helm template test-release "${chart_dir}" --set ngcConfig.serviceKey=fakekey \
+    --values "${values_file}" > "${output_file}" 2>&1; then
+    echo "Expected ${label} to reject bundle transport trust with QUIC insecure" >&2
+    return 1
+  fi
+  if ! grep -Fq "${validation_error}" "${output_file}"; then
+    echo "Expected ${label} validation error to explain the incompatible settings" >&2
+    cat "${output_file}" >&2
+    return 1
+  fi
+  if ! grep -Fq "set workload.stargateQUICInsecure=false or use trustMode=system" "${output_file}"; then
+    echo "Expected ${label} validation error to include remediation" >&2
+    cat "${output_file}" >&2
+    return 1
+  fi
+}
+
+assert_valid() {
+  local chart_dir="$1"
+  local label="$2"
+  local values_file="$3"
+
+  if ! helm template test-release "${chart_dir}" --set ngcConfig.serviceKey=fakekey \
+    --values "${values_file}" > /dev/null; then
+    echo "Expected ${label} to render" >&2
+    return 1
+  fi
+}
+
+for chart_dir in \
+  "${repo_root}/deployments/nvca-operator" \
+  "${repo_root}/../../../deploy/helm/nvca-operator/nvca-operator"; do
+  chart_label="$(basename "$(dirname "${chart_dir}")")/$(basename "${chart_dir}")"
+  assert_invalid "${chart_dir}" "${chart_label} direct bundle input" "${test_dir}/invalid-direct.yaml"
+  assert_invalid "${chart_dir}" "${chart_label} secret-backed bundle input" "${test_dir}/invalid-secret.yaml"
+  assert_valid "${chart_dir}" "${chart_label} system mode with QUIC insecure" "${test_dir}/valid-system.yaml"
+  assert_valid "${chart_dir}" "${chart_label} bundle mode with QUIC insecure false" "${test_dir}/valid-bundle.yaml"
+  assert_valid "${chart_dir}" "${chart_label} bundle mode with QUIC insecure unset" "${test_dir}/valid-bundle-unset.yaml"
+done

--- a/src/compute-plane-services/nvca/scripts/test_transport_trust_validation.sh
+++ b/src/compute-plane-services/nvca/scripts/test_transport_trust_validation.sh
@@ -56,6 +56,28 @@ agentConfig:
         trustMode: bundle
 EOF
 
+cat > "${test_dir}/valid-secret-bundle.yaml" <<'EOF'
+agentConfig:
+  mergeConfig: |
+    workload:
+      stargateQUICInsecure: false
+operatorConfig:
+  workload:
+    transportTLS:
+      trustBundle:
+        secretKeyRef:
+          name: nvcf-trust
+EOF
+
+cat > "${test_dir}/valid-secret-bundle-unset.yaml" <<'EOF'
+operatorConfig:
+  workload:
+    transportTLS:
+      trustBundle:
+        secretKeyRef:
+          name: nvcf-trust
+EOF
+
 validation_error="workload.stargateQUICInsecure=true cannot be used with workload.transportTLS.trustMode=bundle"
 
 assert_invalid() {
@@ -102,4 +124,8 @@ for chart_dir in \
   assert_valid "${chart_dir}" "${chart_label} system mode with QUIC insecure" "${test_dir}/valid-system.yaml"
   assert_valid "${chart_dir}" "${chart_label} bundle mode with QUIC insecure false" "${test_dir}/valid-bundle.yaml"
   assert_valid "${chart_dir}" "${chart_label} bundle mode with QUIC insecure unset" "${test_dir}/valid-bundle-unset.yaml"
+  assert_valid "${chart_dir}" "${chart_label} secret-backed bundle with QUIC insecure false" \
+    "${test_dir}/valid-secret-bundle.yaml"
+  assert_valid "${chart_dir}" "${chart_label} secret-backed bundle with QUIC insecure unset" \
+    "${test_dir}/valid-secret-bundle-unset.yaml"
 done

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/types/nvca/config/types.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/types/nvca/config/types.go
@@ -483,6 +483,9 @@ func (c Config) Complete() Config {
 
 // Validate rejects configuration combinations that cannot be applied safely.
 func (c Config) Validate() error {
+	if err := c.Workload.Validate(); err != nil {
+		return err
+	}
 	if err := c.Agent.BYOOOTelCollector.Validate(); err != nil {
 		return fmt.Errorf("agent.byooOtelCollector: %w", err)
 	}
@@ -846,6 +849,14 @@ type TransportTLSConfig struct {
 	TrustBundleFingerprint   string    `yaml:"trustBundleFingerprint"`
 	TrustBundlePEM           string    `yaml:"trustBundlePem"`
 	InstalledBundleMountPath string    `yaml:"installedBundleMountPath"`
+}
+
+// Validate rejects workload settings that disable configured transport trust.
+func (t WorkloadConfig) Validate() error {
+	if t.StargateQUICInsecure && t.TransportTLS != nil && t.TransportTLS.TrustMode == TrustModeBundle {
+		return fmt.Errorf("workload.stargateQUICInsecure=true cannot be used with workload.transportTLS.trustMode=bundle; set workload.stargateQUICInsecure=false or use trustMode=system")
+	}
+	return nil
 }
 
 func (t WorkloadConfig) Complete() WorkloadConfig {

--- a/src/libraries/go/lib/pkg/types/nvca/config/config_test.go
+++ b/src/libraries/go/lib/pkg/types/nvca/config/config_test.go
@@ -482,6 +482,54 @@ agent:
 		require.ErrorContains(t, err, "validate merged config: agent.byooOtelCollector: log sampling: samplingPercentage must be 0 or at least")
 	})
 
+	t.Run("rejects_bundle_transport_trust_with_quic_insecure", func(t *testing.T) {
+		_, err := DecodeConfig([]byte(`
+workload:
+  stargateQUICInsecure: true
+  transportTLS:
+    trustMode: bundle
+`))
+		require.ErrorContains(t, err, "workload.stargateQUICInsecure=true cannot be used with workload.transportTLS.trustMode=bundle")
+		require.ErrorContains(t, err, "set workload.stargateQUICInsecure=false or use trustMode=system")
+	})
+
+	for _, tc := range []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "allows_system_transport_trust_with_quic_insecure",
+			yaml: `
+workload:
+  stargateQUICInsecure: true
+  transportTLS:
+    trustMode: system
+`,
+		},
+		{
+			name: "allows_bundle_transport_trust_with_quic_insecure_false",
+			yaml: `
+workload:
+  stargateQUICInsecure: false
+  transportTLS:
+    trustMode: bundle
+`,
+		},
+		{
+			name: "allows_bundle_transport_trust_with_quic_insecure_unset",
+			yaml: `
+workload:
+  transportTLS:
+    trustMode: bundle
+`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := DecodeConfig([]byte(tc.yaml))
+			require.NoError(t, err)
+		})
+	}
+
 	t.Run("duration_parsing", func(t *testing.T) {
 		data := []byte(`
 agent:

--- a/src/libraries/go/lib/pkg/types/nvca/config/types.go
+++ b/src/libraries/go/lib/pkg/types/nvca/config/types.go
@@ -483,6 +483,9 @@ func (c Config) Complete() Config {
 
 // Validate rejects configuration combinations that cannot be applied safely.
 func (c Config) Validate() error {
+	if err := c.Workload.Validate(); err != nil {
+		return err
+	}
 	if err := c.Agent.BYOOOTelCollector.Validate(); err != nil {
 		return fmt.Errorf("agent.byooOtelCollector: %w", err)
 	}
@@ -846,6 +849,14 @@ type TransportTLSConfig struct {
 	TrustBundleFingerprint   string    `yaml:"trustBundleFingerprint"`
 	TrustBundlePEM           string    `yaml:"trustBundlePem"`
 	InstalledBundleMountPath string    `yaml:"installedBundleMountPath"`
+}
+
+// Validate rejects workload settings that disable configured transport trust.
+func (t WorkloadConfig) Validate() error {
+	if t.StargateQUICInsecure && t.TransportTLS != nil && t.TransportTLS.TrustMode == TrustModeBundle {
+		return fmt.Errorf("workload.stargateQUICInsecure=true cannot be used with workload.transportTLS.trustMode=bundle; set workload.stargateQUICInsecure=false or use trustMode=system")
+	}
+	return nil
 }
 
 func (t WorkloadConfig) Complete() WorkloadConfig {


### PR DESCRIPTION
## TL;DR

Reject NVCA configurations that combine bundle transport trust with
`workload.stargateQUICInsecure: true`. The validation runs at supported CLI and
Helm boundaries and is repeated in the operator and NVCA reconciliation paths.

## Additional Details

### Why

Bundle transport trust configures workloads to verify QUIC peers with an
installed CA bundle. `stargateQUICInsecure: true` disables that verification.
The settings previously traveled through independent configuration paths and
could be accepted together, producing a workload that appeared to configure
bundle trust but did not verify QUIC certificates.

### What changed

- Validate direct `agentConfig.mergeConfig` input in the self-hosted CLI.
- Reject direct and secret-backed bundle combinations during Helm rendering.
- Add the cross-field rule to shared NVCA configuration validation.
- Validate the operator's final combined agent configuration.
- Classify invalid static operator configuration as fatal to prevent requeue
  loops.
- Add terminal defense-in-depth validation to direct Pod and MiniService
  reconciliation before Kubernetes resources are created.
- Regenerate the vendored NVCA chart and shared configuration dependency.

System trust with `stargateQUICInsecure: true` remains supported. Bundle trust
remains supported when `stargateQUICInsecure` is false or unset.

### Customer Release Notes

NVCA now rejects bundle transport trust when QUIC certificate verification is
explicitly disabled and reports how to correct the configuration.

### Plan Summary

Configuration validation only. This change does not add, remove, or resize
Kubernetes resources.

### Usage

For bundle transport trust, leave `workload.stargateQUICInsecure` unset or set
it to `false`. Workloads that require the insecure compatibility setting must
use system trust instead.

### Notes

Existing installations using the invalid combination must correct their values
before upgrading. Mixed-version deployments only gain the validation at the
boundaries provided by the upgraded artifacts.

### Related Pull Requests

None.

### Dependencies

None. No third-party dependency, license, or NOTICE changes.

## For the Reviewer

Please focus on:

- fatal and terminal error classification in the operator and both NVCA
  reconciliation paths
- coverage of direct merge configuration and operator-generated secret-backed
  bundle configuration
- synchronization between source and vendored chart templates

## For QA

Live installation validation completed on fresh self-managed control-plane and
compute-plane k3d clusters:

- Built the CLI, operator, and agent binaries from this pull request commit.
- Installed the full self-managed control-plane stack and registered the
  compute cluster through the supported CLI path.
- Negative: an actual Helm install with a Secret-backed bundle and
  `stargateQUICInsecure: true` exited 1 with the actionable remediation message
  and left no Helm release.
- Positive: the same bundle with `stargateQUICInsecure` unset installed and
  reconciled successfully. The operator and agent were both 1/1 Available with
  zero restarts, and the NVCFBackend agent status was `healthy`.
- The generated agent config used bundle mode, contained the bundle PEM and
  fingerprint, and resolved `stargateQUICInsecure` to false.
- A final stability window had no restarts and no error or fatal logs from the
  operator, agent, or webhook.

The disposable local environment required a task-scoped supplemental RBAC
grant because the current chart does not grant the operator the
`nvsnapfunctionstates` permissions it delegates to the agent ClusterRole. This
pre-existing chart issue is outside this diff.

Automated tests run:

- focused Go tests for shared config, CLI, operator, Pod, and MiniService paths
- CLI `go test ./...`
- Bazel tests for shared config and all three changed NVCA packages
- source and vendored Helm validation tests
- full NVCA Helm lint suite
- scoped `golangci-lint` for changed NVCA packages
- `go vet` for CLI and shared config packages
- shell syntax checks and `git diff --check`

The broader shared-library and NVCA test runs also exposed unrelated existing
or environment-specific failures: an SPDX golden-file mismatch, macOS
restrictions on monkey-patching `os.Exit`, a platform-specific x509 error
string expectation, and four lint findings outside the changed packages.

## Issues

Fixes #910

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent insecure QUIC transport alongside bundle-based TLS trust.
  * Invalid configurations now fail clearly during deployment or reconciliation, preventing incomplete workloads and resources from being created.
  * Valid system-trust configurations and bundle-trust configurations without insecure QUIC remain supported.
  * In bundle-trust mode, insecure QUIC settings are no longer passed to workload workers.

* **Tests**
  * Added coverage for CLI validation, deployment rendering, reconciliation behavior, and supported trust-mode combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->