### PR TITLE
fix(pylon): reject calibration without throughput data

### DIFF
--- a/src/libraries/rust/stargate/crates/pylon-lib/src/bringup.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/bringup.rs
@@ -141,7 +141,10 @@ mod tests {
     }
 
     fn test_stats_collector() -> (PylonRuntimeState, StatsCollectorHandle) {
-        let config = StatsCollectorConfig::default();
+        let config = StatsCollectorConfig {
+            duration_floor: Duration::ZERO,
+            ..StatsCollectorConfig::default()
+        };
         let (runtime_state, observations) = PylonRuntimeState::observed(
             InferenceServerStatus::Active,
             &["test-model".to_string()],
@@ -418,7 +421,7 @@ mod tests {
         let prompt_lengths = Arc::new(Mutex::new(Vec::new()));
         let base_url = spawn_test_server(TestServerState {
             prompt_too_long_above: Some(700),
-            completions_before_block: Some(Arc::new(AtomicUsize::new(4))),
+            completions_before_block: Some(Arc::new(AtomicUsize::new(20))),
             prompt_lengths: Some(prompt_lengths.clone()),
             ..TestServerState::default()
         })
@@ -464,7 +467,7 @@ mod tests {
         let prompt_rejections = Arc::new(Mutex::new(vec![1024, 512]));
         let base_url = spawn_test_server(TestServerState {
             prompt_rejections: Some(prompt_rejections.clone()),
-            completions_before_block: Some(Arc::new(AtomicUsize::new(6))),
+            completions_before_block: Some(Arc::new(AtomicUsize::new(20))),
             prompt_lengths: Some(prompt_lengths.clone()),
             ..TestServerState::default()
         })
@@ -693,10 +696,11 @@ mod tests {
 
         tokio::time::pause();
         tokio::time::advance(Duration::from_secs(30)).await;
-        calibration
+        let error = calibration
             .await
             .expect("calibration task should not panic")
-            .expect("the first load-step timeout should complete calibration");
+            .expect_err("a timeout before sufficient throughput samples must fail");
+        assert!(matches!(error, BringupError::InsufficientCalibrationData));
         tokio::time::resume();
         stats.shutdown().await;
     }

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/bringup/calibration.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/bringup/calibration.rs
@@ -16,6 +16,7 @@
 use std::time::{Duration, Instant};
 
 use futures::stream::{self, StreamExt, TryStreamExt};
+use stargate_protocol::common::valid_last_mean_input_tps;
 
 use crate::generated_request_id::GeneratedRequestKind;
 use crate::runtime_state::{ModelGeneration, PylonRuntimeState};
@@ -88,6 +89,9 @@ pub(crate) async fn run_calibration(
                     current_stats = ?stats,
                     "model calibration reached its saturation timeout"
                 );
+                if !valid_last_mean_input_tps(stats.last_mean_input_tps) {
+                    return Err(BringupError::InsufficientCalibrationData);
+                }
                 return Ok(());
             }
             Err(BringupError::PromptTooLong) => {

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/bringup/upstream.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/bringup/upstream.rs
@@ -203,6 +203,8 @@ pub enum BringupError {
     RunawayGeneration { tokens: u32 },
     #[error("invalid completion response: {0}")]
     InvalidResponse(String),
+    #[error("calibration saturated before measuring positive input throughput")]
+    InsufficientCalibrationData,
     #[error("stats collector stopped during model initialization")]
     StatsCollectorStopped,
     #[error("model generation retired during initialization")]

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/model_lifecycle.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/model_lifecycle.rs
@@ -48,6 +48,7 @@ pub enum ModelSource {
 pub enum ModelInitialization {
     Calibration(CalibrationConfig),
     ConfiguredInputTps { input_tps: f64, pin: bool },
+    Uncalibrated,
 }
 
 #[derive(Clone, Debug)]
@@ -344,7 +345,9 @@ impl ModelLifecycleSupervisor {
                 return Err(ModelLifecycleError::StaleGeneration);
             }
             let initialization = match &self.config.initialization {
-                ModelInitialization::Calibration(_) => ModelStatsInitialization::Empty,
+                ModelInitialization::Calibration(_) | ModelInitialization::Uncalibrated => {
+                    ModelStatsInitialization::Empty
+                }
                 ModelInitialization::ConfiguredInputTps { input_tps, pin } => {
                     ModelStatsInitialization::ConfiguredInputTps {
                         input_tps: *input_tps,
@@ -634,10 +637,12 @@ async fn initialization_attempt(
 fn health_probe_timeout(config: &ModelLifecycleConfig) -> Option<Duration> {
     match &config.initialization {
         ModelInitialization::Calibration(calibration) => Some(calibration.health_timeout),
-        ModelInitialization::ConfiguredInputTps { .. } if config.bringup.enabled => {
+        ModelInitialization::ConfiguredInputTps { .. } | ModelInitialization::Uncalibrated
+            if config.bringup.enabled =>
+        {
             Some(config.bringup.canary_timeout)
         }
-        ModelInitialization::ConfiguredInputTps { .. } => None,
+        ModelInitialization::ConfiguredInputTps { .. } | ModelInitialization::Uncalibrated => None,
     }
 }
 

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/model_lifecycle.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/model_lifecycle.rs
@@ -746,6 +746,7 @@ mod tests {
         FailModel {
             model_id: &'static str,
             failing: Arc<AtomicBool>,
+            completed_requests_per_generation: usize,
         },
     }
 
@@ -943,37 +944,40 @@ mod tests {
             .calibrations
             .send(generation.clone())
             .expect("test should still observe calibration traffic");
-        match state.completion_behavior {
-            CompletionBehavior::Pending => std::future::pending().await,
+        let completed_requests_per_generation = match state.completion_behavior {
+            CompletionBehavior::Pending => return std::future::pending().await,
             CompletionBehavior::SaturateAfter {
                 completed_requests_per_generation,
-            } => {
-                let should_complete = {
-                    let mut completed = state
-                        .completed_requests
-                        .lock()
-                        .expect("completed request counts should not be poisoned");
-                    let completed = completed.entry(generation).or_default();
-                    if *completed < completed_requests_per_generation {
-                        *completed += 1;
-                        true
-                    } else {
-                        false
-                    }
-                };
-                if should_complete {
-                    Json(json!({"usage": {"completion_tokens": 1}})).into_response()
-                } else {
-                    std::future::pending().await
-                }
-            }
+            } => completed_requests_per_generation,
             CompletionBehavior::FailModel {
                 model_id: failed_model,
                 ref failing,
+                ..
             } if model_id == failed_model && failing.load(Ordering::SeqCst) => {
-                StatusCode::SERVICE_UNAVAILABLE.into_response()
+                return StatusCode::SERVICE_UNAVAILABLE.into_response();
             }
-            CompletionBehavior::FailModel { .. } => std::future::pending().await,
+            CompletionBehavior::FailModel {
+                completed_requests_per_generation,
+                ..
+            } => completed_requests_per_generation,
+        };
+        let should_complete = {
+            let mut completed = state
+                .completed_requests
+                .lock()
+                .expect("completed request counts should not be poisoned");
+            let completed = completed.entry(generation).or_default();
+            if *completed < completed_requests_per_generation {
+                *completed += 1;
+                true
+            } else {
+                false
+            }
+        };
+        if should_complete {
+            Json(json!({"usage": {"completion_tokens": 1}})).into_response()
+        } else {
+            std::future::pending().await
         }
     }
 
@@ -1368,7 +1372,7 @@ mod tests {
 
     #[tokio::test]
     async fn calibration_traffic_seeds_positive_observed_stats_before_publication() {
-        let upstream = TestUpstream::spawn(
+        let mut upstream = TestUpstream::spawn(
             &[],
             CompletionBehavior::SaturateAfter {
                 completed_requests_per_generation: 7,
@@ -1388,30 +1392,46 @@ mod tests {
         );
         let stats = start_stats_collector(stats_config, observations, runtime_state.clone());
 
-        let lifecycle = start_model_lifecycle(
-            ModelLifecycleConfig {
-                upstream_http_base_url: upstream.base_url.clone(),
-                source: ModelSource::Static(BTreeSet::from(["model-a".to_string()])),
-                initialization: ModelInitialization::Calibration(CalibrationConfig {
-                    health_timeout: Duration::from_secs(1),
-                    calibration_requests: 1,
-                    calibration_prompt_units: 1024,
-                    calibration_max_concurrency: 1,
-                    calibration_timeout: Duration::from_millis(20),
-                }),
-                bringup: BringupConfig {
-                    enabled: false,
-                    ..BringupConfig::default()
+        let lifecycle_handle = {
+            let lifecycle = start_model_lifecycle(
+                ModelLifecycleConfig {
+                    upstream_http_base_url: upstream.base_url.clone(),
+                    source: ModelSource::Static(BTreeSet::from(["model-a".to_string()])),
+                    initialization: ModelInitialization::Calibration(CalibrationConfig {
+                        health_timeout: Duration::from_secs(1),
+                        calibration_requests: 1,
+                        calibration_prompt_units: 1024,
+                        calibration_max_concurrency: 1,
+                        calibration_timeout: Duration::from_secs(30),
+                    }),
+                    bringup: BringupConfig {
+                        enabled: false,
+                        ..BringupConfig::default()
+                    },
+                    health_paths: UpstreamHealthPaths::default(),
+                    startup_health_wait: Duration::ZERO,
                 },
-                health_paths: UpstreamHealthPaths::default(),
-                startup_health_wait: Duration::ZERO,
-            },
-            runtime_state.clone(),
-            &stats,
-            None,
-        )
-        .await
-        .expect("calibration timeout should complete startup");
+                runtime_state.clone(),
+                &stats,
+                None,
+            );
+            tokio::pin!(lifecycle);
+            for _ in 0..8 {
+                tokio::select! {
+                    _ = upstream.next_calibration() => {}
+                    _ = &mut lifecycle => {
+                        panic!("calibration completed before reaching saturation")
+                    }
+                }
+            }
+            tokio::time::pause();
+            tokio::time::advance(Duration::from_secs(30)).await;
+            lifecycle
+                .as_mut()
+                .await
+                .expect("calibration timeout should complete startup")
+        };
+        tokio::time::resume();
 
         let published = runtime_state
             .advertised_models()
@@ -1424,7 +1444,7 @@ mod tests {
             "completed calibration traffic must seed the ordinary observed stats window"
         );
 
-        lifecycle.shutdown().await;
+        lifecycle_handle.shutdown().await;
         stats.shutdown().await;
         upstream.shutdown().await;
     }
@@ -1437,6 +1457,7 @@ mod tests {
             CompletionBehavior::FailModel {
                 model_id: "model-a",
                 failing,
+                completed_requests_per_generation: 7,
             },
         )
         .await;
@@ -1814,10 +1835,14 @@ mod tests {
             CompletionBehavior::FailModel {
                 model_id: "model-b",
                 failing: failing.clone(),
+                completed_requests_per_generation: 7,
             },
         )
         .await;
-        let stats_config = StatsCollectorConfig::default();
+        let stats_config = StatsCollectorConfig {
+            duration_floor: Duration::ZERO,
+            ..StatsCollectorConfig::default()
+        };
         let (runtime_state, observations) = PylonRuntimeState::observed(
             InferenceServerStatus::Active,
             &[],
@@ -1826,7 +1851,7 @@ mod tests {
         );
         let stats = start_stats_collector(stats_config, observations, runtime_state.clone());
         let mut config =
-            calibration_discovery_config(&upstream.base_url, Duration::from_millis(20));
+            calibration_discovery_config(&upstream.base_url, Duration::from_millis(100));
         let ModelSource::Discovered(discovery) = &mut config.source else {
             unreachable!("test config must use discovery")
         };
@@ -1837,7 +1862,9 @@ mod tests {
                 .expect("empty initial discovery should start");
 
         upstream.set_models(&["model-a"]).await;
-        assert_eq!(upstream.next_calibration().await.model_id(), "model-a");
+        for _ in 0..8 {
+            assert_eq!(upstream.next_calibration().await.model_id(), "model-a");
+        }
         wait_for_model_ids(&runtime_state, &["model-a"]).await;
 
         failing.store(true, Ordering::SeqCst);
@@ -1945,9 +1972,18 @@ mod tests {
 
     #[tokio::test]
     async fn blocked_discovery_does_not_pause_or_inflate_active_calibration() {
-        let mut upstream = TestUpstream::spawn(&[], CompletionBehavior::Pending).await;
+        let mut upstream = TestUpstream::spawn(
+            &[],
+            CompletionBehavior::SaturateAfter {
+                completed_requests_per_generation: 7,
+            },
+        )
+        .await;
         let metrics = PylonMetrics::new().expect("metrics should initialize");
-        let stats_config = StatsCollectorConfig::default();
+        let stats_config = StatsCollectorConfig {
+            duration_floor: Duration::ZERO,
+            ..StatsCollectorConfig::default()
+        };
         let (runtime_state, observations) = PylonRuntimeState::observed(
             InferenceServerStatus::Active,
             &[],
@@ -1991,9 +2027,18 @@ mod tests {
 
     #[tokio::test]
     async fn sibling_reconciliation_does_not_pause_or_inflate_active_calibration() {
-        let mut upstream = TestUpstream::spawn(&[], CompletionBehavior::Pending).await;
+        let mut upstream = TestUpstream::spawn(
+            &[],
+            CompletionBehavior::SaturateAfter {
+                completed_requests_per_generation: 7,
+            },
+        )
+        .await;
         let metrics = PylonMetrics::new().expect("metrics should initialize");
-        let stats_config = StatsCollectorConfig::default();
+        let stats_config = StatsCollectorConfig {
+            duration_floor: Duration::ZERO,
+            ..StatsCollectorConfig::default()
+        };
         let (runtime_state, observations) = PylonRuntimeState::observed(
             InferenceServerStatus::Active,
             &[],
@@ -2007,7 +2052,7 @@ mod tests {
         assert!(runtime_state.publish_generation(&sibling));
         let stats = start_stats_collector(stats_config, observations, runtime_state.clone());
         let mut config =
-            calibration_discovery_config(&upstream.base_url, Duration::from_millis(50));
+            calibration_discovery_config(&upstream.base_url, Duration::from_millis(100));
         let ModelSource::Discovered(discovery) = &mut config.source else {
             unreachable!("test config must use discovery")
         };
@@ -2135,8 +2180,17 @@ mod tests {
 
     #[tokio::test]
     async fn discovery_errors_during_calibration_retain_the_pending_generation() {
-        let mut upstream = TestUpstream::spawn(&[], CompletionBehavior::Pending).await;
-        let stats_config = StatsCollectorConfig::default();
+        let mut upstream = TestUpstream::spawn(
+            &[],
+            CompletionBehavior::SaturateAfter {
+                completed_requests_per_generation: 7,
+            },
+        )
+        .await;
+        let stats_config = StatsCollectorConfig {
+            duration_floor: Duration::ZERO,
+            ..StatsCollectorConfig::default()
+        };
         let (runtime_state, observations) = PylonRuntimeState::observed(
             InferenceServerStatus::Active,
             &[],
@@ -2183,10 +2237,15 @@ mod tests {
     async fn initial_discovered_calibrations_run_sequentially() {
         let mut upstream = TestUpstream::spawn(
             &["model-d", "model-b", "model-a", "model-c"],
-            CompletionBehavior::Pending,
+            CompletionBehavior::SaturateAfter {
+                completed_requests_per_generation: 7,
+            },
         )
         .await;
-        let stats_config = StatsCollectorConfig::default();
+        let stats_config = StatsCollectorConfig {
+            duration_floor: Duration::ZERO,
+            ..StatsCollectorConfig::default()
+        };
         let (runtime_state, observations) = PylonRuntimeState::observed(
             InferenceServerStatus::Active,
             &[],
@@ -2194,7 +2253,7 @@ mod tests {
             None,
         );
         let stats = start_stats_collector(stats_config, observations, runtime_state.clone());
-        let config = calibration_discovery_config(&upstream.base_url, Duration::from_millis(20));
+        let config = calibration_discovery_config(&upstream.base_url, Duration::from_secs(30));
         let start_runtime = runtime_state.clone();
         let start = tokio::spawn(async move {
             let result = start_model_lifecycle(config, start_runtime, &stats, None).await;
@@ -2202,13 +2261,14 @@ mod tests {
         });
 
         let mut order = Vec::new();
-        for _ in 0..4 {
-            let generation = upstream.next_calibration().await;
-            assert!(
-                !order.contains(&generation.model_id().to_string()),
-                "one generation should reach its timeout before the next starts"
-            );
-            order.push(generation.model_id().to_string());
+        for expected_model in ["model-a", "model-b", "model-c", "model-d"] {
+            for _ in 0..8 {
+                assert_eq!(upstream.next_calibration().await.model_id(), expected_model);
+            }
+            order.push(expected_model.to_string());
+            tokio::time::pause();
+            tokio::time::advance(Duration::from_secs(30)).await;
+            tokio::time::resume();
         }
         let (lifecycle, stats) = start.await.expect("lifecycle startup should not panic");
         let lifecycle = lifecycle.expect("all expected timeouts should complete calibration");

--- a/src/libraries/rust/stargate/crates/pylon/src/main.rs
+++ b/src/libraries/rust/stargate/crates/pylon/src/main.rs
@@ -505,11 +505,11 @@ mod tests {
     }
 
     #[test]
-    fn startup_requires_exactly_one_input_tps_bootstrap_source() {
+    fn startup_rejects_conflicting_input_tps_bootstrap_sources() {
         let neither = parse_args("");
         let both = parse_args("--do-calibration --initial-input-tps 2200");
 
-        assert!(startup::PylonStartupPlan::from_args(&neither).is_err());
+        assert!(startup::PylonStartupPlan::from_args(&neither).is_ok());
         assert!(startup::PylonStartupPlan::from_args(&both).is_err());
         assert!(startup::PylonStartupPlan::from_args(&parse_args("--do-calibration")).is_ok());
         assert!(
@@ -537,9 +537,11 @@ mod tests {
 
     #[test]
     fn benchmark_pin_requires_initial_input_tps() {
+        let uncalibrated = parse_args("--benchmark-pin-input-tps");
         let calibration = parse_args("--do-calibration --benchmark-pin-input-tps");
         let initial = parse_args("--initial-input-tps 2200 --benchmark-pin-input-tps");
 
+        assert!(startup::PylonStartupPlan::from_args(&uncalibrated).is_err());
         assert!(startup::PylonStartupPlan::from_args(&calibration).is_err());
         assert!(startup::PylonStartupPlan::from_args(&initial).is_ok());
     }

--- a/src/libraries/rust/stargate/crates/pylon/src/startup.rs
+++ b/src/libraries/rust/stargate/crates/pylon/src/startup.rs
@@ -590,22 +590,22 @@ pub(crate) fn pylon_queue_mismatch_retry_config_from_args(
 
 fn model_initialization_from_args(args: &Args) -> Result<ModelInitialization> {
     ensure!(
-        args.do_calibration ^ args.initial_input_tps.is_some(),
-        "exactly one of --do-calibration or --initial-input-tps is required"
+        !(args.do_calibration && args.initial_input_tps.is_some()),
+        "--do-calibration and --initial-input-tps cannot be used together"
     );
     ensure!(
         args.initial_input_tps
             .is_none_or(|input_tps| input_tps.is_finite() && input_tps > 0.0),
         "initial input TPS must be finite and positive"
     );
+    ensure!(
+        !args.benchmark_pin_input_tps || args.initial_input_tps.is_some(),
+        "--benchmark-pin-input-tps requires --initial-input-tps"
+    );
     if args.do_calibration {
         ensure!(
             args.calibration_requests > 0,
             "--do-calibration requires --calibration-requests greater than zero"
-        );
-        ensure!(
-            !args.benchmark_pin_input_tps,
-            "--benchmark-pin-input-tps requires --initial-input-tps"
         );
         return Ok(ModelInitialization::Calibration(CalibrationConfig {
             health_timeout: Duration::from_millis(args.bringup_canary_timeout_ms),
@@ -616,11 +616,12 @@ fn model_initialization_from_args(args: &Args) -> Result<ModelInitialization> {
         }));
     }
 
-    Ok(ModelInitialization::ConfiguredInputTps {
-        input_tps: args
-            .initial_input_tps
-            .expect("exactly one bootstrap source was validated"),
-        pin: args.benchmark_pin_input_tps,
+    Ok(match args.initial_input_tps {
+        Some(input_tps) => ModelInitialization::ConfiguredInputTps {
+            input_tps,
+            pin: args.benchmark_pin_input_tps,
+        },
+        None => ModelInitialization::Uncalibrated,
     })
 }
 
@@ -1559,24 +1560,53 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn invalid_bootstrap_source_selection_makes_zero_stargate_calls() {
+    async fn conflicting_bootstrap_sources_make_zero_stargate_calls() {
         let upstream = TestUpstream::spawn(false).await;
         let control_plane = TestControlPlane::spawn().await;
 
-        for bootstrap_args in [
-            Vec::<&str>::new(),
-            vec!["--do-calibration", "--initial-input-tps", "100"],
-        ] {
-            let args = runtime_args(
-                &upstream.base_url,
-                control_plane.addr,
-                &["model-a"],
-                &bootstrap_args,
+        let args = runtime_args(
+            &upstream.base_url,
+            control_plane.addr,
+            &["model-a"],
+            &["--do-calibration", "--initial-input-tps", "100"],
+        );
+        assert!(PylonStartupPlan::from_args(&args).is_err());
+        control_plane.assert_no_calls();
+
+        upstream.shutdown().await;
+        control_plane.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn uncalibrated_models_are_advertised_without_positive_input_tps() {
+        let upstream = TestUpstream::spawn(false).await;
+        let mut control_plane = TestControlPlane::spawn().await;
+        let args = runtime_args(
+            &upstream.base_url,
+            control_plane.addr,
+            &["model-a", "model-b"],
+            &[],
+        );
+        let plan = PylonStartupPlan::from_args(&args).expect("startup plan should build");
+        let runtime = start_pylon_runtime(&args, &plan)
+            .await
+            .expect("pylon startup should succeed");
+
+        let registration = control_plane.first_registration().await;
+        assert_eq!(upstream.calibration_requests.load(Ordering::SeqCst), 0);
+        assert_eq!(registration.models.len(), 2);
+        for model_id in ["model-a", "model-b"] {
+            assert_eq!(
+                registration.models[model_id]
+                    .stats
+                    .as_ref()
+                    .expect("first heartbeat should contain stats")
+                    .last_mean_input_tps,
+                0.0
             );
-            assert!(PylonStartupPlan::from_args(&args).is_err());
-            control_plane.assert_no_calls();
         }
 
+        runtime.shutdown().await;
         upstream.shutdown().await;
         control_plane.shutdown().await;
     }

--- a/src/libraries/rust/stargate/crates/pylon/src/startup.rs
+++ b/src/libraries/rust/stargate/crates/pylon/src/startup.rs
@@ -841,6 +841,7 @@ mod tests {
         if state.calibration_request_errors {
             return StatusCode::INTERNAL_SERVER_ERROR.into_response();
         }
+        tokio::time::sleep(Duration::from_millis(20)).await;
         Json(serde_json::json!({"usage": {"completion_tokens": 1}})).into_response()
     }
 
@@ -1471,7 +1472,7 @@ mod tests {
                 "--calibration-max-concurrency",
                 "1",
                 "--bringup-calibration-timeout-ms",
-                "20",
+                "1000",
             ],
         );
         let plan = PylonStartupPlan::from_args(&args).expect("startup plan should build");
@@ -1482,13 +1483,13 @@ mod tests {
             Some("model-a")
         );
         control_plane.assert_no_calls();
-        upstream.calibration_release.add_permits(1);
+        upstream.calibration_release.add_permits(5);
         assert_eq!(
             upstream.calibration_started.recv().await.as_deref(),
             Some("model-b")
         );
         control_plane.assert_no_calls();
-        upstream.calibration_release.add_permits(1);
+        upstream.calibration_release.add_permits(5);
 
         let registration = control_plane.first_registration().await;
         assert_eq!(upstream.calibration_plans.load(Ordering::SeqCst), 2);
@@ -1502,7 +1503,7 @@ mod tests {
                 .as_ref()
                 .expect("first heartbeat should contain stats")
                 .last_mean_input_tps;
-            assert!(input_tps.is_finite());
+            assert!(input_tps.is_finite() && input_tps > 0.0);
         }
 
         startup
@@ -1530,7 +1531,7 @@ mod tests {
                 "--calibration-prompt-units",
                 "256",
                 "--bringup-calibration-timeout-ms",
-                "20",
+                "1000",
             ],
         );
         let plan = PylonStartupPlan::from_args(&args).expect("startup plan should build");
@@ -1540,7 +1541,7 @@ mod tests {
             upstream.calibration_started.recv().await.as_deref(),
             Some("model-a")
         );
-        upstream.calibration_release.add_permits(1);
+        upstream.calibration_release.add_permits(5);
         let runtime = startup
             .await
             .expect("pylon startup task should not panic")


### PR DESCRIPTION
## Why

A calibration saturation timeout was treated as successful even when the stats collector had not received enough valid samples to calculate positive input throughput. Under scheduler contention, this could advertise a calibrated model with zero throughput and made the lifecycle test timing-dependent.

Models that deliberately skip calibration must still be advertised even when no positive input TPS is configured or observed.

## What changed

- Reject calibration saturation when the flushed stats snapshot has no valid positive input throughput.
- Return the initialization error through the existing lifecycle retry and failure paths instead of publishing the generation.
- Allow startup without calibration or configured input TPS, and advertise those models with empty throughput stats.
- Keep positive finite TPS validation for explicit `--initial-input-tps` values.
- Make saturation tests wait for the intended request boundary and use virtual time where appropriate.
- Update calibration fixtures to produce the required throughput samples before simulating saturation.

## Customer Release Notes

Pylon requires valid positive throughput before advertising calibrated models. Models that skip calibration can still be advertised without positive input TPS.

## Plan Summary

Not applicable.

## Usage

Omit both `--do-calibration` and `--initial-input-tps` to advertise models without calibrated or configured input TPS.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `bazel test //src/libraries/rust/stargate/crates/pylon-lib:pylon-lib_test //src/libraries/rust/stargate/crates/pylon:pylon_test`
- High-contention reproducer: 48/48 passes on one CPU; the original test failed 36/48 runs before the fix.

No additional QA is required.

## Notes

Existing calibration outcome metrics record the new failure through the existing error outcome. No metric, span, or dashboard names changed.

## References

Closes #923

## Related Pull Requests

None.

## Dependencies

None. No license review or NOTICE update is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Models can now start in an uncalibrated mode when no initial throughput is provided.
  * Startup accepts either calibration or an initial throughput value, but not both.
  * Benchmark throughput pinning now requires an initial throughput value.

* **Bug Fixes**
  * Calibration now reports insufficient data when saturation occurs before valid throughput is measured.
  * Improved handling of calibration timeouts and delayed completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->