### PR TITLE
fix(bazel): disable caching for Docker-backed Java tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,6 +353,15 @@ change, or refactor with full existing coverage).
 
 Prefer the repo-native test runner (`make test`, `go test`, `cargo test`, etc.). Run tests before committing. Check coverage requirements in the subtree `AGENTS.md` or CI config.
 
+### Java Bazel test target contract
+
+The `manual` tag placement in `rules/java/defs.bzl` is intentional.
+`nvcf_java_test` creates the native Java target used by IntelliJ and direct test
+runs. Its companion `nvcf_java_coverage_test` remains eligible for wildcard
+selection so each suite runs once and CI receives JUnit and JaCoCo artifacts.
+Do not reverse these tags without also updating `.github/workflows/bazel.yml`,
+Java artifact staging, and `BAZEL.md`.
+
 ## Code Style
 
 Write self-documenting code. Add comments only when the logic is non-obvious. Match the existing package structure, naming, and error-handling conventions of each subtree instead of imposing a new framework.

--- a/BAZEL.md
+++ b/BAZEL.md
@@ -166,6 +166,28 @@ the target name.
 Each Java component's `BAZEL.md` shows the same mapping with names from that
 component.
 
+### Java test and coverage target selection
+
+The shared Java macros use an intentional test-selection contract:
+
+- `nvcf_java_test` creates the native `java_test` target used by IntelliJ and
+  direct test commands. The macro adds `manual` so wildcard target patterns do
+  not select it.
+- `nvcf_java_coverage_test` creates the report-producing wrapper. The macro
+  does not add `manual`, so wildcard test patterns select this target. It runs
+  the native Java target once and writes the JUnit and JaCoCo artifacts used by
+  CI.
+
+This arrangement avoids running the same suite once as a native Java test and
+again for coverage. The IntelliJ project view sets
+`allow_manual_targets_sync: true`, so the `manual` tag does not hide the native
+test target from the IDE.
+
+Do not move `manual` from `nvcf_java_test` to
+`nvcf_java_coverage_test` as an isolated cleanup. Such a change must also
+update target selection in `.github/workflows/bazel.yml`, Java artifact
+staging, and the component test documentation.
+
 Set a portable output root once per local shell:
 
 ```bash

--- a/rules/java/defs.bzl
+++ b/rules/java/defs.bzl
@@ -239,6 +239,10 @@ def nvcf_java_test(
         "resources": resources,
         "runtime_deps": test_runtime_deps,
         "size": size,
+        # Intentional: wildcard test patterns must select the companion coverage
+        # target, not this Java target, so the suite runs once and CI gets its
+        # JUnit and JaCoCo artifacts. IntelliJ imports this manual target through
+        # allow_manual_targets_sync.
         "tags": _unique(tags + ["manual"] + ([] if ide_visible else ["no-ide"])),
         "testonly": True,
         "timeout": timeout,
@@ -301,6 +305,10 @@ def nvcf_java_coverage_test(
             _JACOCO_CLI,
         ] + coverage_sourcefiles),
         size = size,
+        # Intentional: do not add manual by default. Wildcard test patterns
+        # select this report-producing wrapper. Do not reverse the manual tag
+        # placement without updating .github/workflows/bazel.yml, artifact
+        # staging, and the Java Bazel documentation together.
         tags = tags,
         timeout = timeout,
         visibility = visibility,

--- a/src/control-plane-services/api-keys/BUILD.bazel
+++ b/src/control-plane-services/api-keys/BUILD.bazel
@@ -135,6 +135,7 @@ nvcf_java_test(
     size = "large",
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     timeout = "long",
@@ -146,6 +147,7 @@ nvcf_java_coverage_test(
     size = "large",
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     test = ":tests",

--- a/src/control-plane-services/cloud-functions/nvcf-core/BUILD.bazel
+++ b/src/control-plane-services/cloud-functions/nvcf-core/BUILD.bazel
@@ -271,6 +271,7 @@ nvcf_java_test(
     size = "large",
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     timeout = "eternal",
@@ -282,6 +283,7 @@ nvcf_java_coverage_test(
     size = "large",
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     test = ":tests",

--- a/src/control-plane-services/cloud-functions/nvcf-service/BUILD.bazel
+++ b/src/control-plane-services/cloud-functions/nvcf-service/BUILD.bazel
@@ -82,6 +82,7 @@ nvcf_java_test(
     size = "large",
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     timeout = "long",
@@ -93,6 +94,7 @@ nvcf_java_coverage_test(
     size = "large",
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     test = ":tests",

--- a/src/control-plane-services/cloud-tasks/nvct-core/BUILD.bazel
+++ b/src/control-plane-services/cloud-tasks/nvct-core/BUILD.bazel
@@ -239,6 +239,7 @@ nvcf_java_test(
     size = "large",
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     timeout = "long",
@@ -250,6 +251,7 @@ nvcf_java_coverage_test(
     size = "large",
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     test = ":tests",

--- a/src/control-plane-services/cloud-tasks/nvct-service/BUILD.bazel
+++ b/src/control-plane-services/cloud-tasks/nvct-service/BUILD.bazel
@@ -79,6 +79,7 @@ nvcf_java_test(
     size = "large",
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     timeout = "long",
@@ -90,6 +91,7 @@ nvcf_java_coverage_test(
     size = "large",
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     test = ":tests",

--- a/src/control-plane-services/encrypted-secret-store/ess-core/BUILD.bazel
+++ b/src/control-plane-services/encrypted-secret-store/ess-core/BUILD.bazel
@@ -129,6 +129,7 @@ nvcf_java_test(
     srcs = ESS_CORE_TEST_SRCS,
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     deps = ESS_CORE_TEST_DEPS,
@@ -176,6 +177,7 @@ nvcf_java_test(
     srcs = ESS_CORE_TEST_SRCS,
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     deps = ESS_CORE_TEST_DEPS,
@@ -189,6 +191,7 @@ nvcf_java_coverage_test(
     size = "large",
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     test = ":integration_tests_runner",

--- a/src/control-plane-services/encrypted-secret-store/ess-encryption/BUILD.bazel
+++ b/src/control-plane-services/encrypted-secret-store/ess-encryption/BUILD.bazel
@@ -86,6 +86,7 @@ nvcf_java_test(
     srcs = ESS_ENCRYPTION_TEST_SRCS,
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     deps = ESS_ENCRYPTION_TEST_DEPS,
@@ -132,6 +133,7 @@ nvcf_java_test(
     srcs = ESS_ENCRYPTION_TEST_SRCS,
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     deps = ESS_ENCRYPTION_TEST_DEPS,
@@ -145,6 +147,7 @@ nvcf_java_coverage_test(
     size = "large",
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     test = ":base_integration_tests_runner",
@@ -169,6 +172,7 @@ nvcf_java_test(
     srcs = ESS_ENCRYPTION_TEST_SRCS,
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     deps = ESS_ENCRYPTION_TEST_DEPS,
@@ -182,6 +186,7 @@ nvcf_java_coverage_test(
     size = "large",
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     test = ":other_integration_tests_runner",

--- a/src/control-plane-services/encrypted-secret-store/ess-service/BUILD.bazel
+++ b/src/control-plane-services/encrypted-secret-store/ess-service/BUILD.bazel
@@ -58,6 +58,7 @@ nvcf_java_test(
     srcs = ESS_SERVICE_TEST_SRCS,
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     deps = [
@@ -86,6 +87,7 @@ nvcf_java_coverage_test(
     size = "large",
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     test = ":tests",

--- a/src/control-plane-services/instance-cluster-management/icms-core/BUILD.bazel
+++ b/src/control-plane-services/instance-cluster-management/icms-core/BUILD.bazel
@@ -203,6 +203,7 @@ nvcf_java_test(
     size = "large",
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     timeout = "long",
@@ -214,6 +215,7 @@ nvcf_java_coverage_test(
     size = "large",
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     test = ":tests",

--- a/src/control-plane-services/instance-cluster-management/icms-service/BUILD.bazel
+++ b/src/control-plane-services/instance-cluster-management/icms-service/BUILD.bazel
@@ -69,6 +69,7 @@ nvcf_java_test(
     resources = ICMS_SERVICE_TEST_RESOURCES,
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     timeout = "long",
@@ -79,6 +80,7 @@ nvcf_java_coverage_test(
     coverage_target = ":app_classes",
     tags = [
         "exclusive",
+        "external",
         "requires-docker",
     ],
     test = ":tests",

--- a/src/libraries/java/nv-boot-parent/nv-boot-starter-cassandra/BUILD.bazel
+++ b/src/libraries/java/nv-boot-parent/nv-boot-starter-cassandra/BUILD.bazel
@@ -62,6 +62,7 @@ nvcf_java_test(
     size = "large",
     tags = [
         "integration",
+        "external",
         "requires-docker",
     ],
     timeout = "long",
@@ -73,6 +74,7 @@ nvcf_java_coverage_test(
     size = "large",
     tags = [
         "integration",
+        "external",
         "requires-docker",
     ],
     test = ":tests",


### PR DESCRIPTION
## TL;DR

Disable Bazel test-result caching for Docker-backed Java tests so each requested
run validates the current Docker environment.

## Additional Details

### Why

The Java integration targets use Docker and Testcontainers, but their tags only
included `requires-docker`. That repository tag selects the Docker-capable CI
lane; it does not change Bazel test caching.

Docker daemon state, containers, images, networks, and port availability are
not fully represented by declared Bazel inputs. A cached result could therefore
report success without executing the test against the current Docker state.
This was identified by CodeRabbit during review of #913.

### What changed

- Add Bazel's `external` tag to all 26 Java test and coverage targets already
  tagged `requires-docker`.
- Cover API Keys, Cloud Functions, Cloud Tasks, Encrypted Secret Store,
  Instance Cluster Management, and nv-boot Cassandra targets.
- Preserve the existing `exclusive`, `integration`, and `requires-docker`
  tags.
- Keep unit-only tests cacheable.
- Document the intentional `manual` tag placement in `rules/java/defs.bzl`,
  root agent guidance, and the contributor Bazel guide so future changes
  account for CI target selection and report staging.

### Customer Release Notes

Not customer visible.

### Plan Summary

Not applicable.

### Usage

No command changes are required. Bazel will execute these Docker-backed tests
whenever they are requested while continuing to cache their build outputs.

### Testing

- Queried the expanded Bazel graph and confirmed all 26 `requires-docker` Java
  targets also contain `external`.
- Confirmed there are no `requires-docker` Java targets missing `external` in
  the affected control-plane and nv-boot-parent scopes.
- Ran `git diff --check`.
- Loaded the native Java test and coverage targets with `bazel query`.
- Ran `tools/ci/check-docs`; it passed with one advisory version-sync warning.
- Did not execute the Docker integration suites because this change only
  adjusts Bazel test-cache metadata.

### Notes

The `external` tag disables test-result caching. It does not disable compilation
or dependency caches.

The native Java tests remain `manual` by design. Wildcard target patterns run
the coverage wrappers once so CI receives JUnit and JaCoCo artifacts without
executing each suite twice.

### References

- #888

### Related Pull Requests

- #913

### Dependencies

None. No license review or NOTICE update is required.

## For the Reviewer

Verify that each added `external` tag is paired with an existing
`requires-docker` tag. Review the test-selection contract in
`rules/java/defs.bzl`, `AGENTS.md`, and `BAZEL.md` together. No test commands,
dependencies, or runtime behavior changed.

## For QA

No separate product QA is needed. This change affects Bazel test execution
policy only.

## Issues

Relates to #888

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented Java Bazel test-selection behavior, coverage reporting, artifact generation, and required updates when tagging changes.
  - Added clarifying guidance for test target and coverage wrapper tagging.

- **Build & Test Configuration**
  - Marked Java test and coverage targets across control-plane services and libraries as external.
  - Improved consistency for selecting and running external tests and integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->