### PR TITLE
fix(nvcf-api): pin the LLM worker sidecar to pylon 0.10.0

### DIFF
--- a/deploy/helm/cloud-functions/nvcf-api/values.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/values.yaml
@@ -243,7 +243,7 @@ api:
           ess-agent-container: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/ess-agent:1.3.1
           otel-collector-container: dummy
           llm-credential-manager-image: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/nvcf-worker-llm-credentials-oss:1.0.4
-          llm-router-client-image: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/pylon:0.3.2
+          llm-router-client-image: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/pylon:0.10.0
         notary:
           turn:
             enabled: true

--- a/deploy/helm/cloud-functions/tests/sidecar_release_artifacts_test.sh
+++ b/deploy/helm/cloud-functions/tests/sidecar_release_artifacts_test.sh
@@ -53,7 +53,7 @@ expected_annotations=(
   "release-artifact-niclls-container-image: \"${hostname}/${repository}/nvcf_worker_niclls:2.109.4\""
   "release-artifact-ess-agent-container-image: \"${hostname}/${repository}/ess-agent:1.3.1\""
   "release-artifact-llm-credential-manager-image: \"${hostname}/${repository}/nvcf-worker-llm-credentials-oss:1.0.4\""
-  "release-artifact-llm-router-client-image: \"${hostname}/${repository}/pylon:0.3.2\""
+  "release-artifact-llm-router-client-image: \"${hostname}/${repository}/pylon:0.10.0\""
 )
 
 for annotation in "${expected_annotations[@]}"; do


### PR DESCRIPTION
## TL;DR

Pins the `llm-worker` sidecar to `pylon:0.10.0`. The previous pin, `0.3.2`, predates the upstream health probe fix, so an LLM function whose inference container serves `/v1/health/ready` and no `/health` never completed bringup and crash-looped next to a healthy inference container.

## Additional Details

`llm-router-client-image` in `nvcf-api` values renders into the `nvcf-api-remote-config` ConfigMap, reaches the compute plane as `LLM_ROUTER_CLIENT_IMAGE`, and selects the `llm-worker` image. Pylon 0.10.0 probes `/health` then `/v1/health/ready`, reuses whichever answers, forwards the router's health RTT probe to that path, and waits for a slow-loading engine instead of exiting on the first failed probe.

Both `pylon:0.9.1` (the fix) and `pylon:0.10.0` (the fix plus #878) are published; this pins the later one.

This pin should land before nvca ships the matching translate change, which starts passing `--upstream-health-path` to the sidecar. Pylon rejects unknown arguments, so a new nvca next to an older pinned pylon would fail at startup.

## For QA

Deploy an LLM function on an engine image that serves only `/v1/health/ready` and confirm the worker pod reaches full readiness rather than 2/3.

## Issues

Relates to #906

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the LLM router service to use image version 0.10.0, providing access to the latest fixes and enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->