### PR TITLE
fix(self-managed): bump nvcf-api and grpc-proxy chart pins

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -56,7 +56,7 @@ releases:
       - template: service
 
   - name: api
-    version: 1.23.9
+    version: 1.24.1
     namespace: nvcf
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -79,7 +79,7 @@ releases:
       - nvcf/api
 
   - name: grpc-proxy
-    version: 1.6.7
+    version: 1.7.1
     namespace: nvcf
     inherit:
       - template: service


### PR DESCRIPTION
## TL;DR

Bumps two self-managed stack chart pins: `nvcf-api` `1.23.9` -> `1.24.1`, and `grpc-proxy` `1.6.7` -> `1.7.1`.

## Additional Details

`nvcf-api` 1.24.1 carries the `pylon:0.10.0` LLM worker sidecar pin from #928. Pylon 0.10.0 probes `/health` then `/v1/health/ready`, reuses whichever answers, forwards the router's health RTT probe to that path, and waits for a slow-loading engine instead of exiting on the first failed probe. Before this, an LLM function on an inference container that serves only `/v1/health/ready` never completed bringup and crash-looped at 2/3 while holding a GPU.

`grpc-proxy` 1.7.1 picks up PodDisruptionBudget support via values (1.7.0, #808) and the `ratelimiterToken` render fix for the rate-limit client (1.7.1, #905). The token is rendered from the chart's own vault-agent template, so no stack-side values change is needed.

`docs/v0.6.1/manifest.md` still references `1.23.9`; that is the published manifest for that release and is intentionally left alone.

## For QA

The nvcf-api bump requires a redeploy of any LLM function after upgrading, since the sidecar image is resolved when the deployment request is translated. Existing worker pods keep the old image.

## Issues

Relates to #906

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the API release to version 1.24.1.
  * Updated the gRPC proxy release to version 1.7.1, providing the latest available improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->