### PR TITLE
fix(event-ledger): register event-ledger in release automation

### DIFF
--- a/tools/ci/github-release-subprojects.json
+++ b/tools/ci/github-release-subprojects.json
@@ -275,6 +275,11 @@
       "service_name": "nvcf-api-keys"
     },
     {
+      "id": "event-ledger",
+      "path": "src/control-plane-services/event-ledger",
+      "service_name": "nvcf-event-ledger"
+    },
+    {
       "id": "ess",
       "path": "src/control-plane-services/encrypted-secret-store",
       "service_name": "nvcf-ess",


### PR DESCRIPTION
## Summary

- Adds `event-ledger` to `tools/ci/github-release-subprojects.json` so the release pipeline creates tags for `src/control-plane-services/event-ledger` on merge to main.

## Test plan

- [ ] Verify `release-tags` CI job picks up event-ledger after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added the `event-ledger` service to automated release processing.
  * Future releases for this service will now be included and handled consistently through the standard release workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->