### PR TITLE
fix(self-managed): bump llm stacks, nvcf-api and cassandra chart 

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
@@ -65,7 +65,7 @@ releases:
       - nats-system/nats
 
   - name: cassandra
-    version: 0.17.0
+    version: 0.19.1
     condition: cassandra.enabled # From defaults.yaml or env overrides
     namespace: cassandra-system
     <<: *dependency # Inherits base values from the dependency template

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -166,7 +166,7 @@ releases:
 
   - name: llm-request-router
     chart: nvcf/helm-nvcf-llm-request-router
-    version: 1.6.6
+    version: 1.7.2
     namespace: nvcf
     condition: addons.llm.enabled
     values:
@@ -178,7 +178,7 @@ releases:
 
   - name: llm-api-gateway
     chart: nvcf/helm-nvcf-llm-api-gateway
-    version: 1.0.1
+    version: 1.4.1
     namespace: nvcf
     condition: addons.llm.enabled
     values:


### PR DESCRIPTION
## TL;DR

Bump the self-managed stack chart pins for the LLM addon and Cassandra: llm-request-router 1.6.6 -> 1.7.2, llm-api-gateway 1.0.1 -> 1.4.1, cassandra 0.17.0 -> 0.19.1. This makes the LLM request-priority feature deployable on a stack install and picks up the recent fixes and changes in the LLM components.

## Additional Details

- llm-request-router 1.6.6 -> 1.7.2 moves the stargate image 0.3.2 -> 0.9.0.
- llm-api-gateway 1.0.1 -> 1.4.1 moves the gateway image 1.0.1 -> 0.13.0: The image tag drops numerically because images now publish from the monorepo release line.
- cassandra 0.17.0 -> 0.19.1 moves the base image off Bitnami to official Apache Cassandra (5.0.6-nv-1 -> 5.0.8-nv-0, #328), makes PodDisruptionBudget configurable via values (#808), and moves the migrations job image 0.11.0 -> 0.15.0 (#851).
- The migrations image 0.11.0 -> 0.15.0 contains: the llm_config column on nvcf_api.functions_v3 (#643), first-time publication of the event_ledger, nvcf_autoscaler, and nvct_api keyspace schemas (#207, #439), a fix for the rendered migration replica count (#414), and skipping non-directory entries under keyspaces/ (#192). All DDL is additive with IF NOT EXISTS.
- The nvcf-api chart needs no bump here: it was already moved to 1.24.1 in #929. 

## For QA

- Local sanity test: installed the stack with these pins on a local cluster; the deployment came up end to end, including the Cassandra migrations job and the LLM addon.
- Each pin verified against its release tag and traced to the image it carries.

## Issues

Relates to https://github.com/NVIDIA/nvcf/issues/852

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the self-managed deployment stack’s core platform components to newer versions.
  * Updated the Cassandra-backed data service and request-routing components for improved compatibility and access to the latest fixes and enhancements.
  * Updated the API gateway component to its latest supported release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->