### PR TITLE
fix(vanity-gateway): pin chart 0.3.0 and add the gateway service image to the manifest

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -189,7 +189,7 @@ releases:
       release-group: services
 
   - name: vanity-gateway
-    version: 0.1.0-nvcf-10204.1
+    version: 0.3.0
     namespace: nvcf
     condition: addons.vanityGateway.enabled
     inherit:

--- a/docs/user/manifest.md
+++ b/docs/user/manifest.md
@@ -130,7 +130,7 @@ The following tables list the complete artifact inventory.
 | `helm-nvcf-sis` | `1.18.3` | Required | Deploys the Spot Instance Service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-sis:1.18.3` |  |
 | `helm-nvcf-state-metrics` | `1.0.2` | Optional | Deploys NVCF state metrics for observability. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-state-metrics:1.0.2` |  |
 | `helm-nvcf-ui` | `1.1.2` | Optional | Deploys the optional NVCF UI admin panel. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-ui:1.1.2` |  |
-| `helm-nvcf-vanity-gateway` | `0.3.0` | Optional | Deploys the optional vanity hostname gateway. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-vanity-gateway:0.3.0` |  |
+| `helm-nvcf-vanity-gateway` | `0.3.0` | Optional | Deploys the optional vanity hostname gateway. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-vanity-gateway:0.3.0` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/vanity-gateway) |
 | `helm-reval` | `1.3.8` | Required | Deploys the function revalidation service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-reval:1.3.8` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/helm-reval) |
 | `nvcf-example-dashboards` | `1.6.0` | Optional | Deploys example Grafana dashboards for NVCF telemetry. | `https://helm.ngc.nvidia.com/nvidia/nvcf/nvcf-example-dashboards:1.6.0` |  |
 | `nvcf-gateway-routes` | `1.15.0` | Optional | Deploys Gateway API routes for the reference architecture. | `https://helm.ngc.nvidia.com/nvidia/nvcf/nvcf-gateway-routes:1.15.0` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/gateway-routes) |
@@ -153,7 +153,7 @@ The following tables list the complete artifact inventory.
 | `nats-server` | `2.11.17-alpine3.22` | Required | Provides messaging for function deployment and invocation. | `nvcr.io/nvidia/nvcf/nats-server:2.11.17-alpine3.22` | [Upstream](https://github.com/nats-io/nats-server) |
 | `nats-server-config-reloader` | `0.23.0` | Required | Reloads NATS server configuration when mounted settings change. | `docker.io/natsio/nats-server-config-reloader:0.23.0` | [Upstream](https://github.com/nats-io/k8s) |
 | `notary-service` | `1.8.1` | Required | Signs and validates functions and cluster nodes. | `nvcr.io/nvidia/nvcf/notary-service:1.8.1` |  |
-| `nvcf-ai-api-gateway-service` | `1.32.1` | Optional | Serves the optional vanity hostname gateway. | `nvcr.io/nvidia/nvcf/nvcf-ai-api-gateway-service:1.32.1` |  |
+| `nvcf-ai-api-gateway-service` | `1.32.1` | Optional | Serves the optional vanity hostname gateway. | `nvcr.io/nvidia/nvcf/nvcf-ai-api-gateway-service:1.32.1` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/invocation-plane-services/vanity-gateway) |
 | `nvcf-api-keys-service` | `1.5.0` | Required | Creates and manages NVCF API keys. | `nvcr.io/nvidia/nvcf/nvcf-api-keys-service:1.5.0` |  |
 | `nvcf-grpc-proxy` | `1.29.1` | Required | Proxies bidirectional gRPC traffic between the control and compute planes. | `nvcr.io/nvidia/nvcf/nvcf-grpc-proxy:1.29.1` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/invocation-plane-services/grpc-proxy) |
 | `nvcf-invocation-service` | `0.8.5` | Required | Routes stateless HTTP function invocation requests. | `nvcr.io/nvidia/nvcf/nvcf-invocation-service:0.8.5` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/invocation-plane-services/http-invocation) |

--- a/docs/user/manifest.md
+++ b/docs/user/manifest.md
@@ -130,7 +130,7 @@ The following tables list the complete artifact inventory.
 | `helm-nvcf-sis` | `1.18.3` | Required | Deploys the Spot Instance Service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-sis:1.18.3` |  |
 | `helm-nvcf-state-metrics` | `1.0.2` | Optional | Deploys NVCF state metrics for observability. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-state-metrics:1.0.2` |  |
 | `helm-nvcf-ui` | `1.1.2` | Optional | Deploys the optional NVCF UI admin panel. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-ui:1.1.2` |  |
-| `helm-nvcf-vanity-gateway` | `0.1.0-nvcf-10204.1` | Optional | Deploys the optional vanity hostname gateway. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-vanity-gateway:0.1.0-nvcf-10204.1` |  |
+| `helm-nvcf-vanity-gateway` | `0.3.0` | Optional | Deploys the optional vanity hostname gateway. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-vanity-gateway:0.3.0` |  |
 | `helm-reval` | `1.3.8` | Required | Deploys the function revalidation service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-reval:1.3.8` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/helm-reval) |
 | `nvcf-example-dashboards` | `1.6.0` | Optional | Deploys example Grafana dashboards for NVCF telemetry. | `https://helm.ngc.nvidia.com/nvidia/nvcf/nvcf-example-dashboards:1.6.0` |  |
 | `nvcf-gateway-routes` | `1.15.0` | Optional | Deploys Gateway API routes for the reference architecture. | `https://helm.ngc.nvidia.com/nvidia/nvcf/nvcf-gateway-routes:1.15.0` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/gateway-routes) |
@@ -153,6 +153,7 @@ The following tables list the complete artifact inventory.
 | `nats-server` | `2.11.17-alpine3.22` | Required | Provides messaging for function deployment and invocation. | `nvcr.io/nvidia/nvcf/nats-server:2.11.17-alpine3.22` | [Upstream](https://github.com/nats-io/nats-server) |
 | `nats-server-config-reloader` | `0.23.0` | Required | Reloads NATS server configuration when mounted settings change. | `docker.io/natsio/nats-server-config-reloader:0.23.0` | [Upstream](https://github.com/nats-io/k8s) |
 | `notary-service` | `1.8.1` | Required | Signs and validates functions and cluster nodes. | `nvcr.io/nvidia/nvcf/notary-service:1.8.1` |  |
+| `nvcf-ai-api-gateway-service` | `1.32.1` | Optional | Serves the optional vanity hostname gateway. | `nvcr.io/nvidia/nvcf/nvcf-ai-api-gateway-service:1.32.1` |  |
 | `nvcf-api-keys-service` | `1.5.0` | Required | Creates and manages NVCF API keys. | `nvcr.io/nvidia/nvcf/nvcf-api-keys-service:1.5.0` |  |
 | `nvcf-grpc-proxy` | `1.29.1` | Required | Proxies bidirectional gRPC traffic between the control and compute planes. | `nvcr.io/nvidia/nvcf/nvcf-grpc-proxy:1.29.1` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/invocation-plane-services/grpc-proxy) |
 | `nvcf-invocation-service` | `0.8.5` | Required | Routes stateless HTTP function invocation requests. | `nvcr.io/nvidia/nvcf/nvcf-invocation-service:0.8.5` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/invocation-plane-services/http-invocation) |

--- a/docs/version-catalog/main.yaml
+++ b/docs/version-catalog/main.yaml
@@ -387,6 +387,7 @@ manifest:
       kind: chart
       requirement: optional
       description: Deploys the optional vanity hostname gateway.
+      github_url: https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/vanity-gateway
     - artifact_id: nvcf-example-dashboards
       plane: control
       kind: chart
@@ -466,6 +467,7 @@ manifest:
       kind: service-image
       requirement: optional
       description: Serves the optional vanity hostname gateway.
+      github_url: https://github.com/NVIDIA/nvcf/tree/main/src/invocation-plane-services/vanity-gateway
     - artifact_id: nvcf-api-keys-service
       plane: control
       kind: service-image

--- a/docs/version-catalog/main.yaml
+++ b/docs/version-catalog/main.yaml
@@ -81,6 +81,9 @@ publications:
   - name: notary-service
     version: 1.8.1
     registry: public-images
+  - name: nvcf-ai-api-gateway-service
+    version: 1.32.1
+    registry: public-images
   - name: nvcf-api-keys-service
     version: 1.5.0
     registry: public-images
@@ -223,7 +226,7 @@ publications:
     registry: public-helm
     chart_format: http
   - name: helm-nvcf-vanity-gateway
-    version: 0.1.0-nvcf-10204.1
+    version: 0.3.0
     registry: public-helm
     chart_format: http
   - name: helm-reval
@@ -458,6 +461,11 @@ manifest:
       kind: service-image
       requirement: required
       description: Signs and validates functions and cluster nodes.
+    - artifact_id: nvcf-ai-api-gateway-service
+      plane: control
+      kind: service-image
+      requirement: optional
+      description: Serves the optional vanity hostname gateway.
     - artifact_id: nvcf-api-keys-service
       plane: control
       kind: service-image
@@ -840,7 +848,7 @@ artifacts:
   - name: helm-nvcf-vanity-gateway
     type: chart
     registry: staging
-    version: 0.1.0-nvcf-10204.1
+    version: 0.3.0
   - name: helm-reval
     type: chart
     registry: staging
@@ -963,6 +971,10 @@ supplemental_artifacts:
     registry: staging
     repository_name: stargate
     version: 0.3.2
+  - name: nvcf-ai-api-gateway-service
+    type: image
+    registry: staging
+    version: 1.32.1
   - name: nvcf-image-credential-helper
     type: image
     registry: staging


### PR DESCRIPTION
## TL;DR

Bumps the vanity-gateway Helm chart pin from `0.1.0-nvcf-10204.1` to `0.3.0` in
the self-managed stack and the published artifact manifest, and adds the image
that chart deploys, `nvcr.io/nvidia/nvcf/nvcf-ai-api-gateway-service:1.32.1`, to
the manifest. The image was never listed, so operators mirroring artifacts from
the manifest had no way to know it was required for the addon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Vanity Gateway deployment chart to version 0.3.0.
  * Added the AI API Gateway Service artifact at version 1.32.1.
  * Updated release catalogs and staging artifacts to reflect the latest versions.
  * Added source information for the Vanity Gateway artifact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->