### PR TITLE
fix(vanity-gateway): classify proxy cancellation outcomes

### DIFF
--- a/src/invocation-plane-services/vanity-gateway/README.md
+++ b/src/invocation-plane-services/vanity-gateway/README.md
@@ -374,6 +374,12 @@ dropped before replay. The `openai_model_name` label identifies the shadow
 target. The `reason` label is one of `body_read_error`, `body_rewrite_error`,
 or `concurrency_limit`.
 
+`gateway_proxy_outcome` is present only on Gateway server metrics emitted when
+the ReverseProxy ErrorHandler writes an error response. Its value is
+`client_canceled` when the inbound request is canceled before upstream response
+headers are written, or `gateway_proxy_error` for another ErrorHandler failure.
+Successful requests and upstream HTTP responses omit this label.
+
 ## Running a Local OpenAI-compatible Model
 
 Use this only when validating OpenAI-compatible request bodies against a local model server.

--- a/src/invocation-plane-services/vanity-gateway/gateway/tracing_attrs.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway/tracing_attrs.go
@@ -23,7 +23,7 @@ const (
 	traceAttrEndpointType              attribute.Key = "endpoint.type"
 	traceAttrFunctionID                attribute.Key = "function.id"
 	traceAttrFunctionVersionID         attribute.Key = "function.version_id"
-	traceAttrGatewayProxyOutcome       attribute.Key = "gateway_proxy_outcome"
+	traceAttrGatewayProxyOutcome       attribute.Key = "gateway.proxy.outcome"
 	traceAttrHTTPResponseStatusCode    attribute.Key = "http.response.status_code"
 	traceAttrIsShadow                  attribute.Key = "is_shadow"
 	traceAttrModelName                 attribute.Key = "model.name"

--- a/src/invocation-plane-services/vanity-gateway/gateway/tracing_attrs.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway/tracing_attrs.go
@@ -23,6 +23,7 @@ const (
 	traceAttrEndpointType              attribute.Key = "endpoint.type"
 	traceAttrFunctionID                attribute.Key = "function.id"
 	traceAttrFunctionVersionID         attribute.Key = "function.version_id"
+	traceAttrGatewayProxyOutcome       attribute.Key = "gateway_proxy_outcome"
 	traceAttrHTTPResponseStatusCode    attribute.Key = "http.response.status_code"
 	traceAttrIsShadow                  attribute.Key = "is_shadow"
 	traceAttrModelName                 attribute.Key = "model.name"

--- a/src/invocation-plane-services/vanity-gateway/gateway/vanity_director.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway/vanity_director.go
@@ -19,6 +19,7 @@ package gateway
 
 import (
 	config "ai-api-gateway-service/gateway_config"
+	"ai-api-gateway-service/middleware"
 	"ai-api-gateway-service/pool"
 	"bytes"
 	"context"
@@ -87,10 +88,22 @@ func clientClosedRequest(request *http.Request) bool {
 	return request != nil && errors.Is(request.Context().Err(), context.Canceled)
 }
 
+func addGatewayProxyOutcome(request *http.Request, outcome middleware.GatewayProxyOutcome) {
+	if request == nil {
+		return
+	}
+	middleware.AddGatewayProxyOutcomeMetricAttribute(request.Context(), outcome)
+	trace.SpanFromContext(request.Context()).SetAttributes(traceAttrGatewayProxyOutcome.String(string(outcome)))
+}
+
 // writeProxyError: confirmed client disconnect => 499, everything else => 502.
 func writeProxyError(writer http.ResponseWriter, request *http.Request, err error) {
 	if clientClosedRequest(request) {
-		zap.L().Warn("client closed request before upstream response", zap.Error(err))
+		addGatewayProxyOutcome(request, middleware.GatewayProxyOutcomeClientCanceled)
+		zap.L().Debug("proxy request canceled",
+			zap.String("gateway_proxy_outcome", string(middleware.GatewayProxyOutcomeClientCanceled)),
+			zap.Error(err),
+		)
 		writer.Header().Set("Content-Type", "application/problem+json")
 		writer.WriteHeader(statusClientClosedRequest)
 		_ = json.NewEncoder(writer).Encode(ProblemDetails{
@@ -104,8 +117,12 @@ func writeProxyError(writer http.ResponseWriter, request *http.Request, err erro
 	writeBadGatewayProblem(writer, request, err)
 }
 
-func writeBadGatewayProblem(writer http.ResponseWriter, _ *http.Request, err error) {
-	zap.L().Warn("proxy request failed", zap.Error(err))
+func writeBadGatewayProblem(writer http.ResponseWriter, request *http.Request, err error) {
+	addGatewayProxyOutcome(request, middleware.GatewayProxyOutcomeUpstreamTransportFailure)
+	zap.L().Warn("proxy request failed",
+		zap.String("gateway_proxy_outcome", string(middleware.GatewayProxyOutcomeUpstreamTransportFailure)),
+		zap.Error(err),
+	)
 	writer.Header().Set("Content-Type", "application/problem+json")
 	writer.WriteHeader(http.StatusBadGateway)
 	_ = json.NewEncoder(writer).Encode(ProblemDetails{

--- a/src/invocation-plane-services/vanity-gateway/gateway/vanity_director.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway/vanity_director.go
@@ -96,12 +96,13 @@ func addGatewayProxyOutcome(request *http.Request, outcome middleware.GatewayPro
 	trace.SpanFromContext(request.Context()).SetAttributes(traceAttrGatewayProxyOutcome.String(string(outcome)))
 }
 
-// writeProxyError: confirmed client disconnect => 499, everything else => 502.
+// writeProxyError maps a canceled inbound request to 499; all other ReverseProxy
+// ErrorHandler failures remain 502.
 func writeProxyError(writer http.ResponseWriter, request *http.Request, err error) {
 	if clientClosedRequest(request) {
 		addGatewayProxyOutcome(request, middleware.GatewayProxyOutcomeClientCanceled)
 		zap.L().Debug("proxy request canceled",
-			zap.String("gateway_proxy_outcome", string(middleware.GatewayProxyOutcomeClientCanceled)),
+			zap.String(string(middleware.GatewayProxyOutcomeMetricAttribute), string(middleware.GatewayProxyOutcomeClientCanceled)),
 			zap.Error(err),
 		)
 		writer.Header().Set("Content-Type", "application/problem+json")
@@ -118,9 +119,9 @@ func writeProxyError(writer http.ResponseWriter, request *http.Request, err erro
 }
 
 func writeBadGatewayProblem(writer http.ResponseWriter, request *http.Request, err error) {
-	addGatewayProxyOutcome(request, middleware.GatewayProxyOutcomeUpstreamTransportFailure)
+	addGatewayProxyOutcome(request, middleware.GatewayProxyOutcomeProxyError)
 	zap.L().Warn("proxy request failed",
-		zap.String("gateway_proxy_outcome", string(middleware.GatewayProxyOutcomeUpstreamTransportFailure)),
+		zap.String(string(middleware.GatewayProxyOutcomeMetricAttribute), string(middleware.GatewayProxyOutcomeProxyError)),
 		zap.Error(err),
 	)
 	writer.Header().Set("Content-Type", "application/problem+json")

--- a/src/invocation-plane-services/vanity-gateway/gateway/vanity_director_test.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway/vanity_director_test.go
@@ -35,6 +35,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
@@ -390,7 +392,7 @@ func TestServeExecReturnsProxyErrorAsProblemDetails(t *testing.T) {
 // A confirmed client disconnect (canceled inbound request context) is accounted
 // as 499 rather than a generic 502.
 func TestServeExecClientDisconnectReturns499(t *testing.T) {
-	core, observedLogs := observer.New(zap.WarnLevel)
+	core, observedLogs := observer.New(zap.DebugLevel)
 	undoLogger := zap.ReplaceGlobals(zap.New(core))
 	defer undoLogger()
 
@@ -424,34 +426,100 @@ func TestServeExecClientDisconnectReturns499(t *testing.T) {
 	assert.Equal(t, "Client Closed Request", pd.Title)
 	assert.Equal(t, statusClientClosedRequest, pd.Status)
 
-	assert.Len(t, observedLogs.FilterMessage("client closed request before upstream response").All(), 1)
+	assert.Len(t, observedLogs.FilterMessage("proxy request canceled").All(), 1)
+	assert.Empty(t, observedLogs.FilterMessage("proxy request failed").All())
 }
 
 // A genuine upstream transport failure (inbound context still live) stays 502.
 func TestServeExecGenuineProxyFailureReturns502(t *testing.T) {
-	director, err := NewVanityDirector("https://nvcf.example.test", roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		return nil, errors.New("connection refused")
+	for _, transportErr := range []error{
+		context.DeadlineExceeded,
+		errors.New("dial tcp: connection refused"),
+		errors.New("read: connection reset by peer"),
+	} {
+		t.Run(transportErr.Error(), func(t *testing.T) {
+			director, err := NewVanityDirector("https://nvcf.example.test", roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return nil, transportErr
+			}))
+			assert.NoError(t, err)
+
+			recorder := httptest.NewRecorder()
+			err = director.ServeExec(VanityExecRequest{FunctionID: "func-123", FunctionVersionID: "version-456"}, recorder, httptest.NewRequest("POST", "/test", nil))
+
+			assert.ErrorIs(t, err, transportErr)
+			assert.Equal(t, http.StatusBadGateway, recorder.Result().StatusCode)
+		})
+	}
+}
+
+func TestServeExecPassesThroughUpstreamBadGateway(t *testing.T) {
+	const upstreamBody = `{"error":"upstream unavailable"}`
+	upstreamServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(upstreamBody))
 	}))
-	assert.NoError(t, err)
+	t.Cleanup(upstreamServer.Close)
 
-	req := httptest.NewRequest("POST", "/test", nil)
+	director, err := NewVanityDirector(upstreamServer.URL, http.DefaultTransport)
+	require.NoError(t, err)
+
 	recorder := httptest.NewRecorder()
+	err = director.ServeExec(VanityExecRequest{FunctionID: "func-123"}, recorder, httptest.NewRequest("POST", "/test", nil))
+	require.NoError(t, err)
 
-	err = director.ServeExec(VanityExecRequest{
-		FunctionID:        "func-123",
-		FunctionVersionID: "version-456",
-	}, recorder, req)
-
-	assert.Error(t, err)
 	result := recorder.Result()
-	defer result.Body.Close()
-	assert.Equal(t, http.StatusBadGateway, result.StatusCode)
+	t.Cleanup(func() { _ = result.Body.Close() })
+	body, err := io.ReadAll(result.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadGateway, result.StatusCode)
+	require.Equal(t, upstreamBody, string(body))
+}
 
-	var pd ProblemDetails
-	err = json.NewDecoder(result.Body).Decode(&pd)
-	assert.NoError(t, err)
-	assert.Equal(t, "Bad Gateway", pd.Title)
-	assert.Equal(t, http.StatusBadGateway, pd.Status)
+func TestServeExecRecordsGatewayProxyOutcomeOnParentSpan(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+
+	for _, test := range []struct {
+		name       string
+		cancel     bool
+		proxyError error
+		outcome    middleware.GatewayProxyOutcome
+	}{
+		{
+			name:       "client canceled",
+			cancel:     true,
+			proxyError: context.Canceled,
+			outcome:    middleware.GatewayProxyOutcomeClientCanceled,
+		},
+		{
+			name:       "upstream transport failure",
+			proxyError: errors.New("connection refused"),
+			outcome:    middleware.GatewayProxyOutcomeUpstreamTransportFailure,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			director, err := NewVanityDirector("https://nvcf.example.test", roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return nil, test.proxyError
+			}))
+			require.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			ctx, span := provider.Tracer("test").Start(ctx, "gateway parent")
+			if test.cancel {
+				cancel()
+			}
+			defer cancel()
+
+			_ = director.ServeExec(VanityExecRequest{}, httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/test", nil).WithContext(ctx))
+			span.End()
+
+			spans := spanRecorder.Ended()
+			require.NotEmpty(t, spans)
+			assert.True(t, spanHasAttribute(spans[len(spans)-1].Attributes(), traceAttrGatewayProxyOutcome, string(test.outcome)))
+		})
+	}
 }
 
 func TestOfflineMessageReturns503(t *testing.T) {
@@ -544,6 +612,10 @@ func TestServeExecClientDisconnectRecords499Metric(t *testing.T) {
 	metrics := collectGatewayMetrics(t, reader)
 	assert.True(t, gatewayMetricHasStatusCode(metrics, statusClientClosedRequest),
 		"gateway must record http.server.request.duration with status_code=499 on client disconnect")
+	assert.True(t, gatewayMetricHasAttributes(metrics, map[attribute.Key]attribute.Value{
+		"http.response.status_code": attribute.Int64Value(statusClientClosedRequest),
+		"gateway_proxy_outcome":     attribute.StringValue(string(middleware.GatewayProxyOutcomeClientCanceled)),
+	}))
 	assert.False(t, gatewayMetricHasStatusCode(metrics, http.StatusBadGateway),
 		"client disconnect must not be recorded as 502")
 }
@@ -575,6 +647,10 @@ func TestServeExecGenuineFailureRecords502Metric(t *testing.T) {
 	metrics := collectGatewayMetrics(t, reader)
 	assert.True(t, gatewayMetricHasStatusCode(metrics, http.StatusBadGateway),
 		"genuine upstream failure must record status_code=502")
+	assert.True(t, gatewayMetricHasAttributes(metrics, map[attribute.Key]attribute.Value{
+		"http.response.status_code": attribute.Int64Value(http.StatusBadGateway),
+		"gateway_proxy_outcome":     attribute.StringValue(string(middleware.GatewayProxyOutcomeUpstreamTransportFailure)),
+	}))
 	assert.False(t, gatewayMetricHasStatusCode(metrics, statusClientClosedRequest),
 		"genuine upstream failure must not be recorded as 499")
 }
@@ -591,6 +667,12 @@ func collectGatewayMetrics(t *testing.T, reader sdkmetric.Reader) []metricdata.M
 }
 
 func gatewayMetricHasStatusCode(metrics []metricdata.Metrics, code int) bool {
+	return gatewayMetricHasAttributes(metrics, map[attribute.Key]attribute.Value{
+		"http.response.status_code": attribute.Int64Value(int64(code)),
+	})
+}
+
+func gatewayMetricHasAttributes(metrics []metricdata.Metrics, want map[attribute.Key]attribute.Value) bool {
 	for _, metric := range metrics {
 		if metric.Name != "http.server.request.duration" {
 			continue
@@ -600,10 +682,26 @@ func gatewayMetricHasStatusCode(metrics []metricdata.Metrics, code int) bool {
 			continue
 		}
 		for _, point := range histogram.DataPoints {
-			if value, ok := point.Attributes.Value("http.response.status_code"); ok &&
-				value == attribute.Int64Value(int64(code)) {
+			matched := true
+			for key, value := range want {
+				actual, ok := point.Attributes.Value(key)
+				if !ok || actual != value {
+					matched = false
+					break
+				}
+			}
+			if matched {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+func spanHasAttribute(attrs []attribute.KeyValue, key attribute.Key, want string) bool {
+	for _, attr := range attrs {
+		if attr.Key == key && attr.Value == attribute.StringValue(want) {
+			return true
 		}
 	}
 	return false

--- a/src/invocation-plane-services/vanity-gateway/gateway/vanity_director_test.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway/vanity_director_test.go
@@ -430,29 +430,45 @@ func TestServeExecClientDisconnectReturns499(t *testing.T) {
 	assert.Empty(t, observedLogs.FilterMessage("proxy request failed").All())
 }
 
-// A genuine upstream transport failure (inbound context still live) stays 502.
-func TestServeExecGenuineProxyFailureReturns502(t *testing.T) {
-	for _, transportErr := range []error{
-		context.DeadlineExceeded,
-		errors.New("dial tcp: connection refused"),
-		errors.New("read: connection reset by peer"),
+// A non-canceled ReverseProxy error (inbound context still live) stays 502.
+func TestServeExecProxyErrorReturns502(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		err  error
+	}{
+		{name: "deadline exceeded", err: context.DeadlineExceeded},
+		{name: "connection refused", err: errors.New("dial tcp: connection refused")},
+		{name: "connection reset", err: errors.New("read: connection reset by peer")},
 	} {
-		t.Run(transportErr.Error(), func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			director, err := NewVanityDirector("https://nvcf.example.test", roundTripFunc(func(req *http.Request) (*http.Response, error) {
-				return nil, transportErr
+				return nil, test.err
 			}))
 			assert.NoError(t, err)
 
 			recorder := httptest.NewRecorder()
 			err = director.ServeExec(VanityExecRequest{FunctionID: "func-123", FunctionVersionID: "version-456"}, recorder, httptest.NewRequest("POST", "/test", nil))
 
-			assert.ErrorIs(t, err, transportErr)
-			assert.Equal(t, http.StatusBadGateway, recorder.Result().StatusCode)
+			assert.ErrorIs(t, err, test.err)
+			result := recorder.Result()
+			t.Cleanup(func() { _ = result.Body.Close() })
+			assert.Equal(t, http.StatusBadGateway, result.StatusCode)
+
+			var pd ProblemDetails
+			require.NoError(t, json.NewDecoder(result.Body).Decode(&pd))
+			assert.Equal(t, "about:blank", pd.Type)
+			assert.Equal(t, "Bad Gateway", pd.Title)
+			assert.Equal(t, http.StatusBadGateway, pd.Status)
+			assert.Equal(t, "Upstream request failed.", pd.Detail)
 		})
 	}
 }
 
 func TestServeExecPassesThroughUpstreamBadGateway(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+
 	const upstreamBody = `{"error":"upstream unavailable"}`
 	upstreamServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -465,8 +481,12 @@ func TestServeExecPassesThroughUpstreamBadGateway(t *testing.T) {
 	require.NoError(t, err)
 
 	recorder := httptest.NewRecorder()
-	err = director.ServeExec(VanityExecRequest{FunctionID: "func-123"}, recorder, httptest.NewRequest("POST", "/test", nil))
-	require.NoError(t, err)
+	handler := middleware.ServerTelemetryMiddleware(otelhttp.WithMeterProvider(provider))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, director.ServeExec(VanityExecRequest{FunctionID: "func-123"}, w, r))
+		}),
+	)
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/test", nil))
 
 	result := recorder.Result()
 	t.Cleanup(func() { _ = result.Body.Close() })
@@ -474,6 +494,12 @@ func TestServeExecPassesThroughUpstreamBadGateway(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadGateway, result.StatusCode)
 	require.Equal(t, upstreamBody, string(body))
+
+	metrics := collectGatewayMetrics(t, reader)
+	require.True(t, gatewayMetricHasAttributeAbsent(metrics, map[attribute.Key]attribute.Value{
+		"http.request.method":       attribute.StringValue(http.MethodPost),
+		"http.response.status_code": attribute.Int64Value(http.StatusBadGateway),
+	}, middleware.GatewayProxyOutcomeMetricAttribute))
 }
 
 func TestServeExecRecordsGatewayProxyOutcomeOnParentSpan(t *testing.T) {
@@ -482,42 +508,66 @@ func TestServeExecRecordsGatewayProxyOutcomeOnParentSpan(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
 
 	for _, test := range []struct {
-		name       string
-		cancel     bool
-		proxyError error
-		outcome    middleware.GatewayProxyOutcome
+		name        string
+		cancel      bool
+		proxyError  error
+		outcome     middleware.GatewayProxyOutcome
+		wantOutcome bool
 	}{
 		{
-			name:       "client canceled",
-			cancel:     true,
-			proxyError: context.Canceled,
-			outcome:    middleware.GatewayProxyOutcomeClientCanceled,
+			name:        "client canceled",
+			cancel:      true,
+			proxyError:  context.Canceled,
+			outcome:     middleware.GatewayProxyOutcomeClientCanceled,
+			wantOutcome: true,
 		},
 		{
-			name:       "upstream transport failure",
-			proxyError: errors.New("connection refused"),
-			outcome:    middleware.GatewayProxyOutcomeUpstreamTransportFailure,
+			name:        "proxy error",
+			proxyError:  errors.New("connection refused"),
+			outcome:     middleware.GatewayProxyOutcomeProxyError,
+			wantOutcome: true,
+		},
+		{
+			name: "upstream response",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			director, err := NewVanityDirector("https://nvcf.example.test", roundTripFunc(func(req *http.Request) (*http.Response, error) {
-				return nil, test.proxyError
+				if test.proxyError != nil {
+					return nil, test.proxyError
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(bytes.NewReader(nil)),
+				}, nil
 			}))
 			require.NoError(t, err)
 
 			ctx, cancel := context.WithCancel(context.Background())
-			ctx, span := provider.Tracer("test").Start(ctx, "gateway parent")
+			defer cancel()
+			ctx, span := provider.Tracer("test").Start(ctx, test.name)
 			if test.cancel {
 				cancel()
 			}
-			defer cancel()
 
-			_ = director.ServeExec(VanityExecRequest{}, httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/test", nil).WithContext(ctx))
-			span.End()
+			func() {
+				defer span.End()
+				err = director.ServeExec(VanityExecRequest{}, httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/test", nil).WithContext(ctx))
+			}()
 
-			spans := spanRecorder.Ended()
-			require.NotEmpty(t, spans)
-			assert.True(t, spanHasAttribute(spans[len(spans)-1].Attributes(), traceAttrGatewayProxyOutcome, string(test.outcome)))
+			if test.proxyError != nil {
+				require.ErrorIs(t, err, test.proxyError)
+			} else {
+				require.NoError(t, err)
+			}
+
+			endedSpan := endedSpanByName(t, spanRecorder, test.name)
+			if test.wantOutcome {
+				assert.True(t, spanHasAttribute(endedSpan.Attributes(), traceAttrGatewayProxyOutcome, string(test.outcome)))
+			} else {
+				assert.False(t, spanHasAttributeKey(endedSpan.Attributes(), traceAttrGatewayProxyOutcome))
+			}
 		})
 	}
 }
@@ -620,9 +670,9 @@ func TestServeExecClientDisconnectRecords499Metric(t *testing.T) {
 		"client disconnect must not be recorded as 502")
 }
 
-// A genuine upstream transport failure (inbound context still live) must be
+// A non-canceled ReverseProxy error (inbound context still live) must be
 // recorded as 502, not 499.
-func TestServeExecGenuineFailureRecords502Metric(t *testing.T) {
+func TestServeExecProxyErrorRecords502Metric(t *testing.T) {
 	reader := sdkmetric.NewManualReader()
 	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
@@ -646,13 +696,13 @@ func TestServeExecGenuineFailureRecords502Metric(t *testing.T) {
 
 	metrics := collectGatewayMetrics(t, reader)
 	assert.True(t, gatewayMetricHasStatusCode(metrics, http.StatusBadGateway),
-		"genuine upstream failure must record status_code=502")
+		"proxy error must record status_code=502")
 	assert.True(t, gatewayMetricHasAttributes(metrics, map[attribute.Key]attribute.Value{
-		"http.response.status_code": attribute.Int64Value(http.StatusBadGateway),
-		"gateway_proxy_outcome":     attribute.StringValue(string(middleware.GatewayProxyOutcomeUpstreamTransportFailure)),
+		"http.response.status_code":                   attribute.Int64Value(http.StatusBadGateway),
+		middleware.GatewayProxyOutcomeMetricAttribute: attribute.StringValue(string(middleware.GatewayProxyOutcomeProxyError)),
 	}))
 	assert.False(t, gatewayMetricHasStatusCode(metrics, statusClientClosedRequest),
-		"genuine upstream failure must not be recorded as 499")
+		"proxy error must not be recorded as 499")
 }
 
 func collectGatewayMetrics(t *testing.T, reader sdkmetric.Reader) []metricdata.Metrics {
@@ -698,6 +748,35 @@ func gatewayMetricHasAttributes(metrics []metricdata.Metrics, want map[attribute
 	return false
 }
 
+func gatewayMetricHasAttributeAbsent(metrics []metricdata.Metrics, want map[attribute.Key]attribute.Value, absent attribute.Key) bool {
+	for _, metric := range metrics {
+		if metric.Name != "http.server.request.duration" {
+			continue
+		}
+		histogram, ok := metric.Data.(metricdata.Histogram[float64])
+		if !ok {
+			continue
+		}
+		for _, point := range histogram.DataPoints {
+			matched := true
+			for key, value := range want {
+				actual, ok := point.Attributes.Value(key)
+				if !ok || actual != value {
+					matched = false
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+			if _, ok := point.Attributes.Value(absent); !ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func spanHasAttribute(attrs []attribute.KeyValue, key attribute.Key, want string) bool {
 	for _, attr := range attrs {
 		if attr.Key == key && attr.Value == attribute.StringValue(want) {
@@ -705,4 +784,24 @@ func spanHasAttribute(attrs []attribute.KeyValue, key attribute.Key, want string
 		}
 	}
 	return false
+}
+
+func spanHasAttributeKey(attrs []attribute.KeyValue, key attribute.Key) bool {
+	for _, attr := range attrs {
+		if attr.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+func endedSpanByName(t *testing.T, recorder *tracetest.SpanRecorder, name string) sdktrace.ReadOnlySpan {
+	t.Helper()
+	for _, span := range recorder.Ended() {
+		if span.Name() == name {
+			return span
+		}
+	}
+	require.FailNow(t, "span not found", name)
+	return nil
 }

--- a/src/invocation-plane-services/vanity-gateway/middleware/metrics_test.go
+++ b/src/invocation-plane-services/vanity-gateway/middleware/metrics_test.go
@@ -83,11 +83,31 @@ func TestServerTelemetryMiddlewareRecordsStatusAndRouteMetrics(t *testing.T) {
 		"function_id":               attribute.StringValue("func-123"),
 	}))
 	require.True(t, hasMetricPointWithAttributes(metrics, "http.server.request.duration", map[attribute.Key]attribute.Value{
-		"http.request.method":       attribute.StringValue(http.MethodPost),
-		"http.response.status_code": attribute.Int64Value(499),
-		"http.route":                attribute.StringValue("/v1/chat/canceled"),
-		"gateway_proxy_outcome":     attribute.StringValue(string(GatewayProxyOutcomeClientCanceled)),
+		"http.request.method":              attribute.StringValue(http.MethodPost),
+		"http.response.status_code":        attribute.Int64Value(499),
+		"http.route":                       attribute.StringValue("/v1/chat/canceled"),
+		GatewayProxyOutcomeMetricAttribute: attribute.StringValue(string(GatewayProxyOutcomeClientCanceled)),
 	}))
+
+	for _, want := range []map[attribute.Key]attribute.Value{
+		{
+			"http.request.method":       attribute.StringValue(http.MethodGet),
+			"http.response.status_code": attribute.Int64Value(http.StatusTooManyRequests),
+			"http.route":                attribute.StringValue("/limited"),
+		},
+		{
+			"http.request.method":       attribute.StringValue(http.MethodGet),
+			"http.response.status_code": attribute.Int64Value(http.StatusGatewayTimeout),
+			"http.route":                attribute.StringValue("/requests/{requestId}"),
+		},
+		{
+			"http.request.method":       attribute.StringValue(http.MethodPost),
+			"http.response.status_code": attribute.Int64Value(http.StatusAccepted),
+			"http.route":                attribute.StringValue("/v1/chat/completions"),
+		},
+	} {
+		require.True(t, hasMetricPointWithoutAttribute(metrics, "http.server.request.duration", want, GatewayProxyOutcomeMetricAttribute))
+	}
 }
 
 func TestHTTPDurationHistogramBoundaries(t *testing.T) {
@@ -136,6 +156,15 @@ func TestAddOpenAIRequestMetricAttributesCopiesModelName(t *testing.T) {
 	runtime.KeepAlive(backing)
 }
 
+func TestAddGatewayProxyOutcomeMetricAttributeRejectsUnknownOutcome(t *testing.T) {
+	labeler := &otelhttp.Labeler{}
+	ctx := otelhttp.ContextWithLabeler(context.Background(), labeler)
+
+	AddGatewayProxyOutcomeMetricAttribute(ctx, GatewayProxyOutcome("unknown"))
+
+	require.Empty(t, labeler.Get())
+}
+
 func serve(handler http.Handler, method, path string) {
 	req := httptest.NewRequest(method, path, nil)
 	rec := httptest.NewRecorder()
@@ -162,6 +191,26 @@ func hasMetricPointWithAttributes(metrics []metricdata.Metrics, name string, wan
 		}
 		if histogramHasAttributes(metric.Data, want) {
 			return true
+		}
+	}
+	return false
+}
+
+func hasMetricPointWithoutAttribute(metrics []metricdata.Metrics, name string, want map[attribute.Key]attribute.Value, absent attribute.Key) bool {
+	for _, metric := range metrics {
+		if metric.Name != name {
+			continue
+		}
+		switch histogram := metric.Data.(type) {
+		case metricdata.Histogram[float64]:
+			for _, point := range histogram.DataPoints {
+				if !dataPointHasAttributes(point.Attributes, want) {
+					continue
+				}
+				if _, ok := point.Attributes.Value(absent); !ok {
+					return true
+				}
+			}
 		}
 	}
 	return false

--- a/src/invocation-plane-services/vanity-gateway/middleware/metrics_test.go
+++ b/src/invocation-plane-services/vanity-gateway/middleware/metrics_test.go
@@ -53,10 +53,15 @@ func TestServerTelemetryMiddlewareRecordsStatusAndRouteMetrics(t *testing.T) {
 		AddOpenAIRequestMetricAttributes(r.Context(), "meta/llama-3", "func-123")
 		w.WriteHeader(http.StatusAccepted)
 	})
+	r.Post("/v1/chat/canceled", func(w http.ResponseWriter, r *http.Request) {
+		AddGatewayProxyOutcomeMetricAttribute(r.Context(), GatewayProxyOutcomeClientCanceled)
+		w.WriteHeader(499)
+	})
 
 	serve(r, http.MethodGet, "/limited")
 	serve(r, http.MethodGet, "/requests/abc123")
 	serve(r, http.MethodPost, "/v1/chat/completions")
+	serve(r, http.MethodPost, "/v1/chat/canceled")
 
 	metrics := collectMetrics(t, reader)
 
@@ -76,6 +81,12 @@ func TestServerTelemetryMiddlewareRecordsStatusAndRouteMetrics(t *testing.T) {
 		"http.route":                attribute.StringValue("/v1/chat/completions"),
 		"openai_model_name":         attribute.StringValue("meta/llama-3"),
 		"function_id":               attribute.StringValue("func-123"),
+	}))
+	require.True(t, hasMetricPointWithAttributes(metrics, "http.server.request.duration", map[attribute.Key]attribute.Value{
+		"http.request.method":       attribute.StringValue(http.MethodPost),
+		"http.response.status_code": attribute.Int64Value(499),
+		"http.route":                attribute.StringValue("/v1/chat/canceled"),
+		"gateway_proxy_outcome":     attribute.StringValue(string(GatewayProxyOutcomeClientCanceled)),
 	}))
 }
 

--- a/src/invocation-plane-services/vanity-gateway/middleware/middleware.go
+++ b/src/invocation-plane-services/vanity-gateway/middleware/middleware.go
@@ -31,16 +31,16 @@ const (
 	serverOperationName = "vanity-gateway"
 	unknownHTTPRoute    = "unknown"
 
-	openAIModelNameAttribute     attribute.Key = "openai_model_name"
-	functionIDAttribute          attribute.Key = "function_id"
-	gatewayProxyOutcomeAttribute attribute.Key = "gateway_proxy_outcome"
+	openAIModelNameAttribute           attribute.Key = "openai_model_name"
+	functionIDAttribute                attribute.Key = "function_id"
+	GatewayProxyOutcomeMetricAttribute attribute.Key = "gateway_proxy_outcome"
 )
 
 type GatewayProxyOutcome string
 
 const (
-	GatewayProxyOutcomeClientCanceled           GatewayProxyOutcome = "client_canceled"
-	GatewayProxyOutcomeUpstreamTransportFailure GatewayProxyOutcome = "upstream_transport_failure"
+	GatewayProxyOutcomeClientCanceled GatewayProxyOutcome = "client_canceled"
+	GatewayProxyOutcomeProxyError     GatewayProxyOutcome = "gateway_proxy_error"
 )
 
 var spanNameFormatter = otelhttp.WithSpanNameFormatter(func(operation string, r *http.Request) string {
@@ -89,7 +89,10 @@ func AddFunctionIDMetricAttribute(ctx context.Context, functionID string) {
 }
 
 func AddGatewayProxyOutcomeMetricAttribute(ctx context.Context, outcome GatewayProxyOutcome) {
-	addRequestMetricAttributes(ctx, gatewayProxyOutcomeAttribute.String(string(outcome)))
+	switch outcome {
+	case GatewayProxyOutcomeClientCanceled, GatewayProxyOutcomeProxyError:
+		addRequestMetricAttributes(ctx, GatewayProxyOutcomeMetricAttribute.String(string(outcome)))
+	}
 }
 
 func addRequestMetricAttributes(ctx context.Context, attrs ...attribute.KeyValue) {

--- a/src/invocation-plane-services/vanity-gateway/middleware/middleware.go
+++ b/src/invocation-plane-services/vanity-gateway/middleware/middleware.go
@@ -31,8 +31,16 @@ const (
 	serverOperationName = "vanity-gateway"
 	unknownHTTPRoute    = "unknown"
 
-	openAIModelNameAttribute attribute.Key = "openai_model_name"
-	functionIDAttribute      attribute.Key = "function_id"
+	openAIModelNameAttribute     attribute.Key = "openai_model_name"
+	functionIDAttribute          attribute.Key = "function_id"
+	gatewayProxyOutcomeAttribute attribute.Key = "gateway_proxy_outcome"
+)
+
+type GatewayProxyOutcome string
+
+const (
+	GatewayProxyOutcomeClientCanceled           GatewayProxyOutcome = "client_canceled"
+	GatewayProxyOutcomeUpstreamTransportFailure GatewayProxyOutcome = "upstream_transport_failure"
 )
 
 var spanNameFormatter = otelhttp.WithSpanNameFormatter(func(operation string, r *http.Request) string {
@@ -78,6 +86,10 @@ func AddFunctionIDMetricAttribute(ctx context.Context, functionID string) {
 		return
 	}
 	addRequestMetricAttributes(ctx, functionIDAttribute.String(functionID))
+}
+
+func AddGatewayProxyOutcomeMetricAttribute(ctx context.Context, outcome GatewayProxyOutcome) {
+	addRequestMetricAttributes(ctx, gatewayProxyOutcomeAttribute.String(string(outcome)))
 }
 
 func addRequestMetricAttributes(ctx context.Context, attrs ...attribute.KeyValue) {


### PR DESCRIPTION
## Why

Canceled inbound requests were grouped with other ReverseProxy ErrorHandler failures in Gateway 502 telemetry. This obscured whether a request was canceled before an upstream response or failed elsewhere in proxy handling.

## What changed

- Add a bounded `gateway_proxy_outcome` label to Gateway server metrics and the matching `gateway.proxy.outcome` parent-span attribute.
- Mark cancellations that reach the ReverseProxy ErrorHandler before upstream response headers are written as `client_canceled`. Label all other ErrorHandler failures as `gateway_proxy_error`.
- Log cancelled proxy work at debug level and retain warning logs for other proxy errors.
- Document the label values and assert that successful and upstream-response pass-through requests omit the label.
- Add coverage for cancellation, deadline, connection errors, upstream 502 pass-through, metric labels, and trace attributes.

## Customer Release Notes

Gateway telemetry identifies pre-response canceled proxy requests and other proxy ErrorHandler failures. Cancellations after response headers are committed remain streaming connection teardown and are not labeled by `gateway_proxy_outcome`.

## Plan Summary

Not applicable.

## Usage

Not applicable.

## Testing

- `go test ./gateway ./middleware`
- `bazel test //src/invocation-plane-services/vanity-gateway/gateway:gateway_test //src/invocation-plane-services/vanity-gateway/middleware:middleware_test --flaky_test_attempts=3`

The full `bazel test //...` is blocked before Gateway tests by an unrelated BYOO OpenTelemetry collector genrule that cannot find a host Go binary.

## Notes

The 499 response is telemetry-only. A disconnected caller cannot receive it.

## References

None. Internal tracking is maintained separately.

## Related Merge Requests/Pull Requests

None.

## Dependencies

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gateway proxy outcome telemetry to distinguish client-canceled requests from proxy errors.
  * Recorded recognized outcomes in gateway metrics and traces.
  * Preserved upstream bad-gateway responses while separately tracking proxy failures.
* **Bug Fixes**
  * Client cancellations now return status 499, while other proxy failures return status 502.
  * Reduced cancellation log severity to avoid treating expected disconnects as warnings.
* **Documentation**
  * Documented gateway proxy outcome labels and when they appear in metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->