### PR TITLE
fix(self-managed): install LLM PKI issuer

### DIFF
--- a/deploy/stacks/self-managed/Makefile
+++ b/deploy/stacks/self-managed/Makefile
@@ -4,4 +4,5 @@ include Makefile.dist
 .PHONY: test
 test:
 	@tests/llm-router-worker-address.sh
+	@tests/llm-pki-release.sh
 	@tests/pdb-value-wiring.sh

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -164,6 +164,29 @@ releases:
     labels:
       release-group: services
 
+  - name: nvcf-pki
+    chart: nvcf/helm-nvcf-pki
+    version: 0.1.0
+    namespace: cert-manager
+    condition: addons.llm.pki.enabled
+    values:
+      - clusterIssuer:
+          enabled: true
+          name: {{ dig "addons" "llm" "pki" "issuerName" "nvcf-openbao-pki" .Values | quote }}
+          server: {{ dig "addons" "llm" "pki" "issuerServer" "http://openbao-server.vault-system.svc.cluster.local:8200" .Values | quote }}
+          path: {{ dig "addons" "llm" "pki" "issuerPath" "services/all/pki/nvcf-service-issuing/sign/nvcf-service-server" .Values | quote }}
+          auth:
+            mountPath: {{ dig "addons" "llm" "pki" "issuerAuthMountPath" "/v1/auth/jwt" .Values | quote }}
+            role: {{ dig "addons" "llm" "pki" "issuerAuthRole" "cert-manager" .Values | quote }}
+            serviceAccount:
+              name: {{ dig "addons" "llm" "pki" "issuerServiceAccountName" "cert-manager" .Values | quote }}
+              audience: {{ dig "addons" "llm" "pki" "issuerAudience" "http://openbao-server.vault-system.svc.cluster.local:8200" .Values | quote }}
+    needs:
+      - cert-manager/cert-manager
+      - vault-system/openbao-server
+    labels:
+      release-group: services
+
   - name: llm-request-router
     chart: nvcf/helm-nvcf-llm-request-router
     version: 1.6.6
@@ -173,6 +196,7 @@ releases:
       - ../global.yaml.gotmpl
     needs:
       - nvcf/api
+      - cert-manager/nvcf-pki
     labels:
       release-group: services
 

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -181,9 +181,6 @@ releases:
             serviceAccount:
               name: {{ dig "addons" "llm" "pki" "issuerServiceAccountName" "cert-manager" .Values | quote }}
               audience: {{ dig "addons" "llm" "pki" "issuerAudience" "http://openbao-server.vault-system.svc.cluster.local:8200" .Values | quote }}
-    needs:
-      - cert-manager/cert-manager
-      - vault-system/openbao-server
     labels:
       release-group: services
 

--- a/deploy/stacks/self-managed/tests/llm-pki-release.sh
+++ b/deploy/stacks/self-managed/tests/llm-pki-release.sh
@@ -49,6 +49,18 @@ releases="$(
       list 2>/dev/null
 )"
 
+release_definition="$(
+  awk '
+    /^  - name: nvcf-pki$/ { in_release = 1 }
+    in_release && /^  - name: / && $0 != "  - name: nvcf-pki" { exit }
+    in_release { print }
+  ' "$test_stack_dir/helmfile.d/02-core.yaml.gotmpl"
+)"
+
+if printf '%s\n' "$release_definition" | grep -q '^    needs:$'; then
+  fail "LLM PKI cannot depend on releases owned by another Helmfile state"
+fi
+
 test "$(printf '%s\n' "$releases" | awk 'NR > 1 && $1 == "nvcf-pki" && $2 == "cert-manager" { count++ } END { print count + 0 }')" = "1" ||
   fail "LLM PKI did not install exactly one nvcf-pki release in cert-manager"
 

--- a/deploy/stacks/self-managed/tests/llm-pki-release.sh
+++ b/deploy/stacks/self-managed/tests/llm-pki-release.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+work_dir="$(mktemp -d)"
+test_stack_dir="$work_dir/self-managed"
+environment_name="llm-pki-release-test"
+environment_file="$test_stack_dir/environments/$environment_name.yaml"
+secrets_file="$test_stack_dir/secrets/$environment_name-secrets.yaml"
+trap 'rm -rf "$work_dir"' EXIT
+
+fail() {
+  echo "llm-pki-release: $*" >&2
+  exit 1
+}
+
+mkdir -p "$test_stack_dir"
+cp -R "$stack_dir"/. "$test_stack_dir"
+printf '{}\n' >"$secrets_file"
+
+cat >"$environment_file" <<'EOF'
+global:
+  image:
+    registry: nvcr.io
+    repository: test/nvcf
+addons:
+  llm:
+    enabled: true
+    pki:
+      enabled: true
+      allowedDomains: cluster.local
+      dnsNames:
+        - llm-request-router.nvcf.svc.cluster.local
+      image:
+        tag: 0.16.2
+EOF
+
+releases="$(
+  HELMFILE_ENV="$environment_name" \
+    HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" \
+    helmfile \
+      --file "$test_stack_dir/helmfile.d/02-core.yaml.gotmpl" \
+      --environment default \
+      --state-values-set ingress.gatewayApi.controllerNamespace=envoy-gateway-system \
+      --state-values-set ingress.gatewayApi.gateways.shared.name=shared-gw \
+      --state-values-set ingress.gatewayApi.gateways.shared.namespace=envoy-gateway-system \
+      --state-values-set ingress.gatewayApi.gateways.grpc.name=grpc-gw \
+      --state-values-set ingress.gatewayApi.gateways.grpc.namespace=envoy-gateway-system \
+      list 2>/dev/null
+)"
+
+test "$(printf '%s\n' "$releases" | awk 'NR > 1 && $1 == "nvcf-pki" && $2 == "cert-manager" { count++ } END { print count + 0 }')" = "1" ||
+  fail "LLM PKI did not install exactly one nvcf-pki release in cert-manager"
+
+echo "llm-pki-release: all checks passed"


### PR DESCRIPTION
## Why

A self-managed LLM deployment with PKI enabled creates a router TLS Certificate that references `nvcf-openbao-pki`, but the core Helmfile did not install that ClusterIssuer. The router could not obtain its mounted server identity.

## What changed

Installs the `nvcf-pki` chart in the self-managed core state when LLM PKI is enabled. Makes the LLM request router depend on that in-state release. Adds a focused Helmfile regression check that prevents cross-state dependency edges.

## Customer Release Notes

Self-managed LLM PKI deployments now install the issuer required for the request router TLS certificate.

## Plan Summary

Adds one conditional `nvcf-pki` Helm release in the `cert-manager` namespace. No infrastructure resources outside the existing self-managed stack are added.

## Usage

Enable `addons.llm.pki.enabled`; the core stack installs `nvcf-openbao-pki` before the LLM request router.

## Testing

Ran:

- `bash deploy/stacks/self-managed/tests/llm-pki-release.sh`
- `helm lint deploy/helm/nvcf-pki`
- `helm template nvcf-pki deploy/helm/nvcf-pki`
- `deploy/helm/nvcf-pki/scripts/check-render.sh`
- `deploy/helm/llm-request-router/scripts/check-pki-render.sh`
- `git diff --check origin/main...HEAD`

## Notes

This is split from #777 so the self-managed bootstrap fix can be reviewed and merged independently.

## References

Closes #943

## Related Pull Requests

#777

## Dependencies

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional PKI release for self-managed deployments, with configurable OpenBao integration settings.
  * Updated the LLM request router deployment to wait for PKI setup when enabled.

* **Bug Fixes**
  * Added validation to ensure the PKI release is installed once in the correct namespace and has no unsupported dependencies.

* **Tests**
  * Expanded self-managed deployment testing to include the LLM PKI release configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->