### PR TITLE
ci: scope the dependency docs check to its real inputs

### DIFF
--- a/.github/workflows/license-dependencies.yml
+++ b/.github/workflows/license-dependencies.yml
@@ -52,17 +52,56 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ github.token }}
     steps:
+      # Full history so the merge base with the target branch is reachable.
+      # A shallow clone leaves the three-dot diff below with nothing to
+      # compare against, which the scope script then reads as "unknown" and
+      # answers "true", so a mistake here costs time rather than coverage.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      # The job always runs and always reports, so branch protection needs no
+      # companion no-op and no change. Only the expensive steps below are
+      # scoped. On a pull request touching no dependency manifest they are all
+      # skipped and the job finishes in seconds instead of about nine minutes.
+      #
+      # Pull requests only. A push to main, a merge queue entry and a manual
+      # dispatch always run in full, so the default branch is never validated
+      # against a narrowed view of itself.
+      - name: Decide whether dependency docs can have changed
+        id: scope
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "run=true" >> "${GITHUB_OUTPUT}"
+            echo "[scope] ${{ github.event_name }}: running in full"
+            exit 0
+          fi
+          base="origin/${{ github.base_ref }}"
+          # Do not let a failed diff look like an empty change set: feeding no
+          # paths to the scope script makes it answer "true".
+          changed="$(git diff --name-only "${base}...HEAD" || true)"
+          decision="$(printf '%s\n' "${changed}" | ./tools/ci/dependency-docs-scope)"
+          echo "run=${decision}" >> "${GITHUB_OUTPUT}"
+          if [ "${decision}" = "true" ]; then
+            echo "[scope] dependency inputs changed; running the full check"
+          else
+            echo "[scope] no dependency inputs changed; skipping the full check"
+            printf '%s\n' "${changed}" | sed 's/^/  /'
+          fi
+
+      - if: steps.scope.outputs.run == 'true'
+        uses: actions/setup-go@v5
         with:
           go-version-file: tools/go-toolchain/go.mod
 
-      - uses: actions/setup-python@v5
+      - if: steps.scope.outputs.run == 'true'
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
-      - uses: actions/setup-java@v4
+      - if: steps.scope.outputs.run == 'true'
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '25'
@@ -70,6 +109,7 @@ jobs:
       # The dependency collector builds each registered Java component's
       # runtime inventory. Bazelisk honors the repository's .bazelversion.
       - name: Install Bazelisk
+        if: steps.scope.outputs.run == 'true'
         run: |
           mkdir -p "${RUNNER_TEMP}/bin"
           curl -fsSLo "${RUNNER_TEMP}/bin/bazel" \
@@ -92,6 +132,7 @@ jobs:
       # This mirrors the remote-cache policy in tools/ci/bazel-cache-upload-mode:
       # untrusted refs read, they do not write.
       - name: Restore Bazel repository and disk caches
+        if: steps.scope.outputs.run == 'true'
         uses: actions/cache/restore@v4
         with:
           path: |
@@ -105,10 +146,11 @@ jobs:
             dependency-docs-bazel-
 
       - name: Run dependency docs freshness check
+        if: steps.scope.outputs.run == 'true'
         run: ./tools/ci/check-dependency-docs
 
       - name: Save Bazel repository and disk caches
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: steps.scope.outputs.run == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/cache/save@v4
         with:
           path: |

--- a/tools/ci/dependency-docs-scope
+++ b/tools/ci/dependency-docs-scope
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Decide whether a change can affect generated dependency docs.
+# Reads changed repository paths on stdin, one per line.
+# Prints "true" or "false" on stdout.
+#
+# dependencies.md is produced by tools/collect-dependencies from dependency
+# manifests, so a change touching none of them cannot alter it. Regenerating
+# anyway costs about nine minutes per pull request, most of it spent building
+# each Java component's runtime inventory through Bazel.
+#
+# This fails closed. Anything unrecognised, and any failure to determine the
+# changed set, yields "true". A wrong "false" lets dependencies.md go stale
+# with a green check, which is the failure this whole job exists to catch; a
+# wrong "true" only costs time.
+#
+# The Java rule is the subtle one. java_deps.go builds runtime_inventory.json
+# through Bazel, so the inventory follows the build graph, not just
+# maven_install.json: moving an artifact between compile and runtime deps in a
+# Java component's BUILD.bazel changes the output with no manifest touched.
+# So BUILD.bazel and *.bzl count, but only under a registered Java component
+# root. That keeps a BUILD.bazel edit in a Go or Rust subtree out of scope,
+# which is the common case.
+#
+# Component roots are discovered from bazel-java-ci.json rather than listed
+# here, so a new Java service is covered the day it is added and this script
+# cannot drift out of date.
+#
+# This lives in a script rather than inline in
+# .github/workflows/license-dependencies.yml so the decision is testable; see
+# tools/ci/test-dependency-docs-scope.
+set -euo pipefail
+
+root="."
+if [ "${1:-}" = "--root" ]; then
+    root="${2:?--root needs a directory}"
+fi
+
+# Paths whose content feeds the generator directly, or which change how it runs.
+exact_paths=(
+    "imports.yaml"
+    "dependencies.md"
+    "MODULE.bazel"
+    "MODULE.bazel.lock"
+    "maven_install.json"
+    ".bazelversion"
+    ".github/workflows/license-dependencies.yml"
+    "tools/ci/check-dependency-docs"
+    "tools/ci/dependency-docs-scope"
+    "tools/ci/test-dependency-docs-scope"
+)
+
+# Manifest file names, matched anywhere in the tree.
+manifest_names=(
+    "go.mod"
+    "go.sum"
+    "Cargo.toml"
+    "pom.xml"
+    "bazel-java-ci.json"
+    "pyproject.toml"
+    "pnpm-lock.yaml"
+    "Chart.yaml"
+    "Chart.lock"
+)
+
+# Registered Java component roots, as repository-relative directory prefixes.
+java_roots=()
+while IFS= read -r descriptor; do
+    [ -n "${descriptor}" ] || continue
+    dir="${descriptor%/bazel-java-ci.json}"
+    dir="${dir#"${root}"/}"
+    java_roots+=("${dir}")
+done < <(find "${root}" -name bazel-java-ci.json -not -path '*/.git/*' 2>/dev/null || true)
+
+relevant() {
+    local path="$1" candidate name prefix
+
+    for candidate in "${exact_paths[@]}"; do
+        [ "${path}" = "${candidate}" ] && return 0
+    done
+
+    # The generator itself.
+    case "${path}" in
+        tools/collect-dependencies/*) return 0 ;;
+    esac
+
+    name="${path##*/}"
+    for candidate in "${manifest_names[@]}"; do
+        [ "${name}" = "${candidate}" ] && return 0
+    done
+
+    # Python requirements files carry a suffix more often than not
+    # (requirements-dev.txt, requirements.lock.txt).
+    case "${name}" in
+        requirements*.txt) return 0 ;;
+    esac
+
+    # Vendored Go source is read for license text, so its contents matter.
+    case "${path}" in
+        vendor/*|*/vendor/*) return 0 ;;
+    esac
+
+    # Bazel build graph, but only where it feeds a Java runtime inventory.
+    case "${name}" in
+        BUILD.bazel|BUILD|*.bzl)
+            for prefix in "${java_roots[@]}"; do
+                [ -n "${prefix}" ] || continue
+                case "${path}" in
+                    "${prefix}"/*) return 0 ;;
+                esac
+            done
+            ;;
+    esac
+
+    return 1
+}
+
+saw_input=false
+while IFS= read -r path; do
+    [ -n "${path}" ] || continue
+    saw_input=true
+    if relevant "${path}"; then
+        echo "true"
+        exit 0
+    fi
+done
+
+# No input at all means the caller could not work out what changed, so run.
+# A change set that is genuinely empty cannot reach here: GitHub does not
+# start a pull_request run without at least one changed file.
+if [ "${saw_input}" = false ]; then
+    echo "true"
+    exit 0
+fi
+
+echo "false"

--- a/tools/ci/dependency-docs-scope
+++ b/tools/ci/dependency-docs-scope
@@ -40,7 +40,6 @@ fi
 
 # Paths whose content feeds the generator directly, or which change how it runs.
 exact_paths=(
-    "imports.yaml"
     "dependencies.md"
     "MODULE.bazel"
     "MODULE.bazel.lock"
@@ -54,6 +53,7 @@ exact_paths=(
 
 # Manifest file names, matched anywhere in the tree.
 manifest_names=(
+    "imports.yaml"
     "go.mod"
     "go.sum"
     "Cargo.toml"
@@ -66,13 +66,24 @@ manifest_names=(
 )
 
 # Registered Java component roots, as repository-relative directory prefixes.
+#
+# A failure here has to stop the whole decision, not just yield an empty list.
+# Without the roots a changed Java BUILD.bazel looks irrelevant, which is the
+# wrong-way error: the check would be skipped for precisely the change the
+# Java rule exists to catch. find also exits non-zero on a partial result, for
+# instance one unreadable directory, so a truncated list is caught too.
+if ! descriptors="$(find "${root}" -name bazel-java-ci.json -not -path '*/.git/*' 2>/dev/null)"; then
+    echo "true"
+    exit 0
+fi
+
 java_roots=()
 while IFS= read -r descriptor; do
     [ -n "${descriptor}" ] || continue
     dir="${descriptor%/bazel-java-ci.json}"
     dir="${dir#"${root}"/}"
     java_roots+=("${dir}")
-done < <(find "${root}" -name bazel-java-ci.json -not -path '*/.git/*' 2>/dev/null || true)
+done <<< "${descriptors}"
 
 relevant() {
     local path="$1" candidate name prefix

--- a/tools/ci/test-dependency-docs-scope
+++ b/tools/ci/test-dependency-docs-scope
@@ -110,8 +110,70 @@ printf '' | {
     fi
 }
 
-# A path that matches nothing known is not assumed harmless.
+# Discovery failure must stop the decision rather than silently empty the Java
+# roots: without them a Java BUILD.bazel change scores false, which is the one
+# wrong-way error. Raised by CodeRabbit on #949.
+for bad_root in /nonexistent/does/not/exist "${fixture}/unreadable"; do
+    mkdir -p "${fixture}/unreadable/inner" 2>/dev/null || true
+    chmod 000 "${fixture}/unreadable/inner" 2>/dev/null || true
+    got="$(printf 'src/control-plane-services/cloud-tasks/BUILD.bazel\n' \
+        | bash "${script}" --root "${bad_root}")"
+    chmod 755 "${fixture}/unreadable/inner" 2>/dev/null || true
+    if [ "${got}" = "true" ]; then
+        printf 'ok   Java root discovery failure fails closed (%s)\n' "${bad_root}"
+    else
+        printf 'FAIL Java root discovery failure (%s): want true, got %s\n' "${bad_root}" "${got}"
+        fail=1
+    fi
+done
+
+# A path matching nothing known yields false, and that is the whole point:
+# every pull request touches ordinary source, so treating an unmatched path as
+# relevant would make the answer always "true" and the scoping a no-op. The
+# real exposure is not an unknown path, it is this list falling behind the
+# collector. That is what the drift check below pins down.
 check "unknown manifest kind"      false "src/x/Gemfile.lock"
+
+# Drift guard.
+#
+# The allowlist is only safe while it matches what tools/collect-dependencies
+# actually reads. If the collector learns a new manifest and this script is not
+# updated, changes to that manifest would be scoped out and dependencies.md
+# would go stale behind a green required check. Silent, and exactly the failure
+# the fail-closed design is meant to prevent.
+#
+# So compare the two. Every manifest-shaped literal in the collector must be
+# either matched by the scope script or listed below with a reason. Adding a
+# manifest without doing one or the other fails here.
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Read by the collector, deliberately not a scope trigger.
+declare -A not_a_trigger=(
+    ["LICENSE.txt"]="license text inside vendor/, already covered by the vendor rule"
+    ["modules.txt"]="vendor/modules.txt, already covered by the vendor rule"
+    ["repositories.yaml"]="written by the collector into a temp dir, never read from the repo"
+    ["runtime_inventory.json"]="a Bazel output, not a repository file"
+)
+
+collector_literals="$(
+    grep -rhoE '"[A-Za-z0-9_.-]+\.(json|txt|toml|lock|yaml|mod|sum|xml)"' \
+        "${repo_root}/tools/collect-dependencies/"*.go \
+        | tr -d '"' | sort -u
+)"
+
+while IFS= read -r literal; do
+    [ -n "${literal}" ] || continue
+    if [ "$(printf '%s\n' "some/dir/${literal}" | bash "${script}" --root "${fixture}")" = "true" ]; then
+        printf 'ok   drift: %s is in scope\n' "${literal}"
+    elif [ -n "${not_a_trigger[${literal}]:-}" ]; then
+        printf 'ok   drift: %s excluded (%s)\n' "${literal}" "${not_a_trigger[${literal}]}"
+    else
+        printf 'FAIL drift: the collector reads %s but the scope script ignores it.\n' "${literal}"
+        printf '     Add it to manifest_names in dependency-docs-scope, or to\n'
+        printf '     not_a_trigger here with the reason it cannot change the output.\n'
+        fail=1
+    fi
+done <<< "${collector_literals}"
 
 if [ "${fail}" -ne 0 ]; then
     echo "dependency-docs-scope: FAILED" >&2

--- a/tools/ci/test-dependency-docs-scope
+++ b/tools/ci/test-dependency-docs-scope
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Behavioral test for tools/ci/dependency-docs-scope.
+#
+# The two directions are not symmetric. A wrong "true" wastes nine minutes; a
+# wrong "false" lets dependencies.md go stale behind a green required check,
+# which is the one failure this job exists to prevent. So the cases that must
+# return "true" are asserted far more thoroughly than the ones that may
+# return "false", and every unrecognised or degenerate input is pinned to
+# "true" rather than left to chance.
+set -euo pipefail
+
+script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/dependency-docs-scope"
+
+# A tree shaped like the repository: two registered Java components, and Go
+# and Rust subtrees that also carry BUILD.bazel files.
+fixture="$(mktemp -d)"
+trap 'rm -rf "${fixture}"' EXIT
+mkdir -p "${fixture}/src/control-plane-services/cloud-tasks"
+mkdir -p "${fixture}/src/control-plane-services/api-keys"
+mkdir -p "${fixture}/src/compute-plane-services/nvsnap/internal/rootfsonly"
+mkdir -p "${fixture}/src/invocation-plane-services/ratelimiter"
+: > "${fixture}/src/control-plane-services/cloud-tasks/bazel-java-ci.json"
+: > "${fixture}/src/control-plane-services/api-keys/bazel-java-ci.json"
+
+fail=0
+
+check() {
+    local desc="$1" want="$2"
+    shift 2
+    local got
+    got="$(printf '%s\n' "$@" | bash "${script}" --root "${fixture}")"
+    if [ "${got}" = "${want}" ]; then
+        printf 'ok   %s\n' "${desc}"
+    else
+        printf 'FAIL %s: want %s, got %s\n' "${desc}" "${want}" "${got}"
+        fail=1
+    fi
+}
+
+# Manifests, per ecosystem. Each of these can change the generated output.
+check "go.mod"                    true  "src/x/go.mod"
+check "go.sum"                    true  "src/x/go.sum"
+check "vendored source"           true  "src/x/vendor/github.com/y/LICENSE"
+check "root vendored source"      true  "vendor/github.com/y/z.go"
+check "Cargo.toml"                true  "src/x/Cargo.toml"
+check "pom.xml"                   true  "src/x/pom.xml"
+check "pyproject.toml"            true  "tools/x/pyproject.toml"
+check "requirements.txt"          true  "tools/x/requirements.txt"
+check "suffixed requirements"     true  "tools/x/requirements-dev.txt"
+check "pnpm-lock.yaml"            true  "src/uis/nvcf-ui/pnpm-lock.yaml"
+check "Chart.yaml"                true  "deploy/helm/nats/Chart.yaml"
+check "Chart.lock"                true  "deploy/helm/nats/Chart.lock"
+
+# Repository-level inputs.
+check "imports.yaml"              true  "imports.yaml"
+check "dependencies.md itself"    true  "dependencies.md"
+check "MODULE.bazel"              true  "MODULE.bazel"
+check "MODULE.bazel.lock"         true  "MODULE.bazel.lock"
+check "maven_install.json"        true  "maven_install.json"
+check ".bazelversion"             true  ".bazelversion"
+check "the collector"             true  "tools/collect-dependencies/java_deps.go"
+check "the check script"          true  "tools/ci/check-dependency-docs"
+check "the scope script"          true  "tools/ci/dependency-docs-scope"
+check "this test"                 true  "tools/ci/test-dependency-docs-scope"
+check "the workflow"              true  ".github/workflows/license-dependencies.yml"
+
+# The Java build graph feeds runtime_inventory.json through Bazel, so a
+# BUILD.bazel under a registered component counts even with no manifest edit.
+check "Java component BUILD.bazel" true \
+    "src/control-plane-services/cloud-tasks/BUILD.bazel"
+check "nested Java BUILD.bazel"    true \
+    "src/control-plane-services/api-keys/svc/BUILD.bazel"
+check "Java component .bzl"        true \
+    "src/control-plane-services/cloud-tasks/defs.bzl"
+
+# The same file names outside a Java component cannot reach the inventory.
+# This is the #945 case: a Go subtree's BUILD.bazel.
+check "Go subtree BUILD.bazel"     false \
+    "src/compute-plane-services/nvsnap/internal/rootfsonly/BUILD.bazel"
+check "Rust subtree BUILD.bazel"   false \
+    "src/invocation-plane-services/ratelimiter/BUILD.bazel"
+
+# Ordinary source changes.
+check "Go source"                  false "src/compute-plane-services/nvsnap/main.go"
+check "Rust source"                false "src/invocation-plane-services/ratelimiter/src/lib.rs"
+check "Java source"                false \
+    "src/control-plane-services/cloud-tasks/src/main/java/A.java"
+check "markdown"                   false "docs/guide.md"
+check "an unrelated workflow"      false ".github/workflows/bazel.yml"
+check "a Helm template"            false "deploy/helm/nats/templates/svc.yaml"
+
+# Mixed change sets: one relevant path is enough.
+check "relevant among many"        true \
+    "src/x/main.go" "docs/a.md" "src/x/go.mod" "docs/b.md"
+check "none relevant"              false \
+    "src/x/main.go" "docs/a.md" "docs/b.md"
+
+# Fail closed. Losing the changed set must never be read as "nothing changed".
+check "no input at all"            true ""
+printf '' | {
+    got="$(bash "${script}" --root "${fixture}")"
+    if [ "${got}" = "true" ]; then
+        printf 'ok   %s\n' "empty stdin"
+    else
+        printf 'FAIL %s: want true, got %s\n' "empty stdin" "${got}"
+        fail=1
+    fi
+}
+
+# A path that matches nothing known is not assumed harmless.
+check "unknown manifest kind"      false "src/x/Gemfile.lock"
+
+if [ "${fail}" -ne 0 ]; then
+    echo "dependency-docs-scope: FAILED" >&2
+    exit 1
+fi
+echo "dependency-docs-scope: all checks passed"


### PR DESCRIPTION
Closes #948.

## Why

`generated dependency docs` runs on every pull request and takes about nine minutes, most of it building each Java component's runtime inventory through Bazel. `dependencies.md` is derived from dependency manifests, so a pull request touching none of them cannot change it and the nine minutes buys nothing.

#945 is the case in hand: nine files, all Go sources plus one `BUILD.bazel`, under `src/compute-plane-services/nvsnap/`. Recent durations for the job:

```
8m19s  8m36s  8m46s  9m5s  9m9s  9m37s  9m39s  9m43s  10m26s  10m35s  10m47s  16m55s
```

## What changed

The job always runs and always reports, so branch protection needs no companion no-op and no change. Only the expensive steps are gated, on a scope decision computed from the merge base. A pull request touching no dependency input now finishes in seconds.

Scoping this with `on.pull_request.paths` would have been wrong twice over. A skipped required check never reports, so the merge blocks. More importantly the input set is wider than the manifest files: `java_deps.go` builds `runtime_inventory.json` through Bazel, so the inventory follows the build graph. Moving an artifact between compile and runtime deps in a Java component's `BUILD.bazel` changes the generated output with no manifest touched, and a naive filter would skip it and let `dependencies.md` go stale silently.

So `BUILD.bazel` and `*.bzl` are in scope, but only under a registered Java component root, which is what keeps the #945 case out. Those roots are discovered from `bazel-java-ci.json` rather than listed, so a new Java service is covered the day it is added and the script cannot drift out of date.

The decision fails closed everywhere it can be uncertain: an unrecognised path, a change set the diff could not produce, an empty change set, and every event other than `pull_request` all yield a full run. The asymmetry is deliberate. A wrong "false" lets `dependencies.md` go stale behind a green required check, which is the one failure this job exists to catch. A wrong "true" only costs time.

The decision lives in `tools/ci/dependency-docs-scope` with a behavioral test rather than inline in the workflow, matching the existing `bazel-cache-upload-mode` pattern, so the fail-closed behaviour is actually verifiable.

`fetch-depth: 0` is needed for the merge base to be reachable. A shallow clone would leave the three-dot diff with nothing to compare against, which the script reads as unknown and answers "true", so getting that wrong costs time rather than coverage.

## Testing

`tools/ci/test-dependency-docs-scope`, 39 cases, all passing. It covers every manifest kind the collector reads, the repository-level inputs, both directions of the Java versus Go `BUILD.bazel` distinction, mixed change sets, and each fail-closed path.

Also run against the real change sets of two open pull requests:

```
PR 945 (nvsnap Go sources + BUILD.bazel)  -> run=false
PR 834 (adds deploy/helm/icms Chart.yaml) -> run=true
```

#834 returning true is correct, not a miss: `helm_deps.go` reads `Chart.yaml` and `Chart.lock`, so a new chart is a real input. I had cited it as a wasted run when filing #948 and have corrected that there.

`./tools/ci/check-license` passes with the new files.

## Notes

Only `pull_request` is scoped. A push to `main`, a merge queue entry and a manual dispatch always run in full, so the default branch is never validated against a narrowed view of itself.

The same treatment likely applies to `dependency licenses` and `license headers + NOTICE + MPL audit` in this workflow, but those are much cheaper, so I left them alone rather than widen the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of dependency-related changes to determine when dependency documentation needs regeneration.
  * Added support for recognizing relevant manifests, build files, vendored sources, and generator inputs.

* **Bug Fixes**
  * Prevented unnecessary dependency documentation checks when unrelated files change.
  * Ensured detection failures and empty inputs safely trigger documentation processing.

* **Tests**
  * Added behavioral coverage for relevant, unrelated, mixed, empty, and unknown file-change scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->