### PR TITLE
fix(self-managed): declare the LLM PKI issuer in one Helmfile state

### DIFF
--- a/deploy/stacks/self-managed/Makefile
+++ b/deploy/stacks/self-managed/Makefile
@@ -5,4 +5,5 @@ include Makefile.dist
 test:
 	@tests/llm-router-worker-address.sh
 	@tests/llm-pki-release.sh
+	@tests/check-llm-pki-issuer.sh
 	@tests/pdb-value-wiring.sh

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -164,26 +164,6 @@ releases:
     labels:
       release-group: services
 
-  - name: nvcf-pki
-    chart: nvcf/helm-nvcf-pki
-    version: 0.1.0
-    namespace: cert-manager
-    condition: addons.llm.pki.enabled
-    values:
-      - clusterIssuer:
-          enabled: true
-          name: {{ dig "addons" "llm" "pki" "issuerName" "nvcf-openbao-pki" .Values | quote }}
-          server: {{ dig "addons" "llm" "pki" "issuerServer" "http://openbao-server.vault-system.svc.cluster.local:8200" .Values | quote }}
-          path: {{ dig "addons" "llm" "pki" "issuerPath" "services/all/pki/nvcf-service-issuing/sign/nvcf-service-server" .Values | quote }}
-          auth:
-            mountPath: {{ dig "addons" "llm" "pki" "issuerAuthMountPath" "/v1/auth/jwt" .Values | quote }}
-            role: {{ dig "addons" "llm" "pki" "issuerAuthRole" "cert-manager" .Values | quote }}
-            serviceAccount:
-              name: {{ dig "addons" "llm" "pki" "issuerServiceAccountName" "cert-manager" .Values | quote }}
-              audience: {{ dig "addons" "llm" "pki" "issuerAudience" "http://openbao-server.vault-system.svc.cluster.local:8200" .Values | quote }}
-    labels:
-      release-group: services
-
   - name: llm-request-router
     chart: nvcf/helm-nvcf-llm-request-router
     version: 1.6.6
@@ -193,7 +173,6 @@ releases:
       - ../global.yaml.gotmpl
     needs:
       - nvcf/api
-      - cert-manager/nvcf-pki
     labels:
       release-group: services
 

--- a/deploy/stacks/self-managed/tests/check-llm-pki-issuer.sh
+++ b/deploy/stacks/self-managed/tests/check-llm-pki-issuer.sh
@@ -121,6 +121,36 @@ expect_no_dangling_issuer() {
   fail "$case_name renders a Certificate for ClusterIssuer/nvcf-openbao-pki while the nvcf-pki release is absent and management was not explicitly declined"
 }
 
+# The ownership cases above render 01-dependencies on its own, which cannot see
+# a second nvcf-pki declaration in a neighbouring state. `make` applies every
+# state in helmfile.d in one invocation, so the ownership decision only holds if
+# it holds across the whole directory.
+render_list_all() {
+  local case_name="$1"
+  shift
+
+  HELMFILE_ENV=base HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" helmfile \
+    --file "$stack_dir/helmfile.d" \
+    --environment default \
+    "${core_state_values[@]}" \
+    "$@" \
+    list --skip-charts --output json \
+    >"$work_dir/$case_name.all.json"
+}
+
+# Counts declarations, not enabled releases. A release that is merely
+# conditioned off is still a second owner of the same cluster-scoped issuer and
+# still reappears whenever its condition flips.
+expect_declared_all() {
+  local case_name="$1"
+  local expected="$2"
+
+  local actual
+  actual="$(jq -r '[.[] | select(.name == "nvcf-pki")] | length' "$work_dir/$case_name.all.json")"
+  test "$actual" = "$expected" ||
+    fail "$case_name expected $expected nvcf-pki releases across helmfile.d, got $actual"
+}
+
 expect_failure() {
   local case_name="$1"
   local expected_error="$2"
@@ -545,5 +575,28 @@ expect_failure managed-bool-without-openbao \
   "${managed_defaults[@]}" \
   --state-values-set openbao.enabled=false \
   --state-values-file "$explicit_true_file"
+
+# Cases 25 and 26: the ownership decision must hold across every state in
+# helmfile.d, not only in the state that gates the release. A second
+# declaration elsewhere installs a ClusterIssuer under the operator's own
+# external issuer name, pointed at an OpenBao the operator did not deploy. The
+# nvcf-pki chart keeps that object on uninstall and rollback, so the router
+# Certificate never issues until it is deleted by hand.
+render_list_all managed-defaults-all \
+  --state-values-set addons.llm.enabled=true \
+  --state-values-set addons.llm.pki.enabled=true \
+  --state-values-set-string addons.llm.pki.allowedDomains=nvcf.svc.cluster.local \
+  --state-values-set-string addons.llm.pki.image.tag=test \
+  "${router_dns_names[@]}"
+expect_declared_all managed-defaults-all 1
+
+render_list_all external-issuer-all \
+  --state-values-set addons.llm.enabled=true \
+  --state-values-set addons.llm.pki.enabled=true \
+  --state-values-set-string addons.llm.pki.issuerName=external-llm-pki \
+  --state-values-set addons.llm.pki.clusterIssuer.enabled=false \
+  --state-values-set openbao.enabled=false \
+  "${router_dns_names[@]}"
+expect_declared_all external-issuer-all 0
 
 echo "check-llm-pki-issuer: all checks passed"

--- a/deploy/stacks/self-managed/tests/llm-pki-release.sh
+++ b/deploy/stacks/self-managed/tests/llm-pki-release.sh
@@ -3,10 +3,7 @@ set -euo pipefail
 
 stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 work_dir="$(mktemp -d)"
-test_stack_dir="$work_dir/self-managed"
-environment_name="llm-pki-release-test"
-environment_file="$test_stack_dir/environments/$environment_name.yaml"
-secrets_file="$test_stack_dir/secrets/$environment_name-secrets.yaml"
+states_dir="$work_dir/states"
 trap 'rm -rf "$work_dir"' EXIT
 
 fail() {
@@ -14,54 +11,105 @@ fail() {
   exit 1
 }
 
-mkdir -p "$test_stack_dir"
-cp -R "$stack_dir"/. "$test_stack_dir"
-printf '{}\n' >"$secrets_file"
+mkdir -p "$states_dir"
 
-cat >"$environment_file" <<'EOF'
-global:
-  image:
-    registry: nvcr.io
-    repository: test/nvcf
-addons:
-  llm:
-    enabled: true
-    pki:
-      enabled: true
-      allowedDomains: cluster.local
-      dnsNames:
-        - llm-request-router.nvcf.svc.cluster.local
-      image:
-        tag: 0.16.2
-EOF
+# The whole helmfile.d directory, because `make` applies every state in one
+# helmfile invocation. Checking a single state file cannot see a release that a
+# neighboring state also declares.
+render_debug() {
+  HELMFILE_ENV=base HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" helmfile \
+    --file "$stack_dir/helmfile.d" \
+    --log-level debug \
+    --environment default \
+    --state-values-set ingress.gatewayApi.controllerNamespace=envoy-gateway-system \
+    --state-values-set ingress.gatewayApi.gateways.shared.name=shared-gw \
+    --state-values-set ingress.gatewayApi.gateways.shared.namespace=envoy-gateway-system \
+    --state-values-set ingress.gatewayApi.gateways.grpc.name=grpc-gw \
+    --state-values-set ingress.gatewayApi.gateways.grpc.namespace=envoy-gateway-system \
+    --state-values-set addons.llm.enabled=true \
+    --state-values-set addons.llm.pki.enabled=true \
+    --state-values-set-string addons.llm.pki.allowedDomains=cluster.local \
+    --state-values-set-string addons.llm.pki.image.tag=test \
+    --state-values-set-string 'addons.llm.pki.dnsNames[0]=llm-request-router.nvcf.svc.cluster.local' \
+    list --skip-charts --output json 2>&1
+}
 
-releases="$(
-  HELMFILE_ENV="$environment_name" \
-    HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" \
-    helmfile \
-      --file "$test_stack_dir/helmfile.d/02-core.yaml.gotmpl" \
-      --environment default \
-      --state-values-set ingress.gatewayApi.controllerNamespace=envoy-gateway-system \
-      --state-values-set ingress.gatewayApi.gateways.shared.name=shared-gw \
-      --state-values-set ingress.gatewayApi.gateways.shared.namespace=envoy-gateway-system \
-      --state-values-set ingress.gatewayApi.gateways.grpc.name=grpc-gw \
-      --state-values-set ingress.gatewayApi.gateways.grpc.namespace=envoy-gateway-system \
-      list 2>/dev/null
-)"
+# The rendered state is the only place that carries both the release
+# declarations and their needs edges. `list` reports enablement but drops
+# needs, and `build` cannot run offline because it pulls every chart. Debug
+# logging prints each rendered state as line-numbered YAML, one block per
+# template part, including the states pulled in through nested helmfiles.
+# Split the blocks back out per state so each one can be checked on its own.
+split_states() {
+  awk -v out="$states_dir" '
+    match($0, /^rendering result of "[^"]+":$/) {
+      state = $0
+      sub(/^rendering result of "/, "", state)
+      sub(/":$/, "", state)
+      sub(/\.part\.[0-9]+$/, "", state)
+      display = state
+      sub(/^.*\//, "", display)
+      gsub("/", "_", state)
+      file = out "/" state ".yaml"
+      print display >(file ".name")
+      print "---" >file
+      capture = 1
+      next
+    }
+    capture && /^ *[0-9]+: / { sub(/^ *[0-9]+: ?/, ""); print >file; next }
+    capture { capture = 0 }
+  '
+}
 
-release_definition="$(
-  awk '
-    /^  - name: nvcf-pki$/ { in_release = 1 }
-    in_release && /^  - name: / && $0 != "  - name: nvcf-pki" { exit }
-    in_release { print }
-  ' "$test_stack_dir/helmfile.d/02-core.yaml.gotmpl"
-)"
+# One line per release: namespace, name, and its needs edges. A release with
+# no explicit namespace is addressed by bare name in a needs entry, so key it
+# the same way helmfile does.
+state_table() {
+  yq ea -N '
+    .releases[]? |
+    (.namespace // "") + "|" + .name + "|" + ((.needs // []) | join(","))
+  ' "$1" |
+    awk -F '|' '{ key = ($1 == "" ? $2 : $1 "/" $2); print key "\t" $3 }'
+}
 
-if printf '%s\n' "$release_definition" | grep -q '^    needs:$'; then
-  fail "LLM PKI cannot depend on releases owned by another Helmfile state"
+if ! render_debug >"$work_dir/debug.log"; then
+  cat "$work_dir/debug.log" >&2
+  fail "helmfile could not render helmfile.d"
 fi
+split_states <"$work_dir/debug.log"
 
-test "$(printf '%s\n' "$releases" | awk 'NR > 1 && $1 == "nvcf-pki" && $2 == "cert-manager" { count++ } END { print count + 0 }')" = "1" ||
-  fail "LLM PKI did not install exactly one nvcf-pki release in cert-manager"
+state_files=("$states_dir"/*.yaml)
+test -f "${state_files[0]}" ||
+  fail "recovered no rendered Helmfile states from the debug render"
+
+declarations=0
+for state_file in "${state_files[@]}"; do
+  state_name="$(head -1 "$state_file.name")"
+  state_table "$state_file" >"$state_file.table"
+  cut -f1 "$state_file.table" >"$state_file.releases"
+
+  # Helmfile applies each state in turn, so a needs entry can only order
+  # releases declared inside the same state. An edge that names a release from
+  # another state file is dangling.
+  while IFS=$'\t' read -r from needs; do
+    test -n "$needs" || continue
+    for target in ${needs//,/ }; do
+      grep -Fxq "$target" "$state_file.releases" ||
+        fail "$state_name declares the needs edge $from -> $target, but no release in $state_name provides $target"
+    done
+  done <"$state_file.table"
+
+  matches="$(grep -Ec '(^|/)nvcf-pki$' "$state_file.releases" || true)"
+  in_cert_manager="$(grep -Fxc 'cert-manager/nvcf-pki' "$state_file.releases" || true)"
+  test "$matches" = "$in_cert_manager" ||
+    fail "$state_name declares nvcf-pki outside the cert-manager namespace"
+  declarations=$((declarations + in_cert_manager))
+done
+
+# The LLM PKI issuer is a single cluster-scoped ClusterIssuer. Two states that
+# both declare it will disagree about when to install it, and the one with the
+# weaker gate silently reinstalls what the other deliberately skipped.
+test "$declarations" = "1" ||
+  fail "expected exactly one nvcf-pki release in cert-manager across helmfile.d, found $declarations"
 
 echo "llm-pki-release: all checks passed"


### PR DESCRIPTION
## Why

`deploy/stacks/self-managed/` declared the `nvcf-pki` Helm release in two
Helmfile states that disagreed with each other. `01-dependencies` gates it on
the full issuer-ownership model (managed ClusterIssuer, external ClusterIssuer,
external namespaced Issuer) and carries `needs` edges on OpenBao and
cert-manager. `02-core` gated it only on `condition: addons.llm.pki.enabled`.
`make` applies the whole `helmfile.d/` directory in one command, so both
declarations were applied together.

With the managed default this double-applied the same release. With an
explicitly external issuer it was worse: `01-dependencies` correctly skipped
the release, and `02-core` installed it anyway with
`clusterIssuer.enabled: true`, the operator's own issuer name, and a `server`
pointing at an OpenBao that was not deployed. The stack created a
cluster-scoped `ClusterIssuer` under the name the operator had reserved for
their external issuer. It never reached `Ready=True`, the request-router
`Certificate` never issued, and the `nvcf-pki` chart sets
`helm.sh/resource-policy: keep`, so the bad object survived uninstall and
rollback.

Two changes landed on the same day and did not see each other. The one that
added the `02-core` declaration described a gap that the other had already
closed.

Neither test caught it. `llm-pki-release.sh` rendered only `02-core`.
`check-llm-pki-issuer.sh` asserted the ownership matrix only against
`01-dependencies`.

## What changed

- Deleted the `nvcf-pki` release from `helmfile.d/02-core.yaml.gotmpl`, and
  removed the `- cert-manager/nvcf-pki` entry from the `llm-request-router`
  release's `needs` list, which would otherwise dangle. Ordering still holds
  because `01-dependencies` completes before `02-core` starts, like every other
  dependency in the stack. The six issuer knobs the `02-core` copy introduced
  (`issuerServer`, `issuerPath`, `issuerAuthMountPath`, `issuerAuthRole`,
  `issuerServiceAccountName`, `issuerAudience`) were referenced nowhere else in
  the repo and are gone with it.
- Rewrote `tests/llm-pki-release.sh` to render the whole `helmfile.d/`
  directory. It keeps both of its original intents and widens them: the issuer
  is declared exactly once in `cert-manager` across all states, and no state
  declares a `needs` edge on a release another state owns. The needs check is
  now generic over every release in every state, including states pulled in
  through nested helmfiles.
- Added two cross-state cases to `tests/check-llm-pki-issuer.sh`: the managed
  default declares exactly one `nvcf-pki` release across `helmfile.d/`, and the
  external-issuer config declares zero. The count is of declarations, not
  enabled releases, so a declaration that is merely conditioned off still
  fails.
- Wired `tests/check-llm-pki-issuer.sh` into `make test`. It was not run by any
  target, which is part of why this slipped through.

`01-dependencies` is the declaration that survives because it owns the
ownership model that `docs/user/llm-function-enablement.md` documents and that
the 549-line `check-llm-pki-issuer.sh` covers, and it is the only one that can
express real `needs` edges on OpenBao and cert-manager.

## Customer Release Notes

Fixed a self-managed stack defect where configuring an external issuer for LLM
request-router TLS still created a stack-owned `ClusterIssuer` under that
issuer's name, pointed at an OpenBao instance that was not installed. The bad
object was retained through uninstall and rollback and had to be deleted by
hand.

## Plan Summary

Removes one duplicate Helm release declaration from the self-managed stack. In
the managed default the same release is now applied once instead of twice, with
identical values. With an external issuer, no `nvcf-pki` release is installed
at all, which is the documented behavior. No chart, image, or value defaults
change.

## Usage

Not applicable.

## Testing

Run from `deploy/stacks/self-managed`:

```
tests/check-llm-pki-issuer.sh          passed
tests/llm-pki-release.sh               passed
tests/llm-router-worker-address.sh     passed
git diff --check                       clean
```

Both new assertions were mutation-tested by restoring the stray declaration:
`llm-pki-release.sh` reports `found 2`, and `check-llm-pki-issuer.sh` reports
`managed-defaults-all expected 1 ... got 2` and, with that case skipped,
`external-issuer-all expected 0 ... got 1`. The new cross-state `needs` check
was mutation-tested by re-adding the `cert-manager/nvcf-pki` edge on
`llm-request-router`, which it reports as dangling.

Verified end to end before and after: the external-issuer config went from 1
declared `nvcf-pki` release to 0, and the managed default from 2 to 1.

`tests/pdb-value-wiring.sh` fails on clean `main` with
`no releases found that matches specified selector(name=cassandra)` against
helmfile 1.7.4. That is pre-existing and unrelated, so the three scripts above
were run individually rather than through `make test`. No QA needed.

## Notes

A separate in-flight branch for a pre-created request-router TLS Secret mode
also edits `02-core.yaml.gotmpl` and wraps the `nvcf-pki` release plus the
router's `needs` edge in a cert-manager-mode guard. Expect a conflict there.
Resolve in favor of this change: drop the wrapped release and the wrapped
`needs` edge, keep the rest. That branch's behavior is correct either way and
needs no logic change.

## References

Closes #950

## Related Pull Requests

None

## Dependencies

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deployment**
  * Removed the self-managed stack’s standalone PKI release configuration.
  * Updated the LLM request router’s deployment dependency.
* **Bug Fixes**
  * Improved validation of PKI issuer ownership across Helmfile states.
  * Added checks to ensure valid release dependencies and namespace placement.
  * Ensured PKI is declared exactly once when enabled and omitted when externally managed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->