### PR TITLE
fix(byoo-otel-collector): guard exporter helper settings

### DIFF
--- a/src/compute-plane-services/byoo-otel-collector/internal/otelconfig/collector_config.go
+++ b/src/compute-plane-services/byoo-otel-collector/internal/otelconfig/collector_config.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/byoo-otel-collector/internal/logger"
 )
@@ -84,6 +85,7 @@ func (c *LogSamplingConfig) IsZero() bool {
 }
 
 // ExporterHelperConfig configures common exporterhelper settings for BYOO exporters.
+// Each setting is applied only to exporter types that support it.
 type ExporterHelperConfig struct {
 	Timeout        string               `json:"timeout,omitempty"`
 	RetryOnFailure RetryOnFailureConfig `json:"retryOnFailure,omitempty"`
@@ -361,23 +363,66 @@ func applySamplingProcessor(otelConfig *OpenTelemetryConfig, pipelineID, process
 	otelConfig.Service.Pipelines[pipelineID] = pipeline
 }
 
+type exporterHelperCapabilities struct {
+	timeout        bool
+	retryOnFailure bool
+	sendingQueue   bool
+}
+
+var exporterHelperCapabilitiesByType = map[string]exporterHelperCapabilities{
+	"azuremonitor": {
+		timeout:      true,
+		sendingQueue: true,
+	},
+	"datadog": {
+		timeout:        true,
+		retryOnFailure: true,
+		sendingQueue:   true,
+	},
+	"otlp": {
+		timeout:        true,
+		retryOnFailure: true,
+		sendingQueue:   true,
+	},
+	"otlp_http": {
+		timeout:        true,
+		retryOnFailure: true,
+		sendingQueue:   true,
+	},
+	"prometheus": {
+		sendingQueue: true,
+	},
+	"prometheus_remote_write": {
+		timeout:        true,
+		retryOnFailure: true,
+	},
+	"splunk_hec": {
+		timeout:        true,
+		retryOnFailure: true,
+		sendingQueue:   true,
+	},
+}
+
+func exporterHelperCapabilitiesForID(exporterID string) exporterHelperCapabilities {
+	exporterType, _, _ := strings.Cut(exporterID, "/")
+	return exporterHelperCapabilitiesByType[exporterType]
+}
+
 func applyExporterHelperConfig(otelConfig *OpenTelemetryConfig, cfg ExporterHelperConfig) {
 	if cfg.IsZero() {
 		return
 	}
 	for exporterID, exporter := range otelConfig.Exporters {
-		if exporterID == "debug" {
-			continue
-		}
-		if cfg.Timeout != "" {
+		capabilities := exporterHelperCapabilitiesForID(exporterID)
+		if cfg.Timeout != "" && capabilities.timeout {
 			exporter["timeout"] = cfg.Timeout
 		}
-		if !cfg.RetryOnFailure.IsZero() {
+		if !cfg.RetryOnFailure.IsZero() && capabilities.retryOnFailure {
 			retry := mapFromInterface(exporter["retry_on_failure"])
 			cfg.RetryOnFailure.applyTo(retry)
 			exporter["retry_on_failure"] = retry
 		}
-		if !cfg.SendingQueue.IsZero() {
+		if !cfg.SendingQueue.IsZero() && capabilities.sendingQueue {
 			queue := mapFromInterface(exporter["sending_queue"])
 			cfg.SendingQueue.applyTo(queue)
 			exporter["sending_queue"] = queue

--- a/src/compute-plane-services/byoo-otel-collector/internal/otelconfig/render_test.go
+++ b/src/compute-plane-services/byoo-otel-collector/internal/otelconfig/render_test.go
@@ -754,6 +754,76 @@ func TestGenerateExportersAndServiceAppliesCollectorOverrides(t *testing.T) {
 	assert.Equal(t, []string{"memory_limiter", "attributes/add-metadata", "probabilistic_sampler/traces", "batch"}, otelConfig.Service.Pipelines["traces"].Processors)
 }
 
+func TestApplyExporterHelperConfigUsesSupportedSettings(t *testing.T) {
+	retryEnabled := true
+	queueConsumers := int64(3)
+	queueSize := int64(2048)
+	otelConfig := &OpenTelemetryConfig{
+		Exporters: map[string]map[string]interface{}{
+			"azuremonitor/example":            {},
+			"datadog/example":                 {},
+			"debug":                           {},
+			"otlp":                            {},
+			"otlp/example":                    {},
+			"otlp_http/example":               {},
+			"prometheus/example":              {},
+			"prometheus_remote_write/example": {},
+			"splunk_hec/example":              {},
+			"unknown/example":                 {},
+		},
+	}
+
+	applyExporterHelperConfig(otelConfig, ExporterHelperConfig{
+		Timeout: "30s",
+		RetryOnFailure: RetryOnFailureConfig{
+			Enabled: &retryEnabled,
+		},
+		SendingQueue: SendingQueueConfig{
+			NumConsumers: &queueConsumers,
+			QueueSize:    &queueSize,
+		},
+	})
+
+	for _, exporterID := range []string{
+		"datadog/example",
+		"otlp",
+		"otlp/example",
+		"otlp_http/example",
+		"splunk_hec/example",
+	} {
+		assert.Equal(t, "30s", otelConfig.Exporters[exporterID]["timeout"], exporterID)
+		assert.Equal(t, map[string]interface{}{"enabled": true}, otelConfig.Exporters[exporterID]["retry_on_failure"], exporterID)
+		assert.Equal(t, map[string]interface{}{
+			"enabled":       true,
+			"num_consumers": int64(3),
+			"queue_size":    int64(2048),
+		}, otelConfig.Exporters[exporterID]["sending_queue"], exporterID)
+	}
+
+	assert.Equal(t, "30s", otelConfig.Exporters["azuremonitor/example"]["timeout"])
+	assert.NotContains(t, otelConfig.Exporters["azuremonitor/example"], "retry_on_failure")
+	assert.Equal(t, map[string]interface{}{
+		"enabled":       true,
+		"num_consumers": int64(3),
+		"queue_size":    int64(2048),
+	}, otelConfig.Exporters["azuremonitor/example"]["sending_queue"])
+
+	assert.Equal(t, "30s", otelConfig.Exporters["prometheus_remote_write/example"]["timeout"])
+	assert.Equal(t, map[string]interface{}{"enabled": true}, otelConfig.Exporters["prometheus_remote_write/example"]["retry_on_failure"])
+	assert.NotContains(t, otelConfig.Exporters["prometheus_remote_write/example"], "sending_queue")
+
+	assert.NotContains(t, otelConfig.Exporters["prometheus/example"], "timeout")
+	assert.NotContains(t, otelConfig.Exporters["prometheus/example"], "retry_on_failure")
+	assert.Equal(t, map[string]interface{}{
+		"enabled":       true,
+		"num_consumers": int64(3),
+		"queue_size":    int64(2048),
+	}, otelConfig.Exporters["prometheus/example"]["sending_queue"])
+
+	assert.Empty(t, otelConfig.Exporters["debug"])
+	assert.Empty(t, otelConfig.Exporters["unknown/example"])
+}
+
 func TestGenerateExportersAndServiceAddsMetricSubsetPipeline(t *testing.T) {
 	cfg := TelemetryConfig{
 		Telemetries: Telemetries{


### PR DESCRIPTION
## TL;DR

- Applies each BYOO exporter helper setting only to collector exporters that support it.

## Additional Details

- Keeps timeout and retry for Prometheus remote write exporters, but omits the unsupported generic sending queue field.
- Keeps sending queue settings for the Prometheus metric-subset exporter, but omits unsupported timeout and retry fields.
- Leaves debug and unknown exporters unchanged.

## For the Reviewer

- Review the exporter capability map and the regression matrix covering every bundled exporter type.

## For QA

- `go test ./...`
- `make validate-otelconfig`
- QA needed: Yes. Verify a telemetry-enabled workload with exporter helper overrides before release.

## Issues

Closes #952

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Exporter settings such as timeouts, retries, and sending queues are now applied only to exporter types that support them.
  - Unsupported settings are no longer applied to debug or unknown exporters, improving configuration reliability and preventing ineffective configuration overrides.
  - Exporter-specific behavior is now handled more consistently across monitoring and remote-write integrations.

- **Tests**
  - Added coverage verifying capability-specific exporter configuration behavior across supported and unsupported exporter types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->