### PR TITLE
fix(nats-auth-callout): enforce webhook TLS verification

### DIFF
--- a/src/control-plane-services/nats-auth-callout/SOFTWARE_DESIGN.md
+++ b/src/control-plane-services/nats-auth-callout/SOFTWARE_DESIGN.md
@@ -169,7 +169,6 @@ config:
   url: "https://auth.service.com/validate"
   timeout: "30s"
   retry_attempts: 3
-  insecure_skip_verify: false
 ```
 
 **Authentication Flow**:
@@ -202,7 +201,7 @@ config:
 
 **Key Features**:
 - Configurable retry logic with exponential backoff
-- TLS configuration options
+- TLS certificate and hostname verification for HTTPS endpoints
 - Flexible payload handling
 - Error mapping to appropriate HTTP status codes
 

--- a/src/control-plane-services/nats-auth-callout/internal/plugins/webhook/webhook.go
+++ b/src/control-plane-services/nats-auth-callout/internal/plugins/webhook/webhook.go
@@ -20,7 +20,6 @@ package webhook
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -36,10 +35,17 @@ import (
 
 // Config contains Webhook plugin configuration.
 type Config struct {
-	URL                string        `mapstructure:"url"                  yaml:"url"`
-	Timeout            time.Duration `mapstructure:"timeout"              yaml:"timeout"`
-	RetryAttempts      int           `mapstructure:"retry_attempts"       yaml:"retry_attempts"`
-	InsecureSkipVerify bool          `mapstructure:"insecure_skip_verify" yaml:"insecure_skip_verify"`
+	URL           string        `mapstructure:"url"            yaml:"url"`
+	Timeout       time.Duration `mapstructure:"timeout"        yaml:"timeout"`
+	RetryAttempts int           `mapstructure:"retry_attempts" yaml:"retry_attempts"`
+}
+
+// configInput retains retired options so insecure legacy configurations fail closed.
+type configInput struct {
+	URL                    string        `mapstructure:"url"                  yaml:"url"`
+	Timeout                time.Duration `mapstructure:"timeout"              yaml:"timeout"`
+	RetryAttempts          int           `mapstructure:"retry_attempts"       yaml:"retry_attempts"`
+	DisableTLSVerification bool          `mapstructure:"insecure_skip_verify" yaml:"insecure_skip_verify"`
 }
 
 // Plugin implements webhook-based authentication.
@@ -83,13 +89,6 @@ func NewPlugin(configData any, logger *zap.Logger) (*Plugin, error) {
 	transport := &http.Transport{
 		MaxIdleConns:    10,
 		IdleConnTimeout: 90 * time.Second,
-	}
-
-	// Configure TLS if needed
-	if webhookConfig.InsecureSkipVerify {
-		transport.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: true, //nolint:gosec // Configurable for development/testing
-		}
 	}
 
 	// Wrap transport with OpenTelemetry instrumentation
@@ -230,13 +229,24 @@ func (p *Plugin) parseSuccessResponse(resp *http.Response) (*types.Result, error
 
 // parseWebhookConfig parses webhook plugin configuration.
 func parseWebhookConfig(configData any) (*Config, error) {
-	webhookConfig := &Config{}
-	if err := config.DecodeConfig(configData, webhookConfig); err != nil {
+	input := &configInput{}
+	if err := config.DecodeConfig(configData, input); err != nil {
 		return nil, fmt.Errorf("failed to decode config: %w", err)
 	}
 
-	if webhookConfig.URL == "" {
+	if input.URL == "" {
 		return nil, fmt.Errorf("url is required")
+	}
+	if input.DisableTLSVerification {
+		return nil, fmt.Errorf(
+			"insecure_skip_verify cannot be enabled; webhook TLS certificate verification is required",
+		)
+	}
+
+	webhookConfig := &Config{
+		URL:           input.URL,
+		Timeout:       input.Timeout,
+		RetryAttempts: input.RetryAttempts,
 	}
 
 	// Set defaults

--- a/src/control-plane-services/nats-auth-callout/internal/plugins/webhook/webhook_test.go
+++ b/src/control-plane-services/nats-auth-callout/internal/plugins/webhook/webhook_test.go
@@ -104,7 +104,7 @@ func TestWebhookPlugin(t *testing.T) {
 				"url":                  "https://example.com/webhook",
 				"timeout":              "30s",
 				"retry_attempts":       5,
-				"insecure_skip_verify": true,
+				"insecure_skip_verify": false,
 			}
 			plugin, err := NewPlugin(configData, logger)
 			assert.NoError(t, err)
@@ -112,14 +112,21 @@ func TestWebhookPlugin(t *testing.T) {
 			assert.Equal(t, "https://example.com/webhook", plugin.config.URL)
 			assert.Equal(t, 30*time.Second, plugin.config.Timeout)
 			assert.Equal(t, 5, plugin.config.RetryAttempts)
-			assert.True(t, plugin.config.InsecureSkipVerify)
+		})
+		t.Run("when TLS certificate verification is disabled", func(t *testing.T) {
+			configData := map[string]any{
+				"url":                  "https://example.com/webhook",
+				"insecure_skip_verify": true,
+			}
+			plugin, err := NewPlugin(configData, logger)
+			assert.Nil(t, plugin)
+			assert.ErrorContains(t, err, "webhook TLS certificate verification is required")
 		})
 		t.Run("with struct configuration parses correctly", func(t *testing.T) {
 			configData := Config{
-				URL:                "https://example.com/webhook",
-				Timeout:            25 * time.Second,
-				RetryAttempts:      2,
-				InsecureSkipVerify: false,
+				URL:           "https://example.com/webhook",
+				Timeout:       25 * time.Second,
+				RetryAttempts: 2,
 			}
 			plugin, err := NewPlugin(configData, logger)
 			assert.NoError(t, err)
@@ -127,7 +134,6 @@ func TestWebhookPlugin(t *testing.T) {
 			assert.Equal(t, "https://example.com/webhook", plugin.config.URL)
 			assert.Equal(t, 25*time.Second, plugin.config.Timeout)
 			assert.Equal(t, 2, plugin.config.RetryAttempts)
-			assert.False(t, plugin.config.InsecureSkipVerify)
 		})
 	})
 
@@ -188,6 +194,21 @@ func TestWebhookPlugin(t *testing.T) {
 
 	t.Run("Error Handling", func(t *testing.T) {
 		t.Run("authentication failures", func(t *testing.T) {
+			t.Run("should reject an untrusted TLS certificate", func(t *testing.T) {
+				server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(createSuccessfulResponse())
+				}))
+				defer server.Close()
+
+				plugin, err := NewPlugin(Config{URL: server.URL, Timeout: 5 * time.Second, RetryAttempts: 1}, logger)
+				assert.NoError(t, err)
+				authReq := &types.Request{Account: "test-account", PluginName: "webhook", Payload: "test-token"}
+				result, err := plugin.Authenticate(context.Background(), authReq)
+				assert.Nil(t, result)
+				assert.ErrorContains(t, err, "certificate")
+			})
+
 			t.Run("should return unauthorized error for 401 status", func(t *testing.T) {
 				server := createTestServer([]testServerResponse{{statusCode: http.StatusUnauthorized}})
 				defer server.Close()


### PR DESCRIPTION
## Why

The webhook authentication plugin allowed configuration to disable TLS certificate verification. A misconfigured deployment could trust a man-in-the-middle endpoint for authentication decisions.

## What changed

- Removed the TLS verification bypass from the webhook HTTP transport.
- Rejects `insecure_skip_verify: true` while accepting legacy `false`.
- Added tests for unsafe configuration and untrusted certificates.
- Updated the webhook design documentation.

## Customer Release Notes

Webhook authentication now always verifies TLS certificates and hostnames.

## Plan Summary

Not applicable.

## Usage

No change is required unless `insecure_skip_verify` is enabled. Remove that option and configure the webhook with a certificate chain trusted by the system.

## Testing

- `go test ./internal/plugins/webhook -count=1`
- `git diff --check`

The focused tests pass. The repository-wide `make test` command on the current `main` branch is blocked because the Go module requires `go mod tidy`.

## Notes

The GitHub snapshot does not currently define a Bazel test target for this package.

## References

NO-REF

## Related Merge Requests/Pull Requests

None.

## Dependencies

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook integrations now consistently verify HTTPS certificates and hostnames.
  * Configurations attempting to disable TLS verification are rejected.
  * Authentication requests to endpoints with untrusted certificates now fail as expected.

* **Documentation**
  * Updated webhook configuration guidance to reflect mandatory TLS verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->