### PR TITLE
feat(invocation): configure baggage span attributes

### DIFF
--- a/deploy/helm/http-invocation/nvcf-invocation-service/templates/configmap-env.yaml
+++ b/deploy/helm/http-invocation/nvcf-invocation-service/templates/configmap-env.yaml
@@ -25,6 +25,9 @@ data:
   {{- range $key, $value := .Values.invocation.env }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
+  {{- with .Values.invocation.tracing.baggageAttributeAllowlist }}
+  SERVER__TRACING__BAGGAGE_ATTRIBUTE_ALLOWLIST: {{ join "," . | quote }}
+  {{- end }}
   {{- if not (hasKey .Values.invocation.env "WORKER_STREAM_PROPERTIES__SERVICE_ADDRESS") }}
   WORKER_STREAM_PROPERTIES__SERVICE_ADDRESS: "http://invocation.{{ include "nvcf-invocation-service.namespace" . }}.svc.cluster.local:{{ (index .Values.invocation.service.ports 0).port }}"
   {{- end }}

--- a/deploy/helm/http-invocation/nvcf-invocation-service/templates/deployment.yaml
+++ b/deploy/helm/http-invocation/nvcf-invocation-service/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- if .Values.invocation.env }}
-        checksum/config-env: {{ toYaml .Values.invocation.env | sha256sum }}
+        checksum/config-env: {{ dict "env" .Values.invocation.env "tracing" .Values.invocation.tracing | toYaml | sha256sum }}
         {{- end }}
       labels:
         {{- include "nvcf-invocation-service.selectorLabels" . | nindent 8 }}

--- a/deploy/helm/http-invocation/nvcf-invocation-service/values.yaml
+++ b/deploy/helm/http-invocation/nvcf-invocation-service/values.yaml
@@ -130,3 +130,7 @@ invocation:
     S3_PROPERTIES__ENABLE_LARGE_RESPONSE_URL: "false"
     SECRETS_PATH: "/vault/secrets/secrets.json"
     OAUTH2_BASE_URL: "https://oauth2.example.com"
+
+  tracing:
+    # Comma-delimited W3C baggage keys copied to invocation span attributes.
+    baggageAttributeAllowlist: []

--- a/deploy/stacks/self-managed/Makefile
+++ b/deploy/stacks/self-managed/Makefile
@@ -6,3 +6,4 @@ test:
 	@tests/llm-router-worker-address.sh
 	@tests/llm-pki-release.sh
 	@tests/pdb-value-wiring.sh
+	@tests/invocation-tracing-baggage.sh

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -465,6 +465,11 @@ invocation:
     {{- with $invocationWorkerBaseURL }}
     WORKER_STREAM_PROPERTIES__SELF_ADDRESS: {{ . | quote }}
     {{- end }}
+  {{- with dig "invocation" "tracing" "baggageAttributeAllowlist" nil .Values }}
+  tracing:
+    baggageAttributeAllowlist:
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
   {{- with dig "invocation" "podDisruptionBudget" dict .Values }}
   podDisruptionBudget:
     {{- toYaml . | nindent 4 }}

--- a/deploy/stacks/self-managed/tests/invocation-tracing-baggage.sh
+++ b/deploy/stacks/self-managed/tests/invocation-tracing-baggage.sh
@@ -120,6 +120,9 @@ changed_checksum="$(yq ea -r 'select(.kind == "Deployment" and .metadata.name ==
 if [ -z "$configured_checksum" ] || [ "$configured_checksum" = null ]; then
   fail "configured baggage allowlist did not render a deployment checksum"
 fi
+if [ -z "$changed_checksum" ] || [ "$changed_checksum" = null ]; then
+  fail "changed baggage allowlist did not render a deployment checksum"
+fi
 if [ "$configured_checksum" = "$changed_checksum" ]; then
   fail "deployment checksum did not change when the baggage allowlist changed"
 fi

--- a/deploy/stacks/self-managed/tests/invocation-tracing-baggage.sh
+++ b/deploy/stacks/self-managed/tests/invocation-tracing-baggage.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="$(cd "$stack_dir/../../.." && pwd)"
+chart_dir="$repo_root/deploy/helm/http-invocation/nvcf-invocation-service"
+work_dir="$(mktemp -d)"
+test_stack_dir="$work_dir/self-managed"
+environment_name="invocation-tracing-baggage-test"
+environment_file="$test_stack_dir/environments/$environment_name.yaml"
+secrets_file="$test_stack_dir/secrets/$environment_name-secrets.yaml"
+trap 'rm -rf "$work_dir"' EXIT
+
+fail() {
+  echo "invocation-tracing-baggage: $*" >&2
+  exit 1
+}
+
+mkdir -p "$test_stack_dir"
+cp -R "$stack_dir"/. "$test_stack_dir"
+printf '{}\n' >"$secrets_file"
+
+render_invocation_values() {
+  local output_file="$1"
+
+  HELMFILE_ENV="$environment_name" \
+    HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" \
+    helmfile \
+      --file "$test_stack_dir/helmfile.d/02-core.yaml.gotmpl" \
+      --environment default \
+      --state-values-set ingress.gatewayApi.controllerNamespace=envoy-gateway-system \
+      --state-values-set ingress.gatewayApi.gateways.shared.name=shared-gw \
+      --state-values-set ingress.gatewayApi.gateways.shared.namespace=envoy-gateway-system \
+      --state-values-set ingress.gatewayApi.gateways.grpc.name=grpc-gw \
+      --state-values-set ingress.gatewayApi.gateways.grpc.namespace=envoy-gateway-system \
+      --selector name=invocation-service \
+      write-values \
+      --output-file-template "$output_file"
+}
+
+render_chart() {
+  local values_file="$1"
+  local output_file="$2"
+
+  helm template invocation-service "$chart_dir" \
+    --namespace nvcf \
+    --values "$values_file" >"$output_file"
+}
+
+assert_yq_eq() {
+  local file="$1"
+  local expression="$2"
+  local expected="$3"
+  local actual
+
+  actual="$(yq ea -r "$expression" "$file")"
+  if [ "$actual" != "$expected" ]; then
+    fail "expected $expression to equal '$expected', got '$actual'"
+  fi
+}
+
+write_default_environment() {
+  cat >"$environment_file" <<'EOF'
+global:
+  image:
+    registry: nvcr.io
+    repository: test/nvcf
+EOF
+}
+
+write_configured_environment() {
+  local second_key="$1"
+
+  cat >"$environment_file" <<EOF
+global:
+  image:
+    registry: nvcr.io
+    repository: test/nvcf
+invocation:
+  tracing:
+    baggageAttributeAllowlist:
+      - allowed.one
+      - $second_key
+EOF
+}
+
+default_values="$work_dir/default-values.yaml"
+configured_values="$work_dir/configured-values.yaml"
+changed_values="$work_dir/changed-values.yaml"
+default_render="$work_dir/default-render.yaml"
+configured_render="$work_dir/configured-render.yaml"
+changed_render="$work_dir/changed-render.yaml"
+
+write_default_environment
+render_invocation_values "$default_values" >/dev/null
+render_chart "$default_values" "$default_render"
+assert_yq_eq \
+  "$default_render" \
+  'select(.kind == "ConfigMap" and .metadata.name == "invocation-service-env") | .data."SERVER__TRACING__BAGGAGE_ATTRIBUTE_ALLOWLIST" // "absent"' \
+  absent
+
+write_configured_environment allowed.two
+render_invocation_values "$configured_values" >/dev/null
+assert_yq_eq \
+  "$configured_values" \
+  '.invocation.tracing.baggageAttributeAllowlist | join(",")' \
+  allowed.one,allowed.two
+render_chart "$configured_values" "$configured_render"
+assert_yq_eq \
+  "$configured_render" \
+  'select(.kind == "ConfigMap" and .metadata.name == "invocation-service-env") | .data."SERVER__TRACING__BAGGAGE_ATTRIBUTE_ALLOWLIST"' \
+  allowed.one,allowed.two
+
+write_configured_environment allowed.three
+render_invocation_values "$changed_values" >/dev/null
+render_chart "$changed_values" "$changed_render"
+
+configured_checksum="$(yq ea -r 'select(.kind == "Deployment" and .metadata.name == "invocation-service") | .spec.template.metadata.annotations."checksum/config-env"' "$configured_render")"
+changed_checksum="$(yq ea -r 'select(.kind == "Deployment" and .metadata.name == "invocation-service") | .spec.template.metadata.annotations."checksum/config-env"' "$changed_render")"
+if [ -z "$configured_checksum" ] || [ "$configured_checksum" = null ]; then
+  fail "configured baggage allowlist did not render a deployment checksum"
+fi
+if [ "$configured_checksum" = "$changed_checksum" ]; then
+  fail "deployment checksum did not change when the baggage allowlist changed"
+fi
+
+echo "invocation-tracing-baggage: all checks passed"

--- a/src/invocation-plane-services/http-invocation/crates/server/src/app.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/src/app.rs
@@ -60,6 +60,7 @@ pub async fn app(
     config: AppConfig,
     secrets: Option<Arc<SecretFileWatcher>>,
 ) -> anyhow::Result<Router> {
+    let baggage_attribute_allowlist = config.server.tracing.baggage_attribute_allowlist.clone();
     let app_state = AppState {
         nvcf_service: NVCFService::new(
             &config.nvcf_api_address,
@@ -93,7 +94,7 @@ pub async fn app(
     };
 
     let trace_layer = TraceLayer::new_for_http()
-        .make_span_with(NVCFMakeSpan::new())
+        .make_span_with(NVCFMakeSpan::new(baggage_attribute_allowlist))
         .on_request(DefaultOnRequest::new().level(Level::DEBUG))
         .on_response(
             |response: &Response<Body>, _latency: Duration, span: &Span| {

--- a/src/invocation-plane-services/http-invocation/crates/server/src/middleware/spans.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/src/middleware/spans.rs
@@ -24,8 +24,9 @@ use tracing_opentelemetry_instrumentation_sdk::http::{
 
 use axum::extract;
 use http::request::Parts;
+use opentelemetry::baggage::{Baggage, BaggageExt};
 use std::collections::HashMap;
-use tracing::{field::Empty, span, Level, Span};
+use tracing::{Level, Span, field::Empty, span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use tracing_opentelemetry_instrumentation_sdk::http as otel_http;
 
@@ -51,17 +52,21 @@ pub async fn _add_path_params_to_span(req: Request<AxumBody>, next: Next) -> imp
 }
 
 #[derive(Debug, Clone)]
-pub struct NVCFMakeSpan {}
+pub struct NVCFMakeSpan {
+    baggage_attribute_allowlist: std::collections::HashSet<String>,
+}
 
 impl NVCFMakeSpan {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(baggage_attribute_allowlist: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            baggage_attribute_allowlist: baggage_attribute_allowlist.into_iter().collect(),
+        }
     }
 }
 
 impl Default for NVCFMakeSpan {
     fn default() -> Self {
-        Self::new()
+        Self::new(std::iter::empty())
     }
 }
 
@@ -137,9 +142,29 @@ impl<B> tower_http::trace::MakeSpan<B> for NVCFMakeSpan {
             query,
             url_scheme
         );
-        let _ = span.set_parent(otel_http::extract_context(request.headers()));
+        let parent_context = otel_http::extract_context(request.headers());
+        let baggage_attributes =
+            allowed_baggage_attributes(parent_context.baggage(), &self.baggage_attribute_allowlist);
+        let _ = span.set_parent(parent_context);
+        for (key, value) in baggage_attributes {
+            span.set_attribute(key, value);
+        }
         span
     }
+}
+
+fn allowed_baggage_attributes(
+    baggage: &Baggage,
+    allowlist: &std::collections::HashSet<String>,
+) -> Vec<(String, String)> {
+    allowlist
+        .iter()
+        .filter_map(|key| {
+            baggage
+                .get(key)
+                .map(|value| (key.clone(), value.as_str().to_owned()))
+        })
+        .collect()
 }
 
 pub async fn _parse_url_params(
@@ -169,4 +194,35 @@ fn http_route<B>(req: &extract::Request<B>) -> &str {
     req.extensions()
         .get::<MatchedPath>()
         .map_or_else(|| "", |mp| mp.as_str())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allowed_baggage_attributes_only_copies_configured_keys() {
+        let mut baggage = Baggage::new();
+        baggage.insert("allowed.one", "one");
+        baggage.insert("allowed.two", "two");
+        baggage.insert("unapproved", "must-not-copy");
+        let allowlist = ["allowed.one".to_string(), "allowed.two".to_string()]
+            .into_iter()
+            .collect();
+
+        let attributes = allowed_baggage_attributes(&baggage, &allowlist);
+
+        assert_eq!(attributes.len(), 2);
+        assert!(attributes.contains(&("allowed.one".to_string(), "one".to_string())));
+        assert!(attributes.contains(&("allowed.two".to_string(), "two".to_string())));
+    }
+
+    #[test]
+    fn allowed_baggage_attributes_ignores_missing_keys() {
+        let mut baggage = Baggage::new();
+        baggage.insert("allowed.one", "one");
+        let allowlist = ["missing".to_string()].into_iter().collect();
+
+        assert!(allowed_baggage_attributes(&baggage, &allowlist).is_empty());
+    }
 }

--- a/src/invocation-plane-services/http-invocation/crates/server/src/settings/mod.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/src/settings/mod.rs
@@ -206,13 +206,17 @@ pub fn load_app_config(config_file: Option<&str>) -> Result<AppConfig, config::C
             config::FileFormat::Json,
         ))
         .add_source(config::File::with_name(&path).required(required))
-        .add_source(
-            config::Environment::default()
-                .separator("__")
-                .try_parsing(true),
-        )
+        .add_source(environment_source())
         .build()
         .and_then(|c| c.try_deserialize::<AppConfig>())
+}
+
+fn environment_source() -> config::Environment {
+    config::Environment::default()
+        .separator("__")
+        .try_parsing(true)
+        .list_separator(",")
+        .with_list_parse_key("server.tracing.baggage_attribute_allowlist")
 }
 
 /// Load application config from a YAML file and environment variable overrides.
@@ -339,5 +343,31 @@ mod tests {
         // Verify that AppConfig includes the grpc_client field with proper defaults
         assert_eq!(config.grpc_client.connect_timeout, Duration::from_secs(4));
         assert_eq!(config.grpc_client.request_timeout, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn environment_source_parses_baggage_attribute_allowlist() {
+        #[derive(Deserialize)]
+        struct EnvironmentSettings {
+            server: ServerSettings,
+        }
+
+        let mut env = std::collections::HashMap::new();
+        env.insert(
+            "SERVER__TRACING__BAGGAGE_ATTRIBUTE_ALLOWLIST".to_string(),
+            "allowed.one,allowed.two".to_string(),
+        );
+
+        let settings = config::Config::builder()
+            .add_source(environment_source().source(Some(env)))
+            .build()
+            .unwrap()
+            .try_deserialize::<EnvironmentSettings>()
+            .unwrap();
+
+        assert_eq!(
+            settings.server.tracing.baggage_attribute_allowlist,
+            vec!["allowed.one", "allowed.two"]
+        );
     }
 }

--- a/src/invocation-plane-services/http-invocation/crates/server/src/telemetry/settings.rs
+++ b/src/invocation-plane-services/http-invocation/crates/server/src/telemetry/settings.rs
@@ -71,6 +71,9 @@ pub struct TracingSettings {
     /// HTTP/gRPC headers forwarded to the OTLP collector (e.g. auth tokens).
     #[serde(default)]
     pub headers: Option<HashMap<String, String>>,
+    /// W3C baggage keys that may be copied to invocation span attributes.
+    #[serde(default)]
+    pub baggage_attribute_allowlist: Vec<String>,
 }
 
 impl TracingSettings {
@@ -171,5 +174,27 @@ mod tests {
     #[test]
     fn endpoint_port_out_of_range_errors() {
         assert!(parse_tracing(r#"{"endpoint_port": 99999}"#).is_err());
+    }
+
+    #[test]
+    fn baggage_attribute_allowlist_defaults_empty() {
+        assert!(
+            parse_tracing(r#"{}"#)
+                .unwrap()
+                .baggage_attribute_allowlist
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn baggage_attribute_allowlist_deserializes() {
+        let settings =
+            parse_tracing(r#"{"baggage_attribute_allowlist": ["allowed.one", "allowed.two"]}"#)
+                .unwrap();
+
+        assert_eq!(
+            settings.baggage_attribute_allowlist,
+            vec!["allowed.one", "allowed.two"]
+        );
     }
 }


### PR DESCRIPTION
## TL;DR

- Adds an operator-configured W3C baggage allowlist for invocation-service span attributes.
- Keeps the public default empty, so deployments opt in to every emitted attribute.

## Additional Details

- Copies only configured baggage keys after W3C parsing; missing keys are ignored.
- Renders the Helm list as an invocation-service environment setting and restarts Pods when it changes.

## For QA

- `cargo test --lib`
- `helm lint nvcf-invocation-service`
- Rendered the chart with and without configured allowlist entries.

## Issues

Closes #961

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] Tests cover the change.
- [x] Documentation reflects current behavior.

## Github

Github commit:
feat(invocation): configure baggage span attributes

Add an operator-configured allowlist for W3C baggage copied to invocation-service
span attributes. Render it through Helm and keep the default empty.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable propagation of selected W3C baggage entries to request tracing spans.
  * Added deployment settings for specifying an allowlist of baggage keys.
  * Baggage propagation is disabled by default until keys are explicitly configured.
  * Unlisted or missing baggage keys are excluded from span attributes.

* **Bug Fixes**
  * Tracing configuration changes now reliably trigger deployment updates.

* **Tests**
  * Added coverage for default behavior, configured allowlists, filtering, and deployment updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->