### PR TITLE
fix(event-ledger): enable authentication by default

### DIFF
--- a/src/control-plane-services/event-ledger/cmd/api/startup/root_cmd.go
+++ b/src/control-plane-services/event-ledger/cmd/api/startup/root_cmd.go
@@ -53,7 +53,7 @@ func BuildRootCmd(logger *otelzap.Logger) *cobra.Command {
 	var cfgFiles []string
 	sugarLog := logger.Sugar()
 
-	v := viper.New()
+	v := newConfigViper()
 	rootCmd := &cobra.Command{
 		Use:           "event-ledger-api",
 		Short:         "Event Ledger API service",
@@ -128,6 +128,12 @@ func BuildRootCmd(logger *otelzap.Logger) *cobra.Command {
 
 	rootCmd.AddCommand(toolbox.NewGenerateConfigCmd(sugarLog, constants.ApiSvcName))
 	return rootCmd
+}
+
+func newConfigViper() *viper.Viper {
+	v := viper.New()
+	v.SetDefault("auth.enabled", true)
+	return v
 }
 
 func applyRuntimeFlagOverrides(cmd *cobra.Command, cfg *config.Config) error {

--- a/src/control-plane-services/event-ledger/cmd/api/startup/root_cmd_test.go
+++ b/src/control-plane-services/event-ledger/cmd/api/startup/root_cmd_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package startup
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -31,6 +32,24 @@ func TestConfigFilesFromEnvUsesEventLedgerConfig(t *testing.T) {
 	t.Setenv("EVENT_LEDGER_CONFIG", "/config/secrets.json, /config/override.json,, ")
 
 	assert.Equal(t, []string{"/config/secrets.json", "/config/override.json"}, configFilesFromEnv())
+}
+
+func TestConfigDefaultsAuthenticationEnabled(t *testing.T) {
+	v := newConfigViper()
+	var cfg config.Config
+
+	require.NoError(t, v.Unmarshal(&cfg))
+	assert.True(t, cfg.Auth.Enabled)
+}
+
+func TestConfigAllowsAuthenticationToBeExplicitlyDisabled(t *testing.T) {
+	v := newConfigViper()
+	v.SetConfigType("json")
+	require.NoError(t, v.ReadConfig(strings.NewReader(`{"auth":{"enabled":false}}`)))
+
+	var cfg config.Config
+	require.NoError(t, v.Unmarshal(&cfg))
+	assert.False(t, cfg.Auth.Enabled)
 }
 
 func TestApplyRuntimeFlagOverrides_CloudEventsConfigPreservedWhenDisableFlagOmitted(t *testing.T) {


### PR DESCRIPTION
## TL;DR

Event Ledger now enables authentication by default. Authentication is disabled only when `auth.enabled: false` or `--disable-authentication` is explicitly set.

## Testing

- `git diff --check`
- Added tests for the default-enabled and explicitly-disabled configuration cases.
- Not run: Go and Bazel are not installed in this environment.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication is now enabled by default when starting the event ledger API.
  * Authentication can still be explicitly disabled through configuration.

* **Tests**
  * Added coverage to verify both the default and configured authentication behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->