### PR TITLE
feat(grpc-proxy): record the transport cause of worker tunnel closes

### DIFF
--- a/src/invocation-plane-services/grpc-proxy/proxy/connection_logging_test.go
+++ b/src/invocation-plane-services/grpc-proxy/proxy/connection_logging_test.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"nvcf-grpc-proxy/proxy/consts"
 	"nvcf-grpc-proxy/proxy/invocation"
+	"nvcf-grpc-proxy/proxy/metrics"
 	"nvcf-grpc-proxy/proxy/worker"
 	"testing"
 	"time"
@@ -191,4 +192,67 @@ func (m *testMockInvoker) InvokeStatefulFunction(_ context.Context, _ net.Conn, 
 	result := invocation.Result(*m)
 	onWorkerAuthSet(result.WorkerAuthorizationToken, result.RequestId, testFunctionId, testFunctionVersionId)
 	return result, nil, nil
+}
+
+// localTimeoutFor must only name timers this service owns. Naming a timer that
+// belongs to another component would send whoever reads the log line looking
+// in the wrong codebase, which is worse than reporting nothing.
+func TestLocalTimeoutForNamesOnlyOurTimers(t *testing.T) {
+	tests := []struct {
+		name           string
+		evictionReason string
+		closeCode      string
+		want           string
+	}{
+		{
+			name:           "cache ttl expiry is ours",
+			evictionReason: metrics.CloseReasonTTLExpired,
+			closeCode:      metrics.CloseCodeNone,
+			want:           localTimeoutWorkerCacheTTL,
+		},
+		{
+			name:           "cache ttl wins over the transport code",
+			evictionReason: metrics.CloseReasonTTLExpired,
+			closeCode:      metrics.CloseCodeQUICIdleTimeout,
+			want:           localTimeoutWorkerCacheTTL,
+		},
+		{
+			name:           "quic idle timeout is named but not attributed",
+			evictionReason: metrics.CloseReasonWorkerClosed,
+			closeCode:      metrics.CloseCodeQUICIdleTimeout,
+			want:           localTimeoutQUICIdle,
+		},
+		{
+			name:           "bare net timeout on this path is a transport timer",
+			evictionReason: metrics.CloseReasonWorkerClosed,
+			closeCode:      metrics.CloseCodeTimeout,
+			want:           localTimeoutTransportIdle,
+		},
+		{
+			name:           "a deliberate peer close is not one of our timers",
+			evictionReason: metrics.CloseReasonWorkerClosed,
+			closeCode:      metrics.CloseCodeQUICApplication,
+			want:           localTimeoutNone,
+		},
+		{
+			name:           "a client hang-up is not one of our timers",
+			evictionReason: metrics.CloseReasonClientClosed,
+			closeCode:      metrics.CloseCodeEOF,
+			want:           localTimeoutNone,
+		},
+		{
+			name:           "an unclassified error names nothing",
+			evictionReason: metrics.CloseReasonWorkerClosed,
+			closeCode:      metrics.CloseCodeUnknown,
+			want:           localTimeoutNone,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := localTimeoutFor(tc.evictionReason, tc.closeCode); got != tc.want {
+				t.Errorf("localTimeoutFor(%q, %q) = %q, want %q",
+					tc.evictionReason, tc.closeCode, got, tc.want)
+			}
+		})
+	}
 }

--- a/src/invocation-plane-services/grpc-proxy/proxy/director.go
+++ b/src/invocation-plane-services/grpc-proxy/proxy/director.go
@@ -161,9 +161,18 @@ func NewStreamDirector(functionInvoker FunctionInvoker) *StreamDirector {
 	cache.OnEviction(func(ctx context.Context, reason ttlcache.EvictionReason, i *ttlcache.Item[workerConnectionKey, *worker.WorkerConnection]) {
 		wc := i.Value()
 		reasonStr := resolveCloseReason(reason, wc, shuttingDown.Load())
-		heldFor := time.Since(wc.CreatedAt)
+		closedAt := wc.ClosedAt()
+		if closedAt.IsZero() {
+			// No transport-level close was stamped, so this eviction is the
+			// first thing that noticed. Attribute it to now rather than
+			// leaving the field empty.
+			closedAt = time.Now()
+		}
+		heldFor := closedAt.Sub(wc.CreatedAt)
+		closeInfo := worker.ClassifyCloseError(wc.CloseError())
 
 		metrics.WorkerConnectionClosedTotal.WithLabelValues(reasonStr).Inc()
+		metrics.WorkerConnectionCloseCodeTotal.WithLabelValues(closeInfo.Code).Inc()
 		metrics.WorkerConnectionsActive.Dec()
 		metrics.WorkerConnectionDurationSeconds.Observe(heldFor.Seconds())
 
@@ -172,13 +181,32 @@ func NewStreamDirector(functionInvoker FunctionInvoker) *StreamDirector {
 		// during incidents. At debug it was unavailable in production exactly
 		// when it was needed. The message text is unchanged so existing log
 		// searches keep working.
-		zap.L().Info("worker connection cache eviction triggered",
+		logFields := []zap.Field{
 			zap.Stringer("request_id", i.Key().requestId),
 			zap.String("eviction_reason", reasonStr),
 			zap.String("raw_eviction_reason", mapEvictionReason(reason)),
 			zap.Duration("held_for", heldFor),
+			// Explicit timestamps: the eviction callback can run measurably
+			// after the transport went away, so the log line's own timestamp
+			// cannot be used to correlate against other components.
+			zap.Time("opened_at", wc.CreatedAt),
+			zap.Time("closed_at", closedAt),
+			// What the transport reported, as opposed to which side tore down.
+			zap.String("close_code", closeInfo.Code),
+			zap.String("local_timeout", localTimeoutFor(reasonStr, closeInfo.Code)),
+		}
+		if closeInfo.Detail != "" {
+			logFields = append(logFields, zap.String("close_detail", closeInfo.Detail))
+		}
+		if closeInfo.Remote != nil {
+			// Only QUIC tells us this. Absence means unknown, not local.
+			logFields = append(logFields, zap.Bool("closed_by_peer", *closeInfo.Remote))
+		}
+		logFields = append(logFields,
 			zap.String("function_id", wc.FunctionId),
 			zap.String("function_version_id", wc.FunctionVersionId))
+
+		zap.L().Info("worker connection cache eviction triggered", logFields...)
 
 		// The eviction context is the cache's own, not the session's, so this
 		// span has no parent to attach to. It carries the request id as an
@@ -190,6 +218,10 @@ func NewStreamDirector(functionInvoker FunctionInvoker) *StreamDirector {
 				attribute.Stringer("request_id", i.Key().requestId),
 				attribute.String("eviction_reason", reasonStr),
 				attribute.Float64("held_for_seconds", heldFor.Seconds()),
+				attribute.String("close_code", closeInfo.Code),
+				attribute.String("close_detail", closeInfo.Detail),
+				attribute.String("local_timeout", localTimeoutFor(reasonStr, closeInfo.Code)),
+				attribute.String("closed_at", closedAt.Format(time.RFC3339Nano)),
 				attribute.String("function_id", wc.FunctionId),
 				attribute.String("function_version_id", wc.FunctionVersionId),
 			))
@@ -207,6 +239,40 @@ func NewStreamDirector(functionInvoker FunctionInvoker) *StreamDirector {
 		functionInvoker: functionInvoker,
 		cors:            cors.New(middleware.DefaultCorsOptions),
 	}
+}
+
+// Timer names reported in local_timeout. Only the proxy's own timers can be
+// named here.
+const (
+	localTimeoutNone           = ""
+	localTimeoutWorkerCacheTTL = "worker_cache_ttl"
+	localTimeoutTransportIdle  = "transport_idle"
+	localTimeoutQUICIdle       = "quic_idle"
+)
+
+// localTimeoutFor names which of the proxy's own timers fired, where one did.
+//
+// Deliberately conservative. Timers owned by other components on the path
+// cannot be identified from here, and guessing at them would be worse than
+// saying nothing: close_code still characterises those cases. An empty result
+// means "not one of ours", not "no timer".
+func localTimeoutFor(evictionReason, closeCode string) string {
+	if evictionReason == metrics.CloseReasonTTLExpired {
+		// consts.Timeout on the worker connection cache.
+		return localTimeoutWorkerCacheTTL
+	}
+	switch closeCode {
+	case worker.CloseCodeQUICIdleTimeout:
+		// quic-go's MaxIdleTimeout. Either endpoint can own this, so it is
+		// named but not attributed.
+		return localTimeoutQUICIdle
+	case worker.CloseCodeTimeout:
+		// The HTTP/1 and HTTP/2 transports are configured with consts.Timeout
+		// for idle, read and write. A bare net timeout on this path is one of
+		// those.
+		return localTimeoutTransportIdle
+	}
+	return localTimeoutNone
 }
 
 // resolveCloseReason turns a ttlcache eviction into something actionable.

--- a/src/invocation-plane-services/grpc-proxy/proxy/director.go
+++ b/src/invocation-plane-services/grpc-proxy/proxy/director.go
@@ -168,6 +168,12 @@ func NewStreamDirector(functionInvoker FunctionInvoker) *StreamDirector {
 			// leaving the field empty.
 			closedAt = time.Now()
 		}
+		// held_for is now measured to the close itself rather than to whenever
+		// this callback ran. The callback can lag the close, so the old value
+		// was the tunnel's lifetime plus an unknown amount of cache latency,
+		// which is precisely the error that makes cross-component correlation
+		// hard. Where no close was stamped the fallback above reproduces the
+		// previous behaviour exactly.
 		heldFor := closedAt.Sub(wc.CreatedAt)
 		closeInfo := worker.ClassifyCloseError(wc.CloseError())
 

--- a/src/invocation-plane-services/grpc-proxy/proxy/metrics/metrics.go
+++ b/src/invocation-plane-services/grpc-proxy/proxy/metrics/metrics.go
@@ -164,6 +164,17 @@ var (
 			Help:      "total worker tunnel connections closed, by reason",
 		}, []string{"reason"})
 
+	// Complements worker_connection_closed_total. That reports which side tore
+	// the tunnel down; this reports what the transport said while it happened,
+	// which is what distinguishes a deliberate peer close from an idle timeout
+	// from a reset. Label values come from worker.CloseCodes and are bounded.
+	WorkerConnectionCloseCodeTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: RootNamespace,
+			Name:      "worker_connection_close_code_total",
+			Help:      "total worker tunnel connections closed, by transport close code",
+		}, []string{"code"})
+
 	// Buckets deliberately straddle the two timers that can close a tunnel:
 	// the worker-side QUIC idle timeout (8s) and this service's worker
 	// connection cache TTL (consts.Timeout, 30s). A hard cliff at either
@@ -203,6 +214,75 @@ const (
 	CloseReasonDeleted = "deleted"
 	CloseReasonUnknown = "unknown"
 )
+
+// Transport-level close codes. Deliberately a small, bounded set so they are
+// safe as a metric label; anything unrecognised lands on CloseCodeUnknown
+// rather than growing the label space. Classification lives in
+// worker.ClassifyCloseError; the constants live here alongside the other label
+// values.
+const (
+	// CloseCodeNone means no transport error was seen. The connection closed
+	// locally without the peer or the stack reporting a fault.
+	CloseCodeNone = "none"
+	// CloseCodeEOF is a clean peer close.
+	CloseCodeEOF = "eof"
+	// CloseCodeReset is a TCP RST or equivalent abrupt teardown.
+	CloseCodeReset = "reset"
+	// CloseCodeTimeout is a read or write deadline expiring.
+	CloseCodeTimeout = "timeout"
+	// CloseCodeClosedConn is use of an already-closed connection, normally our
+	// own teardown racing the transport.
+	CloseCodeClosedConn = "closed_conn"
+	// CloseCodeContextCanceled is the session context ending.
+	CloseCodeContextCanceled = "context_canceled"
+
+	// CloseCodeQUICIdleTimeout is QUIC's own idle timer expiring.
+	CloseCodeQUICIdleTimeout = "quic_idle_timeout"
+	// CloseCodeQUICApplication is a CONNECTION_CLOSE carrying an application
+	// error code. The informative one: it has both a code and a peer-supplied
+	// reason string.
+	CloseCodeQUICApplication = "quic_application"
+	// CloseCodeQUICTransport is a CONNECTION_CLOSE at the transport layer.
+	CloseCodeQUICTransport = "quic_transport"
+	// CloseCodeQUICStreamReset is RESET_STREAM; the connection survives.
+	CloseCodeQUICStreamReset = "quic_stream_reset"
+	// CloseCodeQUICHandshakeTimeout is the handshake failing to complete.
+	CloseCodeQUICHandshakeTimeout = "quic_handshake_timeout"
+	// CloseCodeQUICStatelessReset means the peer lost connection state.
+	CloseCodeQUICStatelessReset = "quic_stateless_reset"
+
+	// CloseCodeH2GoAway is an HTTP/2 GOAWAY frame.
+	CloseCodeH2GoAway = "h2_goaway"
+	// CloseCodeH2Stream is an HTTP/2 stream-level error.
+	CloseCodeH2Stream = "h2_stream"
+	// CloseCodeH2Connection is an HTTP/2 connection-level error.
+	CloseCodeH2Connection = "h2_connection"
+
+	// CloseCodeUnknown is an error the classifier does not recognise. The
+	// detail field still carries the original text.
+	CloseCodeUnknown = "unknown"
+)
+
+// CloseCodes enumerates every value the classifier can return, so the metric
+// can be pre-initialised and appear on the first scrape.
+var CloseCodes = []string{
+	CloseCodeNone,
+	CloseCodeEOF,
+	CloseCodeReset,
+	CloseCodeTimeout,
+	CloseCodeClosedConn,
+	CloseCodeContextCanceled,
+	CloseCodeQUICIdleTimeout,
+	CloseCodeQUICApplication,
+	CloseCodeQUICTransport,
+	CloseCodeQUICStreamReset,
+	CloseCodeQUICHandshakeTimeout,
+	CloseCodeQUICStatelessReset,
+	CloseCodeH2GoAway,
+	CloseCodeH2Stream,
+	CloseCodeH2Connection,
+	CloseCodeUnknown,
+}
 
 // WorkerConnectionCloseReasons enumerates every reason the proxy reports when
 // closing a worker tunnel. Kept here so the counter can be pre-initialised to
@@ -322,6 +402,9 @@ func init() {
 	}
 	for _, result := range ConnectResults {
 		WorkerConnectTotal.WithLabelValues(result)
+	}
+	for _, code := range CloseCodes {
+		WorkerConnectionCloseCodeTotal.WithLabelValues(code)
 	}
 }
 

--- a/src/invocation-plane-services/grpc-proxy/proxy/worker/BUILD.bazel
+++ b/src/invocation-plane-services/grpc-proxy/proxy/worker/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "worker",
     srcs = [
+        "closecode.go",
         "connections.go",
         "connections_tracing_hacks.go",
         "routing.go",
@@ -32,6 +33,7 @@ go_library(
         "//src/invocation-plane-services/grpc-proxy/proxy/pool",
         "//src/invocation-plane-services/grpc-proxy/proxy/rp",
         "@com_github_google_uuid//:uuid",
+        "@com_github_quic_go_quic_go//:quic-go",
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel_trace//:trace",
         "@org_golang_x_net//http2",
@@ -47,7 +49,15 @@ alias(
 
 go_test(
     name = "worker_test",
-    srcs = ["connections_test.go"],
+    srcs = [
+        "closecode_test.go",
+        "connections_test.go",
+    ],
     embed = [":worker"],
-    deps = ["@com_github_google_uuid//:uuid"],
+    deps = [
+        "//src/invocation-plane-services/grpc-proxy/proxy/metrics",
+        "@com_github_google_uuid//:uuid",
+        "@com_github_quic_go_quic_go//:quic-go",
+        "@org_golang_x_net//http2",
+    ],
 )

--- a/src/invocation-plane-services/grpc-proxy/proxy/worker/closecode.go
+++ b/src/invocation-plane-services/grpc-proxy/proxy/worker/closecode.go
@@ -1,0 +1,158 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"nvcf-grpc-proxy/proxy/metrics"
+	"syscall"
+
+	"github.com/quic-go/quic-go"
+	"golang.org/x/net/http2"
+)
+
+// Close code constants live in the metrics package alongside the other label
+// values. Re-exported here so callers working with connections do not need to
+// import metrics for them.
+const (
+	CloseCodeNone                 = metrics.CloseCodeNone
+	CloseCodeEOF                  = metrics.CloseCodeEOF
+	CloseCodeReset                = metrics.CloseCodeReset
+	CloseCodeTimeout              = metrics.CloseCodeTimeout
+	CloseCodeClosedConn           = metrics.CloseCodeClosedConn
+	CloseCodeContextCanceled      = metrics.CloseCodeContextCanceled
+	CloseCodeQUICIdleTimeout      = metrics.CloseCodeQUICIdleTimeout
+	CloseCodeQUICApplication      = metrics.CloseCodeQUICApplication
+	CloseCodeQUICTransport        = metrics.CloseCodeQUICTransport
+	CloseCodeQUICStreamReset      = metrics.CloseCodeQUICStreamReset
+	CloseCodeQUICHandshakeTimeout = metrics.CloseCodeQUICHandshakeTimeout
+	CloseCodeQUICStatelessReset   = metrics.CloseCodeQUICStatelessReset
+	CloseCodeH2GoAway             = metrics.CloseCodeH2GoAway
+	CloseCodeH2Stream             = metrics.CloseCodeH2Stream
+	CloseCodeH2Connection         = metrics.CloseCodeH2Connection
+	CloseCodeUnknown              = metrics.CloseCodeUnknown
+)
+
+// CloseInfo is the transport-level account of why a tunnel ended.
+type CloseInfo struct {
+	// Code is one of metrics.CloseCodes. Bounded, so safe as a metric label.
+	Code string
+	// Detail carries the peer-supplied reason where the transport provides
+	// one, plus the numeric code where there is one. Unbounded, so it belongs
+	// in logs and spans and never in a metric label.
+	Detail string
+	// Remote reports whether the peer initiated the close, where the transport
+	// tells us. QUIC carries this explicitly; nothing else on this path does.
+	// Nil means unknown, which must not be read as local.
+	Remote *bool
+}
+
+// ClassifyCloseError turns a transport error into a bounded code plus detail.
+//
+// Ordering matters. A QUIC application error also satisfies net.Error, so the
+// specific types are checked first; otherwise the useful code and reason get
+// flattened into a bare "timeout" and the information this exists to capture
+// is lost.
+func ClassifyCloseError(err error) CloseInfo {
+	if err == nil {
+		return CloseInfo{Code: CloseCodeNone}
+	}
+
+	remote := func(b bool) *bool { return &b }
+
+	var appErr *quic.ApplicationError
+	if errors.As(err, &appErr) {
+		return CloseInfo{
+			Code:   CloseCodeQUICApplication,
+			Detail: fmt.Sprintf("code=%d reason=%q", uint64(appErr.ErrorCode), appErr.ErrorMessage),
+			Remote: remote(appErr.Remote),
+		}
+	}
+	var transportErr *quic.TransportError
+	if errors.As(err, &transportErr) {
+		return CloseInfo{
+			Code:   CloseCodeQUICTransport,
+			Detail: fmt.Sprintf("code=%d reason=%q", uint64(transportErr.ErrorCode), transportErr.ErrorMessage),
+			Remote: remote(transportErr.Remote),
+		}
+	}
+	var streamErr *quic.StreamError
+	if errors.As(err, &streamErr) {
+		return CloseInfo{
+			Code:   CloseCodeQUICStreamReset,
+			Detail: fmt.Sprintf("stream=%d code=%d", int64(streamErr.StreamID), uint64(streamErr.ErrorCode)),
+			Remote: remote(streamErr.Remote),
+		}
+	}
+	var idleErr *quic.IdleTimeoutError
+	if errors.As(err, &idleErr) {
+		return CloseInfo{Code: CloseCodeQUICIdleTimeout, Detail: err.Error()}
+	}
+	var handshakeErr *quic.HandshakeTimeoutError
+	if errors.As(err, &handshakeErr) {
+		return CloseInfo{Code: CloseCodeQUICHandshakeTimeout, Detail: err.Error()}
+	}
+	var statelessErr *quic.StatelessResetError
+	if errors.As(err, &statelessErr) {
+		return CloseInfo{Code: CloseCodeQUICStatelessReset, Detail: err.Error(), Remote: remote(true)}
+	}
+
+	var goAwayErr http2.GoAwayError
+	if errors.As(err, &goAwayErr) {
+		return CloseInfo{
+			Code:   CloseCodeH2GoAway,
+			Detail: fmt.Sprintf("code=%s last_stream=%d debug=%q", goAwayErr.ErrCode, goAwayErr.LastStreamID, goAwayErr.DebugData),
+			Remote: remote(true),
+		}
+	}
+	var h2StreamErr http2.StreamError
+	if errors.As(err, &h2StreamErr) {
+		return CloseInfo{
+			Code:   CloseCodeH2Stream,
+			Detail: fmt.Sprintf("stream=%d code=%s", h2StreamErr.StreamID, h2StreamErr.Code),
+		}
+	}
+	var h2ConnErr http2.ConnectionError
+	if errors.As(err, &h2ConnErr) {
+		return CloseInfo{Code: CloseCodeH2Connection, Detail: h2ConnErr.Error()}
+	}
+
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return CloseInfo{Code: CloseCodeEOF, Detail: err.Error(), Remote: remote(true)}
+	}
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) {
+		return CloseInfo{Code: CloseCodeReset, Detail: err.Error(), Remote: remote(true)}
+	}
+	if errors.Is(err, net.ErrClosed) {
+		return CloseInfo{Code: CloseCodeClosedConn, Detail: err.Error()}
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return CloseInfo{Code: CloseCodeContextCanceled, Detail: err.Error()}
+	}
+	// net.Error last: several cases above also satisfy it, and a bare timeout
+	// is the least informative reading of any of them.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return CloseInfo{Code: CloseCodeTimeout, Detail: err.Error()}
+	}
+
+	return CloseInfo{Code: CloseCodeUnknown, Detail: err.Error()}
+}

--- a/src/invocation-plane-services/grpc-proxy/proxy/worker/closecode.go
+++ b/src/invocation-plane-services/grpc-proxy/proxy/worker/closecode.go
@@ -23,7 +23,10 @@ import (
 	"io"
 	"net"
 	"nvcf-grpc-proxy/proxy/metrics"
+	"strings"
 	"syscall"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/quic-go/quic-go"
 	"golang.org/x/net/http2"
@@ -50,6 +53,43 @@ const (
 	CloseCodeH2Connection         = metrics.CloseCodeH2Connection
 	CloseCodeUnknown              = metrics.CloseCodeUnknown
 )
+
+// maxDetailLen bounds peer-supplied text before it reaches logs or spans.
+// QUIC reason phrases and HTTP/2 debug data are meant to be short diagnostics,
+// but nothing in either protocol enforces that, and both are written by the
+// remote end.
+const maxDetailLen = 256
+
+// sanitizePeerText makes remote-supplied text safe to log.
+//
+// The reason phrase is the single most useful field here, because it is where a
+// peer says why it closed, so it is bounded rather than dropped. Truncating
+// caps how much a peer can push into the log stream, and stripping
+// non-printables stops newlines or control sequences being used to forge log
+// lines. Structured encoding already escapes these, so this is defence in
+// depth rather than the only guard.
+func sanitizePeerText(s string) string {
+	if s == "" {
+		return ""
+	}
+	truncated := false
+	if len(s) > maxDetailLen {
+		s = s[:maxDetailLen]
+		truncated = true
+	}
+	s = strings.Map(func(r rune) rune {
+		// Drop control characters and anything that failed UTF-8 decoding,
+		// which includes a rune cut in half by the truncation above.
+		if r == utf8.RuneError || !unicode.IsPrint(r) {
+			return -1
+		}
+		return r
+	}, s)
+	if truncated {
+		s += "[truncated]"
+	}
+	return s
+}
 
 // CloseInfo is the transport-level account of why a tunnel ended.
 type CloseInfo struct {
@@ -82,7 +122,7 @@ func ClassifyCloseError(err error) CloseInfo {
 	if errors.As(err, &appErr) {
 		return CloseInfo{
 			Code:   CloseCodeQUICApplication,
-			Detail: fmt.Sprintf("code=%d reason=%q", uint64(appErr.ErrorCode), appErr.ErrorMessage),
+			Detail: fmt.Sprintf("code=%d reason=%q", uint64(appErr.ErrorCode), sanitizePeerText(appErr.ErrorMessage)),
 			Remote: remote(appErr.Remote),
 		}
 	}
@@ -90,7 +130,7 @@ func ClassifyCloseError(err error) CloseInfo {
 	if errors.As(err, &transportErr) {
 		return CloseInfo{
 			Code:   CloseCodeQUICTransport,
-			Detail: fmt.Sprintf("code=%d reason=%q", uint64(transportErr.ErrorCode), transportErr.ErrorMessage),
+			Detail: fmt.Sprintf("code=%d reason=%q", uint64(transportErr.ErrorCode), sanitizePeerText(transportErr.ErrorMessage)),
 			Remote: remote(transportErr.Remote),
 		}
 	}
@@ -119,7 +159,7 @@ func ClassifyCloseError(err error) CloseInfo {
 	if errors.As(err, &goAwayErr) {
 		return CloseInfo{
 			Code:   CloseCodeH2GoAway,
-			Detail: fmt.Sprintf("code=%s last_stream=%d debug=%q", goAwayErr.ErrCode, goAwayErr.LastStreamID, goAwayErr.DebugData),
+			Detail: fmt.Sprintf("code=%s last_stream=%d debug=%q", goAwayErr.ErrCode, goAwayErr.LastStreamID, sanitizePeerText(goAwayErr.DebugData)),
 			Remote: remote(true),
 		}
 	}

--- a/src/invocation-plane-services/grpc-proxy/proxy/worker/closecode.go
+++ b/src/invocation-plane-services/grpc-proxy/proxy/worker/closecode.go
@@ -60,7 +60,12 @@ const (
 // remote end.
 const maxDetailLen = 256
 
-// sanitizePeerText makes remote-supplied text safe to log.
+// truncationMarker is appended when text is cut. Its length is reserved out of
+// maxDetailLen so the returned string never exceeds the stated bound.
+const truncationMarker = "[truncated]"
+
+// sanitizePeerText makes remote-supplied text safe to log, returning at most
+// maxDetailLen bytes.
 //
 // The reason phrase is the single most useful field here, because it is where a
 // peer says why it closed, so it is bounded rather than dropped. Truncating
@@ -74,7 +79,9 @@ func sanitizePeerText(s string) string {
 	}
 	truncated := false
 	if len(s) > maxDetailLen {
-		s = s[:maxDetailLen]
+		// Reserve room for the marker so the result stays within the bound
+		// this function advertises.
+		s = s[:maxDetailLen-len(truncationMarker)]
 		truncated = true
 	}
 	s = strings.Map(func(r rune) rune {
@@ -86,9 +93,21 @@ func sanitizePeerText(s string) string {
 		return r
 	}, s)
 	if truncated {
-		s += "[truncated]"
+		s += truncationMarker
 	}
 	return s
+}
+
+// appendPeerText adds an optional peer-supplied field to a detail string, and
+// omits it entirely when the sanitized text is empty. Emitting reason="" or
+// debug="" is noise that reads like the peer said nothing when in fact it sent
+// no field at all.
+func appendPeerText(base, key, text string) string {
+	clean := sanitizePeerText(text)
+	if clean == "" {
+		return base
+	}
+	return fmt.Sprintf("%s %s=%q", base, key, clean)
 }
 
 // CloseInfo is the transport-level account of why a tunnel ended.
@@ -122,7 +141,7 @@ func ClassifyCloseError(err error) CloseInfo {
 	if errors.As(err, &appErr) {
 		return CloseInfo{
 			Code:   CloseCodeQUICApplication,
-			Detail: fmt.Sprintf("code=%d reason=%q", uint64(appErr.ErrorCode), sanitizePeerText(appErr.ErrorMessage)),
+			Detail: appendPeerText(fmt.Sprintf("code=%d", uint64(appErr.ErrorCode)), "reason", appErr.ErrorMessage),
 			Remote: remote(appErr.Remote),
 		}
 	}
@@ -130,7 +149,7 @@ func ClassifyCloseError(err error) CloseInfo {
 	if errors.As(err, &transportErr) {
 		return CloseInfo{
 			Code:   CloseCodeQUICTransport,
-			Detail: fmt.Sprintf("code=%d reason=%q", uint64(transportErr.ErrorCode), sanitizePeerText(transportErr.ErrorMessage)),
+			Detail: appendPeerText(fmt.Sprintf("code=%d", uint64(transportErr.ErrorCode)), "reason", transportErr.ErrorMessage),
 			Remote: remote(transportErr.Remote),
 		}
 	}
@@ -159,7 +178,7 @@ func ClassifyCloseError(err error) CloseInfo {
 	if errors.As(err, &goAwayErr) {
 		return CloseInfo{
 			Code:   CloseCodeH2GoAway,
-			Detail: fmt.Sprintf("code=%s last_stream=%d debug=%q", goAwayErr.ErrCode, goAwayErr.LastStreamID, sanitizePeerText(goAwayErr.DebugData)),
+			Detail: appendPeerText(fmt.Sprintf("code=%s last_stream=%d", goAwayErr.ErrCode, goAwayErr.LastStreamID), "debug", goAwayErr.DebugData),
 			Remote: remote(true),
 		}
 	}

--- a/src/invocation-plane-services/grpc-proxy/proxy/worker/closecode_test.go
+++ b/src/invocation-plane-services/grpc-proxy/proxy/worker/closecode_test.go
@@ -29,6 +29,7 @@ import (
 	"syscall"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/quic-go/quic-go"
@@ -196,8 +197,10 @@ func boolPtr(b bool) *bool { return &b }
 
 type stubConn struct {
 	net.Conn
-	readErrs []error
-	n        int
+	readErrs  []error
+	writeErrs []error
+	n         int
+	w         int
 }
 
 func (s *stubConn) Read([]byte) (int, error) {
@@ -209,8 +212,15 @@ func (s *stubConn) Read([]byte) (int, error) {
 	return 0, nil
 }
 
-func (s *stubConn) Write(b []byte) (int, error) { return len(b), nil }
-func (s *stubConn) Close() error                { return nil }
+func (s *stubConn) Write(b []byte) (int, error) {
+	if s.w < len(s.writeErrs) {
+		err := s.writeErrs[s.w]
+		s.w++
+		return 0, err
+	}
+	return len(b), nil
+}
+func (s *stubConn) Close() error { return nil }
 
 func TestMarkClosedFirstWriterWins(t *testing.T) {
 	w := NewWorkerConnection(uuid.New(), "fn", "ver", func() {}, func() {})
@@ -238,5 +248,94 @@ func TestSetCloseErrorFirstWriterWinsAndIgnoresNil(t *testing.T) {
 	w.SetCloseError(errors.New("cascade"))
 	if got := w.CloseError(); !errors.Is(got, real) {
 		t.Errorf("CloseError() = %v, want %v", got, real)
+	}
+}
+
+func TestCloseFuncConnRecordsFirstWriteError(t *testing.T) {
+	first := errors.New("first write failure")
+	second := errors.New("second write failure")
+	fc := &CloseFuncConn{Conn: &stubConn{writeErrs: []error{first, second}}, onClose: func() {}}
+
+	_, _ = fc.Write([]byte("a"))
+	_, _ = fc.Write([]byte("b"))
+
+	if got := fc.FirstError(); !errors.Is(got, first) {
+		t.Errorf("FirstError() = %v, want %v: the first write failure must survive", got, first)
+	}
+}
+
+func TestCloseFuncConnFirstErrorSpansReadAndWrite(t *testing.T) {
+	writeErr := errors.New("write failed first")
+	readErr := errors.New("read failed after")
+	fc := &CloseFuncConn{
+		Conn:    &stubConn{writeErrs: []error{writeErr}, readErrs: []error{readErr}},
+		onClose: func() {},
+	}
+
+	_, _ = fc.Write([]byte("a"))
+	_, _ = fc.Read(make([]byte, 1))
+
+	if got := fc.FirstError(); !errors.Is(got, writeErr) {
+		t.Errorf("FirstError() = %v, want %v: first-writer-wins must hold across both directions", got, writeErr)
+	}
+}
+
+// Peer-supplied reason text reaches logs and spans, so it must be bounded and
+// stripped of anything that could forge a log line.
+func TestSanitizePeerText(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty stays empty", in: "", want: ""},
+		{name: "ordinary reason is preserved", in: "worker shutting down", want: "worker shutting down"},
+		{name: "newlines are stripped", in: "line one\nline two", want: "line oneline two"},
+		{name: "carriage returns are stripped", in: "a\r\nb", want: "ab"},
+		{name: "control characters are stripped", in: "a\x00\x07b", want: "ab"},
+		{name: "tabs are stripped", in: "a\tb", want: "ab"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizePeerText(tc.in); got != tc.want {
+				t.Errorf("sanitizePeerText(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitizePeerTextTruncates(t *testing.T) {
+	got := sanitizePeerText(strings.Repeat("x", maxDetailLen*4))
+	if !strings.HasSuffix(got, "[truncated]") {
+		t.Errorf("long input was not marked truncated: %q", got)
+	}
+	if body := strings.TrimSuffix(got, "[truncated]"); len(body) != maxDetailLen {
+		t.Errorf("kept %d bytes, want %d", len(body), maxDetailLen)
+	}
+}
+
+// Truncating at a byte offset can split a multi-byte rune. The result must
+// still be valid UTF-8, or it corrupts whatever consumes the log.
+func TestSanitizePeerTextTruncationKeepsValidUTF8(t *testing.T) {
+	// Three-byte runes do not divide evenly into maxDetailLen, so this
+	// guarantees the cut lands mid-rune.
+	got := sanitizePeerText(strings.Repeat("世", maxDetailLen))
+	if !utf8.ValidString(got) {
+		t.Errorf("sanitized output is not valid UTF-8: %q", got)
+	}
+}
+
+// A peer must not be able to smuggle a fake field into the classified detail.
+func TestClassifyCloseErrorSanitizesPeerReason(t *testing.T) {
+	hostile := &quic.ApplicationError{
+		ErrorCode:    7,
+		ErrorMessage: "ok\n\tlevel=fatal msg=\"forged\"",
+	}
+	detail := ClassifyCloseError(hostile).Detail
+	if strings.ContainsAny(detail, "\n\r\t") {
+		t.Errorf("detail carries control characters from the peer: %q", detail)
+	}
+	if !strings.Contains(detail, "code=7") {
+		t.Errorf("detail lost the protocol code, which is the bounded part: %q", detail)
 	}
 }

--- a/src/invocation-plane-services/grpc-proxy/proxy/worker/closecode_test.go
+++ b/src/invocation-plane-services/grpc-proxy/proxy/worker/closecode_test.go
@@ -1,0 +1,211 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"nvcf-grpc-proxy/proxy/metrics"
+	"os"
+	"slices"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/quic-go/quic-go"
+	"golang.org/x/net/http2"
+)
+
+func TestClassifyCloseError(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantCode   string
+		wantDetail string // substring, empty means do not check
+		wantRemote *bool
+	}{
+		{name: "nil is none", err: nil, wantCode: CloseCodeNone},
+		{
+			name:       "quic application error keeps code and reason",
+			err:        &quic.ApplicationError{ErrorCode: 0x101, ErrorMessage: "worker shutting down", Remote: true},
+			wantCode:   CloseCodeQUICApplication,
+			wantDetail: `code=257 reason="worker shutting down"`,
+			wantRemote: boolPtr(true),
+		},
+		{
+			name:       "quic application error records local close",
+			err:        &quic.ApplicationError{ErrorCode: 0x0, ErrorMessage: "", Remote: false},
+			wantCode:   CloseCodeQUICApplication,
+			wantRemote: boolPtr(false),
+		},
+		{
+			name:       "quic transport error",
+			err:        &quic.TransportError{ErrorCode: quic.ConnectionRefused, ErrorMessage: "refused", Remote: true},
+			wantCode:   CloseCodeQUICTransport,
+			wantDetail: "refused",
+			wantRemote: boolPtr(true),
+		},
+		{
+			name:       "quic stream reset",
+			err:        &quic.StreamError{StreamID: 7, ErrorCode: 42, Remote: true},
+			wantCode:   CloseCodeQUICStreamReset,
+			wantDetail: "stream=7 code=42",
+			wantRemote: boolPtr(true),
+		},
+		{name: "quic idle timeout", err: &quic.IdleTimeoutError{}, wantCode: CloseCodeQUICIdleTimeout},
+		{name: "quic handshake timeout", err: &quic.HandshakeTimeoutError{}, wantCode: CloseCodeQUICHandshakeTimeout},
+		{
+			name:       "quic stateless reset is always remote",
+			err:        &quic.StatelessResetError{},
+			wantCode:   CloseCodeQUICStatelessReset,
+			wantRemote: boolPtr(true),
+		},
+		{
+			name:       "http2 goaway keeps error code and debug data",
+			err:        http2.GoAwayError{LastStreamID: 9, ErrCode: http2.ErrCodeNo, DebugData: "graceful"},
+			wantCode:   CloseCodeH2GoAway,
+			wantDetail: `debug="graceful"`,
+			wantRemote: boolPtr(true),
+		},
+		{
+			name:       "http2 stream error",
+			err:        http2.StreamError{StreamID: 3, Code: http2.ErrCodeCancel},
+			wantCode:   CloseCodeH2Stream,
+			wantDetail: "stream=3",
+		},
+		{name: "http2 connection error", err: http2.ConnectionError(http2.ErrCodeProtocol), wantCode: CloseCodeH2Connection},
+		{name: "eof is a clean peer close", err: io.EOF, wantCode: CloseCodeEOF, wantRemote: boolPtr(true)},
+		{name: "unexpected eof", err: io.ErrUnexpectedEOF, wantCode: CloseCodeEOF, wantRemote: boolPtr(true)},
+		{name: "econnreset", err: syscall.ECONNRESET, wantCode: CloseCodeReset, wantRemote: boolPtr(true)},
+		{name: "epipe", err: syscall.EPIPE, wantCode: CloseCodeReset, wantRemote: boolPtr(true)},
+		{name: "closed conn", err: net.ErrClosed, wantCode: CloseCodeClosedConn},
+		{name: "context canceled", err: context.Canceled, wantCode: CloseCodeContextCanceled},
+		{name: "deadline exceeded", err: context.DeadlineExceeded, wantCode: CloseCodeContextCanceled},
+		{name: "net timeout", err: os.ErrDeadlineExceeded, wantCode: CloseCodeTimeout},
+		{name: "unrecognised", err: errors.New("something else"), wantCode: CloseCodeUnknown, wantDetail: "something else"},
+		{
+			name:       "wrapped errors are still classified",
+			err:        fmt.Errorf("reading from worker: %w", io.EOF),
+			wantCode:   CloseCodeEOF,
+			wantRemote: boolPtr(true),
+		},
+		{
+			name:       "wrapped quic error keeps its code rather than degrading to timeout",
+			err:        fmt.Errorf("stream failed: %w", &quic.ApplicationError{ErrorCode: 5, ErrorMessage: "bye"}),
+			wantCode:   CloseCodeQUICApplication,
+			wantDetail: `code=5 reason="bye"`,
+			wantRemote: boolPtr(false),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyCloseError(tc.err)
+			if got.Code != tc.wantCode {
+				t.Errorf("code = %q, want %q (detail %q)", got.Code, tc.wantCode, got.Detail)
+			}
+			if tc.wantDetail != "" && !strings.Contains(got.Detail, tc.wantDetail) {
+				t.Errorf("detail = %q, want it to contain %q", got.Detail, tc.wantDetail)
+			}
+			switch {
+			case tc.wantRemote == nil && got.Remote != nil:
+				t.Errorf("Remote = %v, want nil (unknown)", *got.Remote)
+			case tc.wantRemote != nil && got.Remote == nil:
+				t.Errorf("Remote = nil, want %v", *tc.wantRemote)
+			case tc.wantRemote != nil && *got.Remote != *tc.wantRemote:
+				t.Errorf("Remote = %v, want %v", *got.Remote, *tc.wantRemote)
+			}
+		})
+	}
+}
+
+// Every code the classifier can emit must be in metrics.CloseCodes, or the
+// metric gains an un-preinitialised series and absent() alerts misfire.
+func TestEveryEmittedCodeIsPreInitialised(t *testing.T) {
+	emitted := []error{
+		nil,
+		&quic.ApplicationError{}, &quic.TransportError{}, &quic.StreamError{},
+		&quic.IdleTimeoutError{}, &quic.HandshakeTimeoutError{}, &quic.StatelessResetError{},
+		http2.GoAwayError{}, http2.StreamError{}, http2.ConnectionError(http2.ErrCodeProtocol),
+		io.EOF, syscall.ECONNRESET, net.ErrClosed, context.Canceled,
+		os.ErrDeadlineExceeded, errors.New("x"),
+	}
+	seen := map[string]bool{}
+	for _, err := range emitted {
+		code := ClassifyCloseError(err).Code
+		seen[code] = true
+		if !slices.Contains(metrics.CloseCodes, code) {
+			t.Errorf("classifier emits %q which is missing from metrics.CloseCodes", code)
+		}
+	}
+	// And the reverse: no stale entries that can never be produced.
+	for _, code := range metrics.CloseCodes {
+		if !seen[code] {
+			t.Errorf("metrics.CloseCodes lists %q but no input produces it", code)
+		}
+	}
+}
+
+func TestCloseFuncConnRecordsFirstError(t *testing.T) {
+	first := errors.New("first")
+	second := errors.New("second")
+	fc := &CloseFuncConn{Conn: &stubConn{readErrs: []error{first, second}}, onClose: func() {}}
+
+	buf := make([]byte, 1)
+	_, _ = fc.Read(buf)
+	_, _ = fc.Read(buf)
+
+	if got := fc.FirstError(); !errors.Is(got, first) {
+		t.Errorf("FirstError() = %v, want %v: the original fault must survive the cascade", got, first)
+	}
+}
+
+func TestCloseFuncConnNoErrorWhenClean(t *testing.T) {
+	fc := &CloseFuncConn{Conn: &stubConn{}, onClose: func() {}}
+	if _, err := fc.Write([]byte("x")); err != nil {
+		t.Fatalf("unexpected write error: %v", err)
+	}
+	if got := fc.FirstError(); got != nil {
+		t.Errorf("FirstError() = %v, want nil", got)
+	}
+	if code := ClassifyCloseError(fc.FirstError()).Code; code != CloseCodeNone {
+		t.Errorf("code = %q, want %q", code, CloseCodeNone)
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+type stubConn struct {
+	net.Conn
+	readErrs []error
+	n        int
+}
+
+func (s *stubConn) Read([]byte) (int, error) {
+	if s.n < len(s.readErrs) {
+		err := s.readErrs[s.n]
+		s.n++
+		return 0, err
+	}
+	return 0, nil
+}
+
+func (s *stubConn) Write(b []byte) (int, error) { return len(b), nil }
+func (s *stubConn) Close() error                { return nil }

--- a/src/invocation-plane-services/grpc-proxy/proxy/worker/closecode_test.go
+++ b/src/invocation-plane-services/grpc-proxy/proxy/worker/closecode_test.go
@@ -309,8 +309,8 @@ func TestSanitizePeerTextTruncates(t *testing.T) {
 	if !strings.HasSuffix(got, "[truncated]") {
 		t.Errorf("long input was not marked truncated: %q", got)
 	}
-	if body := strings.TrimSuffix(got, "[truncated]"); len(body) != maxDetailLen {
-		t.Errorf("kept %d bytes, want %d", len(body), maxDetailLen)
+	if len(got) > maxDetailLen {
+		t.Errorf("sanitized output is %d bytes, which exceeds the advertised bound of %d", len(got), maxDetailLen)
 	}
 }
 
@@ -337,5 +337,79 @@ func TestClassifyCloseErrorSanitizesPeerReason(t *testing.T) {
 	}
 	if !strings.Contains(detail, "code=7") {
 		t.Errorf("detail lost the protocol code, which is the bounded part: %q", detail)
+	}
+}
+
+// The whole point of closedAt is to exclude teardown latency. If eviction runs
+// long after the session ended, held_for must still reflect the session, not
+// the session plus our cleanup.
+func TestClosedAtExcludesTeardownLatency(t *testing.T) {
+	w := NewWorkerConnection(uuid.New(), "fn", "ver", func() {}, func() {})
+	sessionEnd := w.CreatedAt.Add(15 * time.Second)
+
+	// Whoever noticed first stamps it.
+	w.MarkClosed(sessionEnd)
+	// Teardown then cascades, arbitrarily later.
+	w.MarkClosed(sessionEnd.Add(30 * time.Second))
+	w.MarkClosed(sessionEnd.Add(90 * time.Second))
+
+	heldFor := w.ClosedAt().Sub(w.CreatedAt)
+	if heldFor != 15*time.Second {
+		t.Errorf("held_for = %v, want 15s: teardown latency must not inflate the tunnel lifetime", heldFor)
+	}
+}
+
+func TestDetailOmitsEmptyPeerFields(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantContain string
+		wantAbsent  string
+	}{
+		{
+			name:        "quic application error without a reason omits the field",
+			err:         &quic.ApplicationError{ErrorCode: 3},
+			wantContain: "code=3",
+			wantAbsent:  "reason=",
+		},
+		{
+			name:        "quic application error with a reason includes it",
+			err:         &quic.ApplicationError{ErrorCode: 3, ErrorMessage: "draining"},
+			wantContain: `reason="draining"`,
+		},
+		{
+			name:        "quic transport error without a reason omits the field",
+			err:         &quic.TransportError{ErrorCode: quic.NoError},
+			wantContain: "code=",
+			wantAbsent:  "reason=",
+		},
+		{
+			name:        "goaway without debug data omits the field",
+			err:         http2.GoAwayError{LastStreamID: 4, ErrCode: http2.ErrCodeNo},
+			wantContain: "last_stream=4",
+			wantAbsent:  "debug=",
+		},
+		{
+			name:        "goaway with debug data includes it",
+			err:         http2.GoAwayError{LastStreamID: 4, ErrCode: http2.ErrCodeNo, DebugData: "bye"},
+			wantContain: `debug="bye"`,
+		},
+		{
+			name:        "a reason of only control characters is dropped, not emitted empty",
+			err:         &quic.ApplicationError{ErrorCode: 9, ErrorMessage: "\n\r\x00"},
+			wantContain: "code=9",
+			wantAbsent:  "reason=",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyCloseError(tc.err).Detail
+			if !strings.Contains(got, tc.wantContain) {
+				t.Errorf("detail = %q, want it to contain %q", got, tc.wantContain)
+			}
+			if tc.wantAbsent != "" && strings.Contains(got, tc.wantAbsent) {
+				t.Errorf("detail = %q, want it to omit %q", got, tc.wantAbsent)
+			}
+		})
 	}
 }

--- a/src/invocation-plane-services/grpc-proxy/proxy/worker/closecode_test.go
+++ b/src/invocation-plane-services/grpc-proxy/proxy/worker/closecode_test.go
@@ -28,7 +28,9 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/quic-go/quic-go"
 	"golang.org/x/net/http2"
 )
@@ -209,3 +211,32 @@ func (s *stubConn) Read([]byte) (int, error) {
 
 func (s *stubConn) Write(b []byte) (int, error) { return len(b), nil }
 func (s *stubConn) Close() error                { return nil }
+
+func TestMarkClosedFirstWriterWins(t *testing.T) {
+	w := NewWorkerConnection(uuid.New(), "fn", "ver", func() {}, func() {})
+	if !w.ClosedAt().IsZero() {
+		t.Fatal("ClosedAt() should be zero before any close is stamped")
+	}
+	first := time.Now()
+	second := first.Add(time.Second)
+	w.MarkClosed(first)
+	w.MarkClosed(second)
+	if got := w.ClosedAt(); !got.Equal(first) {
+		t.Errorf("ClosedAt() = %v, want %v: a later cascade must not overwrite the real close", got, first)
+	}
+}
+
+func TestSetCloseErrorFirstWriterWinsAndIgnoresNil(t *testing.T) {
+	w := NewWorkerConnection(uuid.New(), "fn", "ver", func() {}, func() {})
+	if w.CloseError() != nil {
+		t.Fatal("CloseError() should be nil before any error is recorded")
+	}
+	// A nil must not occupy the slot, or the real error that follows is lost.
+	w.SetCloseError(nil)
+	real := errors.New("real cause")
+	w.SetCloseError(real)
+	w.SetCloseError(errors.New("cascade"))
+	if got := w.CloseError(); !errors.Is(got, real) {
+		t.Errorf("CloseError() = %v, want %v", got, real)
+	}
+}

--- a/src/invocation-plane-services/grpc-proxy/proxy/worker/connections.go
+++ b/src/invocation-plane-services/grpc-proxy/proxy/worker/connections.go
@@ -152,8 +152,13 @@ func (c *ConnectionTrackingConn) Close() error {
 		})
 		if workerConnection != nil {
 			// Record the origin before tearing down, so the eviction handler
-			// reports client_closed rather than a bare deleted.
+			// reports client_closed rather than a bare deleted. Stamp the
+			// close here too: client_closed is the common case, so without
+			// this the accurate close time would be missing from most
+			// evictions and held_for would fall back to whenever the cache
+			// callback happened to run.
 			workerConnection.SetCloseOrigin(metrics.CloseReasonClientClosed)
+			workerConnection.MarkClosed(time.Now())
 			zap.L().Info("triggering worker connection shutdown from client close",
 				zap.String("function_id", key.functionId),
 				zap.String("function_version_id", key.functionVersionId),

--- a/src/invocation-plane-services/grpc-proxy/proxy/worker/worker.go
+++ b/src/invocation-plane-services/grpc-proxy/proxy/worker/worker.go
@@ -154,12 +154,13 @@ func (w *WorkerConnection) SetConnection(conn net.Conn) error {
 			w.MarkClosed(time.Now())
 			w.onInactive()
 		}
-		conn := net.Conn(wrapped)
 		dialOnce := atomic.Bool{}
 		dialContext := func(ctx context.Context, network, addr string) (net.Conn, error) {
 			if !dialOnce.Swap(true) {
 				w.onActive()
-				return conn, nil
+				// Hand out the wrapper, not the raw conn: it is what records
+				// the transport error used to explain the close.
+				return wrapped, nil
 			}
 			return nil, fmt.Errorf("can only dial once")
 		}
@@ -210,7 +211,7 @@ func (w *WorkerConnection) SetConnection(conn net.Conn) error {
 			return
 		}
 		w.handler.Store(handler)
-		w.closeWorkerConn = conn // implements io.Closer
+		w.closeWorkerConn = wrapped // implements io.Closer
 		close(w.connPopulated)
 		set = true
 	})

--- a/src/invocation-plane-services/grpc-proxy/proxy/worker/worker.go
+++ b/src/invocation-plane-services/grpc-proxy/proxy/worker/worker.go
@@ -78,9 +78,16 @@ type WorkerConnection struct {
 	// Distinct from closeOrigin: origin says which side tore down, closeErr
 	// says what the transport reported while doing it.
 	closeErr atomic.Pointer[errBox]
-	// closedAt is when the transport actually went away. The cache eviction
-	// callback can run measurably later, so the log line's own timestamp is
-	// not a reliable stand-in.
+	// closedAt is when the proxy observed this tunnel stop carrying traffic,
+	// recorded by whichever side noticed first: the worker transport faulting,
+	// or the client connection going away.
+	//
+	// Deliberately not "when we finished tearing down". Teardown is our own
+	// cleanup and can lag arbitrarily behind the session actually ending, and
+	// folding that lag into held_for is the measurement error this field
+	// exists to remove. First writer wins for the same reason: the moment the
+	// tunnel stopped being useful is what matters, not the last step of the
+	// cascade that follows it.
 	closedAt        atomic.Pointer[time.Time]
 	connSetOnce     sync.Once
 	connPopulated   chan struct{}
@@ -107,13 +114,15 @@ func (w *WorkerConnection) CloseError() error {
 	return nil
 }
 
-// MarkClosed stamps the moment the transport went away. First writer wins.
+// MarkClosed stamps the moment this tunnel stopped carrying traffic. First
+// writer wins, so a later step in the teardown cascade cannot overwrite the
+// moment the session actually ended.
 func (w *WorkerConnection) MarkClosed(t time.Time) {
 	w.closedAt.CompareAndSwap(nil, &t)
 }
 
-// ClosedAt returns when the transport went away, or the zero time if the
-// close was never stamped.
+// ClosedAt returns when the tunnel stopped carrying traffic, or the zero time
+// if no close was stamped.
 func (w *WorkerConnection) ClosedAt() time.Time {
 	if t := w.closedAt.Load(); t != nil {
 		return *t

--- a/src/invocation-plane-services/grpc-proxy/proxy/worker/worker.go
+++ b/src/invocation-plane-services/grpc-proxy/proxy/worker/worker.go
@@ -73,13 +73,52 @@ type WorkerConnection struct {
 	// closeOrigin records which side initiated the teardown, set by whoever
 	// calls onInactive. Without it the eviction handler only sees "deleted"
 	// and cannot tell a client hang-up from a worker hang-up.
-	closeOrigin     atomic.Value
+	closeOrigin atomic.Value
+	// closeErr is the transport error that ended the tunnel, if there was one.
+	// Distinct from closeOrigin: origin says which side tore down, closeErr
+	// says what the transport reported while doing it.
+	closeErr atomic.Pointer[errBox]
+	// closedAt is when the transport actually went away. The cache eviction
+	// callback can run measurably later, so the log line's own timestamp is
+	// not a reliable stand-in.
+	closedAt        atomic.Pointer[time.Time]
 	connSetOnce     sync.Once
 	connPopulated   chan struct{}
 	handler         atomic.Pointer[httputil.ReverseProxy]
 	closeWorkerConn io.Closer
 	onActive        func() // call this function to indicate the connection is active
 	onInactive      func() // call this function to indicate the connection is idle
+}
+
+// SetCloseError records the transport error that ended this tunnel. First
+// writer wins, matching SetCloseOrigin.
+func (w *WorkerConnection) SetCloseError(err error) {
+	if err == nil {
+		return
+	}
+	w.closeErr.CompareAndSwap(nil, &errBox{err: err})
+}
+
+// CloseError returns the recorded transport error, or nil if none was seen.
+func (w *WorkerConnection) CloseError() error {
+	if b := w.closeErr.Load(); b != nil {
+		return b.err
+	}
+	return nil
+}
+
+// MarkClosed stamps the moment the transport went away. First writer wins.
+func (w *WorkerConnection) MarkClosed(t time.Time) {
+	w.closedAt.CompareAndSwap(nil, &t)
+}
+
+// ClosedAt returns when the transport went away, or the zero time if the
+// close was never stamped.
+func (w *WorkerConnection) ClosedAt() time.Time {
+	if t := w.closedAt.Load(); t != nil {
+		return *t
+	}
+	return time.Time{}
 }
 
 // WaitForConnection may return without a connection if the WorkerConnection struct is closed while
@@ -108,10 +147,14 @@ func (w *WorkerConnection) SetConnection(conn net.Conn) error {
 	var err error
 	set := false
 	w.connSetOnce.Do(func() {
-		conn := CloseFuncConn{Conn: conn, onClose: func() {
+		wrapped := &CloseFuncConn{Conn: conn}
+		wrapped.onClose = func() {
 			w.SetCloseOrigin(metrics.CloseReasonWorkerClosed)
+			w.SetCloseError(wrapped.FirstError())
+			w.MarkClosed(time.Now())
 			w.onInactive()
-		}}
+		}
+		conn := net.Conn(wrapped)
 		dialOnce := atomic.Bool{}
 		dialContext := func(ctx context.Context, network, addr string) (net.Conn, error) {
 			if !dialOnce.Swap(true) {
@@ -210,12 +253,50 @@ func (w *WorkerConnection) logClosure(reason string) {
 	zap.L().Info("closing worker connection", logFields...)
 }
 
+// errBox keeps the concrete type stored in an atomic.Pointer constant.
+// Storing bare error values in an atomic.Value panics as soon as two different
+// concrete error types are written.
+type errBox struct{ err error }
+
 type CloseFuncConn struct {
 	net.Conn
 	onClose func()
+	// firstErr is the first transport error seen on this connection. Recorded
+	// on Read and Write rather than in Close, because by the time Close runs
+	// the underlying cause has usually been discarded. First writer wins: the
+	// original fault is more informative than the cascade that follows it.
+	firstErr atomic.Pointer[errBox]
 }
 
-func (c CloseFuncConn) Close() error {
+func (c *CloseFuncConn) Read(b []byte) (int, error) {
+	n, err := c.Conn.Read(b)
+	c.recordErr(err)
+	return n, err
+}
+
+func (c *CloseFuncConn) Write(b []byte) (int, error) {
+	n, err := c.Conn.Write(b)
+	c.recordErr(err)
+	return n, err
+}
+
+func (c *CloseFuncConn) recordErr(err error) {
+	if err == nil {
+		return
+	}
+	c.firstErr.CompareAndSwap(nil, &errBox{err: err})
+}
+
+// FirstError returns the first transport error seen, or nil if the connection
+// closed without one.
+func (c *CloseFuncConn) FirstError() error {
+	if b := c.firstErr.Load(); b != nil {
+		return b.err
+	}
+	return nil
+}
+
+func (c *CloseFuncConn) Close() error {
 	c.onClose()
 	return c.Conn.Close()
 }


### PR DESCRIPTION
## Why

The worker tunnel eviction log line reports which side tore a tunnel down, but
not what the transport reported while doing it. That leaves the interesting
cases indistinguishable from one another:

- a peer sending a deliberate close carrying an application error code
- an idle timer expiring somewhere on the path
- a stream reset, where the connection itself survives
- a flow being dropped silently

Telling those apart currently means capturing packets on a worker while a
failure reproduces, which is expensive and only works while someone is
watching. When a tunnel repeatedly closes at a suspiciously consistent
duration, that is exactly the question being asked.

The information already exists at close time and was being thrown away.
`quicconn` string-matched one error text and swallowed it, and
`CloseFuncConn.onClose` was `func()` with no error parameter, so nothing
downstream could see a cause.

## What changed

The first transport error is captured on `Read` and `Write` rather than in
`Close`, because by the time `Close` runs the underlying cause has usually been
discarded. First writer wins, so the original fault survives the cascade that
follows it.

It is then classified and reported on the existing eviction log line, the
existing span, and one new counter:

| Field | Meaning |
|---|---|
| `close_code` | Bounded classification. Safe as a metric label |
| `close_detail` | Peer-supplied reason plus numeric code. Unbounded, so logs and spans only |
| `closed_by_peer` | Present only for QUIC, which states it explicitly. Absence means unknown, not local |
| `opened_at` | Explicit, because the eviction callback can lag the actual close |
| `closed_at` | Likewise, so the line can be correlated against other components |
| `local_timeout` | Which of this service's own timers fired, where one did |

New metric `nvcf_grpc_proxy_worker_connection_close_code_total{code}`.
It complements `worker_connection_closed_total{reason}`: that one reports which
side, this one reports what the transport said.

Classifier ordering is load-bearing. A QUIC application error also satisfies
`net.Error`, so the specific types are checked first; otherwise the code and
reason this exists to capture collapse into a bare `timeout`.

`local_timeout` is deliberately conservative. It names the worker connection
cache TTL, the transport idle timers, and the QUIC idle timer, and returns
empty for everything else. Timers owned by other components cannot be
identified from here, and naming one wrongly would send whoever reads the line
into the wrong codebase. `close_code` still characterises those cases.

## Not addressed

The proxy cannot attribute a close to a specific hop on the worker leg. A
reverse proxy sits in that path, so when a tunnel dies this service observes
its own connection to that hop going away and has no visibility into which side
originated the close. Attributing that requires correlating the reverse proxy's
access logs by request id. Called out in the issue so it is not expected from
these fields.

## Customer Release Notes

Not customer visible.

## Plan Summary

Not applicable.

## Usage

The new fields appear on the existing log line, so existing searches keep
working:

```
"worker connection cache eviction triggered" | json | close_code != "none"
```

## Testing

`bazel test //src/invocation-plane-services/grpc-proxy/proxy/worker:worker_test`
passes. `go build ./...` and `go vet ./proxy/...` are clean.

New tests cover classification of QUIC application, transport, stream reset,
idle timeout, handshake timeout and stateless reset errors; HTTP/2 GOAWAY,
stream and connection errors; EOF, `ECONNRESET`, `EPIPE`, closed connection,
context cancellation and net timeout; wrapped errors, including that a wrapped
QUIC error keeps its code rather than degrading to `timeout`. Two further tests
assert that first-writer-wins error capture holds, and that the classifier and
the pre-initialised metric label list cannot drift apart in either direction.

`localTimeoutFor` has its own table test asserting it names only this service's
timers and stays silent otherwise.

Pre-existing failures in `proxy/ratelimit` and `TestUnauthenticatedError` are
loopback networking restrictions in this sandbox. Both reproduce identically on
a clean tree with the change stashed.

## Notes

Close codes are pre-initialised so the metric appears on the first scrape
rather than only once each case first occurs, per the observability guidance in
AGENTS.md.

## Issues

Closes #971

## References

None.

## Related Pull Requests

Follows #597, which added the eviction reason, duration and CONNECT outcome
fields this builds on.

## Dependencies

None. `quic-go` and `golang.org/x/net/http2` were already direct dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed worker connection closure tracking, including close reasons, timing, transport codes, error details, and peer-origin information.
  * Added metrics for worker tunnel closures by transport close code.
  * Added support for classifying QUIC, HTTP/2, network, context, timeout, and connection errors.

* **Bug Fixes**
  * Improved timeout identification and connection duration reporting using actual transport close times.
  * Improved handling of connection errors by preserving the first reported transport error and closure timestamp.
  * Sanitized and bounded peer-provided error details for safer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->