### PR TITLE
fix(nvcf-api): bump worker-init sidecar to 1.2.0

### DIFF
--- a/deploy/helm/cloud-functions/nvcf-api/values.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/values.yaml
@@ -237,7 +237,7 @@ api:
       nvcf:
         sidecars:
           inference-container: nvcr.io/nvidia/tritonserver:23.04-py3
-          init-container: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/nvcf-worker-init-oss:1.0.9
+          init-container: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/nvcf-worker-init-oss:1.2.0
           utils-container-image:
             go: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/nvcf-worker-utils-oss:1.0.4
           otel-container: dummy

--- a/deploy/helm/cloud-functions/tests/sidecar_release_artifacts_test.sh
+++ b/deploy/helm/cloud-functions/tests/sidecar_release_artifacts_test.sh
@@ -48,7 +48,7 @@ helm template nvcf-api "${chart_dir}" \
 # concrete, placeholder-free release-artifact-*-image annotation resolved from
 # NVCF_SIDECARS_HOSTNAME / NVCF_SIDECARS_REPOSITORY.
 expected_annotations=(
-  "release-artifact-init-container-image: \"${hostname}/${repository}/nvcf-worker-init-oss:1.0.9\""
+  "release-artifact-init-container-image: \"${hostname}/${repository}/nvcf-worker-init-oss:1.2.0\""
   "release-artifact-utils-container-image-go-image: \"${hostname}/${repository}/nvcf-worker-utils-oss:1.0.4\""
   "release-artifact-niclls-container-image: \"${hostname}/${repository}/nvcf_worker_niclls:2.109.4\""
   "release-artifact-ess-agent-container-image: \"${hostname}/${repository}/ess-agent:1.3.1\""


### PR DESCRIPTION
## TL;DR
Bump the worker-init sidecar pin in the nvcf-api remote config from nvcf-worker-init-oss:1.0.9 to 1.2.0, and update the chart test to match. 1.0.9 predates the /usr/bin/nvcf-trust-bundle-install binary, so any deployment with workload transport trust enabled fails at pod start.

## For the Reviewer
Two-line change: the pin in deploy/helm/cloud-functions/nvcf-api/values.yaml and the matching expected annotation in deploy/helm/cloud-functions/tests/sidecar_release_artifacts_test.sh.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
- deploy/helm/cloud-functions/tests/sidecar_release_artifacts_test.sh passes with the new pin.
- Verified on a self-managed k3d cluster from main with addons.llm.pki enabled and nvca 3.2.6: container LLM function deployments ERROR on 1.0.9 and reach ACTIVE on 1.2.0.

## Issues
Relates to #52

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the init-container image to version 1.2.0.
  * Updated release artifact validation to reflect the new image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
