### PR TITLE
fix(compute-plane): bump nvca to 3.2.6

### DIFF
--- a/deploy/stacks/nvcf-compute-plane/environments/base.yaml
+++ b/deploy/stacks/nvcf-compute-plane/environments/base.yaml
@@ -31,9 +31,9 @@ global:
   # NVCA Operator Configuration
   # =============================================================================
   nvcaOperator:
-    imageTag: "3.2.0"
+    imageTag: "3.2.6"
     selfManaged:
-      nvcaVersion: "3.2.0"
+      nvcaVersion: "3.2.6"
       otelCollector:
         imageTag: "0.157.9"
       # ICMS (SIS) service URL — required; set per environment.

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/agent-config-merge-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/agent-config-merge-cm.yaml
@@ -27,8 +27,7 @@ metadata:
     app.kubernetes.io/version: "3.0.4"
     app.kubernetes.io/managed-by: Helm
 data:
-  config.yaml:  |2
-  
+  config.yaml:  |
     cluster:
       validationPolicy:
         allowedExtraKubernetesTypes:

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/deployment.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/deployment.yaml
@@ -119,7 +119,7 @@ spec:
           - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTU3LjExIn0="
           - --task-env-overrides-b64
           - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTU3LjExIn0="
-        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.0
+        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.6
         imagePullPolicy: IfNotPresent
         securityContext:
           # Set here so openbao injection can copy it upon injection
@@ -165,7 +165,7 @@ spec:
             cpu: "1000m"
             memory: "4Gi"
       - name: nvca-mirror
-        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.0
+        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.6
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/pre-delete-cleanup-job.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/pre-delete-cleanup-job.yaml
@@ -52,7 +52,7 @@ spec:
         fsGroup: 1010
       containers:
       - name: cleanup
-        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.0
+        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.6
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/self-managed-nvcfbackend-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/self-managed-nvcfbackend-cm.yaml
@@ -20,7 +20,7 @@ metadata:
   name: nvcfbackend-self-managed
   namespace: nvca-operator
   annotations:
-    release-artifact-nvca-image: "nvcr.io/0651155215864979/ncp-dev/nvca:3.2.0"
+    release-artifact-nvca-image: "nvcr.io/0651155215864979/ncp-dev/nvca:3.2.6"
     release-artifact-nvcf-image-credential-helper-image: "nvcr.io/0651155215864979/ncp-dev/nvcf-image-credential-helper:0.10.2"
     release-artifact-samba-image: "nvcr.io/0651155215864979/ncp-dev/samba:1.0.5"
   labels:
@@ -37,7 +37,7 @@ data:
     clusterDescription: "ncp-local"
     clusterGroupName: "nvcf-default"
     ncaID: "nvcf-default"
-    nvcaVersion: "3.2.0"
+    nvcaVersion: "3.2.6"
     oAuthClientId: ""
     cloudProvider: "NCP"
     region: "us-west-1"


### PR DESCRIPTION
## TL;DR
Bump the compute-plane stack's nvca-operator and NVCA pins from 3.2.0 to 3.2.6 and regenerate the golden testdata. 3.2.6 carries the Helm LLM transport trust backport that self-managed clusters need when addons.llm.pki is enabled.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

Regenerating the goldens also normalizes one line in agent-config-merge-cm.yaml (the merged config block scalar header). That drift predates this change: a fresh render of the unmodified stack produces the same line, so the committed golden was stale and this PR brings it back in sync with what make generate-golden produces today.

## For the Reviewer
The functional change is two values in deploy/stacks/nvcf-compute-plane/environments/base.yaml. Everything else is regenerated golden testdata from make generate-golden.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
- make test-local passes in deploy/stacks/nvcf-compute-plane: the fresh render matches the regenerated goldens and the nvca-entrypoints checks pass.
- Verified live on a self-managed k3d cluster built from main with addons.llm.pki enabled and nvca 3.2.6: the cluster registers, a container LLM function deploys to ACTIVE, and chatinvocations pass over the PKI-secured QUIC path.

## Issues
Relates to #52

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
