### PR TITLE
fix(self-managed): bump api chart to 1.25.1

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -56,7 +56,7 @@ releases:
       - template: service
 
   - name: api
-    version: 1.24.1
+    version: 1.25.1
     namespace: nvcf
     inherit:
       - template: service


### PR DESCRIPTION
## TL;DR
Bump the self-managed stack's api release from chart 1.24.1 to 1.25.1. 1.25.1 carries the worker-init sidecar pin fix (1.0.9 to 1.2.0).

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
Chart 1.25.1 contains two changes over 1.24.1: the worker-init sidecar pin bump from #979 and the api.accountBootstrap.enabled flag from #895. 

The chart's appVersion and default service image stay at 1.12.6, so the bump pulls no new service image.

## For the Reviewer
One-line change: the api release version in deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
- make test in deploy/stacks/self-managed passes.
- Chart 1.25.1 verified published and pullable.
- The sidecar fix this chart delivers was verified live on a self-managed k3d cluster with addons.llm.pki enabled.

## Issues
Relates to #52

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the API service to chart version 1.25.1 for self-managed deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->