### PR TITLE
fix(compute-plane): bump NVCA to 3.2.7

### DIFF
--- a/deploy/helm/nvca-operator/tests/render_values_from_stack_env_test.sh
+++ b/deploy/helm/nvca-operator/tests/render_values_from_stack_env_test.sh
@@ -47,9 +47,9 @@ fi
 if [[ "$1" == "get" && "$2" == "values" ]]; then
   cat <<'YAML'
 image:
-  tag: 2.52.0-rc.1
+  tag: 3.2.6
 selfManaged:
-  nvcaVersion: 2.52.0-rc.1
+  nvcaVersion: 3.2.6
 YAML
   exit 0
 fi
@@ -64,21 +64,21 @@ STACK_ENV_FILE="${stack_env_file}" \
 OUTPUT_FILE="${output_file}" \
 RELEASE="nvca-operator" \
 NAMESPACE="nvca-operator" \
-NVCA_OPERATOR_VERSION="2.52.0-rc.5" \
-NVCA_VERSION="2.52.0-rc.5" \
+NVCA_OPERATOR_VERSION="3.2.7" \
+NVCA_VERSION="3.2.7" \
 "${repo_root}/scripts/render_values_from_stack_env.sh"
 
 actual_image_tag="$(yq -r '.image.tag' "${output_file}")"
 actual_nvca_version="$(yq -r '.selfManaged.nvcaVersion' "${output_file}")"
 
-if [[ "${actual_image_tag}" != "2.52.0-rc.5" ]]; then
-  echo "expected image.tag to stay aligned with vendored chart defaults, got ${actual_image_tag}" >&2
+if [[ "${actual_image_tag}" != "3.2.7" ]]; then
+  echo "expected image.tag to use the requested operator version, got ${actual_image_tag}" >&2
   exit 1
 fi
 
-if [[ "${actual_nvca_version}" != "2.52.0-rc.5" ]]; then
-  echo "expected selfManaged.nvcaVersion to stay aligned with vendored chart defaults, got ${actual_nvca_version}" >&2
+if [[ "${actual_nvca_version}" != "3.2.7" ]]; then
+  echo "expected selfManaged.nvcaVersion to use the requested NVCA version, got ${actual_nvca_version}" >&2
   exit 1
 fi
 
-echo "render_values_from_stack_env.sh keeps upgrade version fields aligned with vendored defaults"
+echo "render_values_from_stack_env.sh keeps upgrade version fields aligned with requested versions"

--- a/deploy/stacks/nvcf-compute-plane/environments/base.yaml
+++ b/deploy/stacks/nvcf-compute-plane/environments/base.yaml
@@ -31,9 +31,9 @@ global:
   # NVCA Operator Configuration
   # =============================================================================
   nvcaOperator:
-    imageTag: "3.2.6"
+    imageTag: "3.2.7"
     selfManaged:
-      nvcaVersion: "3.2.6"
+      nvcaVersion: "3.2.7"
       otelCollector:
         imageTag: "0.157.9"
       # ICMS (SIS) service URL — required; set per environment.

--- a/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
+++ b/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
@@ -156,7 +156,7 @@ releases:
     # Released chart from nvca-operator-deploy. Compute-plane base values own
     # the operator and NVCA versions used by this stack.
     chart: nvcf/helm-nvca-operator
-    version: 1.19.0
+    version: 1.21.3
     namespace: nvca-operator
     values:
       - ../global.yaml.gotmpl

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/agent-config-merge-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/agent-config-merge-cm.yaml
@@ -21,13 +21,14 @@ metadata:
   name: agent-config-merge
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.19.0
+    helm.sh/chart: helm-nvca-operator-1.21.3
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.0.4"
     app.kubernetes.io/managed-by: Helm
 data:
-  config.yaml:  |
+  config.yaml:  |2
+  
     cluster:
       validationPolicy:
         allowedExtraKubernetesTypes:

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/chart-defaults-nvcfbackend-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/chart-defaults-nvcfbackend-cm.yaml
@@ -21,7 +21,7 @@ metadata:
   name: nvcfbackend-chart-defaults
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.19.0
+    helm.sh/chart: helm-nvca-operator-1.21.3
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.0.4"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/crds/nvidia.io_nvcfbackends_crd.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/crds/nvidia.io_nvcfbackends_crd.yaml
@@ -20,7 +20,7 @@ kind: CustomResourceDefinition
 metadata:
   name: nvcfbackends.nvcf.nvidia.io
   labels:
-    helm.sh/chart: helm-nvca-operator-1.19.0
+    helm.sh/chart: helm-nvca-operator-1.21.3
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.0.4"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/custom-annotations-configmap.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/custom-annotations-configmap.yaml
@@ -21,7 +21,7 @@ metadata:
   name: nvca-namespace-pod-annotations
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.19.0
+    helm.sh/chart: helm-nvca-operator-1.21.3
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.0.4"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/custom-network-policies-configmap.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/custom-network-policies-configmap.yaml
@@ -21,7 +21,7 @@ metadata:
   name: nvcf-custom-network-policies
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.19.0
+    helm.sh/chart: helm-nvca-operator-1.21.3
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.0.4"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/deployment.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/deployment.yaml
@@ -21,7 +21,7 @@ metadata:
   name: nvca-operator
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.19.0
+    helm.sh/chart: helm-nvca-operator-1.21.3
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.0.4"
@@ -47,6 +47,17 @@ spec:
         runAsUser: 1000
         runAsGroup: 1010
         fsGroup: 1010
+        # Defense in depth: enforce non-root + seccomp at the pod
+        # level. runAsUser=1000 already guarantees non-root; setting
+        # runAsNonRoot=true makes the constraint explicit (kubelet
+        # will reject the pod if the image's USER somehow goes back
+        # to root). seccompProfile=RuntimeDefault blocks the
+        # ~40 syscalls Docker's default seccomp profile blocks
+        # (clock_settime, modify_ldt, …) — safe for any normal Go
+        # operator.
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 600
       containers:
       - name: nvca-operator
@@ -84,7 +95,7 @@ spec:
         - name: OTEL_COLLECTOR_IMAGE_REPO
           value: "nvcr.io/nvidia/nvcf-byoc/nvcf-otel-collector"
         - name: OTEL_COLLECTOR_IMAGE_TAG
-          value: "0.143.2"
+          value: "0.157.9"
         - name: OTEL_COLLECTOR_RESOURCES_B64
           value: "eyJsaW1pdHMiOnsiY3B1IjoiMTAwMG0iLCJtZW1vcnkiOiIxR2kifSwicmVxdWVzdHMiOnsiY3B1IjoiMjAwbSIsIm1lbW9yeSI6IjI1Nk1pIn19"
         - name: OPERATOR_NAMESPACE
@@ -116,10 +127,10 @@ spec:
           - --nvca-cache-mount-options
           - "ro,norecovery,nouuid"
           - --function-env-overrides-b64
-          - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTU3LjExIn0="
+          - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTU3LjAtbnYtMC4xLjEifQ=="
           - --task-env-overrides-b64
-          - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTU3LjExIn0="
-        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.6
+          - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTU3LjAtbnYtMC4xLjEifQ=="
+        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.7
         imagePullPolicy: IfNotPresent
         securityContext:
           # Set here so openbao injection can copy it upon injection
@@ -165,7 +176,7 @@ spec:
             cpu: "1000m"
             memory: "4Gi"
       - name: nvca-mirror
-        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.6
+        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.7
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/gpu-profiling-config-configmap.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/gpu-profiling-config-configmap.yaml
@@ -25,7 +25,7 @@ metadata:
   name: nvca-gpu-profiling-config
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.19.0
+    helm.sh/chart: helm-nvca-operator-1.21.3
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.0.4"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
@@ -21,7 +21,7 @@ metadata:
   name: nvcfbackend-helm-managed
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.19.0
+    helm.sh/chart: helm-nvca-operator-1.21.3
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.0.4"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/ngc-service-key.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/ngc-service-key.yaml
@@ -20,7 +20,7 @@ kind: Secret
 metadata:
   name: ngc-service-key
   labels:
-    helm.sh/chart: helm-nvca-operator-1.19.0
+    helm.sh/chart: helm-nvca-operator-1.21.3
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.0.4"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/operator-config-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/operator-config-cm.yaml
@@ -20,7 +20,7 @@ metadata:
   name: nvca-operator-config
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.19.0
+    helm.sh/chart: helm-nvca-operator-1.21.3
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.0.4"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/operator-networkpolicy.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/operator-networkpolicy.yaml
@@ -1,0 +1,53 @@
+---
+# Source: helm-nvca-operator/templates/operator-networkpolicy.yaml
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# NetworkPolicy hardening for the nvca-operator pod itself.
+#
+# By default, in clusters with a default-deny CNI (Calico, Cilium with
+# enforcement, etc.) operator egress is wide open inside the cluster.
+# This template adds explicit allow rules for the three legitimate
+# egress targets:
+#
+#   1. kube-apiserver — for CRD watches, leader-election leases,
+#      child-resource create/update, status writes. CIDR-based rule
+#      because the apiserver IP is cluster-specific; default
+#      0.0.0.0/0 - cluster-internal-CIDRs covers the public apiserver
+#      endpoint without leaking to other pods.
+#
+#   2. nvsnap-server (default nvsnap-system/nvsnap-server, port 8080) —
+#      for L2 promote-state polls and audit calls. Namespace + label
+#      selector keeps it tight.
+#
+#   3. kube-dns — for service name resolution. Without this rule the
+#      operator can't resolve nvsnap-server.nvsnap-system.svc anyway.
+#
+# Ingress: container port 8000 (health/metrics) and 8002 (auxiliary).
+# Allowed from any namespace by default (Prometheus scraping +
+# kubelet probes can come from anywhere). Operators can tighten by
+# overriding ingressFrom.
+#
+# Opt-in via .Values.networkPolicy.operator.enabled (default false)
+# so existing deployments keep working unchanged. Turn on after
+# verifying the rule set fits your cluster.
+#
+# Note: K8s NetworkPolicy semantics are "deny by default IF any
+# NetworkPolicy selects the pod." Creating this policy WITHOUT a
+# matching cluster CNI may have no effect (e.g. some kindnet
+# configs); test in your environment before relying on it.

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/poddisruptionbudget.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: helm-nvca-operator/templates/sa.yaml
+# Source: helm-nvca-operator/templates/poddisruptionbudget.yaml
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -7,23 +7,10 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: nvca-operator
-  namespace: nvca-operator
-  labels:
-    helm.sh/chart: helm-nvca-operator-1.21.3
-    app.kubernetes.io/name: nvca-operator
-    app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.0.4"
-    app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: false

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/pre-delete-cleanup-job.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/pre-delete-cleanup-job.yaml
@@ -21,7 +21,7 @@ metadata:
   name: nvca-operator-pre-delete-cleanup
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.19.0
+    helm.sh/chart: helm-nvca-operator-1.21.3
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.0.4"
@@ -52,7 +52,7 @@ spec:
         fsGroup: 1010
       containers:
       - name: cleanup
-        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.6
+        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.7
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/pre-delete-cleanup-rbac.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/pre-delete-cleanup-rbac.yaml
@@ -21,7 +21,7 @@ metadata:
   name: nvca-operator-pre-delete-cleanup
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.19.0
+    helm.sh/chart: helm-nvca-operator-1.21.3
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.0.4"
@@ -39,7 +39,7 @@ kind: ClusterRole
 metadata:
   name: nvca-operator-pre-delete-cleanup
   labels:
-    helm.sh/chart: helm-nvca-operator-1.19.0
+    helm.sh/chart: helm-nvca-operator-1.21.3
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.0.4"
@@ -140,7 +140,7 @@ kind: ClusterRoleBinding
 metadata:
   name: nvca-operator-pre-delete-cleanup
   labels:
-    helm.sh/chart: helm-nvca-operator-1.19.0
+    helm.sh/chart: helm-nvca-operator-1.21.3
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.0.4"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/rbac_allowed_extra_types.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/rbac_allowed_extra_types.yaml
@@ -19,7 +19,7 @@ kind: ClusterRole
 metadata:
   name: nvca-operator-allowed-extra-types
   labels:
-    helm.sh/chart: helm-nvca-operator-1.19.0
+    helm.sh/chart: helm-nvca-operator-1.21.3
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.0.4"
@@ -71,7 +71,7 @@ kind: ClusterRoleBinding
 metadata:
   name: nvca-operator-allowed-extra-types
   labels:
-    helm.sh/chart: helm-nvca-operator-1.19.0
+    helm.sh/chart: helm-nvca-operator-1.21.3
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.0.4"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/role.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/role.yaml
@@ -20,7 +20,7 @@ kind: ClusterRole
 metadata:
   name: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.19.0
+    helm.sh/chart: helm-nvca-operator-1.21.3
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.0.4"
@@ -98,6 +98,19 @@ rules:
   verbs: ["use"]
 - apiGroups: ["nvca.nvcf.nvidia.io"]
   resources: ["miniservices", "miniservices/status"]
+  verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
+# NvSnapFunctionState is granted unconditionally, NOT behind the NvSnap
+# feature flag. The operator generates the agent ClusterRole with this rule on
+# every reconcile, and Kubernetes escalation prevention rejects a role that
+# grants permissions the granting account does not itself hold:
+#   clusterroles "nvca" is forbidden: user "system:serviceaccount:
+#   nvca-operator:nvca-operator" is attempting to grant RBAC permissions not
+#   currently held: {APIGroups:["nvsnap.nvcf.nvidia.io"], ...}
+# That check runs at install time on the delegation itself, long before any
+# feature flag is consulted, so a default-off flag does not avoid it and a
+# clean install cannot reconcile its NVCFBackend without this.
+- apiGroups: ["nvsnap.nvcf.nvidia.io"]
+  resources: ["nvsnapfunctionstates", "nvsnapfunctionstates/status"]
   verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
 - apiGroups: ["resource.nvidia.com"]
   resources: ["computedomains"]

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/role_binding.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/role_binding.yaml
@@ -20,7 +20,7 @@ kind: ClusterRoleBinding
 metadata:
   name: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.19.0
+    helm.sh/chart: helm-nvca-operator-1.21.3
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.0.4"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/self-managed-nvcfbackend-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/self-managed-nvcfbackend-cm.yaml
@@ -20,11 +20,11 @@ metadata:
   name: nvcfbackend-self-managed
   namespace: nvca-operator
   annotations:
-    release-artifact-nvca-image: "nvcr.io/0651155215864979/ncp-dev/nvca:3.2.6"
+    release-artifact-nvca-image: "nvcr.io/0651155215864979/ncp-dev/nvca:3.2.7"
     release-artifact-nvcf-image-credential-helper-image: "nvcr.io/0651155215864979/ncp-dev/nvcf-image-credential-helper:0.10.2"
     release-artifact-samba-image: "nvcr.io/0651155215864979/ncp-dev/samba:1.0.5"
   labels:
-    helm.sh/chart: helm-nvca-operator-1.19.0
+    helm.sh/chart: helm-nvca-operator-1.21.3
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.0.4"
@@ -37,7 +37,7 @@ data:
     clusterDescription: "ncp-local"
     clusterGroupName: "nvcf-default"
     ncaID: "nvcf-default"
-    nvcaVersion: "3.2.6"
+    nvcaVersion: "3.2.7"
     oAuthClientId: ""
     cloudProvider: "NCP"
     region: "us-west-1"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/shutdown-sentinel.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/shutdown-sentinel.yaml
@@ -21,7 +21,7 @@ metadata:
   name: nvca-operator-shutdown-sentinel
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.19.0
+    helm.sh/chart: helm-nvca-operator-1.21.3
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.0.4"

--- a/deploy/stacks/nvcf-compute-plane/tests/observability-profile.sh
+++ b/deploy/stacks/nvcf-compute-plane/tests/observability-profile.sh
@@ -87,6 +87,12 @@ for profile in default disabled control compute all; do
   esac
 done
 
+expected_nvca_version="3.2.7"
+test "$(operator_image_tag "$work_dir/default.yaml")" = "$expected_nvca_version" ||
+  fail "default operator image tag is not $expected_nvca_version"
+test "$(nvca_version "$work_dir/default.yaml")" = "$expected_nvca_version" ||
+  fail "default NVCA version is not $expected_nvca_version"
+
 render_values compute "$work_dir/compute-overrides.yaml" \
   --state-values-set-string global.nvcaOperator.imageTag=operator-test-tag \
   --state-values-set-string global.nvcaOperator.selfManaged.nvcaVersion=nvca-test-tag \


### PR DESCRIPTION
## TL;DR

Update the self-managed compute-plane stack to NVCA 3.2.7 and helm-nvca-operator 1.21.3 so it consumes the corrected BYOO OpenTelemetry collector default.

## Why

The compute-plane stack still pins NVCA 3.2.6 and helm-nvca-operator 1.19.0. Those pins predate the corrected BYOO collector image selection in the current NVCA release.

## What changed

- Updated the NVCA operator image and self-managed agent version to 3.2.7.
- Updated helm-nvca-operator from 1.19.0 to 1.21.3.
- Regenerated the compute-plane golden manifests from the published chart.

## Additional Details

The chart update also carries its current security-context, RBAC, NetworkPolicy template, and PodDisruptionBudget template changes. The new NetworkPolicy and PodDisruptionBudget templates do not emit resources with the current default values.

## For the Reviewer

Please review the version pins in the compute-plane base values and Helmfile, then the generated NVCA manifest drift from chart 1.21.3.

## For QA

QA is recommended for a self-managed compute-plane upgrade smoke test. No live cluster deployment was performed for this PR.

## Issues

Closes #992

## Customer Release Notes

The self-managed compute-plane stack now deploys NVCA 3.2.7 with the corrected BYOO OpenTelemetry collector image.

## Plan Summary

- helm-nvca-operator: 1.19.0 to 1.21.3
- NVCA operator image: 3.2.6 to 3.2.7
- NVCA agent version: 3.2.6 to 3.2.7
- No new resources are enabled by default.

## Usage

Use the normal compute-plane stack upgrade workflow. No new configuration is required.

## Testing

- `make generate-golden`
- `make test-local`
  - observability profile checks passed
  - NVCA entrypoint checks passed
  - rendered output matched the checked-in golden manifests

## Notes

The 1.21.3 chart was pulled and rendered successfully. A live cluster upgrade was not run.

The architecture and sequence diagrams were reviewed for resource ownership, startup ordering, and the OpenTelemetry path. This version-only upgrade does not change those interactions, so the existing diagrams remain accurate.

## References

- #992

## Related Pull Requests

- #968
- #982

## Dependencies

Updated NVIDIA first-party components: helm-nvca-operator 1.21.3 and NVCA 3.2.7. No third-party dependency, license review, or NOTICE change is required.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the NVCA Operator to version 3.2.7.
  * Updated the self-managed NVCA version to 3.2.7.
  * Updated the NVCA Operator Helm chart to version 1.21.3.

* **Validation**
  * Added checks to confirm the configured operator and NVCA versions render correctly in the default deployment profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->