### PR TITLE
fix(logging): stop reporting expected request failures at error level

### DIFF
--- a/src/compute-plane-services/worker-utils/worker/BUILD.bazel
+++ b/src/compute-plane-services/worker-utils/worker/BUILD.bazel
@@ -97,6 +97,8 @@ go_test(
         "@org_golang_google_protobuf//types/known/timestamppb",
         "@org_golang_x_sync//errgroup",
         "@org_uber_go_zap//:zap",
+        "@org_uber_go_zap//zapcore",
+        "@org_uber_go_zap//zaptest/observer",
     ],
 )
 

--- a/src/compute-plane-services/worker-utils/worker/cancel.go
+++ b/src/compute-plane-services/worker-utils/worker/cancel.go
@@ -44,3 +44,18 @@ func (w *NVCFWorker) handleCancelMessage(msg *nats.Msg) {
 		utils.PublicLogMarker,
 		zap.String("req id", requestId))
 }
+
+// logWorkRequestResult reports the outcome of a completed work request. An
+// upstream cancel aborts the in-flight send by design, and handleCancelMessage
+// already records it at info, so it is kept out of the error stream instead of
+// being reported a second time as a request failure.
+func logWorkRequestResult(err error, requestId string) {
+	switch {
+	case err == nil:
+	case errors.Is(err, ErrUpstreamCancel):
+		zap.L().Debug("request aborted by upstream cancel", zap.String("req id", requestId))
+	default:
+		// failure for a single request, keep trying to consume other requests
+		zap.L().Error("failed to handle request", zap.Error(err), zap.String("req id", requestId))
+	}
+}

--- a/src/compute-plane-services/worker-utils/worker/cancel_test.go
+++ b/src/compute-plane-services/worker-utils/worker/cancel_test.go
@@ -20,12 +20,18 @@ package worker
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/nats-io/nats.go"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // Worker stub with just the fields the cancel handler touches.
@@ -79,6 +85,103 @@ func TestHandleCancelMessage_IgnoresUnknownRequest(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatal("ctx should not have been cancelled for unknown request id")
 	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// An upstream cancel is expected teardown and must stay out of the error
+// stream. Anything else must still be reported at error level.
+func TestLogWorkRequestResult_Levels(t *testing.T) {
+	tests := []struct {
+		name  string
+		err   error
+		level zapcore.Level
+		msg   string
+	}{
+		{
+			name: "nil error logs nothing",
+			err:  nil,
+		},
+		{
+			name:  "upstream cancel is demoted to debug",
+			err:   fmt.Errorf("failed to send POST request: %w", ErrUpstreamCancel),
+			level: zapcore.DebugLevel,
+			msg:   "request aborted by upstream cancel",
+		},
+		{
+			name:  "unrelated failure stays at error",
+			err:   errors.New("inference container exploded"),
+			level: zapcore.ErrorLevel,
+			msg:   "failed to handle request",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			core, logs := observer.New(zapcore.DebugLevel)
+			defer zap.ReplaceGlobals(zap.New(core))()
+
+			logWorkRequestResult(tc.err, "req-123")
+
+			if tc.err == nil {
+				if logs.Len() != 0 {
+					t.Fatalf("expected no log lines, got %v", logs.All())
+				}
+				return
+			}
+
+			entries := logs.All()
+			if len(entries) != 1 {
+				t.Fatalf("expected exactly 1 log line, got %v", entries)
+			}
+			if entries[0].Level != tc.level {
+				t.Errorf("level = %v, want %v", entries[0].Level, tc.level)
+			}
+			if entries[0].Message != tc.msg {
+				t.Errorf("message = %q, want %q", entries[0].Message, tc.msg)
+			}
+		})
+	}
+}
+
+// The cancel arrives while an HTTP send is in flight, so the error the worker
+// classifies is a *url.Error produced by net/http rather than the bare
+// sentinel. Guard that the cause still survives errors.Is through that wrapping.
+func TestLogWorkRequestResult_RealCancelledRequest(t *testing.T) {
+	// hold the response open until the client goes away so the cancel lands
+	// mid-flight, and so Close does not wait on a sleeping handler
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel(ErrUpstreamCancel)
+	}()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+	//nolint:bodyclose // the request is cancelled, so there is no body to close
+	_, doErr := http.DefaultClient.Do(req)
+	if doErr == nil {
+		t.Fatal("expected the in-flight request to fail")
+	}
+	wrapped := fmt.Errorf("failed to send POST request: %w", doErr)
+
+	core, logs := observer.New(zapcore.DebugLevel)
+	defer zap.ReplaceGlobals(zap.New(core))()
+
+	logWorkRequestResult(wrapped, "req-123")
+
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 log line, got %v", entries)
+	}
+	if entries[0].Level != zapcore.DebugLevel {
+		t.Errorf("level = %v, want debug (got message %q)", entries[0].Level, entries[0].Message)
 	}
 }
 

--- a/src/compute-plane-services/worker-utils/worker/worker.go
+++ b/src/compute-plane-services/worker-utils/worker/worker.go
@@ -602,11 +602,7 @@ func (w *NVCFWorker) workSession(ctx context.Context) error {
 
 			err := pool.Submit(func() {
 				defer utils.Close(work.Close)
-				err := w.handleWorkRequest(ctx, work)
-				if err != nil {
-					// failure for a single request, keep trying to consume other requests
-					zap.L().Error("failed to handle request", zap.Error(err), zap.String("req id", work.RequestData.RequestId))
-				}
+				logWorkRequestResult(w.handleWorkRequest(ctx, work), work.RequestData.RequestId)
 			})
 			// failure to submit to the pool is a catastrophic error and should never happen
 			// unless the pool is misconfigured. this should be dead code.

--- a/src/libraries/go/lib/pkg/nvkit/clients/retry_logger.go
+++ b/src/libraries/go/lib/pkg/nvkit/clients/retry_logger.go
@@ -26,8 +26,13 @@ import (
 // the global zap logger. Thus, it can be used by retryable http client
 type retryLogger struct{}
 
+// Error logs at warn level on purpose. The retryable http client calls this for
+// every failed attempt inside its retry loop, including attempts it goes on to
+// retry successfully, and it returns the final error to the caller regardless.
+// Logging each attempt at error level reports transient conditions as failures
+// and multiplies the volume by the retry count.
 func (l *retryLogger) Error(msg string, keysAndValues ...interface{}) {
-	zap.S().Errorw(msg, keysAndValues...)
+	zap.S().Warnw(msg, keysAndValues...)
 }
 
 func (l *retryLogger) Info(msg string, keysAndValues ...interface{}) {

--- a/src/libraries/go/lib/pkg/nvkit/clients/retry_logger_test.go
+++ b/src/libraries/go/lib/pkg/nvkit/clients/retry_logger_test.go
@@ -53,11 +53,15 @@ func TestRetryLogger(t *testing.T) {
 	zap.ReplaceGlobals(l)
 
 	rL := newRetryLogger()
-	// assert an error message is logged
+	// the retryable http client reports every failed attempt through Error, so
+	// it is emitted at warn level to keep retried transients out of the error
+	// stream. assert both the payload and the level.
 	rL.Error("error message", "errorKey", "errorValue")
 	output := sink.String()
 	sink.Reset()
 	assert.Contains(t, output, "\"msg\":\"error message\",\"errorKey\":\"errorValue\"")
+	assert.Contains(t, output, "\"level\":\"warn\"")
+	assert.NotContains(t, output, "\"level\":\"error\"")
 
 	// assert an info message is logged
 	rL.Info("info message", "infoKey", "infoValue")


### PR DESCRIPTION
## TL;DR

Two expected conditions in the utils container were logged at error level. The
retry logger now reports failed attempts at warn, and an upstream cancel is no
longer reported as a request failure. Unexpected failures are unaffected.

## Additional Details

During a recent incident these two lines accounted for roughly 3 million log
entries in an 8 hour window, against about 60 thousand that actually explained
the incident, which made the real signal very hard to find.

Neither line represents a fault:

- The retryable http client calls its leveled logger for every failed attempt
  inside the retry loop, including attempts it goes on to retry successfully, and
  it returns the final error to the caller regardless. Logging each attempt at
  error level reports transient conditions as failures and multiplies the volume
  by the retry count.
- The worker logged an upstream cancel as "failed to handle request". The cancel
  aborts the in-flight send by design, and handleCancelMessage already records the
  cancellation at info, so the error line duplicated an expected event.

How the pieces connect: a cancel sets the cause on the per-request context, the
in-flight POST is built from that context, and net/http surfaces the cause inside
a *url.Error. The new logWorkRequestResult matches that with errors.Is on the
sentinel and sends it to debug, leaving every other failure at error.

Worth knowing: errors.Is against context.Canceled does not match this error, so
the intuitive "check for context.Canceled" approach would catch nothing. The
sentinel check is required.

The two changes differ in effect. Debug is dropped by the logger core before
encoding, so at the default info level the cancellation line is not emitted at
all, and that is the bulk of the reported volume. Warn is written and shipped
exactly as error was, so the retry lines remain in the log and only stop matching
error-level filters and alerts.

Limitations:

- The retry logger is shared by every nvkit/clients consumer, so alerting keyed on
  error-level lines from that logger stops firing. The library emits this line
  before both the non-retry and the exhausted-retry exit, so terminal failures are
  demoted as well, not only attempts that get retried. The failure is still
  recorded in full at warn and the error is still returned, so the caller can log
  it at error with real context, which is what already happens for the inference
  health check in worker-utils.
- Adding a terminal error log inside the shared client was considered and not
  done. There is no single point where the final error is returned, because
  HTTPClient exposes Client(ctx) and most callers use the underlying *http.Client
  directly, so a log in Get, Put, Post, or Do would miss them. The library's
  ErrorHandler hook is the only true choke point, but DefaultHTTPClient leaves it
  unset deliberately: the default path drains the response body through an
  unexported helper and formats the "giving up after N attempt(s)" error, both of
  which a custom handler would change. Separately, the health check that motivated
  this change fails terminally on every poll, so a terminal error rule would keep
  emitting one error per poll indefinitely rather than removing the noise.
- worker-utils resolves go-lib through a module pin, so the retry logger change
  reaches that container only once go-lib is repinned.
- This lowers the level of these lines wherever they originate, but does not
  address why the underlying requests fail. One known source is a periodic health
  check against a service that does not resolve in some clusters, and the client
  performing that poll is not part of this repository. That caller needs a
  separate follow-up from the team that owns it.

## For the Reviewer

Closest look at src/libraries/go/lib/pkg/nvkit/clients/retry_logger.go. It is the
shared change and affects worker-utils, worker-task, grpc-proxy, ratelimiter,
nvkit/servers, and the go/worker health, nvcf, and nvct packages. If anyone is
alerting on error-level lines from that logger, they should know before this
merges.

The judgement call worth confirming is that terminal failures are now warn rather
than error. The reasoning is that the shared client cannot tell whether a failure
matters, since the same failure is routine for an optional health poll and an
outage for the control plane, and only the caller has that context. Stamping error
on both is what produced this bug. See the second limitation above for why the
alternatives were rejected. If reviewers want terminal failures at error anyway,
making the terminal level configurable and defaulting it to error is preferable to
a blanket rule, since it does not reintroduce noise for callers that expect
failures.

The worker change is in cancel.go and one call site in worker.go. The levels were
chosen against the log level contract in AGENTS.md:

- The cancel record stays at info in handleCancelMessage, since a client going
  away is a normal state transition rather than a degraded condition. Raising it
  to warn would make it visible at higher log levels, but that would use severity
  to buy prominence rather than to describe the event, which is the same mistake
  that produced this bug.
- The duplicate at the worker call site goes to debug rather than being removed
  outright, so the detail is still available when debugging without costing
  anything in production.

## For QA

No functional QA needed. The change affects log severity only. The error value at
the changed call site was previously used solely for the log call, so ack/nak
behaviour, retries, and returned errors are unchanged.

Verified:

- go test on both packages, including -race
- go vet, gofmt, the Bazel build and test targets, and
  //src/libraries/go/lib:golangci_lint
- Unit tests cover all three classification branches plus a real in-flight HTTP
  request cancelled through a cause, so errors.Is is exercised against the actual
  error type rather than a hand-wrapped sentinel
- Reproduced both log types in a local cluster and compared the same code with and
  without the change. Error-level entries for these paths drop to zero. The
  cancellation line is no longer emitted at all at the default log level, since
  debug is below it, which is the bulk of the reported volume. The retry lines are
  still written at warn, so they remain in the log but no longer match error-level
  filters or alerts.
- Pre-existing flakes checked and unrelated: worker-utils/worker fails about 2 runs
  in 10 on an unmodified tree, due to a goroutine calling t.Error after its test
  completes, and passed 10 of 10 with this change applied

Observability check for the reviewer rather than QA:

- Confirm no alert or dashboard depends on error-level lines from the retry logger
  or on "failed to handle request" for cancellations. Those rules match on level,
  so they would go silent rather than fail loudly.
- Cancellations are recorded by the existing info line in handleCancelMessage,
  which matches the log level contract for a normal state transition. A deployment
  running at warn or above will not see them, which is the intended behaviour for
  an expected event.

## Issues

NO-REF

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced log severity for expected request cancellations, recording them as debug messages instead of errors.
  * Retryable HTTP failures are now logged as warnings to reduce misleading error noise.
  * Preserved error-level logging for unexpected failures.
* **Tests**
  * Added coverage confirming correct log levels for cancellations, wrapped HTTP errors, and retryable failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->