### PR TITLE
feat(perf): backpressure and throttled-sink knobs for Nemotron collector sizing

### DIFF
--- a/tests/perf/byoo-otel-collector/cmd/perf/main.go
+++ b/tests/perf/byoo-otel-collector/cmd/perf/main.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -101,7 +102,7 @@ parser. "yaml" emits a multi-document stream and "json" emits an array, so
 		},
 	}
 	cmd.Flags().StringVar(&cfg.shape, "shape", "both", `deployment shape: "container", "helm", or "both"`)
-	cmd.Flags().StringVar(&cfg.profile, "profile", "dev", `execution profile: "dev" or "baseline"`)
+	cmd.Flags().StringVar(&cfg.profile, "profile", "dev", `execution profile: "dev", "baseline", or "nemotron" (large-record shape)`)
 	cmd.Flags().StringVar(&cfg.collectorImage, "collector-image", spec.DefaultCollectorImage, "BYOO collector image reference")
 	cmd.Flags().StringVar(&cfg.namespace, "namespace", "byoo-perf", "namespace for rendered objects")
 	cmd.Flags().StringVar(&cfg.output, "output", "summary", `output format: "summary", "yaml", or "json"`)
@@ -127,6 +128,19 @@ type runConfig struct {
 	k3dCluster     string
 	importImages   bool
 	resultsDir     string
+
+	logChunking          bool
+	logChunkMaxPayload   int
+	collectorMemoryLimit string
+	backpressure         bool
+	sinkCPULimit         string
+	sinkMemoryLimit      string
+
+	// Load overrides. A sentinel (<0) means "use the profile value".
+	logsPerSec          int
+	workers             int
+	payloadBytes        int
+	largeRecordFraction float64
 }
 
 func newRunCmd() *cobra.Command {
@@ -150,7 +164,7 @@ reporting land in a later milestone.`,
 		},
 	}
 	cmd.Flags().StringVar(&cfg.shape, "shape", "both", `deployment shape: "container", "helm", or "both"`)
-	cmd.Flags().StringVar(&cfg.profile, "profile", "dev", `execution profile: "dev" or "baseline"`)
+	cmd.Flags().StringVar(&cfg.profile, "profile", "dev", `execution profile: "dev", "baseline", or "nemotron" (large-record shape)`)
 	cmd.Flags().StringVar(&cfg.mode, "mode", "k3d", `deployment mode: "k3d" (managed local cluster) or "remote" (ambient kubeconfig)`)
 	cmd.Flags().StringVar(&cfg.collectorImage, "collector-image", spec.DefaultCollectorImage, "BYOO collector image reference")
 	cmd.Flags().StringVar(&cfg.sinkImage, "sink-image", sink.DefaultImage, "OTLP sink (collector-contrib) image reference")
@@ -166,6 +180,16 @@ reporting land in a later milestone.`,
 	cmd.Flags().StringVar(&cfg.k3dCluster, "k3d-cluster", "byoo-perf", "name of the managed k3d cluster (k3d mode)")
 	cmd.Flags().BoolVar(&cfg.importImages, "import-images", false, "import the collector/sink/loadgen images from local Docker into the k3d cluster (k3d mode)")
 	cmd.Flags().StringVar(&cfg.resultsDir, "results-dir", "", "directory to write structured JSON results to (one file per shape and repetition)")
+	cmd.Flags().BoolVar(&cfg.logChunking, "log-chunking", false, "enable the collector's log-chunking processor (the code path that splits and buffers oversized log records)")
+	cmd.Flags().IntVar(&cfg.logChunkMaxPayload, "log-chunk-max-payload-bytes", 0, "log-chunking max payload bytes threshold (0 uses the collector default of 262144); implies --log-chunking")
+	cmd.Flags().StringVar(&cfg.collectorMemoryLimit, "collector-memory-limit", "", `override the collector container memory request/limit (e.g. "512Mi"); empty keeps the translated 2Gi`)
+	cmd.Flags().BoolVar(&cfg.backpressure, "backpressure", false, "delete the OTLP sink after the collector is ready so its exporter cannot drain; the retry+sending_queue backs up with chunked payloads (models an unavailable backend)")
+	cmd.Flags().StringVar(&cfg.sinkCPULimit, "sink-cpu-limit", "", `throttle the OTLP sink's CPU (e.g. "20m") so it drains slowly while staying up; backpressures the collector's exporter queue while the generator keeps pushing (models a slow-but-alive backend). Empty leaves the sink unthrottled`)
+	cmd.Flags().StringVar(&cfg.sinkMemoryLimit, "sink-memory-limit", "", `cap the OTLP sink's memory (e.g. "256Mi"); mainly useful with --sink-cpu-limit. Empty leaves it unset`)
+	cmd.Flags().IntVar(&cfg.logsPerSec, "logs-per-sec", -1, "override the profile's logs generation rate (records/sec); <0 uses the profile")
+	cmd.Flags().IntVar(&cfg.workers, "workers", -1, "override the profile's telemetrygen worker count; <0 uses the profile")
+	cmd.Flags().IntVar(&cfg.payloadBytes, "payload-bytes", -1, "override the profile's large-record payload attribute size in bytes; <0 uses the profile")
+	cmd.Flags().Float64Var(&cfg.largeRecordFraction, "large-record-fraction", -1, "override the profile's fraction (0..1) of records that are large; <0 uses the profile")
 	return cmd
 }
 
@@ -204,6 +228,10 @@ func runRun(stdout io.Writer, cfg runConfig) error {
 		return err
 	}
 	prof, err := profile.Lookup(cfg.profile)
+	if err != nil {
+		return err
+	}
+	prof, err = applyLoadOverrides(prof, cfg)
 	if err != nil {
 		return err
 	}
@@ -313,7 +341,11 @@ func runShape(ctx context.Context, stdout io.Writer, client *deploy.Client, cfg 
 
 	// 1. In-cluster OTLP sink the collector exports to.
 	fmt.Fprintf(stdout, "[%s] deploying OTLP sink to namespace %q ...\n", shape, ns)
-	sinkDep, err := client.DeploySink(ctx, ns, sink.Options{Image: cfg.sinkImage})
+	sinkDep, err := client.DeploySink(ctx, ns, sink.Options{
+		Image:       cfg.sinkImage,
+		CPULimit:    cfg.sinkCPULimit,
+		MemoryLimit: cfg.sinkMemoryLimit,
+	})
 	if err != nil {
 		return cleanupAfterErr(ctx, client, cfg, ns, fmt.Errorf("deploy sink for %s: %w", shape, err))
 	}
@@ -346,7 +378,14 @@ func runShape(ctx context.Context, stdout io.Writer, client *deploy.Client, cfg 
 	}
 
 	fmt.Fprintf(stdout, "[%s] deploying collector to namespace %q ...\n", shape, ns)
-	dep, err := client.Deploy(ctx, ns, res, deploy.WithExportCredentials(exportCredentials()))
+	deployOpts := []deploy.DeployOption{deploy.WithExportCredentials(exportCredentials())}
+	if env := collectorEnvOverrides(cfg); len(env) > 0 {
+		deployOpts = append(deployOpts, deploy.WithCollectorEnv(env))
+	}
+	if cfg.collectorMemoryLimit != "" {
+		deployOpts = append(deployOpts, deploy.WithCollectorMemoryLimit(cfg.collectorMemoryLimit))
+	}
+	dep, err := client.Deploy(ctx, ns, res, deployOpts...)
 	if err != nil {
 		return cleanupAfterErr(ctx, client, cfg, ns, fmt.Errorf("deploy %s: %w", shape, err))
 	}
@@ -376,6 +415,20 @@ func runShape(ctx context.Context, stdout io.Writer, client *deploy.Client, cfg 
 	}
 	fmt.Fprintf(stdout, "  sink metrics    : %s\n", sinkDep.MetricsEndpoint)
 
+	// Backpressure: with the collector healthy and ready, remove the sink pod
+	// (keep its Service) so the export target resolves but refuses connections.
+	// The collector keeps accepting/chunking load while its exporter cannot
+	// drain, so retry_on_failure and the sending_queue fill with buffered
+	// payloads and memory climbs. This models a slow/unavailable telemetry
+	// backend and makes the memory-exhaustion point deterministic rather than
+	// dependent on CPU headroom.
+	if cfg.backpressure && !cfg.skipLoad {
+		fmt.Fprintf(stdout, "[%s] backpressure: deleting sink pod %q so the collector exporter queue backs up ...\n", shape, sinkDep.PodName)
+		if err := client.DeletePod(ctx, ns, sinkDep.PodName); err != nil {
+			return cleanupAfterErr(ctx, client, cfg, ns, fmt.Errorf("backpressure: delete sink pod for %s shape: %w", shape, err))
+		}
+	}
+
 	// 3. Drive load through the collector and measure over the window.
 	if !cfg.skipLoad {
 		grpcEndpoint := dep.Endpoints["otlp-grpc"]
@@ -387,12 +440,16 @@ func runShape(ctx context.Context, stdout io.Writer, client *deploy.Client, cfg 
 			return cleanupAfterErr(ctx, client, cfg, ns, fmt.Errorf("collector container exposes no %q port for %s shape", "metrics", shape))
 		}
 		lgOpts := loadgen.Options{
-			Image:         cfg.loadgenImage,
-			Endpoint:      grpcEndpoint,
-			Insecure:      true,
-			Duration:      loadDuration,
-			LogsPerSec:    prof.LogRecordsPerSec,
-			MetricsPerSec: prof.MetricDataPointsPerSec,
+			Image:               cfg.loadgenImage,
+			Endpoint:            grpcEndpoint,
+			Insecure:            true,
+			Duration:            loadDuration,
+			LogsPerSec:          prof.LogRecordsPerSec,
+			MetricsPerSec:       prof.MetricDataPointsPerSec,
+			Workers:             prof.Workers,
+			LogBodyBytes:        prof.LogBodyBytes,
+			LogPayloadBytes:     prof.LogPayloadBytes,
+			LargeRecordFraction: prof.LargeRecordFraction,
 		}
 		// Execute one load+measure cycle per repetition so a "baseline" run
 		// honors the profile's repetition count instead of collapsing to a
@@ -670,6 +727,54 @@ func exportCredentials() map[string]string {
 		"perf-logs":    "perf",
 		"perf-metrics": "perf",
 	}
+}
+
+// applyLoadOverrides returns prof with any load knobs the user set on the CLI
+// applied over the profile defaults. Sentinels (<0) leave the profile value.
+// Overrides are validated so out-of-range values fail fast with a clear error
+// instead of producing a malformed workload or an unbounded allocation.
+func applyLoadOverrides(prof profile.Profile, cfg runConfig) (profile.Profile, error) {
+	if cfg.logsPerSec >= 0 {
+		prof.LogRecordsPerSec = cfg.logsPerSec
+	}
+	if cfg.workers >= 0 {
+		prof.Workers = cfg.workers
+	}
+	if cfg.payloadBytes >= 0 {
+		if cfg.payloadBytes > loadgen.MaxLogPayloadBytes {
+			return profile.Profile{}, fmt.Errorf("--payload-bytes %d exceeds the maximum of %d bytes", cfg.payloadBytes, loadgen.MaxLogPayloadBytes)
+		}
+		prof.LogPayloadBytes = cfg.payloadBytes
+	}
+	// A negative sentinel means "use the profile"; any supplied value must be a
+	// finite fraction in [0,1]. NaN fails every comparison, so reject it up front
+	// rather than letting it slip through the sentinel check.
+	switch f := cfg.largeRecordFraction; {
+	case math.IsNaN(f):
+		return profile.Profile{}, fmt.Errorf("--large-record-fraction must be in [0,1], got NaN")
+	case f < 0:
+		// sentinel: leave the profile value in place.
+	case f > 1:
+		return profile.Profile{}, fmt.Errorf("--large-record-fraction must be in [0,1], got %v", f)
+	default:
+		prof.LargeRecordFraction = f
+	}
+	return prof, nil
+}
+
+// collectorEnvOverrides returns the collector env overrides implied by the run
+// flags. Enabling log chunking (directly or by setting a payload threshold)
+// turns on the collector's logchunk processor, the code path that splits and
+// buffers oversized records under a large-record workload.
+func collectorEnvOverrides(cfg runConfig) map[string]string {
+	env := map[string]string{}
+	if cfg.logChunking || cfg.logChunkMaxPayload > 0 {
+		env["BYOO_LOG_CHUNKING_ENABLED"] = "true"
+	}
+	if cfg.logChunkMaxPayload > 0 {
+		env["BYOO_LOG_CHUNK_MAX_PAYLOAD_BYTES"] = strconv.Itoa(cfg.logChunkMaxPayload)
+	}
+	return env
 }
 
 // cleanupAfterErr cleans up the namespace (unless --retain) and returns the

--- a/tests/perf/byoo-otel-collector/cmd/perf/main_test.go
+++ b/tests/perf/byoo-otel-collector/cmd/perf/main_test.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -551,5 +552,43 @@ func TestTakeSnapshotReturnsScrapeError(t *testing.T) {
 	}
 	if len(snap.Collector) != 0 || len(snap.Sink) != 1 {
 		t.Errorf("samples = coll %d sink %d, want 0 and 1", len(snap.Collector), len(snap.Sink))
+	}
+}
+
+func TestApplyLoadOverridesValidation(t *testing.T) {
+	base := profile.Nemotron()
+
+	valid := []struct {
+		name string
+		cfg  runConfig
+	}{
+		{"defaults untouched", runConfig{logsPerSec: -1, workers: -1, payloadBytes: -1, largeRecordFraction: -1}},
+		{"fraction lower bound", runConfig{logsPerSec: -1, workers: -1, payloadBytes: -1, largeRecordFraction: 0}},
+		{"fraction upper bound", runConfig{logsPerSec: -1, workers: -1, payloadBytes: -1, largeRecordFraction: 1}},
+		{"payload at max", runConfig{logsPerSec: -1, workers: -1, payloadBytes: loadgen.MaxLogPayloadBytes, largeRecordFraction: -1}},
+	}
+	for _, tc := range valid {
+		t.Run("ok/"+tc.name, func(t *testing.T) {
+			if _, err := applyLoadOverrides(base, tc.cfg); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+
+	invalid := []struct {
+		name string
+		cfg  runConfig
+	}{
+		{"fraction above one", runConfig{logsPerSec: -1, workers: -1, payloadBytes: -1, largeRecordFraction: 1.5}},
+		{"fraction NaN", runConfig{logsPerSec: -1, workers: -1, payloadBytes: -1, largeRecordFraction: math.NaN()}},
+		{"fraction +Inf", runConfig{logsPerSec: -1, workers: -1, payloadBytes: -1, largeRecordFraction: math.Inf(1)}},
+		{"payload above max", runConfig{logsPerSec: -1, workers: -1, payloadBytes: loadgen.MaxLogPayloadBytes + 1, largeRecordFraction: -1}},
+	}
+	for _, tc := range invalid {
+		t.Run("err/"+tc.name, func(t *testing.T) {
+			if _, err := applyLoadOverrides(base, tc.cfg); err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
+			}
+		})
 	}
 }

--- a/tests/perf/byoo-otel-collector/pkg/deploy/deploy.go
+++ b/tests/perf/byoo-otel-collector/pkg/deploy/deploy.go
@@ -29,6 +29,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -152,6 +153,13 @@ type deploySettings struct {
 	// secrets volume so the generated exporter config can resolve the
 	// ${file:...} references it needs to start.
 	exportCredentials map[string]string
+	// collectorEnv adds or overrides environment variables on the collector
+	// container before it is applied (e.g. BYOO_LOG_CHUNKING_ENABLED).
+	collectorEnv map[string]string
+	// collectorMemoryLimit, when non-empty, overrides the collector container's
+	// memory request and limit (a Kubernetes quantity such as "512Mi"). Used to
+	// sweep the collector's memory ceiling to find its OOM point.
+	collectorMemoryLimit string
 }
 
 // DeployOption customizes Deploy.
@@ -165,6 +173,20 @@ type DeployOption func(*deploySettings)
 // rendering.
 func WithExportCredentials(creds map[string]string) DeployOption {
 	return func(s *deploySettings) { s.exportCredentials = creds }
+}
+
+// WithCollectorEnv adds or overrides environment variables on the collector
+// container. It is how the suite toggles collector features (such as log
+// chunking) that are driven by env at startup.
+func WithCollectorEnv(env map[string]string) DeployOption {
+	return func(s *deploySettings) { s.collectorEnv = env }
+}
+
+// WithCollectorMemoryLimit overrides the collector container's memory request
+// and limit with the given Kubernetes quantity (e.g. "512Mi"). An empty value
+// leaves the translated resources untouched.
+func WithCollectorMemoryLimit(limit string) DeployOption {
+	return func(s *deploySettings) { s.collectorMemoryLimit = limit }
 }
 
 // Deploy applies the rendered workload for the shape into the namespace: the
@@ -188,6 +210,10 @@ func (c *Client) Deploy(ctx context.Context, namespace string, res *render.Resul
 	pod.Labels[partOfLabelKey] = partOfLabelValue
 	pod.Labels[managedByLabelKey] = managedByLabelValue
 	pod.Labels[instanceLabelKey] = instance
+
+	if err := applyCollectorOverrides(pod, settings); err != nil {
+		return nil, err
+	}
 
 	if len(settings.exportCredentials) > 0 {
 		secretName := instance + "-export-creds"
@@ -224,6 +250,61 @@ func (c *Client) Deploy(ctx context.Context, namespace string, res *render.Resul
 		deployed.Endpoints[p.Name] = fmt.Sprintf("%s.%s.svc.cluster.local:%d", svc.Name, namespace, p.Port)
 	}
 	return deployed, nil
+}
+
+// applyCollectorOverrides mutates the collector container in the rendered pod
+// per the deploy settings: it adds/overrides environment variables and, when
+// requested, overrides the memory request and limit.
+func applyCollectorOverrides(pod *corev1.Pod, s deploySettings) error {
+	if len(s.collectorEnv) == 0 && s.collectorMemoryLimit == "" {
+		return nil
+	}
+	idx := -1
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == render.CollectorContainerName {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return fmt.Errorf("collector container %q not found in rendered pod", render.CollectorContainerName)
+	}
+	c := &pod.Spec.Containers[idx]
+
+	for k, v := range s.collectorEnv {
+		setEnv(c, k, v)
+	}
+
+	if s.collectorMemoryLimit != "" {
+		q, err := resource.ParseQuantity(s.collectorMemoryLimit)
+		if err != nil {
+			return fmt.Errorf("parse collector memory limit %q: %w", s.collectorMemoryLimit, err)
+		}
+		if q.Sign() <= 0 {
+			return fmt.Errorf("collector memory limit %q: must be positive", s.collectorMemoryLimit)
+		}
+		if c.Resources.Requests == nil {
+			c.Resources.Requests = corev1.ResourceList{}
+		}
+		if c.Resources.Limits == nil {
+			c.Resources.Limits = corev1.ResourceList{}
+		}
+		c.Resources.Requests[corev1.ResourceMemory] = q
+		c.Resources.Limits[corev1.ResourceMemory] = q
+	}
+	return nil
+}
+
+// setEnv adds or overrides a literal environment variable on the container.
+func setEnv(c *corev1.Container, key, value string) {
+	for i := range c.Env {
+		if c.Env[i].Name == key {
+			c.Env[i].Value = value
+			c.Env[i].ValueFrom = nil
+			return
+		}
+	}
+	c.Env = append(c.Env, corev1.EnvVar{Name: key, Value: value})
 }
 
 // mountSecretOverPath finds the volume backing the collector volumeMount at
@@ -347,7 +428,11 @@ func (c *Client) DeploySink(ctx context.Context, namespace string, opts sink.Opt
 	if err := c.applyConfigMap(ctx, namespace, sink.ConfigMap(namespace)); err != nil {
 		return nil, err
 	}
-	if err := c.applyPod(ctx, namespace, sink.Pod(namespace, opts)); err != nil {
+	pod, err := sink.Pod(namespace, opts)
+	if err != nil {
+		return nil, fmt.Errorf("build sink pod: %w", err)
+	}
+	if err := c.applyPod(ctx, namespace, pod); err != nil {
 		return nil, err
 	}
 	svc := sink.Service(namespace)
@@ -361,6 +446,28 @@ func (c *Client) DeploySink(ctx context.Context, namespace string, opts sink.Opt
 		HTTPEndpoint:    sink.HTTPEndpoint(namespace),
 		MetricsEndpoint: sink.MetricsEndpoint(namespace),
 	}, nil
+}
+
+// DeletePod deletes a single pod by name, treating a missing pod as success,
+// and blocks until the pod has actually disappeared. The suite uses it to induce
+// downstream backpressure by removing the OTLP sink pod mid-run while leaving
+// its Service in place, so the collector's export target still resolves but
+// refuses connections. Waiting for the pod to be gone (not just for the delete
+// request to be accepted) ensures the backend is truly down before the caller
+// starts load, so the run does not measure a window where the terminating sink
+// still drains traffic.
+func (c *Client) DeletePod(ctx context.Context, namespace, name string) error {
+	err := c.cs.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("delete pod %q in namespace %q: %w", name, namespace, err)
+	}
+	if err := c.waitPodDeleted(ctx, namespace, name, 60*time.Second); err != nil {
+		return fmt.Errorf("wait for pod %q deletion in namespace %q: %w", name, namespace, err)
+	}
+	return nil
 }
 
 // StartLoad creates the telemetrygen Jobs without waiting. Existing Jobs with

--- a/tests/perf/byoo-otel-collector/pkg/deploy/deploy_loadgen_test.go
+++ b/tests/perf/byoo-otel-collector/pkg/deploy/deploy_loadgen_test.go
@@ -59,6 +59,140 @@ func TestDeploySinkCreatesResources(t *testing.T) {
 	}
 }
 
+func TestDeletePodRemovesPodAndToleratesMissing(t *testing.T) {
+	c := NewClientForClientset(fake.NewSimpleClientset())
+	ctx := context.Background()
+
+	dep, err := c.DeploySink(ctx, "byoo-perf", sink.DefaultOptions())
+	if err != nil {
+		t.Fatalf("DeploySink: %v", err)
+	}
+
+	// Deleting the sink pod removes it while leaving its Service in place, which
+	// is exactly the backpressure setup: the export target still resolves but
+	// has no backing pod.
+	if err := c.DeletePod(ctx, "byoo-perf", dep.PodName); err != nil {
+		t.Fatalf("DeletePod: %v", err)
+	}
+	if _, err := c.cs.CoreV1().Pods("byoo-perf").Get(ctx, dep.PodName, metav1.GetOptions{}); err == nil {
+		t.Errorf("sink pod still present after DeletePod")
+	}
+	if _, err := c.cs.CoreV1().Services("byoo-perf").Get(ctx, dep.ServiceName, metav1.GetOptions{}); err != nil {
+		t.Errorf("sink service should survive pod deletion: %v", err)
+	}
+
+	// A second delete (pod already gone) must be a no-op, so retries and reruns
+	// do not error out.
+	if err := c.DeletePod(ctx, "byoo-perf", dep.PodName); err != nil {
+		t.Errorf("DeletePod on missing pod returned error: %v", err)
+	}
+}
+
+func TestDeletePodWaitsUntilPodIsGone(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	c := NewClientForClientset(cs)
+	ctx := context.Background()
+
+	dep, err := c.DeploySink(ctx, "byoo-perf", sink.DefaultOptions())
+	if err != nil {
+		t.Fatalf("DeploySink: %v", err)
+	}
+
+	// Simulate a terminating pod: the first readiness poll still sees the pod
+	// (as during a real termination grace period), later polls fall through to
+	// the tracker, which returns NotFound once the delete has taken effect.
+	var getCount int
+	cs.PrependReactor("get", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+		ga := action.(ktesting.GetAction)
+		if ga.GetName() == dep.PodName {
+			getCount++
+			if getCount == 1 {
+				return true, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: dep.PodName, Namespace: "byoo-perf"}}, nil
+			}
+		}
+		return false, nil, nil
+	})
+
+	if err := c.DeletePod(ctx, "byoo-perf", dep.PodName); err != nil {
+		t.Fatalf("DeletePod: %v", err)
+	}
+	// More than one poll proves DeletePod blocked until the pod disappeared
+	// rather than returning as soon as the delete request was accepted.
+	if getCount < 2 {
+		t.Errorf("DeletePod polled %d time(s); expected it to wait for the pod to disappear", getCount)
+	}
+}
+
+func TestSetEnv(t *testing.T) {
+	t.Run("appends a new variable", func(t *testing.T) {
+		c := &corev1.Container{Env: []corev1.EnvVar{{Name: "EXISTING", Value: "keep"}}}
+		setEnv(c, "NEW", "v")
+		if len(c.Env) != 2 {
+			t.Fatalf("expected 2 env entries, got %d", len(c.Env))
+		}
+		if c.Env[0].Name != "EXISTING" || c.Env[0].Value != "keep" {
+			t.Errorf("existing entry was disturbed: %+v", c.Env[0])
+		}
+		if c.Env[1].Name != "NEW" || c.Env[1].Value != "v" {
+			t.Errorf("new entry = %+v, want NEW=v", c.Env[1])
+		}
+	})
+
+	t.Run("replaces an existing literal value", func(t *testing.T) {
+		c := &corev1.Container{Env: []corev1.EnvVar{{Name: "KEY", Value: "old"}}}
+		setEnv(c, "KEY", "new")
+		if len(c.Env) != 1 {
+			t.Fatalf("env should not grow, got %d entries", len(c.Env))
+		}
+		if c.Env[0].Value != "new" {
+			t.Errorf("value = %q, want new", c.Env[0].Value)
+		}
+	})
+
+	t.Run("replaces a ValueFrom source and clears it", func(t *testing.T) {
+		c := &corev1.Container{Env: []corev1.EnvVar{{
+			Name:      "KEY",
+			ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"}},
+		}}}
+		setEnv(c, "KEY", "literal")
+		if c.Env[0].Value != "literal" {
+			t.Errorf("value = %q, want literal", c.Env[0].Value)
+		}
+		if c.Env[0].ValueFrom != nil {
+			t.Errorf("ValueFrom should be cleared, got %+v", c.Env[0].ValueFrom)
+		}
+	})
+}
+
+func TestApplyCollectorOverridesRejectsNonPositiveMemory(t *testing.T) {
+	newPod := func() *corev1.Pod {
+		return &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: render.CollectorContainerName}},
+			},
+		}
+	}
+
+	for _, bad := range []string{"0", "-10Mi", "not-a-quantity"} {
+		if err := applyCollectorOverrides(newPod(), deploySettings{collectorMemoryLimit: bad}); err == nil {
+			t.Errorf("collector memory limit %q: expected error, got nil", bad)
+		}
+	}
+
+	// A valid positive limit is applied to both request and limit.
+	pod := newPod()
+	if err := applyCollectorOverrides(pod, deploySettings{collectorMemoryLimit: "256Mi"}); err != nil {
+		t.Fatalf("valid memory limit rejected: %v", err)
+	}
+	c := pod.Spec.Containers[0]
+	if got := c.Resources.Limits.Memory().String(); got != "256Mi" {
+		t.Errorf("memory limit = %q, want 256Mi", got)
+	}
+	if got := c.Resources.Requests.Memory().String(); got != "256Mi" {
+		t.Errorf("memory request = %q, want 256Mi", got)
+	}
+}
+
 // stringDataToDataReactor mirrors the API server: on create it folds a Secret's
 // StringData into Data (as raw bytes) and clears StringData, so tests observe
 // the same shape a real cluster would return on read.

--- a/tests/perf/byoo-otel-collector/pkg/loadgen/loadgen.go
+++ b/tests/perf/byoo-otel-collector/pkg/loadgen/loadgen.go
@@ -24,6 +24,7 @@ package loadgen
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -36,7 +37,26 @@ import (
 // DefaultImage is the upstream telemetrygen image. The tag can be overridden
 // per run; it defaults to a build that matches the collector-contrib tag used
 // elsewhere in the repo.
-const DefaultImage = "ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:0.129.1"
+const DefaultImage = "ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0"
+
+// argMaxBytes bounds the payload carried by a single telemetrygen CLI argument.
+// Linux caps one argument string at MAX_ARG_STRLEN (128 KiB); a large payload is
+// split across several attributes so no single argument approaches that limit.
+const argMaxBytes = 96 * 1024
+
+// MaxLogPayloadBytes bounds the synthetic per-record payload attribute size.
+// The generator materializes the payload in memory and passes it as process
+// arguments, so an unbounded value could exhaust local memory or overflow the
+// argument vector. 1 MiB comfortably exceeds the largest observed real record
+// (~330 KiB) while staying well within argv limits. Callers must reject larger
+// values before building Jobs.
+const MaxLogPayloadBytes = 1 << 20
+
+// MaxLogBodyBytes bounds the synthetic log body size. The body is a single
+// telemetrygen argument (--body), so it must stay under one argument's limit;
+// an unbounded value would allocate the whole string up front and could produce
+// a --body argument the container process cannot start with.
+const MaxLogBodyBytes = argMaxBytes
 
 // Signal is an OTLP signal telemetrygen can generate.
 type Signal string
@@ -61,28 +81,78 @@ type Options struct {
 	// zero disables that signal's Job.
 	LogsPerSec    int
 	MetricsPerSec int
+	// Workers is telemetrygen's --workers (concurrent generators per Job). Zero
+	// leaves telemetrygen's default (1).
+	Workers int
+	// LogBodyBytes pads each synthetic log body to approximately this size. Zero
+	// keeps telemetrygen's default tiny body.
+	LogBodyBytes int
+	// LogPayloadBytes attaches a synthetic string attribute of approximately
+	// this many bytes to a log record, split across several attributes so no CLI
+	// argument exceeds argMaxBytes. This is what pushes a record past the
+	// collector's log-chunking threshold. Zero adds no payload attribute.
+	LogPayloadBytes int
+	// LargeRecordFraction (0..1) is the fraction of the logs rate emitted as
+	// large (payload-bearing) records; the remainder are small body-only
+	// records, reproducing a bimodal record-size mix. A value <= 0 applies
+	// LogPayloadBytes uniformly to every record; a value >= 1 does the same.
+	LargeRecordFraction float64
 }
 
-// Job builds the telemetrygen Job for a single signal at the given rate.
+// Job builds the telemetrygen Job for a single signal at the given rate. For
+// logs it applies the body/payload shaping in opts; metrics ignore shaping.
 func Job(namespace, instance string, signal Signal, rate int, opts Options) *batchv1.Job {
+	body, payload := 0, 0
+	if signal == SignalLogs {
+		body, payload = opts.LogBodyBytes, opts.LogPayloadBytes
+	}
+	name := fmt.Sprintf("%s-loadgen-%s", instance, signal)
+	return jobShaped(namespace, instance, name, signal, float64(rate), body, payload, opts)
+}
+
+// jobShaped builds a telemetrygen Job with an explicit (possibly fractional)
+// rate and log body/payload sizes.
+func jobShaped(namespace, instance, name string, signal Signal, rate float64, bodyBytes, payloadBytes int, opts Options) *batchv1.Job {
 	image := opts.Image
 	if image == "" {
 		image = DefaultImage
 	}
-	name := fmt.Sprintf("%s-loadgen-%s", instance, signal)
 
 	l := labels.Base()
 	l[labels.Instance] = instance
 	l[labels.Component] = labels.ComponentLoadgen
 
+	// telemetrygen's --rate is per worker (each worker emits at that rate), so
+	// to hit the requested aggregate rate we divide it across the workers. An
+	// unset/non-positive worker count means telemetrygen runs a single worker.
+	workers := opts.Workers
+	if workers <= 0 {
+		workers = 1
+	}
+	perWorkerRate := rate / float64(workers)
+
 	args := []string{
 		string(signal),
 		"--otlp-endpoint", opts.Endpoint,
 		"--duration", opts.Duration.String(),
-		"--rate", strconv.Itoa(rate),
+		"--rate", formatRate(perWorkerRate),
 	}
 	if opts.Insecure {
 		args = append(args, "--otlp-insecure")
+	}
+	if opts.Workers > 0 {
+		args = append(args, "--workers", strconv.Itoa(opts.Workers))
+	}
+	if bodyBytes > 0 {
+		// Defensive cap so a misconfigured profile can never allocate an
+		// unbounded body or produce an oversized single --body argument.
+		if bodyBytes > MaxLogBodyBytes {
+			bodyBytes = MaxLogBodyBytes
+		}
+		args = append(args, "--body", strings.Repeat("x", bodyBytes))
+	}
+	for _, kv := range payloadAttrs(payloadBytes) {
+		args = append(args, "--telemetry-attributes", kv)
 	}
 
 	// A load generator must never be retried: a retry would replay the whole
@@ -113,14 +183,77 @@ func Job(namespace, instance string, signal Signal, rate int, opts Options) *bat
 	}
 }
 
-// Jobs builds one telemetrygen Job per enabled signal (rate > 0).
+// Jobs builds the telemetrygen Jobs for the enabled signals (rate > 0). When a
+// bimodal log mix is requested (LogPayloadBytes and a LargeRecordFraction in the
+// open interval (0,1)), logs are split into a small body-only Job and a large
+// payload-bearing Job whose rates sum to LogsPerSec.
 func Jobs(namespace, instance string, opts Options) []*batchv1.Job {
 	var jobs []*batchv1.Job
-	if opts.LogsPerSec > 0 {
-		jobs = append(jobs, Job(namespace, instance, SignalLogs, opts.LogsPerSec, opts))
-	}
+	jobs = append(jobs, logJobs(namespace, instance, opts)...)
 	if opts.MetricsPerSec > 0 {
 		jobs = append(jobs, Job(namespace, instance, SignalMetrics, opts.MetricsPerSec, opts))
 	}
 	return jobs
+}
+
+// logJobs builds the log generator Job(s), splitting into small/large variants
+// when a bimodal record-size mix is requested.
+func logJobs(namespace, instance string, opts Options) []*batchv1.Job {
+	if opts.LogsPerSec <= 0 {
+		return nil
+	}
+	total := float64(opts.LogsPerSec)
+	logsName := fmt.Sprintf("%s-loadgen-logs", instance)
+
+	// One uniform Job unless a bimodal split is explicitly requested. Only a
+	// finite fraction strictly inside (0,1) splits the load; anything else
+	// (no payload, fraction <=0 or >=1, or a non-finite NaN/Inf) is treated as
+	// uniform, which also keeps the computed --rate finite.
+	frac := opts.LargeRecordFraction
+	if opts.LogPayloadBytes <= 0 || !(frac > 0 && frac < 1) {
+		return []*batchv1.Job{jobShaped(namespace, instance, logsName, SignalLogs, total, opts.LogBodyBytes, opts.LogPayloadBytes, opts)}
+	}
+
+	largeRate := total * frac
+	smallRate := total - largeRate
+	var jobs []*batchv1.Job
+	if smallRate > 0 {
+		jobs = append(jobs, jobShaped(namespace, instance, logsName+"-small", SignalLogs, smallRate, opts.LogBodyBytes, 0, opts))
+	}
+	jobs = append(jobs, jobShaped(namespace, instance, logsName+"-large", SignalLogs, largeRate, opts.LogBodyBytes, opts.LogPayloadBytes, opts))
+	return jobs
+}
+
+// payloadAttrs returns telemetrygen --telemetry-attributes values (key="value")
+// whose combined value bytes total approximately totalBytes, split so no single
+// argument exceeds argMaxBytes. Each attribute is counted toward a log record's
+// size by the collector's log-chunking processor.
+func payloadAttrs(totalBytes int) []string {
+	if totalBytes <= 0 {
+		return nil
+	}
+	// Defensive cap: the CLI rejects oversized --payload-bytes, but clamp here
+	// too so a misconfigured profile can never trigger an unbounded allocation.
+	if totalBytes > MaxLogPayloadBytes {
+		totalBytes = MaxLogPayloadBytes
+	}
+	// Reserve room for the key and the key="" wrapper within one argument.
+	const perAttr = argMaxBytes - 32
+	var attrs []string
+	remaining := totalBytes
+	for i := 0; remaining > 0; i++ {
+		n := remaining
+		if n > perAttr {
+			n = perAttr
+		}
+		attrs = append(attrs, fmt.Sprintf("payload%d=%q", i, strings.Repeat("x", n)))
+		remaining -= n
+	}
+	return attrs
+}
+
+// formatRate renders a telemetrygen --rate value, trimming trailing zeros so an
+// integer rate stays integer-formatted.
+func formatRate(rate float64) string {
+	return strconv.FormatFloat(rate, 'f', -1, 64)
 }

--- a/tests/perf/byoo-otel-collector/pkg/loadgen/loadgen_test.go
+++ b/tests/perf/byoo-otel-collector/pkg/loadgen/loadgen_test.go
@@ -18,12 +18,34 @@ limitations under the License.
 package loadgen
 
 import (
+	"fmt"
+	"math"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	batchv1 "k8s.io/api/batch/v1"
+
 	"github.com/NVIDIA/nvcf/tests/perf/byoo-otel-collector/pkg/labels"
 )
+
+func findBySuffix(jobs []*batchv1.Job, suffix string) *batchv1.Job {
+	for _, j := range jobs {
+		if strings.HasSuffix(j.Name, suffix) {
+			return j
+		}
+	}
+	return nil
+}
+
+func jobNames(jobs []*batchv1.Job) []string {
+	var out []string
+	for _, j := range jobs {
+		out = append(out, j.Name)
+	}
+	return out
+}
 
 func baseOpts() Options {
 	return Options{
@@ -126,5 +148,194 @@ func TestJobImageOverride(t *testing.T) {
 	job := Job("byoo-perf", "perf-collector", SignalLogs, 10, o)
 	if got := job.Spec.Template.Spec.Containers[0].Image; got != o.Image {
 		t.Errorf("image override not applied: %q", got)
+	}
+}
+
+func telemetryAttrs(args []string) []string {
+	var out []string
+	for i, a := range args {
+		if a == "--telemetry-attributes" && i+1 < len(args) {
+			out = append(out, args[i+1])
+		}
+	}
+	return out
+}
+
+func TestPayloadAttrsSplitUnderArgLimit(t *testing.T) {
+	total := 320 * 1024
+	attrs := payloadAttrs(total)
+	if len(attrs) < 2 {
+		t.Fatalf("expected payload split across multiple attributes, got %d", len(attrs))
+	}
+	sum := 0
+	for i, kv := range attrs {
+		if len(kv) > argMaxBytes {
+			t.Errorf("attribute %d is %d bytes, exceeds argMaxBytes %d", i, len(kv), argMaxBytes)
+		}
+		prefix := fmt.Sprintf("payload%d=\"", i)
+		if !strings.HasPrefix(kv, prefix) || !strings.HasSuffix(kv, "\"") {
+			t.Fatalf("attribute %d not in key=\"value\" form", i)
+		}
+		sum += len(kv) - len(prefix) - 1
+	}
+	if sum != total {
+		t.Errorf("payload value bytes = %d, want %d", sum, total)
+	}
+}
+
+func TestPayloadAttrsClampsToMax(t *testing.T) {
+	// At the documented maximum the full payload is materialized.
+	if got := payloadValueBytes(payloadAttrs(MaxLogPayloadBytes)); got != MaxLogPayloadBytes {
+		t.Errorf("at max: payload value bytes = %d, want %d", got, MaxLogPayloadBytes)
+	}
+	// Above the maximum the helper clamps rather than allocating unbounded.
+	if got := payloadValueBytes(payloadAttrs(MaxLogPayloadBytes * 4)); got != MaxLogPayloadBytes {
+		t.Errorf("above max: payload value bytes = %d, want clamp to %d", got, MaxLogPayloadBytes)
+	}
+	// Every attribute still respects the per-argument limit.
+	for i, kv := range payloadAttrs(MaxLogPayloadBytes * 4) {
+		if len(kv) > argMaxBytes {
+			t.Errorf("attribute %d is %d bytes, exceeds argMaxBytes %d", i, len(kv), argMaxBytes)
+		}
+	}
+}
+
+func payloadValueBytes(attrs []string) int {
+	sum := 0
+	for i, kv := range attrs {
+		prefix := fmt.Sprintf("payload%d=\"", i)
+		sum += len(kv) - len(prefix) - 1
+	}
+	return sum
+}
+
+func TestLogsBimodalSplit(t *testing.T) {
+	o := baseOpts()
+	o.MetricsPerSec = 0
+	o.LogsPerSec = 6
+	o.LogBodyBytes = 8 * 1024
+	o.LogPayloadBytes = 320 * 1024
+	o.LargeRecordFraction = 0.5
+
+	jobs := Jobs("byoo-perf", "perf-collector", o)
+	if len(jobs) != 2 {
+		t.Fatalf("expected small+large log jobs, got %d", len(jobs))
+	}
+	smallJob, largeJob := findBySuffix(jobs, "logs-small"), findBySuffix(jobs, "logs-large")
+	if smallJob == nil || largeJob == nil {
+		t.Fatalf("expected logs-small and logs-large jobs, got %v", jobNames(jobs))
+	}
+	if got := argValue(smallJob.Spec.Template.Spec.Containers[0].Args, "--rate"); got != "3" {
+		t.Errorf("small --rate = %q, want 3", got)
+	}
+	if got := argValue(largeJob.Spec.Template.Spec.Containers[0].Args, "--rate"); got != "3" {
+		t.Errorf("large --rate = %q, want 3", got)
+	}
+	if attrs := telemetryAttrs(smallJob.Spec.Template.Spec.Containers[0].Args); len(attrs) != 0 {
+		t.Errorf("small job must carry no payload attributes, got %d", len(attrs))
+	}
+	if attrs := telemetryAttrs(largeJob.Spec.Template.Spec.Containers[0].Args); len(attrs) == 0 {
+		t.Errorf("large job must carry payload attributes")
+	}
+}
+
+func TestLogsUniformPayloadNoSplit(t *testing.T) {
+	o := baseOpts()
+	o.MetricsPerSec = 0
+	o.LogsPerSec = 4
+	o.LogPayloadBytes = 300 * 1024
+	// No LargeRecordFraction -> every record large, single job.
+	jobs := Jobs("byoo-perf", "perf-collector", o)
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 uniform log job, got %d (%v)", len(jobs), jobNames(jobs))
+	}
+	if !strings.HasSuffix(jobs[0].Name, "-loadgen-logs") {
+		t.Errorf("unexpected job name %q", jobs[0].Name)
+	}
+	if attrs := telemetryAttrs(jobs[0].Spec.Template.Spec.Containers[0].Args); len(attrs) == 0 {
+		t.Errorf("uniform payload job must carry payload attributes")
+	}
+}
+
+func TestLogBodyBytesClampedToMax(t *testing.T) {
+	o := baseOpts()
+	o.MetricsPerSec = 0
+	o.LogsPerSec = 1
+	o.LogBodyBytes = MaxLogBodyBytes * 4 // oversized
+
+	jobs := Jobs("byoo-perf", "perf-collector", o)
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 log job, got %d (%v)", len(jobs), jobNames(jobs))
+	}
+	body := argValue(jobs[0].Spec.Template.Spec.Containers[0].Args, "--body")
+	if len(body) != MaxLogBodyBytes {
+		t.Errorf("body length = %d, want clamp to %d", len(body), MaxLogBodyBytes)
+	}
+	if len(body) > argMaxBytes {
+		t.Errorf("body length %d exceeds argMaxBytes %d", len(body), argMaxBytes)
+	}
+}
+
+func TestBimodalRateNeverNonFiniteForNaNFraction(t *testing.T) {
+	o := baseOpts()
+	o.MetricsPerSec = 0
+	o.LogsPerSec = 40
+	o.LogPayloadBytes = 300 * 1024
+	o.LargeRecordFraction = math.NaN() // must not split into NaN-rate Jobs
+
+	jobs := Jobs("byoo-perf", "perf-collector", o)
+	if len(jobs) != 1 {
+		t.Fatalf("NaN fraction should fall back to a single uniform job, got %d (%v)", len(jobs), jobNames(jobs))
+	}
+	for _, j := range jobs {
+		rate := argValue(j.Spec.Template.Spec.Containers[0].Args, "--rate")
+		f, err := strconv.ParseFloat(rate, 64)
+		if err != nil {
+			t.Fatalf("job %s --rate %q not parseable: %v", j.Name, rate, err)
+		}
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			t.Errorf("job %s has non-finite --rate %q", j.Name, rate)
+		}
+	}
+}
+
+func TestWorkersFlag(t *testing.T) {
+	o := baseOpts()
+	o.Workers = 4
+	job := Job("byoo-perf", "perf-collector", SignalLogs, 10, o)
+	args := job.Spec.Template.Spec.Containers[0].Args
+	if got := argValue(args, "--workers"); got != "4" {
+		t.Errorf("--workers = %q, want 4", got)
+	}
+	// telemetrygen's --rate is per worker, so the requested aggregate rate of 10
+	// with 4 workers must be emitted as 2.5 per worker.
+	if got := argValue(args, "--rate"); got != "2.5" {
+		t.Errorf("--rate = %q, want 2.5 (10 requested / 4 workers)", got)
+	}
+}
+
+func TestRatePerWorkerAppliesToMetricsAndBimodalLogs(t *testing.T) {
+	o := baseOpts()
+	o.Workers = 4
+	o.LogsPerSec = 40
+	o.MetricsPerSec = 20
+	o.LogPayloadBytes = 300 * 1024
+	o.LargeRecordFraction = 0.25 // 10 large + 30 small, each divided by 4 workers
+
+	jobs := Jobs("byoo-perf", "perf-collector", o)
+	rateByJob := map[string]string{}
+	for _, j := range jobs {
+		rateByJob[j.Name] = argValue(j.Spec.Template.Spec.Containers[0].Args, "--rate")
+	}
+
+	want := map[string]string{
+		"perf-collector-loadgen-logs-small": "7.5", // 30 / 4
+		"perf-collector-loadgen-logs-large": "2.5", // 10 / 4
+		"perf-collector-loadgen-metrics":    "5",   // 20 / 4
+	}
+	for name, wantRate := range want {
+		if got := rateByJob[name]; got != wantRate {
+			t.Errorf("%s --rate = %q, want %q", name, got, wantRate)
+		}
 	}
 }

--- a/tests/perf/byoo-otel-collector/pkg/profile/profile.go
+++ b/tests/perf/byoo-otel-collector/pkg/profile/profile.go
@@ -40,6 +40,17 @@ type Profile struct {
 	LogRecordsPerSec int
 	// MetricDataPointsPerSec is the default metrics load rate.
 	MetricDataPointsPerSec int
+	// Workers is the telemetrygen concurrency per generator Job. Zero uses
+	// telemetrygen's default.
+	Workers int
+	// LogBodyBytes pads each synthetic log body to approximately this size.
+	LogBodyBytes int
+	// LogPayloadBytes is the size of the oversized string attribute attached to
+	// large log records. Zero adds none.
+	LogPayloadBytes int
+	// LargeRecordFraction is the fraction of the logs rate emitted as large
+	// (payload-bearing) records; the rest are small body-only records.
+	LargeRecordFraction float64
 }
 
 // Dev is a short run intended to validate wiring and support local iteration.
@@ -67,6 +78,32 @@ func Baseline() Profile {
 	}
 }
 
+// Nemotron models a large-record log workload: a bimodal record-size mix
+// emitted at a modest rate. Small records carry an ~8 KB body (p50 record
+// ~8.8 KB); ~45% of records additionally carry a ~320 KB string attribute
+// (p95 record ~327 KB). The bytes live in the attribute rather than the body,
+// so log chunking must size on the full record; chunking splits at the 256 KB
+// threshold.
+//
+// The 40 rec/s rate is low but the large-record fraction makes each record
+// heavy, so throughput is dominated by payload bytes. Sweep the collector's
+// memory limit around this profile (optionally with --sink-cpu-limit to model
+// a slow backend) to find where it exhausts memory versus holds.
+func Nemotron() Profile {
+	return Profile{
+		Name:                   "nemotron",
+		Warmup:                 30 * time.Second,
+		MeasurementWindow:      3 * time.Minute,
+		Repetitions:            1,
+		LogRecordsPerSec:       40,
+		MetricDataPointsPerSec: 0,
+		Workers:                1,
+		LogBodyBytes:           8 * 1024,
+		LogPayloadBytes:        320 * 1024,
+		LargeRecordFraction:    0.45,
+	}
+}
+
 // Lookup returns the named profile, or an error if the name is unknown.
 func Lookup(name string) (Profile, error) {
 	switch name {
@@ -74,7 +111,9 @@ func Lookup(name string) (Profile, error) {
 		return Dev(), nil
 	case "baseline":
 		return Baseline(), nil
+	case "nemotron":
+		return Nemotron(), nil
 	default:
-		return Profile{}, fmt.Errorf("unknown profile %q (want \"dev\" or \"baseline\")", name)
+		return Profile{}, fmt.Errorf("unknown profile %q (want \"dev\", \"baseline\", or \"nemotron\")", name)
 	}
 }

--- a/tests/perf/byoo-otel-collector/pkg/profile/profile_test.go
+++ b/tests/perf/byoo-otel-collector/pkg/profile/profile_test.go
@@ -60,6 +60,25 @@ func TestBaselineDefaults(t *testing.T) {
 	}
 }
 
+func TestNemotronDefaults(t *testing.T) {
+	p := Nemotron()
+	if p.Name != "nemotron" {
+		t.Errorf("Name = %q, want nemotron", p.Name)
+	}
+	// Rate is the modest 40 logs/s the profile targets.
+	if p.LogRecordsPerSec != 40 {
+		t.Errorf("LogRecordsPerSec = %d, want 40", p.LogRecordsPerSec)
+	}
+	// The large-record shape lives in a payload attribute over the 256 KB chunk
+	// threshold, on a minority of records.
+	if p.LogPayloadBytes <= 256*1024 {
+		t.Errorf("LogPayloadBytes = %d, want > 256KiB to exceed the chunk threshold", p.LogPayloadBytes)
+	}
+	if p.LargeRecordFraction <= 0 || p.LargeRecordFraction >= 1 {
+		t.Errorf("LargeRecordFraction = %v, want a bimodal fraction in (0,1)", p.LargeRecordFraction)
+	}
+}
+
 func TestLookup(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -68,6 +87,7 @@ func TestLookup(t *testing.T) {
 	}{
 		{"dev", "dev", false},
 		{"baseline", "baseline", false},
+		{"nemotron", "nemotron", false},
 		{"unknown", "", true},
 	}
 	for _, tt := range tests {

--- a/tests/perf/byoo-otel-collector/pkg/render/render.go
+++ b/tests/perf/byoo-otel-collector/pkg/render/render.go
@@ -111,6 +111,22 @@ func Render(shape spec.Shape, o spec.Options) (*Result, error) {
 	return res, nil
 }
 
+// ensureNonEmptyEnv guarantees the collector container carries a non-empty
+// literal value for key. If the env var is present but empty (and not sourced
+// from a fieldRef/secret), its value is set to fallback; if absent, it is
+// appended. A value the translator already populated is left untouched.
+func ensureNonEmptyEnv(c *corev1.Container, key, fallback string) {
+	for i := range c.Env {
+		if c.Env[i].Name == key {
+			if c.Env[i].Value == "" && c.Env[i].ValueFrom == nil {
+				c.Env[i].Value = fallback
+			}
+			return
+		}
+	}
+	c.Env = append(c.Env, corev1.EnvVar{Name: key, Value: fallback})
+}
+
 // copyStringMap returns a shallow copy of m, always non-nil so callers can
 // safely write into the result.
 func copyStringMap(m map[string]string) map[string]string {
@@ -167,6 +183,15 @@ func (r *Result) BenchPod(namespace string) *corev1.Pod {
 	pod.Labels[common.BYOOMetricsEgressTargetLabelKey] = common.BYOOMetricsEgressTargetLabelValue
 
 	collector := *r.Collector.DeepCopy()
+	// The translator leaves the collector's self-telemetry OTLP env empty when
+	// no real tracing backend is configured. Collector v0.157.x nil-derefs
+	// while unmarshaling service::telemetry::traces with an empty OTLP exporter
+	// endpoint, so the pod crash-loops before it can serve /health. These traces
+	// are not part of what the suite measures, so harmless placeholders are
+	// enough: the collector starts and reports healthy; its own trace export
+	// simply no-ops against an unused local endpoint.
+	ensureNonEmptyEnv(&collector, "OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+	ensureNonEmptyEnv(&collector, "OTEL_TRACING_ACCESS_TOKEN", "perf-suite-disabled")
 	pod.Spec.Containers = []corev1.Container{collector}
 	pod.Spec.RestartPolicy = corev1.RestartPolicyNever
 

--- a/tests/perf/byoo-otel-collector/pkg/render/render_test.go
+++ b/tests/perf/byoo-otel-collector/pkg/render/render_test.go
@@ -20,6 +20,8 @@ package render
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/common"
 
 	"github.com/NVIDIA/nvcf/tests/perf/byoo-otel-collector/pkg/spec"
@@ -140,4 +142,64 @@ func TestBenchPodPropagatesOwnerMetadata(t *testing.T) {
 			t.Error("mutating pod.Annotations mutated Result.OwnerAnnotations (maps are aliased)")
 		}
 	}
+}
+
+func envValue(env []corev1.EnvVar, key string) (corev1.EnvVar, bool) {
+	for _, e := range env {
+		if e.Name == key {
+			return e, true
+		}
+	}
+	return corev1.EnvVar{}, false
+}
+
+func TestEnsureNonEmptyEnv(t *testing.T) {
+	const key = "OTEL_EXPORTER_OTLP_ENDPOINT"
+	const fallback = "http://localhost:4317"
+
+	t.Run("empty literal is filled", func(t *testing.T) {
+		c := &corev1.Container{Env: []corev1.EnvVar{{Name: key, Value: ""}}}
+		ensureNonEmptyEnv(c, key, fallback)
+		got, ok := envValue(c.Env, key)
+		if !ok || got.Value != fallback {
+			t.Fatalf("empty literal not filled: %+v", c.Env)
+		}
+		if len(c.Env) != 1 {
+			t.Errorf("env should not grow, got %d entries", len(c.Env))
+		}
+	})
+
+	t.Run("non-empty literal is preserved", func(t *testing.T) {
+		c := &corev1.Container{Env: []corev1.EnvVar{{Name: key, Value: "http://real:4317"}}}
+		ensureNonEmptyEnv(c, key, fallback)
+		got, _ := envValue(c.Env, key)
+		if got.Value != "http://real:4317" {
+			t.Errorf("existing value overwritten: %q", got.Value)
+		}
+	})
+
+	t.Run("valueFrom is left untouched", func(t *testing.T) {
+		ref := &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"}}
+		c := &corev1.Container{Env: []corev1.EnvVar{{Name: key, ValueFrom: ref}}}
+		ensureNonEmptyEnv(c, key, fallback)
+		got, _ := envValue(c.Env, key)
+		if got.Value != "" {
+			t.Errorf("valueFrom var got a literal value %q", got.Value)
+		}
+		if got.ValueFrom != ref {
+			t.Errorf("valueFrom source was modified")
+		}
+	})
+
+	t.Run("missing var is appended", func(t *testing.T) {
+		c := &corev1.Container{Env: []corev1.EnvVar{{Name: "OTHER", Value: "x"}}}
+		ensureNonEmptyEnv(c, key, fallback)
+		got, ok := envValue(c.Env, key)
+		if !ok || got.Value != fallback {
+			t.Fatalf("missing var not appended: %+v", c.Env)
+		}
+		if len(c.Env) != 2 {
+			t.Errorf("expected 2 env entries, got %d", len(c.Env))
+		}
+	})
 }

--- a/tests/perf/byoo-otel-collector/pkg/sink/sink.go
+++ b/tests/perf/byoo-otel-collector/pkg/sink/sink.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -68,6 +69,20 @@ const (
 type Options struct {
 	// Image is the collector-contrib image used as the sink.
 	Image string
+
+	// CPULimit, when non-empty, caps the sink container's CPU (e.g. "20m").
+	// Starving the sink's CPU makes it drain OTLP slowly while staying up and
+	// keeping its Service endpoint, which backpressures the BYOO collector's
+	// exporter: the collector keeps accepting load at full rate while its
+	// sending_queue fills with chunked payloads. This models a slow-but-alive
+	// telemetry backend without killing the sink (which would instead
+	// backpressure the load generator itself).
+	CPULimit string
+
+	// MemoryLimit, when non-empty, caps the sink container's memory (e.g.
+	// "256Mi"). Mostly useful alongside CPULimit to keep the throttled sink
+	// small; empty leaves it unset.
+	MemoryLimit string
 }
 
 // DefaultOptions returns the standard sink options.
@@ -132,11 +147,16 @@ func ConfigMap(namespace string) *corev1.ConfigMap {
 	}
 }
 
-// Pod is the sink collector pod.
-func Pod(namespace string, opts Options) *corev1.Pod {
+// Pod is the sink collector pod. It returns an error if the resource-limit
+// options are malformed or non-positive.
+func Pod(namespace string, opts Options) (*corev1.Pod, error) {
 	image := opts.Image
 	if image == "" {
 		image = DefaultImage
+	}
+	resources, err := sinkResources(opts)
+	if err != nil {
+		return nil, err
 	}
 	return &corev1.Pod{
 		TypeMeta:   metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
@@ -147,25 +167,17 @@ func Pod(namespace string, opts Options) *corev1.Pod {
 			// of the Service and break the run.
 			RestartPolicy: corev1.RestartPolicyAlways,
 			Containers: []corev1.Container{{
-				Name:  "otlp-sink",
-				Image: image,
-				Args:  []string{fmt.Sprintf("--config=%s/%s", configMountPath, configFileName)},
+				Name:      "otlp-sink",
+				Image:     image,
+				Resources: resources,
+				Args:      []string{fmt.Sprintf("--config=%s/%s", configMountPath, configFileName)},
 				Ports: []corev1.ContainerPort{
 					{Name: PortNameOTLPGRPC, ContainerPort: portOTLPGRPC, Protocol: corev1.ProtocolTCP},
 					{Name: PortNameOTLPHTTP, ContainerPort: portOTLPHTTP, Protocol: corev1.ProtocolTCP},
 					{Name: PortNameMetrics, ContainerPort: portMetrics, Protocol: corev1.ProtocolTCP},
 					{Name: portNameHealth, ContainerPort: portHealth, Protocol: corev1.ProtocolTCP},
 				},
-				ReadinessProbe: &corev1.Probe{
-					ProbeHandler: corev1.ProbeHandler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path: "/",
-							Port: intstr.FromString(portNameHealth),
-						},
-					},
-					InitialDelaySeconds: 2,
-					PeriodSeconds:       2,
-				},
+				ReadinessProbe: readinessProbe(opts),
 				VolumeMounts: []corev1.VolumeMount{{
 					Name:      configVolumeName,
 					MountPath: configMountPath,
@@ -180,6 +192,77 @@ func Pod(namespace string, opts Options) *corev1.Pod {
 				},
 			}},
 		},
+	}, nil
+}
+
+// sinkResources returns the sink container's resource requirements. With no
+// overrides it returns the zero value (unbounded, as before). When CPULimit or
+// MemoryLimit is set, both request and limit are pinned to that value so the
+// kernel enforces a hard cap; a low CPU cap throttles the sink's drain rate.
+// A malformed or non-positive quantity is reported as an error rather than
+// panicking, so callers (DeploySink) can surface it.
+func sinkResources(opts Options) (corev1.ResourceRequirements, error) {
+	if opts.CPULimit == "" && opts.MemoryLimit == "" {
+		return corev1.ResourceRequirements{}, nil
+	}
+	reqs := corev1.ResourceList{}
+	lims := corev1.ResourceList{}
+	if opts.CPULimit != "" {
+		q, err := parsePositiveQuantity("CPULimit", opts.CPULimit)
+		if err != nil {
+			return corev1.ResourceRequirements{}, err
+		}
+		reqs[corev1.ResourceCPU] = q
+		lims[corev1.ResourceCPU] = q
+	}
+	if opts.MemoryLimit != "" {
+		q, err := parsePositiveQuantity("MemoryLimit", opts.MemoryLimit)
+		if err != nil {
+			return corev1.ResourceRequirements{}, err
+		}
+		reqs[corev1.ResourceMemory] = q
+		lims[corev1.ResourceMemory] = q
+	}
+	return corev1.ResourceRequirements{Requests: reqs, Limits: lims}, nil
+}
+
+// parsePositiveQuantity parses a Kubernetes resource quantity and rejects
+// unparseable or non-positive values with a contextual error.
+func parsePositiveQuantity(field, value string) (resource.Quantity, error) {
+	q, err := resource.ParseQuantity(value)
+	if err != nil {
+		return resource.Quantity{}, fmt.Errorf("sink %s %q: %w", field, value, err)
+	}
+	if q.Sign() <= 0 {
+		return resource.Quantity{}, fmt.Errorf("sink %s %q: must be positive", field, value)
+	}
+	return q, nil
+}
+
+// readinessProbe returns the sink readiness probe. A CPU-throttled sink starts
+// and serves health slowly, so when a CPU cap is set the probe is relaxed
+// (longer period and per-probe timeout) to give the collector-contrib time to
+// come up and stay in the Service; readiness failures never restart the pod.
+func readinessProbe(opts Options) *corev1.Probe {
+	handler := corev1.ProbeHandler{
+		HTTPGet: &corev1.HTTPGetAction{
+			Path: "/",
+			Port: intstr.FromString(portNameHealth),
+		},
+	}
+	if opts.CPULimit != "" {
+		return &corev1.Probe{
+			ProbeHandler:        handler,
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       5,
+			TimeoutSeconds:      5,
+			FailureThreshold:    60,
+		}
+	}
+	return &corev1.Probe{
+		ProbeHandler:        handler,
+		InitialDelaySeconds: 2,
+		PeriodSeconds:       2,
 	}
 }
 

--- a/tests/perf/byoo-otel-collector/pkg/sink/sink_test.go
+++ b/tests/perf/byoo-otel-collector/pkg/sink/sink_test.go
@@ -60,7 +60,10 @@ func TestConfigMapCarriesSuiteLabelsAndConfig(t *testing.T) {
 }
 
 func TestPodExposesReceiverAndMetricsPorts(t *testing.T) {
-	pod := Pod(testNS, DefaultOptions())
+	pod, err := Pod(testNS, DefaultOptions())
+	if err != nil {
+		t.Fatalf("Pod: %v", err)
+	}
 	if got := pod.Spec.Containers[0].Image; got != DefaultImage {
 		t.Errorf("image = %q, want %q", got, DefaultImage)
 	}
@@ -88,9 +91,77 @@ func TestPodExposesReceiverAndMetricsPorts(t *testing.T) {
 }
 
 func TestPodImageOverride(t *testing.T) {
-	pod := Pod(testNS, Options{Image: "example.invalid/sink:testtag"})
+	pod, err := Pod(testNS, Options{Image: "example.invalid/sink:testtag"})
+	if err != nil {
+		t.Fatalf("Pod: %v", err)
+	}
 	if got := pod.Spec.Containers[0].Image; got != "example.invalid/sink:testtag" {
 		t.Errorf("image override not applied: %q", got)
+	}
+}
+
+func TestPodUnthrottledHasNoResourceLimits(t *testing.T) {
+	pod, err := Pod(testNS, DefaultOptions())
+	if err != nil {
+		t.Fatalf("Pod: %v", err)
+	}
+	res := pod.Spec.Containers[0].Resources
+	if len(res.Limits) != 0 || len(res.Requests) != 0 {
+		t.Errorf("default sink should be unbounded, got requests=%v limits=%v", res.Requests, res.Limits)
+	}
+}
+
+func TestPodCPUThrottleAppliesLimitAndRelaxesProbe(t *testing.T) {
+	pod, err := Pod(testNS, Options{Image: DefaultImage, CPULimit: "20m", MemoryLimit: "256Mi"})
+	if err != nil {
+		t.Fatalf("Pod: %v", err)
+	}
+	res := pod.Spec.Containers[0].Resources
+	if got := res.Limits.Cpu().String(); got != "20m" {
+		t.Errorf("cpu limit = %q, want 20m", got)
+	}
+	if got := res.Requests.Cpu().String(); got != "20m" {
+		t.Errorf("cpu request = %q, want 20m", got)
+	}
+	if got := res.Limits.Memory().String(); got != "256Mi" {
+		t.Errorf("memory limit = %q, want 256Mi", got)
+	}
+	// A throttled sink starts slowly, so the readiness probe must be relaxed
+	// enough to let it come up and stay in the Service.
+	probe := pod.Spec.Containers[0].ReadinessProbe
+	if probe == nil {
+		t.Fatalf("throttled sink should still have a readiness probe")
+	}
+	if probe.FailureThreshold < 10 {
+		t.Errorf("throttled readiness FailureThreshold = %d, want relaxed (>=10)", probe.FailureThreshold)
+	}
+	if probe.TimeoutSeconds < 5 {
+		t.Errorf("throttled readiness TimeoutSeconds = %d, want relaxed (>=5)", probe.TimeoutSeconds)
+	}
+}
+
+func TestPodRejectsInvalidResourceLimits(t *testing.T) {
+	cases := []struct {
+		name string
+		opts Options
+	}{
+		{"malformed cpu", Options{CPULimit: "not-a-quantity"}},
+		{"malformed memory", Options{MemoryLimit: "12notabyte"}},
+		{"zero cpu", Options{CPULimit: "0"}},
+		{"negative cpu", Options{CPULimit: "-10m"}},
+		{"zero memory", Options{MemoryLimit: "0"}},
+		{"negative memory", Options{MemoryLimit: "-1Mi"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod, err := Pod(testNS, tc.opts)
+			if err == nil {
+				t.Fatalf("expected error for %s, got pod %+v", tc.name, pod)
+			}
+			if pod != nil {
+				t.Errorf("expected nil pod on error, got %+v", pod)
+			}
+		})
 	}
 }
 

--- a/tests/perf/byoo-otel-collector/pkg/spec/spec.go
+++ b/tests/perf/byoo-otel-collector/pkg/spec/spec.go
@@ -53,6 +53,13 @@ const (
 // current production.
 const (
 	DefaultCollectorImage = "nvcr.io/nvidia/nvcf-core/byoo-otel-collector:0.153.1"
+
+	// CollectorImageAlt pins an older 0.126.x-line sidecar (log chunking plus
+	// collector health metrics). Pass it via --collector-image to size against
+	// this build instead of the default 0.15x line. The tag and registry may
+	// differ depending on where the image is published.
+	CollectorImageAlt = "nvcr.io/nvidia/nvcf-core/byoo-otel-collector:0.126.31"
+
 	DefaultInferenceImage = "nvcr.io/nvidia/nvcf-perf/stub-inference:latest"
 	DefaultUtilsImage     = "nvcr.io/nvidia/nvcf-core/worker-utils:latest"
 	DefaultInitImage      = "nvcr.io/nvidia/nvcf-core/worker-init:latest"

--- a/tests/perf/byoo-otel-collector/pkg/spec/spec_test.go
+++ b/tests/perf/byoo-otel-collector/pkg/spec/spec_test.go
@@ -84,6 +84,29 @@ func TestHelmMessageEnvironment(t *testing.T) {
 	}
 }
 
+func TestCollectorImageAltOverride(t *testing.T) {
+	// The alternate collector image must flow through the CollectorImage
+	// override into the launch spec for both workload shapes.
+	for _, shape := range []Shape{ShapeContainer, ShapeHelm} {
+		t.Run(string(shape), func(t *testing.T) {
+			o := DefaultOptions()
+			o.CollectorImage = CollectorImageAlt
+
+			msg, err := Message(shape, o)
+			if err != nil {
+				t.Fatalf("Message: %v", err)
+			}
+			got, err := common.GetEncodedVarByKey(msg.LaunchSpecification.EnvironmentB64, common.BYOOOTelCollectorImageEnv)
+			if err != nil {
+				t.Fatalf("decode collector image env: %v", err)
+			}
+			if got != CollectorImageAlt {
+				t.Errorf("collector image env = %q, want %q", got, CollectorImageAlt)
+			}
+		})
+	}
+}
+
 func TestUnknownShapeErrors(t *testing.T) {
 	if _, err := Message("bogus", DefaultOptions()); err == nil {
 		t.Error("expected error for unknown shape")


### PR DESCRIPTION
## TL;DR
Extends the BYOO perf suite so we can size the collector against the Nemotron Ultra log shape under a degraded telemetry backend. Adds two knobs to model backend degradation, corrects the Nemotron profile to the prod-observed rate, and pins the prod-hotfix collector image as an option.

## Additional Details
The Nemotron Ultra incident showed the collector OOMing when its exporter could not drain (backend slow/unavailable) and chunked payloads accumulated off-heap faster than `memory_limiter` (heap-only, 1s interval) could react. To reproduce and size against that, this PR adds:

- `--backpressure`: after the collector is ready, delete the OTLP sink pod but keep its Service, so the export target resolves but refuses connections. The exporter's retry/sending_queue fills with chunked payloads (models a backend **outage**).
- `--sink-cpu-limit` / `--sink-memory-limit`: throttle the sink so it drains slowly while staying up (models a backend **slow but alive**). The sink readiness probe is relaxed so a CPU-starved sink still joins the Service.
- `pkg/sink`: `sinkResources()` applies the CPU/memory caps; unbounded by default (unchanged behavior).
- `pkg/deploy`: `DeletePod()` (not-found tolerant) used by `--backpressure`.

It also corrects the `nemotron` profile rate to the prod-observed ~40 rec/s (previously 6/s, derived from a static dump that undercounted the live stream), and adds `spec.CollectorImageProdHotfix` for the `0.126.31` sidecar line prod rolled back to (pass via `--collector-image`).

Together with the existing `--log-chunking` and `--collector-memory-limit` knobs, this lets the suite sweep the memory cap and observe whether the collector OOMs or backpressures the source under a realistic Ultra shape.

## For the Reviewer
- Key files: `pkg/sink/sink.go` (resource caps + relaxed readiness probe), `cmd/perf/main.go` (new flags + sink-delete step in `runShape`), `pkg/deploy/deploy.go` (`DeletePod`), `pkg/profile/profile.go` (40/s).
- Note: absolute numbers were gathered on `0.157.0` in k3d; the knobs are mechanism-focused and version-independent.

## For QA
- `GOWORK=off go build ./... && go vet ./... && go test ./...` all pass in `tests/perf/byoo-otel-collector`.
- New unit tests: sink resource overrides + relaxed probe, `DeletePod`, nemotron profile defaults.
- Manually exercised in k3d: `--backpressure` and `--sink-cpu-limit` runs at 40/s across memory caps.

## Issues
Relates to #416

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Nemotron performance profile for bimodal log workloads.
  * Added runtime controls for workers, rates, payload sizes, resource limits, environment variables, and backpressure.
  * Added configurable CPU and memory limits for sink components.
  * Added support for alternate collector images.
  * Added large-record log generation with payload validation and distribution controls.
* **Bug Fixes**
  * Improved collector startup reliability and readiness handling.
  * Pod cleanup now safely tolerates already-missing resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->