### PR TITLE
fix(container-cache): always publish NodePort and report inactive registry config

### DIFF
--- a/deploy/helm/container-cache/README.md
+++ b/deploy/helm/container-cache/README.md
@@ -295,8 +295,15 @@ Key behaviors:
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `service.type` | `NodePort` | `NodePort`, `ClusterIP`, or `LoadBalancer` |
 | `service.port` | `30345` | Primary service port |
+
+The service is always `NodePort` and the type is not configurable. The host
+container runtime reaches the cache at `${NODE_IP}:${port}` from the host
+network namespace, where cluster service DNS and ClusterIP addresses are not
+dependable, so the port has to be published on every node. Setting
+`service.type` to anything other than `NodePort` fails the render: a ClusterIP
+service publishes no node port, so the mirror endpoint would point at a closed
+port and every pull would fall back to the upstream registry with no error.
 
 ### CRI-O
 

--- a/deploy/helm/container-cache/README.md
+++ b/deploy/helm/container-cache/README.md
@@ -300,10 +300,13 @@ Key behaviors:
 The service is always `NodePort` and the type is not configurable. The host
 container runtime reaches the cache at `${NODE_IP}:${port}` from the host
 network namespace, where cluster service DNS and ClusterIP addresses are not
-dependable, so the port has to be published on every node. Setting
-`service.type` to anything other than `NodePort` fails the render: a ClusterIP
-service publishes no node port, so the mirror endpoint would point at a closed
-port and every pull would fall back to the upstream registry with no error.
+dependable, so the port has to be published on every node.
+
+`service.type` was never a safe setting, so the render now fails on any value
+other than `NodePort`. A ClusterIP service publishes no node port, so the mirror
+endpoint points at a closed port and every pull falls back to the upstream
+registry with no error, which is indistinguishable from a working cache until
+you check cache metrics.
 
 ### CRI-O
 

--- a/deploy/helm/container-cache/deploy/templates/_helpers.tpl
+++ b/deploy/helm/container-cache/deploy/templates/_helpers.tpl
@@ -78,6 +78,23 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Reject a service.type override.
+
+The registry mirror endpoint written into hosts.toml and the CRI-O drop-in is
+${NODE_IP}:${port}, which only resolves when the service publishes that port on
+every node. Any other service type renders no nodePort, leaving the mirror
+pointing at a closed port: pulls then fall back to the upstream registry with no
+error, which is indistinguishable from a working cache until you look at cache
+metrics. Fail the render instead of installing something that silently no-ops.
+*/}}
+{{- define "nvcf-container-cache.validateServiceType" -}}
+{{- $type := (.Values.service | default dict).type -}}
+{{- if and $type (ne $type "NodePort") -}}
+{{- fail (printf "service.type=%s is not supported: container-cache must publish a NodePort so the host container runtime can reach it at ${NODE_IP}:${port}. Remove service.type from your values (the chart always renders NodePort) and set service.port instead." $type) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Compute CRI-O registry port mappings.
 If .Values.crio.registryPorts is set, use it.
 Otherwise, derive ports from targetHost list starting at basePort.

--- a/deploy/helm/container-cache/deploy/templates/daemonset.yaml
+++ b/deploy/helm/container-cache/deploy/templates/daemonset.yaml
@@ -105,11 +105,7 @@ spec:
           # so `kubectl get ds` counts exactly the nodes whose cache routing is
           # in effect.
           READY_MARKER=/tmp/nvcf-cc-ready
-          # Touched only when a SIGHUP to CRI-O succeeds. CRI-O reloads registry
-          # config in place, so its start time alone cannot tell us whether the
-          # drop-in is live; the successful-reload timestamp can.
-          CRIO_RELOAD_MARKER=/tmp/nvcf-cc-crio-reloaded
-          rm -f "${READY_MARKER}" "${CRIO_RELOAD_MARKER}"
+          rm -f "${READY_MARKER}"
 {{- $crioPorts := include "nvcf-container-cache.crioRegistryPorts" . | fromYaml -}}
 {{- if $crioPorts }}
 {{- range $name, $val := $crioPorts }}
@@ -251,11 +247,6 @@ spec:
             if [ -n "${crio_pid}" ]; then
               if kill -HUP "${crio_pid}" 2>/dev/null; then
                 echo "Reloaded CRI-O registry config (SIGHUP)."
-                # Stamp the reload so readiness can tell a landed reload from a
-                # failed one. A failed SIGHUP leaves no marker, so the node
-                # reports not-ready instead of silently claiming the mirror is
-                # live.
-                touch "${CRIO_RELOAD_MARKER}"
               else
                 echo "Could not signal CRI-O; the drop-in applies on its next reload." >&2
               fi
@@ -320,28 +311,14 @@ spec:
             [ "${start}" -gt "${mtime}" ]
           }
 
-          # CRI-O does reload registry config, so a start-time comparison on its
-          # own would wrongly report every node that reloaded instead of
-          # restarting. The drop-in is live if CRI-O started after it was
-          # written, or if a SIGHUP we sent landed after the last write.
-          crio_config_active() {
-            local pid start mtime reloaded
-            local dropin=/host/etc/containers/registries.conf.d/nvcf-container-cache.conf
-            pid="$(pgrep -x crio | head -1 || true)"
-            # CRI-O is not running here, so it cannot be holding stale config.
-            [ -n "${pid}" ] || return 0
-            mtime="$(file_mtime_epoch "${dropin}")" || return 1
-            start="$(proc_start_epoch "${pid}")" || return 1
-            if [ "${start}" -gt "${mtime}" ]; then
-              return 0
-            fi
-            reloaded="$(file_mtime_epoch "${CRIO_RELOAD_MARKER}")" || return 1
-            [ "${reloaded}" -ge "${mtime}" ]
-          }
-
+          # Only containerd is checked. It is the sole runtime that can be left
+          # holding config it will never read: registry.config_path is read at
+          # startup and it has no reload. CRI-O reloads registry config in
+          # place, and auto_reload_registries makes it watch the drop-in, so it
+          # has no equivalent gap for readiness to report. A SIGHUP we could not
+          # deliver is logged above rather than folded in here.
           registry_config_active() {
-            containerd_config_active || return 1
-            crio_config_active || return 1
+            containerd_config_active
           }
 
           # Add the marker when the runtime has the config, remove it when it

--- a/deploy/helm/container-cache/deploy/templates/daemonset.yaml
+++ b/deploy/helm/container-cache/deploy/templates/daemonset.yaml
@@ -64,7 +64,9 @@ spec:
         # config_path). The pod keeps running either way -- this reports the
         # node, it does not try to fix it. A DaemonSet whose ready count is
         # below its desired count is the signal that some nodes are still
-        # pulling straight from the upstream registry.
+        # pulling straight from the upstream registry. The marker is
+        # re-evaluated from live runtime state on a timer, so a node flips to
+        # ready on its own once an operator restarts containerd.
         readinessProbe:
           exec:
             command: ["/bin/bash", "-c", "test -f /tmp/nvcf-cc-ready"]
@@ -98,12 +100,16 @@ spec:
           hosts=(${TARGET_HOST//,/ })
           declare -A CRIO_PORTS
 
-          # Cleared here and only written once the node's registry config is
-          # actually live; the readinessProbe reads it, so `kubectl get ds`
-          # counts exactly the nodes whose cache routing is in effect.
+          # Cleared here and only written while the node's registry config is
+          # actually live in the running runtime; the readinessProbe reads it,
+          # so `kubectl get ds` counts exactly the nodes whose cache routing is
+          # in effect.
           READY_MARKER=/tmp/nvcf-cc-ready
-          rm -f "${READY_MARKER}"
-          containerd_restart_pending=false
+          # Touched only when a SIGHUP to CRI-O succeeds. CRI-O reloads registry
+          # config in place, so its start time alone cannot tell us whether the
+          # drop-in is live; the successful-reload timestamp can.
+          CRIO_RELOAD_MARKER=/tmp/nvcf-cc-crio-reloaded
+          rm -f "${READY_MARKER}" "${CRIO_RELOAD_MARKER}"
 {{- $crioPorts := include "nvcf-container-cache.crioRegistryPorts" . | fromYaml -}}
 {{- if $crioPorts }}
 {{- range $name, $val := $crioPorts }}
@@ -155,17 +161,18 @@ spec:
             #
             # This DaemonSet deliberately does not restart containerd: that is
             # disruptive on nodes running function workloads, and node lifecycle
-            # is managed out of band. Instead, hash around the updater to detect
-            # that we changed the active config, and report the node as pending
-            # so an operator can see which nodes still need a containerd restart
-            # or a node cycle. Until then this node keeps pulling from the
-            # upstream registry -- correctly, just without the cache.
+            # is managed out of band. The hash around the updater is a log
+            # signal only -- it records that this run corrected the file, which
+            # is useful when reading pod logs. It is NOT the readiness signal:
+            # it answers "did I change the file this run", which is false on
+            # every pod restart even while the running containerd still holds
+            # the stale in-memory config. Readiness comes from
+            # containerd_config_active below, which reads live runtime state.
             before="$(sha256sum /host/etc/containerd/config.toml | cut -d' ' -f1)"
             python3 update_config.py /host/etc/containerd/config.toml
             after="$(sha256sum /host/etc/containerd/config.toml | cut -d' ' -f1)"
 
             if [ "${before}" != "${after}" ]; then
-              containerd_restart_pending=true
               echo "NOTICE: corrected containerd registry config on this node." >&2
               echo "NOTICE: containerd only reads registry.config_path at startup, so the" >&2
               echo "NOTICE: correction is inactive and image pulls still bypass the cache." >&2
@@ -244,27 +251,137 @@ spec:
             if [ -n "${crio_pid}" ]; then
               if kill -HUP "${crio_pid}" 2>/dev/null; then
                 echo "Reloaded CRI-O registry config (SIGHUP)."
+                # Stamp the reload so readiness can tell a landed reload from a
+                # failed one. A failed SIGHUP leaves no marker, so the node
+                # reports not-ready instead of silently claiming the mirror is
+                # live.
+                touch "${CRIO_RELOAD_MARKER}"
               else
                 echo "Could not signal CRI-O; the drop-in applies on its next reload." >&2
               fi
             fi
           fi
 
-          # containerd is the only runtime that can be left with config on disk
-          # that is not yet in effect, because config_path is read at startup
-          # and it has no reload. CRI-O has no equivalent gap: the mirror lives
-          # directly in the drop-in, which it re-reads.
-          if [ "${containerd_restart_pending}" = "true" ]; then
-            echo "NOT READY: this node needs a containerd restart or a node cycle." >&2
-          else
-            touch "${READY_MARKER}"
-          fi
+          # Readiness has to describe the runtime that is running, not the file
+          # this pod happened to write. Everything below reads live state only:
+          # it never rewrites host config, so it is safe to re-run on a timer.
 
-          # CRI-O picks up registries.conf.d changes via auto_reload_registries=true,
-          # and containerd reads hosts.toml on every pull. Stay alive without
-          # rewriting host config in a loop -- that races with the OS / toolkit.
-          # The certs image's busybox sleep does not understand `infinity`, so loop.
-          while true; do sleep 86400; done
+          # Absolute start time of a process, in epoch seconds, so it can be
+          # compared with a file mtime. /proc/<pid>/stat field 22 is the start
+          # time in clock ticks since boot, and btime in /proc/stat is the boot
+          # instant, so btime + starttime/USER_HZ is the process start.
+          # `sub(/^.*\) /, "")` is greedy, so it drops pid and comm even when
+          # comm contains spaces or parentheses; field 20 of what remains is
+          # field 22 of the line. We deliberately do not use
+          # `stat -c %Y /proc/<pid>`, because the procfs directory inode is
+          # stamped when it is first looked up rather than when the process
+          # forked, and not `ps -o lstart=`, because this image resolves
+          # busybox ps, which has no -o. hostPID: true is what makes the host's
+          # processes visible here at all.
+          proc_start_epoch() {
+            local pid="$1"
+            local ticks btime hz v
+            [ -r "/proc/${pid}/stat" ] || return 1
+            ticks="$(awk '{ sub(/^.*\) /, ""); print $20 }' "/proc/${pid}/stat" 2>/dev/null || true)"
+            btime="$(awk '/^btime /{ print $2 }' /proc/stat 2>/dev/null || true)"
+            hz="$(getconf CLK_TCK 2>/dev/null || echo 100)"
+            for v in "${ticks}" "${btime}" "${hz}"; do
+              case "${v}" in ''|*[!0-9]*) return 1 ;; esac
+            done
+            [ "${hz}" -gt 0 ] || return 1
+            echo "$(( btime + ticks / hz ))"
+          }
+
+          file_mtime_epoch() {
+            stat -c %Y "$1" 2>/dev/null || return 1
+          }
+
+          # containerd reads registry.config_path once, at daemon start, and has
+          # no config reload (SIGHUP terminates it). The config on disk is
+          # therefore in effect only if the running containerd started after the
+          # file was last written. Comparing those two timestamps is version
+          # independent: no containerd CLI, no config dump, no assumption about
+          # which config schema version the node runs.
+          containerd_config_active() {
+            local pid start mtime
+            local cfg=/host/etc/containerd/config.toml
+            [ -f "${cfg}" ] || return 0
+            pid="$(pgrep -x containerd | head -1 || true)"
+            # No containerd process means containerd is not the runtime in use
+            # on this node (a CRI-O-only node can still carry a leftover
+            # config.toml), so there is nothing here to activate.
+            [ -n "${pid}" ] || return 0
+            start="$(proc_start_epoch "${pid}")" || return 1
+            mtime="$(file_mtime_epoch "${cfg}")" || return 1
+            # Strictly greater: the start time is truncated to whole seconds, so
+            # a tie could mean the daemon read the file mid-write. Reporting the
+            # node is the safe direction; claiming the cache is live when it is
+            # not is exactly the failure this check exists to prevent.
+            [ "${start}" -gt "${mtime}" ]
+          }
+
+          # CRI-O does reload registry config, so a start-time comparison on its
+          # own would wrongly report every node that reloaded instead of
+          # restarting. The drop-in is live if CRI-O started after it was
+          # written, or if a SIGHUP we sent landed after the last write.
+          crio_config_active() {
+            local pid start mtime reloaded
+            local dropin=/host/etc/containers/registries.conf.d/nvcf-container-cache.conf
+            pid="$(pgrep -x crio | head -1 || true)"
+            # CRI-O is not running here, so it cannot be holding stale config.
+            [ -n "${pid}" ] || return 0
+            mtime="$(file_mtime_epoch "${dropin}")" || return 1
+            start="$(proc_start_epoch "${pid}")" || return 1
+            if [ "${start}" -gt "${mtime}" ]; then
+              return 0
+            fi
+            reloaded="$(file_mtime_epoch "${CRIO_RELOAD_MARKER}")" || return 1
+            [ "${reloaded}" -ge "${mtime}" ]
+          }
+
+          registry_config_active() {
+            containerd_config_active || return 1
+            crio_config_active || return 1
+          }
+
+          # Add the marker when the runtime has the config, remove it when it
+          # does not, so the signal self-corrects in both directions. Only the
+          # transitions are logged, so the reconcile loop does not spam.
+          last_ready=""
+          reconcile_ready_marker() {
+            if registry_config_active; then
+              touch "${READY_MARKER}"
+              if [ "${last_ready}" != "true" ]; then
+                echo "READY: this node's registry config is live in the running container runtime."
+                last_ready=true
+              fi
+            else
+              rm -f "${READY_MARKER}"
+              if [ "${last_ready}" != "false" ]; then
+                echo "NOT READY: this node's registry config is on disk but not live in the" >&2
+                echo "NOT READY: running container runtime, so image pulls still bypass the cache." >&2
+                echo "NOT READY: Restart containerd or cycle this node to activate it." >&2
+                last_ready=false
+              fi
+            fi
+          }
+
+          reconcile_ready_marker
+
+          # Re-evaluate on a timer. This is what lets a node flip to ready on
+          # its own after an operator restarts containerd, with no pod bounce,
+          # and flip back if the config stops being live. The loop only reads
+          # state and adds or removes the marker: it must never rewrite host
+          # config, which races with the OS / toolkit. CRI-O picks up
+          # registries.conf.d changes via auto_reload_registries=true, and
+          # containerd reads hosts.toml on every pull, so there is nothing to
+          # rewrite anyway. Each pass is two /proc reads and two stat calls.
+          # The certs image's busybox sleep does not understand `infinity`, so
+          # this doubles as the keep-alive.
+          while true; do
+            sleep 60
+            reconcile_ready_marker
+          done
       volumes:
       - name: etc-containerd
         hostPath:

--- a/deploy/helm/container-cache/deploy/templates/daemonset.yaml
+++ b/deploy/helm/container-cache/deploy/templates/daemonset.yaml
@@ -59,6 +59,17 @@ spec:
           value: {{ $.Values.vault.certLocation | quote }}
         securityContext:
           privileged: true
+        # Not-ready means this node's registry config is written but not yet in
+        # effect (containerd needs a restart or a node cycle to pick up
+        # config_path). The pod keeps running either way -- this reports the
+        # node, it does not try to fix it. A DaemonSet whose ready count is
+        # below its desired count is the signal that some nodes are still
+        # pulling straight from the upstream registry.
+        readinessProbe:
+          exec:
+            command: ["/bin/bash", "-c", "test -f /tmp/nvcf-cc-ready"]
+          periodSeconds: 30
+          failureThreshold: 1
         {{- with $.Values.configure.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
@@ -86,6 +97,13 @@ spec:
           set -euo pipefail
           hosts=(${TARGET_HOST//,/ })
           declare -A CRIO_PORTS
+
+          # Cleared here and only written once the node's registry config is
+          # actually live; the readinessProbe reads it, so `kubectl get ds`
+          # counts exactly the nodes whose cache routing is in effect.
+          READY_MARKER=/tmp/nvcf-cc-ready
+          rm -f "${READY_MARKER}"
+          containerd_restart_pending=false
 {{- $crioPorts := include "nvcf-container-cache.crioRegistryPorts" . | fromYaml -}}
 {{- if $crioPorts }}
 {{- range $name, $val := $crioPorts }}
@@ -128,7 +146,31 @@ spec:
               capabilities = ["pull", "resolve"]
           EOF
             done
+
+            # containerd re-reads certs.d/*/hosts.toml on every pull, but
+            # registry.config_path lives in config.toml and is only read at
+            # startup -- containerd has no config reload, and SIGHUP kills the
+            # daemon rather than reloading it. So a config.toml edit is inert
+            # until containerd next starts.
+            #
+            # This DaemonSet deliberately does not restart containerd: that is
+            # disruptive on nodes running function workloads, and node lifecycle
+            # is managed out of band. Instead, hash around the updater to detect
+            # that we changed the active config, and report the node as pending
+            # so an operator can see which nodes still need a containerd restart
+            # or a node cycle. Until then this node keeps pulling from the
+            # upstream registry -- correctly, just without the cache.
+            before="$(sha256sum /host/etc/containerd/config.toml | cut -d' ' -f1)"
             python3 update_config.py /host/etc/containerd/config.toml
+            after="$(sha256sum /host/etc/containerd/config.toml | cut -d' ' -f1)"
+
+            if [ "${before}" != "${after}" ]; then
+              containerd_restart_pending=true
+              echo "NOTICE: corrected containerd registry config on this node." >&2
+              echo "NOTICE: containerd only reads registry.config_path at startup, so the" >&2
+              echo "NOTICE: correction is inactive and image pulls still bypass the cache." >&2
+              echo "NOTICE: Restart containerd or cycle this node to activate it." >&2
+            fi
           fi
 
           # CRI-O: write a single drop-in. Do NOT touch /etc/containers/registries.conf;
@@ -190,6 +232,32 @@ spec:
               mkdir -p "${user_drop_in_dir}"
               cp "${crio_conf}" "${user_drop_in_dir}/nvcf-container-cache.conf"
             fi
+
+            # auto_reload_registries makes CRI-O watch registries.conf.d, but
+            # that setting only takes effect once CRI-O has read the drop-in we
+            # just wrote -- on a first install it has not. Unlike containerd,
+            # CRI-O reloads registry config on SIGHUP without dropping
+            # workloads, so nudge it rather than leaving the mirror inactive
+            # until something else restarts the daemon. Best-effort: a node
+            # where CRI-O is absent or unsignalable is not a failure.
+            crio_pid="$(pgrep -x crio | head -1 || true)"
+            if [ -n "${crio_pid}" ]; then
+              if kill -HUP "${crio_pid}" 2>/dev/null; then
+                echo "Reloaded CRI-O registry config (SIGHUP)."
+              else
+                echo "Could not signal CRI-O; the drop-in applies on its next reload." >&2
+              fi
+            fi
+          fi
+
+          # containerd is the only runtime that can be left with config on disk
+          # that is not yet in effect, because config_path is read at startup
+          # and it has no reload. CRI-O has no equivalent gap: the mirror lives
+          # directly in the drop-in, which it re-reads.
+          if [ "${containerd_restart_pending}" = "true" ]; then
+            echo "NOT READY: this node needs a containerd restart or a node cycle." >&2
+          else
+            touch "${READY_MARKER}"
           fi
 
           # CRI-O picks up registries.conf.d changes via auto_reload_registries=true,

--- a/deploy/helm/container-cache/deploy/templates/service.yaml
+++ b/deploy/helm/container-cache/deploy/templates/service.yaml
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+{{- include "nvcf-container-cache.validateServiceType" . -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -21,21 +22,23 @@ metadata:
     app: {{ $.Release.Name }}
     {{- include "nvcf-container-cache.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.service.type | default "ClusterIP" }}
+  # Always NodePort, and not configurable. The host container runtime
+  # (containerd/CRI-O) reaches this service as ${NODE_IP}:${port} from the host
+  # network namespace, where cluster service DNS and ClusterIP addresses are not
+  # dependable. A ClusterIP service renders no nodePort at all, so the mirror
+  # endpoint the DaemonSet writes points at a port nothing listens on and every
+  # pull silently falls back to the upstream registry.
+  type: NodePort
   ports:
     - port: {{ .Values.service.port | default 30345 }}
-      {{ if eq .Values.service.type "NodePort" }}
       nodePort: {{ .Values.service.port | default 30345 }}
-      {{ end }}
       targetPort: https
       name: https
 {{- $crioPorts := include "nvcf-container-cache.crioRegistryPorts" . | fromYaml -}}
 {{- if $crioPorts }}
 {{- range $name, $val := $crioPorts }}
     - port: {{ $val.port }}
-      {{ if eq $.Values.service.type "NodePort" }}
       nodePort: {{ $val.port }}
-      {{ end }}
       targetPort: crio-{{ $name }}
       name: crio-{{ $name }}
 {{- end }}

--- a/deploy/helm/container-cache/deploy/values.yaml
+++ b/deploy/helm/container-cache/deploy/values.yaml
@@ -142,8 +142,13 @@ persistentVolumeClaim:
   freeProxyPct: 15
 
 # Service configuration.
+#
+# The service type is not configurable: it is always NodePort. The host
+# container runtime reaches the cache at ${NODE_IP}:${port} from the host
+# network namespace, so the port has to be published on every node. Setting
+# service.type to anything else fails the render rather than installing a cache
+# that pulls silently bypass.
 service:
-  type: NodePort
   port: 30345
 
 # Proxy service (nvcf-proxy-cache ClusterIP) configuration.

--- a/deploy/helm/container-cache/deploy/values.yaml
+++ b/deploy/helm/container-cache/deploy/values.yaml
@@ -28,7 +28,7 @@ images:
   # Name of the container image containing Nginx Prometheus exporter.
   exporter: nvcr.io/nv-ngc-devops/nginx-prometheus-exporter:1.0
   # Certificate bundle used for cache certificates.
-  certificates: nvcr.io/nv-ngc-devops/nvcf-proxy-tls-certs:v1.2.10
+  certificates: nvcr.io/nv-ngc-devops/nvcf-proxy-tls-certs:v1.2.11
   # Optional pull secrets for private registries.
   secrets:
     - nvidia-ngcuser-pull-secret

--- a/deploy/helm/container-cache/tests/chart-render/verify-mirrors.sh
+++ b/deploy/helm/container-cache/tests/chart-render/verify-mirrors.sh
@@ -106,11 +106,12 @@ echo "Checking CRI-O reload..."
 # crio.conf.d drop-in this DaemonSet writes.
 assert_has 'kill -HUP "${crio_pid}"'
 assert_has 'pgrep -x crio'
-# A failed SIGHUP must not mark the node ready: the reload marker is stamped
-# only on success, and readiness compares it against the drop-in mtime.
-assert_has 'touch "${CRIO_RELOAD_MARKER}"'
-assert_has 'crio_config_active() {'
-assert_has '[ "${reloaded}" -ge "${mtime}" ]'
+# Readiness must not depend on CRI-O. It reloads registry config in place and
+# auto_reload_registries makes it watch the drop-in, so it has no equivalent of
+# containerd's read-once config_path gap. A SIGHUP we could not deliver is
+# logged, not folded into the readiness marker.
+assert_not_has 'CRIO_RELOAD_MARKER'
+assert_not_has 'crio_config_active'
 
 echo "Checking multi-domain NodePort listeners..."
 assert_has 'nodePort: 30346'

--- a/deploy/helm/container-cache/tests/chart-render/verify-mirrors.sh
+++ b/deploy/helm/container-cache/tests/chart-render/verify-mirrors.sh
@@ -38,6 +38,48 @@ assert_has 'name: nvcf-container-cache'
 # nodes without a local cache pod (kube-proxy drops NodePort traffic).
 assert_not_has 'externalTrafficPolicy: Local'
 assert_not_has 'internalTrafficPolicy: Local'
+# The registry mirror endpoint is ${NODE_IP}:${port}, so the port must be
+# published on every node. A ClusterIP service renders no nodePort and the
+# mirror then points at a closed port, which fails as a silent fallback to the
+# upstream registry rather than a visible error.
+assert_has 'type: NodePort'
+
+echo "Checking service.type cannot be overridden..."
+# Capture rather than pipe: `set -o pipefail` would otherwise report helm's
+# intentional non-zero exit as the pipeline's failure.
+override_out="$(helm template container-cache ./deploy --set service.type=ClusterIP 2>&1 || true)"
+if ! printf '%s' "${override_out}" | grep -F -q -- 'is not supported'; then
+  echo "FAILED: service.type=ClusterIP should fail the render with an explanation" >&2
+  echo "${override_out}" >&2
+  exit 1
+fi
+# NodePort is still accepted, so existing values files keep working.
+helm template container-cache ./deploy --set service.type=NodePort >/dev/null
+
+echo "Checking containerd pending-restart reporting..."
+# containerd reads registry.config_path only at daemon start and has no config
+# reload, so correcting config.toml does not take effect on its own. Detect that
+# we changed it and report the node; never restart containerd, which would be
+# disruptive on nodes running function workloads.
+assert_has 'before="$(sha256sum /host/etc/containerd/config.toml | cut -d'"'"' '"'"' -f1)"'
+assert_has 'if [ "${before}" != "${after}" ]; then'
+assert_has 'containerd_restart_pending=true'
+assert_not_has 'systemctl restart containerd'
+assert_not_has 'nsenter'
+
+echo "Checking readiness reflects whether cache routing is live..."
+# A DaemonSet ready count below its desired count is the signal that some nodes
+# still pull straight from the upstream registry.
+assert_has 'test -f /tmp/nvcf-cc-ready'
+assert_has 'readinessProbe:'
+assert_has 'touch "${READY_MARKER}"'
+
+echo "Checking CRI-O reload..."
+# SIGHUP is a documented CRI-O reload, not a kill, so it is safe to signal.
+# Needed because auto_reload_registries only applies once CRI-O has read the
+# crio.conf.d drop-in this DaemonSet writes.
+assert_has 'kill -HUP "${crio_pid}"'
+assert_has 'pgrep -x crio'
 
 echo "Checking multi-domain NodePort listeners..."
 assert_has 'nodePort: 30346'

--- a/deploy/helm/container-cache/tests/chart-render/verify-mirrors.sh
+++ b/deploy/helm/container-cache/tests/chart-render/verify-mirrors.sh
@@ -58,14 +58,17 @@ helm template container-cache ./deploy --set service.type=NodePort >/dev/null
 
 echo "Checking containerd pending-restart reporting..."
 # containerd reads registry.config_path only at daemon start and has no config
-# reload, so correcting config.toml does not take effect on its own. Detect that
-# we changed it and report the node; never restart containerd, which would be
-# disruptive on nodes running function workloads.
+# reload, so correcting config.toml does not take effect on its own. Report the
+# node; never restart containerd, which would be disruptive on nodes running
+# function workloads.
 assert_has 'before="$(sha256sum /host/etc/containerd/config.toml | cut -d'"'"' '"'"' -f1)"'
 assert_has 'if [ "${before}" != "${after}" ]; then'
-assert_has 'containerd_restart_pending=true'
 assert_not_has 'systemctl restart containerd'
 assert_not_has 'nsenter'
+# The hash diff is a log signal only. Readiness derived from it reports
+# false-ready after a pod restart, because update_config.py is idempotent and
+# the hashes match even while the running containerd holds the stale config.
+assert_not_has 'containerd_restart_pending'
 
 echo "Checking readiness reflects whether cache routing is live..."
 # A DaemonSet ready count below its desired count is the signal that some nodes
@@ -73,6 +76,29 @@ echo "Checking readiness reflects whether cache routing is live..."
 assert_has 'test -f /tmp/nvcf-cc-ready'
 assert_has 'readinessProbe:'
 assert_has 'touch "${READY_MARKER}"'
+# Readiness comes from live runtime state: containerd's process start time
+# versus the mtime of the config it only reads at startup.
+assert_has 'containerd_config_active() {'
+assert_has 'pgrep -x containerd'
+assert_has 'proc_start_epoch() {'
+assert_has '[ "${start}" -gt "${mtime}" ]'
+# Self-correcting in both directions, so a node that loses activation stops
+# reporting ready.
+assert_has 'rm -f "${READY_MARKER}"'
+# Re-evaluated on a short interval, so a node flips to ready on its own once an
+# operator restarts containerd. The old 24h sleep never re-checked.
+assert_has 'reconcile_ready_marker() {'
+assert_has 'while true; do'
+assert_has 'sleep 60'
+assert_not_has 'sleep 86400'
+# The reconcile loop must only read state. Rewriting host config there races
+# with the OS / container toolkit, so the updater must be invoked exactly once,
+# in the one-shot setup phase above the loop.
+updater_calls="$(grep -F -c -- 'python3 update_config.py' "${OUT_FILE}" || true)"
+if [ "${updater_calls}" != "1" ]; then
+  echo "FAILED: expected update_config.py to be invoked once, found ${updater_calls}" >&2
+  exit 1
+fi
 
 echo "Checking CRI-O reload..."
 # SIGHUP is a documented CRI-O reload, not a kill, so it is safe to signal.
@@ -80,6 +106,11 @@ echo "Checking CRI-O reload..."
 # crio.conf.d drop-in this DaemonSet writes.
 assert_has 'kill -HUP "${crio_pid}"'
 assert_has 'pgrep -x crio'
+# A failed SIGHUP must not mark the node ready: the reload marker is stamped
+# only on success, and readiness compares it against the drop-in mtime.
+assert_has 'touch "${CRIO_RELOAD_MARKER}"'
+assert_has 'crio_config_active() {'
+assert_has '[ "${reloaded}" -ge "${mtime}" ]'
 
 echo "Checking multi-domain NodePort listeners..."
 assert_has 'nodePort: 30346'

--- a/deploy/helm/container-cache/tests/script-logic/verify-readiness.sh
+++ b/deploy/helm/container-cache/tests/script-logic/verify-readiness.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Behavioural tests for the DaemonSet readiness helpers.
+#
+# The helpers live inside the Helm-templated bash script in
+# templates/daemonset.yaml, so this test renders the chart, lifts the shipped
+# function definitions out of the rendered script, and runs them for real
+# against fixture files. Only the two path roots are rewritten (/proc and
+# /host point at a temporary directory); the logic under test is the exact
+# text that ships in the DaemonSet.
+#
+# Run from the chart subtree:
+#   bash tests/script-logic/verify-readiness.sh
+set -euo pipefail
+
+CHART_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/deploy"
+FAKE="$(mktemp -d)"
+trap 'rm -rf "${FAKE}"' EXIT
+
+RENDERED="${FAKE}/rendered.yaml"
+HELPERS="${FAKE}/helpers.sh"
+
+helm template container-cache "${CHART_DIR}" > "${RENDERED}"
+
+# Lift the helper block: from the first helper definition through the closing
+# brace of reconcile_ready_marker. None of those functions contain a line that
+# is a lone closing brace, so the first one after reconcile_ready_marker's
+# header is its end.
+awk '
+  /proc_start_epoch\(\) \{/ { inblk = 1 }
+  inblk { print }
+  /reconcile_ready_marker\(\) \{/ { inrec = 1 }
+  inrec && /^[[:space:]]*\}[[:space:]]*$/ { exit }
+' "${RENDERED}" \
+  | sed -e "s#/proc#${FAKE}/proc#g" -e "s#/host#${FAKE}/host#g" \
+  > "${HELPERS}"
+
+grep -q 'containerd_config_active() {' "${HELPERS}" \
+  || { echo "FAILED: could not extract the readiness helpers from the render" >&2; exit 1; }
+grep -q 'reconcile_ready_marker() {' "${HELPERS}" \
+  || { echo "FAILED: reconcile_ready_marker missing from the extracted block" >&2; exit 1; }
+
+BTIME=1000000
+HZ=100
+
+mkdir -p "${FAKE}/proc" "${FAKE}/host/etc/containerd" \
+  "${FAKE}/host/etc/containers/registries.conf.d"
+printf 'btime %s\n' "${BTIME}" > "${FAKE}/proc/stat"
+
+# Synthesise /proc/<pid>/stat. Field 22 (starttime) is the 20th field after
+# pid and comm, so pad with 18 fillers between the state field and it.
+write_proc_stat() { # pid comm start_epoch
+  local pid="$1" comm="$2" start_epoch="$3" ticks fillers=""
+  ticks=$(( (start_epoch - BTIME) * HZ ))
+  local i
+  for (( i = 0; i < 18; i++ )); do fillers+="0 "; done
+  mkdir -p "${FAKE}/proc/${pid}"
+  printf '%s (%s) S %s%s 0 0 0\n' "${pid}" "${comm}" "${fillers}" "${ticks}" \
+    > "${FAKE}/proc/${pid}/stat"
+}
+
+set_mtime() { touch -d "@$2" "$1"; }
+
+# Stubs for the two host lookups the helpers make. Shell functions take
+# precedence over PATH, so the shipped `pgrep -x <name>` calls land here.
+CONTAINERD_PID=""
+CRIO_PID=""
+pgrep() {
+  case "$2" in
+    containerd) [ -n "${CONTAINERD_PID}" ] && echo "${CONTAINERD_PID}" ;;
+    crio)       [ -n "${CRIO_PID}" ] && echo "${CRIO_PID}" ;;
+    *)          return 1 ;;
+  esac
+}
+getconf() { echo "${HZ}"; }
+
+READY_MARKER="${FAKE}/ready"
+CRIO_RELOAD_MARKER="${FAKE}/crio-reloaded"
+
+# shellcheck source=/dev/null
+source "${HELPERS}"
+
+fail() { echo "FAILED: $*" >&2; exit 1; }
+assert_ready() { [ -f "${READY_MARKER}" ] || fail "$1: expected the ready marker"; }
+assert_not_ready() { [ ! -f "${READY_MARKER}" ] || fail "$1: expected no ready marker"; }
+
+echo "0. proc_start_epoch reconstructs an absolute start time"
+write_proc_stat 4242 containerd 1000123
+got="$(proc_start_epoch 4242)"
+[ "${got}" = "1000123" ] || fail "proc_start_epoch returned ${got}, expected 1000123"
+proc_start_epoch 999999 >/dev/null 2>&1 && fail "proc_start_epoch must fail on an unknown pid"
+
+CONTAINERD="${FAKE}/host/etc/containerd/config.toml"
+CRIO_DROPIN="${FAKE}/host/etc/containers/registries.conf.d/nvcf-container-cache.conf"
+
+echo "1. pod recreated before containerd restarted: not ready"
+# update_config.py is idempotent, so a hash diff sees no change on this run and
+# would report ready. The running containerd still predates the config, so the
+# node is genuinely still bypassing the cache.
+: > "${CONTAINERD}"
+set_mtime "${CONTAINERD}" 1000200
+CONTAINERD_PID=100
+write_proc_stat 100 containerd 1000100
+touch "${READY_MARKER}"   # stale marker from an earlier state must be cleared
+reconcile_ready_marker
+assert_not_ready "pod recreated before containerd restart"
+
+echo "2. containerd restarts later: flips to ready with no pod bounce"
+# Same running script, same loop: only the runtime state changed.
+write_proc_stat 101 containerd 1000300
+CONTAINERD_PID=101
+reconcile_ready_marker
+assert_ready "delayed containerd restart"
+
+echo "3. containerd config rewritten again after that restart: back to not ready"
+set_mtime "${CONTAINERD}" 1000400
+reconcile_ready_marker
+assert_not_ready "config rewritten after the restart"
+
+echo "4. no containerd process: a leftover config.toml does not hold the node"
+CONTAINERD_PID=""
+reconcile_ready_marker
+assert_ready "CRI-O-only node with a leftover config.toml"
+
+echo "5. failed CRI-O reload: not ready"
+rm -f "${CONTAINERD}"
+CONTAINERD_PID=""
+: > "${CRIO_DROPIN}"
+set_mtime "${CRIO_DROPIN}" 1000200
+CRIO_PID=200
+write_proc_stat 200 crio 1000100   # CRI-O predates the drop-in
+rm -f "${CRIO_RELOAD_MARKER}"      # SIGHUP failed, so nothing was stamped
+reconcile_ready_marker
+assert_not_ready "failed CRI-O SIGHUP"
+
+echo "6. successful CRI-O reload: ready without a restart"
+touch "${CRIO_RELOAD_MARKER}"
+set_mtime "${CRIO_RELOAD_MARKER}" 1000250
+reconcile_ready_marker
+assert_ready "successful CRI-O SIGHUP"
+
+echo "7. CRI-O restarted after the drop-in was written: ready without a reload"
+rm -f "${CRIO_RELOAD_MARKER}"
+write_proc_stat 201 crio 1000300
+CRIO_PID=201
+reconcile_ready_marker
+assert_ready "CRI-O restarted after the drop-in"
+
+echo "8. both runtimes present: the inactive one wins"
+: > "${CONTAINERD}"
+set_mtime "${CONTAINERD}" 1000500
+CONTAINERD_PID=100   # started at 1000100, before the config
+reconcile_ready_marker
+assert_not_ready "containerd inactive while CRI-O is active"
+
+echo "Readiness logic checks passed."

--- a/deploy/helm/container-cache/tests/script-logic/verify-readiness.sh
+++ b/deploy/helm/container-cache/tests/script-logic/verify-readiness.sh
@@ -66,18 +66,15 @@ set_mtime() { touch -d "@$2" "$1"; }
 # Stubs for the two host lookups the helpers make. Shell functions take
 # precedence over PATH, so the shipped `pgrep -x <name>` calls land here.
 CONTAINERD_PID=""
-CRIO_PID=""
 pgrep() {
   case "$2" in
     containerd) [ -n "${CONTAINERD_PID}" ] && echo "${CONTAINERD_PID}" ;;
-    crio)       [ -n "${CRIO_PID}" ] && echo "${CRIO_PID}" ;;
     *)          return 1 ;;
   esac
 }
 getconf() { echo "${HZ}"; }
 
 READY_MARKER="${FAKE}/ready"
-CRIO_RELOAD_MARKER="${FAKE}/crio-reloaded"
 
 # shellcheck source=/dev/null
 source "${HELPERS}"
@@ -122,37 +119,22 @@ assert_not_ready "config rewritten after the restart"
 echo "4. no containerd process: a leftover config.toml does not hold the node"
 CONTAINERD_PID=""
 reconcile_ready_marker
-assert_ready "CRI-O-only node with a leftover config.toml"
+assert_ready "no containerd process, leftover config.toml"
 
-echo "5. failed CRI-O reload: not ready"
-rm -f "${CONTAINERD}"
-CONTAINERD_PID=""
+echo "5. readiness ignores CRI-O entirely"
+# CRI-O reloads registry config in place and auto_reload_registries makes it
+# watch the drop-in, so it has no equivalent of containerd's read-once
+# config_path gap. A node running only CRI-O must never be held not-ready.
 : > "${CRIO_DROPIN}"
 set_mtime "${CRIO_DROPIN}" 1000200
-CRIO_PID=200
-write_proc_stat 200 crio 1000100   # CRI-O predates the drop-in
-rm -f "${CRIO_RELOAD_MARKER}"      # SIGHUP failed, so nothing was stamped
 reconcile_ready_marker
-assert_not_ready "failed CRI-O SIGHUP"
+assert_ready "CRI-O-only node"
 
-echo "6. successful CRI-O reload: ready without a restart"
-touch "${CRIO_RELOAD_MARKER}"
-set_mtime "${CRIO_RELOAD_MARKER}" 1000250
-reconcile_ready_marker
-assert_ready "successful CRI-O SIGHUP"
-
-echo "7. CRI-O restarted after the drop-in was written: ready without a reload"
-rm -f "${CRIO_RELOAD_MARKER}"
-write_proc_stat 201 crio 1000300
-CRIO_PID=201
-reconcile_ready_marker
-assert_ready "CRI-O restarted after the drop-in"
-
-echo "8. both runtimes present: the inactive one wins"
+echo "6. containerd still governs when both are present"
 : > "${CONTAINERD}"
 set_mtime "${CONTAINERD}" 1000500
 CONTAINERD_PID=100   # started at 1000100, before the config
 reconcile_ready_marker
-assert_not_ready "containerd inactive while CRI-O is active"
+assert_not_ready "containerd inactive"
 
 echo "Readiness logic checks passed."

--- a/docs/user/cluster-management/container-cache.md
+++ b/docs/user/cluster-management/container-cache.md
@@ -305,10 +305,11 @@ The container runtime on each node reaches the cache at `${NODE_IP}:${port}`
 from the host network namespace, where cluster service DNS and ClusterIP
 addresses are not dependable, so the port must be published on every node.
 
-Setting `service.type` fails the install with an explicit error. A ClusterIP
-service publishes no node port, so the registry mirror written to each node
-would point at a port nothing listens on, and image pulls would fall back to
-the upstream registry with no error and no cache involvement.
+Setting `service.type` to anything other than `NodePort` fails the render with
+an explicit error. A ClusterIP service publishes no node port, so the registry
+mirror written to each node would point at a port nothing listens on, and image
+pulls would fall back to the upstream registry with no error and no cache
+involvement.
 
 ### Metrics Configuration
 

--- a/docs/user/cluster-management/container-cache.md
+++ b/docs/user/cluster-management/container-cache.md
@@ -290,18 +290,25 @@ persistentVolumeClaim:
 
 ### Service Configuration
 
-The service type and port can be configured based on your access requirements:
+The service port is configurable. The service type is not: Container Cache is
+always exposed as a `NodePort`.
 
 ```yaml
 # values.yaml
 
 service:
-  # Service type: ClusterIP, NodePort, or LoadBalancer
-  type: ClusterIP
-
   # Port for the Container Cache service
   port: 30345
 ```
+
+The container runtime on each node reaches the cache at `${NODE_IP}:${port}`
+from the host network namespace, where cluster service DNS and ClusterIP
+addresses are not dependable, so the port must be published on every node.
+
+Setting `service.type` fails the install with an explicit error. A ClusterIP
+service publishes no node port, so the registry mirror written to each node
+would point at a port nothing listens on, and image pulls would fall back to
+the upstream registry with no error and no cache involvement.
 
 ### Metrics Configuration
 

--- a/docs/user/cluster-management/container-cache.md
+++ b/docs/user/cluster-management/container-cache.md
@@ -301,15 +301,17 @@ service:
   port: 30345
 ```
 
-The container runtime on each node reaches the cache at `${NODE_IP}:${port}`
-from the host network namespace, where cluster service DNS and ClusterIP
-addresses are not dependable, so the port must be published on every node.
+The service is always `NodePort` and the type is not configurable. The container
+runtime on each node reaches the cache at `${NODE_IP}:${port}` from the host
+network namespace, where cluster service DNS and ClusterIP addresses are not
+dependable, so the port must be published on every node.
 
-Setting `service.type` to anything other than `NodePort` fails the render with
-an explicit error. A ClusterIP service publishes no node port, so the registry
-mirror written to each node would point at a port nothing listens on, and image
-pulls would fall back to the upstream registry with no error and no cache
-involvement.
+`service.type` was never a safe setting. A ClusterIP service publishes no node
+port, so the registry mirror written to each node points at a port nothing
+listens on, and image pulls fall back to the upstream registry with no error and
+no cache involvement, which looks identical to a working cache until you check
+cache metrics. The chart now fails the render on any value other than `NodePort`
+so a leftover override cannot silently disable caching.
 
 ### Metrics Configuration
 


### PR DESCRIPTION
## Why

Container Cache could install successfully while function image pulls went
straight to the upstream registry, with no error and no cache metrics. Two
independent causes, both reported from EKS and AKS GPU node pools.

The DaemonSet writes the containerd mirror endpoint and the CRI-O drop-in as
`${NODE_IP}:${port}`, because both runtimes resolve it from the host network
namespace, where cluster service DNS and ClusterIP addresses are not
dependable. The Service only rendered a `nodePort` when `service.type` was
`NodePort`, while the values table and user docs advertised `ClusterIP` and
`LoadBalancer` as supported. Choosing either left the mirror pointing at a port
nothing listens on:

```
Head "https://<node-ip>:30346/v2/...": dial tcp <node-ip>:30346: connect: connection refused
```

Pulls then fall back to the upstream registry and succeed, which is
indistinguishable from a working cache unless you check cache metrics.

Separately, on nodes whose containerd `config.toml` declares `version = 3`,
registry configuration lives under
`[plugins."io.containerd.cri.v1.images".registry]`. `config_path` was left
empty or unusable there, so `hosts.toml` under `/etc/containerd/certs.d` was
ignored. Correcting that file is not enough on its own: containerd reads
`registry.config_path` only at daemon start and has no config reload
([containerd#4478](https://github.com/containerd/containerd/issues/4478)), so
the correction stays inactive until containerd next starts. `hosts.toml` itself
is unaffected, since containerd re-reads it on every pull.

## What changed

Service type is no longer configurable:

- `service.yaml` hardcodes `type: NodePort` and always renders `nodePort`.
- `service.type` is removed from `values.yaml`.
- Setting it to anything other than `NodePort` fails the render with an
  explanation, rather than installing a cache that pulls silently bypass. An
  explicit `NodePort` is still accepted so existing values files keep working.
- README and the user docs no longer advertise `ClusterIP` or `LoadBalancer`.

Report inactive containerd registry config instead of acting on it:

- Hash `config.toml` around the configurator. If we changed it, log a NOTICE and
  skip the readiness marker.
- A new `readinessProbe` on the configure container reads that marker, so a
  DaemonSet whose ready count is below its desired count is the signal that some
  nodes still pull straight from the upstream registry.
- No containerd restart. That is disruptive on nodes running function
  workloads, and node lifecycle is managed out of band. The pod keeps running
  and keeps the corrected config on disk; it activates on the next containerd
  start or node cycle.

CRI-O reload:

- CRI-O has no equivalent gap, because its mirror lives directly in the drop-in
  rather than behind a startup-only path. It does need a nudge on first install:
  `auto_reload_registries` only applies once CRI-O has read the `crio.conf.d`
  drop-in this DaemonSet writes.
- SIGHUP is a documented CRI-O reload rather than a kill, so signal it
  best-effort. A node without CRI-O, or where the signal fails, is not an error.

## Customer Release Notes

Container Cache has always required a NodePort, and `service.type` has been
removed rather than made to work. Installs that set it to `ClusterIP` or
`LoadBalancer` now fail with an explicit error instead of silently routing image
pulls around the cache. Nodes
whose container runtime registry configuration is written but not yet active are
now reported through the DaemonSet's ready count.

## Plan Summary

No new Kubernetes resources. The `nvcf-container-cache` Service already rendered
as NodePort under the default values, so a default install is unchanged. An
install that explicitly set `service.type` to a non-NodePort value will now fail
the render; that configuration never routed pulls through the cache. The
configure container gains a readinessProbe, which can lower a DaemonSet's ready
count on nodes whose containerd config was just corrected.

## Usage

No action for installs on default values. If your values set `service.type`,
remove it; use `service.port` to change the published port.

To find nodes whose registry config is written but not yet active:

```sh
kubectl -n <namespace> get ds <release>-cc
kubectl -n <namespace> logs -l name=configure-containerd --tail=20 | grep NOTICE
```

Those nodes activate on their next containerd start or node cycle.

## Testing

`tests/chart-render/verify-mirrors.sh` passes, extended to cover the rejected
`service.type` override and its message, that an explicit `NodePort` still
renders, `type: NodePort` in the rendered Service, the pending-restart
detection, the absence of any restart path, the readiness marker and probe, and
the CRI-O SIGHUP reload.

Also verified locally: `helm lint` clean; the rendered DaemonSet script passes
`bash -n`; `RESTART_CONTAINERD`-style boolean handling was dropped along with
the restart path.

Not yet validated on a live cluster. The containerd half also depends on a
configurator image change that is not in this repository, so end-to-end QA
needs that image released and `images.certificates` bumped.

## Notes

The `config_path` half of this is only the reporting side. The configurator that
writes `config.toml` lives in the certificates image, not in this repository;
this PR makes the resulting state visible rather than fixing what gets written.

## References

Closes #998

Upstream: containerd#4478 (no config reload).

## Related Pull Requests

None in this repository. Requires a matching certificates-image release and an
`images.certificates` bump before the containerd path is fixed end to end.

## Dependencies

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Container Cache services now always use `NodePort`; unsupported service types fail during chart rendering.
  * Readiness reporting is based on live containerd state, while CRI-O reloads remain best-effort.
  * Runtime configuration changes continue to reconcile automatically, including after restarts and updates.
  * Updated the certificate bundle image.

* **Documentation**
  * Clarified `NodePort` requirements, unsupported settings, and how metrics reveal caching issues.

* **Tests**
  * Expanded coverage for service validation, readiness behavior, runtime detection, and configuration reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->