### PR TITLE
feat(event-ledger): register helm chart in release pipeline

### DIFF
--- a/tools/ci/github-release-subprojects.json
+++ b/tools/ci/github-release-subprojects.json
@@ -286,6 +286,11 @@
       "service_name": "nvcf-event-ledger"
     },
     {
+      "id": "event-ledger-helm",
+      "path": "deploy/helm/event-ledger",
+      "service_name": "helm-nvcf-event-ledger"
+    },
+    {
       "id": "ess",
       "path": "src/control-plane-services/encrypted-secret-store",
       "service_name": "nvcf-ess",


### PR DESCRIPTION
## TL;DR

Register the `deploy/helm/event-ledger` chart in `tools/ci/github-release-subprojects.json` so the release pipeline tags and publishes it.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

The event-ledger Helm chart was added in #762 but was not registered in the release pipeline. This adds the `event-ledger-helm` entry so the chart gets a release tag under `helm-nvcf-event-ledger`.

## For the Reviewer

Single entry added to `tools/ci/github-release-subprojects.json` following the pattern used by other chart pairs (e.g., `ratelimiter` / `ratelimiter-helm`).

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

No runtime change. CI release pipeline will begin tagging `deploy/helm/event-ledger` on merge.

## Issues

Relates to #762

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added release configuration for the Event Ledger Helm deployment.
  * Enabled automated release handling for the Helm-based Event Ledger service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->