### PR TITLE
fix(ratelimiter): keep rate-limit counters across pod replacement

### DIFF
--- a/deploy/helm/ratelimiter/nvcf-ratelimiter/templates/_helpers.tpl
+++ b/deploy/helm/ratelimiter/nvcf-ratelimiter/templates/_helpers.tpl
@@ -149,4 +149,4 @@ Create the name of the service account to use
 {{- else }}
 {{- default "default" .Values.rateLimiter.serviceAccount.name }}
 {{- end }}
-{{- end }} 
+{{- end }}

--- a/deploy/helm/ratelimiter/nvcf-ratelimiter/templates/deployment.yaml
+++ b/deploy/helm/ratelimiter/nvcf-ratelimiter/templates/deployment.yaml
@@ -22,6 +22,14 @@ metadata:
     {{- include "nvcf-ratelimiter.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.rateLimiter.replicaCount }}
+  # Surge first so a live member exists to receive the outgoing pod's counters.
+  # Pinned because the percentage defaults allow an unavailable pod at some
+  # replica counts.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       {{- include "nvcf-ratelimiter.selectorLabels" . | nindent 6 }}
@@ -32,10 +40,12 @@ spec:
         {{- with .Values.rateLimiter.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        checksum/config-env: {{ printf "%s|%s|%s" (toYaml .Values.rateLimiter.env) (include "nvcf-ratelimiter.oauth2Issuer" .) (include "nvcf-ratelimiter.audience" .) | sha256sum }}
+        checksum/config-env: {{ printf "%s|%s|%s|%s" (toYaml .Values.rateLimiter.env) (include "nvcf-ratelimiter.oauth2Issuer" .) (include "nvcf-ratelimiter.audience" .) (toString .Values.rateLimiter.olricReplicaCount) | sha256sum }}
       labels:
         {{- include "nvcf-ratelimiter.selectorLabels" . | nindent 8 }}
     spec:
+      # Covers the readiness delay plus the counter hand-off.
+      terminationGracePeriodSeconds: {{ .Values.rateLimiter.terminationGracePeriodSeconds }}
       {{- with .Values.rateLimiter.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -83,6 +93,10 @@ spec:
               value: {{ include "nvcf-ratelimiter.oauth2Issuer" . | quote }}
             - name: AUDIENCE
               value: {{ include "nvcf-ratelimiter.audience" . | quote }}
+            {{- with .Values.rateLimiter.olricReplicaCount }}
+            - name: OLRIC_REPLICA_COUNT
+              value: {{ . | quote }}
+            {{- end }}
             {{- range $key, $value := .Values.rateLimiter.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/deploy/helm/ratelimiter/nvcf-ratelimiter/values.yaml
+++ b/deploy/helm/ratelimiter/nvcf-ratelimiter/values.yaml
@@ -32,6 +32,14 @@ rateLimiter:
 
   replicaCount: 1
 
+  # Copies of each counter in the Olric cluster. Empty uses the service default,
+  # which keeps one backup so losing a member does not reset its counters.
+  olricReplicaCount: ""
+
+  # Headroom for the counter hand-off on SIGTERM. The hand-off fits the 30s
+  # Kubernetes default; this leaves room for a slower cluster.
+  terminationGracePeriodSeconds: 60
+
   podDisruptionBudget:
     enabled: false
     # minAvailable and maxUnavailable are mutually exclusive; set exactly one.

--- a/src/invocation-plane-services/ratelimiter/cmd/info_test.go
+++ b/src/invocation-plane-services/ratelimiter/cmd/info_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	golibversion "github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/version"
@@ -41,7 +42,7 @@ func TestNewHealthServeMux_Info(t *testing.T) {
 		golibversion.GitHash = ""
 	})
 
-	mux := newHealthServeMux(nil)
+	mux := newHealthServeMux(nil, &atomic.Bool{})
 	require.NotNil(t, mux)
 
 	w := httptest.NewRecorder()
@@ -59,7 +60,7 @@ func TestNewHealthServeMux_Info(t *testing.T) {
 }
 
 func TestNewHealthServeMux_Info_RejectsNonGET(t *testing.T) {
-	mux := newHealthServeMux(nil)
+	mux := newHealthServeMux(nil, &atomic.Bool{})
 	require.NotNil(t, mux)
 
 	for _, method := range []string{

--- a/src/invocation-plane-services/ratelimiter/cmd/main.go
+++ b/src/invocation-plane-services/ratelimiter/cmd/main.go
@@ -27,7 +27,9 @@ import (
 	"os"
 	"os/signal"
 	"reflect"
+	"sync/atomic"
 	"syscall"
+	"time"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	olricConfig "github.com/olric-data/olric/config"
@@ -35,6 +37,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
+	"google.golang.org/grpc"
 
 	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/nvkit/config"
 	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/nvkit/logs"
@@ -85,6 +88,17 @@ func setupPprof() {
 	}()
 }
 
+const (
+	// Long enough for the endpoints controller to see the failing probe.
+	drainReadinessDelay = 5 * time.Second
+	// GracefulStop waits on in-flight RPCs and can outlast the grace period on
+	// its own, which would skip the drain entirely.
+	gracefulStopTimeout = 5 * time.Second
+	// All three must fit the default 30s termination grace period, since not
+	// every deployment can raise it.
+	drainTimeout = 15 * time.Second
+)
+
 func setupOlricStats(rateLimiter *ratelimiter.RateLimiter) {
 	// Get the DMap from the store for on-demand stats
 	store, ok := rateLimiter.GetStore().(*ratelimiter.Store)
@@ -103,6 +117,49 @@ func setupOlricStats(rateLimiter *ratelimiter.RateLimiter) {
 			zap.L().Error("Olric stats server failed", zap.Error(err))
 		}
 	}()
+}
+
+// drainAndStop hands this member's counters to the current partition owners
+// before Olric closes. Graceful termination only; an abrupt kill relies on the
+// Olric replica count instead.
+func drainAndStop(draining *atomic.Bool, server *grpc.Server, rateLimiter *ratelimiter.RateLimiter) {
+	draining.Store(true)
+	time.Sleep(drainReadinessDelay)
+
+	stopped := make(chan struct{})
+	go func() {
+		server.GracefulStop()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+	case <-time.After(gracefulStopTimeout):
+		zap.L().Warn("Graceful stop timed out, forcing shutdown")
+		server.Stop()
+	}
+
+	store, ok := rateLimiter.GetStore().(*ratelimiter.Store)
+	if !ok {
+		zap.L().Warn("Failed to cast store to *ratelimiter.Store for drain")
+		return
+	}
+
+	// Not the command context: the shutdown signal may have cancelled it.
+	ctx, cancel := context.WithTimeout(context.Background(), drainTimeout)
+	defer cancel()
+
+	start := time.Now()
+	drained, failed, err := store.Drain(ctx)
+	if err != nil {
+		zap.L().Error("Failed to drain counters", zap.Int("drained", drained), zap.Int("failed", failed), zap.Error(err))
+		return
+	}
+	if failed > 0 {
+		zap.L().Error("Drained counters with failures", zap.Int("drained", drained), zap.Int("failed", failed),
+			zap.Duration("took", time.Since(start)))
+		return
+	}
+	zap.L().Info("Drained counters", zap.Int("drained", drained), zap.Duration("took", time.Since(start)))
 }
 
 func InterceptorLogger(l *zap.Logger) logging.Logger {
@@ -142,9 +199,14 @@ func InterceptorLogger(l *zap.Logger) logging.Logger {
 
 // newHealthServeMux builds the management HTTP mux serving /health and the
 // GET /info build-version endpoint.
-func newHealthServeMux(rateLimiter *ratelimiter.RateLimiter) *http.ServeMux {
+func newHealthServeMux(rateLimiter *ratelimiter.RateLimiter, draining *atomic.Bool) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		// Unready first so the Service drops this pod before counters move.
+		if draining.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
 		if err := rateLimiter.Health(); err != nil {
 			zap.L().Error("rate limiter error", zap.Error(err))
 			w.WriteHeader(http.StatusInternalServerError)
@@ -179,6 +241,9 @@ func NewRootCommand() *cobra.Command {
 			}
 			if c.SecretsPath == "" {
 				c.SecretsPath = "vault/secrets.json"
+			}
+			if c.OlricReplicaCount <= 0 {
+				c.OlricReplicaCount = ratelimiter.DefaultOlricReplicaCount
 			}
 			if c.OAuth2Issuer == "" {
 				return fmt.Errorf("missing required OAUTH2_ISSUER (expected JWT iss claim on inbound gRPC calls)")
@@ -222,6 +287,10 @@ func NewRootCommand() *cobra.Command {
 			}
 			cfg.DMaps.EvictionPolicy = olricConfig.LRUEviction
 			cfg.DMaps.MaxInuse = 100_000_000 // 100 MB
+			cfg.ReplicaCount = rateLimiterConfig.OlricReplicaCount
+			// Quorum of one so a degraded cluster keeps serving checks.
+			cfg.ReadQuorum = 1
+			cfg.WriteQuorum = 1
 			rateLimiter, err := ratelimiter.NewRateLimiter(*rateLimiterConfig, cfg)
 			if err != nil {
 				return err
@@ -231,7 +300,8 @@ func NewRootCommand() *cobra.Command {
 			// Setup Olric stats endpoint for debugging
 			setupOlricStats(rateLimiter)
 			// make a http health endpoint since astro doesn't support gRPC health endpoint
-			healthServer := newHealthServeMux(rateLimiter)
+			var draining atomic.Bool
+			healthServer := newHealthServeMux(rateLimiter, &draining)
 			healthErrChan := make(chan error, 1)
 			go func() {
 				if err := http.ListenAndServe(":8080", healthServer); err != nil {
@@ -259,6 +329,7 @@ func NewRootCommand() *cobra.Command {
 			select {
 			case sig := <-sigChan:
 				zap.L().Info("Received signal, shutting down...", zap.String("signal", sig.String()))
+				drainAndStop(&draining, baseServer, rateLimiter)
 				return nil
 			case err := <-grpcErrChan:
 				zap.L().Error("grpc server error, shutting down...", zap.Error(err))

--- a/src/invocation-plane-services/ratelimiter/olric_store.go
+++ b/src/invocation-plane-services/ratelimiter/olric_store.go
@@ -20,6 +20,8 @@ package ratelimiter
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -153,6 +155,35 @@ func (store *Store) Get(ctx context.Context, key string, rate limiter.Rate) (lim
 	return common.GetContextFromState(now, rate, expiration, int64(value)), nil
 }
 
+// Drain re-writes every entry so it replicates to the current partition owners.
+// Olric only seeds a member on write, so without this a pod that joined while a
+// counter sat idle holds nothing.
+func (store *Store) Drain(ctx context.Context) (drained int, failed int, err error) {
+	iter, err := store.dmap.Scan(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to scan DMap for drain: %w", err)
+	}
+	defer iter.Close()
+
+	for iter.Next() {
+		if ctx.Err() != nil {
+			return drained, failed, ctx.Err()
+		}
+		key := iter.Key()
+		// Zero delta: atomic per key and keeps the TTL.
+		if _, err := store.dmap.Incr(ctx, key, 0); err != nil {
+			if errors.Is(err, olric.ErrKeyNotFound) {
+				continue
+			}
+			failed++
+			zap.L().Warn("Failed to drain key", zap.String("key", redactKey(key)), zap.Error(err))
+			continue
+		}
+		drained++
+	}
+	return drained, failed, nil
+}
+
 // Peek returns the limit for the given identifier, without modification on current values.
 // NOT USED
 func (store *Store) Peek(ctx context.Context, key string, rate limiter.Rate) (limiter.Context, error) {
@@ -171,6 +202,20 @@ func (store *Store) Reset(ctx context.Context, key string, rate limiter.Rate) (l
 	expiration := now.Add(rate.Period)
 
 	return common.GetContextFromState(now, rate, expiration, 0), nil
+}
+
+// redactKey hashes the subject in a per-user counter key. Keys are built as
+// "<prefix>:user:<clientAuthSubject>:<ncaId>:..." for the per-user tier, so the
+// segment after the "user" sentinel is the caller identity.
+func redactKey(key string) string {
+	parts := strings.Split(key, ":")
+	for i, part := range parts {
+		if part == "user" && i+1 < len(parts) {
+			parts[i+1] = redactSubject(parts[i+1])
+			return strings.Join(parts, ":")
+		}
+	}
+	return key
 }
 
 // getCacheKey returns the full path for an identifier.

--- a/src/invocation-plane-services/ratelimiter/olric_store_test.go
+++ b/src/invocation-plane-services/ratelimiter/olric_store_test.go
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ratelimiter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/olric-data/olric"
+	olricConfig "github.com/olric-data/olric/config"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+
+	cfg := olricConfig.New("local")
+	cfg.DMaps.EvictionPolicy = olricConfig.LRUEviction
+	cfg.DMaps.MaxInuse = 100_000_000
+
+	started := make(chan struct{})
+	cfg.Started = func() { close(started) }
+
+	db, err := olric.New(cfg)
+	require.NoError(t, err)
+
+	go func() {
+		if err := db.Start(); err != nil {
+			t.Errorf("olric failed to start: %v", err)
+		}
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(30 * time.Second):
+		t.Fatal("olric did not start in time")
+	}
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = db.Shutdown(ctx)
+	})
+
+	dmap, err := db.NewEmbeddedClient().NewDMap("test-limiter")
+	require.NoError(t, err)
+
+	return &Store{Prefix: "test-limiter", dmap: dmap}
+}
+
+func TestDrainReplicatesEveryKeyWithoutChangingCounts(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	require.NoError(t, store.dmap.Put(ctx, "a", 4, olric.EX(time.Hour)))
+	require.NoError(t, store.dmap.Put(ctx, "b", 9, olric.EX(time.Hour)))
+
+	ttlBefore := map[string]int64{}
+	for _, key := range []string{"a", "b"} {
+		entry, err := store.dmap.Get(ctx, key)
+		require.NoError(t, err)
+		ttlBefore[key] = entry.TTL()
+	}
+
+	drained, failed, err := store.Drain(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 2, drained)
+	require.Zero(t, failed)
+
+	for key, want := range map[string]int{"a": 4, "b": 9} {
+		got, err := store.dmap.Get(ctx, key)
+		require.NoError(t, err)
+		value, err := got.Int()
+		require.NoError(t, err)
+		require.Equal(t, want, value, "drain must not change the counter for %q", key)
+		// The window must end when it would have without the drain, so compare
+		// against the deadline recorded before draining rather than just
+		// asserting some TTL survived.
+		require.InDelta(t, ttlBefore[key], got.TTL(), float64(2*time.Second/time.Millisecond),
+			"drain must keep the window deadline for %q", key)
+	}
+}
+
+func TestDrainOnEmptyStore(t *testing.T) {
+	store := newTestStore(t)
+
+	drained, failed, err := store.Drain(context.Background())
+	require.NoError(t, err)
+	require.Zero(t, drained)
+	require.Zero(t, failed)
+}
+
+func TestRedactKeyHidesSubject(t *testing.T) {
+	// Non per-user keys carry no caller identity and pass through untouched.
+	require.Equal(t, "limiter:nca-1:version-1:10-H", redactKey("limiter:nca-1:version-1:10-H"))
+
+	// Real per-user keys are prefixed by the store, so the sentinel is not first.
+	got := redactKey("limiter:user:caller@example.com:nca-1:version-1:10-H")
+	require.NotContains(t, got, "caller@example.com")
+	require.Equal(t, "limiter:user:"+redactSubject("caller@example.com")+":nca-1:version-1:10-H", got)
+}

--- a/src/invocation-plane-services/ratelimiter/rate_limiter.go
+++ b/src/invocation-plane-services/ratelimiter/rate_limiter.go
@@ -70,6 +70,9 @@ import (
 const (
 	defaultLimiterCacheCapacity       = 300
 	defaultIndexedPolicyCacheCapacity = 100
+	// Keep a backup of every counter so losing a member does not reset it.
+	// Olric warns and places fewer backups when the cluster is smaller.
+	DefaultOlricReplicaCount = 2
 )
 
 type FunctionRateLimitConfig struct {
@@ -99,6 +102,9 @@ type Config struct {
 	NvcfApiUrl               string `mapstructure:"NVCF_API_URL"`
 	CacheTTL                 int    `mapstructure:"CACHE_TTL"`
 	CollectMetrics           bool   `mapstructure:"COLLECT_METRICS"`
+	// Copies of each counter kept in the cluster. At 1 the owning member is a
+	// single point of failure for the counters it holds.
+	OlricReplicaCount int `mapstructure:"OLRIC_REPLICA_COUNT"`
 }
 
 type CustomClaims struct {
@@ -419,8 +425,17 @@ func (r *RateLimiter) Health() error {
 		}
 		return errors.New("olric db shutdown")
 	default:
-		return nil
 	}
+	// Not ready until this member is in the cluster: a member on its own counts
+	// against an empty view, and cannot receive counters from a member leaving.
+	members, err := r.db.NewEmbeddedClient().Members(context.Background())
+	if err != nil {
+		return fmt.Errorf("failed to list olric members: %w", err)
+	}
+	if len(members) == 0 {
+		return errors.New("olric member list is empty")
+	}
+	return nil
 }
 
 // GetStore returns the limiter store for metrics/debugging purposes


### PR DESCRIPTION
## TL;DR
Rate-limit counters were lost whenever the pods holding them were replaced, so a rolling upgrade of the ratelimiter silently handed every caller a fresh budget. This keeps a backup copy of each counter, hands a terminating pod's counters to the surviving members, and stops reporting a pod ready before it has joined the cluster.

## Why
Counters live only in the ratelimiter's Olric cluster memory, one copy each, on whichever member owns that key's partition. Two properties combine badly:

- The Olric replica count was never set, so it defaulted to 1. No backup copy exists, and losing the owning member erases the counters it held.
- Olric only puts data on a member when a write lands on it. Its balancer moves a partition when the current holder stops owning it, but nothing back-fills a member that joined while a counter sat idle. A freshly started pod therefore holds nothing for existing counters.

So replacing every pod in turn drops every counter. The next check finds no key, treats it as a new window, and admits a full budget again. Nothing logs it and no metric distinguishes it from a legitimately new window.

Measured with three pods and a function limited to 10 per hour: spend 4, replace all three pods, invoke again, and all 10 further calls are admitted, so 14 pass against a limit of 10. Interleaving a single request between replacements preserves the counter, confirming writes are the only path that seeds a new member.

## What changed
Four parts. None is sufficient alone, and the correctness lives in the service rather than in per-deployment config.

- The Olric replica count defaults to 2 in the service, so each counter has a backup wherever it runs. Read and write quorums stay at 1 so a degraded cluster keeps serving checks. `rateLimiter.olricReplicaCount` overrides it.
- On SIGTERM the pod reports unready, waits for the Service to drop it, stops serving gRPC, then re-writes each entry so the put path replicates it to the members that own it now. `Incr` with a zero delta is used rather than `Get` plus `Put` because it is atomic per key and preserves the TTL. The hand-off is budgeted to fit the default 30s grace period, so no deployment has to raise it.
- Readiness now reports unready until this member has joined the cluster. A member on its own counts against an empty view and cannot receive a hand-off. This also paces rolling updates: with `maxUnavailable: 0`, the next pod is not replaced until the new member is in the cluster, which removes the need for a `minReadySeconds` timer.
- The chart pins `maxSurge: 1` and `maxUnavailable: 0` so a live member always exists to receive the hand-off. The percentage defaults allow an unavailable pod at some replica counts.

Replication covers abrupt death where no hand-off is possible, the hand-off covers graceful death where replication alone would not seed the new pods, and readiness plus the surge give the hand-off a destination.

## Deployment
- Self-hosted: chart upgrade, no values changes required.
- Managed (astro, which deploys the image without this chart): image bump only. The replica count defaults in the service, the hand-off fits the 30s grace period already in use, and the readiness probe is already wired, so no `envConfig` or grace-period changes are needed.

## What this fixes

Each scenario uses a fresh counter limited to 10 per hour: spend 4, perturb the cluster, then send 10 more. "10 admitted" means the limit held exactly, with denials after.

| Scenario | Before | After |
|---|---|---|
| No churn (control) | 10 admitted | 10 admitted |
| Graceful kill of 1 pod | 10 or 14, depending on which pod owned the key | 10 admitted |
| Graceful kill of 2 pods | 14 admitted | 10 admitted |
| Graceful kill of all 3 pods | 14 admitted | 10 admitted |
| `kubectl rollout restart`, no traffic during it (x2 runs) | 14 admitted | 10 admitted |
| Scale 3 to 2 to 3 | not measured | 10 admitted |
| SIGKILL of 1 pod | not measured | 10 admitted |
| SIGKILL of all 3 pods, one at a time | not measured | 10 admitted |

## What this does not fix

- Losing every member at the same instant. Deleting all three pods simultaneously with `--grace-period=0` admits 14 against a limit of 10, in every run. Counters are held in memory and nothing is persisted, so when every copy disappears at once there is nothing to recover from. Whole-cluster restarts and losing every pod's node together fall in this category.
- Members dying faster than the cluster redistributes. Sequential loss is safe because each removal gives the survivors time to re-own and re-copy the partitions. Compress that interval far enough and it degrades toward the simultaneous case.
- Counter accuracy under concurrency. The counter path is a non-atomic read-modify-write (`Get` then `Put` in `olric_store.go`), so simultaneous checks for the same key can lose an increment. That predates this change and is untouched here. Switching that path to `Incr` would fix it and is worth a follow-up.
- Durability as a guarantee. This makes counters survive pod replacement; it does not make them durable. If rate limits ever need to be exact across arbitrary failures, that calls for a persistent shared store rather than an in-memory grid.

## Customer Release Notes
Rate limits are now enforced correctly across ratelimiter pod restarts and rolling upgrades. Previously a rollout reset every counter, letting callers exceed their configured limit for the duration.

## Plan Summary
The ratelimiter Deployment gains `maxSurge: 1`, `maxUnavailable: 0`, and `terminationGracePeriodSeconds: 60`. Rollouts of this service become slower by design, because each new member must join the cluster and pass readiness before the next pod is replaced.

## Usage
`rateLimiter.olricReplicaCount` overrides the service default of 2. Empty uses the default.

## Testing
Unit tests cover the drain preserving values and TTLs, and the empty-store case. The scenario table above was run end to end against a self-hosted control plane and compute plane, driving the ratelimiter gRPC API directly, with no `minReadySeconds` set, so the pacing comes from readiness alone. QA on an amd64 cluster is still worth doing since local coverage was arm64.

Pre-existing and unrelated: `TestRateLimiterService/testNoRateLimit` in `ratelimiter/cmd` fails on clean `main` as well, so it is not addressed here.

## Notes
- Readiness is now a cluster-membership check, so a misjudged condition here would keep pods out of service. It gates on membership only, not on partitions or backups being fully distributed.
- `Scan` iterates the whole keyspace rather than only this member's keys, so each terminating pod re-writes every counter. That is cheap at current key counts and worth revisiting if the keyspace grows.
- Drain reports through logs (`Drained counters`), not metrics. Metrics emitted during termination are unlikely to be scraped before the pod exits.

## References
Closes #975

## Related Pull Requests
None

## Dependencies
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable counter replication.
  * Added graceful shutdown draining to preserve rate-limit counters during deployments.

* **Reliability**
  * Health checks report the service as unavailable while draining or when cluster membership is unavailable.
  * Deployments now use controlled rolling updates and readiness safeguards.

* **Configuration**
  * Added configurable replica counts and a 60-second termination grace period.
  * Replica counts can be explicitly configured or use the service default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->