### PR TITLE
fix(cassandra): update the image tag to the published Apache build

### DIFF
--- a/deploy/helm/cassandra/helm/Chart.yaml
+++ b/deploy/helm/cassandra/helm/Chart.yaml
@@ -24,4 +24,4 @@ description: >
 type: application
 
 version: 0.8.0
-appVersion: 5.0.8-nv-0
+appVersion: 5.0.8-nv-2.0.1

--- a/deploy/helm/cassandra/helm/values.yaml
+++ b/deploy/helm/cassandra/helm/values.yaml
@@ -31,7 +31,7 @@ cassandra:
     # repository: must be supplied in additional values
     registry: ""
     repository: ""
-    tag: 5.0.8-nv-0
+    tag: 5.0.8-nv-2.0.1
     pullPolicy: IfNotPresent
 
   replicaCount: 3


### PR DESCRIPTION
## Why

The chart's Apache-based image ships under the "cassandra" repository
name, but the default tag 5.0.8-nv-0 predates that rename and is not
published under it. Any install that relies on the chart default (no
per-environment tag override) cannot pull the image on a fresh
cluster.

## What changed

- deploy/helm/cassandra/helm/values.yaml: default cassandra.image.tag
  bumped from 5.0.8-nv-0 to 5.0.8-nv-2.0.1, the published multiarch
  build.
- deploy/helm/cassandra/helm/Chart.yaml: appVersion bumped to match.

## Customer Release Notes

Self-hosted: the cassandra chart now defaults to a published image
tag, so installs no longer need a per-environment tag override.

## Plan Summary

Not applicable

## Usage

Not applicable

## Testing

- helm lint with the CI values (tools/ci/helm-validate-values/
  cassandra.yaml): clean.
- helm template with the same values renders the new tag for both the
  cassandra container and the cassandra-conf-init initContainer (both
  read the same cassandra.image.tag value).
- The 5.0.8-nv-2.0.1 image was validated live by the BDD
  TestSingleClusterUp run in the companion PR.

## Notes

Follow-up once this chart version publishes: bump the chart pin in
deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl and
drop the cassandra.image.tag pins from the BDD fixtures added by the
companion PR.

## References

Relates to https://github.com/NVIDIA/nvcf/issues/1019

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the Cassandra deployment to use the latest application image.
  * Updated the database migrations image to version 0.16.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->