### PR TITLE
fix(self-managed): update the cassandra chart pin and naming

### DIFF
--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -69,11 +69,13 @@ cassandra:
       repository: {{ .Values.global.image.repository }}/alpine-k8s
   image:
     registry: {{ .Values.global.image.registry }}
-    repository: {{ .Values.global.image.repository }}/bitnami-cassandra
-  dynamicSeedDiscovery:
-    image:
-      registry: {{ .Values.global.image.registry }}
-      repository: {{ .Values.global.image.repository }}/bitnami-cassandra
+    # The Apache-based chart publishes its image as "cassandra", not
+    # "bitnami-cassandra". Tag knob follows the migrations pattern above so
+    # environments can override the chart default.
+    repository: {{ .Values.global.image.repository }}/cassandra
+    {{- if dig "cassandra" "image" "tag" "" .Values }}
+    tag: {{ dig "cassandra" "image" "tag" "" .Values }}
+    {{- end }}
 
 # cert-manager subchart image overrides. The helm-nvcf-cert-manager wrapper
 # passes these through to the upstream cert-manager subchart under the

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -69,9 +69,6 @@ cassandra:
       repository: {{ .Values.global.image.repository }}/alpine-k8s
   image:
     registry: {{ .Values.global.image.registry }}
-    # The Apache-based chart publishes its image as "cassandra", not
-    # "bitnami-cassandra". Tag knob follows the migrations pattern above so
-    # environments can override the chart default.
     repository: {{ .Values.global.image.repository }}/cassandra
     {{- if dig "cassandra" "image" "tag" "" .Values }}
     tag: {{ dig "cassandra" "image" "tag" "" .Values }}

--- a/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
@@ -156,7 +156,7 @@ releases:
 {{- end }}
 
   - name: cassandra
-    version: 0.19.1
+    version: 0.20.1
     condition: cassandra.enabled # From defaults.yaml or env overrides
     namespace: cassandra-system
     <<: *dependency # Inherits base values from the dependency template


### PR DESCRIPTION
## Why

Chart helm-nvcf-cassandra 0.20.1 was published with the corrected image
defaults (cassandra 5.0.8-nv-2.0.1; the previous default tag was never
published under the Apache image name). The self-managed stack still
pins 0.19.1 and still points the image at the retired
"bitnami-cassandra" repository, so cassandra installs from main cannot
pull the image.

## What changed

- deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl:
  cassandra release chart version 0.19.1 to 0.20.1.
- deploy/stacks/self-managed/global.yaml.gotmpl: point the cassandra
  image at the renamed "cassandra" repository and add a tag knob
  following the migrations pattern; drop the dynamicSeedDiscovery image
  block, which the chart has no key for (dead Bitnami-era values).

## Customer Release Notes

Self-hosted: cassandra installs pull the published Apache-based image
by default; environments can still override the tag.

## Plan Summary

Cassandra release in the self-managed stack: chart 0.19.1 to 0.20.1,
image repository "bitnami-cassandra" to "cassandra". Image defaults
move to cassandra 5.0.8-nv-2.0.1 and migrations 0.16.0.

## Usage

Not applicable

## Testing

- Full self-managed stack render with a local environment succeeds and
  emits the renamed image at the published tag for both the cassandra
  container and the cassandra-conf-init initContainer.
- Standalone render of chart 0.20.1 with the CI values confirms the
  chart defaults alone resolve the same tag.
- Stack wiring tests (make -C deploy/stacks/self-managed test) pass.
- tests/bdd short suite passes (it asserts on global.yaml.gotmpl).
- The migrations 0.16.0 image is published.

## Notes

Overlaps with the CLI install-path PR, which carries the same
global.yaml.gotmpl rename for the BDD suite: after this merges, that
branch needs a rebase that drops its duplicate hunk, and the
cassandra.image.tag pins in its BDD fixtures become redundant.

## References

Relates to https://github.com/NVIDIA/nvcf/issues/1019

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Cassandra deployment component to a newer chart version.
  * Updated Cassandra image configuration to use the standard Cassandra image repository.
  * Added support for optionally specifying a Cassandra image tag for more flexible deployment control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->