### PR TITLE
feat(container-cache): per-asset cache metrics and correct metric coverage

### DIFF
--- a/deploy/helm/container-cache/deploy/files/nginx.conf
+++ b/deploy/helm/container-cache/deploy/files/nginx.conf
@@ -45,6 +45,9 @@
 
         # Cache Metrics are updated at every log request processing phase.
         lua_shared_dict cache_metrics {{ $.Values.metrics.cacheMetricsStorageSize | default "32m" }};
+        # Tracks which asset label values have been admitted, so the per-asset
+        # counters can be capped. Holds one small key per admitted asset.
+        lua_shared_dict asset_labels {{ $.Values.metrics.assetLabelDictSize | default "1m" }};
 
         lua_shared_dict certs_crt 32m;
         lua_shared_dict certs_crl 32m;
@@ -105,9 +108,13 @@
               live sample had 45.6 percent of requests, and 786 GiB, carrying
               an empty status and being skipped entirely.
 
-              Cardinality is bounded by the number of distinct assets pulled,
-              which is small in practice. Asset names are truncated so a
-              pathological URI cannot create an unbounded label value.
+              Cardinality is capped, not merely small. The asset is derived
+              from a client-controlled path and host, so nothing about the
+              request prevents a caller from minting new values. Admission is
+              limited to metrics.maxAssetLabels distinct values per worker and
+              everything beyond that folds into "other", which bounds the series
+              count at (maxAssetLabels + 1) x sources x statuses x 2 counters.
+              Truncation additionally bounds the length of any single value.
             */}}
             proxy_asset_requests = prometheus:counter(
                 "proxy_cache_asset_requests_total", "Requests per cached asset", {"source", "asset", "cache_status"})

--- a/deploy/helm/container-cache/deploy/files/nginx.conf
+++ b/deploy/helm/container-cache/deploy/files/nginx.conf
@@ -87,6 +87,33 @@
             proxy_response_body_size = prometheus:gauge(
                 "proxy_cache_response_body_size_bytes", "Number of bytes sent to client, not counting the response header", {"cache_status", "http_status"})
 
+            {{- /*
+              Per-asset request and byte counters.
+
+              `asset` groups every file and byte range belonging to one model,
+              repo, or bucket under a single value, so a model that is fetched
+              as hundreds of 512MiB ranges counts once. `source` says where it
+              came from: ngc, hf, s3, or other.
+
+              Counters, not gauges. proxy_cache_response_body_size_bytes above
+              is a gauge overwritten on every request, so total bytes served
+              cannot be derived from it; these can be rate()'d.
+
+              cache_status is normalised here, so a request the cache never
+              consulted is counted as NONE rather than dropped. Uncounted
+              traffic was the largest source of error in the old numbers: a
+              live sample had 45.6 percent of requests, and 786 GiB, carrying
+              an empty status and being skipped entirely.
+
+              Cardinality is bounded by the number of distinct assets pulled,
+              which is small in practice. Asset names are truncated so a
+              pathological URI cannot create an unbounded label value.
+            */}}
+            proxy_asset_requests = prometheus:counter(
+                "proxy_cache_asset_requests_total", "Requests per cached asset", {"source", "asset", "cache_status"})
+            proxy_asset_bytes = prometheus:counter(
+                "proxy_cache_asset_bytes_total", "Bytes sent to clients per cached asset", {"source", "asset", "cache_status"})
+
             proxy_cache_throughput = prometheus:histogram(
                 "proxy_cache_throughput", "Throughput of proxy cache(bytes/msec)", {"cache_status", "http_status", "route"}, { {{ $.Values.metrics.throughputHistogramBuckets | default "25000000, 30000000, 35000000, 40000000, 50000000, 60000000, 80000000, 100000000" }} })
             proxy_cache_upstream_throughput = prometheus:histogram(

--- a/deploy/helm/container-cache/deploy/files/nginx.conf
+++ b/deploy/helm/container-cache/deploy/files/nginx.conf
@@ -70,8 +70,16 @@
             proxy_http_request_time_ms_total = prometheus:counter(
                 "proxy_cache_http_requests_time_ms_total", "Sum of time elapsed between reading the first bytes from the client and writing a log entry after the last bytes were sent for each request", {"request_method", "cache_status", "http_status"})
 
+            {{- /*
+              `route` distinguishes how a request was served under
+              consistent-hash routing, and is always "local" when it is off:
+                local   served from this pod's own cache or origin fetch
+                relayed forwarded to the owner pod, so it paid the peer hop
+                peer    served for another pod that relayed it here
+              Three bounded values, so this does not add unbounded cardinality.
+            */}}
             proxy_http_requests_count = prometheus:counter(
-                "proxy_cache_http_requests_count", "Count of requests with additional labels", {"request_method", "cache_status", "http_status"})
+                "proxy_cache_http_requests_count", "Count of requests with additional labels", {"request_method", "cache_status", "http_status", "route"})
 
             proxy_http_upstream_requests_count = prometheus:counter(
                 "proxy_cache_http_upstream_requests_count", "Count of upstream requests with additional labels", {"request_method", "cache_status", "http_status"})
@@ -80,13 +88,28 @@
                 "proxy_cache_response_body_size_bytes", "Number of bytes sent to client, not counting the response header", {"cache_status", "http_status"})
 
             proxy_cache_throughput = prometheus:histogram(
-                "proxy_cache_throughput", "Throughput of proxy cache(bytes/msec)", {"cache_status", "http_status"}, { {{ $.Values.metrics.throughputHistogramBuckets | default "25000000, 30000000, 35000000, 40000000, 50000000, 60000000, 80000000, 100000000" }} })
+                "proxy_cache_throughput", "Throughput of proxy cache(bytes/msec)", {"cache_status", "http_status", "route"}, { {{ $.Values.metrics.throughputHistogramBuckets | default "25000000, 30000000, 35000000, 40000000, 50000000, 60000000, 80000000, 100000000" }} })
             proxy_cache_upstream_throughput = prometheus:histogram(
                 "proxy_cache_upstream_throughput", "Throughput of upstream server(bytes/msec)", {"host", "http_status"}, { {{ $.Values.metrics.throughputHistogramBuckets | default "25000000, 30000000, 35000000, 40000000, 50000000, 60000000, 80000000, 100000000" }} })
-            metric_latency = prometheus:histogram("proxy_cache_request_duration_seconds", "HTTP request latency", {"host", "request_method", "cache_status", "http_status"}, {0.005, 0.01, 0.02, 0.03, 0.05, 0.075, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1, 1.5, 2, 3, 4, 5, 10})
-            metric_upstream_latency = prometheus:histogram("proxy_cache_upstream_request_duration_seconds", "HTTP request latency", {"host", "request_method", "cache_status", "http_status"}, {0.005, 0.01, 0.02, 0.03, 0.05, 0.075, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1, 1.5, 2, 3, 4, 5, 10})
+            {{- /*
+              Duration buckets must cover a whole object transfer, not an API
+              call. These are multi-hundred-MB model files, so a request that
+              takes tens of seconds is normal and says nothing about cache
+              health. With a 10s top bucket a large share of traffic landed in
+              +Inf, and histogram_quantile clamps at the last finite bucket, so
+              any reported high quantile was the bucket edge rather than a
+              measurement. Buckets past 10s exist to make those quantiles real.
+            */}}
+            metric_latency = prometheus:histogram("proxy_cache_request_duration_seconds", "HTTP request latency", {"host", "request_method", "cache_status", "http_status", "route"}, { {{ $.Values.metrics.durationHistogramBuckets | default "0.005, 0.01, 0.02, 0.03, 0.05, 0.075, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1, 1.5, 2, 3, 4, 5, 10, 15, 30, 60, 120, 300, 600" }} })
+            metric_upstream_latency = prometheus:histogram("proxy_cache_upstream_request_duration_seconds", "HTTP request latency", {"host", "request_method", "cache_status", "http_status"}, { {{ $.Values.metrics.durationHistogramBuckets | default "0.005, 0.01, 0.02, 0.03, 0.05, 0.075, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1, 1.5, 2, 3, 4, 5, 10, 15, 30, 60, 120, 300, 600" }} })
             metric_connections = prometheus:gauge("nginx_http_connections", "Number of HTTP connections", {"state"})
-            metric_response_sizes = prometheus:histogram("proxy_cache_response_size_bytes", "Size of HTTP responses", nil,{1000,2000,4000,8000,16000,32000,64000,128000,256000,1048576, 10485760, 104857600, 1000000000, 10000000000, 100000000000})
+            {{- /*
+              Response-size buckets previously jumped 100MB -> 1GB -> 10GB, so
+              essentially all model traffic fell in a single bucket and the
+              distribution was unreadable. The added steps give resolution
+              across the range these objects actually occupy.
+            */}}
+            metric_response_sizes = prometheus:histogram("proxy_cache_response_size_bytes", "Size of HTTP responses", nil, { {{ $.Values.metrics.responseSizeHistogramBuckets | default "1000, 2000, 4000, 8000, 16000, 32000, 64000, 128000, 256000, 1048576, 10485760, 104857600, 268435456, 536870912, 805306368, 1073741824, 2147483648, 5368709120, 10737418240, 107374182400" }} })
 
             instance_info = prometheus:gauge("proxy_cache_instance_info", "Information about proxy cache instance", {"chart_version"})
             instance_info:set(1, { "{{ $.Chart.Version }}" })
@@ -129,6 +152,13 @@
             {{- if gt $n 1 }}
             server {{ $.Release.Name }}-peer-{{ mod (add $i 1) $n }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ $port }} backup;
             {{- end }}
+            # Keep idle connections to the peer. Without this every relayed
+            # request pays a fresh TCP and TLS handshake, which is worst for the
+            # many small Range requests the hash spreads across owners.
+            # @cc_relay must also send `Connection ""` for these to be reused.
+            keepalive {{ ($.Values.consistentHashRouting).peerKeepaliveConnections | default 32 }};
+            keepalive_timeout {{ ($.Values.consistentHashRouting).peerKeepaliveTimeout | default "60s" }};
+            keepalive_requests {{ ($.Values.consistentHashRouting).peerKeepaliveRequests | default 1000 }};
         }
         {{- end }}
 {{- end }}

--- a/deploy/helm/container-cache/deploy/files/proxy-common.conf
+++ b/deploy/helm/container-cache/deploy/files/proxy-common.conf
@@ -115,6 +115,23 @@
                 end
                 -- Truncate so a pathological path cannot widen the label set.
                 if #asset > 120 then asset = asset:sub(1, 120) end
+                -- Cap the number of distinct values. The asset comes from a
+                -- client-controlled path and host, so length truncation alone
+                -- bounds each value but not how many exist. Admit up to
+                -- maxAssetLabels and fold the rest into "other", so a caller
+                -- minting paths cannot grow the series count without limit.
+                if asset ~= "other" then
+                    local admitted = ngx.shared.asset_labels
+                    if admitted:get(asset) == nil then
+                        local n = admitted:incr("__count", 1, 0)
+                        if n ~= nil and n > {{ ($.Values.metrics).maxAssetLabels | default 50 }} then
+                            admitted:incr("__count", -1)
+                            asset = "other"
+                        else
+                            admitted:set(asset, 1)
+                        end
+                    end
+                end
                 -- Requests the cache never consulted (uploads, redirects, auth
                 -- failures) report an empty status. Name it rather than drop it.
                 local status = cache_status

--- a/deploy/helm/container-cache/deploy/files/proxy-common.conf
+++ b/deploy/helm/container-cache/deploy/files/proxy-common.conf
@@ -39,12 +39,19 @@
             -- undeclared variable raises in OpenResty.
             local route = "local"
 {{- if ($.Values.consistentHashRouting).enabled }}
-            -- Non-empty owner means the route helper sent this to a peer, so it
-            -- paid the relay hop. The inbound relay marker means this pod is the
-            -- owner answering for a peer.
+            -- Classify by what the request actually cost, not by what routing
+            -- decided. A non-empty owner means the object belongs to a peer,
+            -- but the relay may still have served it from this pod's own
+            -- replica once relayCacheMinUses is reached, and a cache hit never
+            -- contacts the peer. Labelling those "relayed" would overstate the
+            -- peer hop and hide the replication that removed it.
             local cc_owner = ngx.var.cc_owner
             if cc_owner ~= nil and cc_owner ~= "" then
-                route = "relayed"
+                if cache_status == "HIT" then
+                    route = "local"
+                else
+                    route = "relayed"
+                end
             elseif ngx.var.http_x_nvcf_cc_relayed == "1" then
                 route = "peer"
             end

--- a/deploy/helm/container-cache/deploy/files/proxy-common.conf
+++ b/deploy/helm/container-cache/deploy/files/proxy-common.conf
@@ -78,6 +78,58 @@
                     metric_response_sizes:observe(body_size)
                 end
             end
+
+            -- Per-asset accounting. Deliberately outside the block above: that
+            -- one drops any request with an empty upstream_cache_status, which
+            -- on a live sample was 45.6 percent of requests and 786 GiB. Those
+            -- are real bytes, so they are counted here as NONE instead.
+            --
+            -- All files and byte ranges of one asset collapse to a single
+            -- label value, so a model pulled as hundreds of 512MiB ranges is
+            -- one series, not hundreds.
+            if request_uri ~= nil and not string.find(request_uri, "manifest") then
+                local path = request_uri:match("^([^?]*)") or ""
+                local source, asset = "other", "other"
+                if host ~= nil then
+                    if host:find("ngc%.nvidia%.com$") then
+                        -- /org/<org>/team/<team>/modelsv2/<name>/... and the
+                        -- team-less form some orgs use.
+                        source = "ngc"
+                        -- No trailing slash is required: the model name can be
+                        -- the last segment. The team-less fallback is guarded on
+                        -- the path not being a team path, because otherwise it
+                        -- matches one and labels the TEAM as the model.
+                        local org, team, name = path:match("^/org/([^/]+)/team/([^/]+)/[^/]+/([^/]+)")
+                        if org == nil and not path:find("^/org/[^/]+/team/") then
+                            org, name = path:match("^/org/([^/]+)/[^/]+/([^/]+)")
+                            team = "no-team"
+                        end
+                        if org ~= nil and name ~= nil then
+                            asset = org .. "/" .. team .. "/" .. name
+                        end
+                    elseif host:find("huggingface%.co$") or host:find("hf%.co$") then
+                        -- /<org>/<repo>/resolve/<rev>/<file>
+                        source = "hf"
+                        local org, repo = path:match("^/([^/]+)/([^/]+)/")
+                        if org ~= nil then asset = org .. "/" .. repo end
+                    elseif host:find("amazonaws%.com$") then
+                        -- Bucket is the first host label; the key is unbounded
+                        -- and deliberately not used.
+                        source = "s3"
+                        asset = host:match("^([^.]+)%.") or "other"
+                    end
+                end
+                -- Truncate so a pathological path cannot widen the label set.
+                if #asset > 120 then asset = asset:sub(1, 120) end
+                -- Requests the cache never consulted (uploads, redirects, auth
+                -- failures) report an empty status. Name it rather than drop it.
+                local status = cache_status
+                if status == nil or status == "" then status = "NONE" end
+                proxy_asset_requests:inc(1, {source, asset, status})
+                if body_size ~= nil and body_size > 0 then
+                    proxy_asset_bytes:inc(body_size, {source, asset, status})
+                end
+            end
         }
 
         set_by_lua_block $cache_ttl {

--- a/deploy/helm/container-cache/deploy/files/proxy-common.conf
+++ b/deploy/helm/container-cache/deploy/files/proxy-common.conf
@@ -32,14 +32,32 @@
             local upstream_time = tonumber(ngx.var.upstream_response_time)
             local host = ngx.var.host
 
+            -- How this request was served. Peer routing is optional, and when
+            -- it is off every request is served here, so "local" is accurate
+            -- and the lookup below is not emitted at all. The routing variable
+            -- is only declared when routing is enabled, and reading an
+            -- undeclared variable raises in OpenResty.
+            local route = "local"
+{{- if ($.Values.consistentHashRouting).enabled }}
+            -- Non-empty owner means the route helper sent this to a peer, so it
+            -- paid the relay hop. The inbound relay marker means this pod is the
+            -- owner answering for a peer.
+            local cc_owner = ngx.var.cc_owner
+            if cc_owner ~= nil and cc_owner ~= "" then
+                route = "relayed"
+            elseif ngx.var.http_x_nvcf_cc_relayed == "1" then
+                route = "peer"
+            end
+{{- end }}
+
             if request_uri ~= nil and cache_status ~= nil and remote_addr ~= nil and not string.find(request_uri, "manifest") then
                 if request_time ~= nil and request_time > 0 then
                     proxy_http_request_time_ms_total:inc(request_time, {request_method, cache_status, http_status})
-                    proxy_http_requests_count:inc(1, {request_method, cache_status, http_status})
+                    proxy_http_requests_count:inc(1, {request_method, cache_status, http_status, route})
 
-                    metric_latency:observe(request_time, {host, request_method, cache_status, http_status})
+                    metric_latency:observe(request_time, {host, request_method, cache_status, http_status, route})
                     if body_size ~= nil then
-                        proxy_cache_throughput:observe(body_size / request_time, {cache_status, http_status})
+                        proxy_cache_throughput:observe(body_size / request_time, {cache_status, http_status, route})
                         if upstream_time ~= nil and upstream_time > 0 then
                           proxy_cache_upstream_throughput:observe(body_size / upstream_time, {host, http_status})
                           metric_upstream_latency:observe(upstream_time, {host, request_method, cache_status, http_status})
@@ -154,15 +172,38 @@
         # every block, so the relay location is not duplicated per block.
         set $cc_owner "";
         location @cc_relay {
-          # Relay to the owner pod: a pure stream that never writes the local
-          # cache or temp files; only the owner stores the object. lua-access
-          # runs on the owner, which sees the original request headers.
+          # Relay to the owner pod. lua-access runs on the owner, which sees the
+          # original request headers.
+          {{- $relayMinUses := int (($.Values.consistentHashRouting).relayCacheMinUses | default 0) }}
+          {{- if gt $relayMinUses 0 }}
+          # Objects pulled through this pod repeatedly are replicated locally
+          # after relayCacheMinUses requests, so hot objects stop paying the
+          # relay hop while one-off objects still live only on their owner.
+          # Keyed on $cc_hash_key, which each server block sets to the same
+          # value it uses for proxy_cache_key, so the local copy has exactly the
+          # owner's cache identity. Bounded by the same min_free eviction as
+          # every other zone.
+          proxy_cache proxy_ngc;
+          proxy_cache_key $cc_hash_key;
+          proxy_cache_min_uses {{ $relayMinUses }};
+          proxy_cache_valid 200 206 {{ $.Values.cache.valid | default "31d" }};
+          {{- else }}
+          # A pure stream that never writes the local cache; only the owner
+          # stores the object. Set consistentHashRouting.relayCacheMinUses to
+          # replicate hot objects locally instead.
           proxy_cache off;
+          {{- end }}
           proxy_http_version 1.1;
           proxy_pass_request_headers on;
           proxy_set_header Host $host;
           proxy_set_header Range $http_range;
           proxy_set_header X-NVCF-CC-Relayed "1";
+          # Declaring any proxy_set_header here cancels inheritance of the
+          # server-level set, which includes `Connection ""`. Without repeating
+          # it nginx sends its default `Connection: close` and the upstream
+          # keepalive pool is never used, so every relay reconnects and
+          # re-handshakes TLS.
+          proxy_set_header Connection "";
           # The peer serves the same ssl listener with a per-pod internal leaf
           # cert, so system-CA verification cannot pass. Verification is skipped
           # on this internal peer hop only; the tier is an internal,

--- a/deploy/helm/container-cache/deploy/files/proxy-common.conf
+++ b/deploy/helm/container-cache/deploy/files/proxy-common.conf
@@ -39,19 +39,13 @@
             -- undeclared variable raises in OpenResty.
             local route = "local"
 {{- if ($.Values.consistentHashRouting).enabled }}
-            -- Classify by what the request actually cost, not by what routing
-            -- decided. A non-empty owner means the object belongs to a peer,
-            -- but the relay may still have served it from this pod's own
-            -- replica once relayCacheMinUses is reached, and a cache hit never
-            -- contacts the peer. Labelling those "relayed" would overstate the
-            -- peer hop and hide the replication that removed it.
+            -- Non-empty owner means the route helper sent this to a peer, so it
+            -- paid the relay hop. The relay never serves from a local cache, so
+            -- a non-empty owner always means the hop was taken. The inbound
+            -- relay marker means this pod is the owner answering for a peer.
             local cc_owner = ngx.var.cc_owner
             if cc_owner ~= nil and cc_owner ~= "" then
-                if cache_status == "HIT" then
-                    route = "local"
-                else
-                    route = "relayed"
-                end
+                route = "relayed"
             elseif ngx.var.http_x_nvcf_cc_relayed == "1" then
                 route = "peer"
             end
@@ -231,27 +225,15 @@
         # every block, so the relay location is not duplicated per block.
         set $cc_owner "";
         location @cc_relay {
-          # Relay to the owner pod. lua-access runs on the owner, which sees the
-          # original request headers.
-          {{- $relayMinUses := int (($.Values.consistentHashRouting).relayCacheMinUses | default 0) }}
-          {{- if gt $relayMinUses 0 }}
-          # Objects pulled through this pod repeatedly are replicated locally
-          # after relayCacheMinUses requests, so hot objects stop paying the
-          # relay hop while one-off objects still live only on their owner.
-          # Keyed on $cc_hash_key, which each server block sets to the same
-          # value it uses for proxy_cache_key, so the local copy has exactly the
-          # owner's cache identity. Bounded by the same min_free eviction as
-          # every other zone.
-          proxy_cache proxy_ngc;
-          proxy_cache_key $cc_hash_key;
-          proxy_cache_min_uses {{ $relayMinUses }};
-          proxy_cache_valid 200 206 {{ $.Values.cache.valid | default "31d" }};
-          {{- else }}
-          # A pure stream that never writes the local cache; only the owner
-          # stores the object. Set consistentHashRouting.relayCacheMinUses to
-          # replicate hot objects locally instead.
+          # Relay to the owner pod: a pure stream that never writes the local
+          # cache or temp files; only the owner stores the object. lua-access
+          # runs on the owner, which sees the original request headers.
+          #
+          # Caching here would remove the peer hop for hot objects, but it
+          # would also put a second copy of them on disk and break the
+          # single-copy property the hash exists to provide. Not worth trading
+          # blind, particularly while the tier sits at its eviction watermark.
           proxy_cache off;
-          {{- end }}
           proxy_http_version 1.1;
           proxy_pass_request_headers on;
           proxy_set_header Host $host;

--- a/deploy/helm/container-cache/deploy/values.yaml
+++ b/deploy/helm/container-cache/deploy/values.yaml
@@ -191,11 +191,38 @@ consistentHashRouting:
   # Owner pods are in-cluster peers, so this stays short: a slow connect means
   # the owner is down, and failing over fast is correct.
   relayConnectTimeout: 2s
+  # Idle connections kept open to each owner pod. Without a pool every relayed
+  # request pays a fresh TCP and TLS handshake to the peer, which is worst for
+  # the many small Range requests the hash spreads across owners. Cheap: these
+  # are in-cluster peers and the pool is per worker process.
+  peerKeepaliveConnections: 32
+  peerKeepaliveTimeout: 60s
+  peerKeepaliveRequests: 1000
+  # Replicate an object locally after this many requests arrive here for an
+  # object owned by another pod, so hot objects stop paying the relay hop while
+  # one-off objects still live only on their owner. Storage is bounded by the
+  # same min_free eviction as every other zone, and the extra copies are by
+  # definition the objects being requested most.
+  #
+  # 0 disables local replication and restores the strict single-copy behavior,
+  # where every request for a non-owned object relays for the object's whole
+  # lifetime.
+  relayCacheMinUses: 3
 
 # Metrics configuration.
 metrics:
   cacheMetricsStorageSize: 300m
   throughputHistogramBuckets: 25000000, 30000000, 35000000, 40000000, 50000000, 60000000, 80000000, 100000000
+  # Request-duration buckets. These requests are whole model-file transfers, not
+  # API calls, so tens of seconds is normal and the top bucket has to cover a
+  # full object. If the largest finite bucket is below real traffic, everything
+  # above it lands in +Inf and histogram_quantile clamps to that edge, reporting
+  # the bucket boundary instead of a latency.
+  durationHistogramBuckets: 0.005, 0.01, 0.02, 0.03, 0.05, 0.075, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1, 1.5, 2, 3, 4, 5, 10, 15, 30, 60, 120, 300, 600
+  # Response-size buckets, with resolution across the range model objects
+  # actually occupy. A 100MB -> 1GB -> 10GB ladder puts nearly all traffic in
+  # one bucket and hides the distribution entirely.
+  responseSizeHistogramBuckets: 1000, 2000, 4000, 8000, 16000, 32000, 64000, 128000, 256000, 1048576, 10485760, 104857600, 268435456, 536870912, 805306368, 1073741824, 2147483648, 5368709120, 10737418240, 107374182400
 
 # Custom annotations and labels for pods.
 podAnnotations: {}

--- a/deploy/helm/container-cache/deploy/values.yaml
+++ b/deploy/helm/container-cache/deploy/values.yaml
@@ -212,6 +212,15 @@ metrics:
   # Response-size buckets, with resolution across the range model objects
   # actually occupy. A 100MB -> 1GB -> 10GB ladder puts nearly all traffic in
   # one bucket and hides the distribution entirely.
+  # Maximum distinct `asset` label values admitted to the per-asset counters.
+  # The asset is derived from a client-controlled request path and host, so it
+  # is capped rather than assumed small: once this many distinct values have
+  # been seen, further ones are recorded as "other". Raise it if a fleet
+  # legitimately serves more assets than this and the series count is
+  # acceptable.
+  maxAssetLabels: 50
+  # Shared dictionary holding the admitted asset names. One small key each.
+  assetLabelDictSize: 1m
   responseSizeHistogramBuckets: 1000, 2000, 4000, 8000, 16000, 32000, 64000, 128000, 256000, 1048576, 10485760, 104857600, 268435456, 536870912, 805306368, 1073741824, 2147483648, 5368709120, 10737418240, 107374182400
 
 # Custom annotations and labels for pods.

--- a/deploy/helm/container-cache/deploy/values.yaml
+++ b/deploy/helm/container-cache/deploy/values.yaml
@@ -198,16 +198,6 @@ consistentHashRouting:
   peerKeepaliveConnections: 32
   peerKeepaliveTimeout: 60s
   peerKeepaliveRequests: 1000
-  # Replicate an object locally after this many requests arrive here for an
-  # object owned by another pod, so hot objects stop paying the relay hop while
-  # one-off objects still live only on their owner. Storage is bounded by the
-  # same min_free eviction as every other zone, and the extra copies are by
-  # definition the objects being requested most.
-  #
-  # 0 disables local replication and restores the strict single-copy behavior,
-  # where every request for a non-owned object relays for the object's whole
-  # lifetime.
-  relayCacheMinUses: 3
 
 # Metrics configuration.
 metrics:

--- a/deploy/helm/container-cache/tests/chart-render/verify-asset-metrics.sh
+++ b/deploy/helm/container-cache/tests/chart-render/verify-asset-metrics.sh
@@ -59,8 +59,15 @@ asset_guard='if request_uri ~= nil and not string.find(request_uri, "manifest") 
 grep -F -q -- "$asset_guard" "$OUT" \
   || fail "asset counters must use a guard free of cache_status, or they inherit the drop"
 
-echo "6. label values are bounded"
+echo "6. label values and label COUNT are both bounded"
 has 'if #asset > 120 then asset = asset:sub(1, 120) end'
+# Truncation bounds the length of one value. The asset is derived from a
+# client-controlled path and host, so the number of distinct values has to be
+# capped too, or the series count is unbounded.
+has 'ngx.shared.asset_labels'
+has 'asset = "other"'
+grep -F -q 'lua_shared_dict asset_labels' "$OUT" \
+  || fail "the admission dictionary must be declared or the cap cannot work"
 
 echo "7. manifest traffic stays excluded, as it is for the other metrics"
 n_manifest="$(grep -c 'string.find(request_uri, "manifest")' "$OUT" || true)"

--- a/deploy/helm/container-cache/tests/chart-render/verify-asset-metrics.sh
+++ b/deploy/helm/container-cache/tests/chart-render/verify-asset-metrics.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Per-asset request and byte counters. Two properties matter and neither is
+# obvious from reading the rendered config:
+#
+#   1. Every file and byte range of one model, repo, or bucket collapses to a
+#      single label value, so a model pulled as hundreds of 512MiB ranges is one
+#      series rather than hundreds.
+#   2. Requests the cache never consulted are counted as NONE rather than
+#      dropped. On a live sample those were 45.6 percent of requests and 786
+#      GiB, and the older metric block skipped all of them.
+#
+# Run from the chart subtree:
+#   bash tests/chart-render/verify-asset-metrics.sh
+set -euo pipefail
+CHART_DIR="$(cd "$(dirname "$0")/../.." && pwd)/deploy"
+OUT="$(mktemp)"; trap 'rm -f "$OUT"' EXIT
+fail() { echo "FAIL: $*" >&2; exit 1; }
+has() { grep -F -q -- "$1" "$OUT" || fail "missing: $1"; }
+
+helm template t "$CHART_DIR" > "$OUT" 2>/dev/null
+
+echo "1. counters exist and are counters, not gauges"
+has 'proxy_cache_asset_requests_total'
+has 'proxy_cache_asset_bytes_total'
+# The declaration spans two lines: `<var> = prometheus:counter(` then the metric
+# name on the next. Match the pair rather than a single line.
+counter_type() { grep -B1 -F "\"$1\"" "$OUT" | grep -o 'prometheus:[a-z]*' | head -1; }
+[ "$(counter_type proxy_cache_asset_bytes_total)" = "prometheus:counter" ] \
+  || fail "asset bytes must be a counter; a gauge cannot be rate()'d for GB/s"
+[ "$(counter_type proxy_cache_asset_requests_total)" = "prometheus:counter" ] \
+  || fail "asset requests must be a counter"
+
+echo "2. labelled by source, asset and cache_status"
+has '{"source", "asset", "cache_status"}'
+
+echo "3. all three upstream families are classified"
+has 'source = "ngc"'
+has 'source = "hf"'
+has 'source = "s3"'
+has 'source, asset = "other", "other"'
+
+echo "4. the asset key drops the query string, so ranges and presigned params collapse"
+# NGC range URLs carry versionId, Signature and ssec-key. Keying on anything
+# past '?' would make every byte range its own series.
+has 'request_uri:match("^([^?]*)")'
+
+echo "5. uncounted traffic is named, not dropped"
+has 'if status == nil or status == "" then status = "NONE" end'
+# The counters must sit outside the older guard, which requires a non-nil
+# cache_status and therefore discards exactly the traffic we are trying to see.
+# The asset block must have its own guard that does NOT require cache_status;
+# the older guard does, and therefore discards the traffic we want to see.
+# Note: no `... | grep -q` here. grep -q exits on first match, awk takes SIGPIPE,
+# and `set -o pipefail` reports the pipeline as failed even when it matched.
+asset_guard='if request_uri ~= nil and not string.find(request_uri, "manifest") then'
+grep -F -q -- "$asset_guard" "$OUT" \
+  || fail "asset counters must use a guard free of cache_status, or they inherit the drop"
+
+echo "6. label values are bounded"
+has 'if #asset > 120 then asset = asset:sub(1, 120) end'
+
+echo "7. manifest traffic stays excluded, as it is for the other metrics"
+n_manifest="$(grep -c 'string.find(request_uri, "manifest")' "$OUT" || true)"
+[ "${n_manifest}" -ge 2 ] \
+  || fail "asset counters must keep the manifest exclusion the other metrics use"
+
+echo "PASS: per-asset metric render assertions hold"

--- a/deploy/helm/container-cache/tests/render-consistent-hash-test.sh
+++ b/deploy/helm/container-cache/tests/render-consistent-hash-test.sh
@@ -85,6 +85,11 @@ grep -q '"cache_status", "http_status", "route"' "$TMP/on.yaml" \
 grep -q 'local route = "local"' "$TMP/on.yaml" || fail "route must default to local"
 grep -q 'route = "relayed"' "$TMP/on.yaml" || fail "relayed requests must be labelled"
 grep -q 'route = "peer"' "$TMP/on.yaml" || fail "requests served for a peer must be labelled"
+# A relay that serves from its own replica never contacts the owner, so it must
+# not be counted as a peer hop. Without this the label overstates relay traffic
+# and hides the replication that removed the hop.
+grep -q 'if cache_status == "HIT" then' "$TMP/on.yaml" \
+  || fail "a relay-served cache hit must be classified local, not relayed"
 # The objects here are whole model files, so a 10s ceiling put a large share of
 # traffic in +Inf and histogram_quantile then reports the bucket edge, not a
 # latency.

--- a/deploy/helm/container-cache/tests/render-consistent-hash-test.sh
+++ b/deploy/helm/container-cache/tests/render-consistent-hash-test.sh
@@ -52,6 +52,12 @@ grep -q 'set $cc_hash_key "$request_method|$uri|$arg_versionId|$http_range"' "$T
 grep -q 'proxy_set_header X-NVCF-CC-Relayed "1"' "$TMP/on.yaml" || fail "relay hop must emit the one-hop marker"
 grep -q 'ngx.req.get_headers()\["X-NVCF-CC-Relayed"\]' "$TMP/on.yaml" || fail "cc-route.lua must reject an inbound relay marker (serve locally, prevents relay loops)"
 
+# The relay block is matched repeatedly below. Capture it once rather than
+# piping awk into `grep -q`: grep exits on first match, awk takes SIGPIPE, and
+# `set -o pipefail` then reports the pipeline as failed even though it matched.
+relay_block="$(awk '/location @cc_relay/,/^ *}$/' "$TMP/on.yaml")"
+relay_has() { grep -F -q -- "$1" <<<"$relay_block"; }
+
 echo "7. enabled: the peer hop reuses connections"
 # Both halves are required. A keepalive pool with no `Connection ""` is dead
 # weight, because nginx then sends its default `Connection: close` and every
@@ -59,23 +65,21 @@ echo "7. enabled: the peer hop reuses connections"
 # @cc_relay specifically: declaring any proxy_set_header in a location cancels
 # inheritance of the server-level set.
 [ "$(count 'keepalive [0-9]+;' "$TMP/on.yaml")" = 3 ] || fail "each cc_owner upstream needs a keepalive pool"
-awk '/location @cc_relay/,/^ *}$/' "$TMP/on.yaml" | grep -q 'proxy_set_header Connection ""' \
+relay_has 'proxy_set_header Connection ""' \
   || fail '@cc_relay must repeat Connection "" or the keepalive pool is never used'
 
-echo "8. enabled: hot objects replicate locally after relayCacheMinUses"
-awk '/location @cc_relay/,/^ *}$/' "$TMP/on.yaml" | grep -q 'proxy_cache_min_uses 3' \
-  || fail "relay must cache locally after the configured use threshold"
-awk '/location @cc_relay/,/^ *}$/' "$TMP/on.yaml" | grep -q 'proxy_cache_key \$cc_hash_key' \
-  || fail "relay cache key must match the owner's identity, not the default key"
-
-echo "8b. relayCacheMinUses=0 restores strict single-copy relaying"
-helm template t "$CHART_DIR" --set consistentHashRouting.enabled=true --set replicaCount=3 \
-  --set consistentHashRouting.relayCacheMinUses=0 > "$TMP/on-nocache.yaml" 2>/dev/null
-awk '/location @cc_relay/,/^ *}$/' "$TMP/on-nocache.yaml" | grep -q 'proxy_cache off' \
-  || fail "relayCacheMinUses=0 must leave the relay a pure stream"
-if awk '/location @cc_relay/,/^ *}$/' "$TMP/on-nocache.yaml" | grep -q 'proxy_cache_min_uses'; then
-  fail "relayCacheMinUses=0 must not emit proxy_cache_min_uses"
+echo "8. the relay never writes a local copy"
+# The hash exists to keep exactly one copy of an object in the tier. Caching on
+# the relay would remove the peer hop for hot objects but put a second copy of
+# them on disk, so it stays off.
+relay_has 'proxy_cache off' \
+  || fail "the relay must not cache; that would break the single-copy property"
+if relay_has 'proxy_cache_min_uses'; then
+  fail "relay-side caching must not render"
 fi
+# It must also not spool a large relayed body to local disk.
+relay_has 'proxy_max_temp_file_size 0' \
+  || fail "the relay must stream, not spool to disk"
 
 echo "9. relay cost is observable, and duration buckets outlast a whole transfer"
 # Without the route label a relayed request is indistinguishable from a local
@@ -85,11 +89,6 @@ grep -q '"cache_status", "http_status", "route"' "$TMP/on.yaml" \
 grep -q 'local route = "local"' "$TMP/on.yaml" || fail "route must default to local"
 grep -q 'route = "relayed"' "$TMP/on.yaml" || fail "relayed requests must be labelled"
 grep -q 'route = "peer"' "$TMP/on.yaml" || fail "requests served for a peer must be labelled"
-# A relay that serves from its own replica never contacts the owner, so it must
-# not be counted as a peer hop. Without this the label overstates relay traffic
-# and hides the replication that removed the hop.
-grep -q 'if cache_status == "HIT" then' "$TMP/on.yaml" \
-  || fail "a relay-served cache hit must be classified local, not relayed"
 # The objects here are whole model files, so a 10s ceiling put a large share of
 # traffic in +Inf and histogram_quantile then reports the bucket edge, not a
 # latency.

--- a/deploy/helm/container-cache/tests/render-consistent-hash-test.sh
+++ b/deploy/helm/container-cache/tests/render-consistent-hash-test.sh
@@ -52,4 +52,49 @@ grep -q 'set $cc_hash_key "$request_method|$uri|$arg_versionId|$http_range"' "$T
 grep -q 'proxy_set_header X-NVCF-CC-Relayed "1"' "$TMP/on.yaml" || fail "relay hop must emit the one-hop marker"
 grep -q 'ngx.req.get_headers()\["X-NVCF-CC-Relayed"\]' "$TMP/on.yaml" || fail "cc-route.lua must reject an inbound relay marker (serve locally, prevents relay loops)"
 
+echo "7. enabled: the peer hop reuses connections"
+# Both halves are required. A keepalive pool with no `Connection ""` is dead
+# weight, because nginx then sends its default `Connection: close` and every
+# relayed request re-handshakes TLS. The header must be repeated inside
+# @cc_relay specifically: declaring any proxy_set_header in a location cancels
+# inheritance of the server-level set.
+[ "$(count 'keepalive [0-9]+;' "$TMP/on.yaml")" = 3 ] || fail "each cc_owner upstream needs a keepalive pool"
+awk '/location @cc_relay/,/^ *}$/' "$TMP/on.yaml" | grep -q 'proxy_set_header Connection ""' \
+  || fail '@cc_relay must repeat Connection "" or the keepalive pool is never used'
+
+echo "8. enabled: hot objects replicate locally after relayCacheMinUses"
+awk '/location @cc_relay/,/^ *}$/' "$TMP/on.yaml" | grep -q 'proxy_cache_min_uses 3' \
+  || fail "relay must cache locally after the configured use threshold"
+awk '/location @cc_relay/,/^ *}$/' "$TMP/on.yaml" | grep -q 'proxy_cache_key \$cc_hash_key' \
+  || fail "relay cache key must match the owner's identity, not the default key"
+
+echo "8b. relayCacheMinUses=0 restores strict single-copy relaying"
+helm template t "$CHART_DIR" --set consistentHashRouting.enabled=true --set replicaCount=3 \
+  --set consistentHashRouting.relayCacheMinUses=0 > "$TMP/on-nocache.yaml" 2>/dev/null
+awk '/location @cc_relay/,/^ *}$/' "$TMP/on-nocache.yaml" | grep -q 'proxy_cache off' \
+  || fail "relayCacheMinUses=0 must leave the relay a pure stream"
+if awk '/location @cc_relay/,/^ *}$/' "$TMP/on-nocache.yaml" | grep -q 'proxy_cache_min_uses'; then
+  fail "relayCacheMinUses=0 must not emit proxy_cache_min_uses"
+fi
+
+echo "9. relay cost is observable, and duration buckets outlast a whole transfer"
+# Without the route label a relayed request is indistinguishable from a local
+# hit, which is what made the relay's latency cost unmeasurable.
+grep -q '"cache_status", "http_status", "route"' "$TMP/on.yaml" \
+  || fail "request/throughput metrics must carry the route label"
+grep -q 'local route = "local"' "$TMP/on.yaml" || fail "route must default to local"
+grep -q 'route = "relayed"' "$TMP/on.yaml" || fail "relayed requests must be labelled"
+grep -q 'route = "peer"' "$TMP/on.yaml" || fail "requests served for a peer must be labelled"
+# The objects here are whole model files, so a 10s ceiling put a large share of
+# traffic in +Inf and histogram_quantile then reports the bucket edge, not a
+# latency.
+grep -q 'proxy_cache_request_duration_seconds' "$TMP/on.yaml" || fail "duration histogram missing"
+awk '/proxy_cache_request_duration_seconds/{print; exit}' "$TMP/on.yaml" | grep -q '600' \
+  || fail "duration buckets must extend past a full object transfer"
+
+echo "9b. route label renders even with routing disabled (no undeclared-variable read)"
+grep -q 'local route = "local"' "$TMP/off.yaml" || fail "route label must still render when routing is off"
+[ "$(count 'ngx.var.cc_owner' "$TMP/off.yaml")" = 0 ] \
+  || fail "must not read the routing variable when it is undeclared (OpenResty raises)"
+
 echo "PASS: all consistent-hash routing render assertions hold"

--- a/deploy/helm/container-cache/tests/script-logic/verify-asset-classification.sh
+++ b/deploy/helm/container-cache/tests/script-logic/verify-asset-classification.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Behavioural tests for the per-asset metric classification.
+#
+# This lifts the shipped Lua out of the rendered ConfigMap and executes it, so
+# it tests the code that actually runs rather than a reimplementation of it.
+# The fixtures are real request URIs and hosts captured from production traffic.
+#
+# The property under test is grouping: one model is pulled as hundreds of
+# 512MiB ranges, each with its own versionId, Signature and ssec-key query
+# parameters. All of them must collapse to a single label value, or the metric
+# becomes unusable and blows up cardinality.
+#
+# Requires a Lua 5.1-compatible interpreter (lua5.1, lua, or luajit). Skips with
+# a visible notice if none is present, rather than passing silently.
+#
+# Run from the chart subtree:
+#   bash tests/script-logic/verify-asset-classification.sh
+set -euo pipefail
+
+LUA=""
+for c in luajit lua5.1 lua; do
+  if command -v "$c" >/dev/null 2>&1; then LUA="$c"; break; fi
+done
+if [ -z "${LUA}" ]; then
+  echo "SKIP: no Lua interpreter found (tried luajit, lua5.1, lua)." >&2
+  echo "      Install one to run these assertions, e.g. apt-get install lua5.1." >&2
+  exit 0
+fi
+
+CHART_DIR="$(cd "$(dirname "$0")/../.." && pwd)/deploy"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+helm template t "$CHART_DIR" > "$TMP/rendered.yaml" 2>/dev/null
+
+# Lift the classification block: from the marker comment to the line that closes
+# it, which is the byte counter's `end`. Taking it verbatim is the point; if the
+# shipped logic changes, these tests exercise the change.
+# The block contains nested `if`s, so stopping at the first `end` truncates it.
+# Record the indentation of the outer guard and stop at the `end` that matches
+# it, which is the only one that closes the block.
+awk '/-- Per-asset accounting\./{f=1}
+     f && !guard && /if request_uri ~= nil/ {
+       match($0, /^ */); guard = RLENGTH; print; next
+     }
+     f{print}
+     guard && /^ *end$/ {
+       match($0, /^ */)
+       if (RLENGTH == guard) exit
+     }' "$TMP/rendered.yaml" > "$TMP/block.lua"
+
+if [ ! -s "$TMP/block.lua" ]; then
+  echo "FAIL: could not lift the asset classification block from the render" >&2
+  exit 1
+fi
+
+# Harness: stub the two metric objects, feed one request, return what was
+# recorded. The lifted block references request_uri, host, cache_status and
+# body_size as locals from the enclosing log_by_lua_block, so they are declared
+# here the same way.
+cat > "$TMP/run.lua" <<'LUA'
+local block = ...
+local recorded = {}
+proxy_asset_requests = { inc = function(self, n, labels)
+  recorded.req = { n = n, source = labels[1], asset = labels[2], status = labels[3] }
+end }
+proxy_asset_bytes = { inc = function(self, n, labels)
+  recorded.bytes = { n = n, source = labels[1], asset = labels[2], status = labels[3] }
+end }
+
+-- loadstring in 5.1/LuaJIT, load in 5.2+.
+local compile = loadstring or load
+
+local function classify(uri, host_in, status_in, size_in)
+  recorded = {}
+  local chunk = assert(compile(
+    "local request_uri, host, cache_status, body_size = ...\n" .. block))
+  chunk(uri, host_in, status_in, size_in)
+  return recorded
+end
+
+local failures = 0
+local function check(name, got, want)
+  if got ~= want then
+    print(string.format("FAIL: %s\n        got:  %s\n        want: %s",
+      name, tostring(got), tostring(want)))
+    failures = failures + 1
+  end
+end
+
+-- Real NGC model range request. Query string carries versionId, ssec-key and a
+-- CloudFront Signature; none of it may reach the label.
+local ngc_host = "xfiles.ngc.nvidia.com"
+local ngc1 = "/org/qc69jvmznzxy/team/llm_nim/modelsv2/nemotron3-ultra-genrm/blobs/sha256/34/34933feef4b44a022d56f34a0a64932b8fd939cdbcf8ae2e0cd19070b716679b/file?ssec-algo=AES256&versionId=QthslkuRtCpclJmdfB600fvoNmeWT4hF&Signature=wrF0mIIi6UptQTXT"
+local r = classify(ngc1, ngc_host, "HIT", 536870912)
+check("ngc source",  r.req.source, "ngc")
+check("ngc asset",   r.req.asset,  "qc69jvmznzxy/llm_nim/nemotron3-ultra-genrm")
+check("ngc status",  r.req.status, "HIT")
+check("ngc bytes",   r.bytes.n,    536870912)
+
+-- GROUPING: a different file, a different byte range and a different versionId
+-- of the same model must produce the identical label value.
+local ngc2 = "/org/qc69jvmznzxy/team/llm_nim/modelsv2/nemotron3-ultra-genrm/blobs/sha256/24/24e6f4c84eec7c10872d4f18c5ea031ab41d25ebd575228e29eb03ca95b2f73c/file?versionId=y4mfHRXUsYBsiVSmmtbqaURE8Tlhg_ss"
+local r2 = classify(ngc2, ngc_host, "MISS", 536870912)
+check("grouping: same asset across files/ranges", r2.req.asset, r.req.asset)
+check("miss still recorded", r2.req.status, "MISS")
+
+-- The query string must be stripped before matching. A query value that
+-- contains a slash otherwise satisfies the `([^/]+)/` segment matcher and
+-- smuggles request-unique text into the label, which is unbounded cardinality.
+local tricky = "/org/o/team/t/modelsv2/mymodel?redirect=/a/b/c"
+local rq = classify(tricky, ngc_host, "HIT", 1)
+check("query string cannot leak into the asset label", rq.req.asset, "o/t/mymodel")
+
+-- Regression: the team-less fallback used to match a team path and label the
+-- TEAM as the model, so /org/o/team/t/... came out as "o/no-team/t".
+local rteam = classify("/org/o/team/myteam/modelsv2/mymodel/blobs/x", ngc_host, "HIT", 1)
+check("team is not mistaken for the model", rteam.req.asset, "o/myteam/mymodel")
+
+-- A second model must NOT collapse into the first.
+local r3 = classify("/org/qc69jvmznzxy/team/llm_nim/modelsv2/kimi-k3/blobs/sha256/aa/aa/file?x=1", ngc_host, "HIT", 1)
+check("distinct models stay distinct", r3.req.asset, "qc69jvmznzxy/llm_nim/kimi-k3")
+
+-- Empty cache_status is the case the older metric block dropped entirely:
+-- 45.6 percent of requests and 786 GiB on a live sample.
+local r4 = classify(ngc1, ngc_host, "", 536870912)
+check("empty status becomes NONE", r4.req.status, "NONE")
+check("empty status still counts bytes", r4.bytes.n, 536870912)
+local r5 = classify(ngc1, ngc_host, nil, 100)
+check("nil status becomes NONE", r5.req.status, "NONE")
+
+-- S3. The bucket is the useful grouping; the object key is unbounded and must
+-- not appear. This is a real upload path seen in production.
+local r6 = classify("/bulk-upload-temp-folder/f5e47a34-b184-4322-83c3-d73f29671db0/part-0.p",
+  "nim-payload-metrics-byoo-kratos-xpor2.s3.us-west-2.amazonaws.com", "", 0)
+check("s3 source", r6.req.source, "s3")
+check("s3 asset is the bucket", r6.req.asset, "nim-payload-metrics-byoo-kratos-xpor2")
+-- A zero-byte response must not record a byte sample.
+check("zero-byte response records no bytes", r6.bytes, nil)
+
+-- The same bucket in another region is the same asset.
+local r7 = classify("/x/y", "nim-payload-metrics-byoo-kratos-xpor2.s3.us-west-1.amazonaws.com", "", 1)
+check("s3 asset is region independent", r7.req.asset, r6.req.asset)
+
+-- HuggingFace.
+local r8 = classify("/meta-llama/Llama-3-8B/resolve/main/model.safetensors?download=true",
+  "huggingface.co", "HIT", 10)
+check("hf source", r8.req.source, "hf")
+check("hf asset",  r8.req.asset,  "meta-llama/Llama-3-8B")
+
+-- NGC without a team segment.
+local r9 = classify("/org/someorg/modelsv2/somemodel/blobs/sha256/aa/bb/file", ngc_host, "HIT", 1)
+check("ngc team-less asset", r9.req.asset, "someorg/no-team/somemodel")
+
+-- Unknown host falls back rather than inventing a label.
+local r10 = classify("/whatever/path", "example.invalid", "HIT", 1)
+check("unknown host source", r10.req.source, "other")
+check("unknown host asset",  r10.req.asset,  "other")
+
+-- An NGC path that does not match the expected shape must not produce a
+-- half-parsed label.
+local r11 = classify("/health", ngc_host, "HIT", 1)
+check("unparseable ngc path", r11.req.asset, "other")
+
+-- Manifest traffic is excluded, matching the other metrics.
+local r12 = classify("/v2/foo/manifests/latest", ngc_host, "HIT", 1)
+check("manifest excluded", r12.req, nil)
+
+-- Label values are bounded even for a pathological path.
+local long = "/org/" .. string.rep("a", 300) .. "/team/b/modelsv2/c/blobs/x"
+local r13 = classify(long, ngc_host, "HIT", 1)
+if r13.req and #r13.req.asset > 120 then
+  print(string.format("FAIL: asset label not truncated: %d chars", #r13.req.asset))
+  failures = failures + 1
+end
+
+if failures > 0 then
+  print(string.format("\n%d assertion(s) failed", failures))
+  os.exit(1)
+end
+print("PASS: asset classification behaves correctly on real production URIs")
+LUA
+
+"${LUA}" -e "
+local f = assert(io.open('$TMP/block.lua')); local block = f:read('*a'); f:close()
+local run = assert(loadfile('$TMP/run.lua')); run(block)
+"

--- a/deploy/helm/container-cache/tests/script-logic/verify-asset-classification.sh
+++ b/deploy/helm/container-cache/tests/script-logic/verify-asset-classification.sh
@@ -63,6 +63,23 @@ fi
 cat > "$TMP/run.lua" <<'LUA'
 local block = ...
 local recorded = {}
+
+-- Stub of the shared dictionary the admission cap uses. Only get/set/incr are
+-- referenced by the shipped code.
+local store = {}
+ngx = { shared = { asset_labels = {
+  get  = function(self, k) return store[k] end,
+  set  = function(self, k, v) store[k] = v end,
+  incr = function(self, k, delta, init)
+    if store[k] == nil then
+      if init == nil then return nil, "not found" end
+      store[k] = init
+    end
+    store[k] = store[k] + delta
+    return store[k]
+  end,
+} } }
+local function reset_admissions() store = {} end
 proxy_asset_requests = { inc = function(self, n, labels)
   recorded.req = { n = n, source = labels[1], asset = labels[2], status = labels[3] }
 end }
@@ -175,6 +192,27 @@ if r13.req and #r13.req.asset > 120 then
   print(string.format("FAIL: asset label not truncated: %d chars", #r13.req.asset))
   failures = failures + 1
 end
+
+-- Admission cap. The asset comes from a client-controlled path, so the number
+-- of distinct values must be bounded, not merely small in practice.
+reset_admissions()
+local admitted, folded = 0, 0
+for i = 1, 80 do
+  local r = classify(string.format("/org/o%d/team/t/modelsv2/m%d/blobs/x", i, i), ngc_host, "HIT", 1)
+  if r.req.asset == "other" then folded = folded + 1 else admitted = admitted + 1 end
+end
+if admitted == 80 then
+  print("FAIL: asset admission is uncapped; 80 distinct values all became labels")
+  failures = failures + 1
+end
+if folded == 0 then
+  print("FAIL: nothing folded into 'other' once the cap was reached")
+  failures = failures + 1
+end
+
+-- An already-admitted asset keeps its label after the cap is reached.
+local again = classify("/org/o1/team/t/modelsv2/m1/blobs/x", ngc_host, "HIT", 1)
+check("admitted assets keep their label past the cap", again.req.asset, "o1/t/m1")
 
 if failures > 0 then
   print(string.format("\n%d assertion(s) failed", failures))


### PR DESCRIPTION
## Why

The proxy-cache metrics do not describe the traffic. Four separate problems, all
verified against a live cluster.

Roughly half of requests are not counted at all. The metric block requires a
non-nil `upstream_cache_status`, and every request the cache never consulted has
an empty one. On a live sample that was 45.6 percent of requests and 786 GiB,
silently dropped. Any hit rate read off these metrics today describes about half
the traffic.

Total bytes served is not derivable. `proxy_cache_response_body_size_bytes` is a
gauge overwritten on every request, so it cannot be summed or rated. That is why
there is no panel for GB/s served from cache versus fetched from origin.

There is no model dimension on any metric, so per-model download behaviour
cannot be seen at all.

Quantiles are artefacts. The request-duration histogram's largest finite bucket
was 10s while a large share of traffic exceeded it. `histogram_quantile` clamps
at the last finite bucket, so a p99 read as exactly `10`. Response-size buckets
jumped 100MB to 1GB to 10GB, putting nearly all traffic in a single bucket.

## What changed

Per-asset counters:

```
proxy_cache_asset_requests_total{source, asset, cache_status}
proxy_cache_asset_bytes_total{source, asset, cache_status}
```

Every file and byte range of one model, repo or bucket collapses to a single
`asset` value, so a model pulled as hundreds of 512MiB ranges is one series
rather than hundreds. `source` classifies NGC, HuggingFace and S3; S3 groups by
bucket because the object key is unbounded. Non-model paths fall into `other`.

These are counters, not gauges, so `rate()` works.
`proxy_cache_response_body_size_bytes` is left in place unchanged for
compatibility, but the byte counter supersedes it for any rate or total.

Uncounted traffic is now counted. The new counters sit outside the
`cache_status ~= nil` guard and normalise an empty status to `NONE`, so uploads,
redirects and auth failures appear rather than vanishing.

Cardinality is capped, not assumed small. The asset derives from a
client-controlled path and host, so admission is limited to
`metrics.maxAssetLabels` distinct values (default 50) tracked in a shared
dictionary, and anything beyond folds into `other`. Series are bounded at
(maxAssetLabels + 1) x sources x statuses x 2 counters. Values are also
length-truncated. Live traffic across three pods produces 3 asset values and 6
series.

Histogram buckets now cover the range this traffic actually occupies. Duration
extends past a whole object transfer, and response sizes gain resolution between
100MB and 1GB. Both are exposed as values.

A `route` label is added to the request, duration and throughput metrics, with
three bounded values: `local`, `relayed`, `peer`. Under consistent-hash routing a
relayed request was previously indistinguishable from a locally served one, so
the split could not be measured. The lookup is only emitted when routing is
enabled, because the variable is undeclared otherwise and OpenResty raises on
reading an undeclared variable.

One defect fix rides along, in the same file and needed for the `route` label to
mean anything: `@cc_relay` declares its own `proxy_set_header` directives, which
cancels inheritance of the server-level `Connection ""`, so nginx fell back to
its default `Connection: close`. The `cc_owner_*` upstreams also declared no
`keepalive` pool. Every relayed request therefore opened a new connection and
performed a new TLS handshake. Both halves are fixed together, since a pool with
no `Connection ""` is dead weight.

## Customer Release Notes

Adds per-model cache hit, miss and byte metrics, and corrects cache metrics that
previously omitted a large share of requests.

## Plan Summary

Chart-only change. No new Kubernetes resources.

With `consistentHashRouting` disabled, which remains the default, the rendered
manifest differs from `main` by 92 added and 10 removed lines: the two counters
and their classification block, the `lua_shared_dict asset_labels` they use for
the admission cap, the widened duration and response-size buckets, and a `route`
label that is constant. In that render there are no reads of the routing
variable and no `relayed` or `peer` values, so the label is inert until routing
is turned on.

## Usage

Per-model hit and miss:

```
sum by (asset) (rate(proxy_cache_asset_requests_total{cache_status="HIT"}[$__rate_interval]))
sum by (asset) (rate(proxy_cache_asset_requests_total{cache_status="MISS"}[$__rate_interval]))
```

GB/s served from cache versus fetched from origin:

```
sum by (cache_status) (rate(proxy_cache_asset_bytes_total[$__rate_interval]))
```

`cache_status="NONE"` is traffic the cache never consulted: uploads, redirects
and auth failures. Exclude it from hit-rate maths, but it is real bytes and is
now visible rather than dropped.

Relay fraction, previously not measurable:

```
sum(rate(proxy_cache_http_requests_count{route="relayed"}[$__rate_interval]))
/
sum(rate(proxy_cache_http_requests_count[$__rate_interval]))
```

New values under `metrics`: `durationHistogramBuckets`,
`responseSizeHistogramBuckets`, `maxAssetLabels` (default 50) and
`assetLabelDictSize` (default 1m).

## Testing

`tests/script-logic/verify-asset-classification.sh` is behavioural rather than a
render grep: it lifts the shipped Lua out of the rendered ConfigMap and executes
it against real request URIs captured from production, so it exercises the code
that runs rather than a reimplementation. It covers grouping across files and
byte ranges, distinct models staying distinct, empty and nil cache status, S3
bucket extraction and region independence, HuggingFace repos, the team-less NGC
form, unknown hosts, manifest exclusion, label truncation, and the admission cap
including that an already-admitted asset keeps its label once the cap is hit.

Every assertion was verified by mutation: each property was reverted in turn and
the suite confirmed to fail. That process found two defects in the classification
code, both fixed here and now covered: the team-less NGC fallback pattern matched
team paths and labelled the team as the model, and the model name could not be
the last path segment.

It also found a defect in the tests themselves. Two render assertions were
silently always-failing because `awk | grep -q` races: grep exits on first match,
awk takes SIGPIPE, and `set -o pipefail` reports the pipeline as failed even when
it matched. Those assertions now match against a captured variable instead.

`tests/chart-render/verify-asset-metrics.sh` covers the render-level properties,
including that the counters are counters, that they sit outside the
`cache_status` guard, and that the admission dictionary is declared, since the
cap is a silent no-op without it.

Full suite passes: `render-consistent-hash-test.sh`, `verify-asset-metrics.sh`,
`verify-mirrors.sh`, `verify-monitoring.sh`, `verify-registry-auth.sh`,
`verify-asset-classification.sh`. `helm lint` clean. Renders verified with
routing off and on with 3 replicas.

Reviewer note on CI: the behavioural suite needs a Lua 5.1-compatible
interpreter and skips with a visible notice when none is present. There is none
on the CI tools image today, so it will skip rather than run there. Adding
`lua5.1` to that image would turn it into real coverage; until then it is
developer-run. Locally it was executed against a Lua runtime and passes.

Not run: `nginx -t` against the rendered config, because no container runtime is
available in this environment. QA is recommended on a cluster with
`consistentHashRouting.enabled=true`, where the `route` label can be checked
against real traffic.

## Notes

The relay is deliberately left as a pure stream: `proxy_cache off` with
`proxy_max_temp_file_size 0`, so only the owner stores an object. Caching on the
relay was implemented and reverted, because it writes a second copy to disk and
breaks the single-copy property the hash exists to provide.

Still open, unconfirmed against a live proxy: the relay runs `proxy_cache off`,
which leaves `$upstream_cache_status` unset. A live log sample shows 1,642 NGC
range GETs in that state. If the relay path is the cause, that traffic is absent
from the older counters entirely rather than mislabelled. The new `NONE` bucket
makes it visible either way, which is how it can be confirmed once this ships.

## References

Closes #1037

Follow-up tracked in #1104.

## Related Pull Requests

None

## Dependencies

None
## Summary by CodeRabbit

* **New Features**
  * Added configurable worker capacity based on explicit settings or CPU limits.
  * Added peer connection reuse for relayed requests.
  * Added per-asset request and byte metrics for NGC, Hugging Face, S3, and other sources.
  * Added route labels to cache metrics and expanded duration and response-size ranges.

* **Bug Fixes**
  * Corrected route classification for cache hits and misses.
  * Ensured relayed requests bypass local caching while preserving upstream keepalive behavior.
  * Improved handling of missing cache status, query strings, and long asset labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->