### PR TITLE
fix(nvct): request task instances from SIS

### DIFF
--- a/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/icms/IcmsStubService.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/main/java/com/nvidia/nvct/service/icms/IcmsStubService.java
@@ -50,7 +50,7 @@ public interface IcmsStubService {
         UUID requestId;
     }
 
-    @PostExchange(value = "/v1/si?Action=RequestInstances",
+    @PostExchange(value = "/v1/si?Action=RequestInstancesForTask",
             accept = "application/json",
             contentType = "application/x-www-form-urlencoded")
     CreateInstancesResponse createInstance(

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/test/java/com/nvidia/nvct/service/icms/IcmsServiceTest.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/test/java/com/nvidia/nvct/service/icms/IcmsServiceTest.java
@@ -164,8 +164,7 @@ class IcmsServiceTest {
         // Assert
         assertThat(requestId).isNotNull();
         List<ServeEvent> allServeEvents = MockIcmsServer.getMockIcmsServer().getAllServeEvents();
-        String formUrlEncodedBody = allServeEvents.getFirst().getRequest().getBodyAsString();
-        validateTaskInstancePayload(formUrlEncodedBody, task1);
+        validateTaskInstanceRequest(allServeEvents.getFirst(), task1);
 
         taskService.deleteTask(task1);
     }
@@ -183,8 +182,7 @@ class IcmsServiceTest {
         // Assert
         assertThat(requestId).isNotNull();
         List<ServeEvent> allServeEvents = MockIcmsServer.getMockIcmsServer().getAllServeEvents();
-        String formUrlEncodedBody = allServeEvents.getFirst().getRequest().getBodyAsString();
-        validateTaskInstancePayload(formUrlEncodedBody, task1);
+        validateTaskInstanceRequest(allServeEvents.getFirst(), task1);
 
         taskService.deleteTask(task1);
     }
@@ -209,7 +207,11 @@ class IcmsServiceTest {
     }
 
     @SneakyThrows
-    private void validateTaskInstancePayload(String formUrlEncodedBody, TaskEntity task) {
+    private void validateTaskInstanceRequest(ServeEvent serveEvent, TaskEntity task) {
+        assertThat(serveEvent.getRequest().queryParameter("Action").firstValue())
+                .isEqualTo("RequestInstancesForTask");
+
+        String formUrlEncodedBody = serveEvent.getRequest().getBodyAsString();
         Map<String, Object> paramMap = Arrays.stream(formUrlEncodedBody.split("&"))
                 .map(s -> s.split("=", 2))
                 .collect(Collectors.toMap(

--- a/src/control-plane-services/cloud-tasks/nvct-core/src/test/java/com/nvidia/nvct/util/MockIcmsServer.java
+++ b/src/control-plane-services/cloud-tasks/nvct-core/src/test/java/com/nvidia/nvct/util/MockIcmsServer.java
@@ -137,7 +137,7 @@ public class MockIcmsServer {
         mockIcmsServer = new WireMockServer(config);
         mockIcmsServer.stubFor(post(urlPathEqualTo("/v1/si"))
                                       .withQueryParam("Action",
-                                                      new EqualToPattern("RequestInstances"))
+                                                      new EqualToPattern("RequestInstancesForTask"))
                                       .willReturn(aResponse().withStatus(200)
                                                           .withTransformers(instanceRequestExtension.getName())
                                                           .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)

--- a/src/libraries/go/lib/pkg/icms-translate/translate/common/types_test.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/common/types_test.go
@@ -149,6 +149,16 @@ func TestMessageAction_Normalize(t *testing.T) {
 			expected: TaskCreationAction,
 		},
 		{
+			name:     "legacy SPOT function action normalizes",
+			input:    MessageAction("RequestSpotInstances"),
+			expected: FunctionCreationAction,
+		},
+		{
+			name:     "legacy SPOT task action normalizes",
+			input:    MessageAction("RequestSpotInstancesForTask"),
+			expected: TaskCreationAction,
+		},
+		{
 			name:     "legacy RequestInstances action normalizes",
 			input:    MessageAction("RequestInstances"),
 			expected: FunctionCreationAction,
@@ -234,6 +244,16 @@ func TestMessageAction_UnmarshalJSON(t *testing.T) {
 		{
 			name:     "legacy RequestSparInstancesForTask normalizes to RequestICMSInstancesForTask",
 			json:     `"RequestSparInstancesForTask"`,
+			expected: RequestICMSInstancesForTask,
+		},
+		{
+			name:     "legacy RequestSpotInstances normalizes to RequestICMSInstances",
+			json:     `"RequestSpotInstances"`,
+			expected: RequestICMSInstances,
+		},
+		{
+			name:     "legacy RequestSpotInstancesForTask normalizes to RequestICMSInstancesForTask",
+			json:     `"RequestSpotInstancesForTask"`,
 			expected: RequestICMSInstancesForTask,
 		},
 		{


### PR DESCRIPTION
## TL;DR

Send NVCT task launches through the SIS task action so NVCA creates task instances instead of treating them as function instances.

## Additional Details

### Why

NVCT used `Action=RequestInstances`, the generic function creation action. The managed SIS deployment corrected requests containing `TaskId`, but standalone self-managed ICMS uses its default no-op validation extension and preserved the incorrect function action. The shared translator then normalized it to `RequestICMSInstances`, leaving self-managed tasks queued with zero instances.

### Regression seam

Legacy action support was not removed. The difference was a managed-only correction at the SIS boundary:

```text
Managed path:
NVCT sends wrong function action
  -> managed SIS detects TaskId
  -> rewrites action to RequestSpotInstancesForTask
  -> NVCA handles the task

Self-managed path:
NVCT sends wrong function action
  -> standalone ICMS uses NoOpInstanceValidationService
  -> action remains a function action
  -> NVCA enters the function handler
  -> task creates zero instances
```

The self-managed cutover exposed the latent NVCT producer bug because the managed-only correction was no longer present. NVCT must send `RequestInstancesForTask` itself.

### What changed

- Use `RequestInstancesForTask` for NVCT instance creation.
- Make the ICMS mock require the task action.
- Assert the action for container-based and Helm-based task launches.
- Cover exact legacy `RequestSpotInstances` and `RequestSpotInstancesForTask` normalization and JSON decoding.

### Customer Release Notes

Self-managed container tasks now launch without manually editing their ICMS request.

### Plan Summary

Not applicable.

### Usage

No operator changes are required.

### Notes

The full multi-cluster BDD scenario remains useful as release QA against a published NVCT image.

### References

- https://github.com/NVIDIA/nvcf/issues/1032

### Related Pull Requests

- https://github.com/NVIDIA/nvcf/pull/1033

### Dependencies

None. No license review or NOTICE update is required.

## For the Reviewer

Review the SIS action contract in `IcmsStubService`, its assertion in `IcmsServiceTest`, and the legacy-action compatibility cases in `types_test.go`.

## For QA

- `bazel --output_user_root=/tmp/nvcf-issue-1032-bazel build //src/control-plane-services/cloud-tasks/nvct-core:nvct_core //src/control-plane-services/cloud-tasks/nvct-core:nvct_core_test_fixtures --java_runtime_version=remotejdk_25 --tool_java_runtime_version=remotejdk_25`
- `bazel --output_user_root=/tmp/nvcf-issue-1032-bazel test //src/control-plane-services/cloud-tasks/nvct-core:tests --test_filter=IcmsServiceTest --java_runtime_version=remotejdk_25 --tool_java_runtime_version=remotejdk_25 --test_output=errors`
- `GOWORK=off GOFLAGS=-mod=vendor go test ./pkg/icms-translate/translate/common` from `src/libraries/go/lib`
- `bazel test //src/libraries/go/lib/pkg/icms-translate/translate/common:common_test --test_output=errors`
- QA needed: Yes. Run the multi-cluster BDD task smoke against the published fix.

## Issues

Fixes #1032

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated instance creation requests to use the correct task-specific action.
  * Improved scheduling request validation to confirm the expected action while preserving existing payload and configuration checks.
  * Added coverage for legacy spot-instance request actions during message processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
