### PR TITLE
fix(llm-api-gateway): preserve long-lived SSE responses

### DIFF
--- a/deploy/helm/gateway-routes/chart/templates/httproute-llm-api-gateway.yaml
+++ b/deploy/helm/gateway-routes/chart/templates/httproute-llm-api-gateway.yaml
@@ -37,7 +37,9 @@ spec:
     {{- end }}
 
   rules:
-    - matches:
+    - timeouts:
+        request: 0s
+      matches:
         - path:
             type: PathPrefix
             value: /

--- a/deploy/helm/gateway-routes/scripts/test-render-routes.sh
+++ b/deploy/helm/gateway-routes/scripts/test-render-routes.sh
@@ -102,6 +102,10 @@ assert_resource_field "$default_render" HTTPRoute llm-api-gateway gateway '.spec
 assert_resource_field "$default_render" HTTPRoute llm-api-gateway gateway '.spec.rules[0].backendRefs[0].name' llm-api-gateway
 assert_resource_field "$default_render" HTTPRoute llm-api-gateway gateway '.spec.rules[0].backendRefs[0].namespace' nvcf
 assert_resource_field "$default_render" HTTPRoute llm-api-gateway gateway '.spec.rules[0].backendRefs[0].port' 8080
+# A request timeout truncates long-lived SSE responses even when the backend
+# terminates them correctly. The zero duration disables the route-level request
+# deadline while still allowing a caller disconnect to close the downstream request.
+assert_resource_field "$default_render" HTTPRoute llm-api-gateway gateway '.spec.rules[0].timeouts.request' 0s
 
 assert_resource_count "$default_render" HTTPRoute sis gateway 1
 assert_resource_field "$default_render" HTTPRoute sis gateway '.metadata.labels."app.kubernetes.io/component"' sis-route


### PR DESCRIPTION
## Summary

- disable the route-level request deadline for the llm-api-gateway HTTPRoute so
  SSE responses are not truncated by the ingress default
- add a render regression assertion for the disabled route deadline
- preserve request-router routing, TLS, worker configuration, and application
  cancellation behavior

This draft currently addresses the confirmed 15-second ingress boundary. The
additional evidence below identifies a second, application-level boundary that
must also be addressed before the PR fully resolves #1060.

## Root cause

The llm-api-gateway route did not specify a request timeout, so Envoy Gateway
applied its 15-second default. When that deadline expired, ingress returned 504
and disconnected llm-api-gateway; the resulting downstream cancellation then
propagated to the upstream request.

Direct upstream, request-router, and gateway-process requests all carried the
same 16-second SSE response successfully outside ingress. The failure occurred
only through the HTTPRoute.

## Validation of the route fix

- `make test` in `deploy/helm/gateway-routes`
- existing llm-api-gateway upstream-cancellation tests
- before: caller 504 at 15.006 seconds, no `[DONE]`
- after: caller 200 at 16.007 seconds, `[DONE]` received, upstream completed in
  16.000 seconds, no caller or upstream error

## Additional long-stream evidence

A public-safe backend emitted valid SSE chunks every 10 seconds and sent
`[DONE]` at 75 seconds. The active stream still ended at 60.004 seconds under
the gateway's current Go HTTP server write deadline, after HTTP 200 headers but
before `[DONE]`, producing an incomplete caller response.

With only that write deadline disabled in an isolated test harness, the same
request returned HTTP 200 in 75.004 seconds with `[DONE]`; the upstream
completed in 75.000 seconds without a disconnect.

This confirms that disabling the HTTPRoute deadline is necessary but not
sufficient for streams longer than 60 seconds.

## Remaining fix

Manage the write deadline at the SSE endpoint so streaming responses are not
limited by the server-wide total response-write duration. The implementation
must retain the server-wide deadline for ordinary requests, preserve prompt
upstream cancellation when the caller disconnects, and include a
shortened-duration regression test.

This is a focused prerequisite for completing the end-to-end validation in
#999.

Fixes #1060


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the LLM API gateway route to use a zero-second request timeout, preventing unintended request time limits.

* **Tests**
  * Added validation to ensure the gateway route consistently renders with the expected timeout setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->