### PR TITLE
fix(stack): default LLM transport to managed PKI

### DIFF
--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -291,8 +291,9 @@ addons:
   # LLM addon: gateway + request router (stargate) for LLM function invocation
   llm:
     enabled: false
-    # QUIC TLS certificate for the request router (Stargate). Disabled by
-    # default; opt in per env.
+    # QUIC TLS certificate for the request router (Stargate). Managed PKI is
+    # active by default whenever addons.llm.enabled is true. Set enabled=false
+    # only when an environment deliberately supplies another transport policy.
     #
     # mode selects who owns the server identity:
     #   certManager    - the chart requests a Certificate from the configured
@@ -306,15 +307,15 @@ addons:
     #                    issuance, renewal, rotation, and recovery, and the
     #                    stack validates neither the SANs nor the expiry.
     pki:
-      enabled: false
+      enabled: true
       mode: certManager
-      # REQUIRED for a managed issuer. Comma-separated DNS suffixes the
-      # OpenBao PKI role accepts. Typically the customer domain plus
-      # cluster.local for in-cluster service identity.
-      allowedDomains: ""
-      # REQUIRED for mode certManager. SANs requested on the issued
-      # certificate. Must be empty for mode existingSecret.
-      dnsNames: []
+      # Comma-separated DNS suffixes the managed OpenBao role accepts.
+      allowedDomains: cluster.local
+      # SANs for both the stable Service and authority/SNI-selected Stargate
+      # pod identities. Must be empty for mode existingSecret.
+      dnsNames:
+        - llm-request-router.nvcf.svc.cluster.local
+        - "*.llm-request-router-headless.nvcf.svc.cluster.local"
       # REQUIRED for mode existingSecret; the kubernetes.io/tls Secret in the
       # nvcf namespace holding the tls.crt and tls.key entries. Optional for
       # mode certManager, where it names the Secret cert-manager writes.
@@ -332,8 +333,8 @@ addons:
       # certPath: /etc/stargate/tls/tls.crt
       # keyPath: /etc/stargate/tls/tls.key
       # Image defaults to ${global.image.registry}/${global.image.repository}/nvcf-openbao-migrations.
-      # tag falls back to openbao.migrations.image.tag if unset here, so the
-      # operator can pin both in one place.
+      # tag falls back to openbao.migrations.image.tag and then 0.16.2 if
+      # neither location is set.
       # image:
       #   registry: ""
       #   repository: ""

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -309,10 +309,17 @@ addons:
     pki:
       enabled: true
       mode: certManager
-      # Comma-separated DNS suffixes the managed OpenBao role accepts.
+      # Comma-separated DNS suffixes the managed OpenBao role accepts. For a
+      # split/multi-cluster deployment, extend this to cover the suffix of each
+      # external router DNS name used by compute workers.
       allowedDomains: cluster.local
       # SANs for both the stable Service and authority/SNI-selected Stargate
-      # pod identities. Must be empty for mode existingSecret.
+      # pod identities. For a split/multi-cluster deployment, also add every
+      # external router DNS name configured through
+      # addons.llm.requestRouter.backendRouter.pylonGrpcDialAddress or
+      # addons.llm.requestRouter.backendRouter.pylonReverseTunnelDialAddress.
+      # The reverse-tunnel hostname is used as QUIC SNI and must match this
+      # Certificate. Must be empty for mode existingSecret.
       dnsNames:
         - llm-request-router.nvcf.svc.cluster.local
         - "*.llm-request-router-headless.nvcf.svc.cluster.local"

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -997,13 +997,10 @@ llmRequestRouter:
     quicInsecure: false
   {{- if $managedIssuer }}
   {{- $allowedDomains := required "addons.llm.pki.allowedDomains is required when addons.llm.pki.clusterIssuer management is enabled" (dig "addons" "llm" "pki" "allowedDomains" "" .Values) }}
-  {{- /* Provisioning hook reuses the same image the k8s-openbao chart drives;
-       fall back to openbao.migrations.image.tag so operators set the version
-       in one place. */ -}}
-  {{- $pkiImageTag := dig "addons" "llm" "pki" "image" "tag" (dig "openbao" "migrations" "image" "tag" "" .Values) .Values }}
-  {{- if not $pkiImageTag }}
-  {{- fail "addons.llm.pki.image.tag (or openbao.migrations.image.tag) is required when addons.llm.pki.clusterIssuer management is enabled" }}
-  {{- end }}
+  {{- /* Provisioning reuses the OpenBao migrations image. Prefer an explicit
+       PKI tag, then the OpenBao migrations tag, and finally the compatible
+       stack default so a normal environment need not duplicate chart values. */ -}}
+  {{- $pkiImageTag := dig "addons" "llm" "pki" "image" "tag" (dig "openbao" "migrations" "image" "tag" "" .Values) .Values | default "0.16.2" }}
   pki:
     enabled: true
     namespace: {{ dig "addons" "llm" "pki" "namespace" "vault-system" .Values | quote }}

--- a/deploy/stacks/self-managed/tests/check-llm-pki-issuer.sh
+++ b/deploy/stacks/self-managed/tests/check-llm-pki-issuer.sh
@@ -195,6 +195,29 @@ render_router() {
     >"$manifests_file"
 }
 
+render_default_router() {
+  local case_name="$1"
+  local values_file="$work_dir/$case_name.router-values.yaml"
+  local manifests_file="$work_dir/$case_name.router-manifests.yaml"
+  local router_chart="$stack_dir/../../helm/llm-request-router/llm-request-router"
+
+  HELMFILE_ENV=base HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" helmfile \
+    --file "$stack_dir/helmfile.d/02-core.yaml.gotmpl" \
+    --environment default \
+    --selector name=llm-request-router \
+    --chart "$router_chart" \
+    --skip-deps \
+    "${core_state_values[@]}" \
+    --state-values-set addons.llm.enabled=true \
+    write-values \
+    --output-file-template "$values_file" >/dev/null
+
+  helm template llm-request-router "$router_chart" \
+    --namespace nvcf \
+    --values "$values_file" \
+    >"$manifests_file"
+}
+
 expect_external_router() {
   local case_name="$1"
   local issuer_kind="$2"
@@ -241,12 +264,19 @@ expect_external_router() {
 }
 
 # existingSecret mode cannot reuse render_router: that helper always passes
-# dnsNames, which this mode rejects as a mixed-ownership conflict.
+# managed issuance values, which this mode rejects as a mixed-ownership
+# conflict. Clear the managed defaults before applying each case override.
 render_existing_secret_router() {
   local case_name="$1"
   shift
   local values_file="$work_dir/$case_name.router-values.yaml"
   local router_chart="$stack_dir/../../helm/llm-request-router/llm-request-router"
+  local ownership_override_file
+  ownership_override_file="$(pki_override "$case_name-existing-secret-ownership" <<'YAML'
+allowedDomains: ""
+dnsNames: []
+YAML
+)"
 
   HELMFILE_ENV=base HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" helmfile \
     --file "$stack_dir/helmfile.d/02-core.yaml.gotmpl" \
@@ -258,6 +288,7 @@ render_existing_secret_router() {
     --state-values-set addons.llm.enabled=true \
     --state-values-set addons.llm.pki.enabled=true \
     --state-values-set-string addons.llm.pki.mode=existingSecret \
+    --state-values-file "$ownership_override_file" \
     "$@" \
     write-values \
     --output-file-template "$values_file" \
@@ -361,10 +392,32 @@ expect_enabled llm-disabled false
 # Case 2: LLM enabled, PKI disabled.
 render_list pki-disabled \
   --state-values-set addons.llm.enabled=true \
+  --state-values-set addons.llm.pki.enabled=false \
   --state-values-set addons.llm.pki.clusterIssuer.enabled=true
 expect_enabled pki-disabled false
 
-# Case 3: LLM and PKI enabled with the default managed ClusterIssuer.
+# Case 3: enabling LLM with no PKI overrides must select the managed issuer and
+# render an identity that covers both the stable and per-pod router names.
+render_list secure-defaults \
+  --state-values-set addons.llm.enabled=true
+expect_enabled secure-defaults true
+render_default_router secure-defaults
+secure_defaults_manifests="$work_dir/secure-defaults.router-manifests.yaml"
+secure_defaults_dns_names="$(
+  yq ea -r 'select(.kind == "Certificate") | .spec.dnsNames[]' \
+    "$secure_defaults_manifests"
+)"
+test "$secure_defaults_dns_names" = "$(printf '%s\n%s' \
+  'llm-request-router.nvcf.svc.cluster.local' \
+  '*.llm-request-router-headless.nvcf.svc.cluster.local')" ||
+  fail "secure defaults did not render the stable and per-pod request-router DNS names"
+grep -Fq 'name: addons-llm-migrations' "$secure_defaults_manifests" ||
+  fail "secure defaults did not render the managed OpenBao provisioning hook"
+if grep -Fq -- '--quic-insecure' "$secure_defaults_manifests"; then
+  fail "secure defaults enabled insecure request-router transport"
+fi
+
+# Case 4: LLM and PKI explicitly enabled with the default managed ClusterIssuer.
 managed_defaults=(
   --state-values-set addons.llm.enabled=true
   --state-values-set addons.llm.pki.enabled=true

--- a/deploy/stacks/self-managed/tests/check-llm-pki-issuer.sh
+++ b/deploy/stacks/self-managed/tests/check-llm-pki-issuer.sh
@@ -403,6 +403,18 @@ render_list secure-defaults \
 expect_enabled secure-defaults true
 render_default_router secure-defaults
 secure_defaults_manifests="$work_dir/secure-defaults.router-manifests.yaml"
+secure_defaults_issuer_kind="$(
+  yq ea -r 'select(.kind == "Certificate") | .spec.issuerRef.kind' \
+    "$secure_defaults_manifests"
+)"
+secure_defaults_issuer_name="$(
+  yq ea -r 'select(.kind == "Certificate") | .spec.issuerRef.name' \
+    "$secure_defaults_manifests"
+)"
+test "$secure_defaults_issuer_kind" = "ClusterIssuer" ||
+  fail "secure defaults did not render Certificate issuer kind ClusterIssuer"
+test "$secure_defaults_issuer_name" = "nvcf-openbao-pki" ||
+  fail "secure defaults did not render Certificate issuer name nvcf-openbao-pki"
 secure_defaults_dns_names="$(
   yq ea -r 'select(.kind == "Certificate") | .spec.dnsNames[]' \
     "$secure_defaults_manifests"

--- a/deploy/stacks/self-managed/tests/llm-pki-release.sh
+++ b/deploy/stacks/self-managed/tests/llm-pki-release.sh
@@ -34,6 +34,60 @@ render_debug() {
     list --skip-charts --output json 2>&1
 }
 
+# The managed issuer hook needs the same OpenBao migrations image as the
+# control-plane chart. An environment should not have to duplicate its tag.
+render_pki_image_case() {
+  local case_name="$1"
+  shift
+
+  HELMFILE_ENV=base HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" helmfile \
+    --file "$stack_dir/helmfile.d" \
+    --environment default \
+    --output-file-template "$work_dir/$case_name-{{ .Release.Name }}.yaml" \
+    --state-values-set ingress.gatewayApi.controllerNamespace=envoy-gateway-system \
+    --state-values-set ingress.gatewayApi.gateways.shared.name=shared-gw \
+    --state-values-set ingress.gatewayApi.gateways.shared.namespace=envoy-gateway-system \
+    --state-values-set ingress.gatewayApi.gateways.grpc.name=grpc-gw \
+    --state-values-set ingress.gatewayApi.gateways.grpc.namespace=envoy-gateway-system \
+    --state-values-set addons.llm.enabled=true \
+    --state-values-set addons.llm.pki.enabled=true \
+    --state-values-set-string addons.llm.pki.allowedDomains=cluster.local \
+    --state-values-set-string 'addons.llm.pki.dnsNames[0]=llm-request-router.nvcf.svc.cluster.local' \
+    --state-values-set-string 'addons.llm.pki.dnsNames[1]=*.llm-request-router-headless.nvcf.svc.cluster.local' \
+    "$@" \
+    write-values --selector name=llm-request-router 2>&1
+}
+
+assert_pki_image_case() {
+  local case_name="$1"
+  local expected_tag="$2"
+  local values_file="$work_dir/$case_name-llm-request-router.yaml"
+  local manifests_file="$work_dir/$case_name-manifests.yaml"
+  local router_chart="$stack_dir/../../helm/llm-request-router/llm-request-router"
+  local expected_image="nvcr.io/YOUR_ORG/YOUR_TEAM/nvcf-openbao-migrations:$expected_tag"
+  local actual_tag actual_image
+
+  actual_tag="$(yq -r '.llmRequestRouter.pki.image.tag' "$values_file")"
+  test "$actual_tag" = "$expected_tag" ||
+    fail "$case_name resolved PKI image tag $actual_tag, expected $expected_tag"
+
+  helm template llm-request-router "$router_chart" \
+    --namespace nvcf \
+    --values "$values_file" \
+    >"$manifests_file"
+
+  actual_image="$(
+    yq ea -r '
+      select(.kind == "Job" and .metadata.name == "addons-llm-migrations") |
+      .spec.template.spec.containers[] |
+      select(.name == "addons-llm-migrations") |
+      .image
+    ' "$manifests_file"
+  )"
+  test "$actual_image" = "$expected_image" ||
+    fail "$case_name rendered migrations image $actual_image, expected $expected_image"
+}
+
 # The rendered state is the only place that carries both the release
 # declarations and their needs edges. `list` reports enablement but drops
 # needs, and `build` cannot run offline because it pulls every chart. Debug
@@ -71,6 +125,25 @@ state_table() {
   ' "$1" |
     awk -F '|' '{ key = ($1 == "" ? $2 : $1 "/" $2); print key "\t" $3 }'
 }
+
+if ! render_pki_image_case default-image-tag \
+  --state-values-set-string openbao.migrations.image.tag= \
+  >"$work_dir/default-image-tag.log"; then
+  cat "$work_dir/default-image-tag.log" >&2
+  fail "managed LLM PKI must render when both PKI image tags are omitted"
+fi
+assert_pki_image_case default-image-tag 0.16.2
+
+render_pki_image_case legacy-image-tag \
+  --state-values-set-string openbao.migrations.image.tag=legacy-tag \
+  >"$work_dir/legacy-image-tag.log"
+assert_pki_image_case legacy-image-tag legacy-tag
+
+render_pki_image_case explicit-image-tag \
+  --state-values-set-string openbao.migrations.image.tag=legacy-tag \
+  --state-values-set-string addons.llm.pki.image.tag=explicit-tag \
+  >"$work_dir/explicit-image-tag.log"
+assert_pki_image_case explicit-image-tag explicit-tag
 
 if ! render_debug >"$work_dir/debug.log"; then
   cat "$work_dir/debug.log" >&2


### PR DESCRIPTION
## Why

The LLM backend router terminates worker-facing QUIC TLS and re-originates the connection to Stargate pods. Leaving managed PKI off by default makes the zero-config LLM path depend on insecure transport or on every operator independently assembling an issuer, wildcard certificate, trust distribution, and migrations-image override.

The secure product default should follow the feature that needs it: when the LLM addon is enabled, managed LLM PKI should be enabled unless the operator explicitly chooses another supported mode. The migrations hook also needs a usable image tag without duplicating configuration in every environment.

## What changed

- default managed LLM PKI to `addons.llm.enabled`;
- default the OpenBao role to `cluster.local`;
- issue the exact request-router service name and the wildcard headless-service name required by authority/SNI routing;
- preserve explicit PKI configuration and existing-Secret mode;
- resolve the migrations image tag in this order: explicit LLM PKI tag, legacy OpenBao migrations tag, then `0.16.2`;
- render the actual local request-router chart in regression tests and assert the resulting hook image, SANs, and secure QUIC arguments;
- document the external SAN and allowed-domain requirements for split/multi-cluster deployments.

## Multi-cluster requirement

The zero-config certificate SANs cover only the in-cluster request-router identities. When compute workers run in a separate cluster and reach the router through an external gateway or load balancer, operators must:

- configure the externally reachable addresses with `addons.llm.requestRouter.backendRouter.pylonGrpcDialAddress` and `addons.llm.requestRouter.backendRouter.pylonReverseTunnelDialAddress`;
- add every external router DNS name used by compute workers to `addons.llm.pki.dnsNames`;
- extend `addons.llm.pki.allowedDomains` so the managed OpenBao role permits those external DNS suffixes.

The hostname from `pylonReverseTunnelDialAddress` is used as QUIC SNI and therefore must match a SAN in the issued router certificate. Without that SAN, the single-cluster secure path can pass while the split-cluster reverse tunnel fails TLS hostname verification.

## For the Reviewer

Please focus on the default/override precedence in `environments/base.yaml` and `global.yaml.gotmpl`, plus the secure-default and existing-Secret cases in `check-llm-pki-issuer.sh`. The comments beside `allowedDomains` and `dnsNames` record the additional multi-cluster certificate requirement.

## Validation

- `make test` in `deploy/stacks/self-managed`

## Issues

Relates to #999

## Coordination

- Router feature: #999
- Stargate image prerequisite: #1088
- Self-hosted collector reliability: #1071

This secure-default change is independently testable and can merge before the router feature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Managed PKI is enabled by default for the LLM request router.
  * Router TLS supports `cluster.local` and stable/headless service DNS names.
  * Self-managed deployments support per-component image overrides, with upstream defaults for selected services.

* **Bug Fixes**
  * PKI provisioning now falls back to version 0.16.2 when no tag is specified.
  * Prevented deployment failures caused by missing PKI image configuration.

* **Documentation**
  * Added guidance for split and multi-cluster external router names and migration image tags.

* **Tests**
  * Added coverage for default, legacy, explicit, and disabled PKI configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
