### PR TITLE
fix(compute-stack): harden self-hosted collector defaults

### DIFF
--- a/deploy/stacks/nvcf-compute-plane/README.md
+++ b/deploy/stacks/nvcf-compute-plane/README.md
@@ -43,8 +43,10 @@ without the `.yaml` suffix.
 ## Observability
 
 The stack defaults `observability.profile` to `compute`. The `compute` and
-`all` profiles enable the NVCA collector and `BYOObservability` feature gate.
-The `control` and `disabled` profiles leave both off.
+`all` profiles enable the `BYOObservability` feature gate. The optional NVCA
+collector stays disabled for every profile until the operator opts in. This
+prevents a self-hosted install from depending on an image that was not mirrored
+into its registry.
 
 One value selects the normal behavior:
 
@@ -53,16 +55,27 @@ observability:
   profile: compute
 ```
 
-Explicit NVCA values override the profile defaults:
+Enable the collector after publishing it under `global.image`. Its repository
+defaults to `${global.image.registry}/${global.image.repository}/nvcf-otel-collector`:
 
 ```yaml
 global:
   nvcaOperator:
     selfManaged:
       otelCollector:
-        enabled: false
-      featureGateValues:
-        - "-BYOObservability"
+        enabled: true
+```
+
+If the collector is published outside that global image path, set its explicit
+repository override while opting in:
+
+```yaml
+global:
+  nvcaOperator:
+    selfManaged:
+      otelCollector:
+        enabled: true
+        imageRepository: nvcr.io/example/collectors/nvcf-otel-collector
 ```
 
 ## Chart and Image Sources

--- a/deploy/stacks/nvcf-compute-plane/environments/base.yaml
+++ b/deploy/stacks/nvcf-compute-plane/environments/base.yaml
@@ -35,14 +35,17 @@ global:
     selfManaged:
       nvcaVersion: "3.2.7"
       otelCollector:
+        # Self-hosted registries do not always mirror this optional image.
+        # Enable it only after publishing the collector in global.image.
+        enabled: false
         imageTag: "0.157.9"
-      # ICMS (SIS) service URL — required; set per environment.
+      # ICMS (SIS) service URL: required; set per environment.
       icmsServiceURL: ""
       icmsServiceHostHeaderOverride: ""
-      # Reval service URL — required; set per environment.
+      # Reval service URL: required; set per environment.
       revalServiceURL: ""
       revalServiceHostHeaderOverride: ""
-      # NATS URL — required; set per environment.
+      # NATS URL: required; set per environment.
       natsURL: ""
       natsHostOverride: ""
       # Feature gates enabled on this cluster. Extra gates set here are added on

--- a/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
+++ b/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
@@ -90,7 +90,9 @@ helmDefaults:
 {{- $nvcaOp := dig "nvcaOperator" dict .Values.global }}
 {{- $selfManaged := dig "selfManaged" dict $nvcaOp }}
 {{- $otelCollector := dig "otelCollector" dict $selfManaged }}
-{{- $otelCollectorEnabled := dig "enabled" $computeObservabilityEnabled $otelCollector }}
+{{- $otelCollectorEnabled := dig "enabled" false $otelCollector }}
+{{- $defaultOTelCollectorImageRepository := printf "%s/%s/nvcf-otel-collector" .Values.global.image.registry .Values.global.image.repository }}
+{{- $otelCollectorImageRepository := dig "imageRepository" $defaultOTelCollectorImageRepository $otelCollector }}
 
 {{- $featureGateValues := dig "featureGateValues" list $selfManaged }}
 {{- $kaiSchedulerEnabled := dig "addons" "kaiScheduler" "enabled" false .Values }}
@@ -224,9 +226,7 @@ releases:
                 "dynamoOperatorEnabled" $dynamoOperatorEnabled) | nindent 10 }}
           otelCollector:
             enabled: {{ $otelCollectorEnabled }}
-            {{- with dig "imageRepository" "" $otelCollector }}
-            imageRepository: {{ . | quote }}
-            {{- end }}
+            imageRepository: {{ $otelCollectorImageRepository | quote }}
             {{- with dig "imageTag" "" $otelCollector }}
             imageTag: {{ . | quote }}
             {{- end }}

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/self-managed-nvcfbackend-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/self-managed-nvcfbackend-cm.yaml
@@ -61,9 +61,9 @@ data:
       imageRepository: "nvcr.io/0651155215864979/ncp-dev/samba"
       imageTag: "1.0.5"
     otelCollector:
-      enabled: true
+      enabled: false
       imageConfig:
-        repository: "nvcr.io/nvidia/nvcf-byoc/nvcf-otel-collector"
+        repository: "nvcr.io/0651155215864979/ncp-dev/nvcf-otel-collector"
         tag: "0.157.9"
     agent:
       natsURL: "nats://nats.nats-system.svc.cluster.local:4222"

--- a/deploy/stacks/nvcf-compute-plane/tests/observability-profile.sh
+++ b/deploy/stacks/nvcf-compute-plane/tests/observability-profile.sh
@@ -57,6 +57,14 @@ collector_image_tag() {
   ' "$1"
 }
 
+collector_image_repository() {
+  awk '
+    /^selfManaged:$/ { self_managed = 1; next }
+    self_managed && /^  otelCollector:$/ { collector = 1; next }
+    collector && /^    imageRepository:/ { gsub(/"/, "", $2); print $2; exit }
+  ' "$1"
+}
+
 operator_image_tag() {
   awk '
     /^image:$/ { image = 1; next }
@@ -76,13 +84,9 @@ for profile in default disabled control compute all; do
   render_values "$profile" "$values"
 
   case "$profile" in
-    default|compute|all)
-      test "$(collector_enabled "$values")" = "true" ||
-        fail "$profile profile did not enable the NVCA collector"
-      ;;
-    disabled|control)
+    default|disabled|control|compute|all)
       test "$(collector_enabled "$values")" = "false" ||
-        fail "$profile profile enabled the NVCA collector"
+        fail "$profile profile enabled the self-managed NVCA collector by default"
       ;;
   esac
 done
@@ -92,6 +96,14 @@ test "$(operator_image_tag "$work_dir/default.yaml")" = "$expected_nvca_version"
   fail "default operator image tag is not $expected_nvca_version"
 test "$(nvca_version "$work_dir/default.yaml")" = "$expected_nvca_version" ||
   fail "default NVCA version is not $expected_nvca_version"
+
+render_values compute "$work_dir/ncp-dev-default.yaml" \
+  --state-values-set-string global.image.registry=nvcr.io \
+  --state-values-set-string global.image.repository=0651155215864979/ncp-dev
+
+test "$(collector_image_repository "$work_dir/ncp-dev-default.yaml")" = \
+  "nvcr.io/0651155215864979/ncp-dev/nvcf-otel-collector" ||
+  fail "collector image repository did not inherit the global image repository"
 
 render_values compute "$work_dir/compute-overrides.yaml" \
   --state-values-set-string global.nvcaOperator.imageTag=operator-test-tag \

--- a/tests/bdd/features/observability-all.feature
+++ b/tests/bdd/features/observability-all.feature
@@ -31,11 +31,11 @@ Feature: Install local Helmfile observability for both planes
       | observability.profile           | all                                  |
     # Configure NVCA to join the same cluster and enable its collector.
     And I prepare Helmfile environment "local-bdd-observability-all" for stack "nvcf-compute-plane" from fixture "tests/bdd/fixtures/nvcf-compute-plane-local-bdd.yaml" with values:
-      | global.imagePullSecrets[0].name                               | nvcr-pull-secret                                                  |
-      | global.helm.sources.repository                                | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}                              |
-      | global.image.repository                                       | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}                              |
-      | global.nvcaOperator.selfManaged.otelCollector.imageRepository | nvcr.io/${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}/nvcf-otel-collector |
-      | observability.profile                                         | all                                                               |
+      | global.imagePullSecrets[0].name                       | nvcr-pull-secret                     |
+      | global.helm.sources.repository                        | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM} |
+      | global.image.repository                               | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM} |
+      | global.nvcaOperator.selfManaged.otelCollector.enabled | true                                 |
+      | observability.profile                                 | all                                  |
     And I prepare self-managed secrets file "deploy/stacks/self-managed/secrets/local-bdd-observability-all-secrets.yaml" from template "deploy/stacks/self-managed/secrets/secrets.yaml.template" using the current NGC registry credential
     # Conflict precheck: the split topology claims host ports used by the
     # single-cluster topology. From the repository root, run
@@ -133,4 +133,5 @@ Feature: Install local Helmfile observability for both planes
       selfManaged:
         otelCollector:
           enabled: true
+          imageRepository: nvcr.io/${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}/nvcf-otel-collector
       """

--- a/tests/bdd/features/observability-compute.feature
+++ b/tests/bdd/features/observability-compute.feature
@@ -33,11 +33,11 @@ Feature: Install local Helmfile observability with the compute profile
       | observability.profile           | compute                              |
     # Configure NVCA to use the same compute observability profile.
     And I prepare Helmfile environment "local-bdd-observability-compute" for stack "nvcf-compute-plane" from fixture "tests/bdd/fixtures/nvcf-compute-plane-local-bdd-multi.yaml" with values:
-      | global.imagePullSecrets[0].name                               | nvcr-pull-secret                                                  |
-      | global.helm.sources.repository                                | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}                              |
-      | global.image.repository                                       | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}                              |
-      | global.nvcaOperator.selfManaged.otelCollector.imageRepository | nvcr.io/${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}/nvcf-otel-collector |
-      | observability.profile                                         | compute                                                           |
+      | global.imagePullSecrets[0].name                       | nvcr-pull-secret                     |
+      | global.helm.sources.repository                        | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM} |
+      | global.image.repository                               | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM} |
+      | global.nvcaOperator.selfManaged.otelCollector.enabled | true                                 |
+      | observability.profile                                 | compute                              |
     And I prepare self-managed secrets file "deploy/stacks/self-managed/secrets/local-bdd-observability-compute-secrets.yaml" from template "deploy/stacks/self-managed/secrets/secrets.yaml.template" using the current NGC registry credential
     # Conflict precheck: single-cluster ncp-local claims host ports used by the
     # split topology. From the repository root, run
@@ -150,6 +150,7 @@ Feature: Install local Helmfile observability with the compute profile
       selfManaged:
         otelCollector:
           enabled: true
+          imageRepository: nvcr.io/${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}/nvcf-otel-collector
       """
 
     When I run command "helm status function-autoscaler --namespace nvcf --kube-context k3d-ncp-local-compute-1"

--- a/tests/bdd/godog_test.go
+++ b/tests/bdd/godog_test.go
@@ -627,7 +627,7 @@ func TestObservabilityComputeFeatureFileWiresToSteps(t *testing.T) {
 		serviceMonitorCommand:       {ExitCode: 0},
 		podMonitorCommand:           {ExitCode: 0},
 		absentServiceMonitorCommand: {ExitCode: 0},
-		collectorValuesCommand:      {ExitCode: 0, Stdout: "selfManaged:\n  otelCollector:\n    enabled: true\n"},
+		collectorValuesCommand:      {ExitCode: 0, Stdout: "selfManaged:\n  otelCollector:\n    enabled: true\n    imageRepository: nvcr.io/test-org/test-team/nvcf-otel-collector\n"},
 		"helm list --all-namespaces --kube-context k3d-ncp-local-compute-1 -o json": {
 			ExitCode: 0,
 			Stdout:   observabilityComputeHelmListJSON(),
@@ -699,7 +699,7 @@ func TestObservabilityComputeFeatureFileWiresToSteps(t *testing.T) {
 	}
 	computeEnvironmentPath := filepath.Join(suite.Config.RepoRoot, "deploy", "stacks", "nvcf-compute-plane", "environments", "local-bdd-observability-compute.yaml")
 	for key, want := range map[string]string{
-		"global.nvcaOperator.selfManaged.otelCollector.imageRepository": "nvcr.io/test-org/test-team/nvcf-otel-collector",
+		"global.nvcaOperator.selfManaged.otelCollector.enabled": "true",
 	} {
 		got, found, err := dsl.ReadYAMLKey(computeEnvironmentPath, key)
 		if err != nil {
@@ -727,12 +727,12 @@ func observabilityComputeHelmListJSON() string {
 // local context and verifies that one shared stack serves both monitor sets.
 func TestObservabilityAllFeatureFileWiresToSteps(t *testing.T) {
 	const (
-		registryLoginCommand    = "helm registry login nvcr.io --username '$oauthtoken' --password-stdin"
-		serviceMonitorCommand   = "kubectl get servicemonitor/nvcf-default-monitors-state-metrics --namespace monitoring --context k3d-ncp-local -o name"
-		podMonitorCommand       = "kubectl get podmonitor/nvcf-default-monitors-worker --namespace monitoring --context k3d-ncp-local -o name"
-		collectorValuesCommand  = "helm get values nvca-operator --namespace nvca-operator --kube-context k3d-ncp-local -o yaml"
-		collectorYAMLCommand    = "kubectl get opentelemetrycollector/nvcf-observability --namespace monitoring --context k3d-ncp-local -o yaml"
-		serviceKeyCommand       = `bash -c 'set -eo pipefail; printf %s "$NGC_API_KEY" |` +
+		registryLoginCommand   = "helm registry login nvcr.io --username '$oauthtoken' --password-stdin"
+		serviceMonitorCommand  = "kubectl get servicemonitor/nvcf-default-monitors-state-metrics --namespace monitoring --context k3d-ncp-local -o name"
+		podMonitorCommand      = "kubectl get podmonitor/nvcf-default-monitors-worker --namespace monitoring --context k3d-ncp-local -o name"
+		collectorValuesCommand = "helm get values nvca-operator --namespace nvca-operator --kube-context k3d-ncp-local -o yaml"
+		collectorYAMLCommand   = "kubectl get opentelemetrycollector/nvcf-observability --namespace monitoring --context k3d-ncp-local -o yaml"
+		serviceKeyCommand      = `bash -c 'set -eo pipefail; printf %s "$NGC_API_KEY" |` +
 			` kubectl --context k3d-ncp-local create secret generic ngc-service-api-key` +
 			` --namespace nvca-system --from-file=ngc-service-api-key=/dev/stdin --dry-run=client -o yaml |` +
 			` kubectl --context k3d-ncp-local apply -f -'`
@@ -748,7 +748,7 @@ func TestObservabilityAllFeatureFileWiresToSteps(t *testing.T) {
 		"k3d cluster get ncp-local-cp": {ExitCode: 1},
 		serviceMonitorCommand:          {ExitCode: 0},
 		podMonitorCommand:              {ExitCode: 0},
-		collectorValuesCommand:         {ExitCode: 0, Stdout: "selfManaged:\n  otelCollector:\n    enabled: true\n"},
+		collectorValuesCommand:         {ExitCode: 0, Stdout: "selfManaged:\n  otelCollector:\n    enabled: true\n    imageRepository: nvcr.io/test-org/test-team/nvcf-otel-collector\n"},
 		serviceKeyCommand:              {ExitCode: 0},
 		restartNVCACommand:             {ExitCode: 0},
 		"helm list --all-namespaces --kube-context k3d-ncp-local -o json": {
@@ -832,7 +832,7 @@ func TestObservabilityAllFeatureFileWiresToSteps(t *testing.T) {
 		want  string
 	}{
 		{stack: "self-managed", key: "functionAutoscaler.image.tag", want: "1.18.10"},
-		{stack: "nvcf-compute-plane", key: "global.nvcaOperator.selfManaged.otelCollector.imageRepository", want: "nvcr.io/test-org/test-team/nvcf-otel-collector"},
+		{stack: "nvcf-compute-plane", key: "global.nvcaOperator.selfManaged.otelCollector.enabled", want: "true"},
 	}
 	for _, assertion := range assertions {
 		environmentPath := filepath.Join(suite.Config.RepoRoot, "deploy", "stacks", assertion.stack, "environments", "local-bdd-observability-all.yaml")


### PR DESCRIPTION
## Why

The self-hosted compute profile implicitly enabled the NVCA OpenTelemetry collector whenever compute observability was enabled. That made a normal bootstrap depend on an optional collector image that is not published in every self-hosted repository. If the image was absent, telemetry prevented an otherwise valid compute plane from becoming healthy.

Environments that do publish the collector had a second problem: its repository did not inherit the global image registry/repository override, so an installation could mirror every required image correctly while this optional sidecar still pulled from another location.

Optional telemetry should not be an availability dependency. It should remain available through explicit opt-in and obey the same image-mirror settings as the rest of the stack.

## What changed

- default the self-hosted collector to disabled across observability profiles;
- keep the compute/BYOO feature gates independent from collector enablement;
- retain explicit collector opt-in;
- inherit `<global.image.registry>/<global.image.repository>/nvcf-otel-collector` by default;
- retain and document an explicit collector repository override;
- update the BDD feature, Go wiring tests, documentation, and rendered golden values for the opt-in contract.

## For the Reviewer

Please focus on the distinction between enabling the BYO compute feature and explicitly enabling its collector, plus the repository-precedence assertions and README examples for both inherited and explicit repositories.

## Validation

- `go test -short ./...` in `tests/bdd`
- `make test-local DEV_MODE=1` in `deploy/stacks/nvcf-compute-plane`, with the repository-pinned Helmfile `1.1.9` and Helm `3.15.4` first in `PATH`
- `git diff --check origin/main...HEAD`

The local `tests/bdd/scripts/lint.sh` invocation did not reach analysis: `golangci-lint 2.11.4` (built with Go 1.26.2) reported `no go files to analyze` under the active Go 1.27.0 toolchain. The Go tests, formatting checks, and render/golden suite passed.

## Issues

Relates to #999

## Coordination

- Router feature: #999
- Managed PKI default: #1070

This bootstrap reliability fix is independent of router authority/SNI behavior and can merge separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Self-managed OpenTelemetry collectors are now disabled by default unless explicitly enabled.
  * Collector images consistently inherit the configured global image registry and repository.
  * Custom collector image tags continue to be honored when provided.

* **Documentation**
  * Updated observability guidance for publishing and enabling the self-managed collector.
  * Clarified which observability profiles enable observability features by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
