### PR TITLE
fix(stargate): include Kubernetes router in runtime image

### DIFF
--- a/src/libraries/rust/stargate/Dockerfile
+++ b/src/libraries/rust/stargate/Dockerfile
@@ -129,6 +129,7 @@ ARG TARGETARCH
 # Health probe changes less often than the binary, so copy it first for layer caching.
 COPY --from=health-probe-downloader /usr/local/bin/grpc_health_probe /usr/local/bin/grpc_health_probe
 COPY --from=binary-builder /out/stargate /usr/local/bin/stargate
+COPY --from=binary-builder /out/stargate-k8s-router /usr/local/bin/stargate-k8s-router
 
 ENTRYPOINT ["stargate"]
 CMD []

--- a/src/libraries/rust/stargate/README.md
+++ b/src/libraries/rust/stargate/README.md
@@ -91,6 +91,10 @@ load-balancer topology for production backend traffic.
 - `crates/mock-dynamo`: local OpenAI-style backend
 - `crates/stargate-bench`: benchmark runner
 
+The versioned Stargate runtime image also includes
+`/usr/local/bin/stargate-k8s-router`. Kubernetes deployments can run the main
+Stargate process and the backend router from the same immutable image tag.
+
 ## Benchmarks
 
 ```bash

--- a/src/libraries/rust/stargate/crates/stargate-k8s-router/BUILD.bazel
+++ b/src/libraries/rust/stargate/crates/stargate-k8s-router/BUILD.bazel
@@ -48,7 +48,7 @@ rust_test(
 # Multi-arch OCI image. distroless/cc base, binary at
 # /usr/local/bin/stargate-k8s-router.
 rust_oci_image(
-    name = "image",
+    name = "stargate-k8s-router-image",
     base = "@distroless_cc",
     binary = ":stargate-k8s-router",
     binary_path = "/usr/local/bin/stargate-k8s-router",
@@ -62,8 +62,8 @@ sh_test(
     name = "image_entrypoint_mode_test",
     srcs = ["//src/libraries/rust/stargate/tools/ci:image_entrypoint_mode_test.sh"],
     args = [
-        "$(location :image_layer)",
+        "$(location :stargate-k8s-router-image_layer)",
         "/usr/local/bin/stargate-k8s-router",
     ],
-    data = [":image_layer"],
+    data = [":stargate-k8s-router-image_layer"],
 )

--- a/src/libraries/rust/stargate/crates/stargate/BUILD.bazel
+++ b/src/libraries/rust/stargate/crates/stargate/BUILD.bazel
@@ -116,6 +116,7 @@ rust_oci_image(
     base = "@distroless_cc",
     binary = ":stargate",
     binary_path = "/usr/local/bin/stargate",
+    extra_layers = ["//src/libraries/rust/stargate/crates/stargate-k8s-router:stargate-k8s-router-image_layer"],
     tags = ["stargate"],
     visibility = ["//visibility:public"],
 )
@@ -131,4 +132,16 @@ sh_test(
         "/usr/local/bin/stargate",
     ],
     data = [":image_layer"],
+)
+
+# Composite-image guard. Inspect the assembled OCI layout so removing the
+# router's extra layer fails this test.
+sh_test(
+    name = "image_router_binary_test",
+    srcs = ["//src/libraries/rust/stargate/tools/ci:test-oci-image-contains-path.sh"],
+    args = [
+        "$(location :image)",
+        "/usr/local/bin/stargate-k8s-router",
+    ],
+    data = [":image"],
 )

--- a/src/libraries/rust/stargate/tools/ci/BUILD.bazel
+++ b/src/libraries/rust/stargate/tools/ci/BUILD.bazel
@@ -4,6 +4,7 @@
 exports_files(
     [
         "image_entrypoint_mode_test.sh",
+        "test-oci-image-contains-path.sh",
     ],
     visibility = ["//visibility:public"],
 )

--- a/src/libraries/rust/stargate/tools/ci/test-oci-image-contains-path.sh
+++ b/src/libraries/rust/stargate/tools/ci/test-oci-image-contains-path.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <oci-image-layout> <path>" >&2
+  exit 2
+fi
+
+image_layout="$1"
+image_path="${2#/}"
+
+if [[ ! -f "${image_layout}/index.json" || ! -d "${image_layout}/blobs/sha256" ]]; then
+  echo "${image_layout} is not an OCI image layout" >&2
+  exit 1
+fi
+
+while IFS= read -r -d '' blob; do
+  if entries="$(tar -tf "${blob}" 2>/dev/null)"; then
+    while IFS= read -r entry; do
+      entry="${entry#./}"
+      entry="${entry#/}"
+      if [[ "${entry}" == "${image_path}" ]]; then
+        exit 0
+      fi
+    done <<< "${entries}"
+  fi
+# rules_oci may symlink blob files to their source layers. Select those links
+# directly without following symlinked directories outside the blob tree.
+done < <(find "${image_layout}/blobs/sha256" \( -type f -o -type l \) -print0)
+
+echo "missing /${image_path} in ${image_layout}" >&2
+exit 1


### PR DESCRIPTION
## TL;DR

Include `stargate-k8s-router` in the versioned, multi-architecture Stargate runtime image and retain a named standalone Bazel target for local validation.

This is the artifact prerequisite for #999. The latest Stargate release contains the router source, but its runtime image does not contain `/usr/local/bin/stargate-k8s-router`, so the Helm feature cannot safely reference any released image yet.

## Additional Details

- Names the standalone router Bazel target `stargate-k8s-router-image` for local build and sideload validation.
- Adds the router layer to the Stargate Bazel image and copies the binary into the released Dockerfile `stargate-runtime` image.
- Inspects the assembled Stargate OCI layout in a test so removal of the router binary fails CI.

Landing order:

1. Merge this prerequisite.
2. Let the normal Stargate release bridge publish the new `stargate` patch image and verify that it contains the router binary.
3. Rebase #999, pin that published Stargate image tag, and complete the live authority/SNI routing validation.

## For the Reviewer

Please focus on the named standalone router target, the extra layer in the Stargate image, and the OCI-layout assertion.

## For QA

- `bazel query 'kind("oci_image_index", //src/libraries/rust/stargate/...)' --output=label`
  - includes `stargate-k8s-router-image_index` and the main Stargate `image_index`
- Linux CI is expected to run the OCI entrypoint and composite-image tests. Local macOS execution reached the repository hermetic Zig bootstrap and was blocked there by its known `AccessDenied` wrapper-build failure before target analysis.

## Issues

Relates to #999

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stargate runtime images now include the Kubernetes router binary.
  * Kubernetes deployments can run both Stargate processes from a single immutable image tag.
* **Bug Fixes**
  * Added validation to ensure the router binary is present in assembled OCI images.
* **Documentation**
  * Updated Stargate runtime image documentation to describe the included router binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->