### PR TITLE
test(bdd): add Kubernetes readiness assertions

### DIFF
--- a/tests/bdd/PLAN.md
+++ b/tests/bdd/PLAN.md
@@ -142,6 +142,8 @@ refactor in every consumer; that is a feature.
 | `Then these Helm releases should be deployed using context {string}:` (table) | Requires `name` and `namespace` headers, with an optional `revision` header. Runs one explicit-context, all-namespaces `helm list` and asserts that every listed release has status `deployed`; non-empty revision cells are also matched. |
 | `Then these Kubernetes resources should exist in namespace {string} using context {string}:` (table) | Requires `kind` and `name` headers. Gets each named resource with the explicit namespace and context, and reports the row whose resource is missing. |
 | `Then these Kubernetes resources should not exist in namespace {string} using context {string}:` (table) | Requires `kind` and `name` headers. Gets each named resource with `--ignore-not-found` and requires empty name output, so absence does not depend on human-readable error text. |
+| `Then deployment {string} in namespace {string} using context {string} should complete rollout within {string}` | Runs `kubectl rollout status` for the named deployment with the explicit namespace, context, and timeout. Failure messages name the deployment without printing command output. |
+| `Then NVCFBackend {string} in namespace {string} using context {string} should report agent status {string} within {string}` | Waits for the named backend's `status.agentStatus` to equal the visible value using the explicit namespace, context, and timeout. Failure messages name the backend without printing resource output. |
 
 #### YAML comparison semantics
 
@@ -261,8 +263,8 @@ Going away in `tests/bdd`:
   `InstallNvcaOperator`). Replaced by `When I run command "make ..."`.
 - The Helm release readback methods (`HelmReleaseDeployed`,
   `NVCAOperatorReady`, `NVCAAgentReady`). Release deployment checks use the
-  table-driven Helm assertion; readiness remains explicit through
-  `kubectl rollout status` / `kubectl wait` in Gherkin.
+  table-driven Helm assertion. NVCA readiness uses explicit-context deployment
+  rollout and NVCFBackend agent-status assertion steps.
 - The `harness.CLIHarness` interface and its five domain methods
   (`SelfHostedUp`, `SelfHostedInstallControlPlane`,
   `SelfHostedComputePlaneRegister`, `SelfHostedComputePlaneInstall`,

--- a/tests/bdd/dsl/kubectl.go
+++ b/tests/bdd/dsl/kubectl.go
@@ -28,6 +28,13 @@ type KubernetesResource struct {
 	Name string
 }
 
+type kubernetesWaitTarget struct {
+	name        string
+	namespace   string
+	kubeContext string
+	timeout     string
+}
+
 // KubernetesResourceGetCommand builds an explicit-context kubectl get for one
 // resource. ignoreNotFound makes a missing resource produce empty name output.
 func KubernetesResourceGetCommand(namespace, kubeContext string, resource KubernetesResource, ignoreNotFound bool) (string, error) {
@@ -90,6 +97,63 @@ func KubernetesResourceAbsent(raw string, resource KubernetesResource) error {
 		return fmt.Errorf("kubernetes resource %s/%s exists, want absent", resource.Kind, resource.Name)
 	}
 	return nil
+}
+
+// KubernetesDeploymentRolloutCommand builds an explicit-context rollout wait
+// for one deployment.
+func KubernetesDeploymentRolloutCommand(name, namespace, kubeContext, timeout string) (string, error) {
+	target, err := resolveKubernetesWaitTarget("deployment", name, namespace, kubeContext, timeout)
+	if err != nil {
+		return "", err
+	}
+	return strings.Join([]string{
+		"kubectl", "rollout", "status", quoteCommandArg("deployment/" + target.name),
+		"-n", quoteCommandArg(target.namespace),
+		"--context", quoteCommandArg(target.kubeContext),
+		quoteCommandArg("--timeout=" + target.timeout),
+	}, " "), nil
+}
+
+// NVCFBackendAgentStatusCommand builds an explicit-context wait for one
+// backend's agent status.
+func NVCFBackendAgentStatusCommand(name, namespace, kubeContext, agentStatus, timeout string) (string, error) {
+	target, err := resolveKubernetesWaitTarget("NVCFBackend", name, namespace, kubeContext, timeout)
+	if err != nil {
+		return "", err
+	}
+	agentStatus = strings.TrimSpace(Interpolate(agentStatus))
+	if agentStatus == "" {
+		return "", fmt.Errorf("NVCFBackend agent status is empty")
+	}
+	return strings.Join([]string{
+		"kubectl", "wait", "nvcfbackend", quoteCommandArg(target.name),
+		"-n", quoteCommandArg(target.namespace),
+		"--context", quoteCommandArg(target.kubeContext),
+		"--for=jsonpath={.status.agentStatus}=" + quoteCommandArg(agentStatus),
+		quoteCommandArg("--timeout=" + target.timeout),
+	}, " "), nil
+}
+
+func resolveKubernetesWaitTarget(resourceType, name, namespace, kubeContext, timeout string) (kubernetesWaitTarget, error) {
+	target := kubernetesWaitTarget{
+		name:        strings.TrimSpace(Interpolate(name)),
+		namespace:   strings.TrimSpace(Interpolate(namespace)),
+		kubeContext: strings.TrimSpace(Interpolate(kubeContext)),
+		timeout:     strings.TrimSpace(Interpolate(timeout)),
+	}
+	if target.name == "" {
+		return kubernetesWaitTarget{}, fmt.Errorf("%s name is empty", resourceType)
+	}
+	if target.namespace == "" {
+		return kubernetesWaitTarget{}, fmt.Errorf("namespace is empty")
+	}
+	if target.kubeContext == "" {
+		return kubernetesWaitTarget{}, fmt.Errorf("kube context is empty")
+	}
+	if target.timeout == "" {
+		return kubernetesWaitTarget{}, fmt.Errorf("timeout is empty")
+	}
+	return target, nil
 }
 
 // KubectlApplyCommand builds a kubectl apply command for a manifest file.

--- a/tests/bdd/dsl/kubectl_test.go
+++ b/tests/bdd/dsl/kubectl_test.go
@@ -99,6 +99,68 @@ func TestKubernetesResourceAbsentRejectsNameOutput(t *testing.T) {
 	}
 }
 
+func TestKubernetesDeploymentRolloutCommandBuildsExplicitWait(t *testing.T) {
+	t.Setenv("BDD_KUBE_CONTEXT", "k3d-ncp-local")
+	got, err := KubernetesDeploymentRolloutCommand("nvca-operator", "nvca-operator", "${BDD_KUBE_CONTEXT}", "10m")
+	if err != nil {
+		t.Fatalf("build command: %v", err)
+	}
+	want := "kubectl rollout status deployment/nvca-operator -n nvca-operator --context k3d-ncp-local --timeout=10m"
+	if got != want {
+		t.Fatalf("command = %q, want %q", got, want)
+	}
+}
+
+func TestNVCFBackendAgentStatusCommandBuildsExplicitWait(t *testing.T) {
+	t.Setenv("BDD_BACKEND_NAME", "ncp-local-compute-1")
+	got, err := NVCFBackendAgentStatusCommand("${BDD_BACKEND_NAME}", "nvca-operator", "k3d-ncp-local-compute-1", "healthy", "10m")
+	if err != nil {
+		t.Fatalf("build command: %v", err)
+	}
+	want := "kubectl wait nvcfbackend ncp-local-compute-1 -n nvca-operator --context k3d-ncp-local-compute-1 --for=jsonpath={.status.agentStatus}=healthy --timeout=10m"
+	if got != want {
+		t.Fatalf("command = %q, want %q", got, want)
+	}
+}
+
+func TestKubernetesWaitCommandsRejectMissingInputs(t *testing.T) {
+	tests := []struct {
+		name        string
+		resource    string
+		namespace   string
+		kubeContext string
+		status      string
+		timeout     string
+	}{
+		{name: "resource", namespace: "nvca-operator", kubeContext: "k3d-ncp-local", status: "healthy", timeout: "10m"},
+		{name: "namespace", resource: "ncp-local", kubeContext: "k3d-ncp-local", status: "healthy", timeout: "10m"},
+		{name: "context", resource: "ncp-local", namespace: "nvca-operator", status: "healthy", timeout: "10m"},
+		{name: "status", resource: "ncp-local", namespace: "nvca-operator", kubeContext: "k3d-ncp-local", timeout: "10m"},
+		{name: "timeout", resource: "ncp-local", namespace: "nvca-operator", kubeContext: "k3d-ncp-local", status: "healthy"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := NVCFBackendAgentStatusCommand(test.resource, test.namespace, test.kubeContext, test.status, test.timeout); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+	if _, err := KubernetesDeploymentRolloutCommand("", "nvca-operator", "k3d-ncp-local", "10m"); err == nil {
+		t.Fatal("expected empty deployment name error")
+	}
+}
+
+func TestKubernetesWaitCommandsQuoteArguments(t *testing.T) {
+	got, err := NVCFBackendAgentStatusCommand("backend name", "operator namespace", "context name", "not ready", "10 m")
+	if err != nil {
+		t.Fatalf("build command: %v", err)
+	}
+	want := "kubectl wait nvcfbackend 'backend name' -n 'operator namespace' --context 'context name' --for=jsonpath={.status.agentStatus}='not ready' '--timeout=10 m'"
+	if got != want {
+		t.Fatalf("command = %q, want %q", got, want)
+	}
+}
+
 func TestKubectlApplyCommandTargetsExplicitContext(t *testing.T) {
 	got, err := KubectlApplyCommand("/tmp/bdd manifests/secret.yaml", "k3d-ncp-local-compute-1")
 	if err != nil {

--- a/tests/bdd/features/multi-cluster-eks-helmfile.feature
+++ b/tests/bdd/features/multi-cluster-eks-helmfile.feature
@@ -354,14 +354,12 @@ Feature: Install a multi-cluster NVCF stack across two pre-provisioned EKS clust
         | name          | namespace     |
         | nvca-operator | nvca-operator |
 
-      When I run command "kubectl rollout status deployment/nvca-operator -n nvca-operator --context ${EKS_COMPUTE_CONTEXT} --timeout=10m"
-      Then the command exit code should be 0
+      Then deployment "nvca-operator" in namespace "nvca-operator" using context "${EKS_COMPUTE_CONTEXT}" should complete rollout within "10m"
 
       # Wait for the NVCFBackend on the compute cluster to report the
       # agent healthy. The agent reaching ICMS healthy confirms the
       # cross-cluster Host-header + registration wiring works.
-      When I run command "kubectl wait nvcfbackend ${EKS_COMPUTE_CLUSTER_NAME} -n nvca-operator --context ${EKS_COMPUTE_CONTEXT} --for=jsonpath={.status.agentStatus}=healthy --timeout=10m"
-      Then the command exit code should be 0
+      Then NVCFBackend "${EKS_COMPUTE_CLUSTER_NAME}" in namespace "nvca-operator" using context "${EKS_COMPUTE_CONTEXT}" should report agent status "healthy" within "10m"
 
       # The pull secret is created only in nvca-operator; confirm the
       # operator propagated it to nvca-system. Asserting propagation here

--- a/tests/bdd/features/multi-cluster-helmfile.feature
+++ b/tests/bdd/features/multi-cluster-helmfile.feature
@@ -220,8 +220,7 @@ Feature: Install a local multi-cluster NVCF stack with Helmfile
         | name          | namespace     |
         | nvca-operator | nvca-operator |
 
-      When I run command "kubectl rollout status deployment/nvca-operator -n nvca-operator --context k3d-ncp-local-compute-1 --timeout=10m"
-      Then the command exit code should be 0
+      Then deployment "nvca-operator" in namespace "nvca-operator" using context "k3d-ncp-local-compute-1" should complete rollout within "10m"
 
       # The default NVCFBackend CR is created on the compute cluster
       # by the nvca-operator helm chart at install time (helm reports
@@ -229,8 +228,7 @@ Feature: Install a local multi-cluster NVCF stack with Helmfile
       # its own .status.agentStatus locally. The NVCFBackend CRD is
       # therefore only registered on k3d-ncp-local-compute-1, not on
       # k3d-ncp-local-cp. Wait on the compute cluster.
-      When I run command "kubectl wait nvcfbackend ncp-local-compute-1 -n nvca-operator --context k3d-ncp-local-compute-1 --for=jsonpath={.status.agentStatus}=healthy --timeout=10m"
-      Then the command exit code should be 0
+      Then NVCFBackend "ncp-local-compute-1" in namespace "nvca-operator" using context "k3d-ncp-local-compute-1" should report agent status "healthy" within "10m"
 
   Rule: Helmfile-installed multi-cluster NVCF can run workloads
 

--- a/tests/bdd/features/observability-all.feature
+++ b/tests/bdd/features/observability-all.feature
@@ -115,10 +115,8 @@ Feature: Install local Helmfile observability for both planes
       | default-monitors         | monitoring    | 1        |
       | nvca-operator            | nvca-operator | 1        |
 
-    When I run command "kubectl rollout status deployment/nvca-operator -n nvca-operator --context k3d-ncp-local --timeout=10m"
-    Then the command exit code should be 0
-    When I run command "kubectl wait nvcfbackend ncp-local -n nvca-operator --context k3d-ncp-local --for=jsonpath={.status.agentStatus}=healthy --timeout=10m"
-    Then the command exit code should be 0
+    Then deployment "nvca-operator" in namespace "nvca-operator" using context "k3d-ncp-local" should complete rollout within "10m"
+    Then NVCFBackend "ncp-local" in namespace "nvca-operator" using context "k3d-ncp-local" should report agent status "healthy" within "10m"
 
     Then Kubernetes resource "OpenTelemetryCollector/nvcf-observability" in namespace "monitoring" using context "k3d-ncp-local" should contain:
       """

--- a/tests/bdd/features/observability-compute.feature
+++ b/tests/bdd/features/observability-compute.feature
@@ -129,10 +129,8 @@ Feature: Install local Helmfile observability with the compute profile
       | default-monitors         | monitoring    |
       | nvca-operator            | nvca-operator |
 
-    When I run command "kubectl rollout status deployment/nvca-operator -n nvca-operator --context k3d-ncp-local-compute-1 --timeout=10m"
-    Then the command exit code should be 0
-    When I run command "kubectl wait nvcfbackend ncp-local-compute-1 -n nvca-operator --context k3d-ncp-local-compute-1 --for=jsonpath={.status.agentStatus}=healthy --timeout=10m"
-    Then the command exit code should be 0
+    Then deployment "nvca-operator" in namespace "nvca-operator" using context "k3d-ncp-local-compute-1" should complete rollout within "10m"
+    Then NVCFBackend "ncp-local-compute-1" in namespace "nvca-operator" using context "k3d-ncp-local-compute-1" should report agent status "healthy" within "10m"
 
     Then Kubernetes resource "OpenTelemetryCollector/nvcf-observability" in namespace "monitoring" using context "k3d-ncp-local-compute-1" should contain:
       """

--- a/tests/bdd/features/single-cluster-eks-helmfile.feature
+++ b/tests/bdd/features/single-cluster-eks-helmfile.feature
@@ -277,13 +277,11 @@ Feature: Install a single-cluster NVCF stack on a pre-provisioned EKS cluster wi
         | name          | namespace     |
         | nvca-operator | nvca-operator |
 
-      When I run command "kubectl rollout status deployment/nvca-operator -n nvca-operator --context ${EKS_CONTEXT} --timeout=10m"
-      Then the command exit code should be 0
+      Then deployment "nvca-operator" in namespace "nvca-operator" using context "${EKS_CONTEXT}" should complete rollout within "10m"
 
       # With chart-native Host headers the agent dials the bare-ELB URLs
       # (which DNS-resolve) and sends the gateway-matching Host header, so
       # the former dig + hostAliases patch + nvca rollout restart is no
       # longer needed. The operator brings the agent up directly; wait for
       # the NVCFBackend to report the agent healthy.
-      When I run command "kubectl wait nvcfbackend ${EKS_CLUSTER_NAME} -n nvca-operator --context ${EKS_CONTEXT} --for=jsonpath={.status.agentStatus}=healthy --timeout=10m"
-      Then the command exit code should be 0
+      Then NVCFBackend "${EKS_CLUSTER_NAME}" in namespace "nvca-operator" using context "${EKS_CONTEXT}" should report agent status "healthy" within "10m"

--- a/tests/bdd/features/single-cluster-helmfile.feature
+++ b/tests/bdd/features/single-cluster-helmfile.feature
@@ -145,11 +145,9 @@ Feature: Install a local single-cluster NVCF stack with Helmfile
         | name          | namespace     |
         | nvca-operator | nvca-operator |
 
-      When I run command "kubectl rollout status deployment/nvca-operator -n nvca-operator --timeout=10m"
-      Then the command exit code should be 0
+      Then deployment "nvca-operator" in namespace "nvca-operator" using context "k3d-ncp-local" should complete rollout within "10m"
 
-      When I run command "kubectl wait nvcfbackend ncp-local -n nvca-operator --for=jsonpath={.status.agentStatus}=healthy --timeout=10m"
-      Then the command exit code should be 0
+      Then NVCFBackend "ncp-local" in namespace "nvca-operator" using context "k3d-ncp-local" should report agent status "healthy" within "10m"
 
   Rule: Helmfile-installed local NVCF can run a sample function
 

--- a/tests/bdd/features/single-cluster-up-oneclick.feature
+++ b/tests/bdd/features/single-cluster-up-oneclick.feature
@@ -96,5 +96,4 @@ Feature: Bring up a local single-cluster NVCF stack with the self-hosted up one-
         | nvca-operator | nvca-operator |
 
       # The agent registered by up reports healthy.
-      When I run command "kubectl wait nvcfbackend ncp-local -n nvca-operator --context k3d-ncp-local --for=jsonpath={.status.agentStatus}=healthy --timeout=10m"
-      Then the command exit code should be 0
+      Then NVCFBackend "ncp-local" in namespace "nvca-operator" using context "k3d-ncp-local" should report agent status "healthy" within "10m"

--- a/tests/bdd/steps/assertion_steps.go
+++ b/tests/bdd/steps/assertion_steps.go
@@ -50,6 +50,8 @@ func registerAssertionSteps(ctx *godog.ScenarioContext, sc *ScenarioContext) {
 	ctx.Step(`^these Kubernetes resources should exist in namespace "([^"]*)" using context "([^"]*)":$`, sc.kubernetesResourcesShouldExist)
 	ctx.Step(`^these Kubernetes resources should not exist in namespace "([^"]*)" using context "([^"]*)":$`, sc.kubernetesResourcesShouldNotExist)
 	ctx.Step(`^Kubernetes resource "([^"/]+)/([^"]+)" in namespace "([^"]*)" using context "([^"]*)" should contain:$`, sc.kubernetesResourceShouldContain)
+	ctx.Step(`^deployment "([^"]*)" in namespace "([^"]*)" using context "([^"]*)" should complete rollout within "([^"]*)"$`, sc.deploymentShouldCompleteRollout)
+	ctx.Step(`^NVCFBackend "([^"]*)" in namespace "([^"]*)" using context "([^"]*)" should report agent status "([^"]*)" within "([^"]*)"$`, sc.nvcfBackendShouldReportAgentStatus)
 }
 
 func (sc *ScenarioContext) commandExitCodeShouldBe(expected int) error {
@@ -313,6 +315,28 @@ func (sc *ScenarioContext) kubernetesResourceShouldContain(ctx context.Context, 
 	}
 	if err := dsl.MatchYAMLDocument(sc.LastResult.Stdout, doc.Content, dsl.MatchSubset); err != nil {
 		return fmt.Errorf("kubernetes resource %s/%s does not contain the expected YAML subset: %w", kind, name, err)
+	}
+	return nil
+}
+
+func (sc *ScenarioContext) deploymentShouldCompleteRollout(ctx context.Context, name, namespace, kubeContext, timeout string) error {
+	command, err := dsl.KubernetesDeploymentRolloutCommand(name, namespace, kubeContext, timeout)
+	if err != nil {
+		return err
+	}
+	if err := sc.runSuccessfully(ctx, command); err != nil {
+		return fmt.Errorf("deployment %q did not complete rollout: %w", dsl.Interpolate(name), err)
+	}
+	return nil
+}
+
+func (sc *ScenarioContext) nvcfBackendShouldReportAgentStatus(ctx context.Context, name, namespace, kubeContext, agentStatus, timeout string) error {
+	command, err := dsl.NVCFBackendAgentStatusCommand(name, namespace, kubeContext, agentStatus, timeout)
+	if err != nil {
+		return err
+	}
+	if err := sc.runSuccessfully(ctx, command); err != nil {
+		return fmt.Errorf("NVCFBackend %q did not report agent status %q: %w", dsl.Interpolate(name), dsl.Interpolate(agentStatus), err)
 	}
 	return nil
 }

--- a/tests/bdd/steps/steps_test.go
+++ b/tests/bdd/steps/steps_test.go
@@ -669,6 +669,19 @@ func TestKubernetesResourceShouldContainRunsExplicitYAMLGet(t *testing.T) {
 	}
 }
 
+func TestDeploymentShouldCompleteRolloutRunsExplicitWait(t *testing.T) {
+	sc, fake := newScenarioContext(t)
+	fake.result = harness.Result{ExitCode: 0}
+
+	if err := sc.deploymentShouldCompleteRollout(context.Background(), "nvca-operator", "nvca-operator", "k3d-ncp-local", "10m"); err != nil {
+		t.Fatalf("wait for deployment rollout: %v", err)
+	}
+	want := "kubectl rollout status deployment/nvca-operator -n nvca-operator --context k3d-ncp-local --timeout=10m"
+	if len(fake.runs) != 1 || fake.runs[0].command != want {
+		t.Fatalf("runs = %#v, want %q", fake.runs, want)
+	}
+}
+
 func TestKubernetesResourceShouldContainFailureDoesNotExposeResourceValues(t *testing.T) {
 	sc, fake := newScenarioContext(t)
 	fake.result = harness.Result{ExitCode: 0, Stdout: `data:
@@ -693,6 +706,55 @@ func TestKubernetesResourceShouldContainFailureDoesNotExposeResourceValues(t *te
 		if strings.Contains(err.Error(), sensitive) {
 			t.Fatalf("error %q exposes %q", err, sensitive)
 		}
+	}
+}
+
+func TestNVCFBackendShouldReportAgentStatusRunsExplicitWait(t *testing.T) {
+	sc, fake := newScenarioContext(t)
+	fake.result = harness.Result{ExitCode: 0}
+
+	if err := sc.nvcfBackendShouldReportAgentStatus(context.Background(), "ncp-local", "nvca-operator", "k3d-ncp-local", "healthy", "10m"); err != nil {
+		t.Fatalf("wait for NVCFBackend status: %v", err)
+	}
+	want := "kubectl wait nvcfbackend ncp-local -n nvca-operator --context k3d-ncp-local --for=jsonpath={.status.agentStatus}=healthy --timeout=10m"
+	if len(fake.runs) != 1 || fake.runs[0].command != want {
+		t.Fatalf("runs = %#v, want %q", fake.runs, want)
+	}
+}
+
+func TestKubernetesReadinessFailuresNameTargetWithoutCommandOutput(t *testing.T) {
+	secretOutput := "registry-token-value"
+	for _, test := range []struct {
+		name string
+		run  func(*ScenarioContext) error
+		want string
+	}{
+		{
+			name: "deployment",
+			run: func(sc *ScenarioContext) error {
+				return sc.deploymentShouldCompleteRollout(context.Background(), "nvca-operator", "nvca-operator", "k3d-ncp-local", "10m")
+			},
+			want: "deployment \"nvca-operator\" did not complete rollout",
+		},
+		{
+			name: "backend",
+			run: func(sc *ScenarioContext) error {
+				return sc.nvcfBackendShouldReportAgentStatus(context.Background(), "ncp-local", "nvca-operator", "k3d-ncp-local", "healthy", "10m")
+			},
+			want: "NVCFBackend \"ncp-local\" did not report agent status \"healthy\"",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			sc, fake := newScenarioContext(t)
+			fake.result = harness.Result{ExitCode: 1, Stdout: secretOutput, Stderr: secretOutput}
+			err := test.run(sc)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want target context", err)
+			}
+			if strings.Contains(err.Error(), secretOutput) {
+				t.Fatalf("error leaked command output: %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## TL;DR

Add explicit-context BDD steps for Kubernetes deployment rollouts and NVCFBackend agent status, then migrate the local and EKS Helmfile features that repeat those waits.

## Additional Details

Raw `kubectl` command and exit-code pairs made the intent harder to scan. The new steps keep the deployment or backend name, namespace, context, expected status, and timeout visible while centralizing validation, shell quoting, and secret-safe failures.

The two issues are grouped because they share the same Kubernetes readiness seam and affected features.

## For the Reviewer

Focus on command construction in `tests/bdd/dsl/kubectl.go` and the abstraction level of the migrated Gherkin. Merged PR #1077's Kubernetes YAML assertion remains registered alongside these steps.

## For QA

Live local single- and multi-cluster coverage was run. Live EKS validation is still needed and tracked in #1087.

## Customer Release Notes

Not customer visible.

## Plan Summary

Not applicable.

## Usage

Feature files can assert rollout completion or NVCFBackend agent status without spelling out `kubectl` and a separate exit-code assertion. Namespace, context, status, and timeout remain explicit in Gherkin.

## Testing

- `go test -short ./...`: passed after rebase.
- `golangci-lint run --config .golangci.yml ./...`: 0 issues after rebase.
- `TestSingleClusterHelmfile`: passed, 6 scenarios and 65 steps.
- `TestObservabilityCompute`: passed, 1 scenario and 43 steps.
- `TestObservabilityAll`: passed, 1 scenario and 35 steps.
- `TestSingleClusterUpOneClick`: passed, 1 scenario and 12 steps, with the missing local environments and `OUTPUT_DIR` supplied as workarounds for #1090 and #1091.
- `TestMultiClusterHelmfile`: install, registration, rollout, and backend-health scenarios passed. The later NVCT task scenario failed because the installed pre-#1042 image emits the legacy function action; publishing and consuming the fix is tracked in #1093.
- EKS feature wiring passed under the short suite. Live EKS was not run.

## Notes

The local E2E runs used only `/tmp/kubeconfig-k3d-ncp-local` and explicitly named k3d contexts. No ambient EKS context was used.

## References

- #858
- #1087
- #1090
- #1091
- #1093

## Related Pull Requests

- #1077

## Dependencies

None. License review and NOTICE updates are not applicable.

## Issues

Closes #1081

Closes #1085

Relates to #858

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated validation steps for deployment rollout completion.
  * Added checks that NVCFBackend agents reach a healthy status.
  * Validation now supports explicit cluster context, namespace, and timeout settings.

* **Bug Fixes**
  * Improved failure reporting by identifying the affected deployment or backend resource.

* **Tests**
  * Added coverage for command validation, quoting, timeouts, and readiness failure handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->