### PR TITLE
fix(cli): make one-click local installs self-contained

### DIFF
--- a/src/clis/nvcf-cli/cmd/self_hosted_up.go
+++ b/src/clis/nvcf-cli/cmd/self_hosted_up.go
@@ -683,7 +683,7 @@ func (r *selfHostedUpRun) applyComputePlane(stackPath string, registration upClu
 		Stdout:          r.helmfileStdout,
 		Stderr:          r.helmfileStderr,
 		Ctx:             r.ctx,
-		ExtraEnv:        registration.computePlaneEnv(),
+		ExtraEnv:        registration.computePlaneEnv(filepath.Join(stackPath, "out")),
 	})
 	stopWatcher(cancelWatcher, watcherDone)
 	if err != nil {
@@ -1064,7 +1064,7 @@ func (r *selfHostedUpRun) emitFinalFailure() {
 	})
 }
 
-func (r upClusterRegistration) computePlaneEnv() []string {
+func (r upClusterRegistration) computePlaneEnv(outputDir string) []string {
 	return []string{
 		"CLUSTER_NAME=" + upClusterName,
 		"CLUSTER_ID=" + r.ClusterID,
@@ -1072,6 +1072,9 @@ func (r upClusterRegistration) computePlaneEnv() []string {
 		"IDENTITY_SOURCE=" + r.IdentitySource,
 		"NCA_ID=" + r.NCAID,
 		"CLUSTER_REGION=" + r.Region,
+		// The compute-plane Helmfile reads its registration handoff from
+		// $OUTPUT_DIR/$CLUSTER_NAME-register-values.yaml.
+		"OUTPUT_DIR=" + outputDir,
 	}
 }
 

--- a/src/clis/nvcf-cli/cmd/self_hosted_up_test.go
+++ b/src/clis/nvcf-cli/cmd/self_hosted_up_test.go
@@ -208,17 +208,22 @@ func TestSelfHostedUp_PlainEmitsPhaseLines(t *testing.T) {
 		return "https://k8s.example/.well-known/oidc", `{"keys":[]}`, "psat", nil
 	}
 
-	// Provide a stack tree + a fake helmfile binary that emits a stub
-	// manifest. The helmfile binary is invoked twice: once for control plane
-	// (helmfile.d/ default) and once for compute plane.
-	stackDir := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(stackDir, "helmfile.d"), 0o755))
-	require.NoError(t, os.MkdirAll(filepath.Join(stackDir, "out"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(stackDir, "global.yaml.gotmpl"), []byte("# stub\n"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(stackDir, "out", "test-register-values.yaml"), []byte("clusterID: stale-id\n"), 0o644))
+	// Provide separate custom stack trees so the test proves compute-plane
+	// environment values are derived from the resolved compute stack.
+	controlPlaneStackDir := t.TempDir()
+	computePlaneStackDir := t.TempDir()
+	for _, stackDir := range []string{controlPlaneStackDir, computePlaneStackDir} {
+		require.NoError(t, os.MkdirAll(filepath.Join(stackDir, "helmfile.d"), 0o755))
+		require.NoError(t, os.MkdirAll(filepath.Join(stackDir, "out"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(stackDir, "global.yaml.gotmpl"), []byte("# stub\n"), 0o644))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(computePlaneStackDir, "out", "test-register-values.yaml"), []byte("clusterID: stale-id\n"), 0o644))
+	helmfileLog := filepath.Join(t.TempDir(), "helmfile.log")
+	t.Setenv("NVCF_TEST_HELMFILE_LOG", helmfileLog)
+	t.Setenv("OUTPUT_DIR", "")
 	fakeBin := filepath.Join(t.TempDir(), "helmfile")
 	require.NoError(t, os.WriteFile(fakeBin,
-		[]byte("#!/bin/sh\nprintf 'apiVersion: v1\\nkind: ConfigMap\\nmetadata:\\n  name: stub\\n'\n"),
+		[]byte("#!/bin/sh\nprintf '%s|%s\\n' \"$*\" \"$OUTPUT_DIR\" >> \"$NVCF_TEST_HELMFILE_LOG\"\nprintf 'apiVersion: v1\\nkind: ConfigMap\\nmetadata:\\n  name: stub\\n'\n"),
 		0o755))
 	t.Setenv("PATH", filepath.Dir(fakeBin)+":"+os.Getenv("PATH"))
 
@@ -238,8 +243,8 @@ func TestSelfHostedUp_PlainEmitsPhaseLines(t *testing.T) {
 	rootCmd.SetArgs([]string{
 		"self-hosted", "up",
 		"--cluster-name=test",
-		"--control-plane-stack", stackDir,
-		"--compute-plane-stack", stackDir,
+		"--control-plane-stack", controlPlaneStackDir,
+		"--compute-plane-stack", computePlaneStackDir,
 		"--plain",
 	})
 	require.NoError(t, rootCmd.Execute())
@@ -253,7 +258,7 @@ func TestSelfHostedUp_PlainEmitsPhaseLines(t *testing.T) {
 	assert.Regexp(t, `\[03/8\] render-cp: starting`, out)
 	assert.Regexp(t, `\[04/8\] apply-cp: starting`, out)
 	assert.Regexp(t, `\[04/8\] apply-cp: complete`, out)
-	profilePath := filepath.Join(stackDir, "out", "control-plane-profile.yaml")
+	profilePath := filepath.Join(controlPlaneStackDir, "out", "control-plane-profile.yaml")
 	assert.Contains(t, out, "Wrote control-plane profile: "+profilePath)
 	assert.Regexp(t, `\[05/8\] check-cp: starting`, out)
 	assert.Regexp(t, `\[06/8\] register: starting`, out)
@@ -280,11 +285,19 @@ func TestSelfHostedUp_PlainEmitsPhaseLines(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(profileBody), "kind: ControlPlaneProfile")
 	assert.Contains(t, string(profileBody), "clusterName: test")
-	registerValues, err := os.ReadFile(filepath.Join(stackDir, "out", "test-register-values.yaml"))
+	registerValues, err := os.ReadFile(filepath.Join(computePlaneStackDir, "out", "test-register-values.yaml"))
 	require.NoError(t, err)
 	assert.Contains(t, string(registerValues), "icmsServiceURL: http://api.sis.svc.cluster.local:8080")
 	assert.Contains(t, string(registerValues), "revalServiceURL: http://reval.nvcf.svc.cluster.local:8080")
 	assert.Contains(t, string(registerValues), "natsURL: nats://nats.nats-system.svc.cluster.local:4222")
+	helmfileInvocations, err := os.ReadFile(helmfileLog)
+	require.NoError(t, err)
+	invocations := strings.Split(strings.TrimSpace(string(helmfileInvocations)), "\n")
+	require.Len(t, invocations, 2)
+	assert.Contains(t, invocations[0], controlPlaneStackDir+"/helmfile.d/")
+	assert.True(t, strings.HasSuffix(invocations[0], "|"), "control-plane Helmfile must not receive OUTPUT_DIR: %s", invocations[0])
+	assert.Contains(t, invocations[1], computePlaneStackDir+"/helmfile.d/")
+	assert.True(t, strings.HasSuffix(invocations[1], "|"+filepath.Join(computePlaneStackDir, "out")), "compute-plane Helmfile must receive its stack-local OUTPUT_DIR: %s", invocations[1])
 }
 
 // TestUp_PlanOnly_NoHelmfileInvocation runs the orchestrator with --plan-only

--- a/tests/bdd/features/single-cluster-up-oneclick.feature
+++ b/tests/bdd/features/single-cluster-up-oneclick.feature
@@ -29,12 +29,26 @@ Feature: Bring up a local single-cluster NVCF stack with the self-hosted up one-
         | NGC_API_KEY     |
         | SAMPLE_NGC_ORG  |
         | SAMPLE_NGC_TEAM |
-      # self-hosted up --env local reads operator-authored local secrets
-      # from both split stacks:
-      # deploy/stacks/self-managed/secrets/local-secrets.yaml.
-      # Only secrets.yaml.template is tracked in each stack. Author both
-      # files from the templates; the Ledger restores or removes them at
+      # self-hosted up --env local reads operator-authored environment
+      # values from both split stacks. Author both local.yaml files from
+      # the tracked BDD fixtures; the Ledger restores or removes them at
       # suite teardown.
+      And I copy the file "tests/bdd/fixtures/self-managed-local-bdd.yaml" to "deploy/stacks/self-managed/environments/local.yaml"
+      And I update yaml file "deploy/stacks/self-managed/environments/local.yaml" with keys:
+        | global.imagePullSecrets[0].name               | nvcr-pull-secret                                                   |
+        | global.helm.sources.repository                | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}                               |
+        | global.image.repository                       | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}                               |
+        | api.env.NVCF_SIDECARS_LLM_ROUTER_CLIENT_IMAGE | nvcr.io/${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}/stargate-client:0.2.0 |
+        | observability.profile                         | disabled                                                           |
+      And I copy the file "tests/bdd/fixtures/nvcf-compute-plane-local-bdd.yaml" to "deploy/stacks/nvcf-compute-plane/environments/local.yaml"
+      And I update yaml file "deploy/stacks/nvcf-compute-plane/environments/local.yaml" with keys:
+        | global.imagePullSecrets[0].name | nvcr-pull-secret                     |
+        | global.helm.sources.repository  | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM} |
+        | global.image.repository         | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM} |
+        | observability.profile           | disabled                             |
+      # The control-plane stack also requires an operator-authored local
+      # secrets file. Author it from the tracked template; the Ledger gives
+      # it the same restore-or-remove behavior as the environment files.
       And I copy the file "deploy/stacks/self-managed/secrets/secrets.yaml.template" to "deploy/stacks/self-managed/secrets/local-secrets.yaml"
       And I substitute "REPLACE_WITH_BASE64_DOCKER_CREDENTIAL" in file "deploy/stacks/self-managed/secrets/local-secrets.yaml" with base64 of "$oauthtoken:${NGC_API_KEY}"
       # Conflict precheck: ncp-local-cp's k3d serverlb claims

--- a/tests/bdd/godog_test.go
+++ b/tests/bdd/godog_test.go
@@ -322,6 +322,8 @@ func TestSingleClusterUpOneClickFeatureFileWiresToSteps(t *testing.T) {
 		"k3d cluster get ncp-local-cp": {ExitCode: 1},
 	}))
 	seedStackSecretsTemplate(t, suite.Config.RepoRoot)
+	seedHelmfileLocalBDDFixture(t, suite.Config.RepoRoot)
+	seedComputePlaneLocalBDDFixture(t, suite.Config.RepoRoot)
 
 	sc := steps.NewScenarioContext(suite)
 	featurePath := mustResolveFeaturePath(t, "single-cluster-up-oneclick.feature")


### PR DESCRIPTION
## TL;DR

Make the local one-click BDD scenario self-contained and let `nvcf-cli self-hosted up` locate the compute-plane registration handoff without a caller-provided `OUTPUT_DIR`.

## Additional Details

A fresh worktree lacked both operator-owned `local.yaml` files, so the one-click feature failed before install. After supplying those files, compute-plane Helmfile rendering failed because the CLI did not provide its required output directory.

The feature now authors both local environments from tracked fixtures. The CLI passes `<resolved-compute-stack>/out` only to the compute-plane Helmfile process, matching the stack Makefile contract without polluting control-plane or parent processes. The full-flow unit test uses distinct custom stack paths and verifies that boundary.

This PR is stacked on #1094. It can be rebased onto `main` after #1094 merges.

## For the Reviewer

Focus on the scoped environment construction in `self_hosted_up.go` and the one-click Background setup. The implementation intentionally leaves the user action as one `self-hosted up` command.

## For QA

Local destructive QA passed from a fresh `ncp-local` topology. No additional local QA is needed. CI and the existing EKS follow-up remain applicable.

## Customer Release Notes

`nvcf-cli self-hosted up` now completes local compute-plane installation without requiring callers to set `OUTPUT_DIR`.

## Plan Summary

No deployed resource shape changes. The CLI supplies the compute stack's existing output-directory contract to Helmfile.

## Usage

No command changes. Continue using `nvcf-cli self-hosted up` without exporting `OUTPUT_DIR`.

## Testing

- `go test ./...` in `src/clis/nvcf-cli`: passed.
- `go test -short ./...` in `tests/bdd`: passed.
- `go vet ./...` in both modules: passed.
- `TestSingleClusterUpOneClick`: passed, 1 scenario and 16 steps in 14m08s after destructive topology cleanup.
- Live run used only `/tmp/kubeconfig-k3d-ncp-local`, explicitly unset parent `OUTPUT_DIR`, installed `nvca-operator`, and observed `NVCFBackend/ncp-local` healthy.
- Local `golangci-lint 2.12.2` could not discover Go files under either this worktree or the unchanged #1094 worktree with Go 1.26.3. CI lint validation is still required.

## Notes

- The BDD ledger removed the authored local environment and secret files after the passing run.
- The final `ncp-local` cluster remains available for inspection.
- No architecture or sequence diagram changes are needed.

## References

- #1090
- #1091

## Related Pull Requests

- #1094

## Dependencies

None. License review and NOTICE updates are not applicable.

## Issues

Closes #1090

Closes #1091

Relates to #858

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved self-hosted deployments by enabling compute-plane registration handoff through the stack’s output directory.
  * Ensured control-plane and compute-plane deployments use their respective stack paths and configuration.

* **Tests**
  * Expanded end-to-end coverage for separate control-plane and compute-plane stacks.
  * Added validation for Helmfile invocation paths and compute-plane output settings.
  * Updated one-click deployment scenarios with complete local environment fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->