### PR TITLE
fix(ratelimiter): log metrics server bind failures at error level

### DIFF
--- a/src/invocation-plane-services/ratelimiter/cmd/BUILD.bazel
+++ b/src/invocation-plane-services/ratelimiter/cmd/BUILD.bazel
@@ -85,6 +85,7 @@ go_test(
     srcs = [
         "info_test.go",
         "main_test.go",
+        "metrics_test.go",
     ],
     embed = [":cmd_lib"],
     deps = [
@@ -100,5 +101,6 @@ go_test(
         "@org_golang_google_grpc//status",
         "@org_golang_x_exp//rand",
         "@org_uber_go_zap//:zap",
+        "@org_uber_go_zap//zaptest/observer",
     ],
 )

--- a/src/invocation-plane-services/ratelimiter/cmd/main.go
+++ b/src/invocation-plane-services/ratelimiter/cmd/main.go
@@ -68,7 +68,7 @@ func setupMetrics() {
 	go func() {
 		err := http.ListenAndServe("0.0.0.0:7776", mux)
 		if err != nil {
-
+			zap.L().Error("metrics server failed", zap.Error(err))
 		}
 	}()
 }

--- a/src/invocation-plane-services/ratelimiter/cmd/metrics_test.go
+++ b/src/invocation-plane-services/ratelimiter/cmd/metrics_test.go
@@ -1,0 +1,48 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// TestSetupMetricsLogsServeFailure guards against silently discarding the
+// metrics server's ListenAndServe error (NVIDIA/nvcf#540). The metrics port is
+// occupied up front so the bind fails deterministically, and the global logger
+// is swapped for an observer so the error-level log line can be asserted.
+func TestSetupMetricsLogsServeFailure(t *testing.T) {
+	ln, err := net.Listen("tcp", "0.0.0.0:7776")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	observed, logs := observer.New(zap.InfoLevel)
+	restore := zap.ReplaceGlobals(zap.New(observed))
+	defer restore()
+
+	setupMetrics()
+
+	require.Eventually(t, func() bool {
+		return len(logs.FilterMessage("metrics server failed").All()) > 0
+	}, 5*time.Second, 10*time.Millisecond)
+}


### PR DESCRIPTION
## What

`setupMetrics` in `src/invocation-plane-services/ratelimiter/cmd/main.go` discarded the `http.ListenAndServe` error in an empty branch:

```go
err := http.ListenAndServe("0.0.0.0:7776", mux)
if err != nil {

}
```

If the Prometheus listener cannot bind, the service keeps running with no metrics and logs nothing — scrapes fail with connection refused and there is no signal in the pod logs. This fixes #540.

## Change

- Log the bind/serve failure at error level, matching the sibling `setupPprof` and `setupOlricStats` servers in the same file.
- Add `metrics_test.go`: a regression test that occupies `0.0.0.0:7776` so the bind fails deterministically, swaps the global logger for a `zaptest/observer`, and asserts the `metrics server failed` log line is emitted.
- Wire `metrics_test.go` into the `cmd_test` bazel target.

## Verification

- `go build ./cmd/...` passes.
- `go vet ./cmd/` passes.
- `go test ./cmd/ -run TestSetupMetricsLogsServeFailure -count=1` passes.

The empty branch is the only code path the fix touches; the error log uses the same `zap.L().Error(...)` idiom already used by the other two servers in the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Metrics server startup or serving failures are now logged with an error message, improving visibility when the metrics endpoint cannot run.

- **Tests**
  - Added coverage to verify that metrics server listen failures produce the expected log message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->