### PR TITLE
fix(cassandra): support current NVCT task schema

### DIFF
--- a/deploy/helm/cassandra/helm/values.yaml
+++ b/deploy/helm/cassandra/helm/values.yaml
@@ -196,7 +196,7 @@ cassandra:
       # repository: must be supplied in additional values
       registry: ""
       repository: ""
-      tag: 0.16.0
+      tag: 0.17.1
       pullPolicy: Always
 
   dbUser:

--- a/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
@@ -162,7 +162,7 @@ releases:
 {{- end }}
 
   - name: cassandra
-    version: 0.20.1
+    version: 0.20.2
     condition: cassandra.enabled # From defaults.yaml or env overrides
     namespace: cassandra-system
     <<: *dependency # Inherits base values from the dependency template

--- a/migrations/cassandra/tests/test-execute-sqls.sh
+++ b/migrations/cassandra/tests/test-execute-sqls.sh
@@ -90,4 +90,15 @@ if ! grep -q '^until cqlsh ' "${script}"; then
   fail "execute_sqls.sh must retain the Cassandra authentication readiness check"
 fi
 
+nvct_schema="${keyspaces}/nvct_api/03_init_tables.up.sql"
+if ! grep -F -q 'health                         TEXT' "${nvct_schema}"; then
+  fail "NVCT fresh schema is missing tasks_v2.health"
+fi
+
+nvct_health_migration="${keyspaces}/nvct_api/04_add_health.up.sql"
+if ! grep -F -q 'ALTER TABLE nvct_api.tasks_v2 ADD IF NOT EXISTS health TEXT;' \
+  "${nvct_health_migration}"; then
+  fail "NVCT upgrade migration does not add tasks_v2.health idempotently"
+fi
+
 exit "${status}"


### PR DESCRIPTION
## TL;DR

Makes the packaged Cassandra schema and initialization hook compatible with
current NVCT releases.

## Additional Details

Current NVCT writes `tasks_v2.health`, but the self-managed schema does not
define that column. Fresh installs now include it, and existing keyspaces
receive an additive, idempotent migration.

Cassandra pod readiness can also precede CQL native transport and bootstrap
superuser authentication. The initialization hook now waits for both states
before deciding whether password reconciliation is required.

The migration image moves to `0.17.1`, the Cassandra chart release moves to
`0.20.2`, and the self-managed stack consumes that chart.

## For the Reviewer

Review the fresh-install schema and upgrade migration together. The hook retry
test covers delayed native transport and delayed authentication without logging
credentials.

## Customer Release Notes

Self-managed Cassandra supports current NVCT task records and handles normal
startup readiness races.

## Plan Summary

Adds one nullable Cassandra column and bounded readiness checks to the existing
initialization job. No Kubernetes resources are added or removed.

## Usage

Use the existing self-managed install or upgrade workflow.

## For QA

- `deploy/helm/cassandra/tests/test-initdb.sh`
- `migrations/cassandra/tests/test-execute-sqls.sh`
- `helm lint deploy/helm/cassandra/helm`
- A combined local multi-cluster run completed an NVCT task when this change
  and the corrected NVCT release were applied together.
- The standalone NVCT task E2E remains blocked until the release from #1032 is
  consumed by the self-managed stack.

## Notes

This PR contains no NVCT image or NVCT chart changes.

## References

- #1098
- #1032

## Related Pull Requests

- #1042
- #1097
- #1100

## Dependencies

No third-party dependency changes. License review and NOTICE updates are not
required.

## Issues

Fixes #1098
Relates to #1032

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the latest Cassandra migrations release.
  * Updated the Cassandra dependency release.

* **Bug Fixes**
  * Improved database schema upgrades by safely adding the task health field when it is missing.

* **Tests**
  * Added validation for the task health field in both the canonical schema and upgrade migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->