### PR TITLE
fix(nvct-api): consume corrected task scheduling release

### DIFF
--- a/deploy/helm/cloud-tasks/nvct-api/Chart.yaml
+++ b/deploy/helm/cloud-tasks/nvct-api/Chart.yaml
@@ -4,4 +4,4 @@ description: NCP Compatible deployment of NVCT API (nvct-service)
 
 type: application
 version: 0.0.0 # autoversioning enabled via release pipeline
-appVersion: "1.63.2"
+appVersion: "1.64.1"

--- a/deploy/helm/cloud-tasks/nvct-api/values.yaml
+++ b/deploy/helm/cloud-tasks/nvct-api/values.yaml
@@ -3,7 +3,7 @@ nvctApi:
     registry: "" # must be supplied
     repository: "" # must be supplied
     pullPolicy: IfNotPresent
-    tag: "1.63.2"
+    tag: "1.64.1"
 
   # Namespace to deploy the resources. The default value is the release namespace.
   namespace: ""

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -65,7 +65,7 @@ releases:
       - ess/ess-api
 
   - name: nvct-api
-    version: 1.4.3
+    version: 1.5.2
     namespace: nvcf
     inherit:
       - template: service


### PR DESCRIPTION
## TL;DR

Updates the native NVCT chart to Cloud Tasks `1.63.4` and makes the
self-managed stack consume NVCT chart `1.5.2`.

## Additional Details

The self-managed stack still consumes an NVCT release that sends the generic
SIS request action for tasks. The shared translator treats that as a function
request. #1042 corrected the NVCT request to `RequestInstancesForTask`, and the
fix is available in Cloud Tasks `1.63.4`.

This PR updates both the native chart image default and the top-level
self-managed Helmfile pin so the corrected behavior reaches installations.

## For the Reviewer

The Cloud Tasks `1.63.4` source tag exists. The native chart release generated
from this change is `1.5.2`; the self-managed stack pin consumes that release.

## Customer Release Notes

Self-managed NVCT tasks use the task-specific instance request path.

## Plan Summary

No resources are added or removed. One service image and one chart pin change.

## Usage

Use the existing self-managed install or upgrade workflow.

## For QA

- `helm lint deploy/helm/cloud-tasks/nvct-api`
- Rendered image and app labels resolve to `1.63.4`.
- A combined local multi-cluster run completed an NVCT task when this change
  and #1098's Cassandra compatibility fix were applied together.
- The standalone NVCT task E2E remains blocked by #1098.

## Notes

This PR contains no Cassandra schema or initialization changes.

## References

- #1032

## Related Pull Requests

- #1042
- #1097
- #1099

## Dependencies

No third-party dependency changes. License review and NOTICE updates are not
required.

## Issues

Relates to #1032
Relates to #1098

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the NVCT API deployment to version 1.64.1.
  * Updated the associated Helm release to chart version 1.5.2.
  * Aligned deployment metadata and container image versions for the latest release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->