### PR TITLE
test(bdd): authenticate Helm registries safely

### DIFF
--- a/tests/bdd/AGENTS.md
+++ b/tests/bdd/AGENTS.md
@@ -55,8 +55,9 @@ logic into `dsl/`.
 - Bootstrap Givens (`a single-cluster ncp-local cluster is running`,
   `multi-cluster ncp-local compute clusters are running:`, `Helm is
   authenticated to OCI registry ...`, `the ... image pull secret exists in
-  namespaces:`) each wrap exactly one Make target, one Helm invocation, or one
-  `kubectl apply` per row. Caching is idempotent per suite; the underlying
+  namespaces:`) each wrap exactly one Make target or one Helm invocation. The
+  image pull secret Given applies one namespace manifest and one docker-registry
+  secret manifest per row. Caching is idempotent per suite; the underlying
   bootstrap runs at most once even if multiple scenarios name the Given.
 - The Helm OCI registry authentication Given reads `NGC_API_KEY` from the
   process environment and passes it only through

--- a/tests/bdd/AGENTS.md
+++ b/tests/bdd/AGENTS.md
@@ -53,11 +53,15 @@ logic into `dsl/`.
   env vars differ must miss the cache. The cache lives in
   `Suite.Cache`.
 - Bootstrap Givens (`a single-cluster ncp-local cluster is running`,
-  `multi-cluster ncp-local compute clusters are running:`, `the ...
-  image pull secret exists in namespaces:`) each wrap exactly one
-  Make target or one `kubectl apply` per row. Caching is idempotent
-  per suite; the underlying Make runs at most once even if multiple
-  scenarios name the Given.
+  `multi-cluster ncp-local compute clusters are running:`, `Helm is
+  authenticated to OCI registry ...`, `the ... image pull secret exists in
+  namespaces:`) each wrap exactly one Make target, one Helm invocation, or one
+  `kubectl apply` per row. Caching is idempotent per suite; the underlying
+  bootstrap runs at most once even if multiple scenarios name the Given.
+- The Helm OCI registry authentication Given reads `NGC_API_KEY` from the
+  process environment and passes it only through
+  `CommandRunner.RunWithSensitiveStdin`. The key must never be interpolated
+  into command text, argv, command logs, captured output, or failure messages.
 - Features that bring up a `tools/ncp-local-cluster` topology must
   include a conflict precheck in their Background before the
   bootstrap Given, asserting the OTHER topology is absent. Use

--- a/tests/bdd/PLAN.md
+++ b/tests/bdd/PLAN.md
@@ -57,7 +57,7 @@ implementation detail, not a license to omit the precondition.
 | `Given a single-cluster ncp-local cluster is running` | `make -C tools/ncp-local-cluster build-and-deploy-cluster`. Runs once per suite. |
 | `Given multi-cluster ncp-local compute clusters are running:` (table, see below) | Wraps `make -C tools/ncp-local-cluster build-and-deploy-multicluster COMPUTE_CLUSTER_COUNT=N`. Runs once per suite. |
 | `Given Helm is authenticated to OCI registry {string} using the current NGC API key` | Runs `helm registry login` once per explicit, interpolated registry. The current `NGC_API_KEY` is supplied through sensitive stdin and is redacted from captured output, command logs, and failures. |
-| `Given the {string} image pull secret exists in namespaces:` (table) | `kubectl create namespace <ns>` + `kubectl create secret docker-registry` for each row. Hidden because the docker-registry secret syntax leaks the API key to argv. |
+| `Given the {string} image pull secret exists in namespaces:` (table) | Applies one namespace manifest and one docker-registry secret manifest for each row. Hidden because direct docker-registry secret commands leak the API key to argv. |
 
 Compute-cluster table contract for the multi-cluster bootstrap Given:
 

--- a/tests/bdd/PLAN.md
+++ b/tests/bdd/PLAN.md
@@ -41,9 +41,10 @@ regex restricted to `\$\{[A-Z0-9_]+\}`.
 ### Infrastructure bootstrap (Given)
 
 These are the only Givens that hide a CLI invocation, and each one wraps
-exactly one Make target or one composite of `kubectl` calls. They contain
-no business logic. Spelling them out in raw `make` calls would balloon
-the feature file without adding coverage.
+exactly one Make target, one Helm authentication command, or one composite of
+`kubectl` calls. They contain no business logic. Spelling out their stable
+command and secret-handling mechanics would balloon the feature file without
+adding coverage.
 
 The bootstrap Givens are idempotent and cached per suite. The first
 scenario that names the Given runs the underlying Make target; later
@@ -55,6 +56,7 @@ implementation detail, not a license to omit the precondition.
 |------|-------|
 | `Given a single-cluster ncp-local cluster is running` | `make -C tools/ncp-local-cluster build-and-deploy-cluster`. Runs once per suite. |
 | `Given multi-cluster ncp-local compute clusters are running:` (table, see below) | Wraps `make -C tools/ncp-local-cluster build-and-deploy-multicluster COMPUTE_CLUSTER_COUNT=N`. Runs once per suite. |
+| `Given Helm is authenticated to OCI registry {string} using the current NGC API key` | Runs `helm registry login` once per explicit, interpolated registry. The current `NGC_API_KEY` is supplied through sensitive stdin and is redacted from captured output, command logs, and failures. |
 | `Given the {string} image pull secret exists in namespaces:` (table) | `kubectl create namespace <ns>` + `kubectl create secret docker-registry` for each row. Hidden because the docker-registry secret syntax leaks the API key to argv. |
 
 Compute-cluster table contract for the multi-cluster bootstrap Given:
@@ -246,11 +248,12 @@ only these steps. Add a shared step when a repeated action or observable keeps
 its meaningful inputs visible and hides only command or output-format
 mechanics. Otherwise use `When I run command` plus an output assertion.
 
-The infrastructure-bootstrap Givens (cluster up, image pull secret) and
-the single `Given command has succeeded:` carry-over are the only places
-where the strict DSL bends to share state across scenarios. Each one's
-hidden work is one CLI invocation, visible by either the wrapped Make
-target or the docstring command text.
+The infrastructure-bootstrap Givens (cluster up, Helm registry
+authentication, image pull secret) and the single
+`Given command has succeeded:` carry-over are the only places where the strict
+DSL bends to share state across scenarios. Each one's hidden work is one CLI
+invocation, visible through the named operator action, explicit target, wrapped
+Make target, or docstring command text.
 
 ## What this displaces from tests/bdd
 

--- a/tests/bdd/dsl/helm.go
+++ b/tests/bdd/dsl/helm.go
@@ -38,6 +38,20 @@ type helmRelease struct {
 	Status    string `json:"status"`
 }
 
+// HelmRegistryLoginCommand builds a Helm OCI registry login command whose
+// password must be supplied on stdin by the caller.
+func HelmRegistryLoginCommand(registry string) (string, error) {
+	registry = strings.TrimSpace(Interpolate(registry))
+	if registry == "" {
+		return "", fmt.Errorf("OCI registry is empty")
+	}
+	return strings.Join([]string{
+		"helm", "registry", "login", quoteCommandArg(registry),
+		"--username", quoteCommandArg("$oauthtoken"),
+		"--password-stdin",
+	}, " "), nil
+}
+
 // HelmListCommand builds an explicit-context, all-namespaces Helm list command.
 func HelmListCommand(kubeContext string) (string, error) {
 	kubeContext = strings.TrimSpace(Interpolate(kubeContext))

--- a/tests/bdd/dsl/helm_test.go
+++ b/tests/bdd/dsl/helm_test.go
@@ -27,6 +27,24 @@ const deployedHelmReleases = `[
   {"name":"api","namespace":"nvcf","revision":3,"status":"failed"}
 ]`
 
+func TestHelmRegistryLoginCommandInterpolatesRegistry(t *testing.T) {
+	t.Setenv("BDD_TMP_REGISTRY", "nvcr.io")
+	got, err := HelmRegistryLoginCommand("${BDD_TMP_REGISTRY}")
+	if err != nil {
+		t.Fatalf("build command: %v", err)
+	}
+	want := "helm registry login nvcr.io --username '$oauthtoken' --password-stdin"
+	if got != want {
+		t.Fatalf("command = %q, want %q", got, want)
+	}
+}
+
+func TestHelmRegistryLoginCommandRejectsEmptyRegistry(t *testing.T) {
+	if _, err := HelmRegistryLoginCommand(""); err == nil {
+		t.Fatal("expected empty registry error")
+	}
+}
+
 func TestHelmListCommandUsesExplicitContext(t *testing.T) {
 	t.Setenv("BDD_TMP_CONTEXT", "k3d-ncp-local")
 	got, err := HelmListCommand("${BDD_TMP_CONTEXT}")

--- a/tests/bdd/features/multi-cluster-eks-helmfile.feature
+++ b/tests/bdd/features/multi-cluster-eks-helmfile.feature
@@ -65,13 +65,9 @@ Feature: Install a multi-cluster NVCF stack across two pre-provisioned EKS clust
       | EKS_COMPUTE_CLUSTER_NAME |
       | EKS_REGION               |
     # Helmfile pulls OCI charts through helm, so host-side helm
-    # registry auth must be present before any helmfile sync.
-    # Keep $NGC_API_KEY unbraced so the BDD runner does not expand
-    # the secret into command logs; bash expands it at execution time.
-    And command has succeeded:
-      """
-      bash -c 'set -eo pipefail; printf %s "$NGC_API_KEY" | helm registry login nvcr.io --username "\$oauthtoken" --password-stdin'
-      """
+    # Registry authentication must be present before any helmfile sync. The
+    # current API key is passed through sensitive stdin.
+    And Helm is authenticated to OCI registry "nvcr.io" using the current NGC API key
     # Create NGC dockerconfig registry credentials.
     And I prepare self-managed secrets file "deploy/stacks/self-managed/secrets/eks-bdd-multi-secrets.yaml" from template "deploy/stacks/self-managed/secrets/secrets.yaml.template" using the current NGC registry credential
     # Both clusters must be reachable before we start.

--- a/tests/bdd/features/observability-all.feature
+++ b/tests/bdd/features/observability-all.feature
@@ -13,12 +13,9 @@ Feature: Install local Helmfile observability for both planes
       | SAMPLE_NGC_TEAM |
       | NVCF_CLI        |
       | REPO_ROOT       |
-    # Helmfile pulls OCI charts during installation. Keep $NGC_API_KEY unbraced
-    # so the BDD runner does not expand it into command logs.
-    And command has succeeded:
-      """
-      bash -c 'set -eo pipefail; printf %s "$NGC_API_KEY" | helm registry login nvcr.io --username "\$oauthtoken" --password-stdin'
-      """
+    # Helmfile pulls OCI charts during installation. Authenticate before sync
+    # without exposing the current API key in command arguments or logs.
+    And Helm is authenticated to OCI registry "nvcr.io" using the current NGC API key
     # Configure the control-plane stack and its shared observability child.
     And I prepare Helmfile environment "local-bdd-observability-all" for stack "self-managed" from fixture "tests/bdd/fixtures/self-managed-local-bdd.yaml" with values:
       | global.imagePullSecrets[0].name | nvcr-pull-secret                     |

--- a/tests/bdd/features/observability-compute.feature
+++ b/tests/bdd/features/observability-compute.feature
@@ -14,12 +14,9 @@ Feature: Install local Helmfile observability with the compute profile
       | SAMPLE_NGC_TEAM |
       | NVCF_CLI        |
       | REPO_ROOT       |
-    # Helmfile pulls OCI charts during installation. Keep $NGC_API_KEY unbraced
-    # so the BDD runner does not expand it into command logs.
-    And command has succeeded:
-      """
-      bash -c 'set -eo pipefail; printf %s "$NGC_API_KEY" | helm registry login nvcr.io --username "\$oauthtoken" --password-stdin'
-      """
+    # Helmfile pulls OCI charts during installation. Authenticate before sync
+    # without exposing the current API key in command arguments or logs.
+    And Helm is authenticated to OCI registry "nvcr.io" using the current NGC API key
     # Install only control-plane prerequisites on ncp-local-cp. Shared
     # observability is installed separately on the compute cluster below.
     And I prepare Helmfile environment "local-bdd-observability-compute" for stack "self-managed" from fixture "tests/bdd/fixtures/self-managed-local-bdd-multi.yaml" with values:

--- a/tests/bdd/features/observability-control.feature
+++ b/tests/bdd/features/observability-control.feature
@@ -10,12 +10,9 @@ Feature: Install local Helmfile observability with the control profile
       | NGC_API_KEY     |
       | SAMPLE_NGC_ORG  |
       | SAMPLE_NGC_TEAM |
-    # Helmfile pulls OCI charts during installation. Keep $NGC_API_KEY unbraced
-    # so the BDD runner does not expand it into command logs.
-    And command has succeeded:
-      """
-      bash -c 'set -eo pipefail; printf %s "$NGC_API_KEY" | helm registry login nvcr.io --username "\$oauthtoken" --password-stdin'
-      """
+    # Helmfile pulls OCI charts during installation. Authenticate before sync
+    # without exposing the current API key in command arguments or logs.
+    And Helm is authenticated to OCI registry "nvcr.io" using the current NGC API key
     # Set the self-managed stack environment.
     And I prepare Helmfile environment "local-bdd-observability-control" for stack "self-managed" from fixture "tests/bdd/fixtures/self-managed-local-bdd.yaml" with values:
       | global.imagePullSecrets[0].name | nvcr-pull-secret                     |

--- a/tests/bdd/features/observability-disabled.feature
+++ b/tests/bdd/features/observability-disabled.feature
@@ -11,7 +11,7 @@ Feature: Render local Helmfile stacks with observability disabled
       | SAMPLE_NGC_ORG  |
       | SAMPLE_NGC_TEAM |
       | REPO_ROOT       |
-    # Helmfile pulls OCI charts during rendering. Authenticate before sync
+    # Helmfile pulls OCI charts during rendering. Authenticate before render
     # without exposing the current API key in command arguments or logs.
     And Helm is authenticated to OCI registry "nvcr.io" using the current NGC API key
     # Create the self-managed stack environment used by the control-plane render.

--- a/tests/bdd/features/observability-disabled.feature
+++ b/tests/bdd/features/observability-disabled.feature
@@ -11,12 +11,9 @@ Feature: Render local Helmfile stacks with observability disabled
       | SAMPLE_NGC_ORG  |
       | SAMPLE_NGC_TEAM |
       | REPO_ROOT       |
-    # Helmfile pulls OCI charts during rendering. Keep $NGC_API_KEY unbraced
-    # so the BDD runner does not expand it into command logs.
-    And command has succeeded:
-      """
-      bash -c 'set -eo pipefail; printf %s "$NGC_API_KEY" | helm registry login nvcr.io --username "\$oauthtoken" --password-stdin'
-      """
+    # Helmfile pulls OCI charts during rendering. Authenticate before sync
+    # without exposing the current API key in command arguments or logs.
+    And Helm is authenticated to OCI registry "nvcr.io" using the current NGC API key
     # Create the self-managed stack environment used by the control-plane render.
     And I prepare Helmfile environment "local-bdd-observability-disabled" for stack "self-managed" from fixture "tests/bdd/fixtures/self-managed-local-bdd.yaml" with values:
       | global.imagePullSecrets[0].name | nvcr-pull-secret                     |

--- a/tests/bdd/features/single-cluster-eks-helmfile.feature
+++ b/tests/bdd/features/single-cluster-eks-helmfile.feature
@@ -63,13 +63,9 @@ Feature: Install a single-cluster NVCF stack on a pre-provisioned EKS cluster wi
       | EKS_CLUSTER_NAME |
       | EKS_REGION       |
     # Helmfile pulls OCI charts through helm, so host-side helm
-    # registry auth must be present before any helmfile sync.
-    # Keep $NGC_API_KEY unbraced so the BDD runner does not expand
-    # the secret into command logs; bash expands it at execution time.
-    And command has succeeded:
-      """
-      bash -c 'set -eo pipefail; printf %s "$NGC_API_KEY" | helm registry login nvcr.io --username "\$oauthtoken" --password-stdin'
-      """
+    # Registry authentication must be present before any helmfile sync. The
+    # current API key is passed through sensitive stdin.
+    And Helm is authenticated to OCI registry "nvcr.io" using the current NGC API key
     # Create NGC dockerconfig registry credentials
     And I prepare self-managed secrets file "deploy/stacks/self-managed/secrets/eks-bdd-secrets.yaml" from template "deploy/stacks/self-managed/secrets/secrets.yaml.template" using the current NGC registry credential
     And I run command "kubectl --context ${EKS_CONTEXT} get nodes -o name"

--- a/tests/bdd/godog_test.go
+++ b/tests/bdd/godog_test.go
@@ -50,6 +50,16 @@ func (f *fakeRunner) Run(_ context.Context, command string) (harness.Result, err
 	return harness.Result{ExitCode: 0}, nil
 }
 
+// RunWithSensitiveStdin records only the command. Sensitive input must never
+// enter wiring-test diagnostics or command assertions.
+func (f *fakeRunner) RunWithSensitiveStdin(
+	ctx context.Context,
+	command,
+	_ string,
+) (harness.Result, error) {
+	return f.Run(ctx, command)
+}
+
 // RunWithTTY records and resolves identically to Run; the fake does not
 // allocate a pty.
 func (f *fakeRunner) RunWithTTY(ctx context.Context, command string) (harness.Result, error) {
@@ -500,7 +510,7 @@ func TestSingleClusterHelmfileFeatureFileWiresToSteps(t *testing.T) {
 // shared releases and monitor resources through explicit local context calls.
 func TestObservabilityControlFeatureFileWiresToSteps(t *testing.T) {
 	const (
-		registryLoginCommand    = `bash -c 'set -eo pipefail; printf %s "$NGC_API_KEY" | helm registry login nvcr.io --username "\$oauthtoken" --password-stdin'`
+		registryLoginCommand    = "helm registry login nvcr.io --username '$oauthtoken' --password-stdin"
 		serviceMonitorCommand   = "kubectl get servicemonitor/nvcf-default-monitors-state-metrics --namespace monitoring --context k3d-ncp-local -o name"
 		absentPodMonitorCommand = "kubectl get podmonitor/nvcf-default-monitors-worker --namespace monitoring --context k3d-ncp-local --ignore-not-found -o name"
 		collectorYAMLCommand    = "kubectl get opentelemetrycollector/nvcf-observability --namespace monitoring --context k3d-ncp-local -o yaml"
@@ -594,7 +604,7 @@ spec:
 // cluster and that the compute profile verifies its releases and monitors.
 func TestObservabilityComputeFeatureFileWiresToSteps(t *testing.T) {
 	const (
-		registryLoginCommand        = `bash -c 'set -eo pipefail; printf %s "$NGC_API_KEY" | helm registry login nvcr.io --username "\$oauthtoken" --password-stdin'`
+		registryLoginCommand        = "helm registry login nvcr.io --username '$oauthtoken' --password-stdin"
 		serviceMonitorCommand       = "kubectl get servicemonitor/nvcf-default-monitors-nvca --namespace monitoring --context k3d-ncp-local-compute-1 -o name"
 		podMonitorCommand           = "kubectl get podmonitor/nvcf-default-monitors-worker --namespace monitoring --context k3d-ncp-local-compute-1 -o name"
 		absentServiceMonitorCommand = "kubectl get servicemonitor/nvcf-default-monitors-state-metrics --namespace monitoring --context k3d-ncp-local-compute-1 --ignore-not-found -o name"
@@ -717,7 +727,7 @@ func observabilityComputeHelmListJSON() string {
 // local context and verifies that one shared stack serves both monitor sets.
 func TestObservabilityAllFeatureFileWiresToSteps(t *testing.T) {
 	const (
-		registryLoginCommand    = `bash -c 'set -eo pipefail; printf %s "$NGC_API_KEY" | helm registry login nvcr.io --username "\$oauthtoken" --password-stdin'`
+		registryLoginCommand    = "helm registry login nvcr.io --username '$oauthtoken' --password-stdin"
 		serviceMonitorCommand   = "kubectl get servicemonitor/nvcf-default-monitors-state-metrics --namespace monitoring --context k3d-ncp-local -o name"
 		podMonitorCommand       = "kubectl get podmonitor/nvcf-default-monitors-worker --namespace monitoring --context k3d-ncp-local -o name"
 		collectorEnabledCommand = `bash -c 'set -eo pipefail; helm get values nvca-operator --namespace nvca-operator --kube-context k3d-ncp-local -o json | jq -r ".selfManaged.otelCollector.enabled"'`
@@ -1011,6 +1021,7 @@ func TestSingleClusterHelmfileUpstreamImagesFeatureFileWiresToSteps(t *testing.T
 // mirrors the local Helmfile inputs while the feature asserts disabled profile
 // renders omit observability resources from both stacks.
 func TestObservabilityDisabledFeatureFileWiresToSteps(t *testing.T) {
+	const registryLoginCommand = "helm registry login nvcr.io --username '$oauthtoken' --password-stdin"
 	t.Setenv("NGC_API_KEY", "test-key")
 	t.Setenv("SAMPLE_NGC_ORG", "test-org")
 	t.Setenv("SAMPLE_NGC_TEAM", "test-team")
@@ -1041,6 +1052,9 @@ func TestObservabilityDisabledFeatureFileWiresToSteps(t *testing.T) {
 		t.Fatalf("godog suite status = %d\n%s", status, out.String())
 	}
 	runs := suite.Runner.(*fakeRunner).runs
+	if !commandRanExactly(runs, registryLoginCommand) {
+		t.Fatal("Helm OCI registry login command was never invoked")
+	}
 	if !commandRanThatContains(runs, "deploy/stacks/self-managed template HELMFILE_ENV=local-bdd-observability-disabled") {
 		t.Fatal("control-plane Helmfile template command was never invoked")
 	}
@@ -1349,10 +1363,11 @@ selfManaged:
 // assertion expects to see.
 func TestSingleClusterEKSHelmfileFeatureFileWiresToSteps(t *testing.T) {
 	const (
-		eksContext      = "arn:aws:eks:us-east-1:000000000000:cluster/wiring-test"
-		eksClusterName  = "wiring-test"
-		eksRegion       = "us-east-1"
-		wiringGatewayLB = "wiring-elb.example.invalid"
+		eksContext           = "arn:aws:eks:us-east-1:000000000000:cluster/wiring-test"
+		eksClusterName       = "wiring-test"
+		eksRegion            = "us-east-1"
+		wiringGatewayLB      = "wiring-elb.example.invalid"
+		registryLoginCommand = "helm registry login nvcr.io --username '$oauthtoken' --password-stdin"
 	)
 	t.Setenv("NGC_API_KEY", "test-key")
 	t.Setenv("SAMPLE_NGC_ORG", "test-org")
@@ -1401,6 +1416,9 @@ func TestSingleClusterEKSHelmfileFeatureFileWiresToSteps(t *testing.T) {
 	if status != 0 {
 		t.Fatalf("godog suite status = %d\n%s", status, out.String())
 	}
+	if !commandRanExactly(suite.Runner.(*fakeRunner).runs, registryLoginCommand) {
+		t.Fatal("Helm OCI registry login command was never invoked")
+	}
 	if !commandRanThatContains(suite.Runner.(*fakeRunner).runs, "install HELMFILE_ENV=eks-bdd") {
 		t.Fatal("helmfile install make target was never invoked")
 	}
@@ -1422,12 +1440,13 @@ func TestSingleClusterEKSHelmfileFeatureFileWiresToSteps(t *testing.T) {
 // EKS_GATEWAY_ADDR from the canned gateway stdout.
 func TestMultiClusterEKSHelmfileFeatureFileWiresToSteps(t *testing.T) {
 	const (
-		cpContext           = "arn:aws:eks:us-east-1:000000000000:cluster/wiring-cp"
-		computeContext      = "arn:aws:eks:us-east-1:000000000000:cluster/wiring-compute"
-		computeClusterName  = "wiring-compute"
-		eksRegion           = "us-east-1"
-		wiringGatewayLB     = "wiring-cp-elb.example.invalid"
-		wiringGatewayDomain = "192-0-2-10.nip.io"
+		cpContext            = "arn:aws:eks:us-east-1:000000000000:cluster/wiring-cp"
+		computeContext       = "arn:aws:eks:us-east-1:000000000000:cluster/wiring-compute"
+		computeClusterName   = "wiring-compute"
+		eksRegion            = "us-east-1"
+		wiringGatewayLB      = "wiring-cp-elb.example.invalid"
+		wiringGatewayDomain  = "192-0-2-10.nip.io"
+		registryLoginCommand = "helm registry login nvcr.io --username '$oauthtoken' --password-stdin"
 	)
 	t.Setenv("NGC_API_KEY", "test-key")
 	t.Setenv("SAMPLE_NGC_ORG", "test-org")
@@ -1512,6 +1531,9 @@ func TestMultiClusterEKSHelmfileFeatureFileWiresToSteps(t *testing.T) {
 	}.Run()
 	if status != 0 {
 		t.Fatalf("godog suite status = %d\n%s", status, out.String())
+	}
+	if !commandRanExactly(suite.Runner.(*fakeRunner).runs, registryLoginCommand) {
+		t.Fatal("Helm OCI registry login command was never invoked")
 	}
 	if !commandRanThatContains(suite.Runner.(*fakeRunner).runs, "install HELMFILE_ENV=eks-bdd-multi") {
 		t.Fatal("helmfile install make target was never invoked")

--- a/tests/bdd/harness/cleanup_test.go
+++ b/tests/bdd/harness/cleanup_test.go
@@ -37,6 +37,14 @@ func (r *recordingRunner) Run(_ context.Context, command string) (Result, error)
 	return r.nextResult, r.nextErr
 }
 
+func (r *recordingRunner) RunWithSensitiveStdin(
+	ctx context.Context,
+	command,
+	_ string,
+) (Result, error) {
+	return r.Run(ctx, command)
+}
+
 func (r *recordingRunner) RunWithTTY(ctx context.Context, command string) (Result, error) {
 	return r.Run(ctx, command)
 }

--- a/tests/bdd/harness/runner.go
+++ b/tests/bdd/harness/runner.go
@@ -48,6 +48,10 @@ type Result struct {
 // calling here; the runner sees only the resolved argv.
 type CommandRunner interface {
 	Run(ctx context.Context, commandText string) (Result, error)
+	// RunWithSensitiveStdin supplies sensitiveStdin on the child's stdin.
+	// The value is redacted from captured output, command logs, and returned
+	// errors. Callers must still keep it out of commandText and argv.
+	RunWithSensitiveStdin(ctx context.Context, commandText, sensitiveStdin string) (Result, error)
 	// RunWithTTY runs commandText with stdin attached to a pseudo-terminal
 	// so the child process sees a terminal on fd 0 (term.IsTerminal(0) is
 	// true). It is for commands that gate interactive-only behavior on a
@@ -83,19 +87,38 @@ func NewCommandRunner(cwd, logDir string) CommandRunner {
 // A non-zero exit code is reported through the returned error along
 // with a populated Result.
 func (r *execRunner) Run(ctx context.Context, commandText string) (Result, error) {
-	return r.run(ctx, commandText, false)
+	return r.run(ctx, commandText, runOptions{})
+}
+
+// RunWithSensitiveStdin is Run with sensitiveStdin connected to the child's
+// stdin and redacted from every value returned or persisted by the runner.
+func (r *execRunner) RunWithSensitiveStdin(
+	ctx context.Context,
+	commandText,
+	sensitiveStdin string,
+) (Result, error) {
+	return r.run(ctx, commandText, runOptions{
+		stdin:           sensitiveStdin,
+		sensitiveValues: []string{sensitiveStdin},
+	})
 }
 
 // RunWithTTY is Run with the child's stdin attached to a pty slave so it
 // observes a terminal on fd 0. See the CommandRunner interface comment.
 func (r *execRunner) RunWithTTY(ctx context.Context, commandText string) (Result, error) {
-	return r.run(ctx, commandText, true)
+	return r.run(ctx, commandText, runOptions{withTTY: true})
 }
 
-func (r *execRunner) run(ctx context.Context, commandText string, withTTY bool) (Result, error) {
+type runOptions struct {
+	withTTY         bool
+	stdin           string
+	sensitiveValues []string
+}
+
+func (r *execRunner) run(ctx context.Context, commandText string, options runOptions) (Result, error) {
 	argv, err := shlex.Split(commandText)
 	if err != nil {
-		return Result{}, fmt.Errorf("parse command %q: %w", commandText, err)
+		return Result{}, fmt.Errorf("parse command %q: %w", redactSensitive(commandText, options.sensitiveValues), err)
 	}
 	if len(argv) == 0 {
 		return Result{}, errors.New("empty command")
@@ -106,7 +129,7 @@ func (r *execRunner) run(ctx context.Context, commandText string, withTTY bool) 
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	var ptmx *os.File
-	if withTTY {
+	if options.withTTY {
 		// Attach stdin to a pty slave so term.IsTerminal(0) is true in the
 		// child. Keep the master open until the command exits so Linux keeps
 		// fd 0 attached to a live terminal; callers use ctx to bound commands
@@ -114,7 +137,7 @@ func (r *execRunner) run(ctx context.Context, commandText string, withTTY bool) 
 		var pts *os.File
 		ptmxFile, ptsFile, ptyErr := pty.Open()
 		if ptyErr != nil {
-			return Result{}, fmt.Errorf("open pty for %q: %w", commandText, ptyErr)
+			return Result{}, fmt.Errorf("open pty for %q: %w", redactSensitive(commandText, options.sensitiveValues), ptyErr)
 		}
 		ptmx = ptmxFile
 		pts = ptsFile
@@ -125,25 +148,45 @@ func (r *execRunner) run(ctx context.Context, commandText string, withTTY bool) 
 				_ = ptmx.Close()
 			}
 		}()
+	} else if options.stdin != "" {
+		cmd.Stdin = strings.NewReader(options.stdin)
 	}
 	runErr := cmd.Start()
 	if runErr == nil {
 		runErr = cmd.Wait()
 	}
 	result := Result{
-		Stdout: stdout.String(),
-		Stderr: stderr.String(),
+		Stdout: redactSensitive(stdout.String(), options.sensitiveValues),
+		Stderr: redactSensitive(stderr.String(), options.sensitiveValues),
 	}
 	if cmd.ProcessState != nil {
 		result.ExitCode = cmd.ProcessState.ExitCode()
 	} else {
 		result.ExitCode = -1
 	}
-	r.writeLog(commandText, argv, result)
+	redactedCommand := redactSensitive(commandText, options.sensitiveValues)
+	redactedArgv := make([]string, len(argv))
+	for i, arg := range argv {
+		redactedArgv[i] = redactSensitive(arg, options.sensitiveValues)
+	}
+	r.writeLog(redactedCommand, redactedArgv, result)
 	if runErr != nil {
-		return result, fmt.Errorf("command %q failed: %w", commandText, runErr)
+		return result, fmt.Errorf(
+			"command %q failed: %w",
+			redactedCommand,
+			errors.New(redactSensitive(runErr.Error(), options.sensitiveValues)),
+		)
 	}
 	return result, nil
+}
+
+func redactSensitive(value string, sensitiveValues []string) string {
+	for _, sensitive := range sensitiveValues {
+		if sensitive != "" {
+			value = strings.ReplaceAll(value, sensitive, "[REDACTED]")
+		}
+	}
+	return value
 }
 
 func (r *execRunner) writeLog(commandText string, argv []string, result Result) {

--- a/tests/bdd/harness/runner_test.go
+++ b/tests/bdd/harness/runner_test.go
@@ -132,3 +132,37 @@ func TestCommandRunnerWritesLogFiles(t *testing.T) {
 		}
 	}
 }
+
+func TestCommandRunnerSensitiveStdinIsRedacted(t *testing.T) {
+	logDir := t.TempDir()
+	runner := NewCommandRunner(t.TempDir(), logDir)
+	const secret = "runner-secret-value"
+	command := `sh -c "value=$(cat); printf '%s' \"$value\"; printf '%s' \"$value\" >&2; exit 1"`
+	result, err := runner.RunWithSensitiveStdin(context.Background(), command, secret)
+	if err == nil {
+		t.Fatal("expected command failure")
+	}
+	for label, value := range map[string]string{
+		"stdout": result.Stdout,
+		"stderr": result.Stderr,
+		"error":  err.Error(),
+	} {
+		if strings.Contains(value, secret) {
+			t.Fatalf("%s leaked sensitive stdin: %q", label, value)
+		}
+	}
+	for label, value := range map[string]string{"stdout": result.Stdout, "stderr": result.Stderr} {
+		if !strings.Contains(value, "[REDACTED]") {
+			t.Fatalf("%s did not preserve a redacted diagnostic: %q", label, value)
+		}
+	}
+	for _, suffix := range []string{".cmd", ".stdout", ".stderr"} {
+		body, readErr := os.ReadFile(filepath.Join(logDir, "0001"+suffix))
+		if readErr != nil {
+			t.Fatalf("read log %s: %v", suffix, readErr)
+		}
+		if strings.Contains(string(body), secret) {
+			t.Fatalf("log %s leaked sensitive stdin: %q", suffix, body)
+		}
+	}
+}

--- a/tests/bdd/steps/infra_steps.go
+++ b/tests/bdd/steps/infra_steps.go
@@ -19,6 +19,7 @@ package steps
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -27,6 +28,7 @@ import (
 	"github.com/cucumber/godog"
 
 	"nvcf-bdd/dsl"
+	"nvcf-bdd/harness"
 )
 
 const (
@@ -38,16 +40,64 @@ const (
 
 var computeClusterRE = regexp.MustCompile(computeClusterNamePattern)
 
-// registerInfraSteps hooks the three infrastructure-bootstrap Givens
-// spelled out in PLAN.md. Each wraps exactly one Make target or one
-// composite of kubectl calls; the bootstrap make commands are cached
-// per suite so a feature with N scenarios re-runs the cluster build
-// at most once.
+// registerInfraSteps hooks the infrastructure-bootstrap Givens spelled out in
+// PLAN.md. Each wraps one named operator action, Make target, or composite of
+// kubectl calls. Idempotent actions are cached per suite.
 func registerInfraSteps(ctx *godog.ScenarioContext, sc *ScenarioContext) {
 	ctx.Step(`^a single-cluster ncp-local cluster is running$`, sc.singleClusterIsRunning)
 	ctx.Step(`^multi-cluster ncp-local compute clusters are running:$`, sc.multiClusterComputeRunning)
+	ctx.Step(`^Helm is authenticated to OCI registry "([^"]*)" using the current NGC API key$`, sc.helmIsAuthenticatedToOCIRegistry)
 	ctx.Step(`^the "([^"]*)" image pull secret exists in namespaces:$`, sc.pullSecretInNamespaces)
 	ctx.Step(`^the "([^"]*)" image pull secret exists in namespaces using context "([^"]*)":$`, sc.pullSecretInNamespacesUsingContext)
+}
+
+func (sc *ScenarioContext) helmIsAuthenticatedToOCIRegistry(ctx context.Context, registry string) error {
+	resolvedRegistry := strings.TrimSpace(dsl.Interpolate(registry))
+	command, err := dsl.HelmRegistryLoginCommand(resolvedRegistry)
+	if err != nil {
+		return err
+	}
+	apiKey := os.Getenv("NGC_API_KEY")
+	if apiKey == "" {
+		return fmt.Errorf("NGC_API_KEY is not set")
+	}
+	if sc.Suite.Cache.Has(command) {
+		sc.LastResult = harness.Result{ExitCode: 0}
+		sc.LastErr = nil
+		sc.LastCommand = command
+		return nil
+	}
+
+	result, runErr := sc.Suite.Runner.RunWithSensitiveStdin(ctx, command, apiKey)
+	result.Stdout = redactValue(result.Stdout, apiKey)
+	result.Stderr = redactValue(result.Stderr, apiKey)
+	sc.LastResult = result
+	sc.LastCommand = command
+	if runErr != nil {
+		safeRunErr := errors.New(redactValue(runErr.Error(), apiKey))
+		sc.LastErr = safeRunErr
+		diagnostic := strings.TrimSpace(result.Stderr)
+		if diagnostic == "" {
+			diagnostic = safeRunErr.Error()
+		}
+		return fmt.Errorf(
+			"authenticate Helm to OCI registry %q: exit code %d: %s",
+			resolvedRegistry,
+			result.ExitCode,
+			diagnostic,
+		)
+	}
+
+	sc.LastErr = nil
+	sc.Suite.Cache.Record(command)
+	return nil
+}
+
+func redactValue(value, sensitive string) string {
+	if sensitive == "" {
+		return value
+	}
+	return strings.ReplaceAll(value, sensitive, "[REDACTED]")
 }
 
 func (sc *ScenarioContext) singleClusterIsRunning(ctx context.Context) error {

--- a/tests/bdd/steps/steps_test.go
+++ b/tests/bdd/steps/steps_test.go
@@ -34,7 +34,8 @@ import (
 )
 
 type recordedRun struct {
-	command string
+	command        string
+	sensitiveStdin string
 }
 
 type fakeRunner struct {
@@ -45,6 +46,15 @@ type fakeRunner struct {
 
 func (f *fakeRunner) Run(_ context.Context, command string) (harness.Result, error) {
 	f.runs = append(f.runs, recordedRun{command: command})
+	return f.result, f.err
+}
+
+func (f *fakeRunner) RunWithSensitiveStdin(
+	_ context.Context,
+	command,
+	sensitiveStdin string,
+) (harness.Result, error) {
+	f.runs = append(f.runs, recordedRun{command: command, sensitiveStdin: sensitiveStdin})
 	return f.result, f.err
 }
 
@@ -777,6 +787,70 @@ func TestSingleClusterBootstrapCachesAcrossCalls(t *testing.T) {
 	}
 	if len(fake.runs) != 1 {
 		t.Fatalf("runs = %d, want 1 (cache should suppress the second call)", len(fake.runs))
+	}
+}
+
+func TestHelmRegistryAuthenticationUsesSensitiveStdinAndCaches(t *testing.T) {
+	sc, fake := newScenarioContext(t)
+	t.Setenv("NGC_API_KEY", "super-secret-token")
+	t.Setenv("BDD_TMP_REGISTRY", "nvcr.io")
+
+	for i := 0; i < 2; i++ {
+		if err := sc.helmIsAuthenticatedToOCIRegistry(context.Background(), "${BDD_TMP_REGISTRY}"); err != nil {
+			t.Fatalf("authenticate call %d: %v", i+1, err)
+		}
+	}
+	if len(fake.runs) != 1 {
+		t.Fatalf("runs = %d, want 1", len(fake.runs))
+	}
+	wantCommand := "helm registry login nvcr.io --username '$oauthtoken' --password-stdin"
+	if fake.runs[0].command != wantCommand {
+		t.Fatalf("command = %q, want %q", fake.runs[0].command, wantCommand)
+	}
+	if fake.runs[0].sensitiveStdin != "super-secret-token" {
+		t.Fatal("NGC API key was not supplied through sensitive stdin")
+	}
+	if strings.Contains(fake.runs[0].command, "super-secret-token") {
+		t.Fatalf("NGC API key leaked into command: %q", fake.runs[0].command)
+	}
+	if sc.LastResult.ExitCode != 0 {
+		t.Fatalf("cached result exit code = %d, want 0", sc.LastResult.ExitCode)
+	}
+}
+
+func TestHelmRegistryAuthenticationRedactsFailure(t *testing.T) {
+	sc, fake := newScenarioContext(t)
+	const apiKey = "super-secret-token"
+	t.Setenv("NGC_API_KEY", apiKey)
+	fake.result = harness.Result{ExitCode: 1, Stderr: "unauthorized: " + apiKey}
+	fake.err = errors.New("login failed for " + apiKey)
+
+	err := sc.helmIsAuthenticatedToOCIRegistry(context.Background(), "nvcr.io")
+	if err == nil {
+		t.Fatal("expected authentication failure")
+	}
+	for label, value := range map[string]string{
+		"returned error": err.Error(),
+		"LastErr":        sc.LastErr.Error(),
+		"stderr":         sc.LastResult.Stderr,
+	} {
+		if strings.Contains(value, apiKey) {
+			t.Fatalf("%s leaked NGC API key: %q", label, value)
+		}
+	}
+	if !strings.Contains(err.Error(), "exit code 1") || !strings.Contains(err.Error(), "unauthorized") {
+		t.Fatalf("error lacks useful diagnostics: %v", err)
+	}
+}
+
+func TestHelmRegistryAuthenticationRequiresAPIKey(t *testing.T) {
+	sc, fake := newScenarioContext(t)
+	t.Setenv("NGC_API_KEY", "")
+	if err := sc.helmIsAuthenticatedToOCIRegistry(context.Background(), "nvcr.io"); err == nil {
+		t.Fatal("expected error when NGC_API_KEY is unset")
+	}
+	if len(fake.runs) != 0 {
+		t.Fatalf("runs = %d, want 0", len(fake.runs))
 	}
 }
 


### PR DESCRIPTION
## TL;DR

Replace six repeated Helm OCI login shell pipelines with one explicit BDD step that keeps the NGC API key out of command text, argv, logs, and failures.

## Additional Details

- Add `Helm is authenticated to OCI registry ... using the current NGC API key` to the strict DSL catalog.
- Pass the key through `CommandRunner.RunWithSensitiveStdin` and redact accidental echoes from captured output, logs, and errors.
- Migrate the four observability and two EKS Helmfile features.
- Cover command construction, interpolation, caching, diagnostics, secret hygiene, and feature wiring.

## For the Reviewer

The main review seam is the sensitive-stdin and redaction contract in `tests/bdd/harness/runner.go`, followed by the thin handler in `tests/bdd/steps/infra_steps.go`.

## For QA

Passed:

- `go test ./dsl ./harness ./steps`
- `go test -short ./...`
- `golangci-lint run --config .golangci.yml ./...`
- `TestObservabilityDisabled` live render
- `TestObservabilityControl` live on a fresh single-cluster k3d topology
- `TestObservabilityAll` live on a fresh single-cluster k3d topology
- `TestObservabilityCompute` live on a fresh multi-cluster k3d topology

The EKS feature wiring passed in the short suite. Live EKS runs require pre-provisioned clusters and remain tracked by #1087. The local `ncp-local*` clusters were removed after testing.

## Issues

Closes #1079

## Related Pull Requests

None.

## Dependencies

None. No license or NOTICE changes.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dedicated Helm OCI registry authentication during infrastructure setup.
  - Supports authentication for each configured registry using the current API key.
  - Image pull secret bootstrap now applies namespace and registry secret manifests consistently.

- **Security**
  - Sensitive credentials are supplied via protected input and redacted from commands, logs, output, and errors.
  - Missing credentials fail clearly without attempting authentication.

- **Bug Fixes**
  - Prevented repeated authentication for registries already logged in successfully.
  - Improved failure diagnostics while protecting sensitive information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->