### PR TITLE
fix(openbao-migrations): retry kv-v2 upgrade errors

### DIFF
--- a/.github/workflows/openbao-migrations.yml
+++ b/.github/workflows/openbao-migrations.yml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Integration test for the OpenBao migrations helper functions. Runs a real
+# OpenBao server in Docker and drives the helpers through the kv-v2
+# storage-upgrade window that every mount setup opens, asserting they retry
+# through the transient 400, preserve skip semantics, and still fail fast
+# on real errors.
+
+name: openbao-migrations
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'migrations/openbao/**'
+      - '.github/workflows/openbao-migrations.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'migrations/openbao/**'
+      - '.github/workflows/openbao-migrations.yml'
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: openbao-migrations-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  kv-write-retry:
+    name: kv write retry integration test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run kv write retry test
+        run: migrations/openbao/tests/kv-write-retry-test.sh

--- a/.github/workflows/openbao-migrations.yml
+++ b/.github/workflows/openbao-migrations.yml
@@ -3,9 +3,9 @@
 #
 # Integration test for the OpenBao migrations helper functions. Runs a real
 # OpenBao server in Docker and drives the helpers through the kv-v2
-# storage-upgrade window that every mount setup opens, asserting they retry
-# through the transient 400, preserve skip semantics, and still fail fast
-# on real errors.
+# storage-upgrade window that every mount setup opens, asserting the
+# readiness wait rides it out, unwaited writes fail without overwriting,
+# and other errors fail fast.
 
 name: openbao-migrations
 

--- a/migrations/openbao/README.md
+++ b/migrations/openbao/README.md
@@ -71,7 +71,7 @@ Environment variables consumed by the entrypoint:
 | `DEFAULT_CASSANDRA_PASSWORD` | `ch@ng3m3` (override required) | See above |
 | `NVCF_API_SIDECARS_IMAGE_PULL_SECRET` | `""` | Image pull secret name passed to the NVCF API sidecar mount |
 | `MIGRATIONS_ALLOW_FAILURES` | `false` | Emergency rollback only. When `true`, the entrypoint exits 0 even if core migrations or opted-in addons failed. Default behavior fails the Job non-zero so a misconfigured deployment blocks the Helm hook Job instead of silently leaving OpenBao in a partial state. |
-| `BAO_TRANSIENT_RETRY_BUDGET_SECONDS` | `60` | Total time the helper functions retry kv-v2 reads and writes that fail with OpenBao's transient storage-upgrade error (HTTP 400 "Upgrading from non-versioned to versioned data") before failing the migration. Also bounds the readiness wait after enabling a kv-v2 mount. Other errors fail immediately. |
+| `BAO_KV_UPGRADE_RETRY_BUDGET_SECONDS` | `60` | Total time the helper functions retry kv-v2 reads and writes that fail with OpenBao's storage-upgrade error (HTTP 400 "Upgrading from non-versioned to versioned data") before failing the migration. Also bounds the readiness wait after enabling a kv-v2 mount. Other errors fail immediately. |
 
 ### Example Kubernetes Job
 

--- a/migrations/openbao/README.md
+++ b/migrations/openbao/README.md
@@ -71,7 +71,7 @@ Environment variables consumed by the entrypoint:
 | `DEFAULT_CASSANDRA_PASSWORD` | `ch@ng3m3` (override required) | See above |
 | `NVCF_API_SIDECARS_IMAGE_PULL_SECRET` | `""` | Image pull secret name passed to the NVCF API sidecar mount |
 | `MIGRATIONS_ALLOW_FAILURES` | `false` | Emergency rollback only. When `true`, the entrypoint exits 0 even if core migrations or opted-in addons failed. Default behavior fails the Job non-zero so a misconfigured deployment blocks the Helm hook Job instead of silently leaving OpenBao in a partial state. |
-| `BAO_KV_UPGRADE_RETRY_BUDGET_SECONDS` | `60` | Total time the helper functions retry kv-v2 reads and writes that fail with OpenBao's storage-upgrade error (HTTP 400 "Upgrading from non-versioned to versioned data") before failing the migration. Also bounds the readiness wait after enabling a kv-v2 mount. Other errors fail immediately. |
+| `BAO_KV_UPGRADE_RETRY_BUDGET_SECONDS` | `60` | Total time `enable_secrets_mount` waits for a kv-v2 mount's storage upgrade (HTTP 400 "Upgrading from non-versioned to versioned data") to finish before failing the migration. Errors outside that wait fail immediately. |
 
 ### Example Kubernetes Job
 

--- a/migrations/openbao/README.md
+++ b/migrations/openbao/README.md
@@ -71,7 +71,7 @@ Environment variables consumed by the entrypoint:
 | `DEFAULT_CASSANDRA_PASSWORD` | `ch@ng3m3` (override required) | See above |
 | `NVCF_API_SIDECARS_IMAGE_PULL_SECRET` | `""` | Image pull secret name passed to the NVCF API sidecar mount |
 | `MIGRATIONS_ALLOW_FAILURES` | `false` | Emergency rollback only. When `true`, the entrypoint exits 0 even if core migrations or opted-in addons failed. Default behavior fails the Job non-zero so a misconfigured deployment blocks the Helm hook Job instead of silently leaving OpenBao in a partial state. |
-| `BAO_TRANSIENT_RETRY_BUDGET_SECONDS` | `60` | Total time the helper functions retry kv-v2 reads and writes that fail with OpenBao's transient storage-upgrade error (HTTP 400 "Upgrading from non-versioned to versioned data") before failing the migration. Other errors fail immediately. |
+| `BAO_TRANSIENT_RETRY_BUDGET_SECONDS` | `60` | Total time the helper functions retry kv-v2 reads and writes that fail with OpenBao's transient storage-upgrade error (HTTP 400 "Upgrading from non-versioned to versioned data") before failing the migration. Also bounds the readiness wait after enabling a kv-v2 mount. Other errors fail immediately. |
 
 ### Example Kubernetes Job
 

--- a/migrations/openbao/README.md
+++ b/migrations/openbao/README.md
@@ -14,6 +14,7 @@ This repository ships:
 - Verified `jwker` binary and signed-package `kubectl` copied from downloader stages
 - Optional addons under `addons/` (e.g., LLS / TURN secret rotation)
 - An example Kubernetes Job manifest (`job.yaml`)
+- A Docker-based integration test for the helper functions (`tests/`)
 
 ## Prerequisites
 
@@ -70,6 +71,7 @@ Environment variables consumed by the entrypoint:
 | `DEFAULT_CASSANDRA_PASSWORD` | `ch@ng3m3` (override required) | See above |
 | `NVCF_API_SIDECARS_IMAGE_PULL_SECRET` | `""` | Image pull secret name passed to the NVCF API sidecar mount |
 | `MIGRATIONS_ALLOW_FAILURES` | `false` | Emergency rollback only. When `true`, the entrypoint exits 0 even if core migrations or opted-in addons failed. Default behavior fails the Job non-zero so a misconfigured deployment blocks the Helm hook Job instead of silently leaving OpenBao in a partial state. |
+| `BAO_TRANSIENT_RETRY_BUDGET_SECONDS` | `60` | Total time the helper functions spend retrying kv-v2 operations that fail with the transient storage-upgrade error (see the section below). |
 
 ### Example Kubernetes Job
 
@@ -78,6 +80,32 @@ Environment variables consumed by the entrypoint:
 ```bash
 kubectl apply -f job.yaml
 ```
+
+## Transient kv-v2 upgrade errors
+
+OpenBao rejects kv-v2 reads and writes with HTTP 400 `Upgrading from
+non-versioned to versioned data` while a mount's storage upgrade runs. The
+upgrade starts on every backend setup (fresh enable, version tune, server
+unseal, leader failover) and finishes asynchronously, so operations issued
+right after a mount operation can land inside that window. On a loaded
+cluster the window can outlast several requests.
+
+The helpers in `migrations/utils/functions.sh` handle this window:
+
+- `enable_secrets_mount` waits for a kv-v2 mount to serve requests before
+  returning, including when the mount already existed (a re-run can find a
+  mount whose upgrade re-opened after a server restart).
+- `write_secrets_kv` retries the existence check and the write while they
+  fail with the transient error, backing off at 1s, 2s, 4s, 8s, then 10s,
+  within `BAO_TRANSIENT_RETRY_BUDGET_SECONDS` in total.
+- Existence checks that still fail transiently after the full budget abort
+  the migration rather than writing, so an existing secret is never
+  overwritten because its mount was temporarily unreadable.
+
+All other errors keep failing immediately; the retry never weakens the
+fail-hard Job contract. `tests/kv-write-retry-test.sh` runs these helpers
+against a real OpenBao server in Docker with the upgrade window held open
+and asserts the behavior above.
 
 ## Service onboarding
 

--- a/migrations/openbao/README.md
+++ b/migrations/openbao/README.md
@@ -71,7 +71,7 @@ Environment variables consumed by the entrypoint:
 | `DEFAULT_CASSANDRA_PASSWORD` | `ch@ng3m3` (override required) | See above |
 | `NVCF_API_SIDECARS_IMAGE_PULL_SECRET` | `""` | Image pull secret name passed to the NVCF API sidecar mount |
 | `MIGRATIONS_ALLOW_FAILURES` | `false` | Emergency rollback only. When `true`, the entrypoint exits 0 even if core migrations or opted-in addons failed. Default behavior fails the Job non-zero so a misconfigured deployment blocks the Helm hook Job instead of silently leaving OpenBao in a partial state. |
-| `BAO_TRANSIENT_RETRY_BUDGET_SECONDS` | `60` | Total time the helper functions spend retrying kv-v2 operations that fail with the transient storage-upgrade error (see the section below). |
+| `BAO_TRANSIENT_RETRY_BUDGET_SECONDS` | `60` | Total time the helper functions retry kv-v2 reads and writes that fail with OpenBao's transient storage-upgrade error (HTTP 400 "Upgrading from non-versioned to versioned data") before failing the migration. Other errors fail immediately. |
 
 ### Example Kubernetes Job
 
@@ -80,32 +80,6 @@ Environment variables consumed by the entrypoint:
 ```bash
 kubectl apply -f job.yaml
 ```
-
-## Transient kv-v2 upgrade errors
-
-OpenBao rejects kv-v2 reads and writes with HTTP 400 `Upgrading from
-non-versioned to versioned data` while a mount's storage upgrade runs. The
-upgrade starts on every backend setup (fresh enable, version tune, server
-unseal, leader failover) and finishes asynchronously, so operations issued
-right after a mount operation can land inside that window. On a loaded
-cluster the window can outlast several requests.
-
-The helpers in `migrations/utils/functions.sh` handle this window:
-
-- `enable_secrets_mount` waits for a kv-v2 mount to serve requests before
-  returning, including when the mount already existed (a re-run can find a
-  mount whose upgrade re-opened after a server restart).
-- `write_secrets_kv` retries the existence check and the write while they
-  fail with the transient error, backing off at 1s, 2s, 4s, 8s, then 10s,
-  within `BAO_TRANSIENT_RETRY_BUDGET_SECONDS` in total.
-- Existence checks that still fail transiently after the full budget abort
-  the migration rather than writing, so an existing secret is never
-  overwritten because its mount was temporarily unreadable.
-
-All other errors keep failing immediately; the retry never weakens the
-fail-hard Job contract. `tests/kv-write-retry-test.sh` runs these helpers
-against a real OpenBao server in Docker with the upgrade window held open
-and asserts the behavior above.
 
 ## Service onboarding
 

--- a/migrations/openbao/migrations/utils/functions.sh
+++ b/migrations/openbao/migrations/utils/functions.sh
@@ -149,8 +149,9 @@ function is_kv_upgrade_window_error() {
 # and its call sites in enable_secrets_mount if OpenBao ports the upstream
 # synchronous-upgrade fix (vault-plugin-secrets-kv v0.26.0).
 #
-# Probes the mount's config endpoint (behind the same upgrade gate as the
-# data handlers), backing off 1s up to 10s. Non-window errors are left
+# Probes the mount's config path, not the data path; both are gated by
+# the same upgrade check, so a successful config read implies the data
+# path is serving. Backs off 1s up to 10s. Non-window errors are left
 # for the caller's next operation to surface.
 #
 # @param mount_path The mount path of the kv-v2 secrets engine
@@ -201,8 +202,9 @@ function enable_secrets_mount() {
     secrets_mounts=$(bao secrets list -format=json 2>/dev/null) || true
     if [[ "$secrets_mounts" == *"\"${mount_path}/\""* ]]; then
         log_info "$mount_type secrets engine already mounted at path '$mount_path'"
-        # A re-run can find the mount still mid-upgrade (the upgrade re-runs
-        # on every server restart), so wait here too.
+        # A rerun can find a kv-v2 mount already registered while its
+        # initial storage upgrade is still in progress or incomplete, so
+        # wait here too.
         if [[ "$mount_type" == "kv-v2" ]]; then
             wait_kv_v2_mount_data_path_ready "$mount_path" || return 1
         fi

--- a/migrations/openbao/migrations/utils/functions.sh
+++ b/migrations/openbao/migrations/utils/functions.sh
@@ -146,18 +146,25 @@ function is_kv_upgrade_window_error() {
 }
 
 ##
-# Run a bao command, retrying while it fails with the kv-v2 upgrade-window
-# error. Backoff 1s, 2s, 4s, 8s, then 10s, bounded by
-# BAO_KV_UPGRADE_RETRY_BUDGET_SECONDS (default 60) in total; any other
-# failure returns immediately. The command output is echoed for the caller
-# to capture; retry notices go to stderr to keep that output clean.
+# Block until a kv-v2 mount's data path serves requests, or the budget
+# (BAO_KV_UPGRADE_RETRY_BUDGET_SECONDS, default 60s) expires. This is the
+# single place the migrations wait out the upgrade window; if OpenBao ports
+# the upstream synchronous-upgrade fix (vault-plugin-secrets-kv v0.26.0),
+# delete this function and its call sites in enable_secrets_mount.
 #
-# @param ... The command to run
+# Probes the mount's config endpoint, which sits behind the same upgrade
+# gate as the data handlers, backing off 1s, 2s, 4s, 8s, then 10s. Fails
+# only when the mount is still upgrading after the full budget; other
+# errors are left for the caller's next operation to surface.
 #
-function retry_on_kv_upgrade_error() {
+# @param mount_path The mount path of the kv-v2 secrets engine
+#
+function wait_kv_v2_mount_data_path_ready() {
+    local mount_path=$1
+
     local budget=${BAO_KV_UPGRADE_RETRY_BUDGET_SECONDS:-60}
     if ! [[ "$budget" =~ ^[0-9]+$ ]]; then
-        log_warn "Invalid BAO_KV_UPGRADE_RETRY_BUDGET_SECONDS '${budget}'; using 60" >&2
+        log_warn "Invalid BAO_KV_UPGRADE_RETRY_BUDGET_SECONDS '${budget}'; using 60"
         budget=60
     fi
     local delay=1
@@ -165,48 +172,23 @@ function retry_on_kv_upgrade_error() {
     local output
 
     while true; do
-        if output=$("$@" 2>&1); then
-            echo "$output"
+        if output=$(bao read "${mount_path}/config" 2>&1); then
             return 0
         fi
         if ! is_kv_upgrade_window_error "$output"; then
-            echo "$output"
-            return 1
+            return 0
         fi
         if (( SECONDS - start + delay > budget )); then
-            echo "$output"
+            log_error "kv-v2 mount '${mount_path}' is still running its storage upgrade after ${budget}s: $output"
             return 1
         fi
-        log_info "OpenBao kv-v2 upgrade in progress; retrying in ${delay}s..." >&2
+        log_info "kv-v2 upgrade in progress on '${mount_path}'; retrying in ${delay}s..."
         sleep "$delay"
         delay=$((delay * 2))
         if (( delay > 10 )); then
             delay=10
         fi
     done
-}
-
-##
-# Block until a kv-v2 mount is serving requests, by retrying a read of the
-# mount's config endpoint (gated by the same upgrade check as data
-# operations) within the retry budget. Fails only when the mount is still
-# upgrading after the full budget; other errors are left for the caller's
-# next operation to surface.
-#
-# @param mount_path The mount path of the kv-v2 secrets engine
-#
-function wait_kv_mount_ready() {
-    local mount_path=$1
-
-    local output
-    if output=$(retry_on_kv_upgrade_error bao read "${mount_path}/config"); then
-        return 0
-    fi
-    if is_kv_upgrade_window_error "$output"; then
-        log_error "kv-v2 mount '${mount_path}' is still running its storage upgrade after the retry budget: $output"
-        return 1
-    fi
-    return 0
 }
 
 ##
@@ -226,7 +208,7 @@ function enable_secrets_mount() {
         # A re-run can find the mount still mid-upgrade (the upgrade re-runs
         # on every server restart), so wait here too.
         if [[ "$mount_type" == "kv-v2" ]]; then
-            wait_kv_mount_ready "$mount_path" || return 1
+            wait_kv_v2_mount_data_path_ready "$mount_path" || return 1
         fi
         return 0
     fi
@@ -239,7 +221,7 @@ function enable_secrets_mount() {
 
     # The enable call returns before the backend's storage upgrade finishes.
     if [[ "$mount_type" == "kv-v2" ]]; then
-        wait_kv_mount_ready "$mount_path" || return 1
+        wait_kv_v2_mount_data_path_ready "$mount_path" || return 1
     fi
 
     log_success "$mount_type secrets engine enabled at path '$mount_path'"
@@ -397,25 +379,20 @@ function write_secrets_kv() {
     # Skip the existence check when overwriting; its result would be ignored.
     if [ "$overwrite" != "true" ]; then
         local get_output
-        if get_output=$(retry_on_kv_upgrade_error bao kv get "$mount_path/$secret"); then
+        if get_output=$(bao kv get "$mount_path/$secret" 2>&1); then
             log_info "Secrets KV '$secret' already exists in '$mount_path', skipping..."
             return 0
         fi
-        if is_kv_upgrade_window_error "$get_output"; then
-            # Still upgrading after the full budget. Not "secret missing":
-            # writing now could clobber an existing secret once it recovers.
-            log_error "Error checking secrets KV '$mount_path/$secret': $get_output"
-            return 1
-        fi
         if [[ "$get_output" != *"No value found"* ]]; then
             # The read failed for a reason other than "secret does not
-            # exist". Do not write over a secret that could not be read.
+            # exist" (this includes the kv-v2 upgrade-window rejection).
+            # Do not write over a secret that could not be read.
             log_error "Error checking secrets KV '$mount_path/$secret': $get_output"
             return 1
         fi
     fi
 
-    if ! output=$(retry_on_kv_upgrade_error bao kv put $mount_path/$secret $value); then
+    if ! output=$(bao kv put $mount_path/$secret $value 2>&1); then
         log_error "Error writing secrets KV to '$mount_path/$secret': $output"
         return 1
     fi

--- a/migrations/openbao/migrations/utils/functions.sh
+++ b/migrations/openbao/migrations/utils/functions.sh
@@ -128,9 +128,14 @@ function configure_auth_jwt() {
 # clears it asynchronously. The second message is the read-enabled standby
 # variant.
 #
+# The API carries no structured code for this condition, so the match is on
+# the message text. If a future OpenBao rewords it, this check misses and
+# callers fail immediately (the pre-retry behavior); the integration test
+# revalidates the match against the pinned server version on every bump.
+#
 # @param output The captured output of the failed command
 #
-function is_transient_bao_error() {
+function is_kv_upgrade_window_error() {
     local output=$1
 
     case "$output" in
@@ -141,18 +146,18 @@ function is_transient_bao_error() {
 }
 
 ##
-# Run a bao command, retrying while it fails with a transient kv-v2 upgrade
+# Run a bao command, retrying while it fails with the kv-v2 upgrade-window
 # error. Backoff 1s, 2s, 4s, 8s, then 10s, bounded by
-# BAO_TRANSIENT_RETRY_BUDGET_SECONDS (default 60) in total; any other
+# BAO_KV_UPGRADE_RETRY_BUDGET_SECONDS (default 60) in total; any other
 # failure returns immediately. The command output is echoed for the caller
 # to capture; retry notices go to stderr to keep that output clean.
 #
 # @param ... The command to run
 #
-function retry_transient_bao() {
-    local budget=${BAO_TRANSIENT_RETRY_BUDGET_SECONDS:-60}
+function retry_on_kv_upgrade_error() {
+    local budget=${BAO_KV_UPGRADE_RETRY_BUDGET_SECONDS:-60}
     if ! [[ "$budget" =~ ^[0-9]+$ ]]; then
-        log_warn "Invalid BAO_TRANSIENT_RETRY_BUDGET_SECONDS '${budget}'; using 60" >&2
+        log_warn "Invalid BAO_KV_UPGRADE_RETRY_BUDGET_SECONDS '${budget}'; using 60" >&2
         budget=60
     fi
     local delay=1
@@ -164,7 +169,7 @@ function retry_transient_bao() {
             echo "$output"
             return 0
         fi
-        if ! is_transient_bao_error "$output"; then
+        if ! is_kv_upgrade_window_error "$output"; then
             echo "$output"
             return 1
         fi
@@ -182,10 +187,11 @@ function retry_transient_bao() {
 }
 
 ##
-# Wait until a kv-v2 mount is serving requests, by polling the mount's
-# config endpoint (gated by the same upgrade check as data operations).
-# Fails only when the mount is still upgrading after the full retry budget;
-# other errors are left for the caller's next operation to surface.
+# Block until a kv-v2 mount is serving requests, by retrying a read of the
+# mount's config endpoint (gated by the same upgrade check as data
+# operations) within the retry budget. Fails only when the mount is still
+# upgrading after the full budget; other errors are left for the caller's
+# next operation to surface.
 #
 # @param mount_path The mount path of the kv-v2 secrets engine
 #
@@ -193,10 +199,10 @@ function wait_kv_mount_ready() {
     local mount_path=$1
 
     local output
-    if output=$(retry_transient_bao bao read "${mount_path}/config"); then
+    if output=$(retry_on_kv_upgrade_error bao read "${mount_path}/config"); then
         return 0
     fi
-    if is_transient_bao_error "$output"; then
+    if is_kv_upgrade_window_error "$output"; then
         log_error "kv-v2 mount '${mount_path}' is still running its storage upgrade after the retry budget: $output"
         return 1
     fi
@@ -391,19 +397,25 @@ function write_secrets_kv() {
     # Skip the existence check when overwriting; its result would be ignored.
     if [ "$overwrite" != "true" ]; then
         local get_output
-        if get_output=$(retry_transient_bao bao kv get "$mount_path/$secret"); then
+        if get_output=$(retry_on_kv_upgrade_error bao kv get "$mount_path/$secret"); then
             log_info "Secrets KV '$secret' already exists in '$mount_path', skipping..."
             return 0
         fi
-        if is_transient_bao_error "$get_output"; then
+        if is_kv_upgrade_window_error "$get_output"; then
             # Still upgrading after the full budget. Not "secret missing":
             # writing now could clobber an existing secret once it recovers.
             log_error "Error checking secrets KV '$mount_path/$secret': $get_output"
             return 1
         fi
+        if [[ "$get_output" != *"No value found"* ]]; then
+            # The read failed for a reason other than "secret does not
+            # exist". Do not write over a secret that could not be read.
+            log_error "Error checking secrets KV '$mount_path/$secret': $get_output"
+            return 1
+        fi
     fi
 
-    if ! output=$(retry_transient_bao bao kv put $mount_path/$secret $value); then
+    if ! output=$(retry_on_kv_upgrade_error bao kv put $mount_path/$secret $value); then
         log_error "Error writing secrets KV to '$mount_path/$secret': $output"
         return 1
     fi

--- a/migrations/openbao/migrations/utils/functions.sh
+++ b/migrations/openbao/migrations/utils/functions.sh
@@ -123,6 +123,91 @@ function configure_auth_jwt() {
 }
 
 ##
+# Check whether a bao command failed because a kv-v2 mount is still running
+# its storage upgrade. OpenBao sets an upgrade flag while a kv-v2 backend is
+# set up (fresh enable, version tune, or re-setup after unseal or leader
+# failover) and clears it asynchronously, so reads and writes issued right
+# after a mount operation can fail with these errors until the window closes.
+# The second message is the variant returned by read-enabled standby nodes.
+#
+# @param output The captured output of the failed command
+#
+function is_transient_bao_error() {
+    local output=$1
+
+    case "$output" in
+        *"Upgrading from non-versioned to versioned data"*) return 0 ;;
+        *"Waiting for the primary to upgrade from non-versioned to versioned data"*) return 0 ;;
+    esac
+    return 1
+}
+
+##
+# Run a bao command, retrying while it fails with a transient kv-v2 upgrade
+# error. Retries back off at 1s, 2s, 4s, 8s, then 10s, bounded by
+# BAO_TRANSIENT_RETRY_BUDGET_SECONDS (default 60) in total. Any other
+# failure returns immediately so real errors stay loud. The command output
+# (stdout and stderr combined) is echoed for the caller to capture; retry
+# notices go to stderr so they do not pollute captured output.
+#
+# @param ... The command to run
+#
+function retry_transient_bao() {
+    local budget=${BAO_TRANSIENT_RETRY_BUDGET_SECONDS:-60}
+    if ! [[ "$budget" =~ ^[0-9]+$ ]]; then
+        log_warn "Invalid BAO_TRANSIENT_RETRY_BUDGET_SECONDS '${budget}'; using 60" >&2
+        budget=60
+    fi
+    local delay=1
+    local start=$SECONDS
+    local output
+
+    while true; do
+        if output=$("$@" 2>&1); then
+            echo "$output"
+            return 0
+        fi
+        if ! is_transient_bao_error "$output"; then
+            echo "$output"
+            return 1
+        fi
+        if (( SECONDS - start + delay > budget )); then
+            echo "$output"
+            return 1
+        fi
+        log_info "OpenBao kv-v2 upgrade in progress; retrying in ${delay}s..." >&2
+        sleep "$delay"
+        delay=$((delay * 2))
+        if (( delay > 10 )); then
+            delay=10
+        fi
+    done
+}
+
+##
+# Wait until a kv-v2 mount is serving requests. Polls the mount's config
+# endpoint, which passes through the same upgrade gate as data operations.
+# Fails only when the mount is still upgrading after the full retry budget;
+# any other error is left for the caller's next operation to surface with
+# proper context.
+#
+# @param mount_path The mount path of the kv-v2 secrets engine
+#
+function wait_kv_mount_ready() {
+    local mount_path=$1
+
+    local output
+    if output=$(retry_transient_bao bao read "${mount_path}/config"); then
+        return 0
+    fi
+    if is_transient_bao_error "$output"; then
+        log_error "kv-v2 mount '${mount_path}' is still running its storage upgrade after the retry budget: $output"
+        return 1
+    fi
+    return 0
+}
+
+##
 # Enable a secrets engine
 #
 # @param mount_path The mount path of the secrets engine
@@ -136,6 +221,12 @@ function enable_secrets_mount() {
     secrets_mounts=$(bao secrets list -format=json 2>/dev/null) || true
     if [[ "$secrets_mounts" == *"\"${mount_path}/\""* ]]; then
         log_info "$mount_type secrets engine already mounted at path '$mount_path'"
+        # A re-run can find the mount present while its storage upgrade is
+        # still in flight: the upgrade re-runs on every backend setup until
+        # its completion marker lands, so wait here as well.
+        if [[ "$mount_type" == "kv-v2" ]]; then
+            wait_kv_mount_ready "$mount_path" || return 1
+        fi
         return 0
     fi
 
@@ -143,6 +234,12 @@ function enable_secrets_mount() {
     if ! output=$(bao secrets enable -path=$mount_path $mount_type 2>&1); then
         log_error "Error enabling $mount_type secrets engine: $output"
         return 1
+    fi
+
+    # The enable call returns before the backend's storage upgrade finishes,
+    # so an immediate read or write can be rejected. Wait for readiness.
+    if [[ "$mount_type" == "kv-v2" ]]; then
+        wait_kv_mount_ready "$mount_path" || return 1
     fi
 
     log_success "$mount_type secrets engine enabled at path '$mount_path'"
@@ -297,15 +394,29 @@ function write_secrets_kv() {
 
     log_step "Writing secrets KV to '$mount_path/$secret'"
 
-    if ! output=$(bao kv get $mount_path/$secret > /dev/null 2>&1) || [ "$overwrite" == "true" ]; then
-      if ! output=$(bao kv put $mount_path/$secret $value 2>&1); then
-          log_error "Error writing secrets KV to '$mount_path/$secret': $output"
-          return 1
-      fi
-      log_success "Secrets KV '$secret' written successfully to '$mount_path'"
-    else
-      log_info "Secrets KV '$secret' already exists in '$mount_path', skipping..."
+    # The existence check only matters when overwrite is off; skip it
+    # entirely for overwrite=true callers so they neither stall on it nor
+    # fail on a check whose result they would ignore.
+    if [ "$overwrite" != "true" ]; then
+        local get_output
+        if get_output=$(retry_transient_bao bao kv get "$mount_path/$secret"); then
+            log_info "Secrets KV '$secret' already exists in '$mount_path', skipping..."
+            return 0
+        fi
+        if is_transient_bao_error "$get_output"; then
+            # The mount is still upgrading after the full retry budget. Do
+            # not treat this as "secret missing": writing now could clobber
+            # an existing secret once the mount recovers.
+            log_error "Error checking secrets KV '$mount_path/$secret': $get_output"
+            return 1
+        fi
     fi
+
+    if ! output=$(retry_transient_bao bao kv put $mount_path/$secret $value); then
+        log_error "Error writing secrets KV to '$mount_path/$secret': $output"
+        return 1
+    fi
+    log_success "Secrets KV '$secret' written successfully to '$mount_path'"
 }
 
 ##

--- a/migrations/openbao/migrations/utils/functions.sh
+++ b/migrations/openbao/migrations/utils/functions.sh
@@ -124,14 +124,11 @@ function configure_auth_jwt() {
 
 ##
 # Check whether a bao command failed because a kv-v2 mount is still running
-# its storage upgrade. OpenBao opens this window on every backend setup and
-# clears it asynchronously. The second message is the read-enabled standby
-# variant.
-#
-# The API carries no structured code for this condition, so the match is on
-# the message text. If a future OpenBao rewords it, this check misses and
-# callers fail immediately (the pre-retry behavior); the integration test
-# revalidates the match against the pinned server version on every bump.
+# its storage upgrade (opened on every backend setup, cleared
+# asynchronously). The second message is the read-enabled standby variant.
+# The API carries no structured code for this, so the match is on message
+# text; a missed match fails hard, and the integration test revalidates
+# the strings against the pinned server version.
 #
 # @param output The captured output of the failed command
 #
@@ -146,16 +143,15 @@ function is_kv_upgrade_window_error() {
 }
 
 ##
-# Block until a kv-v2 mount's data path serves requests, or the budget
-# (BAO_KV_UPGRADE_RETRY_BUDGET_SECONDS, default 60s) expires. This is the
-# single place the migrations wait out the upgrade window; if OpenBao ports
-# the upstream synchronous-upgrade fix (vault-plugin-secrets-kv v0.26.0),
-# delete this function and its call sites in enable_secrets_mount.
+# Block until a kv-v2 mount's data path serves requests, or
+# BAO_KV_UPGRADE_RETRY_BUDGET_SECONDS (default 60) expires. The single
+# place the migrations wait out the upgrade window; delete this function
+# and its call sites in enable_secrets_mount if OpenBao ports the upstream
+# synchronous-upgrade fix (vault-plugin-secrets-kv v0.26.0).
 #
-# Probes the mount's config endpoint, which sits behind the same upgrade
-# gate as the data handlers, backing off 1s, 2s, 4s, 8s, then 10s. Fails
-# only when the mount is still upgrading after the full budget; other
-# errors are left for the caller's next operation to surface.
+# Probes the mount's config endpoint (behind the same upgrade gate as the
+# data handlers), backing off 1s up to 10s. Non-window errors are left
+# for the caller's next operation to surface.
 #
 # @param mount_path The mount path of the kv-v2 secrets engine
 #
@@ -384,9 +380,8 @@ function write_secrets_kv() {
             return 0
         fi
         if [[ "$get_output" != *"No value found"* ]]; then
-            # The read failed for a reason other than "secret does not
-            # exist" (this includes the kv-v2 upgrade-window rejection).
-            # Do not write over a secret that could not be read.
+            # Not a plain "secret does not exist" (includes the upgrade
+            # window): never write over a secret that could not be read.
             log_error "Error checking secrets KV '$mount_path/$secret': $get_output"
             return 1
         fi

--- a/migrations/openbao/migrations/utils/functions.sh
+++ b/migrations/openbao/migrations/utils/functions.sh
@@ -124,11 +124,9 @@ function configure_auth_jwt() {
 
 ##
 # Check whether a bao command failed because a kv-v2 mount is still running
-# its storage upgrade. OpenBao sets an upgrade flag while a kv-v2 backend is
-# set up (fresh enable, version tune, or re-setup after unseal or leader
-# failover) and clears it asynchronously, so reads and writes issued right
-# after a mount operation can fail with these errors until the window closes.
-# The second message is the variant returned by read-enabled standby nodes.
+# its storage upgrade. OpenBao opens this window on every backend setup and
+# clears it asynchronously. The second message is the read-enabled standby
+# variant.
 #
 # @param output The captured output of the failed command
 #
@@ -144,11 +142,10 @@ function is_transient_bao_error() {
 
 ##
 # Run a bao command, retrying while it fails with a transient kv-v2 upgrade
-# error. Retries back off at 1s, 2s, 4s, 8s, then 10s, bounded by
-# BAO_TRANSIENT_RETRY_BUDGET_SECONDS (default 60) in total. Any other
-# failure returns immediately so real errors stay loud. The command output
-# (stdout and stderr combined) is echoed for the caller to capture; retry
-# notices go to stderr so they do not pollute captured output.
+# error. Backoff 1s, 2s, 4s, 8s, then 10s, bounded by
+# BAO_TRANSIENT_RETRY_BUDGET_SECONDS (default 60) in total; any other
+# failure returns immediately. The command output is echoed for the caller
+# to capture; retry notices go to stderr to keep that output clean.
 #
 # @param ... The command to run
 #
@@ -185,11 +182,10 @@ function retry_transient_bao() {
 }
 
 ##
-# Wait until a kv-v2 mount is serving requests. Polls the mount's config
-# endpoint, which passes through the same upgrade gate as data operations.
+# Wait until a kv-v2 mount is serving requests, by polling the mount's
+# config endpoint (gated by the same upgrade check as data operations).
 # Fails only when the mount is still upgrading after the full retry budget;
-# any other error is left for the caller's next operation to surface with
-# proper context.
+# other errors are left for the caller's next operation to surface.
 #
 # @param mount_path The mount path of the kv-v2 secrets engine
 #
@@ -221,9 +217,8 @@ function enable_secrets_mount() {
     secrets_mounts=$(bao secrets list -format=json 2>/dev/null) || true
     if [[ "$secrets_mounts" == *"\"${mount_path}/\""* ]]; then
         log_info "$mount_type secrets engine already mounted at path '$mount_path'"
-        # A re-run can find the mount present while its storage upgrade is
-        # still in flight: the upgrade re-runs on every backend setup until
-        # its completion marker lands, so wait here as well.
+        # A re-run can find the mount still mid-upgrade (the upgrade re-runs
+        # on every server restart), so wait here too.
         if [[ "$mount_type" == "kv-v2" ]]; then
             wait_kv_mount_ready "$mount_path" || return 1
         fi
@@ -236,8 +231,7 @@ function enable_secrets_mount() {
         return 1
     fi
 
-    # The enable call returns before the backend's storage upgrade finishes,
-    # so an immediate read or write can be rejected. Wait for readiness.
+    # The enable call returns before the backend's storage upgrade finishes.
     if [[ "$mount_type" == "kv-v2" ]]; then
         wait_kv_mount_ready "$mount_path" || return 1
     fi
@@ -394,9 +388,7 @@ function write_secrets_kv() {
 
     log_step "Writing secrets KV to '$mount_path/$secret'"
 
-    # The existence check only matters when overwrite is off; skip it
-    # entirely for overwrite=true callers so they neither stall on it nor
-    # fail on a check whose result they would ignore.
+    # Skip the existence check when overwriting; its result would be ignored.
     if [ "$overwrite" != "true" ]; then
         local get_output
         if get_output=$(retry_transient_bao bao kv get "$mount_path/$secret"); then
@@ -404,9 +396,8 @@ function write_secrets_kv() {
             return 0
         fi
         if is_transient_bao_error "$get_output"; then
-            # The mount is still upgrading after the full retry budget. Do
-            # not treat this as "secret missing": writing now could clobber
-            # an existing secret once the mount recovers.
+            # Still upgrading after the full budget. Not "secret missing":
+            # writing now could clobber an existing secret once it recovers.
             log_error "Error checking secrets KV '$mount_path/$secret': $get_output"
             return 1
         fi

--- a/migrations/openbao/tests/inner-kv-write-retry.sh
+++ b/migrations/openbao/tests/inner-kv-write-retry.sh
@@ -38,8 +38,8 @@ seed_keys() {
   local count=$2
   local i
   for i in $(seq 1 "${count}"); do
-    curl -s -o /dev/null -X POST -H "X-Vault-Token: ${BAO_TOKEN}" \
-      -d '{"x":"y"}' "${BAO_ADDR}/v1/${mount}/seed${i}"
+    curl -sf -o /dev/null -X POST -H "X-Vault-Token: ${BAO_TOKEN}" \
+      -d '{"x":"y"}' "${BAO_ADDR}/v1/${mount}/seed${i}" || return 1
   done
 }
 
@@ -49,33 +49,46 @@ seed_keys() {
 # window stays open for hundreds of milliseconds instead of a few.
 open_upgrade_window() {
   local mount=$1
-  bao secrets enable -path="${mount}" kv >/dev/null
-  seed_keys "${mount}" "${KEYS}"
-  bao secrets tune -version=2 "${mount}" >/dev/null
+  bao secrets enable -path="${mount}" kv >/dev/null || return 1
+  seed_keys "${mount}" "${KEYS}" || return 1
+  bao secrets tune -version=2 "${mount}" >/dev/null || return 1
 }
 
+# S1 and S2 additionally require that a transient-error retry was actually
+# observed (the helper's retry notice on stderr), so they cannot pass
+# vacuously if the setup failed to hold the upgrade window open.
+
 # S1: a write issued inside the upgrade window succeeds.
-open_upgrade_window s1
-if write_secrets_kv "s1" "cassandra/creds" "username=x password=y" \
+open_upgrade_window s1 || { echo "setup failed for s1" >&2; exit 2; }
+s1_out=$(write_secrets_kv "s1" "cassandra/creds" "username=x password=y" 2>&1)
+s1_rc=$?
+if [ "${s1_rc}" -eq 0 ] \
+    && grep -q "retrying in" <<<"${s1_out}" \
     && [ "$(bao kv get -field=username s1/cassandra/creds)" = "x" ]; then
-  pass "write inside the upgrade window succeeds"
+  pass "write inside the upgrade window succeeds after observed retry"
 else
-  fail "write inside the upgrade window succeeds"
+  echo "${s1_out}"
+  fail "write inside the upgrade window succeeds after observed retry"
 fi
 
 # S2: an existing secret is not overwritten when the existence check runs
 # inside the upgrade window. Before the retry fix, the transient 400 on
 # the get was read as "secret missing".
-bao secrets enable -path=s2 kv >/dev/null
-curl -s -o /dev/null -X POST -H "X-Vault-Token: ${BAO_TOKEN}" \
-  -d '{"username":"original"}' "${BAO_ADDR}/v1/s2/cassandra/creds"
-seed_keys s2 "${KEYS}"
-bao secrets tune -version=2 s2 >/dev/null
-if write_secrets_kv "s2" "cassandra/creds" "username=replacement" \
+bao secrets enable -path=s2 kv >/dev/null || { echo "setup failed for s2" >&2; exit 2; }
+curl -sf -o /dev/null -X POST -H "X-Vault-Token: ${BAO_TOKEN}" \
+  -d '{"username":"original"}' "${BAO_ADDR}/v1/s2/cassandra/creds" \
+  || { echo "setup failed for s2" >&2; exit 2; }
+seed_keys s2 "${KEYS}" || { echo "setup failed for s2" >&2; exit 2; }
+bao secrets tune -version=2 s2 >/dev/null || { echo "setup failed for s2" >&2; exit 2; }
+s2_out=$(write_secrets_kv "s2" "cassandra/creds" "username=replacement" 2>&1)
+s2_rc=$?
+if [ "${s2_rc}" -eq 0 ] \
+    && grep -q "retrying in" <<<"${s2_out}" \
     && [ "$(bao kv get -field=username s2/cassandra/creds)" = "original" ]; then
-  pass "existing secret preserved across the upgrade window"
+  pass "existing secret preserved across the upgrade window after observed retry"
 else
-  fail "existing secret preserved across the upgrade window"
+  echo "${s2_out}"
+  fail "existing secret preserved across the upgrade window after observed retry"
 fi
 
 # S3: the production sequence, a fresh kv-v2 enable followed by an

--- a/migrations/openbao/tests/inner-kv-write-retry.sh
+++ b/migrations/openbao/tests/inner-kv-write-retry.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Scenario driver for kv-write-retry-test.sh. Runs inside the OpenBao
+# container and exercises the real helper functions against live kv-v2
+# storage-upgrade windows. Expects BAO_ADDR and BAO_TOKEN in the
+# environment; KEYS controls how long the deterministic window stays open.
+
+set -u
+
+source /test/utils/utils.sh
+source /test/utils/functions.sh
+
+: "${BAO_ADDR:?}"
+: "${BAO_TOKEN:?}"
+KEYS=${KEYS:-400}
+
+failures=0
+
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1"; failures=$((failures + 1)); }
+
+seed_keys() {
+  local mount=$1
+  local count=$2
+  local i
+  for i in $(seq 1 "${count}"); do
+    curl -s -o /dev/null -X POST -H "X-Vault-Token: ${BAO_TOKEN}" \
+      -d '{"x":"y"}' "${BAO_ADDR}/v1/${mount}/seed${i}"
+  done
+}
+
+# Open the kv-v2 upgrade window deterministically: tune a seeded kv-v1
+# mount to version 2. The tune re-runs the same backend setup and upgrade
+# routine as a fresh kv-v2 enable, but with KEYS entries to migrate the
+# window stays open for hundreds of milliseconds instead of a few.
+open_upgrade_window() {
+  local mount=$1
+  bao secrets enable -path="${mount}" kv >/dev/null
+  seed_keys "${mount}" "${KEYS}"
+  bao secrets tune -version=2 "${mount}" >/dev/null
+}
+
+# S1: a write issued inside the upgrade window succeeds.
+open_upgrade_window s1
+if write_secrets_kv "s1" "cassandra/creds" "username=x password=y" \
+    && [ "$(bao kv get -field=username s1/cassandra/creds)" = "x" ]; then
+  pass "write inside the upgrade window succeeds"
+else
+  fail "write inside the upgrade window succeeds"
+fi
+
+# S2: an existing secret is not overwritten when the existence check runs
+# inside the upgrade window. Before the retry fix, the transient 400 on
+# the get was read as "secret missing".
+bao secrets enable -path=s2 kv >/dev/null
+curl -s -o /dev/null -X POST -H "X-Vault-Token: ${BAO_TOKEN}" \
+  -d '{"username":"original"}' "${BAO_ADDR}/v1/s2/cassandra/creds"
+seed_keys s2 "${KEYS}"
+bao secrets tune -version=2 s2 >/dev/null
+if write_secrets_kv "s2" "cassandra/creds" "username=replacement" \
+    && [ "$(bao kv get -field=username s2/cassandra/creds)" = "original" ]; then
+  pass "existing secret preserved across the upgrade window"
+else
+  fail "existing secret preserved across the upgrade window"
+fi
+
+# S3: the production sequence, a fresh kv-v2 enable followed by an
+# immediate write. The fresh-mount window is short, so this is usually
+# green even without the fix on fast hardware, but it pins the readiness
+# wait and catches regressions on slow runners.
+if enable_secrets_mount "s3/kv" "kv-v2" \
+    && write_secrets_kv "s3/kv" "cassandra/creds" "username=x password=y"; then
+  pass "fresh kv-v2 enable then immediate write"
+else
+  fail "fresh kv-v2 enable then immediate write"
+fi
+
+# S4: non-transient errors are not retried. A write to a mount that does
+# not exist must fail, and fail fast.
+start=${SECONDS}
+if write_secrets_kv "does-not-exist/kv" "foo" "bar=baz"; then
+  fail "write to a missing mount fails"
+elif (( SECONDS - start > 15 )); then
+  fail "write to a missing mount fails fast (took $((SECONDS - start))s)"
+else
+  pass "write to a missing mount fails fast"
+fi
+
+if [ "${failures}" -gt 0 ]; then
+  echo "RESULT: ${failures} scenario(s) failed"
+  exit 1
+fi
+echo "RESULT: all scenarios passed"

--- a/migrations/openbao/tests/inner-kv-write-retry.sh
+++ b/migrations/openbao/tests/inner-kv-write-retry.sh
@@ -57,16 +57,16 @@ open_upgrade_window() {
 # S0: the classifier accepts each upgrade-window message independently and
 # rejects other errors. The standby variant cannot be produced by this
 # single-node harness, so it is checked directly here.
-if is_transient_bao_error "Code: 400. Errors: * Upgrading from non-versioned to versioned data. This backend will be unavailable for a brief period and will resume service shortly." \
-    && is_transient_bao_error "Code: 400. Errors: * Waiting for the primary to upgrade from non-versioned to versioned data. This backend will be unavailable for a brief period and will resume service shortly." \
-    && ! is_transient_bao_error "Code: 403. Errors: * permission denied" \
-    && ! is_transient_bao_error "No value found at s1/data/cassandra/creds"; then
+if is_kv_upgrade_window_error "Code: 400. Errors: * Upgrading from non-versioned to versioned data. This backend will be unavailable for a brief period and will resume service shortly." \
+    && is_kv_upgrade_window_error "Code: 400. Errors: * Waiting for the primary to upgrade from non-versioned to versioned data. This backend will be unavailable for a brief period and will resume service shortly." \
+    && ! is_kv_upgrade_window_error "Code: 403. Errors: * permission denied" \
+    && ! is_kv_upgrade_window_error "No value found at s1/data/cassandra/creds"; then
   pass "classifier accepts only the two upgrade-window messages"
 else
   fail "classifier accepts only the two upgrade-window messages"
 fi
 
-# S1 and S2 additionally require that a transient-error retry was actually
+# S1 and S2 additionally require that an upgrade-window retry was actually
 # observed (the helper's retry notice on stderr), so they cannot pass
 # vacuously if the setup failed to hold the upgrade window open.
 

--- a/migrations/openbao/tests/inner-kv-write-retry.sh
+++ b/migrations/openbao/tests/inner-kv-write-retry.sh
@@ -118,7 +118,7 @@ else
   fail "fresh kv-v2 enable then immediate write"
 fi
 
-# S4: non-transient errors are not retried. A write to a mount that does
+# S4: errors outside the upgrade window fail fast. A write to a mount that does
 # not exist must fail, and fail fast.
 start=${SECONDS}
 if write_secrets_kv "does-not-exist/kv" "foo" "bar=baz"; then

--- a/migrations/openbao/tests/inner-kv-write-retry.sh
+++ b/migrations/openbao/tests/inner-kv-write-retry.sh
@@ -54,6 +54,18 @@ open_upgrade_window() {
   bao secrets tune -version=2 "${mount}" >/dev/null || return 1
 }
 
+# S0: the classifier accepts each upgrade-window message independently and
+# rejects other errors. The standby variant cannot be produced by this
+# single-node harness, so it is checked directly here.
+if is_transient_bao_error "Code: 400. Errors: * Upgrading from non-versioned to versioned data. This backend will be unavailable for a brief period and will resume service shortly." \
+    && is_transient_bao_error "Code: 400. Errors: * Waiting for the primary to upgrade from non-versioned to versioned data. This backend will be unavailable for a brief period and will resume service shortly." \
+    && ! is_transient_bao_error "Code: 403. Errors: * permission denied" \
+    && ! is_transient_bao_error "No value found at s1/data/cassandra/creds"; then
+  pass "classifier accepts only the two upgrade-window messages"
+else
+  fail "classifier accepts only the two upgrade-window messages"
+fi
+
 # S1 and S2 additionally require that a transient-error retry was actually
 # observed (the helper's retry notice on stderr), so they cannot pass
 # vacuously if the setup failed to hold the upgrade window open.

--- a/migrations/openbao/tests/inner-kv-write-retry.sh
+++ b/migrations/openbao/tests/inner-kv-write-retry.sh
@@ -66,26 +66,29 @@ else
   fail "classifier accepts only the two upgrade-window messages"
 fi
 
-# S1 and S2 additionally require that an upgrade-window retry was actually
-# observed (the helper's retry notice on stderr), so they cannot pass
-# vacuously if the setup failed to hold the upgrade window open.
+# S1 requires that the wait actually observed the upgrade window (its
+# retry notice), so it cannot pass vacuously if the setup failed to hold
+# the window open.
 
-# S1: a write issued inside the upgrade window succeeds.
+# S1: the readiness wait blocks through the upgrade window, after which a
+# plain write succeeds.
 open_upgrade_window s1 || { echo "setup failed for s1" >&2; exit 2; }
-s1_out=$(write_secrets_kv "s1" "cassandra/creds" "username=x password=y" 2>&1)
-s1_rc=$?
-if [ "${s1_rc}" -eq 0 ] \
-    && grep -q "retrying in" <<<"${s1_out}" \
+s1_wait_out=$(wait_kv_v2_mount_data_path_ready "s1" 2>&1)
+s1_wait_rc=$?
+if [ "${s1_wait_rc}" -eq 0 ] \
+    && grep -q "retrying in" <<<"${s1_wait_out}" \
+    && write_secrets_kv "s1" "cassandra/creds" "username=x password=y" \
     && [ "$(bao kv get -field=username s1/cassandra/creds)" = "x" ]; then
-  pass "write inside the upgrade window succeeds after observed retry"
+  pass "readiness wait rides out the upgrade window, then the write succeeds"
 else
-  echo "${s1_out}"
-  fail "write inside the upgrade window succeeds after observed retry"
+  echo "${s1_wait_out}"
+  fail "readiness wait rides out the upgrade window, then the write succeeds"
 fi
 
-# S2: an existing secret is not overwritten when the existence check runs
-# inside the upgrade window. Before the retry fix, the transient 400 on
-# the get was read as "secret missing".
+# S2: a write issued inside the upgrade window without the readiness wait
+# fails safely: the migration aborts and the existing secret is not
+# overwritten. Before the fix, the 400 on the existence check was read as
+# "secret missing" and the write went through.
 bao secrets enable -path=s2 kv >/dev/null || { echo "setup failed for s2" >&2; exit 2; }
 curl -sf -o /dev/null -X POST -H "X-Vault-Token: ${BAO_TOKEN}" \
   -d '{"username":"original"}' "${BAO_ADDR}/v1/s2/cassandra/creds" \
@@ -94,13 +97,14 @@ seed_keys s2 "${KEYS}" || { echo "setup failed for s2" >&2; exit 2; }
 bao secrets tune -version=2 s2 >/dev/null || { echo "setup failed for s2" >&2; exit 2; }
 s2_out=$(write_secrets_kv "s2" "cassandra/creds" "username=replacement" 2>&1)
 s2_rc=$?
-if [ "${s2_rc}" -eq 0 ] \
-    && grep -q "retrying in" <<<"${s2_out}" \
+wait_kv_v2_mount_data_path_ready "s2" >/dev/null 2>&1
+if [ "${s2_rc}" -ne 0 ] \
+    && grep -q "Upgrading from non-versioned" <<<"${s2_out}" \
     && [ "$(bao kv get -field=username s2/cassandra/creds)" = "original" ]; then
-  pass "existing secret preserved across the upgrade window after observed retry"
+  pass "unwaited write inside the window aborts and preserves the secret"
 else
   echo "${s2_out}"
-  fail "existing secret preserved across the upgrade window after observed retry"
+  fail "unwaited write inside the window aborts and preserves the secret"
 fi
 
 # S3: the production sequence, a fresh kv-v2 enable followed by an

--- a/migrations/openbao/tests/kv-write-retry-test.sh
+++ b/migrations/openbao/tests/kv-write-retry-test.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Integration test for the migration helper functions in
+# migrations/utils/functions.sh against a real OpenBao server.
+#
+# OpenBao's kv-v2 backend rejects reads and writes with HTTP 400
+# "Upgrading from non-versioned to versioned data" while its storage
+# upgrade runs. The upgrade is started on every backend setup and cleared
+# asynchronously, so writes issued right after a mount operation can land
+# inside that window. This test opens the window deterministically and
+# asserts the helpers retry through it, preserve skip semantics, and still
+# fail fast on non-transient errors.
+#
+# Requires Docker. The OpenBao version is read from the migrations image
+# Dockerfile so the test tracks the shipped server version. Set UTILS_DIR
+# to point the test at a different copy of the helper functions (useful to
+# demonstrate the failure against an older revision).
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+utils_dir="${UTILS_DIR:-${script_dir}/../migrations/utils}"
+
+bao_version="$(sed -n 's|^FROM openbao/openbao:||p' "${script_dir}/../Dockerfile" | head -1)"
+if [ -z "${bao_version}" ]; then
+  echo "could not read the OpenBao version from ${script_dir}/../Dockerfile" >&2
+  exit 1
+fi
+
+container="nvcf-openbao-kv-test-$$"
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/nvcf-openbao-kv-test.XXXXXX")"
+cleanup() {
+  docker rm -f "${container}" >/dev/null 2>&1 || true
+  rm -rf "${tmpdir}"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+# Raft storage rather than dev mode: production runs raft, and the upgrade
+# window scales with storage latency, so raft keeps the window realistic.
+cat > "${tmpdir}/config.hcl" <<'EOF'
+ui = false
+disable_mlock = true
+
+listener "tcp" {
+  address     = "127.0.0.1:8200"
+  tls_disable = 1
+}
+
+storage "raft" {
+  path    = "/openbao/data"
+  node_id = "node1"
+}
+
+cluster_addr = "http://127.0.0.1:8201"
+api_addr     = "http://127.0.0.1:8200"
+EOF
+
+echo "Starting OpenBao ${bao_version} (container ${container})..."
+docker run -d --name "${container}" -u root --entrypoint /bin/sh \
+  -v "${tmpdir}/config.hcl":/test/config.hcl:ro \
+  -v "${script_dir}/inner-kv-write-retry.sh":/test/inner.sh:ro \
+  -v "${utils_dir}":/test/utils:ro \
+  "openbao/openbao:${bao_version}" \
+  -c 'mkdir -p /openbao/data && exec bao server -config=/test/config.hcl' >/dev/null
+
+export_addr=(-e BAO_ADDR=http://127.0.0.1:8200)
+
+ready=0
+for _ in $(seq 1 30); do
+  rc=0
+  docker exec "${export_addr[@]}" "${container}" bao status >/dev/null 2>&1 || rc=$?
+  # 0 = up and unsealed, 2 = up and sealed; both mean the API is serving.
+  if [ "${rc}" = "0" ] || [ "${rc}" = "2" ]; then
+    ready=1
+    break
+  fi
+  sleep 1
+done
+if [ "${ready}" != "1" ]; then
+  docker logs "${container}" >&2
+  echo "OpenBao did not become responsive" >&2
+  exit 1
+fi
+
+docker exec "${export_addr[@]}" "${container}" \
+  bao operator init -key-shares=1 -key-threshold=1 -format=json > "${tmpdir}/init.json"
+unseal_key="$(python3 -c "import json,sys; print(json.load(sys.stdin)['unseal_keys_b64'][0])" < "${tmpdir}/init.json")"
+root_token="$(python3 -c "import json,sys; print(json.load(sys.stdin)['root_token'])" < "${tmpdir}/init.json")"
+docker exec "${export_addr[@]}" "${container}" bao operator unseal "${unseal_key}" >/dev/null
+
+active=0
+for _ in $(seq 1 30); do
+  if docker exec "${container}" sh -c \
+    'wget -qO- http://127.0.0.1:8200/v1/sys/health 2>/dev/null | grep -q "\"standby\":false"'; then
+    active=1
+    break
+  fi
+  sleep 1
+done
+if [ "${active}" != "1" ]; then
+  docker logs "${container}" >&2
+  echo "OpenBao did not become the active node" >&2
+  exit 1
+fi
+
+# The stock image lacks bash, jq, and curl, which the helpers and the
+# scenarios need. The migrations image installs the same set.
+if ! docker exec -u root "${container}" apk add --no-cache bash jq curl >/dev/null; then
+  echo "apk add failed in the test container" >&2
+  exit 1
+fi
+
+docker exec "${export_addr[@]}" -e BAO_TOKEN="${root_token}" -e KEYS="${KEYS:-400}" \
+  "${container}" bash /test/inner.sh

--- a/migrations/openbao/tests/kv-write-retry-test.sh
+++ b/migrations/openbao/tests/kv-write-retry-test.sh
@@ -16,9 +16,9 @@
 
 # Integration test for the migration helper functions in
 # migrations/utils/functions.sh against a real OpenBao server. Opens the
-# kv-v2 storage-upgrade window (the transient 400) deterministically and
+# kv-v2 storage-upgrade window (the 400 rejection) deterministically and
 # asserts the helpers retry through it, preserve skip semantics, and fail
-# fast on non-transient errors.
+# fast on other errors.
 #
 # Requires Docker. The OpenBao version is read from the migrations image
 # Dockerfile so the test tracks the shipped server version. Set UTILS_DIR

--- a/migrations/openbao/tests/kv-write-retry-test.sh
+++ b/migrations/openbao/tests/kv-write-retry-test.sh
@@ -15,15 +15,10 @@
 # limitations under the License.
 
 # Integration test for the migration helper functions in
-# migrations/utils/functions.sh against a real OpenBao server.
-#
-# OpenBao's kv-v2 backend rejects reads and writes with HTTP 400
-# "Upgrading from non-versioned to versioned data" while its storage
-# upgrade runs. The upgrade is started on every backend setup and cleared
-# asynchronously, so writes issued right after a mount operation can land
-# inside that window. This test opens the window deterministically and
-# asserts the helpers retry through it, preserve skip semantics, and still
-# fail fast on non-transient errors.
+# migrations/utils/functions.sh against a real OpenBao server. Opens the
+# kv-v2 storage-upgrade window (the transient 400) deterministically and
+# asserts the helpers retry through it, preserve skip semantics, and fail
+# fast on non-transient errors.
 #
 # Requires Docker. The OpenBao version is read from the migrations image
 # Dockerfile so the test tracks the shipped server version. Set UTILS_DIR

--- a/migrations/openbao/tests/kv-write-retry-test.sh
+++ b/migrations/openbao/tests/kv-write-retry-test.sh
@@ -17,8 +17,8 @@
 # Integration test for the migration helper functions in
 # migrations/utils/functions.sh against a real OpenBao server. Opens the
 # kv-v2 storage-upgrade window (the 400 rejection) deterministically and
-# asserts the helpers retry through it, preserve skip semantics, and fail
-# fast on other errors.
+# asserts the readiness wait rides it out, an unwaited write fails without
+# overwriting, and other errors fail fast.
 #
 # Requires Docker. The OpenBao version is read from the migrations image
 # Dockerfile so the test tracks the shipped server version. Set UTILS_DIR


### PR DESCRIPTION
## TL;DR

OpenBao rejects kv-v2 reads and writes with HTTP 400 "Upgrading from non-versioned to versioned data" while a mount's storage upgrade runs. The migration helpers wrote immediately after enabling a mount with no handling for that window, so the openbao-server-migrations job failed on loaded clusters during phase 1 installs. This adds one bounded readiness wait at mount setup and a guard that never writes over a secret that could not be read.

## Additional Details

- The window opens on every kv-v2 backend setup (fresh enable, version tune, unseal, leader failover) and closes asynchronously. Upstream fixed the empty-mount case in hashicorp/vault-plugin-secrets-kv v0.26.0 (PRs [212](https://github.com/hashicorp/vault-plugin-secrets-kv/pull/212), [213](https://github.com/hashicorp/vault-plugin-secrets-kv/pull/213)); OpenBao through 2.6.2 has not ported it.
- Window handling is concentrated in one function, wait_kv_v2_mount_data_path_ready, called only from enable_secrets_mount (on both the fresh-enable and already-mounted paths). It backs off 1s, 2s, 4s, 8s, then 10s within BAO_KV_UPGRADE_RETRY_BUDGET_SECONDS (default 60). If OpenBao ports the upstream fix, removal is one function, two call sites, the env var, and the tests.
- Reads and writes stay fail-hard with no retries. write_secrets_kv proceeds to its write only when the existence check failed with the CLI's missing-secret message; any other read failure (including a window that reopens mid-run after a failover) aborts the migration, and the next Job attempt's readiness wait absorbs the window.

## For the Reviewer

- migrations/openbao/migrations/utils/functions.sh is the whole behavior change; the tests and workflow are new. The workflow exists because nothing else in this repo runs anything under migrations/openbao, mirroring the openbao-jwt-plugin workflow's isolation rationale.

## For QA

- New Docker-based integration test (migrations/openbao/tests/kv-write-retry-test.sh) against a real OpenBao 2.5.5 with the upgrade window held open: the error classifier, the readiness wait riding out an observed window, an unwaited write aborting without overwriting the existing secret, the production enable-then-write sequence, and fail-fast on a missing mount. Red on the previous helpers, green with this change; the new workflow runs it in CI.
- Reproduced the original failure 10/10 against stock openbao/openbao:2.5.5 before the fix.
- No QA needed beyond CI.

## Issues

Closes #1110

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret-write reliability during transient OpenBao KV-v2 upgrade conditions.
  * Preserved existing secrets during migrations.
  * Added bounded retries and prompt failures for unavailable mounts.

* **Tests**
  * Added Docker-based integration coverage for retries, readiness, upgrades, and failure scenarios.
  * Added automated validation for code changes and manual runs.

* **Documentation**
  * Clarified retry settings, migration-related errors, and integration test usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->