### PR TITLE
fix(nvca-operator): use NGC core BYOO image

### DIFF
--- a/deploy/helm/nvca-operator/nvca-operator/templates/_helpers.tpl
+++ b/deploy/helm/nvca-operator/nvca-operator/templates/_helpers.tpl
@@ -188,7 +188,7 @@ Usage: {{ include "nvcaop.byooOtelCollectorImage" . }}
 {{- if .imageRepository -}}
 {{- .imageRepository -}}
 {{- else if hasPrefix "stg.nvcr.io/nvidia/nvcf-byoc" .defaultRepository -}}
-stg.nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector
+stg.nvcr.io/nv-cf/nvcf-core/byoo-otel-collector
 {{- else -}}
 nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector
 {{- end -}}

--- a/deploy/helm/nvca-operator/tests/self_managed_nvca_image_reference_test.sh
+++ b/deploy/helm/nvca-operator/tests/self_managed_nvca_image_reference_test.sh
@@ -212,7 +212,7 @@ if [[ "${byoo_function_image}" != "nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector:
   exit 1
 fi
 
-if [[ "${stage_byoo_function_image}" != "stg.nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector:0.157.0-nv-0.1.1" || \
+if [[ "${stage_byoo_function_image}" != "stg.nvcr.io/nv-cf/nvcf-core/byoo-otel-collector:0.157.0-nv-0.1.1" || \
   "${stage_byoo_task_image}" != "${stage_byoo_function_image}" ]]; then
   echo "expected BYOO collector defaults to use the staging image repository" >&2
   exit 1

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/templates/_helpers.tpl
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/templates/_helpers.tpl
@@ -188,7 +188,7 @@ Usage: {{ include "nvcaop.byooOtelCollectorImage" . }}
 {{- if .imageRepository -}}
 {{- .imageRepository -}}
 {{- else if hasPrefix "stg.nvcr.io/nvidia/nvcf-byoc" .defaultRepository -}}
-stg.nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector
+stg.nvcr.io/nv-cf/nvcf-core/byoo-otel-collector
 {{- else -}}
 nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector
 {{- end -}}


### PR DESCRIPTION
## TL;DR

Route the staging BYOO OpenTelemetry Collector default to the NGC core repository so NCP function and task sidecars use the repository available to their deployment credential.

## Additional Details

The NVCA Operator chart derived the staging collector location from the operator repository. That selected a repository different from the NGC core location used by the other workload sidecars.

The source chart and vendored release chart now default staging BYOO workloads to `stg.nvcr.io/nv-cf/nvcf-core/byoo-otel-collector`. Explicit image overrides and the production default are unchanged.

## Customer Release Notes

Fixed BYOO function and task deployments that could not pull the default OpenTelemetry Collector sidecar in staging NCP clusters.

## Plan Summary

No Kubernetes resources are added or removed. The rendered function and task environment overrides use the NGC core collector repository for staging installations.

## Usage

No operator action is required after upgrading the chart. An explicit `agent.byooOtelCollector.imageRepository` override still takes precedence.

## For the Reviewer

Please review the staging fallback in both chart copies and the rendered function and task image assertion.

## For QA

Passed:

- `make test-self-managed-nvca-image-reference`
- `make lint`
- `make test-release-image-manifest`
- Direct comparison of the source and vendored `_helpers.tpl` files

`make check-vendor-chart` could not complete outside the release environment because `NVCA_OPERATOR_VERSION` is not set. Its generated changes were restored before committing.

QA needed: Yes. Validate a BYOO function and task on a staging NCP node without a cached collector image.

## Issues

Fixes #1039

## Related Pull Requests

#1040 is the NVCA 3.2 backport and depends on this mainline PR.

## Dependencies

None. No dependency, license, or NOTICE changes.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
