### PR TITLE
test(bdd): add function lifecycle command adapters

### DIFF
--- a/tests/bdd/AGENTS.md
+++ b/tests/bdd/AGENTS.md
@@ -20,6 +20,14 @@ meaningful target, value, context, and timeout visible while hiding only
 command or output-format mechanics. Keep `When I run command` plus an
 assertion as the escape hatch for uncommon or command-specific behavior.
 
+Function lifecycle steps are a narrow command-adapter exception. They store
+only the selected `nvcf-cli` config, pass visible arguments to one CLI command,
+and preserve the real command result. They do not store function identity,
+apply defaults, parse or normalize product values, or enforce product
+preconditions. Their `successfully` wording asserts exit code 0 to keep happy
+paths compact. Use raw command steps for negative and exit-code-specific cases
+so `nvcf-cli` and the NVCF API remain the product-validation boundary.
+
 ## Layering
 
 - `harness/` owns suite lifecycle: `Config`, `CommandRunner`, `Ledger`,
@@ -44,6 +52,9 @@ logic into `dsl/`.
 - `${VAR}` interpolation is the only env-var form the DSL recognizes;
   a bare `$word` is left literal. Implementations must not use
   `os.ExpandEnv`. Expansion lives in `dsl.Interpolate`.
+- Function lifecycle CLI option tables preserve row order, repeated options,
+  empty values, and product-invalid values. Only the `option | value` table
+  structure is validated before the command runs.
 - File-mutating steps (`I copy the file`, `I update yaml file`,
   `I prepare self-managed secrets file`, `I substitute a block`)
   snapshot the destination through `Suite.Ledger` before the first write.

--- a/tests/bdd/PLAN.md
+++ b/tests/bdd/PLAN.md
@@ -122,6 +122,35 @@ refactor in every consumer; that is a feature.
 | `When I run command with a terminal:` (docstring) | Same as the docstring form, but stdin is attached to a pseudo-terminal so the child sees a TTY on fd 0. For commands that gate interactive-only behavior on a TTY, such as `nvcf-cli self-hosted up` (its auth-gate mints the admin token only when stdin is a terminal). No input is written; stdout and stderr are captured separately as usual. |
 | `When I export command output to environment variable {string}` | Exports the previous command's trimmed stdout under the named env var. Fails the step unless the prior command exited 0 and produced non-empty stdout. Snapshotted by the env Ledger; restored at suite teardown. |
 
+#### Function lifecycle command adapters
+
+These steps hide the repeated executable, config prefix, fixed subcommand, shell
+quoting, and exit-zero assertion. Every meaningful function, deployment, and
+invocation input remains visible. Each action runs exactly one `nvcf-cli`
+command and preserves its result for existing output assertions.
+
+The adapters validate only Gherkin structure. They do not store function
+identity, apply defaults, parse or normalize product values, enforce product
+preconditions, or allowlist CLI options. Supplied arguments reach `nvcf-cli`
+unchanged after `${VAR}` interpolation. The `successfully` wording is the
+deliberate exception that asserts exit code 0. Negative and exit-code-specific
+scenarios use the raw command steps.
+
+CLI option tables have exactly two headers, `option | value`, and at least one
+data row. Each row emits the option and value as separate arguments in its
+original order. Repeated options and empty values are preserved.
+
+| Step | Command |
+|------|---------|
+| `Given I use NVCF CLI config {string}` | Interpolates and stores the supplied config argument without resolving or checking the path. Later lifecycle steps pass it to `--config`. |
+| `When I successfully create function {string} from image {string} with CLI options:` | Runs `function create --name <name> --image <image>` followed by the option rows. |
+| `When I successfully deploy the function selected by NVCF CLI with options:` | Runs `function deploy create` followed by the option rows. Function selection remains owned by CLI state. |
+| `When I successfully generate a function API key with CLI options:` | Runs `api-key generate --for function` followed by the option rows. |
+| `When I successfully invoke the function selected by NVCF CLI over HTTP with timeout {string} seconds and poll duration {string} seconds:` (JSON docstring) | Runs `function invoke` with the exact request body, timeout, and poll duration. |
+| `When I successfully invoke the function selected by NVCF CLI over plaintext gRPC service {string} method {string} with timeout {string} seconds and poll duration {string} seconds:` (JSON docstring) | Runs `function invoke --grpc --grpc-plaintext` with the visible service, method, request, timeout, and poll duration. |
+| `When I successfully invoke model {string} at {string} with timeout {string} seconds:` (JSON docstring) | Runs `function invoke` with the visible model, inference URL, exact request body, and timeout. |
+| `When I successfully undeploy the function selected by NVCF CLI` | Runs `function delete --deployment-only`. Function selection remains owned by CLI state. |
+
 ### Assertions (Then / And)
 
 | Step | Notes |

--- a/tests/bdd/dsl/command.go
+++ b/tests/bdd/dsl/command.go
@@ -1,0 +1,53 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dsl
+
+import "strings"
+
+// BuildCommand quotes each argument for the runner's POSIX shlex parser and
+// joins them without interpreting their values.
+func BuildCommand(args ...string) string {
+	quoted := make([]string, len(args))
+	for index, arg := range args {
+		quoted[index] = quoteCommandArg(arg)
+	}
+	return strings.Join(quoted, " ")
+}
+
+func quoteCommandArg(value string) string {
+	if isCommandArgSafe(value) {
+		return value
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func isCommandArgSafe(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, char := range value {
+		if char >= 'a' && char <= 'z' ||
+			char >= 'A' && char <= 'Z' ||
+			char >= '0' && char <= '9' ||
+			strings.ContainsRune("_./:@%+=,-", char) {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/tests/bdd/dsl/command_test.go
+++ b/tests/bdd/dsl/command_test.go
@@ -1,0 +1,35 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dsl
+
+import "testing"
+
+func TestBuildCommandPreservesArgumentsForShlex(t *testing.T) {
+	got := BuildCommand(
+		"/tmp/nvcf cli",
+		"--config",
+		"",
+		"--llm-model",
+		"name=model,uris=/v1/chat|/v1/embed,routingMethod=not-an-api-value",
+		"value with 'quotes'",
+	)
+	want := "'/tmp/nvcf cli' --config '' --llm-model 'name=model,uris=/v1/chat|/v1/embed,routingMethod=not-an-api-value' 'value with '\"'\"'quotes'\"'\"''"
+	if got != want {
+		t.Fatalf("command = %q, want %q", got, want)
+	}
+}

--- a/tests/bdd/dsl/kubectl.go
+++ b/tests/bdd/dsl/kubectl.go
@@ -174,26 +174,3 @@ func KubectlApplyCommand(manifestPath, kubeContext string) (string, error) {
 	args = append(args, "apply", "-f", quoteCommandArg(manifestPath))
 	return strings.Join(args, " "), nil
 }
-
-func quoteCommandArg(value string) string {
-	if isCommandArgSafe(value) {
-		return value
-	}
-	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
-}
-
-func isCommandArgSafe(value string) bool {
-	if value == "" {
-		return false
-	}
-	for _, char := range value {
-		if char >= 'a' && char <= 'z' ||
-			char >= 'A' && char <= 'Z' ||
-			char >= '0' && char <= '9' ||
-			strings.ContainsRune("_./:@%+=,-", char) {
-			continue
-		}
-		return false
-	}
-	return true
-}

--- a/tests/bdd/features/multi-cluster-eks-helmfile.feature
+++ b/tests/bdd/features/multi-cluster-eks-helmfile.feature
@@ -374,23 +374,30 @@ Feature: Install a multi-cluster NVCF stack across two pre-provisioned EKS clust
         kubectl wait nvcfbackend ${EKS_COMPUTE_CLUSTER_NAME} -n nvca-operator --context ${EKS_COMPUTE_CONTEXT} --for=jsonpath={.status.agentStatus}=healthy --timeout=10m
         """
 
-      When I run command:
-        """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/out/nvcf-cli-eks-bdd-multi.yaml function create --name bdd-load-tester-supreme --image nvcr.io/${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}/load_tester_supreme:0.0.8 --inference-url /echo --inference-port 8000 --health-uri /health --health-port 8000 --health-timeout PT30S
-        """
-      Then the command exit code should be 0
+      And I use NVCF CLI config "${REPO_ROOT}/tests/bdd/out/nvcf-cli-eks-bdd-multi.yaml"
 
-      When I run command:
-        """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/out/nvcf-cli-eks-bdd-multi.yaml function deploy create --gpu H100 --instance-type NCP.GPU.H100_8x --backend ${EKS_COMPUTE_CLUSTER_NAME} --regions ${EKS_REGION} --min-instances 1 --max-instances 1 --timeout 900
-        """
-      Then the command exit code should be 0
+      When I successfully create function "bdd-load-tester-supreme" from image "nvcr.io/${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}/load_tester_supreme:0.0.8" with CLI options:
+        | option           | value   |
+        | --inference-url  | /echo   |
+        | --inference-port | 8000    |
+        | --health-uri     | /health |
+        | --health-port    | 8000    |
+        | --health-timeout | PT30S   |
 
-      When I run command:
-        """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/out/nvcf-cli-eks-bdd-multi.yaml api-key generate --description bdd-load-tester-supreme --for function --scopes invoke_function,list_functions,queue_details,list_functions_details
-        """
-      Then the command exit code should be 0
+      And I successfully deploy the function selected by NVCF CLI with options:
+        | option          | value                       |
+        | --gpu           | H100                        |
+        | --instance-type | NCP.GPU.H100_8x             |
+        | --backend       | ${EKS_COMPUTE_CLUSTER_NAME} |
+        | --regions       | ${EKS_REGION}               |
+        | --min-instances | 1                           |
+        | --max-instances | 1                           |
+        | --timeout       | 900                         |
+
+      And I successfully generate a function API key with CLI options:
+        | option        | value                                                               |
+        | --description | bdd-load-tester-supreme                                            |
+        | --scopes      | invoke_function,list_functions,queue_details,list_functions_details |
 
       # AWS can briefly return NXDOMAIN for a newly provisioned ELB even after
       # earlier successful lookups. Reconfirm system-resolver stability before
@@ -398,12 +405,11 @@ Feature: Install a multi-cluster NVCF stack across two pre-provisioned EKS clust
       When I run command "tests/bdd/scripts/wait-for-dns.sh ${EKS_GATEWAY_ADDR} 180"
       Then the command exit code should be 0
 
-      When I run command:
+      When I successfully invoke the function selected by NVCF CLI over HTTP with timeout "120" seconds and poll duration "5" seconds:
         """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/out/nvcf-cli-eks-bdd-multi.yaml function invoke --request-body '{"message":"bdd-echo","repeats":1}' --timeout 120 --poll-duration 5
+        {"message":"bdd-echo","repeats":1}
         """
-      Then the command exit code should be 0
-      And the command output should contain "bdd-echo"
+      Then the command output should contain "bdd-echo"
 
     # Failing until GitHub issue #1098 is resolved and the fix from GitHub
     # issue #1032 is consumed by the self-managed stack.

--- a/tests/bdd/features/multi-cluster-helmfile.feature
+++ b/tests/bdd/features/multi-cluster-helmfile.feature
@@ -245,54 +245,67 @@ Feature: Install a local multi-cluster NVCF stack with Helmfile
 
     @function-lifecycle
     Scenario: Operator creates, deploys, and invokes the Load Tester Supreme sample function
-      When I run command:
-        """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml function create --name bdd-load-tester-supreme --image nvcr.io/${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}/load_tester_supreme:0.0.8 --inference-url /echo --inference-port 8000 --health-uri /health --health-port 8000 --health-timeout PT30S
-        """
-      Then the command exit code should be 0
+      Given I use NVCF CLI config "${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml"
 
-      When I run command:
-        """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml function deploy create --gpu H100 --instance-type NCP.GPU.H100_8x --backend ncp-local-compute-1 --regions us-west-1 --min-instances 1 --max-instances 1 --timeout 900
-        """
-      Then the command exit code should be 0
+      When I successfully create function "bdd-load-tester-supreme" from image "nvcr.io/${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}/load_tester_supreme:0.0.8" with CLI options:
+        | option           | value   |
+        | --inference-url  | /echo   |
+        | --inference-port | 8000    |
+        | --health-uri     | /health |
+        | --health-port    | 8000    |
+        | --health-timeout | PT30S   |
 
-      When I run command:
-        """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml api-key generate --description bdd-load-tester-supreme --for function --scopes invoke_function,list_functions,queue_details,list_functions_details
-        """
-      Then the command exit code should be 0
+      And I successfully deploy the function selected by NVCF CLI with options:
+        | option          | value               |
+        | --gpu           | H100                |
+        | --instance-type | NCP.GPU.H100_8x     |
+        | --backend       | ncp-local-compute-1 |
+        | --regions       | us-west-1           |
+        | --min-instances | 1                   |
+        | --max-instances | 1                   |
+        | --timeout       | 900                 |
 
-      When I run command:
+      And I successfully generate a function API key with CLI options:
+        | option        | value                                                               |
+        | --description | bdd-load-tester-supreme                                            |
+        | --scopes      | invoke_function,list_functions,queue_details,list_functions_details |
+
+      When I successfully invoke the function selected by NVCF CLI over HTTP with timeout "120" seconds and poll duration "5" seconds:
         """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml function invoke --request-body '{"message":"bdd-echo","repeats":1}' --timeout 120 --poll-duration 5
+        {"message":"bdd-echo","repeats":1}
         """
-      Then the command exit code should be 0
-      And the command output should contain "bdd-echo"
+      Then the command output should contain "bdd-echo"
 
     @function-lifecycle @grpc
     Scenario: Operator creates, deploys, and invokes the gRPC Load Tester Supreme sample function
-      When I run command:
-        """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml function create --name bdd-grpc-load-tester-supreme --image nvcr.io/${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}/load_tester_supreme:0.0.8 --inference-url /grpc --inference-port 8001 --health-protocol GRPC --health-uri / --health-port 8001 --health-timeout PT30S
-        """
-      Then the command exit code should be 0
+      Given I use NVCF CLI config "${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml"
 
-      When I run command:
-        """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml function deploy create --gpu H100 --instance-type NCP.GPU.H100_8x --backend ncp-local-compute-1 --regions us-west-1 --min-instances 1 --max-instances 1 --timeout 900
-        """
-      Then the command exit code should be 0
+      When I successfully create function "bdd-grpc-load-tester-supreme" from image "nvcr.io/${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}/load_tester_supreme:0.0.8" with CLI options:
+        | option            | value   |
+        | --inference-url   | /grpc   |
+        | --inference-port  | 8001    |
+        | --health-protocol | GRPC    |
+        | --health-uri      | /       |
+        | --health-port     | 8001    |
+        | --health-timeout  | PT30S   |
 
-      When I run command:
-        """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml api-key generate --description bdd-grpc-load-tester-supreme --for function --scopes invoke_function,list_functions,queue_details,list_functions_details
-        """
-      Then the command exit code should be 0
+      And I successfully deploy the function selected by NVCF CLI with options:
+        | option          | value               |
+        | --gpu           | H100                |
+        | --instance-type | NCP.GPU.H100_8x     |
+        | --backend       | ncp-local-compute-1 |
+        | --regions       | us-west-1           |
+        | --min-instances | 1                   |
+        | --max-instances | 1                   |
+        | --timeout       | 900                 |
 
-      When I run command:
+      And I successfully generate a function API key with CLI options:
+        | option        | value                                                               |
+        | --description | bdd-grpc-load-tester-supreme                                       |
+        | --scopes      | invoke_function,list_functions,queue_details,list_functions_details |
+
+      When I successfully invoke the function selected by NVCF CLI over plaintext gRPC service "Echo" method "EchoMessage" with timeout "120" seconds and poll duration "5" seconds:
         """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml function invoke --grpc --grpc-plaintext --grpc-service Echo --grpc-method EchoMessage --request-body '{"message":"bdd-grpc-echo"}' --timeout 120 --poll-duration 5
+        {"message":"bdd-grpc-echo"}
         """
-      Then the command exit code should be 0
-      And the command output should contain "bdd-grpc-echo"
+      Then the command output should contain "bdd-grpc-echo"

--- a/tests/bdd/features/single-cluster-helmfile.feature
+++ b/tests/bdd/features/single-cluster-helmfile.feature
@@ -152,72 +152,77 @@ Feature: Install a local single-cluster NVCF stack with Helmfile
     # this feature run, and is not a standalone tag target.
     @function-lifecycle
     Scenario: Operator creates, deploys, and invokes the Load Tester Supreme sample function
-      When I run command:
-        """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml function create --name bdd-load-tester-supreme --image nvcr.io/${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}/load_tester_supreme:0.0.8 --inference-url /echo --inference-port 8000 --health-uri /health --health-port 8000 --health-timeout PT30S
-        """
-      Then the command exit code should be 0
+      Given I use NVCF CLI config "${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml"
 
-      When I run command:
-        """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml function deploy create --gpu H100 --instance-type NCP.GPU.H100_8x --backend ncp-local --regions us-west-1 --min-instances 1 --max-instances 1 --timeout 900
-        """
-      Then the command exit code should be 0
+      When I successfully create function "bdd-load-tester-supreme" from image "nvcr.io/${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}/load_tester_supreme:0.0.8" with CLI options:
+        | option           | value   |
+        | --inference-url  | /echo   |
+        | --inference-port | 8000    |
+        | --health-uri     | /health |
+        | --health-port    | 8000    |
+        | --health-timeout | PT30S   |
 
-      When I run command:
-        """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml api-key generate --description bdd-load-tester-supreme --for function --scopes invoke_function,list_functions,queue_details,list_functions_details
-        """
-      Then the command exit code should be 0
+      And I successfully deploy the function selected by NVCF CLI with options:
+        | option          | value               |
+        | --gpu           | H100                |
+        | --instance-type | NCP.GPU.H100_8x     |
+        | --backend       | ncp-local           |
+        | --regions       | us-west-1           |
+        | --min-instances | 1                   |
+        | --max-instances | 1                   |
+        | --timeout       | 900                 |
 
-      When I run command:
+      And I successfully generate a function API key with CLI options:
+        | option        | value                                                                       |
+        | --description | bdd-load-tester-supreme                                                    |
+        | --scopes      | invoke_function,list_functions,queue_details,list_functions_details         |
+
+      When I successfully invoke the function selected by NVCF CLI over HTTP with timeout "120" seconds and poll duration "5" seconds:
         """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml function invoke --request-body '{"message":"bdd-echo","repeats":1}' --timeout 120 --poll-duration 5
+        {"message":"bdd-echo","repeats":1}
         """
-      Then the command exit code should be 0
-      And the command output should contain "bdd-echo"
+      Then the command output should contain "bdd-echo"
 
       # Remove the deployment: the local sizing cannot hold every
       # scenario's deployment at once.
-      When I run command:
-        """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml function delete --deployment-only
-        """
-      Then the command exit code should be 0
+      And I successfully undeploy the function selected by NVCF CLI
 
     @function-lifecycle @grpc
     Scenario: Operator creates, deploys, and invokes the gRPC Load Tester Supreme sample function
-      When I run command:
-        """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml function create --name bdd-grpc-load-tester-supreme --image nvcr.io/${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}/load_tester_supreme:0.0.8 --inference-url /grpc --inference-port 8001 --health-protocol GRPC --health-uri / --health-port 8001 --health-timeout PT30S
-        """
-      Then the command exit code should be 0
+      Given I use NVCF CLI config "${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml"
 
-      When I run command:
-        """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml function deploy create --gpu H100 --instance-type NCP.GPU.H100_8x --backend ncp-local --regions us-west-1 --min-instances 1 --max-instances 1 --timeout 900
-        """
-      Then the command exit code should be 0
+      When I successfully create function "bdd-grpc-load-tester-supreme" from image "nvcr.io/${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}/load_tester_supreme:0.0.8" with CLI options:
+        | option            | value   |
+        | --inference-url   | /grpc   |
+        | --inference-port  | 8001    |
+        | --health-protocol | GRPC    |
+        | --health-uri      | /       |
+        | --health-port     | 8001    |
+        | --health-timeout  | PT30S   |
 
-      When I run command:
-        """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml api-key generate --description bdd-grpc-load-tester-supreme --for function --scopes invoke_function,list_functions,queue_details,list_functions_details
-        """
-      Then the command exit code should be 0
+      And I successfully deploy the function selected by NVCF CLI with options:
+        | option          | value               |
+        | --gpu           | H100                |
+        | --instance-type | NCP.GPU.H100_8x     |
+        | --backend       | ncp-local           |
+        | --regions       | us-west-1           |
+        | --min-instances | 1                   |
+        | --max-instances | 1                   |
+        | --timeout       | 900                 |
 
-      When I run command:
+      And I successfully generate a function API key with CLI options:
+        | option        | value                                                                       |
+        | --description | bdd-grpc-load-tester-supreme                                               |
+        | --scopes      | invoke_function,list_functions,queue_details,list_functions_details         |
+
+      When I successfully invoke the function selected by NVCF CLI over plaintext gRPC service "Echo" method "EchoMessage" with timeout "120" seconds and poll duration "5" seconds:
         """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml function invoke --grpc --grpc-plaintext --grpc-service Echo --grpc-method EchoMessage --request-body '{"message":"bdd-grpc-echo"}' --timeout 120 --poll-duration 5
+        {"message":"bdd-grpc-echo"}
         """
-      Then the command exit code should be 0
-      And the command output should contain "bdd-grpc-echo"
+      Then the command output should contain "bdd-grpc-echo"
 
       # Free the GPU node for the LLM scenario.
-      When I run command:
-        """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml function delete --deployment-only
-        """
-      Then the command exit code should be 0
+      And I successfully undeploy the function selected by NVCF CLI
 
     # Proves the serve path the @llm-gateway scenario only installs:
     # LLM-type functions route through llm-api-gateway and
@@ -227,32 +232,40 @@ Feature: Install a local single-cluster NVCF stack with Helmfile
     # registration scenarios; not a standalone tag target.
     @llm-function-type
     Scenario: Operator creates, deploys, and invokes an LLM-type OpenAI-compatible sample function
-      When I run command:
-        """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml function create --name bdd-openai-compatible-sample --image nvcr.io/${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}/nvcf-openai-compatible-sample:local --function-type LLM --inference-url /v1/chat/completions --inference-port 8000 --health-uri /health --health-port 8000 --health-timeout PT30S --llm-model 'name=openai-compatible-sample,uris=/v1/chat/completions|/v1/embeddings,routingMethod=round_robin'
-        """
-      Then the command exit code should be 0
+      Given I use NVCF CLI config "${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml"
 
-      When I run command:
-        """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml function deploy create --gpu H100 --instance-type NCP.GPU.H100_8x --backend ncp-local --regions us-west-1 --min-instances 1 --max-instances 1 --timeout 900
-        """
-      Then the command exit code should be 0
+      When I successfully create function "bdd-openai-compatible-sample" from image "nvcr.io/${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}/nvcf-openai-compatible-sample:local" with CLI options:
+        | option           | value                                                                                               |
+        | --function-type  | LLM                                                                                                 |
+        | --inference-url  | /v1/chat/completions                                                                                |
+        | --inference-port | 8000                                                                                                |
+        | --health-uri     | /health                                                                                             |
+        | --health-port    | 8000                                                                                                |
+        | --health-timeout | PT30S                                                                                               |
+        | --llm-model      | name=openai-compatible-sample,uris=/v1/chat/completions\|/v1/embeddings,routingMethod=round_robin |
 
-      When I run command:
-        """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml api-key generate --description bdd-openai-compatible-sample --for function --scopes invoke_function,list_functions,queue_details,list_functions_details
-        """
-      Then the command exit code should be 0
+      And I successfully deploy the function selected by NVCF CLI with options:
+        | option          | value               |
+        | --gpu           | H100                |
+        | --instance-type | NCP.GPU.H100_8x     |
+        | --backend       | ncp-local           |
+        | --regions       | us-west-1           |
+        | --min-instances | 1                   |
+        | --max-instances | 1                   |
+        | --timeout       | 900                 |
+
+      And I successfully generate a function API key with CLI options:
+        | option        | value                                                                       |
+        | --description | bdd-openai-compatible-sample                                                 |
+        | --scopes      | invoke_function,list_functions,queue_details,list_functions_details         |
 
       # The gateway answers synchronously (no queue polling). The
       # sample always returns its fixed load-testing message.
-      When I run command:
+      When I successfully invoke model "openai-compatible-sample" at "/v1/chat/completions" with timeout "120" seconds:
         """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml function invoke --inference-url /v1/chat/completions --model-name openai-compatible-sample --request-body '{"messages":[{"role":"user","content":"bdd-llm-echo"}]}' --timeout 120
+        {"messages":[{"role":"user","content":"bdd-llm-echo"}]}
         """
-      Then the command exit code should be 0
-      And the command output should contain "chat.completion"
+      Then the command output should contain "chat.completion"
       And the command output should contain "fixed 128-byte response"
 
       # curl reports only the status code so the assertion cannot
@@ -265,8 +278,4 @@ Feature: Install a local single-cluster NVCF stack with Helmfile
       And the command output should contain "401"
 
       # Leave the GPU capacity free, same as the echo scenarios.
-      When I run command:
-        """
-        ${NVCF_CLI} --config ${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml function delete --deployment-only
-        """
-      Then the command exit code should be 0
+      And I successfully undeploy the function selected by NVCF CLI

--- a/tests/bdd/godog_test.go
+++ b/tests/bdd/godog_test.go
@@ -480,10 +480,14 @@ func TestSingleClusterHelmfileFeatureFileWiresToSteps(t *testing.T) {
 		"--health-protocol GRPC --health-uri / --health-port 8001") {
 		t.Fatal("gRPC sample function was not configured with a gRPC health endpoint")
 	}
-	if !commandRanThatContains(suite.Runner.(*fakeRunner).runs, "api-key generate --description bdd-load-tester-supreme --for function") {
+	if !commandRanThatContainsAll(suite.Runner.(*fakeRunner).runs,
+		"api-key generate --for function",
+		"--description bdd-load-tester-supreme") {
 		t.Fatal("HTTP sample function API key was not generated for the function service")
 	}
-	if !commandRanThatContains(suite.Runner.(*fakeRunner).runs, "api-key generate --description bdd-grpc-load-tester-supreme --for function") {
+	if !commandRanThatContainsAll(suite.Runner.(*fakeRunner).runs,
+		"api-key generate --for function",
+		"--description bdd-grpc-load-tester-supreme") {
 		t.Fatal("gRPC sample function API key was not generated for the function service")
 	}
 	if !commandRanThatContainsAll(suite.Runner.(*fakeRunner).runs,
@@ -939,10 +943,14 @@ func TestMultiClusterHelmfileFeatureFileWiresToSteps(t *testing.T) {
 		"--health-protocol GRPC --health-uri / --health-port 8001") {
 		t.Fatal("gRPC sample function was not configured with a gRPC health endpoint")
 	}
-	if !commandRanThatContains(suite.Runner.(*fakeRunner).runs, "api-key generate --description bdd-load-tester-supreme --for function") {
+	if !commandRanThatContainsAll(suite.Runner.(*fakeRunner).runs,
+		"api-key generate --for function",
+		"--description bdd-load-tester-supreme") {
 		t.Fatal("HTTP sample function API key was not generated for the function service")
 	}
-	if !commandRanThatContains(suite.Runner.(*fakeRunner).runs, "api-key generate --description bdd-grpc-load-tester-supreme --for function") {
+	if !commandRanThatContainsAll(suite.Runner.(*fakeRunner).runs,
+		"api-key generate --for function",
+		"--description bdd-grpc-load-tester-supreme") {
 		t.Fatal("gRPC sample function API key was not generated for the function service")
 	}
 	if commandRanThatContains(suite.Runner.(*fakeRunner).runs, "api-key generate --description bdd-nvct-task-smoke") {

--- a/tests/bdd/steps/command_steps.go
+++ b/tests/bdd/steps/command_steps.go
@@ -104,6 +104,16 @@ func (sc *ScenarioContext) runSuccessfully(ctx context.Context, commandText stri
 	return sc.commandExitCodeShouldBe(0)
 }
 
+// runResolvedSuccessfully is the exit-zero path for commands assembled from
+// individually interpolated and quoted arguments. It avoids interpolating the
+// assembled command a second time.
+func (sc *ScenarioContext) runResolvedSuccessfully(ctx context.Context, resolved string) error {
+	if err := sc.runResolvedAndRecord(ctx, resolved); err != nil {
+		return err
+	}
+	return sc.commandExitCodeShouldBe(0)
+}
+
 // runAndRecordWith interpolates, executes via the supplied runner method
 // (Run or RunWithTTY), and stores the Result on the ScenarioContext so
 // later assertions can read it. The non-zero-exit-is-not-a-failure
@@ -111,6 +121,14 @@ func (sc *ScenarioContext) runSuccessfully(ctx context.Context, commandText stri
 // runner method is used.
 func (sc *ScenarioContext) runAndRecordWith(ctx context.Context, commandText string, run func(context.Context, string) (harness.Result, error)) error {
 	resolved := strings.TrimSpace(dsl.Interpolate(commandText))
+	return sc.runResolvedAndRecordWith(ctx, resolved, run)
+}
+
+func (sc *ScenarioContext) runResolvedAndRecord(ctx context.Context, resolved string) error {
+	return sc.runResolvedAndRecordWith(ctx, strings.TrimSpace(resolved), sc.Suite.Runner.Run)
+}
+
+func (sc *ScenarioContext) runResolvedAndRecordWith(ctx context.Context, resolved string, run func(context.Context, string) (harness.Result, error)) error {
 	result, err := run(ctx, resolved)
 	sc.LastResult = result
 	sc.LastErr = err

--- a/tests/bdd/steps/context.go
+++ b/tests/bdd/steps/context.go
@@ -45,10 +45,11 @@ import (
 // for the same resolved text hits the cache instead of rerunning a destructive
 // command.
 type ScenarioContext struct {
-	Suite       *harness.Suite
-	LastResult  harness.Result
-	LastErr     error
-	LastCommand string
+	Suite         *harness.Suite
+	LastResult    harness.Result
+	LastErr       error
+	LastCommand   string
+	NVCFCLIConfig string
 }
 
 // NewScenarioContext wraps suite in a fresh per-scenario state. The
@@ -65,6 +66,7 @@ func RegisterAll(ctx *godog.ScenarioContext, sc *ScenarioContext) {
 		sc.LastResult = harness.Result{}
 		sc.LastErr = nil
 		sc.LastCommand = ""
+		sc.NVCFCLIConfig = ""
 		return c, nil
 	})
 	// Godog's default pretty formatter buffers the scenario block until
@@ -77,6 +79,7 @@ func RegisterAll(ctx *godog.ScenarioContext, sc *ScenarioContext) {
 	})
 	registerFileSteps(ctx, sc)
 	registerCommandSteps(ctx, sc)
+	registerNVCFCLISteps(ctx, sc)
 	registerAssertionSteps(ctx, sc)
 	registerInfraSteps(ctx, sc)
 }

--- a/tests/bdd/steps/nvcf_cli_steps.go
+++ b/tests/bdd/steps/nvcf_cli_steps.go
@@ -1,0 +1,160 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package steps
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cucumber/godog"
+
+	"nvcf-bdd/dsl"
+)
+
+func registerNVCFCLISteps(ctx *godog.ScenarioContext, sc *ScenarioContext) {
+	ctx.Step(`^I use NVCF CLI config "([^"]*)"$`, sc.iUseNVCFCLIConfig)
+	ctx.Step(`^I successfully create function "([^"]*)" from image "([^"]*)" with CLI options:$`, sc.iSuccessfullyCreateFunction)
+	ctx.Step(`^I successfully deploy the function selected by NVCF CLI with options:$`, sc.iSuccessfullyDeploySelectedFunction)
+	ctx.Step(`^I successfully generate a function API key with CLI options:$`, sc.iSuccessfullyGenerateFunctionAPIKey)
+	ctx.Step(`^I successfully invoke the function selected by NVCF CLI over HTTP with timeout "([^"]*)" seconds and poll duration "([^"]*)" seconds:$`, sc.iSuccessfullyInvokeFunctionHTTP)
+	ctx.Step(`^I successfully invoke the function selected by NVCF CLI over plaintext gRPC service "([^"]*)" method "([^"]*)" with timeout "([^"]*)" seconds and poll duration "([^"]*)" seconds:$`, sc.iSuccessfullyInvokeFunctionGRPC)
+	ctx.Step(`^I successfully invoke model "([^"]*)" at "([^"]*)" with timeout "([^"]*)" seconds:$`, sc.iSuccessfullyInvokeModel)
+	ctx.Step(`^I successfully undeploy the function selected by NVCF CLI$`, sc.iSuccessfullyUndeploySelectedFunction)
+}
+
+func (sc *ScenarioContext) iUseNVCFCLIConfig(config string) error {
+	sc.NVCFCLIConfig = dsl.Interpolate(config)
+	return nil
+}
+
+func (sc *ScenarioContext) iSuccessfullyCreateFunction(
+	ctx context.Context,
+	name,
+	image string,
+	table *godog.Table,
+) error {
+	return sc.runNVCFCLIWithOptions(ctx, []string{
+		"function", "create", "--name", name, "--image", image,
+	}, table)
+}
+
+func (sc *ScenarioContext) iSuccessfullyDeploySelectedFunction(ctx context.Context, table *godog.Table) error {
+	return sc.runNVCFCLIWithOptions(ctx, []string{"function", "deploy", "create"}, table)
+}
+
+func (sc *ScenarioContext) iSuccessfullyGenerateFunctionAPIKey(ctx context.Context, table *godog.Table) error {
+	return sc.runNVCFCLIWithOptions(ctx, []string{"api-key", "generate", "--for", "function"}, table)
+}
+
+func (sc *ScenarioContext) iSuccessfullyInvokeFunctionHTTP(
+	ctx context.Context,
+	timeout,
+	pollDuration string,
+	doc *godog.DocString,
+) error {
+	return sc.runNVCFCLI(ctx,
+		"function", "invoke",
+		"--request-body", doc.Content,
+		"--timeout", timeout,
+		"--poll-duration", pollDuration,
+	)
+}
+
+func (sc *ScenarioContext) iSuccessfullyInvokeFunctionGRPC(
+	ctx context.Context,
+	service,
+	method,
+	timeout,
+	pollDuration string,
+	doc *godog.DocString,
+) error {
+	return sc.runNVCFCLI(ctx,
+		"function", "invoke", "--grpc", "--grpc-plaintext",
+		"--grpc-service", service,
+		"--grpc-method", method,
+		"--request-body", doc.Content,
+		"--timeout", timeout,
+		"--poll-duration", pollDuration,
+	)
+}
+
+func (sc *ScenarioContext) iSuccessfullyInvokeModel(
+	ctx context.Context,
+	model,
+	inferenceURL,
+	timeout string,
+	doc *godog.DocString,
+) error {
+	return sc.runNVCFCLI(ctx,
+		"function", "invoke",
+		"--inference-url", inferenceURL,
+		"--model-name", model,
+		"--request-body", doc.Content,
+		"--timeout", timeout,
+	)
+}
+
+func (sc *ScenarioContext) iSuccessfullyUndeploySelectedFunction(ctx context.Context) error {
+	return sc.runNVCFCLI(ctx, "function", "delete", "--deployment-only")
+}
+
+func (sc *ScenarioContext) runNVCFCLIWithOptions(
+	ctx context.Context,
+	fixed []string,
+	table *godog.Table,
+) error {
+	options, err := nvcfCLIOptions(table)
+	if err != nil {
+		return err
+	}
+	return sc.runNVCFCLI(ctx, append(fixed, options...)...)
+}
+
+func (sc *ScenarioContext) runNVCFCLI(ctx context.Context, args ...string) error {
+	commandArgs := make([]string, 0, len(args)+3)
+	commandArgs = append(commandArgs,
+		dsl.Interpolate("${NVCF_CLI}"),
+		"--config",
+		sc.NVCFCLIConfig,
+	)
+	for _, arg := range args {
+		commandArgs = append(commandArgs, dsl.Interpolate(arg))
+	}
+	return sc.runResolvedSuccessfully(ctx, dsl.BuildCommand(commandArgs...))
+}
+
+func nvcfCLIOptions(table *godog.Table) ([]string, error) {
+	if table == nil || len(table.Rows) < 2 {
+		return nil, fmt.Errorf("table must have option and value headers and at least one data row")
+	}
+	header := table.Rows[0]
+	if len(header.Cells) != 2 ||
+		strings.TrimSpace(header.Cells[0].Value) != "option" ||
+		strings.TrimSpace(header.Cells[1].Value) != "value" {
+		return nil, fmt.Errorf("table headers must be option and value")
+	}
+	options := make([]string, 0, (len(table.Rows)-1)*2)
+	for index, row := range table.Rows[1:] {
+		if len(row.Cells) != 2 {
+			return nil, fmt.Errorf("row %d has %d cells, expected exactly 2", index+1, len(row.Cells))
+		}
+		options = append(options, row.Cells[0].Value, row.Cells[1].Value)
+	}
+	return options, nil
+}

--- a/tests/bdd/steps/nvcf_cli_steps_test.go
+++ b/tests/bdd/steps/nvcf_cli_steps_test.go
@@ -1,0 +1,145 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package steps
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/cucumber/godog"
+
+	"nvcf-bdd/harness"
+)
+
+func TestNVCFCLIConfigStoresInterpolatedPathWithoutCheckingIt(t *testing.T) {
+	sc, fake := newScenarioContext(t)
+	t.Setenv("BDD_CLI_CONFIG_DIR", "/missing config directory")
+
+	if err := sc.iUseNVCFCLIConfig("${BDD_CLI_CONFIG_DIR}/config.yaml"); err != nil {
+		t.Fatalf("select config: %v", err)
+	}
+	if sc.NVCFCLIConfig != "/missing config directory/config.yaml" {
+		t.Fatalf("config = %q", sc.NVCFCLIConfig)
+	}
+	if len(fake.runs) != 0 {
+		t.Fatalf("selecting a config ran %d commands, want 0", len(fake.runs))
+	}
+}
+
+func TestNVCFCLICreatePassesOptionsWithoutProductValidation(t *testing.T) {
+	sc, fake := newScenarioContext(t)
+	t.Setenv("NVCF_CLI", "/tmp/nvcf cli")
+	sc.NVCFCLIConfig = "/tmp/config file.yaml"
+	fake.result = harness.Result{ExitCode: 0}
+	options := docTable(t, [][]string{
+		{"option", "value"},
+		{"--future-option", "not-an-api-value"},
+		{"--llm-model", ""},
+		{"--llm-model", "name=model,uris=/v1/chat|/v1/embed,routingMethod=unknown"},
+	})
+
+	err := sc.iSuccessfullyCreateFunction(
+		context.Background(),
+		"function with spaces",
+		"registry.example/image:tag",
+		options,
+	)
+	if err != nil {
+		t.Fatalf("create function: %v", err)
+	}
+	want := "'/tmp/nvcf cli' --config '/tmp/config file.yaml' function create" +
+		" --name 'function with spaces' --image registry.example/image:tag" +
+		" --future-option not-an-api-value --llm-model ''" +
+		" --llm-model 'name=model,uris=/v1/chat|/v1/embed,routingMethod=unknown'"
+	if len(fake.runs) != 1 || fake.runs[0].command != want {
+		t.Fatalf("runs = %+v, want command %q", fake.runs, want)
+	}
+}
+
+func TestNVCFCLIInvocationAdaptersExposeAllArguments(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*ScenarioContext) error
+		want string
+	}{
+		{
+			name: "HTTP",
+			run: func(sc *ScenarioContext) error {
+				return sc.iSuccessfullyInvokeFunctionHTTP(context.Background(), "not-seconds", "also-not-seconds", &godog.DocString{Content: `{"message":"value with spaces"}`})
+			},
+			want: `nvcf-cli --config config.yaml function invoke --request-body '{"message":"value with spaces"}' --timeout not-seconds --poll-duration also-not-seconds`,
+		},
+		{
+			name: "gRPC",
+			run: func(sc *ScenarioContext) error {
+				return sc.iSuccessfullyInvokeFunctionGRPC(context.Background(), "Service", "Method", "120", "5", &godog.DocString{Content: `{"message":"grpc"}`})
+			},
+			want: `nvcf-cli --config config.yaml function invoke --grpc --grpc-plaintext --grpc-service Service --grpc-method Method --request-body '{"message":"grpc"}' --timeout 120 --poll-duration 5`,
+		},
+		{
+			name: "model",
+			run: func(sc *ScenarioContext) error {
+				return sc.iSuccessfullyInvokeModel(context.Background(), "model/name", "/v1/chat/completions", "120", &godog.DocString{Content: `{"messages":[]}`})
+			},
+			want: `nvcf-cli --config config.yaml function invoke --inference-url /v1/chat/completions --model-name model/name --request-body '{"messages":[]}' --timeout 120`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sc, fake := newScenarioContext(t)
+			t.Setenv("NVCF_CLI", "nvcf-cli")
+			sc.NVCFCLIConfig = "config.yaml"
+			fake.result = harness.Result{ExitCode: 0}
+
+			if err := test.run(sc); err != nil {
+				t.Fatalf("invoke: %v", err)
+			}
+			if len(fake.runs) != 1 || fake.runs[0].command != test.want {
+				t.Fatalf("runs = %+v, want command %q", fake.runs, test.want)
+			}
+		})
+	}
+}
+
+func TestNVCFCLISuccessStepRequiresExitZero(t *testing.T) {
+	sc, fake := newScenarioContext(t)
+	t.Setenv("NVCF_CLI", "nvcf-cli")
+	sc.NVCFCLIConfig = "config.yaml"
+	fake.result = harness.Result{ExitCode: 22, Stderr: "CLI rejected the request"}
+	fake.err = errors.New("exit status 22")
+	options := docTable(t, [][]string{{"option", "value"}, {"--timeout", "invalid"}})
+
+	err := sc.iSuccessfullyDeploySelectedFunction(context.Background(), options)
+	if err == nil || !strings.Contains(err.Error(), "exit code = 22, want 0") {
+		t.Fatalf("error = %v, want exit-zero assertion failure", err)
+	}
+	if len(fake.runs) != 1 || sc.LastResult.ExitCode != 22 {
+		t.Fatalf("runs = %+v, result = %+v", fake.runs, sc.LastResult)
+	}
+}
+
+func TestNVCFCLIOptionsValidateOnlyTableShape(t *testing.T) {
+	table := docTable(t, [][]string{{"flag", "setting"}, {"--timeout", "120"}})
+	_, err := nvcfCLIOptions(table)
+	if err == nil || !strings.Contains(err.Error(), "headers must be option and value") {
+		t.Fatalf("error = %v, want structural header error", err)
+	}
+}


### PR DESCRIPTION
## TL;DR

Add transparent, table-driven `nvcf-cli` adapters for successful function lifecycle scenarios. Migrate the local single-cluster, local multi-cluster, and multi-cluster EKS Helmfile features so their product inputs remain visible without repeating the executable, config, fixed subcommand, quoting, or exit-zero assertion.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

The lifecycle scenarios repeated long raw commands and a separate exit-code assertion for every successful CLI action. This made the user workflow harder to scan and mixed command mechanics with the behavior under test.

This change adds one config-selection step and thin adapters for function creation, deployment, API-key generation, HTTP invocation, plaintext gRPC invocation, model invocation, and undeployment. The adapters assemble one CLI command, record its real result for existing output assertions, and use shared POSIX argument quoting. The BDD guidance, step catalog, wiring checks, and focused unit tests are updated with the same contract.

### Governing contract

The lifecycle DSL is a transparent command adapter. It validates only Gherkin table structure, passes every supplied CLI option and value in order, does not add product validation, defaulting, or state, and leaves product behavior to `nvcf-cli` and the NVCF API. Repeated options, empty values, unknown options, and product-invalid values pass through unchanged. The deliberate exception is steps phrased `successfully`, which assert exit code 0. Negative and exit-code-specific scenarios continue using raw command steps.

Customer release notes: Not customer visible.

Infrastructure plan summary: Not applicable. The feature workflows are unchanged.

Dependencies: None. No license review or NOTICE update is needed.

## For the Reviewer

Please focus on `tests/bdd/steps/nvcf_cli_steps.go` and its tests. The important boundary is that these steps improve readability without duplicating API or CLI validation.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

Local validation:

- `go test -short ./...`
- `./scripts/lint.sh`
- Feature wiring tests for single-cluster Helmfile, multi-cluster Helmfile, and multi-cluster EKS Helmfile
- Full local single-cluster Helmfile feature: 6 scenarios and 50 steps passed, including HTTP, gRPC, and LLM lifecycle paths
- Full local multi-cluster Helmfile run: control-plane install and compute registration passed, then the pre-existing `@nvct-task-api` scenario stopped the run because the deployed stack still emits the generic `RequestICMSInstances` action instead of consuming the task-action fix from #1032
- Targeted live multi-cluster lifecycle run against the installed topology: 2 scenarios and 12 steps passed, including HTTP and plaintext gRPC invocation

The first single-cluster attempt encountered local Docker disk pressure. After pruning unused images and recreating a fresh `ncp-local`, the complete feature passed. Live EKS was not run; the EKS feature passed its local wiring test.

No additional QA is required for the local adapters. A live EKS run can validate the migrated EKS scenario when that environment is available.

## Issues

Closes #1106

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated BDD steps for configuring the CLI and managing function lifecycles, including creation, deployment, invocation, API-key generation, and undeployment.
  - Added support for HTTP, plaintext gRPC, and model invocation scenarios with structured options.
  - Added safe shell command construction and argument handling.

- **Tests**
  - Expanded coverage for command quoting, option forwarding, invocation arguments, validation, and successful command execution.
  - Updated lifecycle scenarios to use the new structured steps while preserving existing assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->