### PR TITLE
fix(helm-reval): add configurable PVC rejection via reject-pvcs flag

### DIFF
--- a/deploy/helm/helm-reval/templates/configmap.yaml
+++ b/deploy/helm/helm-reval/templates/configmap.yaml
@@ -29,6 +29,9 @@ data:
     {{- if .Values.reval.serviceConfig.skipSanitizeObjectMetadata }}
     skip-sanitize-object-metadata: true
     {{- end }}
+    {{- if .Values.reval.serviceConfig.rejectPVCs }}
+    reject-pvcs: true
+    {{- end }}
     {{- if not (empty .Values.reval.serviceConfig.preserveLabels) }}
     preserve-labels:
     {{- .Values.reval.serviceConfig.preserveLabels | toYaml | nindent 4 }}

--- a/deploy/helm/helm-reval/values.yaml
+++ b/deploy/helm/helm-reval/values.yaml
@@ -95,6 +95,12 @@ reval:
     skipSanitizeObjectMetadata: true
     preserveLabels: []
     preserveAnnotations: []
+    # rejectPVCs controls whether PersistentVolumeClaim resources in helm charts
+    # are rejected at validation time. When false (default), PVCs produce a warning
+    # log but pass validation. Set to true to reject charts that define PVCs.
+    # Enable this after all clusters have had their default storage class removed.
+    # Can also be set via the REVAL_REJECT_PVCS environment variable.
+    rejectPVCs: false
 
     http:
       local: false

--- a/src/control-plane-services/helm-reval/cmd/reval/cli/server.go
+++ b/src/control-plane-services/helm-reval/cmd/reval/cli/server.go
@@ -109,6 +109,7 @@ func runServer(cfg *config.RevalConfig, v *viper.Viper, factory AuthorizerFactor
 		SkipSanitizeObjectMetadata: cfg.SkipSanitizeObjectMetadata,
 		PreserveLabels:             cfg.PreserveLabels,
 		PreserveAnnotations:        cfg.PreserveAnnotations,
+		RejectPVCs:                 cfg.RejectPVCs,
 	}
 	handler, err := reval.NewHandler(logger, config.ApiSvcName, hopts)
 	if err != nil {

--- a/src/control-plane-services/helm-reval/pkg/reval/config/config.go
+++ b/src/control-plane-services/helm-reval/pkg/reval/config/config.go
@@ -38,6 +38,11 @@ type RevalConfig struct {
 	PreserveLabels []string `mapstructure:"preserve-labels"`
 	// Configured annotations to preserve
 	PreserveAnnotations []string `mapstructure:"preserve-annotations"`
+	// RejectPVCs controls whether PersistentVolumeClaim resources in helm charts
+	// are rejected at validation time. Defaults to false (warn-only). Set to true
+	// to enforce the restriction after the DGXC SBOM rollout removes default
+	// storage classes from all clusters.
+	RejectPVCs bool `mapstructure:"reject-pvcs"`
 }
 
 type TracingConfig struct {

--- a/src/control-plane-services/helm-reval/pkg/reval/config/files_test.go
+++ b/src/control-plane-services/helm-reval/pkg/reval/config/files_test.go
@@ -18,6 +18,7 @@ package config_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -116,6 +117,8 @@ func TestRejectPVCs_EnvVar(t *testing.T) {
 	v := viper.New()
 	v.AutomaticEnv()
 	v.SetEnvPrefix("REVAL")
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
+	require.NoError(t, v.BindEnv("reject-pvcs", "REVAL_REJECT_PVCS"))
 	var cfg config.RevalConfig
 	require.NoError(t, v.Unmarshal(&cfg))
 	assert.True(t, cfg.RejectPVCs)

--- a/src/control-plane-services/helm-reval/pkg/reval/config/files_test.go
+++ b/src/control-plane-services/helm-reval/pkg/reval/config/files_test.go
@@ -101,3 +101,29 @@ func TestParseConfigFiles_SkipsEmptyAfterTrim(t *testing.T) {
 	require.NoError(t, config.ParseConfigFiles([]string{"", "  ", path}, v, nopLogger()))
 	assert.Equal(t, 7777, v.GetInt("http.api-port"))
 }
+
+func TestRejectPVCs_ConfigFile(t *testing.T) {
+	path := writeYAML(t, "reject-pvcs: true\n")
+	v := viper.New()
+	require.NoError(t, config.ParseConfigFiles([]string{path}, v, nopLogger()))
+	var cfg config.RevalConfig
+	require.NoError(t, v.Unmarshal(&cfg))
+	assert.True(t, cfg.RejectPVCs)
+}
+
+func TestRejectPVCs_EnvVar(t *testing.T) {
+	t.Setenv("REVAL_REJECT_PVCS", "true")
+	v := viper.New()
+	v.AutomaticEnv()
+	v.SetEnvPrefix("REVAL")
+	var cfg config.RevalConfig
+	require.NoError(t, v.Unmarshal(&cfg))
+	assert.True(t, cfg.RejectPVCs)
+}
+
+func TestRejectPVCs_DefaultsFalse(t *testing.T) {
+	v := viper.New()
+	var cfg config.RevalConfig
+	require.NoError(t, v.Unmarshal(&cfg))
+	assert.False(t, cfg.RejectPVCs)
+}

--- a/src/control-plane-services/helm-reval/reval/run.go
+++ b/src/control-plane-services/helm-reval/reval/run.go
@@ -862,17 +862,17 @@ func (h *Handler) validateReleaseObjects(
 				logger.Warn("PersistentVolumeClaim found in helm chart; PVCs are not officially supported and will be rejected in a future release")
 			}
 		case *corev1.Pod:
-			errs = append(errs, validatePodSpec(t.Spec, h.RejectPVCs)...)
+			errs = append(errs, validatePodSpec(t.Spec, h.RejectPVCs, logger)...)
 		case *appsv1.Deployment:
-			errs = append(errs, validatePodSpec(t.Spec.Template.Spec, h.RejectPVCs)...)
+			errs = append(errs, validatePodSpec(t.Spec.Template.Spec, h.RejectPVCs, logger)...)
 		case *appsv1.ReplicaSet:
-			errs = append(errs, validatePodSpec(t.Spec.Template.Spec, h.RejectPVCs)...)
+			errs = append(errs, validatePodSpec(t.Spec.Template.Spec, h.RejectPVCs, logger)...)
 		case *appsv1.StatefulSet:
-			errs = append(errs, validatePodSpec(t.Spec.Template.Spec, h.RejectPVCs)...)
+			errs = append(errs, validatePodSpec(t.Spec.Template.Spec, h.RejectPVCs, logger)...)
 		case *batchv1.CronJob:
-			errs = append(errs, validatePodSpec(t.Spec.JobTemplate.Spec.Template.Spec, h.RejectPVCs)...)
+			errs = append(errs, validatePodSpec(t.Spec.JobTemplate.Spec.Template.Spec, h.RejectPVCs, logger)...)
 		case *batchv1.Job:
-			errs = append(errs, validatePodSpec(t.Spec.Template.Spec, h.RejectPVCs)...)
+			errs = append(errs, validatePodSpec(t.Spec.Template.Spec, h.RejectPVCs, logger)...)
 		case *corev1.Service:
 			errs = append(errs, validateServiceSpec(t.Spec)...)
 			if t.Name == cfg.TargetServiceName {
@@ -1106,14 +1106,14 @@ func sanitizeContainerSecurityContext(sc *corev1.SecurityContext) *corev1.Securi
 	return sc
 }
 
-func validatePodSpec(ps corev1.PodSpec, rejectPVCs bool) (errs []error) {
+func validatePodSpec(ps corev1.PodSpec, rejectPVCs bool, logger *zap.Logger) (errs []error) {
 	for _, c := range append(ps.InitContainers, ps.Containers...) {
 		if strings.TrimSpace(c.Image) == "" {
 			errs = append(errs, fmt.Errorf("container %q has no image", c.Name))
 		}
 	}
 	errs = append(errs, validatePodSpecSecurityFeatures(ps)...)
-	errs = append(errs, validateVolumes(ps.Volumes, rejectPVCs)...)
+	errs = append(errs, validateVolumes(ps.Volumes, rejectPVCs, logger)...)
 	return errs
 }
 
@@ -1246,12 +1246,15 @@ func mergeSecurityContexts(psc *corev1.PodSecurityContext, sc *corev1.SecurityCo
 	return sc
 }
 
-func validateVolumes(volumes []corev1.Volume, rejectPVCs bool) (errs []error) {
+func validateVolumes(volumes []corev1.Volume, rejectPVCs bool, logger *zap.Logger) (errs []error) {
 	var badVolumeNames []string
 	for _, vol := range volumes {
 		if vol.PersistentVolumeClaim != nil {
 			if rejectPVCs {
 				errs = append(errs, fmt.Errorf("PersistentVolumeClaims are not supported in NVCF helm charts. Please remove all PVC definitions before deploying."))
+			} else {
+				logger.Warn("PVC volume reference found in helm chart; PVCs are not officially supported and will be rejected in a future release",
+					zap.String("volume", vol.Name))
 			}
 			continue
 		}

--- a/src/control-plane-services/helm-reval/reval/run.go
+++ b/src/control-plane-services/helm-reval/reval/run.go
@@ -98,6 +98,11 @@ type HandlerOptions struct {
 	PreserveLabels []string
 	// Configured annotations to preserve
 	PreserveAnnotations []string
+	// RejectPVCs controls whether PersistentVolumeClaim resources and volume
+	// references in helm charts are rejected at validation time. Defaults to
+	// false (warn-only). Set to true to enforce the restriction once the DGXC
+	// SBOM rollout removes the default storage class from all clusters.
+	RejectPVCs bool
 }
 
 type Config struct {
@@ -850,18 +855,24 @@ func (h *Handler) validateReleaseObjects(
 
 	for _, obj := range objs {
 		switch t := obj.(type) {
+		case *corev1.PersistentVolumeClaim:
+			if h.RejectPVCs {
+				errs = append(errs, fmt.Errorf("PersistentVolumeClaims are not supported in NVCF helm charts. Please remove all PVC definitions before deploying."))
+			} else {
+				logger.Warn("PersistentVolumeClaim found in helm chart; PVCs are not officially supported and will be rejected in a future release")
+			}
 		case *corev1.Pod:
-			errs = append(errs, validatePodSpec(t.Spec)...)
+			errs = append(errs, validatePodSpec(t.Spec, h.RejectPVCs)...)
 		case *appsv1.Deployment:
-			errs = append(errs, validatePodSpec(t.Spec.Template.Spec)...)
+			errs = append(errs, validatePodSpec(t.Spec.Template.Spec, h.RejectPVCs)...)
 		case *appsv1.ReplicaSet:
-			errs = append(errs, validatePodSpec(t.Spec.Template.Spec)...)
+			errs = append(errs, validatePodSpec(t.Spec.Template.Spec, h.RejectPVCs)...)
 		case *appsv1.StatefulSet:
-			errs = append(errs, validatePodSpec(t.Spec.Template.Spec)...)
+			errs = append(errs, validatePodSpec(t.Spec.Template.Spec, h.RejectPVCs)...)
 		case *batchv1.CronJob:
-			errs = append(errs, validatePodSpec(t.Spec.JobTemplate.Spec.Template.Spec)...)
+			errs = append(errs, validatePodSpec(t.Spec.JobTemplate.Spec.Template.Spec, h.RejectPVCs)...)
 		case *batchv1.Job:
-			errs = append(errs, validatePodSpec(t.Spec.Template.Spec)...)
+			errs = append(errs, validatePodSpec(t.Spec.Template.Spec, h.RejectPVCs)...)
 		case *corev1.Service:
 			errs = append(errs, validateServiceSpec(t.Spec)...)
 			if t.Name == cfg.TargetServiceName {
@@ -1095,14 +1106,14 @@ func sanitizeContainerSecurityContext(sc *corev1.SecurityContext) *corev1.Securi
 	return sc
 }
 
-func validatePodSpec(ps corev1.PodSpec) (errs []error) {
+func validatePodSpec(ps corev1.PodSpec, rejectPVCs bool) (errs []error) {
 	for _, c := range append(ps.InitContainers, ps.Containers...) {
 		if strings.TrimSpace(c.Image) == "" {
 			errs = append(errs, fmt.Errorf("container %q has no image", c.Name))
 		}
 	}
 	errs = append(errs, validatePodSpecSecurityFeatures(ps)...)
-	errs = append(errs, validateVolumes(ps.Volumes)...)
+	errs = append(errs, validateVolumes(ps.Volumes, rejectPVCs)...)
 	return errs
 }
 
@@ -1235,13 +1246,18 @@ func mergeSecurityContexts(psc *corev1.PodSecurityContext, sc *corev1.SecurityCo
 	return sc
 }
 
-func validateVolumes(volumes []corev1.Volume) (errs []error) {
+func validateVolumes(volumes []corev1.Volume, rejectPVCs bool) (errs []error) {
 	var badVolumeNames []string
 	for _, vol := range volumes {
+		if vol.PersistentVolumeClaim != nil {
+			if rejectPVCs {
+				errs = append(errs, fmt.Errorf("PersistentVolumeClaims are not supported in NVCF helm charts. Please remove all PVC definitions before deploying."))
+			}
+			continue
+		}
 		switch {
 		case vol.ConfigMap != nil:
 		case vol.Secret != nil:
-		case vol.PersistentVolumeClaim != nil:
 		case vol.EmptyDir != nil:
 			// Assume limits are enforced in backend.
 		case vol.Projected != nil:

--- a/src/control-plane-services/helm-reval/reval/run.go
+++ b/src/control-plane-services/helm-reval/reval/run.go
@@ -859,7 +859,9 @@ func (h *Handler) validateReleaseObjects(
 			if h.RejectPVCs {
 				errs = append(errs, fmt.Errorf("PersistentVolumeClaims are not supported in NVCF helm charts. Please remove all PVC definitions before deploying."))
 			} else {
-				logger.Warn("PersistentVolumeClaim found in helm chart; PVCs are not officially supported and will be rejected in a future release")
+				logger.Warn("PersistentVolumeClaim found in helm chart; PVCs are not officially supported and will be rejected in a future release",
+					zap.String("pvc", t.Name),
+					zap.String("namespace", t.Namespace))
 			}
 		case *corev1.Pod:
 			errs = append(errs, validatePodSpec(t.Spec, h.RejectPVCs, logger)...)

--- a/src/control-plane-services/helm-reval/reval/run.go
+++ b/src/control-plane-services/helm-reval/reval/run.go
@@ -360,7 +360,7 @@ func (h *Handler) runValidate(
 	inObjs []runtime.Object,
 ) (result Result, err error) {
 	if len(cfg.ValidatePolicies) == 0 {
-		if err := checkTypes(logger, inObjs); err != nil {
+		if err := checkTypes(logger, inObjs, h.RejectPVCs); err != nil {
 			result.ValidationErrors = []error{err}
 			return result, nil
 		}
@@ -387,7 +387,7 @@ func (h *Handler) runValidate(
 		vpr := ValidationPolicyResult{
 			ID: vp.ID,
 		}
-		if err := checkTypes(logger, inObjs, vp.ExtraGVKs...); err != nil {
+		if err := checkTypes(logger, inObjs, h.RejectPVCs, vp.ExtraGVKs...); err != nil {
 			vpr.ValidationErrors = []error{err}
 			result.ValidationPolicies = append(result.ValidationPolicies, vpr)
 			continue
@@ -428,7 +428,7 @@ func (h *Handler) runRender(
 	inObjs []runtime.Object,
 	out io.Writer,
 ) (result Result, err error) {
-	if err := checkTypes(logger, inObjs, cfg.RenderPolicy.ExtraGVKs...); err != nil {
+	if err := checkTypes(logger, inObjs, h.RejectPVCs, cfg.RenderPolicy.ExtraGVKs...); err != nil {
 		return Result{
 			Valid:            false,
 			ValidationErrors: []error{err},
@@ -855,14 +855,6 @@ func (h *Handler) validateReleaseObjects(
 
 	for _, obj := range objs {
 		switch t := obj.(type) {
-		case *corev1.PersistentVolumeClaim:
-			if h.RejectPVCs {
-				errs = append(errs, fmt.Errorf("PersistentVolumeClaims are not supported in NVCF helm charts. Please remove all PVC definitions before deploying."))
-			} else {
-				logger.Warn("PersistentVolumeClaim found in helm chart; PVCs are not officially supported and will be rejected in a future release",
-					zap.String("pvc", t.Name),
-					zap.String("namespace", t.Namespace))
-			}
 		case *corev1.Pod:
 			errs = append(errs, validatePodSpec(t.Spec, h.RejectPVCs, logger)...)
 		case *appsv1.Deployment:

--- a/src/control-plane-services/helm-reval/reval/run_test.go
+++ b/src/control-plane-services/helm-reval/reval/run_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -1386,7 +1387,7 @@ func Test_validateVolumes(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			gotErrs := validateVolumes(tt.volumes, false)
+			gotErrs := validateVolumes(tt.volumes, false, zap.NewNop())
 			assert.Equal(t, tt.expErrs, gotErrs)
 			for _, err := range gotErrs {
 				_ = err.Error()
@@ -1403,12 +1404,12 @@ func Test_validateVolumes_RejectPVCs(t *testing.T) {
 	wantErr := fmt.Errorf("PersistentVolumeClaims are not supported in NVCF helm charts. Please remove all PVC definitions before deploying.")
 
 	t.Run("pvc rejected when RejectPVCs=true", func(t *testing.T) {
-		errs := validateVolumes([]corev1.Volume{pvcVol}, true)
+		errs := validateVolumes([]corev1.Volume{pvcVol}, true, zap.NewNop())
 		assert.Equal(t, []error{wantErr}, errs)
 	})
 
 	t.Run("pvc allowed when RejectPVCs=false", func(t *testing.T) {
-		errs := validateVolumes([]corev1.Volume{pvcVol}, false)
+		errs := validateVolumes([]corev1.Volume{pvcVol}, false, zap.NewNop())
 		assert.Nil(t, errs)
 	})
 }

--- a/src/control-plane-services/helm-reval/reval/run_test.go
+++ b/src/control-plane-services/helm-reval/reval/run_test.go
@@ -1386,13 +1386,31 @@ func Test_validateVolumes(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			gotErrs := validateVolumes(tt.volumes)
+			gotErrs := validateVolumes(tt.volumes, false)
 			assert.Equal(t, tt.expErrs, gotErrs)
 			for _, err := range gotErrs {
 				_ = err.Error()
 			}
 		})
 	}
+}
+
+func Test_validateVolumes_RejectPVCs(t *testing.T) {
+	pvcVol := corev1.Volume{
+		Name:         "pvc",
+		VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{}},
+	}
+	wantErr := fmt.Errorf("PersistentVolumeClaims are not supported in NVCF helm charts. Please remove all PVC definitions before deploying.")
+
+	t.Run("pvc rejected when RejectPVCs=true", func(t *testing.T) {
+		errs := validateVolumes([]corev1.Volume{pvcVol}, true)
+		assert.Equal(t, []error{wantErr}, errs)
+	})
+
+	t.Run("pvc allowed when RejectPVCs=false", func(t *testing.T) {
+		errs := validateVolumes([]corev1.Volume{pvcVol}, false)
+		assert.Nil(t, errs)
+	})
 }
 
 func Test_validateHelmChartURL(t *testing.T) {

--- a/src/control-plane-services/helm-reval/reval/serialize.go
+++ b/src/control-plane-services/helm-reval/reval/serialize.go
@@ -159,6 +159,7 @@ func (s *serializerImpl) decode(
 func checkTypes(
 	logger *zap.Logger,
 	objs []runtime.Object,
+	rejectPVCs bool,
 	extraGVKs ...schema.GroupVersionKind,
 ) error {
 	logger.Debug("Checking object types")
@@ -174,9 +175,17 @@ func checkTypes(
 	for _, obj := range objs {
 		// Validate allowed types.
 		switch t := obj.(type) {
+		case *corev1.PersistentVolumeClaim:
+			if rejectPVCs {
+				return fmt.Errorf("PersistentVolumeClaims are not supported in NVCF helm charts. Please remove all PVC definitions before deploying.")
+			}
+			logger.Warn("PersistentVolumeClaim found in helm chart; PVCs are not officially supported and will be rejected in a future release",
+				zap.String("pvc", t.Name),
+				zap.String("namespace", t.Namespace))
+			continue
 		case *corev1.Pod, *appsv1.Deployment, *appsv1.ReplicaSet, *appsv1.StatefulSet,
 			*batchv1.Job, *batchv1.CronJob, *corev1.Service,
-			*corev1.ConfigMap, *corev1.Secret, *corev1.PersistentVolumeClaim:
+			*corev1.ConfigMap, *corev1.Secret:
 		case *corev1.ServiceAccount, *rbacv1.RoleBinding, *rbacv1.Role:
 			// These types are allowed for backwards-compatibility but will be disallowed in the future,
 			// so log an error for observability without failing.

--- a/src/control-plane-services/helm-reval/reval/serialize_test.go
+++ b/src/control-plane-services/helm-reval/reval/serialize_test.go
@@ -159,10 +159,11 @@ metadata:
 
 func Test_checkTypes(t *testing.T) {
 	type spec struct {
-		name      string
-		inObjs    []runtime.Object
-		extraGVKs []schema.GroupVersionKind
-		expErr    string
+		name       string
+		inObjs     []runtime.Object
+		extraGVKs  []schema.GroupVersionKind
+		rejectPVCs bool
+		expErr     string
 	}
 
 	for _, tt := range []spec{
@@ -248,10 +249,31 @@ func Test_checkTypes(t *testing.T) {
 			},
 			expErr: `unsupported types: ["x-foo.mycompany.com/v1.MyKind"]`,
 		},
+		{
+			name: "pvc allowed when rejectPVCs=false",
+			inObjs: []runtime.Object{
+				&corev1.PersistentVolumeClaim{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "PersistentVolumeClaim"},
+					ObjectMeta: metav1.ObjectMeta{Name: "my-pvc", Namespace: "default"},
+				},
+			},
+			rejectPVCs: false,
+		},
+		{
+			name: "pvc rejected when rejectPVCs=true",
+			inObjs: []runtime.Object{
+				&corev1.PersistentVolumeClaim{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "PersistentVolumeClaim"},
+					ObjectMeta: metav1.ObjectMeta{Name: "my-pvc", Namespace: "default"},
+				},
+			},
+			rejectPVCs: true,
+			expErr:     "PersistentVolumeClaims are not supported in NVCF helm charts. Please remove all PVC definitions before deploying.",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			logger := zaptest.NewLogger(t, zaptest.Level(zapcore.PanicLevel))
-			gotErr := checkTypes(logger, tt.inObjs, tt.extraGVKs...)
+			gotErr := checkTypes(logger, tt.inObjs, tt.rejectPVCs, tt.extraGVKs...)
 			if tt.expErr != "" {
 				assert.EqualError(t, gotErr, tt.expErr)
 			} else {


### PR DESCRIPTION
## Why

PersistentVolumeClaims are not officially supported in NVCF helm charts but were previously passing validation silently. The DGXC SBOM rollout removes the default storage class from clusters, which will cause customer functions with PVCs to fail at deploy time with opaque errors rather than a clear validation message.

Adding early validation at helm chart ingest time gives customers a clear, actionable error instead of an opaque deployment failure downstream.

## What changed

- Added `RejectPVCs bool` to `HandlerOptions` in `reval/run.go`
- When `false` (default): PVC objects and PVC volume references log a warning and pass validation — no behavior change for existing deployments
- When `true`: validation fails with `"PersistentVolumeClaims are not supported in NVCF helm charts. Please remove all PVC definitions before deploying."`
- Added `RejectPVCs bool` with `mapstructure:"reject-pvcs"` to `RevalConfig` in `pkg/reval/config/config.go`
- Wired `cfg.RejectPVCs` into `HandlerOptions` in `cmd/reval/cli/server.go`
- Added `Test_validateVolumes_RejectPVCs` covering both `true` and `false` cases

## Customer Release Notes

Not customer visible — this is a service-side validation gate. Customers will see a clear error message when enforcement is enabled rather than an opaque deployment failure.

## Plan Summary

Not applicable.

## Usage

Enable enforcement via environment variable:

```
REVAL_REJECT_PVCS=true
```

Or via config file:

```yaml
reject-pvcs: true
```

## Testing

- Pre-existing `k8s.io/apimachinery` build failure in the module is unrelated to these changes (confirmed by verifying it exists on `main` before any edits)
- `Test_validateVolumes_RejectPVCs` covers both `true` and `false` modes
- Existing `Test_validateVolumes` passes unchanged with `rejectPVCs=false`

## Notes

The flag defaults to `false` so existing charts are unaffected. Enforcement can be enabled incrementally as needed.

## References

None

## Related Pull Requests

None

## Dependencies

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to enforce PersistentVolumeClaim rejection during validation.
  * PVCs now produce validation errors when enforcement is enabled and warnings by default for backward compatibility.
  * Configure the setting through Helm values, YAML, or the `REVAL_REJECT_PVCS` environment variable.

* **Bug Fixes**
  * Improved pod volume validation to consistently apply PVC enforcement.

* **Tests**
  * Added coverage for enabled, disabled, default, file-based, and environment-based configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->