### PR TITLE
fix(storage): label model-cache init namespace for nvcf-unbound DNS injection

### DIFF
--- a/src/compute-plane-services/nvca/pkg/storage/cachebackend_samba.go
+++ b/src/compute-plane-services/nvca/pkg/storage/cachebackend_samba.go
@@ -154,8 +154,20 @@ func EnsureSambaModelCacheInfra(
 	}
 
 	rwSecret, roSecret := newSambaModelCacheSecrets()
+
+	// Ensure the namespace first and patch required labels onto it if it already
+	// exists. ensureCreated treats AlreadyExists as success without updating, so
+	// pre-existing namespaces (e.g. from a previous NVCA version that did not
+	// set WorkloadInstanceTypeLabel) must be patched explicitly.
+	ns := NewModelCacheInitNamespace()
+	if err := ensureCreated(ctx, c, ns); err != nil {
+		return false, fmt.Errorf("ensure samba model cache %T: %w", ns, err)
+	}
+	if err := ensureNamespaceLabels(ctx, c, ns); err != nil {
+		return false, fmt.Errorf("patch samba model cache %T labels: %w", ns, err)
+	}
+
 	objs := []client.Object{
-		NewModelCacheInitNamespace(),
 		rwSecret,
 		roSecret,
 		newSambaModelCacheDataPVC(cacheHandle, size),
@@ -188,6 +200,40 @@ func ensureCreated(ctx context.Context, c client.Client, obj client.Object) erro
 		return err
 	}
 	return nil
+}
+
+// ensureNamespaceLabels patches the labels from want onto the live namespace.
+// It is a no-op when all required labels are already present with the correct
+// values, so it is safe to call on every reconcile. NotFound is treated as a
+// no-op: the namespace was just created by ensureCreated with the correct
+// labels and does not need patching.
+func ensureNamespaceLabels(ctx context.Context, c client.Client, want *corev1.Namespace) error {
+	live := &corev1.Namespace{}
+	if err := c.Get(ctx, client.ObjectKey{Name: want.Name}, live); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	// Check whether all required labels are already present with correct values.
+	allPresent := true
+	for k, v := range want.Labels {
+		if live.Labels[k] != v {
+			allPresent = false
+			break
+		}
+	}
+	if allPresent {
+		return nil
+	}
+	patched := live.DeepCopy()
+	if patched.Labels == nil {
+		patched.Labels = make(map[string]string, len(want.Labels))
+	}
+	for k, v := range want.Labels {
+		patched.Labels[k] = v
+	}
+	return c.Patch(ctx, patched, client.MergeFrom(live))
 }
 
 // sambaModelCacheSelector is the unique pod selector for a handle's Samba server.

--- a/src/compute-plane-services/nvca/pkg/storage/cachebackend_samba_test.go
+++ b/src/compute-plane-services/nvca/pkg/storage/cachebackend_samba_test.go
@@ -290,7 +290,7 @@ func TestSambaModelCacheResourceName_LongHandleBounded(t *testing.T) {
 
 // TestEnsureNamespaceLabels_PatchesExistingNamespace verifies that
 // ensureNamespaceLabels adds missing labels to a namespace that already exists
-// without the required keys — the scenario that arises on clusters upgraded
+// without the required keys; the scenario that arises on clusters upgraded
 // from an NVCA version that did not set WorkloadInstanceTypeLabel.
 func TestEnsureNamespaceLabels_PatchesExistingNamespace(t *testing.T) {
 	ctx := context.Background()

--- a/src/compute-plane-services/nvca/pkg/storage/cachebackend_samba_test.go
+++ b/src/compute-plane-services/nvca/pkg/storage/cachebackend_samba_test.go
@@ -287,3 +287,56 @@ func TestSambaModelCacheResourceName_LongHandleBounded(t *testing.T) {
 	// Stable: same input yields same name.
 	assert.Equal(t, name, sambaModelCacheResourceName(long))
 }
+
+// TestEnsureNamespaceLabels_PatchesExistingNamespace verifies that
+// ensureNamespaceLabels adds missing labels to a namespace that already exists
+// without the required keys — the scenario that arises on clusters upgraded
+// from an NVCA version that did not set WorkloadInstanceTypeLabel.
+func TestEnsureNamespaceLabels_PatchesExistingNamespace(t *testing.T) {
+	ctx := context.Background()
+
+	// Existing namespace has only the managed-by label, no workload-instance-type.
+	existing := &corev1.Namespace{}
+	existing.Name = ModelCacheInitNamespace
+	existing.Labels = map[string]string{"app.kubernetes.io/managed-by": "nvca"}
+
+	c := sambaInfraClient(t, existing)
+
+	want := NewModelCacheInitNamespace()
+	require.NoError(t, ensureNamespaceLabels(ctx, c, want))
+
+	got := &corev1.Namespace{}
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: ModelCacheInitNamespace}, got))
+	for k, v := range want.Labels {
+		assert.Equal(t, v, got.Labels[k], "label %s must be patched onto existing namespace", k)
+	}
+	// Pre-existing labels must not be removed.
+	assert.Equal(t, "nvca", got.Labels["app.kubernetes.io/managed-by"])
+}
+
+// TestEnsureNamespaceLabels_NoopWhenLabelsPresent verifies that
+// ensureNamespaceLabels is a no-op (no patch call) when all required labels
+// are already present with the correct values.
+func TestEnsureNamespaceLabels_NoopWhenLabelsPresent(t *testing.T) {
+	ctx := context.Background()
+
+	want := NewModelCacheInitNamespace()
+	existing := want.DeepCopy()
+
+	patchCount := 0
+	sch := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(sch))
+	c := fake.NewClientBuilder().
+		WithScheme(sch).
+		WithObjects(existing).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+				patchCount++
+				return nil
+			},
+		}).
+		Build()
+
+	require.NoError(t, ensureNamespaceLabels(ctx, c, want))
+	assert.Equal(t, 0, patchCount, "Patch must not be called when all labels are already correct")
+}

--- a/src/compute-plane-services/nvca/pkg/storage/controller_modelcache.go
+++ b/src/compute-plane-services/nvca/pkg/storage/controller_modelcache.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	nvcav1new "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/v1"
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/types"
 )
 
 func NewModelCacheInitNamespace() *corev1.Namespace {
@@ -46,6 +47,14 @@ func NewModelCacheInitNamespace() *corev1.Namespace {
 	namespace.Name = ModelCacheInitNamespace
 	namespace.Labels = map[string]string{
 		"app.kubernetes.io/managed-by": "nvca",
+		// The nvcf-unbound Kyverno ClusterPolicy (add-unbound-dns) matches on
+		// this label to inject the cluster's nvcf-unbound nameserver into pods.
+		// Without it the model-cache writer job falls back to the kube-dns
+		// ClusterIP, which is unreachable on clusters where node-local-dns
+		// serves it from the host network (e.g. node-local-dns DaemonSet with
+		// hostNetwork=true binding the kube-dns VIP), causing DNS timeouts and
+		// a ~7m45s backoff before the deploy continues without a cache.
+		types.WorkloadInstanceTypeLabel: types.WorkloadInstanceTypeValueMiniService,
 	}
 	return namespace
 }

--- a/src/compute-plane-services/nvca/pkg/storage/controller_modelcache_test.go
+++ b/src/compute-plane-services/nvca/pkg/storage/controller_modelcache_test.go
@@ -27,7 +27,24 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/types"
 )
+
+// TestNewModelCacheInitNamespace_HasUnboundDNSLabel asserts that the namespace
+// carries the workload-instance-type label so the nvcf-unbound Kyverno policy
+// (add-unbound-dns) injects the cluster's nvcf-unbound nameserver into pods.
+// Without it the model-cache writer job falls back to the kube-dns ClusterIP,
+// which is unreachable on clusters running node-local-dns with hostNetwork=true.
+func TestNewModelCacheInitNamespace_HasUnboundDNSLabel(t *testing.T) {
+	ns := NewModelCacheInitNamespace()
+	assert.Equal(t, ModelCacheInitNamespace, ns.Name)
+	assert.Equal(t,
+		types.WorkloadInstanceTypeValueMiniService,
+		ns.Labels[types.WorkloadInstanceTypeLabel],
+		"workload-instance-type label must be present so add-unbound-dns injects nvcf-unbound nameservers",
+	)
+}
 
 func TestEnsureCacheMountOptionsConfigMap(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
## Customer Summary

Model-cache initialization for helm-chart functions failed silently on clusters running `node-local-dns` with `hostNetwork=true`, causing every model-attached helm deploy to stall ~7m45s and proceed without a cache. Cold cache builds never completed on affected clusters.

## TL;DR

Add `nvca.nvcf.nvidia.io/workload-instance-type: miniservice` to the `nvca-modelcache-init` namespace so the Kyverno `add-unbound-dns` policy injects the cluster's `nvcf-unbound` nameserver into the model-cache writer job pod.

## Additional Details

The `nvca-modelcache-init` namespace lacked the `workload-instance-type` label that the Kyverno ClusterPolicy `add-unbound-dns` selects on. Without it, the model-cache writer job pod used `dnsPolicy: ClusterFirst` and resolved via the kube-dns ClusterIP (e.g. `10.96.0.10`).

On clusters where `node-local-dns` binds that VIP from the host network (`hostNetwork=true`), traffic to the ClusterIP terminates on the node. NVCA's own `allow-egress-internet-no-internal-no-api` NetworkPolicy blocks it: the RFC1918 `except` rule covers node IPs and the `k8s-app: kube-dns` podSelector does not match a hostNetwork DaemonSet.

The three alternative resolvers that _do_ work — the node-local-dns link-local address (`169.254.20.10`), a coredns pod IP, and nvcf-unbound (`10.96.x.100`) — are each admitted by existing policy rules. Only the ClusterIP path was dead.

The fix adds `WorkloadInstanceTypeLabel=miniservice` to `NewModelCacheInitNamespace()`, matching the label already present on `nvcf-backend` (`pod_spec`) and `sr-<uuid>` (`miniservice`) workload namespaces, so `add-unbound-dns` injects nvcf-unbound nameservers identically.

Root cause confirmed on `nvcf-dgxc-k8s-forge-az60-ct1` (forge/DGXC, production). GCP cluster unaffected only because it has no `node-local-dns` DaemonSet — the defect is latent on any cluster where NodeLocal DNSCache is enabled.

## For the Reviewer

Single-call change: `NewModelCacheInitNamespace()` in `pkg/storage/controller_modelcache.go` — adds one label entry and one import. New test `TestNewModelCacheInitNamespace_HasUnboundDNSLabel` in `controller_modelcache_test.go` asserts the label is present and documents the failure mode.

## For QA

- `go test ./pkg/storage/... -run TestNewModelCacheInitNamespace` passes.
- All existing `TestReconcile_ModelCache*` tests pass with `KUBEBUILDER_ASSETS` set.
- Live verification: deploy a model-attached helm-chart function on a cluster with `node-local-dns` — writer job should complete in ~21s (measured on GCP control cluster).

## Tickets

Relates to NO-REF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model cache initialization so mini-service workloads receive the required network configuration.
  * Enabled reliable DNS injection for these workloads.
  * Improved model cache infrastructure setup by ensuring required namespace labels are applied consistently.
  * Preserved existing namespace labels while adding only missing or incorrect configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->