### PR TITLE
feat(event-ledger): generic resource_id context field for non-Pod resources

### DIFF
--- a/src/control-plane-services/event-ledger/cmd/api/service/v3.go
+++ b/src/control-plane-services/event-ledger/cmd/api/service/v3.go
@@ -131,6 +131,15 @@ type EventsV3Response struct {
 	Events    []EventV3Item `json:"events"`
 }
 
+// Context field names used in the canonical context string and as query params.
+const (
+	contextFieldClusterID          = "cluster_id"
+	contextFieldDeploymentID       = "deployment_id"
+	contextFieldGPUSpecificationID = "gpu_specification_id"
+	contextFieldInstanceID         = "instance_id"
+	contextFieldResourceID         = "resource_id"
+)
+
 // ContextV3 represents the context components that identify the scope of an event
 // This is the internal representation, not tied to any wire format
 type ContextV3 struct {
@@ -138,6 +147,12 @@ type ContextV3 struct {
 	DeploymentID       string
 	GPUSpecificationID string
 	ClusterID          string
+	// ResourceID is a generic, optional context field. It lets a producer supply
+	// a unique identifier for events that have no other distinguishing context
+	// field (e.g. an ICMSRequest, keyed by its request id), so distinct resources
+	// do not collapse onto the same dedup key. It is empty for Pod events, which
+	// are already uniquely identified by instance_id.
+	ResourceID string
 }
 
 // cloudEventWireFormat represents the CloudEvents extensions wire format
@@ -149,6 +164,7 @@ type cloudEventWireFormat struct {
 	DeploymentID       string         `mapstructure:"deploymentId"`
 	GPUSpecificationID string         `mapstructure:"gpuSpecificationId"`
 	ClusterID          string         `mapstructure:"clusterId"`
+	ResourceID         string         `mapstructure:"resourceId"`
 	UnmappedExtensions map[string]any `mapstructure:",remain"`
 }
 
@@ -162,6 +178,7 @@ type otlpAttributesWireFormat struct {
 	DeploymentID       string         `mapstructure:"deployment_id"`
 	GPUSpecificationID string         `mapstructure:"gpu_specification_id"`
 	ClusterID          string         `mapstructure:"cluster_id"`
+	ResourceID         string         `mapstructure:"resource_id"`
 	UnmappedAttributes map[string]any `mapstructure:",remain"`
 }
 
@@ -364,15 +381,18 @@ func deduplicateEvents(events []*EventV3) []*EventV3 {
 }
 
 // eventContextToCanonical converts a ContextV3 struct to a canonical string representation
-// Format: key1=value1,key2=value2 (alphabetical order: cluster_id, deployment_id, gpu_specification_id, instance_id)
-// Validates that values contain only alphanumeric characters and dashes. Instance IDs may also
-// contain dots between non-empty segments. Empty fields are omitted.
+// Format: key1=value1,key2=value2 in a fixed field order:
+// cluster_id, deployment_id, gpu_specification_id, instance_id, resource_id.
+// Validates that values contain only alphanumeric characters and dashes; instance IDs
+// may also contain dots between non-empty segments. Empty fields are omitted, so events
+// that do not set resource_id (e.g. Pods) produce the same context string as before it
+// was introduced.
 func eventContextToCanonical(eventContext ContextV3) (string, error) {
 	// Helper to validate field values
 	validate := func(name, value string) error {
 		pattern := contextFieldPattern
 		allowedCharacters := "alphanumeric characters and dashes"
-		if name == "instance_id" {
+		if name == contextFieldInstanceID {
 			pattern = instanceIDFieldPattern
 			allowedCharacters = "alphanumeric characters, dashes, and dots between segments"
 		}
@@ -388,33 +408,27 @@ func eventContextToCanonical(eventContext ContextV3) (string, error) {
 		return nil
 	}
 
-	// Validate all fields
-	if err := validate("cluster_id", eventContext.ClusterID); err != nil {
-		return "", err
-	}
-	if err := validate("deployment_id", eventContext.DeploymentID); err != nil {
-		return "", err
-	}
-	if err := validate("gpu_specification_id", eventContext.GPUSpecificationID); err != nil {
-		return "", err
-	}
-	if err := validate("instance_id", eventContext.InstanceID); err != nil {
-		return "", err
+	// Ordered fields: order defines the canonical string layout and must stay
+	// stable, since the context string is the storage/dedup key.
+	fields := []struct {
+		name  string
+		value string
+	}{
+		{contextFieldClusterID, eventContext.ClusterID},
+		{contextFieldDeploymentID, eventContext.DeploymentID},
+		{contextFieldGPUSpecificationID, eventContext.GPUSpecificationID},
+		{contextFieldInstanceID, eventContext.InstanceID},
+		{contextFieldResourceID, eventContext.ResourceID},
 	}
 
-	// Build canonical string in alphabetical order (with underscores)
-	parts := make([]string, 0, 4)
-	if eventContext.ClusterID != "" {
-		parts = append(parts, "cluster_id="+eventContext.ClusterID)
-	}
-	if eventContext.DeploymentID != "" {
-		parts = append(parts, "deployment_id="+eventContext.DeploymentID)
-	}
-	if eventContext.GPUSpecificationID != "" {
-		parts = append(parts, "gpu_specification_id="+eventContext.GPUSpecificationID)
-	}
-	if eventContext.InstanceID != "" {
-		parts = append(parts, "instance_id="+eventContext.InstanceID)
+	parts := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if err := validate(f.name, f.value); err != nil {
+			return "", err
+		}
+		if f.value != "" {
+			parts = append(parts, f.name+"="+f.value)
+		}
 	}
 
 	return strings.Join(parts, ","), nil
@@ -426,6 +440,8 @@ func eventContextToCanonical(eventContext ContextV3) (string, error) {
 //   - namespace (string): Tenant identifier
 //   - source (string): Event source identifier
 //   - Context fields (optional): instance_id, deployment_id, gpu_specification_id, cluster_id
+//   - resource_id (optional): generic unique identifier for events that have no
+//     other distinguishing context field (e.g. an ICMSRequest keyed by its request id).
 func extractK8sEvent(lr *logsv1.LogRecord) (*EventV3, error) {
 	// Step 1: Convert OTLP protobuf attributes to map
 	attrs := make(map[string]any)
@@ -445,6 +461,7 @@ func extractK8sEvent(lr *logsv1.LogRecord) (*EventV3, error) {
 		DeploymentID:       wireFormat.DeploymentID,
 		GPUSpecificationID: wireFormat.GPUSpecificationID,
 		ClusterID:          wireFormat.ClusterID,
+		ResourceID:         wireFormat.ResourceID,
 	}
 
 	canonicalContext, err := eventContextToCanonical(contextV3)
@@ -521,6 +538,7 @@ func extractCloudEvent(ce *cloudevents.Event) (*EventV3, error) {
 		DeploymentID:       wireFormat.DeploymentID,
 		GPUSpecificationID: wireFormat.GPUSpecificationID,
 		ClusterID:          wireFormat.ClusterID,
+		ResourceID:         wireFormat.ResourceID,
 	}
 
 	canonicalContext, err := eventContextToCanonical(contextV3)
@@ -969,13 +987,16 @@ func (s *Server) GetEventsV3(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Extract context components from query parameters
+	// Extract context components from query parameters. resource_id lets callers
+	// look up rows keyed by a generic resource identifier (e.g. an ICMSRequest);
+	// omitting it yields the same Pod-shaped lookup as before.
 	queryParams := r.URL.Query()
 	contextV3 := ContextV3{
-		InstanceID:         queryParams.Get("instance_id"),
-		DeploymentID:       queryParams.Get("deployment_id"),
-		GPUSpecificationID: queryParams.Get("gpu_specification_id"),
-		ClusterID:          queryParams.Get("cluster_id"),
+		InstanceID:         queryParams.Get(contextFieldInstanceID),
+		DeploymentID:       queryParams.Get(contextFieldDeploymentID),
+		GPUSpecificationID: queryParams.Get(contextFieldGPUSpecificationID),
+		ClusterID:          queryParams.Get(contextFieldClusterID),
+		ResourceID:         queryParams.Get(contextFieldResourceID),
 	}
 
 	// Convert ContextV3 to canonical string

--- a/src/control-plane-services/event-ledger/cmd/api/service/v3_test.go
+++ b/src/control-plane-services/event-ledger/cmd/api/service/v3_test.go
@@ -639,6 +639,92 @@ func TestExtractK8sEvent(t *testing.T) {
 	assert.Equal(t, "extra_value", attrs["extra_field"])
 }
 
+// TestEventContextToCanonical_Ordering verifies the canonical string uses the
+// fixed field order and omits empty fields.
+func TestEventContextToCanonical_Ordering(t *testing.T) {
+	tests := []struct {
+		name   string
+		ctx    ContextV3
+		expect string
+	}{
+		{
+			name:   "pod shape omits empty resource_id",
+			ctx:    ContextV3{ClusterID: "clus-1", DeploymentID: "dep-1", InstanceID: "inst-1"},
+			expect: "cluster_id=clus-1,deployment_id=dep-1,instance_id=inst-1",
+		},
+		{
+			name:   "resource_id participates and sorts last",
+			ctx:    ContextV3{ClusterID: "clus-1", ResourceID: "icms-1"},
+			expect: "cluster_id=clus-1,resource_id=icms-1",
+		},
+		{
+			name:   "resource_id alone",
+			ctx:    ContextV3{ResourceID: "icms-1"},
+			expect: "resource_id=icms-1",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := eventContextToCanonical(tc.ctx)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expect, got)
+		})
+	}
+}
+
+// TestExtractK8sEvent_ResourceID verifies that resource_id participates in the
+// canonical context so resources without other unique fields stay distinct.
+func TestExtractK8sEvent_ResourceID(t *testing.T) {
+	lr := createOTLPLogRecord("instance.creation", "tenant-123", "nvca", "", map[string]string{
+		"cluster_id":  "clus-1",
+		"resource_id": "icms-abc",
+	})
+
+	event, err := extractK8sEvent(lr)
+	require.NoError(t, err)
+
+	// resource_id participates in the context (sorted last), keeping the row unique.
+	assert.Equal(t, "cluster_id=clus-1,resource_id=icms-abc", event.Context)
+}
+
+// TestExtractK8sEvent_DistinctResourceIDsDoNotCollide verifies two resources with
+// the same non-resource context but different resource_id produce distinct contexts.
+func TestExtractK8sEvent_DistinctResourceIDsDoNotCollide(t *testing.T) {
+	makeCtx := func(resourceID string) string {
+		lr := createOTLPLogRecord("instance.creation", "tenant-123", "nvca", "", map[string]string{
+			"cluster_id":  "clus-1",
+			"resource_id": resourceID,
+		})
+		event, err := extractK8sEvent(lr)
+		require.NoError(t, err)
+		return event.Context
+	}
+
+	assert.NotEqual(t, makeCtx("icms-1"), makeCtx("icms-2"))
+}
+
+// TestExtractK8sEvent_PodKeepsUnmappedAttrsInDetails verifies that a Pod event
+// carrying an unmapped attribute (e.g. icms_request_id) keeps it in details and
+// excludes it from the context.
+func TestExtractK8sEvent_PodKeepsUnmappedAttrsInDetails(t *testing.T) {
+	lr := createOTLPLogRecord("pod.ready", "tenant-123", "kubernetes", "pod-1", map[string]string{
+		"cluster_id":      "clus-1",
+		"icms_request_id": "icms-xyz",
+	})
+
+	event, err := extractK8sEvent(lr)
+	require.NoError(t, err)
+
+	// Pod context stays the original shape and excludes the unmapped attribute.
+	assert.Equal(t, "cluster_id=clus-1,instance_id=pod-1", event.Context)
+	assert.NotContains(t, event.Context, "icms_request_id")
+
+	var details map[string]any
+	require.NoError(t, json.Unmarshal(event.DetailsJSON, &details))
+	attrs := details["attributes"].(map[string]any)
+	assert.Equal(t, "icms-xyz", attrs["icms_request_id"])
+}
+
 // Test extractCloudEvent validates source is required
 func TestExtractCloudEvent_SourceRequired(t *testing.T) {
 	ce := cloudevents.NewEvent()
@@ -676,6 +762,22 @@ func TestExtractCloudEvent_IdRequired(t *testing.T) {
 	_, err := extractCloudEvent(&ce)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing required field: id")
+}
+
+// TestExtractCloudEvent_ResourceID verifies the resourceId extension maps into
+// the canonical context, mirroring OTLP ingestion so rows stay queryable.
+func TestExtractCloudEvent_ResourceID(t *testing.T) {
+	ce := cloudevents.NewEvent()
+	ce.SetID("test-id")
+	ce.SetType("test.event")
+	ce.SetSource("/test")
+	ce.SetExtension("namespace", "tenant-1")
+	ce.SetExtension("clusterId", "clus-1")
+	ce.SetExtension("resourceId", "icms-1")
+
+	event, err := extractCloudEvent(&ce)
+	require.NoError(t, err)
+	assert.Equal(t, "cluster_id=clus-1,resource_id=icms-1", event.Context)
 }
 
 // ======================

--- a/src/control-plane-services/event-ledger/internal/db_client/cassandra/v2.go
+++ b/src/control-plane-services/event-ledger/internal/db_client/cassandra/v2.go
@@ -1287,13 +1287,15 @@ func (c *CassandraHandler) upsertPartitionStatsV3(traceCtx context.Context, name
 	logger := logging.GetLogger(traceCtx)
 
 	return c.executeWithSessionRecreation(traceCtx, func() error {
-		selectQuery := `SELECT context, created_at FROM stats_v3 WHERE namespace = ?`
+		selectQuery := `SELECT context, created_at, timestamp FROM stats_v3 WHERE namespace = ?`
 		iter := c.session.Query(selectQuery, namespace).WithContext(traceCtx).Iter()
 		existingCreatedAt := make(map[string]time.Time)
+		existingTimestamp := make(map[string]time.Time)
 		var scannedContext string
-		var scannedCreatedAt time.Time
-		for iter.Scan(&scannedContext, &scannedCreatedAt) {
+		var scannedCreatedAt, scannedTimestamp time.Time
+		for iter.Scan(&scannedContext, &scannedCreatedAt, &scannedTimestamp) {
 			existingCreatedAt[scannedContext] = scannedCreatedAt
+			existingTimestamp[scannedContext] = scannedTimestamp
 		}
 		if err := iter.Close(); err != nil {
 			logger.ErrorContext(traceCtx, "Failed to fetch existing stats for namespace",
@@ -1305,12 +1307,37 @@ func (c *CassandraHandler) upsertPartitionStatsV3(traceCtx context.Context, name
 		insertQuery := `INSERT INTO stats_v3 (namespace, context, event_name, timestamp, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
 		batch := c.session.NewBatch(gocql.UnloggedBatch).WithContext(traceCtx)
 		now := time.Now()
+		skipped := 0
 		for _, ev := range events {
+			// A stats row holds the latest event per context; skip events that are
+			// older than the row already stored so out-of-order delivery cannot
+			// overwrite a newer event. This read-then-write guard is best-effort:
+			// concurrent writers to the same (namespace, context) can still race.
+			// Full atomicity (conditional LWT) is tracked as a follow-up.
+			if ts, exists := existingTimestamp[ev.Context]; exists && ev.Timestamp.Before(ts) {
+				skipped++
+				// Context carries the identifying fields (cluster_id, instance_id,
+				// resource_id, ...), so log it to keep skipped rows traceable.
+				logger.DebugContext(traceCtx, "Skipping out-of-order stats event",
+					zap.String("namespace", ev.Namespace),
+					zap.String("context", ev.Context),
+					zap.String("event_name", ev.EventName),
+					zap.Time("event_timestamp", ev.Timestamp),
+					zap.Time("existing_timestamp", ts))
+				continue
+			}
 			createdAt := ev.Timestamp
 			if ca, exists := existingCreatedAt[ev.Context]; exists {
 				createdAt = ca
 			}
 			batch.Query(insertQuery, ev.Namespace, ev.Context, ev.EventName, ev.Timestamp, createdAt, now)
+		}
+
+		if batch.Size() == 0 {
+			logger.InfoContext(traceCtx, "No stats to insert after out-of-order filtering",
+				zap.String("namespace", namespace),
+				zap.Int("skipped", skipped))
+			return nil
 		}
 
 		if err := c.session.ExecuteBatch(batch); err != nil {
@@ -1322,7 +1349,8 @@ func (c *CassandraHandler) upsertPartitionStatsV3(traceCtx context.Context, name
 
 		logger.InfoContext(traceCtx, "Batch inserted stats",
 			zap.String("namespace", namespace),
-			zap.Int("count", len(events)))
+			zap.Int("count", batch.Size()),
+			zap.Int("skipped", skipped))
 		return nil
 	}, "upsertPartitionStatsV3")
 }


### PR DESCRIPTION
## Summary

Closes #815 (part of epic #809). FnDs adds a single generic, optional `resource_id` context field so events that have no other distinguishing context field (e.g. an `ICMSRequest`, keyed by its request id) get a unique canonical context and stay distinct from Pod rows — without teaching the event ledger anything about ICMS.

- **Generic `resource_id` context field.** `ContextV3` gains `ResourceID`. The canonical context appends `resource_id` last and omits it when empty, so producers set it only when needed. Uniqueness is owned by the producer, not the ledger.
- **No kind-specific concepts.** There is no kind detection, no per-kind field map, and no `context.fields-by-kind` config. `eventContextToCanonical` builds a fixed field order: `cluster_id, deployment_id, gpu_specification_id, instance_id, resource_id`.
- **Ingestion.** OTLP reads `resource_id`; CloudEvents read `resourceId` (camelCase, per the CloudEvents extension naming rules). Any unmapped attributes (e.g. `icms_request_id` on Pod events) continue to flow into `details` unchanged.
- **Read API.** `GetEventsV3` accepts a `resource_id` query param generically, e.g. `GET /v3/ledger/namespace/{ns}/events?resource_id=<id>`. No ICMS-named endpoint or lookup logic.
- **Out-of-order guard (bulk path).** `upsertPartitionStatsV3` skips events older than the stored latest-per-context row, so late delivery cannot overwrite a newer event. (The single-row LWT guard already exists on `main`.) No schema/migration needed.

## Design note

This supersedes the earlier "kind-aware context" approach on this branch. Per review feedback, the event ledger should stay generic and reuse the existing context format rather than baking in ICMS-specific fields, kind detection, and a config-driven kind→fields map. A single generic `resource_id` (blank by default, producer-populated) solves the row-uniqueness problem for `ICMSRequest` while keeping the ledger free of ICMS concepts.

**Producer contract:** for events lacking a natural unique context field, the producer (NVCA) stamps `resource_id` (OTLP) / `resourceId` (CloudEvents) with the identifier (e.g. the ICMS request id). `icms_request_id` may still ride along in `details` for Pod-lane correlation.

> Open for confirmation with reviewers: the field **name** (`resource_id`) and the producer contract above.

## Behavioral guarantees

- Pod context is byte-for-byte unchanged (Pods never set `resource_id`).
- Rows are keyed distinctly whenever `resource_id` is set, so distinct resources cannot collapse onto the same dedup key.
- Unmapped attributes (e.g. `icms_request_id`) on Pod events remain in `details`.
- Dotted `instance_id` support (from the `instance_id` validation on `main`) is preserved.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cmd/api/service/...` (canonical ordering, `resource_id` participates in context, distinct `resource_id`s don't collide, Pods keep unmapped attrs in `details`, CloudEvents `resourceId`)
- [x] `go test ./internal/db_client/cassandra/...`
- [ ] Cassandra integration tests for the stats out-of-order guard (require a live Cassandra; not run locally)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for resource identifiers in event contexts and CloudEvent/OTLP data.
  - Enabled filtering events by resource identifier while preserving existing Pod-based lookups.
  - Improved consistency when generating and matching event contexts.

- **Bug Fixes**
  - Prevented older events from overwriting newer records during bulk updates.
  - Improved handling and reporting of skipped out-of-order events.
  - Avoided executing empty update batches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->