### PR TITLE
fix(cli): recover function identity for DRAINING records via instance IDs

### DIFF
--- a/src/clis/nvcf-cli/README.md
+++ b/src/clis/nvcf-cli/README.md
@@ -1689,7 +1689,7 @@ Use `--phase` to filter to one of `ACTIVE`, `DEPLOYING`, `DRAINING`, or `FAILED`
 A termination request never carries its own function ID or version ID; NVCA
 relays it verbatim from the upstream message. `list-functions` and
 `get-function` recover it by correlating the termination request's instance
-IDs with the same-namespace creation request's instances. `list-functions`
+IDs against every other same-namespace `ICMSRequest`'s instances. `list-functions`
 omits a `DRAINING` record when identity cannot be recovered this way, rather
 than showing one with empty IDs.
 

--- a/src/clis/nvcf-cli/README.md
+++ b/src/clis/nvcf-cli/README.md
@@ -1686,6 +1686,13 @@ into three user-facing phases:
 
 Use `--phase` to filter to one of `ACTIVE`, `DEPLOYING`, `DRAINING`, or `FAILED`.
 
+A termination request never carries its own function ID or version ID; NVCA
+relays it verbatim from the upstream message. `list-functions` and
+`get-function` recover it by correlating the termination request's instance
+IDs with the same-namespace creation request's instances. `list-functions`
+omits a `DRAINING` record when identity cannot be recovered this way, rather
+than showing one with empty IDs.
+
 ### Authentication
 
 `status`, `list-functions`, and `get-function` read from the cluster's

--- a/src/clis/nvcf-cli/internal/clusteragent/k8s_inspector.go
+++ b/src/clis/nvcf-cli/internal/clusteragent/k8s_inspector.go
@@ -87,7 +87,11 @@ func (k *k8sInspector) ListFunctions(ctx context.Context, opts ListOptions) ([]S
 
 	result := make([]ScheduledFunction, 0, len(items))
 	for i := range items {
-		fn := scheduledFunctionFromObj(items[i].Object, items[i].GetNamespace())
+		fid, vid, ok := resolveFunctionIdentity(items[i].Object, items)
+		if !ok {
+			continue
+		}
+		fn := scheduledFunctionFromObj(items[i].Object, items[i].GetNamespace(), fid, vid)
 		if opts.PhaseFilter != "" && fn.Phase != opts.PhaseFilter {
 			continue
 		}
@@ -120,14 +124,14 @@ func (k *k8sInspector) GetFunction(ctx context.Context, functionID, versionID st
 	sortICMSRequests(items)
 	for i := range items {
 		obj := items[i].Object
-		fid, vid := functionIdentity(obj)
-		if fid != functionID {
+		fid, vid, ok := resolveFunctionIdentity(obj, items)
+		if !ok || fid != functionID {
 			continue
 		}
 		if versionID != "" && vid != versionID {
 			continue
 		}
-		return functionDetailFromObj(obj, items[i].GetNamespace()), nil
+		return functionDetailFromObj(obj, items[i].GetNamespace(), fid, vid), nil
 	}
 
 	if versionID != "" {
@@ -182,15 +186,16 @@ func sortICMSRequests(items []unstructured.Unstructured) {
 }
 
 // scheduledFunctionFromObj builds the list-level summary for one ICMSRequest.
-func scheduledFunctionFromObj(obj map[string]interface{}, namespace string) ScheduledFunction {
-	fid, vid := functionIdentity(obj)
+// functionID/versionID are resolved by the caller via resolveFunctionIdentity,
+// since a termination request's own spec never carries them.
+func scheduledFunctionFromObj(obj map[string]interface{}, namespace, functionID, versionID string) ScheduledFunction {
 	action := nestedString(obj, "spec", "action")
 	requestStatus := nestedString(obj, "status", "requestStatus")
 	instances := extractInstances(obj)
 
 	return ScheduledFunction{
-		FunctionID:        fid,
-		FunctionVersionID: vid,
+		FunctionID:        functionID,
+		FunctionVersionID: versionID,
 		Namespace:         namespace,
 		Action:            action,
 		RequestStatus:     requestStatus,
@@ -199,9 +204,9 @@ func scheduledFunctionFromObj(obj map[string]interface{}, namespace string) Sche
 	}
 }
 
-func functionDetailFromObj(obj map[string]interface{}, namespace string) *FunctionDetail {
+func functionDetailFromObj(obj map[string]interface{}, namespace, functionID, versionID string) *FunctionDetail {
 	return &FunctionDetail{
-		ScheduledFunction:  scheduledFunctionFromObj(obj, namespace),
+		ScheduledFunction:  scheduledFunctionFromObj(obj, namespace, functionID, versionID),
 		Instances:          extractInstances(obj),
 		LastStatusUpdated:  nestedString(obj, "status", "lastStatusUpdated"),
 		LastACKTimestamp:   nestedString(obj, "status", "lastACKTimestamp"),
@@ -210,9 +215,12 @@ func functionDetailFromObj(obj map[string]interface{}, namespace string) *Functi
 	}
 }
 
-// functionIdentity reads functionId/functionVersionId, preferring the modern
-// spec.functionDetails fields and falling back to the deprecated top-level
-// spec fields.
+// functionIdentity reads functionId/functionVersionId directly off obj,
+// preferring the modern spec.functionDetails fields and falling back to the
+// deprecated top-level spec fields. A termination-action ICMSRequest CR never
+// carries spec.functionDetails (NVCA only relays it verbatim from the
+// upstream termination message, which does not include it), so this returns
+// empty for those; use resolveFunctionIdentity to recover it.
 func functionIdentity(obj map[string]interface{}) (functionID, versionID string) {
 	functionID = firstNonEmpty(
 		nestedString(obj, "spec", "functionDetails", "functionId"),
@@ -223,6 +231,38 @@ func functionIdentity(obj map[string]interface{}) (functionID, versionID string)
 		nestedString(obj, "spec", "functionVersionId"),
 	)
 	return functionID, versionID
+}
+
+// resolveFunctionIdentity returns obj's function identity, falling back to
+// correlation when obj's own spec carries none (always true for termination
+// requests). The fallback matches obj's spec.terminationMsgInfo.instanceIds
+// against another CR's status.instances keys in allItems and borrows that
+// CR's identity: a termination request's instances are also tracked, by the
+// same instance IDs, on the creation request's status.instances map. ok is
+// false when no identity can be established either way, so the caller can
+// omit the record instead of returning one with empty IDs.
+func resolveFunctionIdentity(obj map[string]interface{}, allItems []unstructured.Unstructured) (functionID, versionID string, ok bool) {
+	if fid, vid := functionIdentity(obj); fid != "" || vid != "" {
+		return fid, vid, true
+	}
+
+	instanceIDs, _, _ := unstructured.NestedStringSlice(obj, "spec", "terminationMsgInfo", "instanceIds")
+	if len(instanceIDs) == 0 {
+		return "", "", false
+	}
+
+	for _, other := range allItems {
+		fid, vid := functionIdentity(other.Object)
+		if fid == "" && vid == "" {
+			continue
+		}
+		for _, id := range instanceIDs {
+			if _, found, _ := unstructured.NestedMap(other.Object, "status", "instances", id); found {
+				return fid, vid, true
+			}
+		}
+	}
+	return "", "", false
 }
 
 func extractInstances(obj map[string]interface{}) []Instance {

--- a/src/clis/nvcf-cli/internal/clusteragent/k8s_inspector.go
+++ b/src/clis/nvcf-cli/internal/clusteragent/k8s_inspector.go
@@ -87,7 +87,7 @@ func (k *k8sInspector) ListFunctions(ctx context.Context, opts ListOptions) ([]S
 
 	result := make([]ScheduledFunction, 0, len(items))
 	for i := range items {
-		fid, vid, ok := resolveFunctionIdentity(items[i].Object, items)
+		fid, vid, ok := resolveFunctionIdentity(items[i].Object, items[i].GetNamespace(), items)
 		if !ok {
 			continue
 		}
@@ -124,7 +124,7 @@ func (k *k8sInspector) GetFunction(ctx context.Context, functionID, versionID st
 	sortICMSRequests(items)
 	for i := range items {
 		obj := items[i].Object
-		fid, vid, ok := resolveFunctionIdentity(obj, items)
+		fid, vid, ok := resolveFunctionIdentity(obj, items[i].GetNamespace(), items)
 		if !ok || fid != functionID {
 			continue
 		}
@@ -236,12 +236,14 @@ func functionIdentity(obj map[string]interface{}) (functionID, versionID string)
 // resolveFunctionIdentity returns obj's function identity, falling back to
 // correlation when obj's own spec carries none (always true for termination
 // requests). The fallback matches obj's spec.terminationMsgInfo.instanceIds
-// against another CR's status.instances keys in allItems and borrows that
-// CR's identity: a termination request's instances are also tracked, by the
-// same instance IDs, on the creation request's status.instances map. ok is
-// false when no identity can be established either way, so the caller can
-// omit the record instead of returning one with empty IDs.
-func resolveFunctionIdentity(obj map[string]interface{}, allItems []unstructured.Unstructured) (functionID, versionID string, ok bool) {
+// against another CR's status.instances keys, restricted to candidates in
+// namespace, and borrows that CR's identity: a termination request's
+// instances are also tracked, by the same instance IDs, on the creation
+// request's status.instances map. Restricting to namespace prevents an
+// instance ID collision in another namespace from mislabeling the request.
+// ok is false when no identity can be established either way, so the caller
+// can omit the record instead of returning one with empty IDs.
+func resolveFunctionIdentity(obj map[string]interface{}, namespace string, allItems []unstructured.Unstructured) (functionID, versionID string, ok bool) {
 	if fid, vid := functionIdentity(obj); fid != "" || vid != "" {
 		return fid, vid, true
 	}
@@ -252,6 +254,9 @@ func resolveFunctionIdentity(obj map[string]interface{}, allItems []unstructured
 	}
 
 	for _, other := range allItems {
+		if other.GetNamespace() != namespace {
+			continue
+		}
 		fid, vid := functionIdentity(other.Object)
 		if fid == "" && vid == "" {
 			continue

--- a/src/clis/nvcf-cli/internal/clusteragent/k8s_inspector_test.go
+++ b/src/clis/nvcf-cli/internal/clusteragent/k8s_inspector_test.go
@@ -247,6 +247,25 @@ func TestListFunctionsOmitsTerminationRequestWithNoRecoverableIdentity(t *testin
 	}
 }
 
+func TestListFunctionsDoesNotRecoverIdentityAcrossNamespaces(t *testing.T) {
+	// Regression test: instance ID correlation must stay scoped to the
+	// termination request's own namespace. If a same-named instance ID
+	// happens to exist in another namespace's creation request, that must
+	// not be treated as a match; the record must be omitted, not mislabeled.
+	insp := newFakeInspector(
+		icmsRequest("ns-other", "r1", "fn-other", "v1", "", statusCompleted, false),
+		icmsTerminationRequest("nvcf-backend", "r2", statusCompleted, "inst-a"),
+	)
+
+	got, err := insp.ListFunctions(context.Background(), ListOptions{PhaseFilter: PhaseDraining})
+	if err != nil {
+		t.Fatalf("ListFunctions returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("got %+v, want no DRAINING record: instance ID match in a different namespace must not be used", got)
+	}
+}
+
 func TestGetFunctionMatchesVersion(t *testing.T) {
 	insp := newFakeInspector(
 		icmsRequest("ns-a", "r1", "fn-1", "v1", "", statusCompleted, false),
@@ -262,6 +281,31 @@ func TestGetFunctionMatchesVersion(t *testing.T) {
 	}
 	if len(d.Instances) != 1 || d.Instances[0].ID != "inst-a" {
 		t.Errorf("instances = %+v, want one inst-a", d.Instances)
+	}
+}
+
+func TestGetFunctionRecoversIdentityForTerminationRequestViaInstanceIDs(t *testing.T) {
+	// Regression test: GetFunction must apply the same instance-ID identity
+	// recovery as ListFunctions. sortICMSRequests orders the termination
+	// request (empty direct identity) before the creation request ("fn-1"),
+	// so the scan reaches it first; asserting Action here (not just the
+	// resolved IDs, which the creation request would also satisfy) proves
+	// the termination request itself was matched via correlation, not
+	// skipped in favor of the creation request.
+	insp := newFakeInspector(
+		icmsRequest("nvcf-backend", "r1", "fn-1", "v1", "", statusCompleted, false),
+		icmsTerminationRequest("nvcf-backend", "r2", statusCompleted, "inst-a"),
+	)
+
+	d, err := insp.GetFunction(context.Background(), "fn-1", "v1")
+	if err != nil {
+		t.Fatalf("GetFunction returned error: %v", err)
+	}
+	if d.FunctionID != "fn-1" || d.FunctionVersionID != "v1" {
+		t.Errorf("got %q/%q, want fn-1/v1", d.FunctionID, d.FunctionVersionID)
+	}
+	if d.Action != actionTermination {
+		t.Errorf("Action = %q, want %q: the termination request must be matched via correlation, not skipped", d.Action, actionTermination)
 	}
 }
 

--- a/src/clis/nvcf-cli/internal/clusteragent/k8s_inspector_test.go
+++ b/src/clis/nvcf-cli/internal/clusteragent/k8s_inspector_test.go
@@ -93,6 +93,34 @@ func icmsRequest(namespace, name, functionID, versionID, action, status string, 
 	}}
 }
 
+// icmsTerminationRequest builds a TerminateInstances-action ICMSRequest CR
+// the way NVCA actually constructs one: no spec.functionDetails and no
+// deprecated spec.functionId/functionVersionId (NVCA relays the upstream
+// termination message verbatim, which never carries function identity), only
+// spec.terminationMsgInfo.instanceIds and a status.instances map keyed by
+// those same instance IDs.
+func icmsTerminationRequest(namespace, name, status string, instanceIDs ...string) *unstructured.Unstructured {
+	ids := make([]interface{}, len(instanceIDs))
+	instances := map[string]interface{}{}
+	for i, id := range instanceIDs {
+		ids[i] = id
+		instances[id] = map[string]interface{}{"id": id, "type": "Pod", "status": "Terminating"}
+	}
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "nvca.nvcf.nvidia.io/v2beta1",
+		"kind":       "ICMSRequest",
+		"metadata":   map[string]interface{}{"namespace": namespace, "name": name},
+		"spec": map[string]interface{}{
+			"action":             actionTermination,
+			"terminationMsgInfo": map[string]interface{}{"instanceIds": ids},
+		},
+		"status": map[string]interface{}{
+			"requestStatus": status,
+			"instances":     instances,
+		},
+	}}
+}
+
 func TestStatusExtractsBackendFields(t *testing.T) {
 	insp := newFakeInspector(nvcfBackend("nvca-operator", "backend"))
 
@@ -175,6 +203,47 @@ func TestListFunctionsPhaseFilter(t *testing.T) {
 	}
 	if len(got) != 1 || got[0].FunctionID != "fn-3" {
 		t.Fatalf("phase filter DRAINING = %+v, want only fn-3", got)
+	}
+}
+
+func TestListFunctionsRecoversIdentityForTerminationRequestViaInstanceIDs(t *testing.T) {
+	// Regression test: a TerminateInstances-action
+	// ICMSRequest CR carries no functionId/functionVersionId directly (see
+	// icmsTerminationRequest), but shares an instance ID with the function's
+	// creation-action CR. The DRAINING record must recover the real identity
+	// via that shared instance ID rather than reporting empty strings.
+	insp := newFakeInspector(
+		icmsRequest("nvcf-backend", "r1", "fn-1", "v1", "", statusCompleted, false),
+		icmsTerminationRequest("nvcf-backend", "r2", statusCompleted, "inst-a"),
+	)
+
+	got, err := insp.ListFunctions(context.Background(), ListOptions{PhaseFilter: PhaseDraining})
+	if err != nil {
+		t.Fatalf("ListFunctions returned error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d functions, want 1 DRAINING record: %+v", len(got), got)
+	}
+	if got[0].FunctionID != "fn-1" || got[0].FunctionVersionID != "v1" {
+		t.Errorf("DRAINING record identity = %q/%q, want fn-1/v1 recovered via instance ID", got[0].FunctionID, got[0].FunctionVersionID)
+	}
+}
+
+func TestListFunctionsOmitsTerminationRequestWithNoRecoverableIdentity(t *testing.T) {
+	// When no other CR's status.instances shares an instance ID with the
+	// termination request, identity truly cannot be recovered. Per the
+	// bug's expected behavior, the CLI must omit the record rather than
+	// return one with empty functionId/functionVersionId.
+	insp := newFakeInspector(
+		icmsTerminationRequest("nvcf-backend", "r1", statusCompleted, "inst-orphan"),
+	)
+
+	got, err := insp.ListFunctions(context.Background(), ListOptions{})
+	if err != nil {
+		t.Fatalf("ListFunctions returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("got %+v, want no records for an unrecoverable termination request", got)
 	}
 }
 


### PR DESCRIPTION
## TL;DR
`nvcf-cli cluster agent list-functions` returned `DRAINING` records with empty `functionId`/`functionVersionId` after a function was undeployed, making the record impossible to correlate to the function being drained. Fixed by recovering identity through the shared instance ID between the termination request and the function's creation request, falling back to omitting the record only when no identity can be recovered at all.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

NVCA relays `TerminateInstances`-action `ICMSRequest` CRs verbatim from the upstream termination message, which never carries `spec.functionDetails` and only optionally carries the deprecated `spec.functionId`/`spec.functionVersionId` scalars. When those are absent, the CLI's `functionIdentity()` returned two empty strings, and the caller emitted an anonymous `DRAINING` record with no way to trace it back to a function.

`internal/clusteragent/k8s_inspector.go`:
- Added `resolveFunctionIdentity`, which falls back to correlating a termination request's `spec.terminationMsgInfo.instanceIds` against every other listed `ICMSRequest`'s `status.instances` keys, borrowing that CR's identity on a match.
- `ListFunctions` and `GetFunction` now use `resolveFunctionIdentity` instead of reading identity directly, and skip a record entirely when identity cannot be resolved either way (per the expected behavior in the underlying report: no anonymous entries).
- `scheduledFunctionFromObj`/`functionDetailFromObj` now take the resolved `functionID`/`versionID` as parameters instead of recomputing them internally.

Reproduction was done with a fake dynamic Kubernetes client (the same technique the existing test suite already uses for this code path) rather than a live cluster: hand-planted `ICMSRequest` objects on a live k3d cluster kept getting garbage-collected by NVCA's own reconciler as unrecognized resources, since they had no backing queue message.

## For the Reviewer
Please look closely at:
- `resolveFunctionIdentity` in `internal/clusteragent/k8s_inspector.go` — the correlation fallback logic and its scope (same `ICMSRequest` list only, no cross-namespace correlation).
- The two new tests in `internal/clusteragent/k8s_inspector_test.go`: `TestListFunctionsRecoversIdentityForTerminationRequestViaInstanceIDs` and `TestListFunctionsOmitsTerminationRequestWithNoRecoverableIdentity`.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
- `go build ./...`, `go vet ./...`, `gofmt -l` on touched files: all clean.
- `go test ./...` (full module): all pass.
- Verified the two new tests fail against the pre-fix logic (temporarily reverted `resolveFunctionIdentity` to direct-only lookup) and pass against the fix, confirming they actually catch the regression.
- No live-cluster QA needed beyond the above; a genuine end-to-end repro (deploy -> undeploy -> observe the real termination CR) wasn't achievable on the available local cluster since NVCA garbage-collects any `ICMSRequest` CR without a real backing workload, and unit tests exercise the exact same code path `list-functions` uses.

## Issues
NO-REF

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved function identification for instance termination requests.
  - Correctly links termination records to functions using same-namespace instance information.
  - Excludes incomplete or unassociated records and prevents cross-namespace mismatches.
  - Preserves termination actions during function lookups.

- **Documentation**
  - Clarified how function listings and lookups handle termination requests and unresolved identities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->