### PR TITLE
feat(event-ledger): generic attribute filter on GET /events

### DIFF
--- a/src/control-plane-services/event-ledger/README.md
+++ b/src/control-plane-services/event-ledger/README.md
@@ -59,7 +59,7 @@ curl -X POST http://localhost:8080/v3/ledger/cloudevents \
 ```
 
 `namespace` is required. The optional context fields are `instanceId`,
-`deploymentId`, `gpuSpecificationId`, and `clusterId`.
+`deploymentId`, `gpuSpecificationId`, `clusterId`, and `resourceId`.
 
 ### Send OTLP log records
 
@@ -73,13 +73,14 @@ Each log record must include these string attributes:
 - `namespace`
 - `source`
 
-It may also include `instance_id`, `deployment_id`, `gpu_specification_id`, and
-`cluster_id`.
+It may also include `instance_id`, `deployment_id`, `gpu_specification_id`,
+`cluster_id`, and `resource_id`.
 
 ### Read events
 
-Pass the same context fields as query parameters. Context values may contain
-letters, numbers, and dashes. Instance IDs may also contain dots between
+Pass the context fields as query parameters: `instance_id`, `deployment_id`,
+`gpu_specification_id`, `cluster_id`, and `resource_id`. Context values may
+contain letters, numbers, and dashes. Instance IDs may also contain dots between
 non-empty segments.
 
 ```bash
@@ -88,6 +89,28 @@ curl 'http://localhost:8080/v3/ledger/namespace/example/events?instance_id=insta
 
 Events are returned newest first. If no context parameters are supplied, the
 endpoint returns events stored without a context.
+
+`resource_id` is a generic context field for events that have no other
+distinguishing context field, keyed by a producer-supplied identifier. It is
+part of the context key, so a lookup by `resource_id` is a direct read:
+
+```bash
+curl 'http://localhost:8080/v3/ledger/namespace/example/events?resource_id=request-123'
+```
+
+#### Filter by a details attribute
+
+The optional `attribute_key` and `attribute_value` parameters narrow the result
+to events whose `details.attributes[attribute_key]` equals `attribute_value`.
+This is a generic correlation filter over any producer-supplied attribute. The
+two parameters must be provided together: omitting both disables filtering and
+all events are returned, while supplying only one returns `400 Bad Request`.
+Filtering runs over the events of the queried context, so it is combined with
+the context parameters above.
+
+```bash
+curl 'http://localhost:8080/v3/ledger/namespace/example/events?instance_id=instance-1&attribute_key=correlation_id&attribute_value=request-123'
+```
 
 ### Read stats
 

--- a/src/control-plane-services/event-ledger/cmd/api/service/v3.go
+++ b/src/control-plane-services/event-ledger/cmd/api/service/v3.go
@@ -140,6 +140,14 @@ const (
 	contextFieldResourceID         = "resource_id"
 )
 
+// Query parameters for the optional generic attribute filter on GetEventsV3.
+// They let callers correlate events by any producer-supplied details attribute
+// (e.g. a request id) without the ledger exposing resource-specific concepts.
+const (
+	queryParamAttributeKey   = "attribute_key"
+	queryParamAttributeValue = "attribute_value"
+)
+
 // ContextV3 represents the context components that identify the scope of an event
 // This is the internal representation, not tied to any wire format
 type ContextV3 struct {
@@ -968,7 +976,13 @@ func (s *Server) GetStatsV3(w http.ResponseWriter, r *http.Request) {
 }
 
 // GetEventsV3 handles GET requests to /v3/ledger/namespace/{namespace}/context/{context}/events
-// Returns all events for a specific namespace and context, ordered by timestamp descending
+// Returns all events for a specific namespace and context, ordered by timestamp descending.
+//
+// An optional generic attribute filter (attribute_key + attribute_value) narrows
+// the result to events whose details.attributes[attribute_key] equals
+// attribute_value. This lets callers correlate events by any producer-supplied
+// attribute (e.g. a request id) using the existing event types, without the
+// ledger exposing resource-specific concepts.
 func (s *Server) GetEventsV3(w http.ResponseWriter, r *http.Request) {
 	traceCtx := r.Context()
 	logger := logging.GetLogger(traceCtx)
@@ -999,6 +1013,23 @@ func (s *Server) GetEventsV3(w http.ResponseWriter, r *http.Request) {
 		ResourceID:         queryParams.Get(contextFieldResourceID),
 	}
 
+	// Optional generic attribute filter. When set, only events whose
+	// details.attributes[attributeKey] equals attributeValue are returned.
+	// Both parameters must be supplied together: the only valid states are
+	// "both empty" (filter disabled) and "both set" (filter applied). A
+	// value-only request would otherwise silently disable the filter and
+	// return every event, so it is rejected.
+	attributeKey := queryParams.Get(queryParamAttributeKey)
+	attributeValue := queryParams.Get(queryParamAttributeValue)
+	if (attributeKey == "") != (attributeValue == "") {
+		logger.WarnContext(traceCtx, "Incomplete attribute filter query parameters",
+			zap.Bool("has_attribute_key", attributeKey != ""),
+			zap.Bool("has_attribute_value", attributeValue != ""))
+		sendProblemDetail(w, http.StatusBadRequest, "Bad Request",
+			fmt.Sprintf("%s and %s must be provided together", queryParamAttributeKey, queryParamAttributeValue))
+		return
+	}
+
 	// Convert ContextV3 to canonical string
 	eventContext, err := eventContextToCanonical(contextV3)
 	if err != nil {
@@ -1010,10 +1041,15 @@ func (s *Server) GetEventsV3(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Context is optional - allow empty string to query events with no context
+	// Log the attribute key for troubleshooting, but not the raw attribute value:
+	// the value is arbitrary caller-supplied input, so we record only its presence
+	// to avoid writing potentially sensitive data to logs (CWE-532).
 	logger.InfoContext(traceCtx, "Retrieving events for namespace and context",
 		zap.String("namespace", namespace),
 		zap.String("context", eventContext),
-		zap.Any("context_components", contextV3))
+		zap.Any("context_components", contextV3),
+		zap.String("attribute_key", attributeKey),
+		zap.Bool("has_attribute_value", attributeValue != ""))
 
 	// Retrieve all events for this namespace+context
 	records, err := s.conns.DbHandlerV2.GetEventsV3(traceCtx, namespace, eventContext)
@@ -1056,6 +1092,11 @@ func (s *Server) GetEventsV3(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		// Apply the optional generic attribute filter.
+		if !attributeMatches(details, attributeKey, attributeValue) {
+			continue
+		}
+
 		response.Events = append(response.Events, EventV3Item{
 			EventName: record.EventName,
 			Source:    record.Source,
@@ -1072,6 +1113,20 @@ func (s *Server) GetEventsV3(w http.ResponseWriter, r *http.Request) {
 		zap.Int("event_count", len(response.Events)))
 
 	sendJSONResponse(w, http.StatusOK, response)
+}
+
+// attributeMatches reports whether an event's details satisfy the optional
+// generic attribute filter. An empty key disables the filter (matches all).
+// Otherwise the attribute must be present and its string form must equal value.
+func attributeMatches(details EventDetails, key, value string) bool {
+	if key == "" {
+		return true
+	}
+	raw, ok := details.Attributes[key]
+	if !ok {
+		return false
+	}
+	return fmt.Sprintf("%v", raw) == value
 }
 
 // sendProblemDetail sends an RFC 9457 problem details response

--- a/src/control-plane-services/event-ledger/cmd/api/service/v3_test.go
+++ b/src/control-plane-services/event-ledger/cmd/api/service/v3_test.go
@@ -1137,6 +1137,66 @@ func TestGetEventsV3_Success(t *testing.T) {
 	assert.NotZero(t, response.Events[0].UpdatedAt)
 }
 
+// TestGetEventsV3_AttributeFilter verifies the optional generic attribute filter
+// narrows the result to events whose details attribute matches, reusing the
+// existing EventsV3Response type (no resource-specific model or namespace scan).
+func TestGetEventsV3_AttributeFilter(t *testing.T) {
+	logger := testutils.InitTestLogger(t)
+	server := NewServer(
+		Connections{DbHandlerV2: &mockDBHandlerV3{}},
+		logger, nil, "test", &config.HTTPClientConfig{}, config.PaginationConfig{}, config.StatsConfig{},
+	)
+
+	newReq := func(query string) *http.Request {
+		req := httptest.NewRequest("GET", "/v3/ledger/namespace/test-namespace/events"+query, nil)
+		ctx := req.Context()
+		ctx = context.WithValue(ctx, logging.LoggerKey, logging.NewTraceLogger(ctx, logger))
+		req = req.WithContext(ctx)
+		return mux.SetURLVars(req, map[string]string{"namespace": "test-namespace"})
+	}
+
+	// pod-1 has two events: "ready" (key2=value2) and "pending" (key1=value1).
+	// Filtering by key2=value2 returns only the "ready" event.
+	w := httptest.NewRecorder()
+	server.GetEventsV3(w, newReq("?instance_id=pod-1&attribute_key=key2&attribute_value=value2"))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var filtered EventsV3Response
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &filtered))
+	require.Len(t, filtered.Events, 1)
+	assert.Equal(t, "ready", filtered.Events[0].EventName)
+	assert.Equal(t, "value2", filtered.Events[0].Details.Attributes["key2"])
+
+	// A non-matching value excludes all events.
+	w = httptest.NewRecorder()
+	server.GetEventsV3(w, newReq("?instance_id=pod-1&attribute_key=key2&attribute_value=nope"))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var none EventsV3Response
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &none))
+	assert.Empty(t, none.Events)
+
+	// Omitting the filter returns both events (filter disabled).
+	w = httptest.NewRecorder()
+	server.GetEventsV3(w, newReq("?instance_id=pod-1"))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var all EventsV3Response
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &all))
+	assert.Len(t, all.Events, 2)
+
+	// attribute_key and attribute_value must be provided together. Supplying
+	// only one is rejected so a value-only request cannot silently disable the
+	// filter and return every event.
+	w = httptest.NewRecorder()
+	server.GetEventsV3(w, newReq("?instance_id=pod-1&attribute_value=value2"))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	w = httptest.NewRecorder()
+	server.GetEventsV3(w, newReq("?instance_id=pod-1&attribute_key=key2"))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
 // Test GetEventsV3 with empty result
 func TestGetEventsV3_EmptyResult(t *testing.T) {
 	mockDB := &mockDBHandlerV3{}


### PR DESCRIPTION
## Summary

Implements #816 (part of epic #809). Adds a generic, optional attribute filter to the existing `GET /events` endpoint so callers can correlate events by any producer-supplied `details.attributes` value. No ingest/schema change; `/stats` is unchanged and the `DBHandlerV2` interface is untouched.

This replaces the earlier ICMS-specific `instance-summary` join endpoint (see history below) with a small, generic building block, per review feedback: correlation stays generic and no ICMS concepts are exposed in the API.

## What changed

**`GET /v3/ledger/namespace/{namespace}/events`** gains two optional query params:

- `attribute_key` + `attribute_value` — when set, only events whose `details.attributes[attribute_key]` equals `attribute_value` are returned. An empty key disables the filter (matches all).

The result reuses the existing `EventsV3Response` type.

## How correlation works now

The ledger no longer performs a server-side, whole-namespace join. Instead callers use two direct, key-based queries and stitch them client-side:

1. **Outcome lane (direct key lookup, no scan):** `GET /events?resource_id=<id>` — the `resource_id` context field (added in #1117) is part of the key, so this is a direct row lookup for an ICMSRequest's events.
2. **Pod lane (direct lookup + generic filter):** `GET /events?instance_id=<pod>&attribute_key=icms_request_id&attribute_value=<id>` — fetches a known pod's events and keeps only those tagged with the correlation id.

Because `resource_id` and `instance_id` are both part of the DB key, every query stays a direct lookup — no cost that grows with namespace cardinality.

## Why the previous design was dropped

The prior `instance-summary` endpoint introduced a bespoke response model and joined the two lanes on read by listing every context in the namespace and reading each context's events. That was `O(namespace)`, could silently return partial data as `200`, produced internally-inconsistent merged metadata, and had no pagination. A directly-queryable cross-lane correlation key (e.g. a secondary index keyed by `icms_request_id`) is the correct prerequisite for such an endpoint and is left as a follow-up.

## Notes

- Registered behind the existing read scopes + tenant authorization, like `/stats` and `/events`.
- Rebased onto `main` after #1117 merged; this PR is now a single commit.

## Test plan

- [x] `go build ./...`
- [x] `gofmt` clean
- [x] `go test ./cmd/api/...` — new `TestGetEventsV3_AttributeFilter` covers match, non-match, and filter-disabled cases

## Follow-ups (not in this PR)

- NVCA OTel collector: map `icms_request_id → resource_id` on the ICMS lane, and lift the `icms-request-id` pod label into `details.attributes.icms_request_id` on the Pod lane, so these queries return data in practice.
- Design a directly-queryable correlation index if cross-lane "all pods for an id" discovery is needed server-side.

Closes #816


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event retrieval now supports filtering by resource ID.
  * Optional attribute key and value filters narrow results to events whose details match the requested attribute.
  * Attribute filters must be provided together; incomplete filter requests return a 400 error.
  * Resource context is preserved across CloudEvents, OTLP data, canonical resource information, and event queries.

* **Documentation**
  * Added guidance for resource identifiers, direct resource lookups, accepted context formats, and event attribute filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->