### PR TITLE
fix(nvca): reconcile self-hosted profile changes

### DIFF
--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/BUILD.bazel
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/BUILD.bazel
@@ -149,7 +149,9 @@ go_test(
         "webhooks_certrefresh_test.go",
         "webhooks_test.go",
     ],
-    data = glob(["testdata/**"]),
+    data = glob(["testdata/**"]) + [
+        "//src/compute-plane-services/nvca/internal/envtest:crds",
+    ],
     embed = [":reconcile"],
     embedsrcs = [
         "testdata/netpols.yaml",
@@ -163,8 +165,10 @@ go_test(
     # failures that GitLab kept reporting as `(cached) PASSED`). Force
     # fresh execution.
     tags = ["external"],
+    rundir = ".",
     deps = [
         "//src/compute-plane-services/nvca/internal/clustervalidator",
+        "//src/compute-plane-services/nvca/internal/envtest",
         "//src/compute-plane-services/nvca/pkg/apis/nvca/v2beta1",
         "//src/compute-plane-services/nvca/pkg/apis/nvcf/v1:nvcf",
         "//src/compute-plane-services/nvca/pkg/client/clientset/versioned/fake",

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/agent.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/agent.go
@@ -634,8 +634,9 @@ func (a *Agent) Start(ctx context.Context) error {
 func (a *Agent) dispatchReconcileCluster(ctx context.Context) {
 	log := core.GetLogger(ctx)
 
-	if a.ClusterSource != nvcaoptypes.ClusterSourceHelmManaged {
-		log.Debug("cluster source is not helm managed, skipping reconcile")
+	if a.ClusterSource != nvcaoptypes.ClusterSourceHelmManaged &&
+		a.ClusterSource != nvcaoptypes.ClusterSourceSelfHosted {
+		log.Debug("cluster source is not ConfigMap managed, skipping reconcile")
 		return
 	}
 

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/agent_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/agent_test.go
@@ -735,9 +735,14 @@ func TestDispatchReconcileCluster(t *testing.T) {
 		expectDispatch     bool
 	}{
 		{
-			name:           "non-helm managed cluster",
+			name:           "ngc managed cluster",
 			clusterSource:  nvcaoptypes.ClusterSourceNGCManaged,
 			expectDispatch: false,
+		},
+		{
+			name:           "self hosted with cache",
+			clusterSource:  nvcaoptypes.ClusterSourceSelfHosted,
+			expectDispatch: true,
 		},
 		{
 			name:               "helm managed but nil cache",

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/backendk8scache.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/backendk8scache.go
@@ -575,8 +575,20 @@ func configMapUpdateForcesNVCAReconcile(name string) bool {
 		nvcfCustomAnnotationsConfigMapName,
 		nvcfGPUProfilingConfigMapName,
 		nvcfBackendChartDefaultsConfigMapName,
+		agentConfigMergeConfigMapName,
 		nvcaOperatorConfigMapName:
 		return true
+	default:
+		return false
+	}
+}
+
+func (c *BackendK8sCache) backendConfigMapMatchesClusterSource(name string) bool {
+	switch c.clusterSource {
+	case nvcaoptypes.ClusterSourceHelmManaged:
+		return name == nvcfBackendHelmManagedConfigMapName
+	case nvcaoptypes.ClusterSourceSelfHosted:
+		return name == nvcfBackendSelfManagedConfigMapName
 	default:
 		return false
 	}
@@ -623,8 +635,7 @@ func (c *BackendK8sCache) handleConfigMapAdd(ctx context.Context, obj interface{
 	case configMapUpdateForcesNVCAReconcile(cm.Name):
 		log.Info("configmap recreated after informer sync, forcing rollout")
 		return c.syncCurrentBackendForConfigMapChange(ctx, log)
-	case cm.Name == nvcfBackendHelmManagedConfigMapName,
-		cm.Name == nvcfBackendSelfManagedConfigMapName:
+	case c.backendConfigMapMatchesClusterSource(cm.Name):
 		log.Info("backend configmap recreated after informer sync, dispatching cluster reconcile event")
 		c.dispatchReconcileClusterFunc(ctx)
 	case cm.Name == cleanup.ShutdownSentinelConfigMapName:
@@ -663,8 +674,7 @@ func (c *BackendK8sCache) handleConfigMapUpdate(ctx context.Context, oldObj, new
 		}
 		log.Debug("configmap data unchanged, skipping sync of current NVCFBackend")
 		return nil
-	case newCM.Name == nvcfBackendHelmManagedConfigMapName,
-		newCM.Name == nvcfBackendSelfManagedConfigMapName:
+	case c.backendConfigMapMatchesClusterSource(newCM.Name):
 		log.Debugf("found %s configmap update, syncing current NVCFBackend", newCM.Name)
 		diff := cmp.Diff(oldCM.Data, newCM.Data, cmpopts.EquateEmpty())
 		log.WithField("diff", diff).Debugf("configmap data diff")
@@ -679,6 +689,37 @@ func (c *BackendK8sCache) handleConfigMapUpdate(ctx context.Context, oldObj, new
 	case newCM.Name == cleanup.ShutdownSentinelConfigMapName:
 		log.Debugf("found %s configmap update, skipping", newCM.Name)
 		return nil
+	}
+	return nil
+}
+
+func (c *BackendK8sCache) handleConfigMapDelete(ctx context.Context, obj interface{}) error {
+	log := core.GetLogger(ctx)
+	cm, ok := obj.(*corev1.ConfigMap)
+	if !ok {
+		var tombstone cache.DeletedFinalStateUnknown
+		switch deleted := obj.(type) {
+		case cache.DeletedFinalStateUnknown:
+			tombstone = deleted
+		case *cache.DeletedFinalStateUnknown:
+			tombstone = *deleted
+		default:
+			return fmt.Errorf("invalid object received in ConfigMap Delete handler: %T", obj)
+		}
+		cm, ok = tombstone.Obj.(*corev1.ConfigMap)
+		if !ok {
+			return fmt.Errorf("invalid tombstone object received in ConfigMap Delete handler: %T", tombstone.Obj)
+		}
+	}
+
+	log = log.WithField("configmapName", cm.Name)
+	switch {
+	case configMapUpdateForcesNVCAReconcile(cm.Name):
+		log.Info("configmap deleted, forcing rollout")
+		return c.syncCurrentBackendForConfigMapChange(ctx, log)
+	case c.backendConfigMapMatchesClusterSource(cm.Name):
+		log.Info("backend configmap deleted, dispatching cluster reconcile event")
+		c.dispatchReconcileClusterFunc(ctx)
 	}
 	return nil
 }
@@ -708,6 +749,14 @@ func addConfigMapInformers(ctx context.Context, c *BackendK8sCache) error {
 					return c.handleConfigMapUpdate(ctx, oldObj, newObj)
 				}, oteltrace.WithSpanKind(oteltrace.SpanKindConsumer)); err != nil {
 				log.WithError(err).Error("failed to handle ConfigMap update")
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			if err := cmnotel.InvokeWithSpan(ctx, c.tracer, "nvca-operator.BackendK8sCache.ConfigMapInformer.DeleteHandler",
+				func(ctx context.Context) error {
+					return c.handleConfigMapDelete(ctx, obj)
+				}, oteltrace.WithSpanKind(oteltrace.SpanKindConsumer)); err != nil {
+				log.WithError(err).Error("failed to handle ConfigMap delete")
 			}
 		},
 	})

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/backendk8scache.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/backendk8scache.go
@@ -583,7 +583,7 @@ func configMapUpdateForcesNVCAReconcile(name string) bool {
 	}
 }
 
-func (c *BackendK8sCache) backendConfigMapMatchesClusterSource(name string) bool {
+func (c *BackendK8sCache) isBackendConfigMapMatchesClusterSource(name string) bool {
 	switch c.clusterSource {
 	case nvcaoptypes.ClusterSourceHelmManaged:
 		return name == nvcfBackendHelmManagedConfigMapName
@@ -635,7 +635,7 @@ func (c *BackendK8sCache) handleConfigMapAdd(ctx context.Context, obj interface{
 	case configMapUpdateForcesNVCAReconcile(cm.Name):
 		log.Info("configmap recreated after informer sync, forcing rollout")
 		return c.syncCurrentBackendForConfigMapChange(ctx, log)
-	case c.backendConfigMapMatchesClusterSource(cm.Name):
+	case c.isBackendConfigMapMatchesClusterSource(cm.Name):
 		log.Info("backend configmap recreated after informer sync, dispatching cluster reconcile event")
 		c.dispatchReconcileClusterFunc(ctx)
 	case cm.Name == cleanup.ShutdownSentinelConfigMapName:
@@ -674,7 +674,7 @@ func (c *BackendK8sCache) handleConfigMapUpdate(ctx context.Context, oldObj, new
 		}
 		log.Debug("configmap data unchanged, skipping sync of current NVCFBackend")
 		return nil
-	case c.backendConfigMapMatchesClusterSource(newCM.Name):
+	case c.isBackendConfigMapMatchesClusterSource(newCM.Name):
 		log.Debugf("found %s configmap update, syncing current NVCFBackend", newCM.Name)
 		diff := cmp.Diff(oldCM.Data, newCM.Data, cmpopts.EquateEmpty())
 		log.WithField("diff", diff).Debugf("configmap data diff")
@@ -717,7 +717,7 @@ func (c *BackendK8sCache) handleConfigMapDelete(ctx context.Context, obj interfa
 	case configMapUpdateForcesNVCAReconcile(cm.Name):
 		log.Info("configmap deleted, forcing rollout")
 		return c.syncCurrentBackendForConfigMapChange(ctx, log)
-	case c.backendConfigMapMatchesClusterSource(cm.Name):
+	case c.isBackendConfigMapMatchesClusterSource(cm.Name):
 		log.Info("backend configmap deleted, dispatching cluster reconcile event")
 		c.dispatchReconcileClusterFunc(ctx)
 	}

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/transport_tls_config_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/transport_tls_config_test.go
@@ -19,13 +19,17 @@ package operator
 
 import (
 	"context"
+	"os"
 	"testing"
+	"time"
 
+	nvcaenvtest "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/envtest"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/transporttls"
 	nvidiaiov1 "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvcf/v1"
 	nvcabelister "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/client/listers/nvcf/v1"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/operator/cleanup"
 	nvcaoperatorerrors "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/operator/internal/errors"
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/operator/internal/kubeclients"
 	nvcaopotel "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/operator/otel"
 	nvcaoptypes "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/operator/types"
 	nvcaconfig "github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/types/nvca/config"
@@ -164,6 +168,35 @@ func TestGetAgentConfigToMerge_RejectsTransportTLSSourceConflict(t *testing.T) {
 	_, _, err = bc.getAgentConfigToMerge(ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "both configure workload.transportTLS")
+}
+
+func TestGetRawAgentConfigToMerge_MissingReturnsNotFound(t *testing.T) {
+	ctx := newTestContext()
+	clients := mockKubeClientsForIntegrationTests()
+	bc := &BackendK8sCache{clients: clients, operatorNamespace: NVCAOperatorNamespace}
+
+	cfg, found, err := bc.getRawAgentConfigToMerge(ctx)
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.Equal(t, nvcaconfig.Config{}, cfg)
+}
+
+func TestGetRawAgentConfigToMerge_MalformedIsFatal(t *testing.T) {
+	ctx := newTestContext()
+	clients := mockKubeClientsForIntegrationTests()
+	bc := &BackendK8sCache{clients: clients, operatorNamespace: NVCAOperatorNamespace}
+
+	_, err := clients.K8s.CoreV1().ConfigMaps(NVCAOperatorNamespace).Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: agentConfigMergeConfigMapName},
+		Data:       map[string]string{agentConfigFile: "workload: ["},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, found, err := bc.getRawAgentConfigToMerge(ctx)
+	require.Error(t, err)
+	assert.False(t, found)
+	assert.True(t, nvcaoperatorerrors.IsFatal(err))
+	assert.Contains(t, err.Error(), "invalid agent-config-merge")
 }
 
 func TestGetAgentConfigToMerge_RejectsBundleWithQUICInsecureAsFatal(t *testing.T) {
@@ -469,6 +502,7 @@ func TestConfigMapAddHandler_ReconcilesRecreatedOperatorConfigAfterSync(t *testi
 func TestConfigMapAddHandler_DispatchesRecreatedBackendConfigAfterSync(t *testing.T) {
 	ctx := newTestContext()
 	bc, _ := newConfigMapEventTestCache(t, ctx)
+	bc.clusterSource = nvcaoptypes.ClusterSourceHelmManaged
 	bc.syncedFuncs = []cache.InformerSynced{func() bool { return true }}
 	bc.configMapHandlerRegistration = testResourceEventHandlerRegistration{synced: true}
 	dispatches := 0
@@ -479,6 +513,22 @@ func TestConfigMapAddHandler_DispatchesRecreatedBackendConfigAfterSync(t *testin
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 1, dispatches)
+}
+
+func TestConfigMapAddHandler_SkipsInactiveBackendConfig(t *testing.T) {
+	ctx := newTestContext()
+	bc, _ := newConfigMapEventTestCache(t, ctx)
+	bc.clusterSource = nvcaoptypes.ClusterSourceSelfHosted
+	bc.syncedFuncs = []cache.InformerSynced{func() bool { return true }}
+	bc.configMapHandlerRegistration = testResourceEventHandlerRegistration{synced: true}
+	dispatches := 0
+	bc.dispatchReconcileClusterFunc = func(context.Context) { dispatches++ }
+
+	err := bc.handleConfigMapAdd(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: nvcfBackendHelmManagedConfigMapName},
+	})
+	require.NoError(t, err)
+	assert.Zero(t, dispatches)
 }
 
 func TestSyncCurrentBackendForConfigMapChange_WrapsError(t *testing.T) {
@@ -505,6 +555,98 @@ func TestConfigMapUpdateHandler_ReconcilesWhenOperatorConfigDataChanges(t *testi
 	assert.Contains(t, storedBackend.Finalizers, cleanup.NVCAOperatorFinalizer)
 }
 
+func TestConfigMapUpdateHandler_ReconcilesWhenAgentMergeConfigDataChanges(t *testing.T) {
+	ctx := newTestContext()
+	bc, backend := newConfigMapEventTestCache(t, ctx)
+
+	err := bc.handleConfigMapUpdate(ctx,
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: agentConfigMergeConfigMapName}, Data: map[string]string{agentConfigFile: "before"}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: agentConfigMergeConfigMapName}, Data: map[string]string{agentConfigFile: "after"}},
+	)
+	require.ErrorContains(t, err, "version cannot be empty")
+
+	storedBackend, err := bc.clients.NVCAOP.NvcfV1().NVCFBackends(NVCAOperatorNamespace).Get(ctx, backend.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Contains(t, storedBackend.Finalizers, cleanup.NVCAOperatorFinalizer)
+}
+
+func TestConfigMapUpdateHandler_PropagatesAgentMergeConfigToExistingBackend(t *testing.T) {
+	ctx := newTestContext()
+	clients := mockKubeClients()
+	backend := getTestNVCFBackendAllFeatures()
+	backend.UID = "existing-backend-uid"
+	backend.Spec.Overrides = nil
+	backend.Spec.ClusterSource = nvcaoptypes.ClusterSourceSelfHosted
+	backend.Spec.ClusterConfig.ClusterID = "existing-cluster-id"
+	backend.Spec.ClusterConfig.ClusterGroupID = "existing-cluster-group-id"
+	_, err := clients.NVCAOP.NvcfV1().NVCFBackends(NVCAOperatorNamespace).Create(ctx, backend, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, indexer.Add(backend))
+	bc := &BackendK8sCache{
+		clients:                 clients,
+		operatorNamespace:       NVCAOperatorNamespace,
+		nvcfBackendLister:       nvcabelister.NewNVCFBackendLister(indexer),
+		eventRecorder:           record.NewFakeRecorder(20),
+		tracer:                  nvcaopotel.NewTracer(),
+		ngcServiceKeyFetcher:    &mockTokenFetcher{token: "randomkey"},
+		now:                     time.Now,
+		enableGXCache:           true,
+		clusterSource:           nvcaoptypes.ClusterSourceSelfHosted,
+		generateImagePullSecret: false,
+	}
+
+	before := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: agentConfigMergeConfigMapName, Namespace: NVCAOperatorNamespace},
+		Data: map[string]string{agentConfigFile: `workload:
+  stargateQUICInsecure: false
+`},
+	}
+	before, err = clients.K8s.CoreV1().ConfigMaps(NVCAOperatorNamespace).Create(ctx, before, metav1.CreateOptions{})
+	require.NoError(t, err)
+	require.NoError(t, bc.syncNVCFBackend(ctx, backend, false))
+
+	after := before.DeepCopy()
+	after.Data[agentConfigFile] = `workload:
+  stargateQUICInsecure: true
+`
+	after, err = clients.K8s.CoreV1().ConfigMaps(NVCAOperatorNamespace).Update(ctx, after, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	require.NoError(t, bc.handleConfigMapUpdate(ctx, before, after))
+
+	managed, err := clients.K8s.CoreV1().ConfigMaps(DefaultNVCASystemNamespace).Get(ctx, agentConfigConfigMapName, metav1.GetOptions{})
+	require.NoError(t, err)
+	managedConfig, err := nvcaconfig.DecodeConfig([]byte(managed.Data[agentConfigFile]))
+	require.NoError(t, err)
+	assert.True(t, managedConfig.Workload.StargateQUICInsecure)
+
+	require.NoError(t, clients.K8s.CoreV1().ConfigMaps(NVCAOperatorNamespace).Delete(ctx, agentConfigMergeConfigMapName, metav1.DeleteOptions{}))
+	require.NoError(t, bc.handleConfigMapDelete(ctx, after))
+	managed, err = clients.K8s.CoreV1().ConfigMaps(DefaultNVCASystemNamespace).Get(ctx, agentConfigConfigMapName, metav1.GetOptions{})
+	require.NoError(t, err)
+	managedConfig, err = nvcaconfig.DecodeConfig([]byte(managed.Data[agentConfigFile]))
+	require.NoError(t, err)
+	assert.False(t, managedConfig.Workload.StargateQUICInsecure)
+	lastGoodData := managed.Data[agentConfigFile]
+
+	_, err = clients.K8s.CoreV1().ConfigMaps(NVCAOperatorNamespace).Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: agentConfigMergeConfigMapName, Namespace: NVCAOperatorNamespace},
+		Data:       map[string]string{agentConfigFile: "workload: ["},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+	err = bc.syncNVCFBackend(ctx, backend, false)
+	require.Error(t, err)
+	assert.True(t, nvcaoperatorerrors.IsFatal(err))
+	managed, err = clients.K8s.CoreV1().ConfigMaps(DefaultNVCASystemNamespace).Get(ctx, agentConfigConfigMapName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, lastGoodData, managed.Data[agentConfigFile])
+
+	storedBackend, err := clients.NVCAOP.NvcfV1().NVCFBackends(NVCAOperatorNamespace).Get(ctx, backend.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, backend.UID, storedBackend.UID)
+}
+
 func TestConfigMapUpdateHandler_SkipsUnchangedOperatorConfig(t *testing.T) {
 	ctx := newTestContext()
 	bc, backend := newConfigMapEventTestCache(t, ctx)
@@ -513,6 +655,222 @@ func TestConfigMapUpdateHandler_SkipsUnchangedOperatorConfig(t *testing.T) {
 		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: nvcaOperatorConfigMapName}, Data: map[string]string{agentConfigFile: "unchanged"}},
 		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: nvcaOperatorConfigMapName}, Data: map[string]string{agentConfigFile: "unchanged"}},
 	)
+	require.NoError(t, err)
+
+	storedBackend, err := bc.clients.NVCAOP.NvcfV1().NVCFBackends(NVCAOperatorNamespace).Get(ctx, backend.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.NotContains(t, storedBackend.Finalizers, cleanup.NVCAOperatorFinalizer)
+}
+
+func TestConfigMapUpdateHandler_DispatchesSelfHostedBackendConfigDataChanges(t *testing.T) {
+	ctx := newTestContext()
+	bc, _ := newConfigMapEventTestCache(t, ctx)
+	bc.clusterSource = nvcaoptypes.ClusterSourceSelfHosted
+	dispatches := 0
+	bc.dispatchReconcileClusterFunc = func(context.Context) { dispatches++ }
+
+	err := bc.handleConfigMapUpdate(ctx,
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: nvcfBackendSelfManagedConfigMapName}, Data: map[string]string{"cluster-dto.yaml": "before"}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: nvcfBackendSelfManagedConfigMapName}, Data: map[string]string{"cluster-dto.yaml": "after"}},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, dispatches)
+}
+
+func TestConfigMapUpdateHandler_SkipsUnchangedSelfHostedBackendConfig(t *testing.T) {
+	ctx := newTestContext()
+	bc, _ := newConfigMapEventTestCache(t, ctx)
+	bc.clusterSource = nvcaoptypes.ClusterSourceSelfHosted
+	dispatches := 0
+	bc.dispatchReconcileClusterFunc = func(context.Context) { dispatches++ }
+
+	err := bc.handleConfigMapUpdate(ctx,
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: nvcfBackendSelfManagedConfigMapName}, Data: map[string]string{"cluster-dto.yaml": "unchanged"}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: nvcfBackendSelfManagedConfigMapName}, Data: map[string]string{"cluster-dto.yaml": "unchanged"}},
+	)
+	require.NoError(t, err)
+	assert.Zero(t, dispatches)
+}
+
+func TestConfigMapUpdateHandler_SkipsInactiveBackendConfig(t *testing.T) {
+	ctx := newTestContext()
+	bc, _ := newConfigMapEventTestCache(t, ctx)
+	bc.clusterSource = nvcaoptypes.ClusterSourceSelfHosted
+	dispatches := 0
+	bc.dispatchReconcileClusterFunc = func(context.Context) { dispatches++ }
+
+	err := bc.handleConfigMapUpdate(ctx,
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: nvcfBackendHelmManagedConfigMapName}, Data: map[string]string{"cluster-dto.yaml": "before"}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: nvcfBackendHelmManagedConfigMapName}, Data: map[string]string{"cluster-dto.yaml": "after"}},
+	)
+	require.NoError(t, err)
+	assert.Zero(t, dispatches)
+}
+
+func TestConfigMapUpdateHandler_SkipsUnrelatedConfigMap(t *testing.T) {
+	ctx := newTestContext()
+	bc, backend := newConfigMapEventTestCache(t, ctx)
+	dispatches := 0
+	bc.dispatchReconcileClusterFunc = func(context.Context) { dispatches++ }
+
+	err := bc.handleConfigMapUpdate(ctx,
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "unrelated-configmap"}, Data: map[string]string{"value": "before"}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "unrelated-configmap"}, Data: map[string]string{"value": "after"}},
+	)
+	require.NoError(t, err)
+	assert.Zero(t, dispatches)
+
+	storedBackend, err := bc.clients.NVCAOP.NvcfV1().NVCFBackends(NVCAOperatorNamespace).Get(ctx, backend.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.NotContains(t, storedBackend.Finalizers, cleanup.NVCAOperatorFinalizer)
+}
+
+func TestConfigMapDeleteHandler_ReconcilesDeletedAgentMergeConfig(t *testing.T) {
+	ctx := newTestContext()
+	bc, backend := newConfigMapEventTestCache(t, ctx)
+
+	err := bc.handleConfigMapDelete(ctx, cache.DeletedFinalStateUnknown{Obj: &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: agentConfigMergeConfigMapName},
+	}})
+	require.ErrorContains(t, err, "version cannot be empty")
+
+	storedBackend, err := bc.clients.NVCAOP.NvcfV1().NVCFBackends(NVCAOperatorNamespace).Get(ctx, backend.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Contains(t, storedBackend.Finalizers, cleanup.NVCAOperatorFinalizer)
+}
+
+func TestConfigMapDeleteHandler_DispatchesDeletedSelfHostedBackendConfig(t *testing.T) {
+	ctx := newTestContext()
+	bc, _ := newConfigMapEventTestCache(t, ctx)
+	bc.clusterSource = nvcaoptypes.ClusterSourceSelfHosted
+	dispatches := 0
+	bc.dispatchReconcileClusterFunc = func(context.Context) { dispatches++ }
+
+	err := bc.handleConfigMapDelete(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: nvcfBackendSelfManagedConfigMapName},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, dispatches)
+}
+
+func TestConfigMapDeleteHandler_SkipsInactiveBackendConfig(t *testing.T) {
+	ctx := newTestContext()
+	bc, _ := newConfigMapEventTestCache(t, ctx)
+	bc.clusterSource = nvcaoptypes.ClusterSourceSelfHosted
+	dispatches := 0
+	bc.dispatchReconcileClusterFunc = func(context.Context) { dispatches++ }
+
+	err := bc.handleConfigMapDelete(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: nvcfBackendHelmManagedConfigMapName},
+	})
+	require.NoError(t, err)
+	assert.Zero(t, dispatches)
+}
+
+func TestBackendConfigMapMatchesClusterSource(t *testing.T) {
+	tests := []struct {
+		name          string
+		clusterSource nvcaoptypes.ClusterSource
+		configMapName string
+		want          bool
+	}{
+		{name: "helm source and helm config", clusterSource: nvcaoptypes.ClusterSourceHelmManaged, configMapName: nvcfBackendHelmManagedConfigMapName, want: true},
+		{name: "helm source and self-hosted config", clusterSource: nvcaoptypes.ClusterSourceHelmManaged, configMapName: nvcfBackendSelfManagedConfigMapName},
+		{name: "self-hosted source and self-hosted config", clusterSource: nvcaoptypes.ClusterSourceSelfHosted, configMapName: nvcfBackendSelfManagedConfigMapName, want: true},
+		{name: "self-hosted source and helm config", clusterSource: nvcaoptypes.ClusterSourceSelfHosted, configMapName: nvcfBackendHelmManagedConfigMapName},
+		{name: "NGC source and helm config", clusterSource: nvcaoptypes.ClusterSourceNGCManaged, configMapName: nvcfBackendHelmManagedConfigMapName},
+		{name: "self-hosted source and unrelated config", clusterSource: nvcaoptypes.ClusterSourceSelfHosted, configMapName: "unrelated-configmap"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bc := &BackendK8sCache{clusterSource: tt.clusterSource}
+			assert.Equal(t, tt.want, bc.backendConfigMapMatchesClusterSource(tt.configMapName))
+		})
+	}
+}
+
+func TestConfigMapInformerEnvtest_DispatchesOnlyActiveSelfHostedSource(t *testing.T) {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		t.Skip("KUBEBUILDER_ASSETS is required for envtest")
+	}
+
+	cfg, k8sClient, cleanupEnvtest, err := nvcaenvtest.SetupEnvtest()
+	require.NoError(t, err)
+	t.Cleanup(cleanupEnvtest)
+
+	ctx, cancel := context.WithCancel(newTestContext())
+	t.Cleanup(cancel)
+	const namespace = "configmap-informer-envtest"
+	_, err = k8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: namespace},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	for _, name := range []string{nvcfBackendHelmManagedConfigMapName, nvcfBackendSelfManagedConfigMapName} {
+		_, err = k8sClient.CoreV1().ConfigMaps(namespace).Create(ctx, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Data:       map[string]string{"cluster-dto.yaml": "before"},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	dispatched := make(chan struct{}, 2)
+	bc := &BackendK8sCache{
+		clients:                      &kubeclients.KubeClients{Config: cfg, K8s: k8sClient},
+		operatorNamespace:            namespace,
+		clusterSource:                nvcaoptypes.ClusterSourceSelfHosted,
+		tracer:                       nvcaopotel.NewTracer(),
+		dispatchReconcileClusterFunc: func(context.Context) { dispatched <- struct{}{} },
+	}
+	require.NoError(t, addConfigMapInformers(ctx, bc))
+	require.Eventually(t, func() bool {
+		return bc.informersSynced() && bc.configMapHandlerRegistration.HasSynced()
+	}, 5*time.Second, 20*time.Millisecond)
+
+	updateConfigMap := func(name string) {
+		cm, getErr := k8sClient.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+		require.NoError(t, getErr)
+		cm.Data["cluster-dto.yaml"] = "after"
+		_, updateErr := k8sClient.CoreV1().ConfigMaps(namespace).Update(ctx, cm, metav1.UpdateOptions{})
+		require.NoError(t, updateErr)
+	}
+	assertNotDispatched := func() {
+		assert.Never(t, func() bool {
+			select {
+			case <-dispatched:
+				return true
+			default:
+				return false
+			}
+		}, 300*time.Millisecond, 20*time.Millisecond)
+	}
+	assertDispatched := func() {
+		select {
+		case <-dispatched:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for cluster reconcile dispatch")
+		}
+	}
+
+	updateConfigMap(nvcfBackendHelmManagedConfigMapName)
+	assertNotDispatched()
+	updateConfigMap(nvcfBackendSelfManagedConfigMapName)
+	assertDispatched()
+
+	require.NoError(t, k8sClient.CoreV1().ConfigMaps(namespace).Delete(ctx, nvcfBackendHelmManagedConfigMapName, metav1.DeleteOptions{}))
+	assertNotDispatched()
+	require.NoError(t, k8sClient.CoreV1().ConfigMaps(namespace).Delete(ctx, nvcfBackendSelfManagedConfigMapName, metav1.DeleteOptions{}))
+	assertDispatched()
+}
+
+func TestConfigMapDeleteHandler_SkipsUnrelatedConfigMap(t *testing.T) {
+	ctx := newTestContext()
+	bc, backend := newConfigMapEventTestCache(t, ctx)
+
+	err := bc.handleConfigMapDelete(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "unrelated-configmap"},
+	})
 	require.NoError(t, err)
 
 	storedBackend, err := bc.clients.NVCAOP.NvcfV1().NVCFBackends(NVCAOperatorNamespace).Get(ctx, backend.Name, metav1.GetOptions{})
@@ -539,6 +897,7 @@ func TestSyncNVCFBackend_WrapsDesiredAgentConfigError(t *testing.T) {
 func TestConfigMapChangesForceNVCAReconcile(t *testing.T) {
 	assert.True(t, configMapUpdateForcesNVCAReconcile(nvcaOperatorConfigMapName))
 	assert.True(t, configMapUpdateForcesNVCAReconcile(nvcfBackendChartDefaultsConfigMapName))
+	assert.True(t, configMapUpdateForcesNVCAReconcile(agentConfigMergeConfigMapName))
 	assert.False(t, configMapUpdateForcesNVCAReconcile("unrelated-configmap"))
 }
 

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/transport_tls_config_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/transport_tls_config_test.go
@@ -785,7 +785,7 @@ func TestBackendConfigMapMatchesClusterSource(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bc := &BackendK8sCache{clusterSource: tt.clusterSource}
-			assert.Equal(t, tt.want, bc.backendConfigMapMatchesClusterSource(tt.configMapName))
+			assert.Equal(t, tt.want, bc.isBackendConfigMapMatchesClusterSource(tt.configMapName))
 		})
 	}
 }


### PR DESCRIPTION
## TL;DR

Automatically reconcile an existing self-hosted `NVCFBackend` when its supported backend profile ConfigMap or generated `agent-config-merge` ConfigMap changes.

## Additional Details

The ConfigMap informer already mapped a narrow set of global configuration objects to the single backend managed by an operator installation. Two paths were incomplete:

- `agent-config-merge` contributed to desired agent configuration but was absent from the exact-name reconcile filter.
- the self-hosted backend source emitted a cluster-refresh event, but the agent accepted that event only for Helm-managed clusters.

This change adds `agent-config-merge` to the existing exact filter, permits ConfigMap-driven refresh for self-hosted clusters, and matches backend-source ConfigMaps to the active cluster source so cross-mode and unrelated ConfigMaps remain inert. Delete events are handled through direct objects or informer tombstones, allowing missing configuration to reconcile deterministically.

The existing single-backend invariant makes reconciling the current backend the precise mapping for global merge configuration. Desired resources continue to be read from the live API and compared before writes, preserving idempotency and new-install behavior.

## For the Reviewer

Please focus on the source/name mapping and add/update/delete event paths in `backendk8scache.go`, plus the self-hosted dispatch guard in `agent.go`.

Regression coverage includes exact positive and negative mapping, real informer callbacks under envtest, downstream managed ConfigMap propagation on an existing backend, deletion, malformed input preserving last-good state, and backend identity preservation.

## For QA

Validated with:

- focused regression tests for ConfigMap handlers, source matching, merge configuration, and self-hosted dispatch;
- the full `pkg/operator/reconcile` package on Linux with Kubernetes 1.34 envtest assets (`ok`, 55.572s);
- `go vet -mod=vendor ./pkg/operator/reconcile` and `git diff --check`;
- an existing local self-hosted Kubernetes deployment.

Live validation changed the merge source on an already-running backend and observed the managed agent ConfigMap update within two seconds without a force annotation, operator restart, reinstall, or backend recreation. Reverting the value propagated the original configuration. Updating and deleting an unrelated ConfigMap did not change the backend or managed resource versions. Deleting and recreating the supported merge ConfigMap automatically removed and restored the managed value. Updating and restoring the self-hosted backend source changed the existing backend generation while preserving its UID. A subsequent periodic reconcile left managed resource versions unchanged.

Is QA Needed? No separate QA pass is required; targeted automated and local self-hosted validation are complete.

## Issues

Fixes #1121

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Self-hosted clusters now participate in reconciliation workflows.
  * Configuration updates and deletions are automatically detected for supported cluster types.
  * Relevant configuration changes can trigger cluster updates and rollout actions.

* **Bug Fixes**
  * Unrelated configuration changes no longer trigger unnecessary reconciliations.
  * Improved handling of missing or malformed configuration.

* **Tests**
  * Expanded coverage for self-hosted clusters, configuration changes, deletions, event filtering, and forced reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->