### PR TITLE
chore(self-managed): update chart pins after nvcf 999

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -168,7 +168,7 @@ releases:
     {{- $llmRequestRouterChartPath := dig "addons" "llm" "requestRouter" "chartPath" "" .Values }}
     chart: {{ $llmRequestRouterChartPath | default "nvcf/helm-nvcf-llm-request-router" | quote }}
     {{- if not $llmRequestRouterChartPath }}
-    version: 1.7.2
+    version: 1.10.0
     {{- end }}
     namespace: nvcf
     condition: addons.llm.enabled
@@ -217,7 +217,7 @@ releases:
     {{- $gatewayRoutesChartPath := dig "ingress" "gatewayApi" "chartPath" "" .Values }}
     chart: {{ $gatewayRoutesChartPath | default "nvcf/nvcf-gateway-routes" | quote }}
     {{- if not $gatewayRoutesChartPath }}
-    version: 1.15.0
+    version: 1.16.0
     {{- end }}
     needs:
       - nvcf/notary-service

--- a/docs/user/manifest.md
+++ b/docs/user/manifest.md
@@ -154,7 +154,7 @@ The following tables list the complete artifact inventory.
 | `helm-nvcf-grpc-proxy` | `1.6.7` | Required | Deploys the gRPC proxy service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-grpc-proxy:1.6.7` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/grpc-proxy) |
 | `helm-nvcf-invocation-service` | `1.5.5` | Required | Deploys the HTTP invocation service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-invocation-service:1.5.5` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/http-invocation) |
 | `helm-nvcf-llm-api-gateway` | `1.2.0` | Optional | Deploys the OpenAI-compatible LLM API gateway. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-llm-api-gateway:1.2.0` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/llm-api-gateway) |
-| `helm-nvcf-llm-request-router` | `1.6.6` | Optional | Deploys the LLM request router. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-llm-request-router:1.6.6` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/llm-request-router) |
+| `helm-nvcf-llm-request-router` | `1.10.0` | Optional | Deploys the LLM request router. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-llm-request-router:1.10.0` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/llm-request-router) |
 | `helm-nvcf-nats` | `0.7.1` | Required | Deploys NATS messaging for the control plane. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-nats:0.7.1` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/nats) / [Upstream](https://github.com/nats-io/k8s) |
 | `helm-nvcf-nats-auth-callout-service` | `1.1.3` | Required | Deploys the NATS authorization callout service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-nats-auth-callout-service:1.1.3` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/nats-auth-callout) |
 | `helm-nvcf-notary-service` | `1.4.2` | Required | Deploys the notary service for signing and validation. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-notary-service:1.4.2` |  |
@@ -168,7 +168,7 @@ The following tables list the complete artifact inventory.
 | `helm-nvcf-vanity-gateway` | `0.3.0` | Optional | Deploys the optional vanity hostname gateway. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-vanity-gateway:0.3.0` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/vanity-gateway) |
 | `helm-reval` | `1.3.8` | Required | Deploys the function revalidation service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-reval:1.3.8` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/helm-reval) |
 | `nvcf-example-dashboards` | `1.6.0` | Optional | Deploys example Grafana dashboards for NVCF telemetry. | `https://helm.ngc.nvidia.com/nvidia/nvcf/nvcf-example-dashboards:1.6.0` |  |
-| `nvcf-gateway-routes` | `1.15.0` | Optional | Deploys Gateway API routes for the reference architecture. | `https://helm.ngc.nvidia.com/nvidia/nvcf/nvcf-gateway-routes:1.15.0` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/gateway-routes) |
+| `nvcf-gateway-routes` | `1.16.0` | Optional | Deploys Gateway API routes for the reference architecture. | `https://helm.ngc.nvidia.com/nvidia/nvcf/nvcf-gateway-routes:1.16.0` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/gateway-routes) |
 | `nvcf-observability-reference-stack` | `1.10.0` | Optional | Deploys a reference observability backend for evaluation. | `https://helm.ngc.nvidia.com/nvidia/nvcf/nvcf-observability-reference-stack:1.10.0` |  |
 
 ### Control plane services and images

--- a/docs/version-catalog/main.yaml
+++ b/docs/version-catalog/main.yaml
@@ -181,7 +181,7 @@ publications:
     registry: public-helm
     chart_format: http
   - name: helm-nvcf-llm-request-router
-    version: 1.6.6
+    version: 1.10.0
     registry: public-helm
     chart_format: http
   - name: helm-nvcf-nats-auth-callout-service
@@ -233,7 +233,7 @@ publications:
     registry: public-helm
     chart_format: http
   - name: nvcf-gateway-routes
-    version: 1.15.0
+    version: 1.16.0
     registry: public-helm
     chart_format: http
   - name: nvcf-container-cache
@@ -805,7 +805,7 @@ artifacts:
   - name: helm-nvcf-llm-request-router
     type: chart
     registry: staging
-    version: 1.6.6
+    version: 1.10.0
   - name: helm-nvcf-nats-auth-callout-service
     type: chart
     registry: staging
@@ -881,7 +881,7 @@ artifacts:
   - name: nvcf-gateway-routes
     type: chart
     registry: staging
-    version: 1.15.0
+    version: 1.16.0
   - name: nvcf-grpc-proxy
     type: image
     registry: staging


### PR DESCRIPTION
## Why

This is the post-#999 release and stable-pinning follow-up. PR #999 changed the LLM worker routing and Gateway API chart contents; the stable self-managed stack must consume the newly published chart versions so those changes are deployable from the standard stack.

## What changed

- Updated the stable self-managed Helmfile pins:
  - `helm-nvcf-llm-request-router`: `1.7.2` -> `1.10.0`
  - `nvcf-gateway-routes`: `1.15.0` -> `1.16.0`
- Updated the version catalog and regenerated the top-level artifact manifest.

Published releases:

- [LLM request router v1.10.0](https://github.com/NVIDIA/nvcf/releases/tag/deploy/helm/llm-request-router/v1.10.0)
- [Gateway routes v1.16.0](https://github.com/NVIDIA/nvcf/releases/tag/deploy/helm/gateway-routes/v1.16.0)

## Customer Release Notes

Not customer visible. This synchronizes stable deployment pins with the charts released after NVIDIA/nvcf#999.

## Plan Summary

The self-managed stack now resolves both charts from the configured published chart registry at the exact released versions. No local chart path or snapshot chart is used.

## Testing

- `make test` in `deploy/helm/llm-request-router`: passed.
- `make test` in `deploy/helm/gateway-routes`: passed.
- `make -C deploy/stacks/self-managed test`: passed.
- `go run -C tools/docs-version-sync . --target main --check`: passed with the repository-root marker required by the current generator.
- Generated `docs/user/manifest.md` with `go run -C tools/docs-version-sync . --target main`.
- Verified the published chart artifacts can be pulled and inspected at the exact versions before this change.
- Full wrapper `make template` was not run to completion because the checked-in environment requires deployment-specific registry credentials and the local Helmfile version is outside the repository's supported v1.1.x range. No cluster or live Kubernetes resources were changed.

## Notes

The chart artifacts were independently verified before pinning. The rendered stack test coverage uses the released chart versions and does not substitute local chart directories or snapshot versions.

## References

Relates to #999

## Related Pull Requests

- https://github.com/NVIDIA/nvcf/pull/999

## Dependencies

No third-party dependencies changed. No NOTICE changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the LLM request router chart to version 1.10.0.
  - Updated the gateway routes chart to version 1.16.0.
  - Synchronized chart versions across deployment configuration and artifact catalogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->