### PR TITLE
fix(self-managed): allow inherited PKI defaults for existing secrets

### DIFF
--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -329,9 +329,10 @@ addons:
     #                    also provisions the OpenBao service-issuing hierarchy
     #                    and defaults to ClusterIssuer/nvcf-openbao-pki.
     #   existingSecret - the chart mounts a Secret you created and manages no
-    #                    issuance. Requires secretName. clusterIssuer.enabled,
-    #                    dnsNames, and allowedDomains must be unset because
-    #                    they only steer stack-managed issuance. You own
+    #                    issuance. Requires secretName. The stable-base
+    #                    dnsNames and allowedDomains defaults are tolerated
+    #                    because Helmfile cannot clear inherited empty lists;
+    #                    any changed managed value is rejected. You own
     #                    issuance, renewal, rotation, and recovery, and the
     #                    stack validates neither the SANs nor the expiry.
     pki:
@@ -345,7 +346,8 @@ addons:
       # path only: Pylon preserves the advertised per-pod hostname as gRPC
       # authority and QUIC SNI, so a load-balancer hostname or IP does not need
       # to be added here. Add SANs only when advertisedHostnameTemplate changes
-      # those identities. Must be empty for mode existingSecret.
+      # those identities. In existingSecret mode, only these unchanged
+      # stable-base defaults are tolerated; custom values are rejected.
       dnsNames:
         - llm-request-router.nvcf.svc.cluster.local
         - "*.llm-request-router-headless.nvcf.svc.cluster.local"

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -331,7 +331,8 @@ addons:
     #   existingSecret - the chart mounts a Secret you created and manages no
     #                    issuance. Requires secretName. The stable-base
     #                    dnsNames and allowedDomains defaults are tolerated
-    #                    because Helmfile cannot clear inherited empty lists;
+    #                    because Helmfile cannot reliably clear inherited
+    #                    values to empty values;
     #                    any changed managed value is rejected. You own
     #                    issuance, renewal, rotation, and recovery, and the
     #                    stack validates neither the SANs nor the expiry.

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -944,8 +944,9 @@ llmRequestRouter:
   {{- if eq $pkiMode "existingSecret" }}
   {{- /* The operator owns issuance in this mode, so custom values that steer
        stack-managed issuance are mixed-ownership conflicts. The stable base
-       profile's managed defaults are tolerated because Helmfile cannot clear
-       an inherited empty list; any changed value fails loudly. */ -}}
+       profile's managed defaults are tolerated because Helmfile cannot
+       reliably clear inherited values to empty values; any changed value
+       fails loudly. */ -}}
   {{- $existingSecretPkiValues := dig "addons" "llm" "pki" dict .Values }}
   {{- if kindIs "map" $existingSecretPkiValues }}
   {{- $existingSecretClusterIssuer := dig "clusterIssuer" dict $existingSecretPkiValues }}
@@ -964,7 +965,7 @@ llmRequestRouter:
   {{- fail "addons.llm.pki.dnsNames applies only to a stack-issued Certificate; only the unchanged stable-base defaults are allowed when addons.llm.pki.mode is existingSecret" }}
   {{- end }}
   {{- $existingSecretAllowedDomains := dig "addons" "llm" "pki" "allowedDomains" "" .Values }}
-  {{- if and $existingSecretAllowedDomains (ne $existingSecretAllowedDomains "cluster.local") }}
+  {{- if and (ne $existingSecretAllowedDomains nil) (not (and (kindIs "string" $existingSecretAllowedDomains) (eq $existingSecretAllowedDomains "cluster.local"))) }}
   {{- fail "addons.llm.pki.allowedDomains constrains the managed OpenBao signing role; only the unchanged stable-base default is allowed when addons.llm.pki.mode is existingSecret" }}
   {{- end }}
   {{- /* No default: the Secret is the operator's, so guessing a name would

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -942,11 +942,10 @@ llmRequestRouter:
   {{- fail (printf "addons.llm.pki.mode must be exactly \"certManager\" or \"existingSecret\", got %q" $pkiMode) }}
   {{- end }}
   {{- if eq $pkiMode "existingSecret" }}
-  {{- /* The operator owns issuance in this mode, so every value that only
-       steers stack-managed issuance is a mixed-ownership conflict. Fail loudly
-       instead of silently ignoring it: a leftover dnsNames list reads as "the
-       stack still issues my certificate" and would go unnoticed until the
-       certificate expired. */ -}}
+  {{- /* The operator owns issuance in this mode, so custom values that steer
+       stack-managed issuance are mixed-ownership conflicts. The stable base
+       profile's managed defaults are tolerated because Helmfile cannot clear
+       an inherited empty list; any changed value fails loudly. */ -}}
   {{- $existingSecretPkiValues := dig "addons" "llm" "pki" dict .Values }}
   {{- if kindIs "map" $existingSecretPkiValues }}
   {{- $existingSecretClusterIssuer := dig "clusterIssuer" dict $existingSecretPkiValues }}
@@ -960,11 +959,13 @@ llmRequestRouter:
   {{- if not (kindIs "slice" $existingSecretDnsNames) }}
   {{- fail "addons.llm.pki.dnsNames must be a list when addons.llm.pki.mode is existingSecret" }}
   {{- end }}
-  {{- if gt (len $existingSecretDnsNames) 0 }}
-  {{- fail "addons.llm.pki.dnsNames applies only to a stack-issued Certificate and must be empty when addons.llm.pki.mode is existingSecret" }}
+  {{- $defaultManagedDnsNames := list "llm-request-router.nvcf.svc.cluster.local" "*.llm-request-router-headless.nvcf.svc.cluster.local" }}
+  {{- if and (gt (len $existingSecretDnsNames) 0) (not (deepEqual $existingSecretDnsNames $defaultManagedDnsNames)) }}
+  {{- fail "addons.llm.pki.dnsNames applies only to a stack-issued Certificate; only the unchanged stable-base defaults are allowed when addons.llm.pki.mode is existingSecret" }}
   {{- end }}
-  {{- if dig "addons" "llm" "pki" "allowedDomains" "" .Values }}
-  {{- fail "addons.llm.pki.allowedDomains constrains the managed OpenBao signing role only and must be empty when addons.llm.pki.mode is existingSecret" }}
+  {{- $existingSecretAllowedDomains := dig "addons" "llm" "pki" "allowedDomains" "" .Values }}
+  {{- if and $existingSecretAllowedDomains (ne $existingSecretAllowedDomains "cluster.local") }}
+  {{- fail "addons.llm.pki.allowedDomains constrains the managed OpenBao signing role; only the unchanged stable-base default is allowed when addons.llm.pki.mode is existingSecret" }}
   {{- end }}
   {{- /* No default: the Secret is the operator's, so guessing a name would
        mount the wrong identity or fail at pod start instead of at render. */ -}}

--- a/deploy/stacks/self-managed/tests/check-llm-pki-issuer.sh
+++ b/deploy/stacks/self-managed/tests/check-llm-pki-issuer.sh
@@ -266,7 +266,8 @@ expect_external_router() {
 # existingSecret mode cannot reuse render_router: that helper always passes
 # managed issuance values, which this mode rejects as a mixed-ownership
 # conflict. This helper models the stable base profile, whose unchanged managed
-# defaults are tolerated because Helmfile cannot clear inherited empty lists.
+# defaults are tolerated because Helmfile cannot reliably clear inherited
+# values to empty values.
 render_existing_secret_router() {
   local case_name="$1"
   shift
@@ -779,6 +780,44 @@ expect_router_failure existing-secret-allowed-domains \
   'addons.llm.pki.allowedDomains constrains the managed OpenBao signing role; only the unchanged stable-base default is allowed when addons.llm.pki.mode is existingSecret' \
   --state-values-set-string addons.llm.pki.secretName=operator-quic-tls \
   --state-values-set-string addons.llm.pki.allowedDomains=nvcf.svc.cluster.local
+
+# allowedDomains is optional in existingSecret mode, but any supplied value
+# other than the inherited stable-base string must fail rather than being
+# silently treated as absent by template truthiness.
+existing_secret_allowed_domains_error='addons.llm.pki.allowedDomains constrains the managed OpenBao signing role; only the unchanged stable-base default is allowed when addons.llm.pki.mode is existingSecret'
+expect_router_failure existing-secret-allowed-domains-false \
+  "$existing_secret_allowed_domains_error" \
+  --state-values-set-string addons.llm.pki.secretName=operator-quic-tls \
+  --state-values-file "$(pki_override existing-secret-allowed-domains-false <<'YAML'
+allowedDomains: false
+YAML
+)"
+
+expect_router_failure existing-secret-allowed-domains-zero \
+  "$existing_secret_allowed_domains_error" \
+  --state-values-set-string addons.llm.pki.secretName=operator-quic-tls \
+  --state-values-file "$(pki_override existing-secret-allowed-domains-zero <<'YAML'
+allowedDomains: 0
+YAML
+)"
+
+render_existing_secret_router existing-secret-allowed-domains-null \
+  --state-values-set openbao.enabled=false \
+  --state-values-set-string addons.llm.pki.secretName=operator-quic-tls \
+  --state-values-file "$(pki_override existing-secret-allowed-domains-null <<'YAML'
+allowedDomains: null
+YAML
+)" || fail "existing-secret allowedDomains null router render failed"
+expect_existing_secret_router existing-secret-allowed-domains-null operator-quic-tls
+
+render_existing_secret_router existing-secret-allowed-domains-default \
+  --state-values-set openbao.enabled=false \
+  --state-values-set-string addons.llm.pki.secretName=operator-quic-tls \
+  --state-values-file "$(pki_override existing-secret-allowed-domains-default <<'YAML'
+allowedDomains: cluster.local
+YAML
+)" || fail "existing-secret allowedDomains stable-base router render failed"
+expect_existing_secret_router existing-secret-allowed-domains-default operator-quic-tls
 
 # Without a Secret name the chart would silently leave the router on plaintext
 # QUIC, so the stack must fail at render instead.

--- a/deploy/stacks/self-managed/tests/check-llm-pki-issuer.sh
+++ b/deploy/stacks/self-managed/tests/check-llm-pki-issuer.sh
@@ -265,18 +265,13 @@ expect_external_router() {
 
 # existingSecret mode cannot reuse render_router: that helper always passes
 # managed issuance values, which this mode rejects as a mixed-ownership
-# conflict. Clear the managed defaults before applying each case override.
+# conflict. This helper models the stable base profile, whose unchanged managed
+# defaults are tolerated because Helmfile cannot clear inherited empty lists.
 render_existing_secret_router() {
   local case_name="$1"
   shift
   local values_file="$work_dir/$case_name.router-values.yaml"
   local router_chart="$stack_dir/../../helm/llm-request-router/llm-request-router"
-  local ownership_override_file
-  ownership_override_file="$(pki_override "$case_name-existing-secret-ownership" <<'YAML'
-allowedDomains: ""
-dnsNames: []
-YAML
-)"
 
   HELMFILE_ENV=base HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" helmfile \
     --file "$stack_dir/helmfile.d/02-core.yaml.gotmpl" \
@@ -288,7 +283,6 @@ YAML
     --state-values-set addons.llm.enabled=true \
     --state-values-set addons.llm.pki.enabled=true \
     --state-values-set-string addons.llm.pki.mode=existingSecret \
-    --state-values-file "$ownership_override_file" \
     "$@" \
     write-values \
     --output-file-template "$values_file" \
@@ -772,9 +766,9 @@ expect_router_failure existing-secret-managed-issuer \
   --state-values-set addons.llm.pki.clusterIssuer.enabled=true
 
 expect_router_failure existing-secret-dns-names \
-  'addons.llm.pki.dnsNames applies only to a stack-issued Certificate and must be empty when addons.llm.pki.mode is existingSecret' \
+  'addons.llm.pki.dnsNames applies only to a stack-issued Certificate; only the unchanged stable-base defaults are allowed when addons.llm.pki.mode is existingSecret' \
   --state-values-set-string addons.llm.pki.secretName=operator-quic-tls \
-  --state-values-set-string 'addons.llm.pki.dnsNames[0]=llm-request-router.nvcf.svc.cluster.local'
+  --state-values-set-string 'addons.llm.pki.dnsNames[0]=custom-router.example.invalid'
 
 expect_router_failure existing-secret-scalar-dns-names \
   'addons.llm.pki.dnsNames must be a list when addons.llm.pki.mode is existingSecret' \
@@ -782,7 +776,7 @@ expect_router_failure existing-secret-scalar-dns-names \
   --state-values-set-string addons.llm.pki.dnsNames=llm-request-router.nvcf.svc.cluster.local
 
 expect_router_failure existing-secret-allowed-domains \
-  'addons.llm.pki.allowedDomains constrains the managed OpenBao signing role only and must be empty when addons.llm.pki.mode is existingSecret' \
+  'addons.llm.pki.allowedDomains constrains the managed OpenBao signing role; only the unchanged stable-base default is allowed when addons.llm.pki.mode is existingSecret' \
   --state-values-set-string addons.llm.pki.secretName=operator-quic-tls \
   --state-values-set-string addons.llm.pki.allowedDomains=nvcf.svc.cluster.local
 


### PR DESCRIPTION
## Why

The self-managed base profile supplies managed request-router PKI defaults. Helmfile cannot reliably clear inherited empty lists through state-value overrides, preventing the supported `existingSecret` mode from rendering.

## What changed

Allow only the unchanged stable-base SAN and allowed-domain defaults in `existingSecret` mode. Custom managed SAN or allowed-domain values remain render errors. Update the regression test and configuration guidance.

## Customer Release Notes

Existing-secret PKI deployments can use the self-managed base profile without a render failure.

## Plan Summary

Not applicable.

## Usage

Set `addons.llm.pki.mode=existingSecret` and provide `addons.llm.pki.secretName`. The stack does not create a Certificate or managed issuer in this mode.

## Testing

`make test` from `deploy/stacks/self-managed`

## Notes

No runtime resources were changed.

## References

Closes #1129

## Related Pull Requests

Related to NVIDIA/nvcf#999.

## Dependencies

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated self-managed deployments to accept unchanged default DNS names and allowed domains when using an existing PKI secret.
  * Continued to reject custom or modified managed PKI values.
  * Improved validation for invalid allowed-domain values, including false, zero, and non-string entries.
  * Updated configuration checks to handle inherited defaults more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->