### PR TITLE
fix(llm): refresh ESS assertion credentials

### DIFF
--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
@@ -42,6 +42,9 @@ const (
 
 	llmDirMountPath    = "/var/run/llm"
 	llmWorkerTokenPath = llmDirMountPath + "/worker-token"
+
+	essAssertionTokenPathEnv = "ESS_ASSERTION_TOKEN_PATH"
+	essAssertionTokenPath    = common.EssConfigDir + "/jwt.token"
 )
 
 func normalizeLLMRequestRouterAddressEnvAliases(envSet map[string]string) {
@@ -235,6 +238,28 @@ func newLLMCredentialManagerContainer(allEnvSet map[string]string, _ TranslateCo
 			Value: llmWorkerTokenPath,
 		},
 	)
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "llm",
+			MountPath: llmDirMountPath,
+		},
+		// config-data backs SHARED_CONFIG_DIR. The credential manager
+		// creates and caches the worker token here, so it must be mounted.
+		{
+			Name:      "config-data",
+			MountPath: ConfigDirPath,
+		},
+	}
+	if allEnvSet[common.SecretsAssertionTokenEnv] != "" {
+		envs = append(envs, corev1.EnvVar{
+			Name:  essAssertionTokenPathEnv,
+			Value: essAssertionTokenPath,
+		})
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      common.EssDataVolumeName,
+			MountPath: common.EssConfigDir,
+		})
+	}
 
 	c := corev1.Container{
 		Name:            "llm-credential-manager",
@@ -251,18 +276,7 @@ func newLLMCredentialManagerContainer(allEnvSet map[string]string, _ TranslateCo
 				corev1.ResourceMemory: *resource.NewQuantity(128*1<<20, resource.BinarySI),
 			},
 		},
-		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      "llm",
-				MountPath: llmDirMountPath,
-			},
-			// config-data backs SHARED_CONFIG_DIR. The credential manager
-			// creates and caches the worker token here, so it must be mounted.
-			{
-				Name:      "config-data",
-				MountPath: ConfigDirPath,
-			},
-		},
+		VolumeMounts: volumeMounts,
 	}
 	return c, nil
 }

--- a/src/compute-plane-services/worker-llm-credentials/README.md
+++ b/src/compute-plane-services/worker-llm-credentials/README.md
@@ -1,10 +1,23 @@
 # worker-llm-credentials
 
-Sidecar that maintains a fresh NVCF worker credential token on disk for the
-LLM inference container. It connects to NVCF over gRPC using the worker token,
-runs a background refresher that periodically fetches a new token, and writes
-it atomically to the configured token path (owner-only `0600` permissions). The
-process runs until its context is cancelled.
+Sidecar that maintains fresh NVCF credentials on disk for explicit LLM
+functions. It connects to NVCF over gRPC using the worker token and always
+refreshes the worker credential used by the LLM router client. When
+`ESS_ASSERTION_TOKEN_PATH` is set, it also refreshes the ESS assertion used by
+the ESS Agent. The process runs until its context is cancelled.
+
+Each refresher fetches its credential immediately, schedules later refreshes
+from the returned expiration, and atomically replaces the configured file. The
+shared files use `0644` permissions because the consuming infrastructure
+sidecars run as different non-root users. Customer workload containers do not
+mount these credential volumes.
+
+## Configuration
+
+- `WORKER_TOKEN_PATH` sets the worker credential file. It defaults to
+  `/var/run/llm/worker-token`.
+- `ESS_ASSERTION_TOKEN_PATH` optionally sets the ESS assertion file. When it is
+  unset, the sidecar does not request or write an ESS assertion.
 
 ## Build
 

--- a/src/compute-plane-services/worker-llm-credentials/configs/BUILD.bazel
+++ b/src/compute-plane-services/worker-llm-credentials/configs/BUILD.bazel
@@ -1,10 +1,16 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "configs",
     srcs = ["configs.go"],
     importpath = "github.com/NVIDIA/nvcf/src/compute-plane-services/worker-llm-credentials/configs",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "configs_test",
+    srcs = ["configs_test.go"],
+    embed = [":configs"],
 )
 
 alias(

--- a/src/compute-plane-services/worker-llm-credentials/configs/configs.go
+++ b/src/compute-plane-services/worker-llm-credentials/configs/configs.go
@@ -18,14 +18,15 @@ limitations under the License.
 package configs
 
 type Config struct {
-	NvcfFqdnGrpc      string `mapstructure:"NVCF_FQDN_GRPC"`
-	NvcfWorkerToken   string `mapstructure:"NVCF_WORKER_TOKEN"`
-	FunctionId        string `mapstructure:"FUNCTION_ID"`
-	FunctionVersionId string `mapstructure:"FUNCTION_VERSION_ID"`
-	NcaId             string `mapstructure:"NCA_ID"`
-	InstanceId        string `mapstructure:"INSTANCE_ID"`
-	SharedConfigDir   string `mapstructure:"SHARED_CONFIG_DIR"`
-	WorkerTokenPath   string `mapstructure:"WORKER_TOKEN_PATH"`
+	NvcfFqdnGrpc          string `mapstructure:"NVCF_FQDN_GRPC"`
+	NvcfWorkerToken       string `mapstructure:"NVCF_WORKER_TOKEN"`
+	FunctionId            string `mapstructure:"FUNCTION_ID"`
+	FunctionVersionId     string `mapstructure:"FUNCTION_VERSION_ID"`
+	NcaId                 string `mapstructure:"NCA_ID"`
+	InstanceId            string `mapstructure:"INSTANCE_ID"`
+	SharedConfigDir       string `mapstructure:"SHARED_CONFIG_DIR"`
+	WorkerTokenPath       string `mapstructure:"WORKER_TOKEN_PATH"`
+	ESSAssertionTokenPath string `mapstructure:"ESS_ASSERTION_TOKEN_PATH"`
 }
 
 const DefaultSharedConfigDir = "/config/shared"

--- a/src/compute-plane-services/worker-llm-credentials/configs/configs_test.go
+++ b/src/compute-plane-services/worker-llm-credentials/configs/configs_test.go
@@ -1,0 +1,33 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configs
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestConfigSupportsOptionalESSAssertionTokenPath(t *testing.T) {
+	field, ok := reflect.TypeOf(Config{}).FieldByName("ESSAssertionTokenPath")
+	if !ok {
+		t.Fatal("Config must expose an optional ESSAssertionTokenPath field")
+	}
+	if got := field.Tag.Get("mapstructure"); got != "ESS_ASSERTION_TOKEN_PATH" {
+		t.Fatalf("ESSAssertionTokenPath mapstructure tag = %q, want %q", got, "ESS_ASSERTION_TOKEN_PATH")
+	}
+}

--- a/src/compute-plane-services/worker-llm-credentials/internal/worker/worker.go
+++ b/src/compute-plane-services/worker-llm-credentials/internal/worker/worker.go
@@ -80,6 +80,9 @@ func (w *Worker) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if w.config.ESSAssertionTokenPath != "" {
+		w.client.StartAssertionTokenRefresher(ctx, w.config.ESSAssertionTokenPath, true)
+	}
 
 	token.StartTokenRefresher(ctx, "llm worker token", true,
 		func(ctx context.Context) (token.Token, error) {

--- a/src/compute-plane-services/worker-llm-credentials/internal/worker/worker_test.go
+++ b/src/compute-plane-services/worker-llm-credentials/internal/worker/worker_test.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -39,6 +40,7 @@ const testWorkerToken = "test-worker-token"
 
 type mockNVCFServer struct {
 	pb.UnimplementedWorkerServer
+	requestSecretCredentials func(context.Context, *pb.SecretCredentialsRequest) (*pb.SecretCredentialsResponse, error)
 }
 
 func (s *mockNVCFServer) ConnectOnce(_ context.Context, _ *pb.WorkerConnect) (*pb.WorkerConnectOnceResponse, error) {
@@ -49,17 +51,63 @@ func (s *mockNVCFServer) ConnectOnce(_ context.Context, _ *pb.WorkerConnect) (*p
 	}, nil
 }
 
+func (s *mockNVCFServer) RequestSecretCredentials(
+	ctx context.Context,
+	req *pb.SecretCredentialsRequest,
+) (*pb.SecretCredentialsResponse, error) {
+	if s.requestSecretCredentials == nil {
+		return s.UnimplementedWorkerServer.RequestSecretCredentials(ctx, req)
+	}
+	return s.requestSecretCredentials(ctx, req)
+}
+
 func startMockNVCFServer(t *testing.T) string {
+	return startMockNVCFServerWithImplementation(t, &mockNVCFServer{})
+}
+
+func startMockNVCFServerWithImplementation(t *testing.T, implementation *mockNVCFServer) string {
 	t.Helper()
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	var listenConfig net.ListenConfig
+	lis, err := listenConfig.Listen(context.Background(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to listen: %v", err)
 	}
 	srv := grpc.NewServer()
-	pb.RegisterWorkerServer(srv, &mockNVCFServer{})
-	go srv.Serve(lis)
-	t.Cleanup(srv.GracefulStop)
+	pb.RegisterWorkerServer(srv, implementation)
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- srv.Serve(lis)
+	}()
+	t.Cleanup(func() {
+		srv.GracefulStop()
+		if err := <-serveErr; err != nil {
+			t.Errorf("serve mock NVCF server: %v", err)
+		}
+	})
 	return fmt.Sprintf("http://%s", lis.Addr().String())
+}
+
+func waitForFileContent(path, want string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		content, err := os.ReadFile(path)
+		if err == nil && string(content) == want {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	content, err := os.ReadFile(path)
+	return err == nil && string(content) == want
+}
+
+func cancelAndWaitForRun(t *testing.T, cancel context.CancelFunc, runErr <-chan error) {
+	t.Helper()
+	cancel()
+	select {
+	case <-runErr:
+	case <-time.After(2 * time.Second):
+		t.Log("Run did not stop within the cleanup timeout")
+	}
 }
 
 func TestRun_WritesTokenToDisk(t *testing.T) {
@@ -108,5 +156,136 @@ func TestRun_WritesTokenToDisk(t *testing.T) {
 	}
 	if string(content) != testWorkerToken {
 		t.Fatalf("expected token %q, got %q", testWorkerToken, string(content))
+	}
+}
+
+func TestRun_RefreshesESSAssertionTokenUntilCancelled(t *testing.T) {
+	tmpDir := t.TempDir()
+	assertionTokenPath := filepath.Join(tmpDir, "ess", "jwt.token")
+	if err := os.MkdirAll(filepath.Dir(assertionTokenPath), 0755); err != nil {
+		t.Fatalf("create assertion token directory: %v", err)
+	}
+	if err := os.WriteFile(assertionTokenPath, []byte("worker-init-token"), 0600); err != nil {
+		t.Fatalf("write initial assertion token: %v", err)
+	}
+
+	var requestCount atomic.Int32
+	addr := startMockNVCFServerWithImplementation(t, &mockNVCFServer{
+		requestSecretCredentials: func(
+			_ context.Context,
+			_ *pb.SecretCredentialsRequest,
+		) (*pb.SecretCredentialsResponse, error) {
+			call := requestCount.Add(1)
+			tokenValue := "refreshed-assertion-1"
+			expiration := time.Now().Add(300 * time.Millisecond)
+			if call > 1 {
+				tokenValue = "refreshed-assertion-2"
+				expiration = time.Now().Add(time.Hour)
+			}
+			return &pb.SecretCredentialsResponse{
+				SecretCredentialsToken: tokenValue,
+				Expiration:             timestamppb.New(expiration),
+			}, nil
+		},
+	})
+
+	cfg := configs.Config{
+		NvcfFqdnGrpc:          addr,
+		NvcfWorkerToken:       "initial-token",
+		FunctionId:            "test-function-id",
+		FunctionVersionId:     "test-function-version-id",
+		NcaId:                 "test-nca-id",
+		InstanceId:            "test-instance-id",
+		SharedConfigDir:       tmpDir,
+		WorkerTokenPath:       filepath.Join(tmpDir, "worker-token"),
+		ESSAssertionTokenPath: assertionTokenPath,
+	}
+
+	w, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErr := lo.Async(func() error { return w.Run(ctx) })
+
+	if !waitForFileContent(assertionTokenPath, "refreshed-assertion-1", 5*time.Second) {
+		cancelAndWaitForRun(t, cancel, runErr)
+		t.Fatal("existing assertion token was not replaced by the immediate refresh")
+	}
+	info, err := os.Stat(assertionTokenPath)
+	if err != nil {
+		cancelAndWaitForRun(t, cancel, runErr)
+		t.Fatalf("stat refreshed assertion token: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0644 {
+		cancelAndWaitForRun(t, cancel, runErr)
+		t.Fatalf("assertion token mode = %o, want 0644", got)
+	}
+	if !waitForFileContent(assertionTokenPath, "refreshed-assertion-2", 5*time.Second) {
+		cancelAndWaitForRun(t, cancel, runErr)
+		t.Fatal("assertion token was not rotated on the next refresh cycle")
+	}
+
+	cancel()
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("Run after cancellation: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not stop cleanly after cancellation")
+	}
+}
+
+func TestRun_WithoutESSAssertionTokenPathSkipsSecretCredentialRefresh(t *testing.T) {
+	var requestCount atomic.Int32
+	addr := startMockNVCFServerWithImplementation(t, &mockNVCFServer{
+		requestSecretCredentials: func(
+			_ context.Context,
+			_ *pb.SecretCredentialsRequest,
+		) (*pb.SecretCredentialsResponse, error) {
+			requestCount.Add(1)
+			return &pb.SecretCredentialsResponse{
+				SecretCredentialsToken: "unexpected-token",
+				Expiration:             timestamppb.New(time.Now().Add(time.Hour)),
+			}, nil
+		},
+	})
+
+	tmpDir := t.TempDir()
+	assertionTokenPath := filepath.Join(tmpDir, "ess", "jwt.token")
+	workerTokenPath := filepath.Join(tmpDir, "worker-token")
+	cfg := configs.Config{
+		NvcfFqdnGrpc:      addr,
+		NvcfWorkerToken:   "initial-token",
+		FunctionId:        "test-function-id",
+		FunctionVersionId: "test-function-version-id",
+		NcaId:             "test-nca-id",
+		InstanceId:        "test-instance-id",
+		SharedConfigDir:   tmpDir,
+		WorkerTokenPath:   workerTokenPath,
+	}
+
+	w, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	runErr := lo.Async(func() error { return w.Run(ctx) })
+	if !waitForFileContent(workerTokenPath, testWorkerToken, 5*time.Second) {
+		cancelAndWaitForRun(t, cancel, runErr)
+		t.Fatal("worker token was not written")
+	}
+	cancel()
+	if err := <-runErr; err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got := requestCount.Load(); got != 0 {
+		t.Fatalf("RequestSecretCredentials calls = %d, want 0", got)
+	}
+	if _, err := os.Stat(assertionTokenPath); !os.IsNotExist(err) {
+		t.Fatalf("assertion token file should not exist without ESS_ASSERTION_TOKEN_PATH, stat error: %v", err)
 	}
 }

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
@@ -42,6 +42,9 @@ const (
 
 	llmDirMountPath    = "/var/run/llm"
 	llmWorkerTokenPath = llmDirMountPath + "/worker-token"
+
+	essAssertionTokenPathEnv = "ESS_ASSERTION_TOKEN_PATH"
+	essAssertionTokenPath    = common.EssConfigDir + "/jwt.token"
 )
 
 func normalizeLLMRequestRouterAddressEnvAliases(envSet map[string]string) {
@@ -235,6 +238,28 @@ func newLLMCredentialManagerContainer(allEnvSet map[string]string, _ TranslateCo
 			Value: llmWorkerTokenPath,
 		},
 	)
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "llm",
+			MountPath: llmDirMountPath,
+		},
+		// config-data backs SHARED_CONFIG_DIR. The credential manager
+		// creates and caches the worker token here, so it must be mounted.
+		{
+			Name:      "config-data",
+			MountPath: ConfigDirPath,
+		},
+	}
+	if allEnvSet[common.SecretsAssertionTokenEnv] != "" {
+		envs = append(envs, corev1.EnvVar{
+			Name:  essAssertionTokenPathEnv,
+			Value: essAssertionTokenPath,
+		})
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      common.EssDataVolumeName,
+			MountPath: common.EssConfigDir,
+		})
+	}
 
 	c := corev1.Container{
 		Name:            "llm-credential-manager",
@@ -251,18 +276,7 @@ func newLLMCredentialManagerContainer(allEnvSet map[string]string, _ TranslateCo
 				corev1.ResourceMemory: *resource.NewQuantity(128*1<<20, resource.BinarySI),
 			},
 		},
-		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      "llm",
-				MountPath: llmDirMountPath,
-			},
-			// config-data backs SHARED_CONFIG_DIR. The credential manager
-			// creates and caches the worker token here, so it must be mounted.
-			{
-				Name:      "config-data",
-				MountPath: ConfigDirPath,
-			},
-		},
+		VolumeMounts: volumeMounts,
 	}
 	return c, nil
 }

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_tolerations_test.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_tolerations_test.go
@@ -186,6 +186,10 @@ func TestTranslateHelmChartLLM_AddsRouterAndCredentialContainers(t *testing.T) {
 	assert.Equal(t, "grpc.example.com", credentialEnv["NVCF_FQDN_GRPC"])
 	assert.Equal(t, ConfigDirPath, credentialEnv["SHARED_CONFIG_DIR"])
 	assert.Equal(t, "/var/run/llm/worker-token", credentialEnv["WORKER_TOKEN_PATH"])
+	assert.NotContains(t, credentialEnv, "ESS_ASSERTION_TOKEN_PATH")
+	for _, mount := range credentialManager.VolumeMounts {
+		assert.NotEqual(t, common.EssDataVolumeName, mount.Name)
+	}
 
 	require.NotNil(t, findVolumeByName(t, utilsPod.Spec.Volumes, "llm").EmptyDir)
 }
@@ -239,8 +243,111 @@ func TestTranslateContainerLLM_AddsRouterAndCredentialContainers(t *testing.T) {
 
 	credentialManager := findContainerByName(t, pod.Spec.Containers, "llm-credential-manager")
 	assert.Equal(t, "nvcr.io/nvidia/credential-manager:latest", credentialManager.Image)
-	assert.Equal(t, "worker-token", envSliceToMap(credentialManager.Env)["NVCF_WORKER_TOKEN"])
+	credentialEnv := envSliceToMap(credentialManager.Env)
+	assert.Equal(t, "worker-token", credentialEnv["NVCF_WORKER_TOKEN"])
+	assert.NotContains(t, credentialEnv, "ESS_ASSERTION_TOKEN_PATH")
+	for _, mount := range credentialManager.VolumeMounts {
+		assert.NotEqual(t, common.EssDataVolumeName, mount.Name)
+	}
 	require.NotNil(t, findVolumeByName(t, pod.Spec.Volumes, "llm").EmptyDir)
+}
+
+func TestTranslateHelmChartLLMWithSecretsSharesAssertionTokenWithCredentialManager(t *testing.T) {
+	msg := newHelmFunctionMessage()
+	msg.Details.FunctionType = FunctionTypeLLM
+	msg.LaunchSpecification.EnvironmentB64 = encodeTextEnv(map[string]string{
+		common.UtilsImageEnv:                "utils:latest",
+		common.InitImageEnv:                 "init:latest",
+		common.ESSAgentContainerEnv:         "ess:latest",
+		common.SecretsAssertionTokenEnv:     "worker-init-assertion",
+		"LLM_REQUEST_ROUTER_ADDRESS":        "llm-router.example.com:443",
+		"INFERENCE_PORT":                    "8080",
+		"HELM_CHART_INFERENCE_SERVICE_NAME": "inference-svc",
+		"NVCF_WORKER_TOKEN":                 "worker-token",
+		"NVCF_FQDN_GRPC":                    "grpc.example.com",
+		"FUNCTION_ID":                       "function-id",
+		"FUNCTION_VERSION_ID":               "function-version-id",
+		"NCA_ID":                            "nca-id",
+	})
+
+	objs, err := Translate(msg, TranslateConfig{TranslateConfig: newFunctionTranslateConfig(nil)})
+	require.NoError(t, err)
+
+	utilsPod := findPodByName(t, objs, common.UtilsPodName)
+	credentialManager := findContainerByName(t, utilsPod.Spec.Containers, "llm-credential-manager")
+	credentialEnv := envSliceToMap(credentialManager.Env)
+	assert.Equal(t, "/config/ess-agent/jwt.token", credentialEnv["ESS_ASSERTION_TOKEN_PATH"])
+	assert.NotContains(t, credentialEnv, common.SecretsAssertionTokenEnv)
+	assert.Contains(t, credentialManager.VolumeMounts, corev1.VolumeMount{
+		Name:      common.EssDataVolumeName,
+		MountPath: common.EssConfigDir,
+	})
+	essContainer := findContainerByName(t, utilsPod.Spec.Containers, "ess")
+	assert.Contains(t, essContainer.VolumeMounts, corev1.VolumeMount{
+		Name:      common.EssDataVolumeName,
+		MountPath: common.EssConfigDir,
+	})
+	require.NotNil(t, findVolumeByName(t, utilsPod.Spec.Volumes, common.EssDataVolumeName).EmptyDir)
+}
+
+func TestTranslateContainerLLMWithSecretsSharesAssertionTokenWithCredentialManager(t *testing.T) {
+	msg := newContainerFunctionMessage()
+	msg.Details.FunctionType = FunctionTypeLLM
+	msg.LaunchSpecification.EnvironmentB64 = encodeTextEnv(map[string]string{
+		common.ContainerFunctionImageEnv: "function:latest",
+		common.UtilsImageEnv:             "utils:latest",
+		common.InitImageEnv:              "init:latest",
+		common.ESSAgentContainerEnv:      "ess:latest",
+		common.SecretsAssertionTokenEnv:  "worker-init-assertion",
+		"LLM_REQUEST_ROUTER_ADDRESS":     "llm-router.example.com:443",
+		"INFERENCE_PORT":                 "8080",
+		"NVCF_WORKER_TOKEN":              "worker-token",
+		"NVCF_FQDN_GRPC":                 "grpc.example.com",
+		"FUNCTION_ID":                    "function-id",
+		"FUNCTION_VERSION_ID":            "function-version-id",
+		"NCA_ID":                         "nca-id",
+	})
+
+	objs, err := Translate(msg, TranslateConfig{TranslateConfig: newFunctionTranslateConfig(nil)})
+	require.NoError(t, err)
+
+	pod := findPodByName(t, objs, "0-request")
+	credentialManager := findContainerByName(t, pod.Spec.Containers, "llm-credential-manager")
+	credentialEnv := envSliceToMap(credentialManager.Env)
+	assert.Equal(t, "/config/ess-agent/jwt.token", credentialEnv["ESS_ASSERTION_TOKEN_PATH"])
+	assert.NotContains(t, credentialEnv, common.SecretsAssertionTokenEnv)
+	assert.Contains(t, credentialManager.VolumeMounts, corev1.VolumeMount{
+		Name:      common.EssDataVolumeName,
+		MountPath: common.EssConfigDir,
+	})
+	essContainer := findContainerByName(t, pod.Spec.Containers, "ess")
+	assert.Contains(t, essContainer.VolumeMounts, corev1.VolumeMount{
+		Name:      common.EssDataVolumeName,
+		MountPath: common.EssConfigDir,
+	})
+	require.NotNil(t, findVolumeByName(t, pod.Spec.Volumes, common.EssDataVolumeName).EmptyDir)
+}
+
+func TestTranslateNonLLMFunctionsDoNotAddCredentialManager(t *testing.T) {
+	for _, functionType := range []string{FunctionTypeDefault, FunctionTypeStreaming} {
+		t.Run(functionType, func(t *testing.T) {
+			msg := newContainerFunctionMessage()
+			msg.Details.FunctionType = functionType
+			msg.LaunchSpecification.EnvironmentB64 = encodeTextEnv(map[string]string{
+				common.ContainerFunctionImageEnv: "function:latest",
+				common.UtilsImageEnv:             "utils:latest",
+				common.NICLLSUtilsImageEnv:       "lls-utils:latest",
+				common.InitImageEnv:              "init:latest",
+			})
+
+			objs, err := Translate(msg, TranslateConfig{TranslateConfig: newFunctionTranslateConfig(nil)})
+			require.NoError(t, err)
+			pod := findPodByName(t, objs, "0-request")
+			for _, container := range pod.Spec.Containers {
+				assert.NotEqual(t, "llm-credential-manager", container.Name)
+			}
+		})
+	}
 }
 
 func TestTranslateContainerWithCacheAndSecrets(t *testing.T) {


### PR DESCRIPTION
## TL;DR

Refresh the ESS assertion for secret-bearing explicit LLM functions by extending `worker-llm-credentials` to use the existing shared NVCF assertion refresher.

The LLM translator now gives the credential manager access to the existing ESS assertion volume only when the function has secrets. LLM functions without secrets and all non-LLM function types retain their current pod configuration.

## Additional Details

### Credential gap and fix

```mermaid
flowchart LR
    subgraph Before
        WI1[Worker init] -->|writes assertion once| F1[jwt.token]
        N1[NVCF credential service] -->|refreshes worker credential| C1[LLM credential manager]
        C1 -. no assertion mount or refresh .-> F1
        F1 --> E1[ESS Agent]
        E1 -->|assertion ages out| X1[ESS reads return 401]
    end

    subgraph After
        WI2[Worker init] -->|writes initial assertion| F2[jwt.token]
        N2[NVCF credential service] -->|refreshes worker credential and assertion| C2[LLM credential manager]
        C2 -->|atomic replacement, mode 0644| F2
        F2 -->|file reload| E2[ESS Agent]
        E2 -->|continued authenticated reads| X2[ESS]
    end
```

### What changed

- Add optional `ESS_ASSERTION_TOKEN_PATH` configuration to `worker-llm-credentials`.
- Start the existing shared assertion refresher after the NVCF connection is established when that path is configured.
- For secret-bearing container and Helm LLM functions, mount `ess-data` at `/config/ess-agent` and set the path to `/config/ess-agent/jwt.token`.
- Keep worker-init responsible for writing the initial assertion.
- Do not pass the raw assertion into the credential-manager container.
- Preserve current behavior when the path is absent, including LLM functions without secrets.
- Regenerate the NVCA vendored translator copy and document both refreshed credentials and shared-file permissions.

No public API, protobuf, CRD, control-plane, or ESS retry/expiration behavior changes are included.

## For the Reviewer

The most important paths are:

- `worker-llm-credentials/internal/worker/worker.go` for the optional refresher startup;
- `icms-translate/translate/function/llm.go` for conditional pod wiring;
- worker and translator tests for the no-secret and non-LLM compatibility cases.

The implementation intentionally reuses the shared refresher so refresh timing, retries, jitter, atomic replacement, and file permissions remain centralized.

## For QA

Automated verification:

- `bazel test //src/compute-plane-services/worker-llm-credentials/... //src/libraries/go/lib/pkg/icms-translate/translate/function:function_test` — passed.
- NVCA vendored translator is byte-identical to the canonical translator and its Bazel target builds successfully.
- NVCA Helm lint suite — passed.
- `git diff --check` — passed.

Final-head CI verification:

- Root, NVCA, and `worker-llm-credentials` Bazel jobs — passed; the aggregate required-check job also passed.
- Documentation, Go-library code generation, Helm chart, dependency-license, license-header/NOTICE, and secret-scan jobs — passed.
- CodeRabbit incremental review — completed with no unresolved review threads.

Review-driven test hardening was also verified:

- The mock credential server uses a context-aware listener and checks the gRPC `Serve` result during shutdown.
- Test failure paths use a bounded cancellation wait so failures cannot hang until the suite timeout.
- No-secret LLM tests reject any credential-manager mount named `ess-data`, regardless of mount path.
- Newly added image fixtures use neutral values without registry endpoints.

Accelerated end-to-end verification used a shortened assertion-acceptance window and an isolated test-only refresh cadence:

1. With the original credential manager, the assertion file remained unchanged past the acceptance window. Reconnecting ESS Agent reproduced the expired-assertion HTTP 401 retry loop.
2. With this fix, the manager immediately replaced the assertion and ESS access recovered with HTTP 200.
3. Seven subsequent rotations changed the assertion file hash and mtime while preserving mode `0644`.
4. After crossing a complete shortened assertion lifetime, another ESS Agent reconnect returned HTTP 200 with no expired-assertion errors.
5. The workload remained ready throughout the fixed-path soak.

The test-only timing overrides were removed after validation. The deployed workload was recreated using the production-only implementation and normal timing.

A standalone local Go lint run was not treated as authoritative because of local toolchain/bootstrap issues. The final-head root Bazel CI job, which uses the repository-pinned toolchain, passed.

## Issues

Fixes #1133

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for refreshing optional ESS assertion credentials alongside worker credentials.
  * Credential-managed workloads now receive the ESS configuration volume when ESS secrets are configured.
  * Credentials are fetched immediately and refreshed upon expiration, with atomic file replacement.

* **Documentation**
  * Updated configuration guidance for worker and ESS credential paths, volume usage, and file permissions.

* **Bug Fixes**
  * Improved credential rotation, cancellation handling, file permissions, and conditional refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
