### PR TITLE
fix(self-managed): order auth callout after OpenBao

### DIFF
--- a/ai-tooling/user/skills/nvcf-self-managed-installation/SKILL.md
+++ b/ai-tooling/user/skills/nvcf-self-managed-installation/SKILL.md
@@ -216,7 +216,7 @@ Helmfile deploys in order with dependencies:
 
 | Phase | Selector | Services | Wait time |
 |-------|----------|----------|-----------|
-| 1 | `release-group=dependencies` | NATS, OpenBao, Cassandra | 5-10 min |
+| 1 | `release-group=dependencies` | NATS, OpenBao, Cassandra, NATS auth-callout | 5-10 min |
 | 2 | `release-group=services` | API, SIS, ESS, invocation, grpc-proxy, notary, api-keys, optional LLM gateway/router, optional Vanity Gateway, NVCF UI when the stack package includes the addon | 5-10 min |
 | 3 | `release-group=ingress` | Gateway routes | 1-2 min |
 | 4 | `release-group=observability` | Observability stack (if enabled) | 1-2 min |

--- a/ai-tooling/user/skills/nvcf-self-managed-installation/examples.md
+++ b/ai-tooling/user/skills/nvcf-self-managed-installation/examples.md
@@ -274,7 +274,7 @@ kubectl --context <compute-plane-context> wait \
 Useful for testing or when iterating on service configuration.
 
 ```bash
-# Deploy just NATS, Cassandra, OpenBao
+# Deploy just NATS, Cassandra, OpenBao, and NATS auth-callout
 HELMFILE_ENV=<env> helmfile --selector release-group=dependencies sync
 
 # Check status
@@ -290,7 +290,7 @@ HELMFILE_ENV=<env> helmfile --selector name=cassandra sync
 
 | Selector | Releases |
 |----------|----------|
-| `release-group=dependencies` | nats, cassandra, openbao-server |
+| `release-group=dependencies` | nats, cassandra, openbao-server, nats-auth-callout-service |
 | `release-group=services` | api-keys, sis, api, invocation-service, grpc-proxy, ess-api, notary-service, reval, optional llm-request-router and llm-api-gateway when `llm.enabled=true`, optional vanity-gateway only in stack packages that include the addon and have `addons.vanityGateway.enabled=true`, optional nvcf-ui only in stack packages that include the addon and have `addons.nvcfUi.enabled=true` |
 | `name=llm-request-router` | Deploy just the LLM request router when `llm.enabled=true` |
 | `name=llm-api-gateway` | Deploy just the LLM API gateway when `llm.enabled=true` |

--- a/ai-tooling/user/skills/nvcf-self-managed-installation/references/helmfile-structure.md
+++ b/ai-tooling/user/skills/nvcf-self-managed-installation/references/helmfile-structure.md
@@ -5,7 +5,7 @@
 ```
 nvcf-self-managed-stack/
 |-- helmfile.d/
-|   |-- 01-dependencies.yaml.gotmpl  # NATS, Cassandra, OpenBao
+|   |-- 01-dependencies.yaml.gotmpl  # NATS, Cassandra, OpenBao, NATS auth-callout
 |   |-- 02-core.yaml.gotmpl          # NVCF services + ingress
 |   `-- 03-observability.yaml.gotmpl # Observability stack (optional)
 |-- environments/

--- a/deploy/stacks/self-managed/Makefile
+++ b/deploy/stacks/self-managed/Makefile
@@ -11,6 +11,7 @@ test:
 	@tests/llm-pki-openbao-migration.sh
 	@tests/api-keys-startup-probe.sh
 	@tests/llm-pki-release.sh
+	@tests/nats-auth-callout-openbao-order.sh
 	@tests/check-llm-pki-issuer.sh
 	@tests/pdb-value-wiring.sh
 	@tests/invocation-tracing-baggage.sh

--- a/deploy/stacks/self-managed/Makefile.dist
+++ b/deploy/stacks/self-managed/Makefile.dist
@@ -161,7 +161,7 @@ install: check-versions $(INSTALL_PRE_HOOKS)
 	$(if $(HELMFILE_SELECTOR),@echo "    Selector: $(HELMFILE_SELECTOR)")
 
 	HELMFILE_ENV="$(HELMFILE_ENV)" \
-	$(PATH_OVERRIDE) helmfile --environment default $(KUBECONFIG_FLAG) $(if $(HELMFILE_SELECTOR),--selector $(HELMFILE_SELECTOR)) sync
+	$(PATH_OVERRIDE) helmfile --environment default $(KUBECONFIG_FLAG) $(if $(HELMFILE_SELECTOR),--selector $(HELMFILE_SELECTOR) --include-transitive-needs) sync
 
 	@echo ">>> Helmfile sync complete."
 
@@ -175,7 +175,7 @@ apply: check-versions $(APPLY_PRE_HOOKS)
 	$(if $(HELMFILE_SELECTOR),@echo "    Selector: $(HELMFILE_SELECTOR)")
 
 	HELMFILE_ENV="$(HELMFILE_ENV)" \
-	$(PATH_OVERRIDE) helmfile --environment default $(KUBECONFIG_FLAG) $(if $(HELMFILE_SELECTOR),--selector $(HELMFILE_SELECTOR)) apply
+	$(PATH_OVERRIDE) helmfile --environment default $(KUBECONFIG_FLAG) $(if $(HELMFILE_SELECTOR),--selector $(HELMFILE_SELECTOR) --include-transitive-needs) apply
 
 	@echo ">>> Helmfile apply complete."
 

--- a/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
@@ -133,6 +133,24 @@ releases:
     needs:
       - nats-system/nats
 
+  # The chart uses the OpenBao injector to render its required
+  # /etc/secrets/secrets.json file.  It must be in this state file so Helmfile
+  # can honor the OpenBao dependency before creating the annotated pod.
+  - name: nats-auth-callout-service
+    chart: nvcf/helm-nvcf-nats-auth-callout-service
+    version: 1.1.3
+    namespace: nats-system
+    values:
+      - ../global.yaml.gotmpl
+      {{- if .Values.global.imagePullSecrets }}
+      - imagePullSecrets:
+          {{- toYaml .Values.global.imagePullSecrets | nindent 10 }}
+      {{- end }}
+    needs:
+      - vault-system/openbao-server
+    labels:
+      release-group: dependencies
+
 {{- if $managedIssuer }}
   - name: nvcf-pki
     chart: nvcf/helm-nvcf-pki

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -151,19 +151,6 @@ releases:
     labels:
       release-group: services
 
-  - name: nats-auth-callout-service
-    chart: nvcf/helm-nvcf-nats-auth-callout-service
-    version: 1.1.3
-    namespace: nats-system
-    values:
-      - ../global.yaml.gotmpl
-      {{- if .Values.global.imagePullSecrets }}
-      - imagePullSecrets:
-          {{- toYaml .Values.global.imagePullSecrets | nindent 10 }}
-      {{- end }}
-    labels:
-      release-group: services
-
   - name: llm-request-router
     {{- $llmRequestRouterChartPath := dig "addons" "llm" "requestRouter" "chartPath" "" .Values }}
     chart: {{ $llmRequestRouterChartPath | default "nvcf/helm-nvcf-llm-request-router" | quote }}

--- a/deploy/stacks/self-managed/tests/nats-auth-callout-openbao-order.sh
+++ b/deploy/stacks/self-managed/tests/nats-auth-callout-openbao-order.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+dependencies_state="$stack_dir/helmfile.d/01-dependencies.yaml.gotmpl"
+core_state="$stack_dir/helmfile.d/02-core.yaml.gotmpl"
+makefile_dist="$stack_dir/Makefile.dist"
+
+fail() {
+  echo "nats-auth-callout-openbao-order: $*" >&2
+  exit 1
+}
+
+release_block="$(awk '
+  /^  - name: nats-auth-callout-service$/ { capture = 1 }
+  capture { print }
+  capture && /^  - name: / && $0 != "  - name: nats-auth-callout-service" { exit }
+' "$dependencies_state")"
+
+test -n "$release_block" ||
+  fail "nats-auth-callout-service must be declared in the dependencies state with OpenBao"
+
+printf '%s\n' "$release_block" |
+  grep -Eq '^    needs:$' ||
+  fail "nats-auth-callout-service must wait for OpenBao before its Vault-agent pod is created"
+
+printf '%s\n' "$release_block" |
+  grep -Eq '^      - vault-system/openbao-server$' ||
+  fail "nats-auth-callout-service must depend on vault-system/openbao-server"
+
+printf '%s\n' "$release_block" |
+  grep -Eq '^      release-group: dependencies$' ||
+  fail "nats-auth-callout-service must remain in the dependencies release group"
+
+if grep -Fqx '  - name: nats-auth-callout-service' "$core_state"; then
+  fail "nats-auth-callout-service must not also be declared in the core state"
+fi
+
+# A name selector otherwise skips dependencies by default. Include the full
+# OpenBao -> NATS chain for supported selected install/apply operations.
+for target in install apply; do
+  target_block="$(awk -v target="$target" '
+    $0 ~ "^" target ":" { capture = 1 }
+    capture { print }
+    capture && /^[-[:alnum:]_]+:/ && $0 !~ "^" target ":" { exit }
+  ' "$makefile_dist")"
+  printf '%s\n' "$target_block" |
+    grep -Fq -- '--include-transitive-needs' ||
+    fail "$target must include transitive Helmfile dependencies when HELMFILE_SELECTOR is set"
+done
+
+echo "nats-auth-callout-openbao-order: PASS"

--- a/docs/v0.6.1/helmfile-installation.md
+++ b/docs/v0.6.1/helmfile-installation.md
@@ -821,6 +821,7 @@ Phase 1: dependency layer (5-10 minutes)
 - NATS messaging service
 - OpenBao (secrets management)
 - Cassandra (database)
+- NATS auth-callout service
 - Helmfile selector: `release-group=dependencies`
 
 Phase 2: control-plane services (5-10 minutes)
@@ -918,7 +919,7 @@ safely redeploy it individually:
 # Redeploy only Cassandra
 HELMFILE_ENV=<environment-name> helmfile --selector name=cassandra apply
 
-# Redeploy all dependencies (NATS, Cassandra, OpenBao)
+# Redeploy all dependencies (NATS, Cassandra, OpenBao, NATS auth-callout)
 HELMFILE_ENV=<environment-name> helmfile --selector release-group=dependencies apply
 ```
 


### PR DESCRIPTION
Fixes #1138.

On a fresh self-managed install, nats-auth-callout-service was applied from a separate Helmfile state concurrently with OpenBao. The injector webhook was not ready, and its Ignore failure policy allowed the annotated pod to start without vault-agent-init or /etc/secrets/secrets.json.

Move the unchanged auth-callout release into the dependencies state, where it has a same-state OpenBao dependency. The supported Makefile selected install/apply paths now include transitive dependencies so name selection also includes OpenBao and NATS. Add a focused regression test and align selector documentation.

Validation: make -C deploy/stacks/self-managed test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NATS auth-callout service deployment to the self-managed stack’s dependency phase.
  * Selector-based installations now include required transitive dependencies automatically.

* **Bug Fixes**
  * Corrected deployment ordering so NATS auth-callout waits for OpenBao.

* **Documentation**
  * Updated installation guides, examples, and dependency references to reflect the new service and recovery steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->