### PR TITLE
fix(self-managed): gate LLM ServiceMonitors by observability

### DIFF
--- a/deploy/stacks/self-managed/Makefile
+++ b/deploy/stacks/self-managed/Makefile
@@ -6,6 +6,7 @@ test:
 	@tests/llm-router-worker-address.sh
 	@tests/llm-router-split-cluster.sh
 	@tests/llm-router-local-chart.sh
+	@tests/llm-servicemonitor-defaults.sh
 	@tests/gateway-routes-local-chart.sh
 	@tests/grpc-proxy-nats-endpoint.sh
 	@tests/llm-pki-openbao-migration.sh

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -848,7 +848,7 @@ llmApiGateway:
   metrics:
     enabled: {{ dig "addons" "llm" "gateway" "metrics" "enabled" true .Values }}
     serviceMonitor:
-      enabled: {{ dig "addons" "llm" "gateway" "metrics" "serviceMonitor" "enabled" .Values.global.observability.metrics.enabled .Values }}
+      enabled: {{ dig "addons" "llm" "gateway" "metrics" "serviceMonitor" "enabled" (and .Values.global.observability.metrics.enabled (dig "addons" "llm" "gateway" "metrics" "enabled" true .Values)) .Values }}
   observability:
     tracing:
       enabled: {{ .Values.global.observability.tracing.enabled }}
@@ -911,7 +911,7 @@ llmRequestRouter:
   metrics:
     enabled: {{ dig "addons" "llm" "requestRouter" "metrics" "enabled" true .Values }}
     serviceMonitor:
-      enabled: {{ dig "addons" "llm" "requestRouter" "metrics" "serviceMonitor" "enabled" .Values.global.observability.metrics.enabled .Values }}
+      enabled: {{ dig "addons" "llm" "requestRouter" "metrics" "serviceMonitor" "enabled" (and .Values.global.observability.metrics.enabled (dig "addons" "llm" "requestRouter" "metrics" "enabled" true .Values)) .Values }}
   observability:
     tracing:
       enabled: {{ .Values.global.observability.tracing.enabled }}

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -848,7 +848,7 @@ llmApiGateway:
   metrics:
     enabled: {{ dig "addons" "llm" "gateway" "metrics" "enabled" true .Values }}
     serviceMonitor:
-      enabled: {{ dig "addons" "llm" "gateway" "metrics" "serviceMonitor" "enabled" (and .Values.global.observability.metrics.enabled (dig "addons" "llm" "gateway" "metrics" "enabled" true .Values)) .Values }}
+      enabled: {{ dig "addons" "llm" "gateway" "metrics" "serviceMonitor" "enabled" (and (ne $observabilityProfile "disabled") .Values.global.observability.metrics.enabled (dig "addons" "llm" "gateway" "metrics" "enabled" true .Values)) .Values }}
   observability:
     tracing:
       enabled: {{ .Values.global.observability.tracing.enabled }}
@@ -911,7 +911,7 @@ llmRequestRouter:
   metrics:
     enabled: {{ dig "addons" "llm" "requestRouter" "metrics" "enabled" true .Values }}
     serviceMonitor:
-      enabled: {{ dig "addons" "llm" "requestRouter" "metrics" "serviceMonitor" "enabled" (and .Values.global.observability.metrics.enabled (dig "addons" "llm" "requestRouter" "metrics" "enabled" true .Values)) .Values }}
+      enabled: {{ dig "addons" "llm" "requestRouter" "metrics" "serviceMonitor" "enabled" (and (ne $observabilityProfile "disabled") .Values.global.observability.metrics.enabled (dig "addons" "llm" "requestRouter" "metrics" "enabled" true .Values)) .Values }}
   observability:
     tracing:
       enabled: {{ .Values.global.observability.tracing.enabled }}

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -848,7 +848,7 @@ llmApiGateway:
   metrics:
     enabled: {{ dig "addons" "llm" "gateway" "metrics" "enabled" true .Values }}
     serviceMonitor:
-      enabled: {{ dig "addons" "llm" "gateway" "metrics" "serviceMonitor" "enabled" (dig "addons" "llm" "gateway" "metrics" "enabled" true .Values) .Values }}
+      enabled: {{ dig "addons" "llm" "gateway" "metrics" "serviceMonitor" "enabled" .Values.global.observability.metrics.enabled .Values }}
   observability:
     tracing:
       enabled: {{ .Values.global.observability.tracing.enabled }}
@@ -911,7 +911,7 @@ llmRequestRouter:
   metrics:
     enabled: {{ dig "addons" "llm" "requestRouter" "metrics" "enabled" true .Values }}
     serviceMonitor:
-      enabled: {{ dig "addons" "llm" "requestRouter" "metrics" "serviceMonitor" "enabled" (dig "addons" "llm" "requestRouter" "metrics" "enabled" true .Values) .Values }}
+      enabled: {{ dig "addons" "llm" "requestRouter" "metrics" "serviceMonitor" "enabled" .Values.global.observability.metrics.enabled .Values }}
   observability:
     tracing:
       enabled: {{ .Values.global.observability.tracing.enabled }}

--- a/deploy/stacks/self-managed/tests/llm-servicemonitor-defaults.sh
+++ b/deploy/stacks/self-managed/tests/llm-servicemonitor-defaults.sh
@@ -78,6 +78,10 @@ assert_service_monitor gateway-observability-disabled false llm-api-gateway fals
 assert_service_monitor router-observability-disabled false llm-request-router false
 assert_service_monitor gateway-observability-enabled true llm-api-gateway true
 assert_service_monitor router-observability-enabled true llm-request-router true
+assert_service_monitor gateway-local-metrics-disabled true llm-api-gateway false \
+  --state-values-set addons.llm.gateway.metrics.enabled=false
+assert_service_monitor router-local-metrics-disabled true llm-request-router false \
+  --state-values-set addons.llm.requestRouter.metrics.enabled=false
 assert_service_monitor gateway-explicit-opt-out true llm-api-gateway false \
   --state-values-set addons.llm.gateway.metrics.serviceMonitor.enabled=false
 assert_service_monitor router-explicit-opt-out true llm-request-router false \

--- a/deploy/stacks/self-managed/tests/llm-servicemonitor-defaults.sh
+++ b/deploy/stacks/self-managed/tests/llm-servicemonitor-defaults.sh
@@ -78,6 +78,10 @@ assert_service_monitor gateway-observability-disabled false llm-api-gateway fals
 assert_service_monitor router-observability-disabled false llm-request-router false
 assert_service_monitor gateway-observability-enabled true llm-api-gateway true
 assert_service_monitor router-observability-enabled true llm-request-router true
+assert_service_monitor gateway-profile-disabled true llm-api-gateway false \
+  --state-values-set observability.profile=disabled
+assert_service_monitor router-profile-disabled true llm-request-router false \
+  --state-values-set observability.profile=disabled
 assert_service_monitor gateway-local-metrics-disabled true llm-api-gateway false \
   --state-values-set addons.llm.gateway.metrics.enabled=false
 assert_service_monitor router-local-metrics-disabled true llm-request-router false \
@@ -86,5 +90,9 @@ assert_service_monitor gateway-explicit-opt-out true llm-api-gateway false \
   --state-values-set addons.llm.gateway.metrics.serviceMonitor.enabled=false
 assert_service_monitor router-explicit-opt-out true llm-request-router false \
   --state-values-set addons.llm.requestRouter.metrics.serviceMonitor.enabled=false
+assert_service_monitor gateway-explicit-opt-in false llm-api-gateway true \
+  --state-values-set addons.llm.gateway.metrics.serviceMonitor.enabled=true
+assert_service_monitor router-explicit-opt-in false llm-request-router true \
+  --state-values-set addons.llm.requestRouter.metrics.serviceMonitor.enabled=true
 
 echo "llm-servicemonitor-defaults: all checks passed"

--- a/deploy/stacks/self-managed/tests/llm-servicemonitor-defaults.sh
+++ b/deploy/stacks/self-managed/tests/llm-servicemonitor-defaults.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_dir="$(cd "$stack_dir/../../.." && pwd)"
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+
+fail() {
+  echo "llm-servicemonitor-defaults: $*" >&2
+  exit 1
+}
+
+write_values() {
+  local global_metrics_enabled="$1"
+  local release="$2"
+  local values_file="$3"
+  shift 3
+
+  (
+    cd "$stack_dir"
+    HELMFILE_ENV=base HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" helmfile \
+      --file helmfile.d/02-core.yaml.gotmpl \
+      --environment default \
+      --state-values-set addons.llm.enabled=true \
+      --state-values-set "global.observability.metrics.enabled=$global_metrics_enabled" \
+      --state-values-set ingress.gatewayApi.gateways.shared.name=shared-gw \
+      --state-values-set ingress.gatewayApi.gateways.shared.namespace=envoy-gateway-system \
+      --state-values-set ingress.gatewayApi.gateways.grpc.name=grpc-gw \
+      --state-values-set ingress.gatewayApi.gateways.grpc.namespace=envoy-gateway-system \
+      "$@" \
+      --selector "name=$release" \
+      write-values --output-file-template "$values_file" >/dev/null
+  )
+}
+
+render_release() {
+  local release="$1"
+  local values_file="$2"
+  local manifests_file="$3"
+  local chart_dir
+
+  case "$release" in
+    llm-api-gateway) chart_dir="$repo_dir/deploy/helm/llm-api-gateway/llm-api-gateway" ;;
+    llm-request-router) chart_dir="$repo_dir/deploy/helm/llm-request-router/llm-request-router" ;;
+    *) fail "unknown LLM release: $release" ;;
+  esac
+
+  helm template "$release" "$chart_dir" \
+    --namespace nvcf \
+    --values "$values_file" >"$manifests_file"
+}
+
+assert_service_monitor() {
+  local name="$1"
+  local global_metrics_enabled="$2"
+  local release="$3"
+  local expected="$4"
+  shift 4
+  local values_file="$work_dir/$name-values.yaml"
+  local manifests_file="$work_dir/$name-manifests.yaml"
+  local actual
+
+  write_values "$global_metrics_enabled" "$release" "$values_file" "$@"
+  render_release "$release" "$values_file" "$manifests_file"
+
+  if grep -q '^kind: ServiceMonitor$' "$manifests_file"; then
+    actual=true
+  else
+    actual=false
+  fi
+
+  test "$actual" = "$expected" ||
+    fail "$release ServiceMonitor expected $expected with global metrics $global_metrics_enabled, got $actual"
+}
+
+assert_service_monitor gateway-observability-disabled false llm-api-gateway false
+assert_service_monitor router-observability-disabled false llm-request-router false
+assert_service_monitor gateway-observability-enabled true llm-api-gateway true
+assert_service_monitor router-observability-enabled true llm-request-router true
+assert_service_monitor gateway-explicit-opt-out true llm-api-gateway false \
+  --state-values-set addons.llm.gateway.metrics.serviceMonitor.enabled=false
+assert_service_monitor router-explicit-opt-out true llm-request-router false \
+  --state-values-set addons.llm.requestRouter.metrics.serviceMonitor.enabled=false
+
+echo "llm-servicemonitor-defaults: all checks passed"


### PR DESCRIPTION
## Summary
- default LLM gateway and request-router ServiceMonitors from global observability metrics
- retain explicit per-service ServiceMonitor overrides
- add render coverage for both LLM charts

## Testing
- make test (deploy/stacks/self-managed)

Fixes #1146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * LLM API gateway and request router monitoring now consistently follows global and component-level metrics settings.
  * Monitoring is disabled when required observability or metrics settings are off.
  * Explicit ServiceMonitor configuration remains supported.

* **Tests**
  * Added integration coverage for ServiceMonitor generation across enabled and disabled metrics configurations.
  * Included the new validation in the self-managed stack test target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->