### PR TITLE
feat(vanity-gateway): configure mapping load timeout

### DIFF
--- a/src/invocation-plane-services/vanity-gateway/BUILD.bazel
+++ b/src/invocation-plane-services/vanity-gateway/BUILD.bazel
@@ -109,6 +109,7 @@ go_test(
         "@com_github_goccy_go_json//:go-json",
         "@com_github_magiconair_properties//assert",
         "@com_github_nvidia_nvcf_go//pkg/nvkit/logs",
+        "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v3//:yaml_v3",
         "@io_k8s_sigs_controller_runtime//:controller-runtime",
         "@org_golang_x_net//http2",

--- a/src/invocation-plane-services/vanity-gateway/README.md
+++ b/src/invocation-plane-services/vanity-gateway/README.md
@@ -43,7 +43,7 @@ Configuration is passed through environment variables.
 | Variable | Required | Default | Description |
 | --- | --- | --- | --- |
 | `MAPPING_PATH` | Yes | None | Path to the rendered mapping config file. |
-| `MAPPING_LOAD_TIMEOUT` | No | `15s` | Maximum time to wait at startup for `MAPPING_PATH` to appear. Increase this when a ConfigMap projection or remote-config sidecar materializes the file after the main container starts. Duration strings require a unit and must be greater than zero, such as `2m` or `90s`. Zero and negative values are rejected at startup. |
+| `MAPPING_LOAD_TIMEOUT` | No | `15s` | Maximum time to wait at startup for `MAPPING_PATH` to appear. Increase this when a ConfigMap projection or remote-config sidecar materializes the file after the main container starts. Duration strings require a unit, such as `2m` or `90s`. A value without a unit is rejected when configuration is loaded, and a negative value is rejected at startup. |
 | `NVCF_API_ENDPOINT` | No | Service default | Upstream invocation service endpoint. In cluster deployments, this usually points to the in-cluster invocation service. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | No | Empty | OTLP endpoint for tracing. Empty disables OTLP export. |
 | `TRACING_ACCESS_TOKEN` | No | Empty | Access token for OTLP tracing. Also configurable in the secrets file under `$.tracingAccessToken`. |

--- a/src/invocation-plane-services/vanity-gateway/README.md
+++ b/src/invocation-plane-services/vanity-gateway/README.md
@@ -43,7 +43,7 @@ Configuration is passed through environment variables.
 | Variable | Required | Default | Description |
 | --- | --- | --- | --- |
 | `MAPPING_PATH` | Yes | None | Path to the rendered mapping config file. |
-| `MAPPING_LOAD_TIMEOUT` | No | `15s` | Maximum time to wait at startup for `MAPPING_PATH` to appear. Increase this when a ConfigMap projection or remote-config sidecar materializes the file after the main container starts. Duration strings require a unit, such as `2m` or `90s`. |
+| `MAPPING_LOAD_TIMEOUT` | No | `15s` | Maximum time to wait at startup for `MAPPING_PATH` to appear. Increase this when a ConfigMap projection or remote-config sidecar materializes the file after the main container starts. Duration strings require a unit and must be greater than zero, such as `2m` or `90s`. Zero and negative values are rejected at startup. |
 | `NVCF_API_ENDPOINT` | No | Service default | Upstream invocation service endpoint. In cluster deployments, this usually points to the in-cluster invocation service. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | No | Empty | OTLP endpoint for tracing. Empty disables OTLP export. |
 | `TRACING_ACCESS_TOKEN` | No | Empty | Access token for OTLP tracing. Also configurable in the secrets file under `$.tracingAccessToken`. |

--- a/src/invocation-plane-services/vanity-gateway/README.md
+++ b/src/invocation-plane-services/vanity-gateway/README.md
@@ -43,6 +43,7 @@ Configuration is passed through environment variables.
 | Variable | Required | Default | Description |
 | --- | --- | --- | --- |
 | `MAPPING_PATH` | Yes | None | Path to the rendered mapping config file. |
+| `MAPPING_LOAD_TIMEOUT` | No | `15s` | Maximum time to wait at startup for `MAPPING_PATH` to appear. Increase this when a ConfigMap projection or remote-config sidecar materializes the file after the main container starts. Duration strings require a unit, such as `2m` or `90s`. |
 | `NVCF_API_ENDPOINT` | No | Service default | Upstream invocation service endpoint. In cluster deployments, this usually points to the in-cluster invocation service. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | No | Empty | OTLP endpoint for tracing. Empty disables OTLP export. |
 | `TRACING_ACCESS_TOKEN` | No | Empty | Access token for OTLP tracing. Also configurable in the secrets file under `$.tracingAccessToken`. |
@@ -63,8 +64,14 @@ the `v2config` mapping for both OpenAI compatible routes and vanity routes.
 Valid file updates are reloaded and the router is swapped without restarting the
 process. Invalid updates are logged and skipped.
 
-The gateway does not depend on how this file is produced. Self-managed
-deployments can provide it directly with a Kubernetes ConfigMap:
+The gateway does not depend on how this file is produced. Self-managed and
+managed deployments can provide it directly with a Kubernetes ConfigMap, or use
+a sidecar that writes remote configuration to a shared volume. Set
+`MAPPING_LOAD_TIMEOUT` when that file may not exist immediately at process
+startup.
+
+Self-managed deployments can provide the mapping directly with a Kubernetes
+ConfigMap:
 
 ```yaml
 apiVersion: v1

--- a/src/invocation-plane-services/vanity-gateway/gateway/gateway.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway/gateway.go
@@ -116,7 +116,7 @@ func NewNVCFGateway(logger *logs.ZapLogger, config Config) (*NVCFGateway, error)
 
 	mappings, err := gatewayConfig.SetupConfigWithConfigPathAndTimeout(config.MappingPath, mappingLoadTimeout)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to load mapping configuration: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/src/invocation-plane-services/vanity-gateway/gateway/gateway.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway/gateway.go
@@ -39,16 +39,16 @@ import (
 )
 
 type Config struct {
-	OTELExporterOTLPEndpoint     string `mapstructure:"OTEL_EXPORTER_OTLP_ENDPOINT"`
-	TracingAccessToken           string `mapstructure:"TRACING_ACCESS_TOKEN"`
-	SecretsPath                  string `mapstructure:"SECRETS_PATH"`
-	MappingPath                  string `mapstructure:"MAPPING_PATH"`
-	MappingLoadTimeout           string `mapstructure:"MAPPING_LOAD_TIMEOUT"`
-	NvcfApiEndpoint              string `mapstructure:"NVCF_API_ENDPOINT"`
-	PrivateModelNameRegexPattern string `mapstructure:"PRIVATE_MODEL_NAME_REGEX_PATTERN"`
-	PodIP                        string `mapstructure:"POD_IP"`
-	AWSRegion                    string `mapstructure:"AWS_REGION"`
-	ShadowMaxConcurrent          int    `mapstructure:"SHADOW_MAX_CONCURRENT"`
+	OTELExporterOTLPEndpoint     string        `mapstructure:"OTEL_EXPORTER_OTLP_ENDPOINT"`
+	TracingAccessToken           string        `mapstructure:"TRACING_ACCESS_TOKEN"`
+	SecretsPath                  string        `mapstructure:"SECRETS_PATH"`
+	MappingPath                  string        `mapstructure:"MAPPING_PATH"`
+	MappingLoadTimeout           time.Duration `mapstructure:"MAPPING_LOAD_TIMEOUT"`
+	NvcfApiEndpoint              string        `mapstructure:"NVCF_API_ENDPOINT"`
+	PrivateModelNameRegexPattern string        `mapstructure:"PRIVATE_MODEL_NAME_REGEX_PATTERN"`
+	PodIP                        string        `mapstructure:"POD_IP"`
+	AWSRegion                    string        `mapstructure:"AWS_REGION"`
+	ShadowMaxConcurrent          int           `mapstructure:"SHADOW_MAX_CONCURRENT"`
 }
 
 type NVCFGateway struct {
@@ -88,9 +88,8 @@ func NewNVCFGateway(logger *logs.ZapLogger, config Config) (*NVCFGateway, error)
 	if config.MappingPath == "" {
 		return nil, fmt.Errorf("MAPPING_PATH is required")
 	}
-	mappingLoadTimeout, err := parseMappingLoadTimeout(config.MappingLoadTimeout)
-	if err != nil {
-		return nil, err
+	if config.MappingLoadTimeout < 0 {
+		return nil, fmt.Errorf("MAPPING_LOAD_TIMEOUT must not be negative")
 	}
 
 	if config.TracingAccessToken == "" {
@@ -114,7 +113,7 @@ func NewNVCFGateway(logger *logs.ZapLogger, config Config) (*NVCFGateway, error)
 		return nil, fmt.Errorf("failed to setup shadow metrics: %w", err)
 	}
 
-	mappings, err := gatewayConfig.SetupConfigWithConfigPathAndTimeout(config.MappingPath, mappingLoadTimeout)
+	mappings, err := gatewayConfig.SetupConfigWithConfigPathAndTimeout(config.MappingPath, config.MappingLoadTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load mapping configuration: %w", err)
 	}
@@ -170,18 +169,4 @@ func NewNVCFGateway(logger *logs.ZapLogger, config Config) (*NVCFGateway, error)
 			servers.WithAdditionalServers(http2ServerPair),
 		),
 	}, nil
-}
-
-func parseMappingLoadTimeout(raw string) (time.Duration, error) {
-	if raw == "" {
-		return 0, nil
-	}
-	timeout, err := time.ParseDuration(raw)
-	if err != nil {
-		return 0, fmt.Errorf("MAPPING_LOAD_TIMEOUT must be a valid duration: %w", err)
-	}
-	if timeout <= 0 {
-		return 0, fmt.Errorf("MAPPING_LOAD_TIMEOUT must be greater than 0")
-	}
-	return timeout, nil
 }

--- a/src/invocation-plane-services/vanity-gateway/gateway/gateway.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway/gateway.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"time"
 
 	gatewayConfig "ai-api-gateway-service/gateway_config"
 	"ai-api-gateway-service/internal/reloadableconfig"
@@ -42,6 +43,7 @@ type Config struct {
 	TracingAccessToken           string `mapstructure:"TRACING_ACCESS_TOKEN"`
 	SecretsPath                  string `mapstructure:"SECRETS_PATH"`
 	MappingPath                  string `mapstructure:"MAPPING_PATH"`
+	MappingLoadTimeout           string `mapstructure:"MAPPING_LOAD_TIMEOUT"`
 	NvcfApiEndpoint              string `mapstructure:"NVCF_API_ENDPOINT"`
 	PrivateModelNameRegexPattern string `mapstructure:"PRIVATE_MODEL_NAME_REGEX_PATTERN"`
 	PodIP                        string `mapstructure:"POD_IP"`
@@ -86,6 +88,10 @@ func NewNVCFGateway(logger *logs.ZapLogger, config Config) (*NVCFGateway, error)
 	if config.MappingPath == "" {
 		return nil, fmt.Errorf("MAPPING_PATH is required")
 	}
+	mappingLoadTimeout, err := parseMappingLoadTimeout(config.MappingLoadTimeout)
+	if err != nil {
+		return nil, err
+	}
 
 	if config.TracingAccessToken == "" {
 		secrets, _ := os.ReadFile(config.SecretsPath)
@@ -108,7 +114,7 @@ func NewNVCFGateway(logger *logs.ZapLogger, config Config) (*NVCFGateway, error)
 		return nil, fmt.Errorf("failed to setup shadow metrics: %w", err)
 	}
 
-	mappings, err := gatewayConfig.SetupConfigWithConfigPath(config.MappingPath)
+	mappings, err := gatewayConfig.SetupConfigWithConfigPathAndTimeout(config.MappingPath, mappingLoadTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -164,4 +170,18 @@ func NewNVCFGateway(logger *logs.ZapLogger, config Config) (*NVCFGateway, error)
 			servers.WithAdditionalServers(http2ServerPair),
 		),
 	}, nil
+}
+
+func parseMappingLoadTimeout(raw string) (time.Duration, error) {
+	if raw == "" {
+		return 0, nil
+	}
+	timeout, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("MAPPING_LOAD_TIMEOUT must be a valid duration: %w", err)
+	}
+	if timeout <= 0 {
+		return 0, fmt.Errorf("MAPPING_LOAD_TIMEOUT must be greater than 0")
+	}
+	return timeout, nil
 }

--- a/src/invocation-plane-services/vanity-gateway/gateway/gateway_test.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway/gateway_test.go
@@ -32,44 +32,13 @@ func TestNewNVCFGatewayRequiresAPIEndpoint(t *testing.T) {
 	require.Contains(t, err.Error(), "NVCF_API_ENDPOINT is required")
 }
 
-func TestParseMappingLoadTimeout(t *testing.T) {
-	tests := []struct {
-		name        string
-		raw         string
-		wantTimeout time.Duration
-		wantErr     string
-	}{
-		{
-			name:        "empty uses default",
-			raw:         "",
-			wantTimeout: 0,
-		},
-		{
-			name:        "duration",
-			raw:         "2m",
-			wantTimeout: 2 * time.Minute,
-		},
-		{
-			name:    "invalid",
-			raw:     "120",
-			wantErr: "MAPPING_LOAD_TIMEOUT must be a valid duration",
-		},
-		{
-			name:    "zero",
-			raw:     "0s",
-			wantErr: "MAPPING_LOAD_TIMEOUT must be greater than 0",
-		},
-	}
+func TestNewNVCFGatewayRejectsNegativeMappingLoadTimeout(t *testing.T) {
+	gateway, err := NewNVCFGateway(nil, Config{
+		NvcfApiEndpoint:    "https://api.example.com",
+		MappingPath:        "config.yaml",
+		MappingLoadTimeout: -5 * time.Second,
+	})
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got, err := parseMappingLoadTimeout(tc.raw)
-			if tc.wantErr != "" {
-				require.ErrorContains(t, err, tc.wantErr)
-				return
-			}
-			require.NoError(t, err)
-			require.Equal(t, tc.wantTimeout, got)
-		})
-	}
+	require.Nil(t, gateway)
+	require.ErrorContains(t, err, "MAPPING_LOAD_TIMEOUT must not be negative")
 }

--- a/src/invocation-plane-services/vanity-gateway/gateway/gateway_test.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway/gateway_test.go
@@ -19,6 +19,7 @@ package gateway
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -29,4 +30,46 @@ func TestNewNVCFGatewayRequiresAPIEndpoint(t *testing.T) {
 	require.Nil(t, gateway)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "NVCF_API_ENDPOINT is required")
+}
+
+func TestParseMappingLoadTimeout(t *testing.T) {
+	tests := []struct {
+		name        string
+		raw         string
+		wantTimeout time.Duration
+		wantErr     string
+	}{
+		{
+			name:        "empty uses default",
+			raw:         "",
+			wantTimeout: 0,
+		},
+		{
+			name:        "duration",
+			raw:         "2m",
+			wantTimeout: 2 * time.Minute,
+		},
+		{
+			name:    "invalid",
+			raw:     "120",
+			wantErr: "MAPPING_LOAD_TIMEOUT must be a valid duration",
+		},
+		{
+			name:    "zero",
+			raw:     "0s",
+			wantErr: "MAPPING_LOAD_TIMEOUT must be greater than 0",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseMappingLoadTimeout(tc.raw)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantTimeout, got)
+		})
+	}
 }

--- a/src/invocation-plane-services/vanity-gateway/gateway_config/gateway_config.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway_config/gateway_config.go
@@ -426,14 +426,25 @@ func (c *GatewayConfig) validateVanityConfig() error {
 }
 
 func SetupConfigWithConfigPath(path string) (rc.ReloadableConfig[GatewayConfig], error) {
-	config, err := rc.SetupConfig[GatewayConfig](path,
+	return SetupConfigWithConfigPathAndTimeout(path, 0)
+}
+
+func SetupConfigWithConfigPathAndTimeout(path string, loadTimeout time.Duration) (rc.ReloadableConfig[GatewayConfig], error) {
+	opts := []rc.ConfigOption[GatewayConfig]{
 		rc.WithValidateFunc(func(c *GatewayConfig) error {
 			return c.Validate()
 		}),
 		rc.WithPostLoadFunc(func(c *GatewayConfig) error {
 			notifySharedReload()
 			return nil
-		}))
+		}),
+	}
+	if loadTimeout > 0 {
+		opts = append(opts, rc.WithInitialLoadTimeout[GatewayConfig](loadTimeout))
+	}
+
+	config, err := rc.SetupConfig[GatewayConfig](path,
+		opts...)
 	return config, err
 }
 

--- a/src/invocation-plane-services/vanity-gateway/internal/reloadableconfig/config.go
+++ b/src/invocation-plane-services/vanity-gateway/internal/reloadableconfig/config.go
@@ -55,6 +55,7 @@ type configData[T any] struct {
 	data    atomic.Pointer[T]
 
 	mu            sync.Mutex
+	loadTimeout   time.Duration
 	initializer   func(*T) error
 	validators    []func(*T) error
 	postLoadHooks []func(*T) error
@@ -63,6 +64,12 @@ type configData[T any] struct {
 func WithPreLoadInitializer[T any](initialize func(*T) error) ConfigOption[T] {
 	return func(cd *configData[T]) {
 		cd.initializer = initialize
+	}
+}
+
+func WithInitialLoadTimeout[T any](timeout time.Duration) ConfigOption[T] {
+	return func(cd *configData[T]) {
+		cd.loadTimeout = timeout
 	}
 }
 
@@ -86,7 +93,11 @@ func SetupConfig[T any](configFilename string, opts ...ConfigOption[T]) (Reloada
 		opt(c)
 	}
 
-	if err := waitForFile(configFilename, defaultConfigLoadTimeout); err != nil {
+	loadTimeout := defaultConfigLoadTimeout
+	if c.loadTimeout > 0 {
+		loadTimeout = c.loadTimeout
+	}
+	if err := waitForFile(configFilename, loadTimeout); err != nil {
 		return nil, err
 	}
 	if err := c.reloadConfig(); err != nil {

--- a/src/invocation-plane-services/vanity-gateway/internal/reloadableconfig/config_test.go
+++ b/src/invocation-plane-services/vanity-gateway/internal/reloadableconfig/config_test.go
@@ -70,6 +70,18 @@ func TestSetupConfigReloadsValidFileUpdates(t *testing.T) {
 	requireConfigValue(t, cfg, "two")
 }
 
+func TestSetupConfigUsesInitialLoadTimeout(t *testing.T) {
+	useFastReloadTiming(t)
+	path := filepath.Join(t.TempDir(), "config.yaml")
+
+	start := time.Now()
+	cfg, err := SetupConfig[testConfig](path, WithInitialLoadTimeout[testConfig](20*time.Millisecond))
+
+	require.Nil(t, cfg)
+	require.ErrorContains(t, err, "timed out waiting for config to become available")
+	require.Less(t, time.Since(start), time.Second)
+}
+
 func TestSetupConfigKeepsLastGoodConfigWhenReloadIsInvalid(t *testing.T) {
 	useFastReloadTiming(t)
 	path := filepath.Join(t.TempDir(), "config.yaml")

--- a/src/invocation-plane-services/vanity-gateway/main.go
+++ b/src/invocation-plane-services/vanity-gateway/main.go
@@ -84,13 +84,19 @@ func NewRootCommand(zapLogger *logs.ZapLogger) *cobra.Command {
 	}
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/"+config.DefaultConfigPath+"/config.yaml)")
 
-	configType := reflect.TypeOf(gateway.Config{})
-	for i := 0; i < configType.NumField(); i++ {
-		field := configType.Field(i)
-		envName := field.Tag.Get("mapstructure")
-		rootCmd.Flags().String(envName, "", "")
-	}
+	registerConfigFlags(rootCmd)
 
 	return rootCmd
 }
 
+// registerConfigFlags declares one flag per gateway.Config field so that
+// PersistentPreRunE can bind each to its environment variable. Values are
+// registered as strings and converted by the viper decode hooks.
+func registerConfigFlags(cmd *cobra.Command) {
+	configType := reflect.TypeOf(gateway.Config{})
+	for i := 0; i < configType.NumField(); i++ {
+		field := configType.Field(i)
+		envName := field.Tag.Get("mapstructure")
+		cmd.Flags().String(envName, "", "")
+	}
+}

--- a/src/invocation-plane-services/vanity-gateway/main_test.go
+++ b/src/invocation-plane-services/vanity-gateway/main_test.go
@@ -38,9 +38,13 @@ import (
 	"ai-api-gateway-service/gateway"
 	gatewayConfig "ai-api-gateway-service/gateway_config"
 
+	"github.com/NVIDIA/nvcf-go/pkg/nvkit/config"
 	"github.com/go-logr/zapr"
 	"github.com/goccy/go-json"
 	"github.com/magiconair/properties/assert"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/net/http2"
@@ -2286,5 +2290,39 @@ func testShadowCancelledOnClientDisconnect(t *testing.T, _ http.Client) {
 
 		// Shadow should be cancelled because the client disconnected
 		waitForSlowShadowSignal(t, &slowShadowCanceledSignal, "shadow was not cancelled after client disconnect")
+	})
+}
+
+func TestConfigDecodesMappingLoadTimeout(t *testing.T) {
+	decode := func(t *testing.T) (gateway.Config, error) {
+		cmd := &cobra.Command{Use: "gateway"}
+		registerConfigFlags(cmd)
+		v, err := config.InitConfig(cmd, "", "", "")
+		if err != nil {
+			return gateway.Config{}, err
+		}
+		cmd.Flags().VisitAll(func(f *pflag.Flag) { v.MustBindEnv(f.Name) })
+		c := gateway.Config{}
+		return c, v.Unmarshal(&c)
+	}
+
+	t.Run("unset falls through to the service default", func(t *testing.T) {
+		c, err := decode(t)
+		require.NoError(t, err)
+		require.Equal(t, time.Duration(0), c.MappingLoadTimeout)
+	})
+
+	t.Run("duration string is converted", func(t *testing.T) {
+		t.Setenv("MAPPING_LOAD_TIMEOUT", "2m")
+		c, err := decode(t)
+		require.NoError(t, err)
+		require.Equal(t, 2*time.Minute, c.MappingLoadTimeout)
+	})
+
+	t.Run("value without a unit is rejected", func(t *testing.T) {
+		t.Setenv("MAPPING_LOAD_TIMEOUT", "120")
+		_, err := decode(t)
+		require.ErrorContains(t, err, "MAPPING_LOAD_TIMEOUT")
+		require.ErrorContains(t, err, "missing unit in duration")
 	})
 }


### PR DESCRIPTION
## TL;DR

Adds an optional `MAPPING_LOAD_TIMEOUT` environment variable that overrides how long the gateway waits at startup for the file at `MAPPING_PATH`. The 15 second default is unchanged when the variable is unset.

## Additional Details

`internal/reloadableconfig` waited on a hardcoded `defaultConfigLoadTimeout = 15 * time.Second`, so operators could not adjust it. Deployments where a ConfigMap projection or a config-producing sidecar materializes the mapping file after the main container starts can exceed that budget, and the gateway exits with `timed out waiting for config to become available`. The container then restarts and comes up healthy, which produces a guaranteed one-time restart per pod on every rollout.

- `SetupConfigWithConfigPath` is preserved as a thin wrapper over the new `SetupConfigWithConfigPathAndTimeout`, so existing callers are unaffected.
- The timeout is threaded through a `WithInitialLoadTimeout` functional option; `SetupConfig` overrides the default only when the value is positive.
- The setting is typed as `time.Duration` on `gateway.Config`. Viper composes `StringToTimeDurationHookFunc` by default, so a value without a unit is rejected while configuration is decoded and no hand-written parser is needed.
- A negative duration is rejected at startup. It decodes cleanly but arms an already-expired timer, so the initial wait would otherwise fail immediately with a misleading timeout error.
- The initial mapping load failure is now wrapped so the startup error names the operation while preserving the original error. That call site previously returned a bare error; it is changed here because it is the failure path this change is about.

## For the Reviewer

Start with `gateway/gateway.go` and `internal/reloadableconfig/config.go`.

`registerConfigFlags` is extracted from `NewRootCommand` in `main.go` with no behavior change, so a test can drive the real flag-and-environment binding instead of duplicating it.

`main.go` also loses a trailing blank line at end of file. It was already failing `gofmt` on `main` for that reason before this change.

## For QA

- `go test ./...` in `src/invocation-plane-services/vanity-gateway` passes.
- Unit tests cover decoding of unset, valid, and unitless values through the real viper binding, rejection of a negative duration at startup, and that the override is applied to the initial wait.
- `go vet ./...` clean; `gofmt` clean on all changed files.

Behavior with the variable unset is identical to today.

## Issues

Closes #1149

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable initial mapping-load timeouts for gateway startup.
  * Duration values such as `2m` are now supported through configuration.
  * Expanded guidance for managed deployments and sidecars that provide remote configuration.

* **Bug Fixes**
  * Negative timeout values are rejected during startup.
  * Unitless timeout values are rejected with a descriptive configuration error.
  * Custom timeouts now correctly control how long the gateway waits for its initial configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->