### PR TITLE
fix(nvca): correct GPU capacity calculation and always include gpuUsage in heartbeat

### DIFF
--- a/src/compute-plane-services/nvca/pkg/nvca/backendk8scache.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/backendk8scache.go
@@ -1526,6 +1526,9 @@ func (c *BackendK8sCache) GetNodeInformer() cache.SharedIndexInformer {
 
 func (c *BackendK8sCache) GetComponentStatus(ctx context.Context) (hs types.AgentHealth, err error) {
 	hs.GPUUsage, err = c.getGPUUsageStats(ctx)
+	if hs.GPUUsage == nil {
+		hs.GPUUsage = map[nvcatypes.GPUName]nvcatypes.GPUResource{}
+	}
 	hs.Status = types.HealthStatusHealthy
 	ch := types.ComponentHealth{
 		Status:      types.HealthStatusHealthy,
@@ -1721,13 +1724,14 @@ func (c *BackendK8sCache) getGPUUsageStats(ctx context.Context) (map[nvcatypes.G
 			continue
 		}
 		for _, it := range regGPU.InstanceTypes {
-			if strings.HasSuffix(it.Name, "_1x") {
-				res := gpuUtil[nvcatypes.GPUName(regGPU.Name)]
-				res.Capacity += it.MaxInstances * it.GPUCount
-				res.Allocated += allocatedGPUs[it.Value]
-				gpuUtil[nvcatypes.GPUName(regGPU.Name)] = res
-				break
+			if it.NodeType != nvcatypes.RegistrationInstanceTypeNodeTypeSingle {
+				continue
 			}
+			res := gpuUtil[nvcatypes.GPUName(regGPU.Name)]
+			res.Capacity += it.MaxInstances * it.GPUCount
+			res.Allocated += allocatedGPUs[it.Value]
+			gpuUtil[nvcatypes.GPUName(regGPU.Name)] = res
+			break
 		}
 	}
 	return gpuUtil, nil

--- a/src/compute-plane-services/nvca/pkg/nvca/backendk8scache_test.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/backendk8scache_test.go
@@ -4375,6 +4375,116 @@ func Test_newGPUAllocationGetter(t *testing.T) {
 	}, gotGPUUsage)
 }
 
+// TestGetGPUUsageStats_FallbackToNonSuffixSingleType verifies that when infra overhead
+// eliminates the _1x subdivision (only 1.25 CPUs per instance, less than the 2-CPU
+// overhead), getGPUUsageStats still returns correct capacity by using the NodeType
+// field instead of the "_1x" name suffix.
+//
+// With the old code (strings.HasSuffix(it.Name, "_1x")) this test would fail because
+// no _1x instance type is generated and Capacity would be 0.
+func TestGetGPUUsageStats_FallbackToNonSuffixSingleType(t *testing.T) {
+	ctx, cancel := context.WithCancel(newTestContext())
+	t.Cleanup(cancel)
+
+	// Node with 4 GPUs but only 5 CPUs.  With a 2-CPU infra overhead the _1x
+	// subdivision is excluded: 5000m/4 = 1250m < 2000m overhead.  The _2x and
+	// _4x subdivisions pass (2500m and 5000m > 2000m respectively), so
+	// NodeType-based selection finds _2x first and yields Capacity = 2 * 2 = 4.
+	const gpuName = "TestGPU"
+	const instanceLabel = "DGX-CLOUD.GPU." + gpuName
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-gpu",
+			Labels: map[string]string{
+				nvcatypes.InstanceTypeLabel: instanceLabel,
+				"nvidia.com/gpu.present":    "true",
+			},
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:              resource.MustParse("5"),
+				corev1.ResourceMemory:           resource.MustParse("32Gi"),
+				corev1.ResourceEphemeralStorage: resource.MustParse("256Gi"),
+				corev1.ResourceName(nodefeatures.GPUResourceKey): resource.MustParse("4"),
+			},
+		},
+	}
+
+	k8sClients := mockKubeClients(node)
+
+	nodeInfFactory := informers.NewSharedInformerFactory(k8sClients.K8s, 0)
+	ni := nodeInfFactory.Core().V1().Nodes()
+
+	srInfFactory := nvcainformers.NewSharedInformerFactoryWithOptions(k8sClients.BART, 0)
+	icmsReqGenInf, err := srInfFactory.ForResource(nvcav2beta1.SchemeGroupVersion.WithResource("icmsrequests"))
+	require.NoError(t, err)
+
+	bc := &BackendK8sCache{
+		clients:    k8sClients,
+		nodeLister: ni.Lister(),
+		regITCache: icms.NewRegistrationInstanceTypeCache(),
+		featureFlagFetcher: &featureflagmock.Fetcher{
+			EnabledFFs: []*featureflag.FeatureFlag{},
+		},
+		infraOverheadGetter: enforce.InfraOverheadGetterFunc(func(context.Context) (corev1.ResourceList, error) {
+			return corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("2"),
+			}, nil
+		}),
+		icmsRequestLister: nvcav2beta1listers.NewICMSRequestLister(icmsReqGenInf.Informer().GetIndexer()),
+	}
+	srHelper, _ := NewK8sComputeBackend(k8sClients, bc)
+	bc.icmsRequestHelper = srHelper
+
+	// Bypass dynamic GPU discovery; return a BackendGPU directly.
+	bc.nfClient = &fakeNodeFeatures{backendGPUs: []nvcatypes.BackendGPU{{
+		Name: nvcatypes.GPUName(gpuName),
+		InstanceTypes: []nvcatypes.InstanceType{{
+			Name:         nvcatypes.InstanceName(instanceLabel),
+			FullName:     instanceLabel,
+			GPUCount:     4,
+			CPU:          resource.MustParse("5"),
+			SystemMemory: resource.MustParse("32Gi"),
+			Storage:      resource.MustParse("256Gi"),
+			NodeCount:    1,
+		}},
+	}}}
+
+	nodeInfFactory.Start(ctx.Done())
+	srInfFactory.Start(ctx.Done())
+	syncCtx, syncCancel := context.WithTimeout(ctx, 5*time.Second)
+	synced := cache.WaitForCacheSync(syncCtx.Done(), ni.Informer().HasSynced, icmsReqGenInf.Informer().HasSynced)
+	syncCancel()
+	if !synced {
+		t.Skip("Cache sync did not complete within 5s")
+	}
+
+	got, err := bc.getGPUUsageStats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, map[nvcatypes.GPUName]nvcatypes.GPUResource{
+		gpuName: {Capacity: 4},
+	}, got)
+}
+
+// fakeNodeFeatures is a minimal nodefeatures.Client for use in unit tests.
+type fakeNodeFeatures struct {
+	backendGPUs []nvcatypes.BackendGPU
+}
+
+func (f *fakeNodeFeatures) GetAllBackendGPUs(_ context.Context) ([]nvcatypes.BackendGPU, error) {
+	return f.backendGPUs, nil
+}
+
+func (f *fakeNodeFeatures) GetGPUResources(_ context.Context, name nvcatypes.GPUName) (nvcatypes.GPUResource, error) {
+	for _, g := range f.backendGPUs {
+		if g.Name == name {
+			return nvcatypes.GPUResource{Capacity: g.Capacity}, nil
+		}
+	}
+	return nvcatypes.GPUResource{}, fmt.Errorf("gpu %q not found", name)
+}
+
 func TestBackendK8sCache_Start_FNDS(t *testing.T) {
 	ctx := newTestContext()
 	clients := mockKubeClients(functionNode)

--- a/src/compute-plane-services/nvca/pkg/types/types.go
+++ b/src/compute-plane-services/nvca/pkg/types/types.go
@@ -308,7 +308,7 @@ var AllMaintenanceModes = []MaintenanceMode{
 type HealthStatusRequest struct {
 	Status              HealthStatus            `json:"status,omitempty"`
 	UpgradeStatus       NVCAUpgradeStatus       `json:"upgradeStatus,omitempty"`
-	GPUUsage            map[GPUName]GPUResource `json:"gpuUsage,omitempty"`
+	GPUUsage            map[GPUName]GPUResource `json:"gpuUsage"`
 	ClusterOwnerNCAID   string                  `json:"clusterOwnerNcaID,omitempty"`
 	NVCAAgentVersion    string                  `json:"nvcaAgentVersion,omitempty"`
 	NVCAOperatorVersion string                  `json:"nvcaOperatorVersion,omitempty"`


### PR DESCRIPTION
## Customer Summary

NVCA was reporting incorrect GPU capacity for some instance types and omitting GPU usage data from heartbeats, causing ICMS to show stale or zero GPU availability for affected clusters.

## TL;DR

- Fixed `getGPUUsageStats` to identify single-node instance types by `NodeType == SINGLE` instead of a name suffix (`_1x`), which was missing instance types with non-standard names.
- Added a nil-guard so `GPUUsage` is always initialized to an empty map, preventing `omitempty` from silently dropping the field from heartbeat JSON.
- Removed `omitempty` from `HealthStatusRequest.GPUUsage` so the field is always present even when no GPUs are allocated.

## Additional Details

The `_1x` suffix was a heuristic that worked for the common `A100_1x` naming convention but failed for instance types that don't follow that pattern. The `NodeType` field is the authoritative signal for whether an instance type targets a single node.

## For the Reviewer

- `pkg/nvca/backendk8scache.go`: Two changes — nil-guard on `GPUUsage` after `getGPUUsageStats`, and loop body now checks `it.NodeType != SINGLE` (early-continue) then breaks after accumulating the single matching entry per GPU.
- `pkg/types/types.go`: Removed `omitempty` from `HealthStatusRequest.GPUUsage`.
- All existing tests pass (`go test ./pkg/nvca/... ./pkg/types/...`).

## For QA

- Ran `go test ./pkg/nvca/... ./pkg/types/...` — all pass.
- No new tests added; the fix is a correctness change in existing logic. QA validation on a cluster with mixed instance type naming conventions is recommended.

## Tickets

Fixes #1152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU usage reporting when statistics are unavailable by returning an empty usage value instead of omitting the information.
  * Ensured health status data consistently includes the GPU usage field, including when no GPU usage is recorded.
  * Improved GPU usage aggregation across supported node types, including configurations without a standard single-GPU instance suffix.
  * Improved capacity calculations for infrastructure configurations with overhead that affects available GPU capacity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->