### PR TITLE
fix(self-managed): align Cassandra application credentials

### DIFF
--- a/deploy/stacks/self-managed/Makefile
+++ b/deploy/stacks/self-managed/Makefile
@@ -11,6 +11,7 @@ test:
 	@tests/grpc-proxy-nats-endpoint.sh
 	@tests/llm-pki-openbao-migration.sh
 	@tests/api-keys-startup-probe.sh
+	@tests/cassandra-openbao-credential-wiring.sh
 	@tests/llm-pki-release.sh
 	@tests/check-llm-pki-issuer.sh
 	@tests/pdb-value-wiring.sh

--- a/deploy/stacks/self-managed/secrets/secrets.yaml.template
+++ b/deploy/stacks/self-managed/secrets/secrets.yaml.template
@@ -4,7 +4,8 @@
 
 # Notes:
 # Cassandra:
-#   The password should match the value set in the cassandra keyspace migrations
+#   This password is shared by the Cassandra keyspace migrations that create
+#   application roles and the OpenBao migrations that publish those credentials.
 #
 # API:
 #   The value for the registry will be used in three places, as it is
@@ -22,12 +23,15 @@
 #   The wrong encoding makes "function create" return
 #   400 "must be base64 encoded username:password format".
 
+cassandra:
+  serviceRolePassword: &cassandra_service_role_password "ch@ng3m3"
+
 openbao:
   migrations:
     env:
       # Stored in OpenBao shared secrets (written by migration job)
       - name: DEFAULT_CASSANDRA_PASSWORD
-        value: "ch@ng3m3"
+        value: *cassandra_service_role_password
       # Stored in OpenBao KV for nvcf-api AND nvct-api (written by migration job)
       - name: NVCF_API_SIDECARS_IMAGE_PULL_SECRET
         value: REPLACE_WITH_BASE64_DOCKER_CREDENTIAL

--- a/deploy/stacks/self-managed/tests/cassandra-openbao-credential-wiring.sh
+++ b/deploy/stacks/self-managed/tests/cassandra-openbao-credential-wiring.sh
@@ -64,23 +64,8 @@ render_chart_values cassandra "$cassandra_values"
 render_chart_values openbao-server "$openbao_values"
 
 cassandra_password="$(yq -r '.cassandra.serviceRolePassword // ""' "$cassandra_values")"
-openbao_password_count="$(yq -r '
-  [.openbao.migrations.env[] |
-    select(.name == "DEFAULT_CASSANDRA_PASSWORD")] |
-  length
-' "$openbao_values")"
-test "$openbao_password_count" = "1" ||
-  fail "OpenBao migrations must receive exactly one application-role password"
-openbao_password="$(yq -r '
-  .openbao.migrations.env[] |
-  select(.name == "DEFAULT_CASSANDRA_PASSWORD") |
-  .value
-' "$openbao_values")"
-
 test -n "$cassandra_password" ||
   fail "Cassandra migrations received no application-role password"
-test -n "$openbao_password" ||
-  fail "OpenBao migrations received no application-role password"
 
 cassandra_manifest="$work_dir/cassandra-manifest.yaml"
 helm template cassandra "$helm_dir/cassandra/helm" \
@@ -98,7 +83,51 @@ test -n "$cassandra_job_password" ||
   fail "Cassandra migration Job received no application-role password"
 test "$cassandra_job_password" = "$cassandra_password" ||
   fail "Cassandra migration Job did not receive the rendered stack password"
-test "$cassandra_job_password" = "$openbao_password" ||
+
+# The wrapper chart's migration Job does not depend on upstream OpenBao
+# templates. Supply an empty dependency chart in the isolated copy so this
+# focused render stays offline while exercising the real wrapper template.
+openbao_chart="$work_dir/openbao-chart"
+cp -R "$helm_dir/openbao/helm" "$openbao_chart"
+mkdir -p "$openbao_chart/charts/openbao"
+openbao_dependency_version="$(yq -r '
+  .dependencies[] |
+  select(.name == "openbao") |
+  .version
+' "$openbao_chart/Chart.yaml")"
+test -n "$openbao_dependency_version" ||
+  fail "OpenBao wrapper chart has no OpenBao dependency version"
+printf '%s\n' \
+  'apiVersion: v2' \
+  'name: openbao' \
+  "version: $openbao_dependency_version" >"$openbao_chart/charts/openbao/Chart.yaml"
+
+openbao_manifest="$work_dir/openbao-manifest.yaml"
+helm template openbao-server "$openbao_chart" \
+  --namespace vault-system \
+  --values "$openbao_values" \
+  --show-only templates/hook-post-02-migrations.yaml >"$openbao_manifest" ||
+  fail "OpenBao migration Job did not render"
+openbao_job_password_count="$(yq -r '
+  [.spec.template.spec.containers[] |
+    select(.name == "bao-migrations") |
+    .env[] |
+    select(.name == "DEFAULT_CASSANDRA_PASSWORD")] |
+  length
+' "$openbao_manifest")"
+test "$openbao_job_password_count" = "1" ||
+  fail "OpenBao migration Job must receive exactly one application-role password"
+openbao_job_password="$(yq -r '
+  .spec.template.spec.containers[] |
+  select(.name == "bao-migrations") |
+  .env[] |
+  select(.name == "DEFAULT_CASSANDRA_PASSWORD") |
+  .value
+' "$openbao_manifest")"
+
+test -n "$openbao_job_password" ||
+  fail "OpenBao migration Job received no application-role password"
+test "$cassandra_job_password" = "$openbao_job_password" ||
   fail "Cassandra and OpenBao migrations received different application-role passwords"
 
 echo "cassandra-openbao-credential-wiring: all checks passed"

--- a/deploy/stacks/self-managed/tests/cassandra-openbao-credential-wiring.sh
+++ b/deploy/stacks/self-managed/tests/cassandra-openbao-credential-wiring.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Verify that the self-managed secrets template gives Cassandra migrations and
+# OpenBao migrations the same non-empty application-role password.
+set -euo pipefail
+
+stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+stacks_dir="$(cd "$stack_dir/.." && pwd)"
+helm_dir="$(cd "$stack_dir/../../helm" && pwd)"
+work_dir="$(mktemp -d)"
+test_stacks_dir="$work_dir/stacks"
+test_stack_dir="$test_stacks_dir/self-managed"
+environment_name="cassandra-openbao-credential-wiring-test"
+secrets_file="$test_stack_dir/secrets/$environment_name-secrets.yaml"
+trap 'rm -rf "$work_dir"' EXIT
+
+fail() {
+  echo "cassandra-openbao-credential-wiring: $*" >&2
+  exit 1
+}
+
+# Exercise the real stack and its shipped secrets template from an isolated
+# copy. The sibling stacks are needed because helmfile.d references them.
+mkdir -p "$test_stacks_dir"
+cp -R "$stacks_dir"/. "$test_stacks_dir"
+cp "$test_stack_dir/secrets/secrets.yaml.template" "$secrets_file"
+
+for stack_environments in "$test_stacks_dir"/*/environments; do
+  test -d "$stack_environments" || continue
+  test -e "$stack_environments/$environment_name.yaml" ||
+    printf '{}\n' >"$stack_environments/$environment_name.yaml"
+done
+
+helmfile_common=(
+  --file "$test_stack_dir/helmfile.d"
+  --environment default
+  --state-values-set ingress.gatewayApi.controllerNamespace=envoy-gateway-system
+  --state-values-set ingress.gatewayApi.gateways.shared.name=shared-gw
+  --state-values-set ingress.gatewayApi.gateways.shared.namespace=envoy-gateway-system
+  --state-values-set ingress.gatewayApi.gateways.grpc.name=grpc-gw
+  --state-values-set ingress.gatewayApi.gateways.grpc.namespace=envoy-gateway-system
+)
+
+render_chart_values() {
+  local release="$1"
+  local output_file="$2"
+  local render_log="$work_dir/$release-write-values.log"
+
+  if ! HELMFILE_ENV="$environment_name" \
+    HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" \
+    helmfile "${helmfile_common[@]}" \
+      --selector "name=$release" \
+      write-values \
+      --output-file-template "$output_file" 2>"$render_log"; then
+    cat "$render_log" >&2
+    fail "$release: helmfile could not render the stack"
+  fi
+
+  test -s "$output_file" || fail "$release: helmfile wrote no values"
+}
+
+cassandra_values="$work_dir/cassandra-values.yaml"
+openbao_values="$work_dir/openbao-values.yaml"
+render_chart_values cassandra "$cassandra_values"
+render_chart_values openbao-server "$openbao_values"
+
+cassandra_password="$(yq -r '.cassandra.serviceRolePassword // ""' "$cassandra_values")"
+openbao_password_count="$(yq -r '
+  [.openbao.migrations.env[] |
+    select(.name == "DEFAULT_CASSANDRA_PASSWORD")] |
+  length
+' "$openbao_values")"
+test "$openbao_password_count" = "1" ||
+  fail "OpenBao migrations must receive exactly one application-role password"
+openbao_password="$(yq -r '
+  .openbao.migrations.env[] |
+  select(.name == "DEFAULT_CASSANDRA_PASSWORD") |
+  .value
+' "$openbao_values")"
+
+test -n "$cassandra_password" ||
+  fail "Cassandra migrations received no application-role password"
+test -n "$openbao_password" ||
+  fail "OpenBao migrations received no application-role password"
+
+cassandra_manifest="$work_dir/cassandra-manifest.yaml"
+helm template cassandra "$helm_dir/cassandra/helm" \
+  --namespace cassandra-system \
+  --values "$cassandra_values" >"$cassandra_manifest" ||
+  fail "Cassandra chart did not render"
+cassandra_job_password="$(yq -r '
+  select(.kind == "Job" and .metadata.name == "cassandra-migrations") |
+  .spec.template.spec.containers[].env[] |
+  select(.name == "SERVICE_ROLE_PASSWORD") |
+  .value
+' "$cassandra_manifest")"
+
+test -n "$cassandra_job_password" ||
+  fail "Cassandra migration Job received no application-role password"
+test "$cassandra_job_password" = "$cassandra_password" ||
+  fail "Cassandra migration Job did not receive the rendered stack password"
+test "$cassandra_job_password" = "$openbao_password" ||
+  fail "Cassandra and OpenBao migrations received different application-role passwords"
+
+echo "cassandra-openbao-credential-wiring: all checks passed"


### PR DESCRIPTION
## Summary

- define the self-managed Cassandra application-role password once in the environment secrets template
- reuse it for both Cassandra role creation and OpenBao credential publication
- add an end-to-end Helmfile/chart rendering regression for the Cassandra migration Job and OpenBao migration environment

## Root cause

The self-managed secrets file set `DEFAULT_CASSANDRA_PASSWORD` only for OpenBao. Cassandra therefore used the chart default for `SERVICE_ROLE_PASSWORD`; any customized OpenBao value produced different credentials for the same application role and caused API Keys Cassandra authentication to fail.

## Validation

- `deploy/stacks/self-managed/tests/cassandra-openbao-credential-wiring.sh`
- `make test` from `deploy/stacks/self-managed`
- `git diff --check`

Tested with Helmfile v1.7.4, Helm v4.2.4, and yq v4.53.6.

Fixes #1169.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured Cassandra and OpenBao migrations use the same non-empty application password.
  * Clarified that the password is shared by Cassandra keyspace and OpenBao migrations, reducing configuration ambiguity.
  * Improved consistency of credential configuration across self-managed deployments.

* **Tests**
  * Added integration coverage validating credential wiring in rendered self-managed deployments.
  * Included the credential-wiring validation in the standard test suite.
  * Verified that the migration configuration contains exactly one matching password.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->