### PR TITLE
fix(container-cache): add authorityKeyIdentifier to minted leaf certificates

### DIFF
--- a/deploy/helm/container-cache/deploy/files/lua/lua-ssl.lua
+++ b/deploy/helm/container-cache/deploy/files/lua/lua-ssl.lua
@@ -130,6 +130,21 @@ local function generate_ca_signed(sni_name, sni_ip, server_ip)
         subject = crt
     })))
 
+    -- RFC 5280 4.2.1.1. Required in practice, not just for conformance:
+    -- OpenSSL 3.x rejects a certificate with no authorityKeyIdentifier when
+    -- X509_V_FLAG_X509_STRICT is set, with "Missing Authority Key Identifier".
+    -- Python 3.13's ssl.create_default_context() enables that flag by default,
+    -- so without this extension every request from a Python 3.13 client fails
+    -- certificate verification against this proxy.
+    --
+    -- "keyid,issuer" rather than "keyid:always": keyid is copied from the
+    -- issuer's subjectKeyIdentifier when it has one, and falls back to issuer
+    -- name and serial when it does not, so this cannot fail on a signing CA
+    -- that lacks a SKID.
+    assert(crt:add_extension(x509_extension.new("authorityKeyIdentifier", "keyid,issuer", {
+        issuer = ca_crt
+    })))
+
     -- All done; sign
     assert(crt:sign(ca_key))
 

--- a/deploy/helm/container-cache/tests/chart-render/verify-mirrors.sh
+++ b/deploy/helm/container-cache/tests/chart-render/verify-mirrors.sh
@@ -31,6 +31,16 @@ assert_not_has() {
   fi
 }
 
+echo "Checking minted leaf certificate extensions..."
+# RFC 5280 4.2.1.1. OpenSSL rejects a certificate without authorityKeyIdentifier
+# when X509_V_FLAG_X509_STRICT is set, and Python 3.13 enables that flag by
+# default, so omitting this fails TLS verification for every such client.
+assert_has 'x509_extension.new("authorityKeyIdentifier", "keyid,issuer"'
+assert_has 'x509_extension.new("subjectKeyIdentifier", "hash"'
+# "keyid:always" fails outright on a signing CA with no SKID; "keyid,issuer"
+# falls back to issuer name and serial.
+assert_not_has 'x509_extension.new("authorityKeyIdentifier", "keyid:always"'
+
 echo "Checking Service shape..."
 assert_has 'kind: Service'
 assert_has 'name: nvcf-container-cache'


### PR DESCRIPTION
## Why

Clients running Python 3.13 with a recent OpenSSL fail TLS verification against
the container-cache proxy for every intercepted HTTPS host:

```
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED]
certificate verify failed: Missing Authority Key Identifier
```

The proxy mints a leaf certificate per SNI. It set `subjectAltName`,
`crlDistributionPoints`, `basicConstraints`, `extendedKeyUsage` and
`subjectKeyIdentifier`, but never `authorityKeyIdentifier`.

RFC 5280 4.2.1.1 requires that extension on non-self-signed certificates, and
OpenSSL enforces it when `X509_V_FLAG_X509_STRICT` is set. Python 3.13 changed
`ssl.create_default_context()` to enable `VERIFY_X509_STRICT` by default. Any
Python 3.13 client on an OpenSSL new enough to carry the check therefore rejects
every certificate the proxy presents.

Certificate captured from the proxy on the wire carried SAN, CRL Distribution
Points, Basic Constraints, Extended Key Usage and Subject Key Identifier, and no
Authority Key Identifier. The root and intermediate CAs are already conformant
(both carry SKID and AKID, with critical `basicConstraints` and `keyUsage`), so
the gap was only in the dynamically minted leaf.

Reported against presigned S3 object URLs, but nothing about it is S3-specific:
every host the proxy intercepts is served with the same minted leaf.

## What changed

Add `authorityKeyIdentifier` to the minted leaf in `lua-ssl.lua`.

`"keyid,issuer"` rather than `"keyid:always"`: keyid is copied from the issuer's
`subjectKeyIdentifier` where present and falls back to issuer name and serial
otherwise, so it cannot fail on a signing CA that lacks a SKID.

`lua-ssl.lua` ships from the chart ConfigMap rather than the proxy image, so this
is deliverable by chart upgrade with no image release.

## Customer Release Notes

Fixed TLS certificate verification failures ("Missing Authority Key Identifier")
for workloads using Python 3.13 or other clients that enforce strict RFC 5280
validation when downloading through the container cache.

## Plan Summary

ConfigMap content change only. No new resources, no image change. Cache pods
re-read the Lua on reload; certificates minted after the change carry the
extension, and cached leaves age out on their one-hour cache.

## Usage

`helm upgrade` the chart. No values change.

## Testing

Reproduced and verified in an affected environment (Python 3.13.14, OpenSSL
3.6.3, `VERIFY_X509_STRICT` on by default) by constructing a CA and two leaves
differing only in this extension and completing a real TLS handshake against
each:

```
leaf WITHOUT AKID (what the proxy minted) -> FAIL: Missing Authority Key Identifier
leaf WITH    AKID (this change)           -> OK
```

Worth recording: this does **not** reproduce on OpenSSL 3.0.x, which does not yet
enforce the check under strict mode. An earlier attempt with `openssl verify
-x509_strict` on 3.0.13 passed in both cases and was a false negative. The check
must be exercised on an OpenSSL that implements it.

`tests/chart-render/verify-mirrors.sh` extended to assert the extension is
present in the rendered ConfigMap and that the brittle `keyid:always` form is not
used. Full suite passes; `helm lint` clean.

## Notes

Affects a growing share of traffic as workload images adopt Python 3.13. Clients
on older Python or older OpenSSL are unaffected, which is why this surfaced as an
isolated report rather than a general outage.

Two follow-ups, both out of scope here:

- The minted leaf also has no `keyUsage` extension. Not required for the strict
  checks that OpenSSL applies to end-entity certificates today, but worth adding
  for RFC conformance before another validator tightens.
- Not every cluster has the proxy-cache opt-out policy deployed, so
  `NVCF_DISABLE_PROXY_CACHE` is inert on those clusters and there is no
  workload-level way to bypass interception when something like this occurs. That
  gap is what made this fully blocking rather than self-mitigable.

## References

Closes #1180

## Related Pull Requests

None.

## Dependencies

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved generated certificates by including authority and subject key identifiers.
  - Ensured certificates remain compatible with strict OpenSSL and Python 3.13 validation.
  - Added fallback handling when issuer certificates lack a subject key identifier.

- **Tests**
  - Added validation to confirm required certificate extensions are present.
  - Added checks to reject unsupported authority key identifier configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->