### PR TITLE
feat(icms-translate): bump BYOO collector default CPU to 1000m

### DIFF
--- a/src/libraries/go/lib/pkg/icms-translate/translate/common/otel.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/common/otel.go
@@ -263,12 +263,12 @@ func getCommonOTelEnvs(allEnvSet map[string]string, otelPodIPOverride string) []
 func GetDefaultContainerResourcesBYOO() corev1.ResourceRequirements {
 	return corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI), // 500m
-			corev1.ResourceMemory: *resource.NewQuantity(1<<31, resource.BinarySI),     // 2Gi
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(1000, resource.DecimalSI), // 1000m
+			corev1.ResourceMemory: *resource.NewQuantity(1<<31, resource.BinarySI),      // 2Gi
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI), // 500m
-			corev1.ResourceMemory: *resource.NewQuantity(1<<31, resource.BinarySI),     // 2Gi
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(1000, resource.DecimalSI), // 1000m
+			corev1.ResourceMemory: *resource.NewQuantity(1<<31, resource.BinarySI),      // 2Gi
 		},
 	}
 }

--- a/src/libraries/go/lib/pkg/icms-translate/translate/common/otel_test.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/common/otel_test.go
@@ -512,9 +512,9 @@ func TestNewOTelContainer(t *testing.T) {
 			assert.Equal(t, []corev1.Capability{"NET_RAW"}, container.SecurityContext.Capabilities.Drop)
 
 			assert.NotNil(t, container.Resources)
-			assert.Equal(t, "500m", container.Resources.Limits.Cpu().String())
+			assert.Equal(t, "1", container.Resources.Limits.Cpu().String())
 			assert.Equal(t, "2Gi", container.Resources.Limits.Memory().String())
-			assert.Equal(t, "500m", container.Resources.Requests.Cpu().String())
+			assert.Equal(t, "1", container.Resources.Requests.Cpu().String())
 			assert.Equal(t, "2Gi", container.Resources.Requests.Memory().String())
 
 			assert.NotNil(t, container.ReadinessProbe)


### PR DESCRIPTION
## TL;DR
Raise the default BYOO OTel collector CPU request/limit from `500m` to `1000m` in `GetDefaultContainerResourcesBYOO()`. Memory default stays `2Gi`.

## Additional Details
Under bursty load the collector saturates a single `500m` core, pins at 100%, and drops data while its exporter queue backs up. Doubling CPU to `1000m` lets it drain faster, which also keeps memory from climbing.

- CPU: `500m -> 1000m` (request + limit).
- Memory: unchanged at `2Gi` default.
- The `4Gi` "ultra-class" sizing from the report is **not** a global default — it is applied per-function via the existing `OTelResources` override (cluster spec `byooResources` / SBOM), which the translator uses in place of the default. No code change needed for that path.
- Report guidance also notes not sizing memory below `1Gi`; that is a floor on the override path and can be enforced as a follow-up if desired.

## For the Reviewer
- Key file: `src/libraries/go/lib/pkg/icms-translate/translate/common/otel.go` (`GetDefaultContainerResourcesBYOO`).
- This default flows into every BYOO collector via NVCA, so it is a platform-wide default bump (intended).

## For QA
- `go test ./pkg/icms-translate/translate/common/...` passes with updated resource assertions.

## Issues
NO-REF

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the default CPU allocation for OpenTelemetry containers from 500m to 1 CPU.
  * Memory allocation remains unchanged at 2Gi.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->