### PR TITLE
fix(worker-task): accept NVCT task identity env vars

### DIFF
--- a/src/compute-plane-services/worker-task/service/service.go
+++ b/src/compute-plane-services/worker-task/service/service.go
@@ -51,6 +51,13 @@ const (
 	withoutHttpServer = false
 )
 
+var workerEnvAliases = map[string][]string{
+	"TASK_ID":     {"NVCT_TASK_ID"},
+	"TASK_NAME":   {"NVCT_TASK_NAME"},
+	"NCA_ID":      {"NVCT_NCA_ID"},
+	"INSTANCE_ID": {"NVCT_INSTANCE_ID"},
+}
+
 // ------------------------------------------------------------------------
 
 // Run is the entrypoint for the NVCT worker service.
@@ -87,9 +94,9 @@ func NewRootCommand(ctx context.Context, logger *logs.ZapLogger, startupTime tim
 			if err != nil {
 				return sharedTypes.NewInternalError(err)
 			}
-			cmd.Flags().VisitAll(func(flag *pflag.Flag) {
-				v.MustBindEnv(flag.Name)
-			})
+			if err := bindWorkerConfigEnvs(v, cmd.Flags()); err != nil {
+				return sharedTypes.NewInternalError(err)
+			}
 
 			v.SetDefault("NVCT_RESULT_HANDLING_STRATEGY", "NONE")
 
@@ -149,6 +156,20 @@ func NewRootCommand(ctx context.Context, logger *logs.ZapLogger, startupTime tim
 	}
 
 	return rootCmd
+}
+
+func bindWorkerConfigEnvs(v *viper.Viper, flags *pflag.FlagSet) error {
+	var bindErr error
+	flags.VisitAll(func(flag *pflag.Flag) {
+		if bindErr != nil {
+			return
+		}
+
+		envNames := append([]string{flag.Name}, workerEnvAliases[flag.Name]...)
+		bindArgs := append([]string{flag.Name}, envNames...)
+		bindErr = v.BindEnv(bindArgs...)
+	})
+	return bindErr
 }
 
 func viperDecoderConfig() viper.DecoderConfigOption {

--- a/src/compute-plane-services/worker-task/service/service_cmd_test.go
+++ b/src/compute-plane-services/worker-task/service/service_cmd_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -68,6 +69,29 @@ func TestPersistentPreRunError(t *testing.T) {
 
 	err := cmd.PersistentPreRunE(cmd, nil)
 	require.Error(t, err, "expected PersistentPreRunE to error on invalid task id")
+}
+
+func TestBindWorkerConfigEnvsSupportsNVCTAliases(t *testing.T) {
+	aliases := map[string]string{
+		"TASK_ID":     "NVCT_TASK_ID",
+		"TASK_NAME":   "NVCT_TASK_NAME",
+		"NCA_ID":      "NVCT_NCA_ID",
+		"INSTANCE_ID": "NVCT_INSTANCE_ID",
+	}
+
+	for legacyName, aliasName := range aliases {
+		t.Run(legacyName, func(t *testing.T) {
+			cmd := NewRootCommand(ctx, zapLogger, time.Now())
+			v := viper.New()
+			require.NoError(t, bindWorkerConfigEnvs(v, cmd.Flags()))
+
+			t.Setenv(aliasName, "nvct-value")
+			assert.Equal(t, "nvct-value", v.GetString(legacyName))
+
+			t.Setenv(legacyName, "legacy-value")
+			assert.Equal(t, "legacy-value", v.GetString(legacyName))
+		})
+	}
 }
 
 // TestPersistentPreRunInitConfigError covers the config.InitConfig error branch
@@ -122,14 +146,14 @@ func TestPersistentPreRunSuccess(t *testing.T) {
 	workerToken, err := testutils.GenerateJWT(time.Now().Unix())
 	require.NoError(t, err, "failed to generate worker token")
 
-	// Env var names are the mapstructure tags from configs.Config.
-	t.Setenv("NCA_ID", "test-nca-id")
+	// BYOO task pods expose task identity through the NVCT_-prefixed aliases.
+	t.Setenv("NVCT_NCA_ID", "test-nca-id")
 	t.Setenv("ACCOUNT_NAME", "test-account")
 	t.Setenv("NVCT_WORKER_TOKEN", workerToken)
 	t.Setenv("NVCT_FQDN_GRPC", "http://localhost:9092")
-	t.Setenv("TASK_ID", "10b076eb-b6d2-4cd9-878b-a3614a931570")
-	t.Setenv("TASK_NAME", "test-task")
-	t.Setenv("INSTANCE_ID", "test-instance")
+	t.Setenv("NVCT_TASK_ID", "10b076eb-b6d2-4cd9-878b-a3614a931570")
+	t.Setenv("NVCT_TASK_NAME", "test-task")
+	t.Setenv("NVCT_INSTANCE_ID", "test-instance")
 	t.Setenv("INSTANCE_TYPE_NAME", "test-instance-type")
 	t.Setenv("HEALTH_PORT", "18080")
 	t.Setenv("NVCT_MAX_RUN_TIME_DURATION", "PT1H")


### PR DESCRIPTION
## TL;DR

Accept NVCT-prefixed task identity environment variables in worker-task, while preserving precedence for the legacy names.

## Additional Details

BYOO task pods provide task identity using NVCT-prefixed environment variables. worker-task previously bound only the legacy names, leaving required task identity unset at startup. This change adds NVCT-prefixed compatibility fallbacks for task ID, task name, NCA ID, and instance ID, with the legacy names taking precedence when both are set.

No dependencies or documentation changes are required.

## For the Reviewer

Please focus on environment-variable binding and the legacy-precedence behavior in `service.go`.

## For QA

No manual QA is needed. The worker-task module test suite covers the aliases and startup path.

## Issues

Closes #1187

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `NVCT_`-prefixed environment variable aliases for selected worker configuration settings.
  * Existing configuration names remain supported, with legacy values taking precedence when both forms are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->