### PR TITLE
fix(nvca-operator): default image tag to chart version

### DIFF
--- a/ai-tooling/dev/skills/nvca-values-customization/SKILL.md
+++ b/ai-tooling/dev/skills/nvca-values-customization/SKILL.md
@@ -45,7 +45,7 @@ The vendoring script already applies defaults such as:
 
 - `ngcConfig.clusterSource = "self-managed"`
 - `ngcConfig.serviceKey = "dummy-api-key"`
-- `image.tag = "$NVCA_OPERATOR_VERSION"`
+- `image.tag` remains empty so templates use the published chart version
 - `selfManaged.nvcaVersion = "$NVCA_VERSION"`
 - `generateImagePullSecret = false`
 - `selfManaged.sharedStorage.imageTag = "$NVCA_SHARED_STORAGE_IMAGE_TAG"`

--- a/deploy/helm/nvca-operator/Makefile
+++ b/deploy/helm/nvca-operator/Makefile
@@ -44,7 +44,7 @@ OCI_REGISTRY_NAMESPACE ?= <your-org>
 CHART_NAME := $(shell yq -r .name $(helm_dir)/Chart.yaml)
 CHART_VERSION := $(shell yq -r .version $(helm_dir)/Chart.yaml)
 
-.PHONY: install uninstall status lint template validate clean package push-oci sync-chart check-synced-chart render-values-from-stack install-from-stack test-render-values test-build-release-assets test-release-image-manifest test-release-artifact-permissions test-package-release-assets test-attach-release-assets test-release-sbom-wrapper test-self-managed-nvca-image-reference test-image-pull-secret-defaults
+.PHONY: install uninstall status lint template validate clean package push-oci sync-chart check-synced-chart render-values-from-stack install-from-stack test-render-values test-vendor-chart-image-tag test-build-release-assets test-release-image-manifest test-release-artifact-permissions test-package-release-assets test-attach-release-assets test-release-sbom-wrapper test-self-managed-nvca-image-reference test-image-pull-secret-defaults
 
 install:
 ifndef values
@@ -91,6 +91,9 @@ install-from-stack: render-values-from-stack
 
 test-render-values:
 	@bash ./tests/render_values_from_stack_env_test.sh
+
+test-vendor-chart-image-tag:
+	@bash ./tests/vendor_chart_image_tag_test.sh
 
 test-build-release-assets:
 	@bash ./tests/build_release_assets_test.sh

--- a/deploy/helm/nvca-operator/nvca-operator/values.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/values.yaml
@@ -19,7 +19,7 @@
 ## @param image.pullPolicy K8s ImagePullPolicy
 image:
   repository: ""
-  tag: "3.0.4"
+  tag: ""
   pullPolicy: IfNotPresent
 ## @param nvcaImage.repositoryOverride (Optional) Full NVCA container registry path, without tag. Only set this if the default needs to be overridden, for example "stg.nvcr.io/nvidia/nvcf-byoc/nvca". The tag is set in the cluster config
 ## @param nvcaImage.pullPolicy K8s ImagePullPolicy

--- a/deploy/helm/nvca-operator/scripts/ci_vendor_nvca_operator_chart
+++ b/deploy/helm/nvca-operator/scripts/ci_vendor_nvca_operator_chart
@@ -207,7 +207,9 @@ main() {
         update_yaml_key ".agent.functionEnvOverrides.BYOO_OTEL_COLLECTOR_CONTAINER = \"${byoo_otel_collector_image}\"" "${TARGET_DIR}/values.yaml"
         update_yaml_key ".agent.taskEnvOverrides.BYOO_OTEL_COLLECTOR_CONTAINER = \"${byoo_otel_collector_image}\"" "${TARGET_DIR}/values.yaml"
     fi
-    update_yaml_key ".image.tag = \"${NVCA_OPERATOR_VERSION:?"NVCA_OPERATOR_VERSION is not set"}\"" "${TARGET_DIR}/values.yaml"
+    # Keep the source chart's empty tag so the templates fall back to the
+    # published chart version. A literal default is retained by Helm
+    # --reuse-values upgrades and pins the operator to an older image.
     update_yaml_key ".selfManaged.nvcaVersion = \"${NVCA_VERSION:?"NVCA_VERSION is not set"}\"" "${TARGET_DIR}/values.yaml"
     update_yaml_key ".selfManaged.icmsServiceURL = \"http://icms.example.invalid:8080\"" "${TARGET_DIR}/values.yaml"
     update_yaml_key ".selfManaged.revalServiceURL = \"http://reval.example.invalid:8080\"" "${TARGET_DIR}/values.yaml"

--- a/deploy/helm/nvca-operator/tests/vendor_chart_image_tag_test.sh
+++ b/deploy/helm/nvca-operator/tests/vendor_chart_image_tag_test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+workspace_root="$(cd "${repo_root}/../../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+fixture_root="${tmp_dir}/fixture"
+
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+
+mkdir -p "${fixture_root}/deploy/helm"
+cp -R "${repo_root}" "${fixture_root}/deploy/helm/nvca-operator"
+mkdir -p "${fixture_root}/src/compute-plane-services/nvca/deployments"
+cp -R "${workspace_root}/src/compute-plane-services/nvca/deployments/nvca-operator" \
+  "${fixture_root}/src/compute-plane-services/nvca/deployments/nvca-operator"
+
+chart_root="${fixture_root}/deploy/helm/nvca-operator"
+NVCA_OPERATOR_VERSION="3.2.11" \
+NVCA_VERSION="3.2.11" \
+NVCA_SHARED_STORAGE_IMAGE_TAG="1.0.5" \
+  "${chart_root}/scripts/ci_vendor_nvca_operator_chart" >/dev/null
+
+actual_tag="$(yq -r '.image.tag' "${chart_root}/nvca-operator/values.yaml")"
+if [[ -n "${actual_tag}" ]]; then
+  echo "expected vendored image.tag to remain empty, got ${actual_tag}" >&2
+  exit 1
+fi
+
+yq eval -i '.version = "3.2.11"' "${chart_root}/nvca-operator/Chart.yaml"
+manifest="${tmp_dir}/manifest.yaml"
+helm template nvca-operator "${chart_root}/nvca-operator" \
+  --set-string image.repository=registry.example.test/nvca-operator \
+  --set-string selfManaged.icmsServiceURL=http://icms.example.invalid:8080 \
+  --set-string selfManaged.revalServiceURL=http://reval.example.invalid:8080 \
+  --set-string selfManaged.natsURL=nats://nats.example.invalid:4222 \
+  > "${manifest}"
+
+if ! grep -Fq 'image: registry.example.test/nvca-operator:3.2.11' "${manifest}"; then
+  echo "expected image.tag to fall back to the chart version" >&2
+  exit 1
+fi
+
+echo "vendor_chart_image_tag_test.sh keeps image.tag empty for chart-version fallback"


### PR DESCRIPTION
## TL;DR

- Backport the chart-version image-tag default to the maintained NVCA 3.2 branch.
- Retain the vendor regression test for the fallback behavior.

## Additional Details

- Cherry-picks [#1190](https://github.com/NVIDIA/nvcf/pull/1190) with commit provenance.
- Explicit `image.tag` overrides still take precedence.

## For QA

- `make -C deploy/helm/nvca-operator check-vendor-chart`
- `make -C deploy/helm/nvca-operator test-vendor-chart-image-tag test-render-values test-self-managed-nvca-image-reference test-release-image-manifest lint template`
- `make -C deploy/helm/nvca-operator validate`
- `git diff --check`

## Issues

Relates to #1189

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.