### PR TITLE
feat(sidecar-registry-configurable): make worker sidecar registry host/repository configurable

### DIFF
--- a/deploy/stacks/self-managed/Makefile
+++ b/deploy/stacks/self-managed/Makefile
@@ -16,3 +16,4 @@ test:
 	@tests/pdb-value-wiring.sh
 	@tests/invocation-tracing-baggage.sh
 	@tests/image-override-wiring.sh
+	@tests/sidecar-registry-wiring.sh

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -49,13 +49,11 @@ global:
   # =============================================================================
   # Worker Sidecar Registry Configuration
   # =============================================================================
-  # Registry host and repository the control plane advertises to workers for the
-  # worker sidecar images (NVCF_SIDECARS_* / NVCT_SIDECARS_*). Leave unset to
-  # inherit global.image, so a mirror-everything install is unchanged. Set these
-  # to source only the worker sidecars from a separate registry/org — for
-  # example a private NGC org that also holds deployment-specific sidecars —
-  # while control-plane images stay on global.image (e.g. the public catalog).
-  # Provide the matching sidecar pull credential separately.
+  # Registry host/repository advertised to workers for the worker sidecar images
+  # (NVCF_SIDECARS_* / NVCT_SIDECARS_*). Unset inherits global.image. Set these to
+  # source the worker sidecars from a separate registry/org (e.g. a private NGC
+  # org) while control-plane images stay on global.image. Supply the matching
+  # sidecar pull credential separately.
   # =============================================================================
   # sidecars:
   #   hostname: nvcr.io

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -46,6 +46,21 @@ global:
     registry: nvcr.io
     repository: YOUR_ORG/YOUR_TEAM
 
+  # =============================================================================
+  # Worker Sidecar Registry Configuration
+  # =============================================================================
+  # Registry host and repository the control plane advertises to workers for the
+  # worker sidecar images (NVCF_SIDECARS_* / NVCT_SIDECARS_*). Leave unset to
+  # inherit global.image, so a mirror-everything install is unchanged. Set these
+  # to source only the worker sidecars from a separate registry/org — for
+  # example a private NGC org that also holds deployment-specific sidecars —
+  # while control-plane images stay on global.image (e.g. the public catalog).
+  # Provide the matching sidecar pull credential separately.
+  # =============================================================================
+  # sidecars:
+  #   hostname: nvcr.io
+  #   repository: YOUR_ORG/YOUR_TEAM
+
   # Worker-facing endpoints advertised by control-plane services into launched
   # workload pods. Leave empty to use service defaults; set per environment when
   # workers run in a different cluster or DNS domain from the control plane.

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -293,14 +293,9 @@ natsAuthCalloutService:
     repository: {{ .Values.global.image.repository }}/nvcf-nats-auth-callout-service
 
 {{- $workerEndpoints := dig "global" "workerEndpoints" dict .Values }}
-{{- /*
-  Worker sidecar registry host/repository. Default to global.image so a
-  mirror-everything install renders unchanged. Override global.sidecars.*
-  to source only the worker sidecars from a separate registry/org (for
-  example a private NGC org) while control-plane images stay on the public
-  catalog. Shared by the NVCF (NVCF_SIDECARS_*) and NVCT (NVCT_SIDECARS_*)
-  env blocks below.
-*/}}
+{{- /* Worker sidecar registry host/repository, shared by the NVCF and NVCT env
+       below. Unset inherits global.image; global.sidecars.* sources the worker
+       sidecars from a separate registry/org while control-plane images stay put. */}}
 {{- $sidecarsHost := dig "global" "sidecars" "hostname" "" .Values | default .Values.global.image.registry }}
 {{- $sidecarsRepo := dig "global" "sidecars" "repository" "" .Values | default .Values.global.image.repository }}
 {{- $nvcfWorkerServiceURL := dig "nvcfServiceURL" "" $workerEndpoints }}

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -293,6 +293,16 @@ natsAuthCalloutService:
     repository: {{ .Values.global.image.repository }}/nvcf-nats-auth-callout-service
 
 {{- $workerEndpoints := dig "global" "workerEndpoints" dict .Values }}
+{{- /*
+  Worker sidecar registry host/repository. Default to global.image so a
+  mirror-everything install renders unchanged. Override global.sidecars.*
+  to source only the worker sidecars from a separate registry/org (for
+  example a private NGC org) while control-plane images stay on the public
+  catalog. Shared by the NVCF (NVCF_SIDECARS_*) and NVCT (NVCT_SIDECARS_*)
+  env blocks below.
+*/}}
+{{- $sidecarsHost := dig "global" "sidecars" "hostname" "" .Values | default .Values.global.image.registry }}
+{{- $sidecarsRepo := dig "global" "sidecars" "repository" "" .Values | default .Values.global.image.repository }}
 {{- $nvcfWorkerServiceURL := dig "nvcfServiceURL" "" $workerEndpoints }}
 {{- $nvcfWorkerGrpcServiceURL := dig "nvcfGrpcServiceURL" "" $workerEndpoints }}
 {{- $grpcProxyNVCFGrpcServiceURL := dig "grpcproxy" "nvcfGrpcServiceURL" "" .Values | default $nvcfWorkerGrpcServiceURL }}
@@ -433,8 +443,8 @@ api:
 
   env:
     NVCF_NATS_REGION_PLACEMENT_TAG: "dc"
-    NVCF_SIDECARS_HOSTNAME: {{ .Values.global.image.registry }}
-    NVCF_SIDECARS_REPOSITORY: {{ .Values.global.image.repository }}
+    NVCF_SIDECARS_HOSTNAME: {{ $sidecarsHost }}
+    NVCF_SIDECARS_REPOSITORY: {{ $sidecarsRepo }}
     {{- with $nvcfWorkerServiceURL }}
     NVCF_FQDN: {{ . | quote }}
     {{- end }}
@@ -516,8 +526,8 @@ nvctApi:
     repository: {{ .Values.global.image.repository }}/nvct-service-oss
 
   env:
-    NVCT_SIDECARS_HOSTNAME: {{ .Values.global.image.registry }}
-    NVCT_SIDECARS_REPOSITORY: {{ .Values.global.image.repository }}
+    NVCT_SIDECARS_HOSTNAME: {{ $sidecarsHost }}
+    NVCT_SIDECARS_REPOSITORY: {{ $sidecarsRepo }}
     {{- with $nvctWorkerServiceURL }}
     NVCT_FQDN: {{ . | quote }}
     {{- end }}

--- a/deploy/stacks/self-managed/tests/sidecar-registry-wiring.sh
+++ b/deploy/stacks/self-managed/tests/sidecar-registry-wiring.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Test that the worker sidecar registry override threads from an environment
+# file through global.yaml.gotmpl into the rendered control-plane env, and that
+# leaving it unset keeps the global.image default.
+#
+# The NVCF_SIDECARS_* / NVCT_SIDECARS_* env values tell the control plane which
+# registry host and repository to advertise to workers for the worker sidecar
+# images. They default to global.image so a mirror-everything install is
+# unchanged; global.sidecars.{hostname,repository} redirects only the worker
+# sidecars to a separate registry/org while control-plane images stay put.
+#
+# One render is enough: the shared global.yaml.gotmpl emits both the NVCF and
+# NVCT env blocks, so rendering nvct-api (which has no release "needs") exposes
+# every key under test.
+set -euo pipefail
+
+stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+work_dir="$(mktemp -d)"
+test_stack_dir="$work_dir/self-managed"
+environment_name="sidecar-registry-wiring-test"
+environment_file="$test_stack_dir/environments/$environment_name.yaml"
+secrets_file="$test_stack_dir/secrets/$environment_name-secrets.yaml"
+trap 'rm -rf "$work_dir"' EXIT
+
+fail() {
+  echo "sidecar-registry-wiring: $*" >&2
+  exit 1
+}
+
+mkdir -p "$test_stack_dir"
+cp -R "$stack_dir"/. "$test_stack_dir"
+printf '{}\n' >"$secrets_file"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+write_env() {
+  cat >"$environment_file"
+}
+
+render_values() {
+  local output_file="$1"
+
+  HELMFILE_ENV="$environment_name" \
+    HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" \
+    helmfile \
+      --file "$test_stack_dir/helmfile.d/02-core.yaml.gotmpl" \
+      --environment default \
+      --state-values-set ingress.gatewayApi.controllerNamespace=envoy-gateway-system \
+      --state-values-set ingress.gatewayApi.gateways.shared.name=shared-gw \
+      --state-values-set ingress.gatewayApi.gateways.shared.namespace=envoy-gateway-system \
+      --state-values-set ingress.gatewayApi.gateways.grpc.name=grpc-gw \
+      --state-values-set ingress.gatewayApi.gateways.grpc.namespace=envoy-gateway-system \
+      --selector name=nvct-api \
+      write-values \
+      --output-file-template "$output_file" >/dev/null
+}
+
+# Read one scalar out of the rendered values by key, unquoted, compared
+# literally so periods in a hostname are not treated as regex wildcards.
+field_value() {
+  local values_file="$1" key="$2"
+  sed -n "s/^[[:space:]]*${key}:[[:space:]]*//p" "$values_file" |
+    head -n1 | sed -e 's/^"//' -e 's/"$//'
+}
+
+assert_env() {
+  local values_file="$1" key="$2" want="$3" label="$4" got
+  got="$(field_value "$values_file" "$key")"
+  [[ "$got" == "$want" ]] ||
+    fail "$label: expected ${key}: ${want}, got: ${got:-<none>}"
+}
+
+# Every scenario checks all four keys, so assert them together.
+assert_sidecars() {
+  local values_file="$1" host="$2" repo="$3" label="$4"
+  assert_env "$values_file" NVCF_SIDECARS_HOSTNAME "$host" "$label"
+  assert_env "$values_file" NVCF_SIDECARS_REPOSITORY "$repo" "$label"
+  assert_env "$values_file" NVCT_SIDECARS_HOSTNAME "$host" "$label"
+  assert_env "$values_file" NVCT_SIDECARS_REPOSITORY "$repo" "$label"
+}
+
+# ---------------------------------------------------------------------------
+# 1. No override — the sidecars inherit global.image
+# ---------------------------------------------------------------------------
+write_env <<'EOF'
+global:
+  image:
+    registry: nvcr.io
+    repository: test/nvcf
+EOF
+
+render_values "$work_dir/default-values.yaml"
+assert_sidecars "$work_dir/default-values.yaml" nvcr.io test/nvcf "no override"
+
+# ---------------------------------------------------------------------------
+# 2. Full override — global.sidecars redirects both host and repository
+# ---------------------------------------------------------------------------
+write_env <<'EOF'
+global:
+  image:
+    registry: nvcr.io
+    repository: test/nvcf
+  sidecars:
+    hostname: private.nvcr.io
+    repository: my-org/nvcf-core
+EOF
+
+render_values "$work_dir/override-values.yaml"
+assert_sidecars "$work_dir/override-values.yaml" private.nvcr.io my-org/nvcf-core "full override"
+
+# ---------------------------------------------------------------------------
+# 3. Partial override — an unset key falls back to global.image independently
+# ---------------------------------------------------------------------------
+write_env <<'EOF'
+global:
+  image:
+    registry: nvcr.io
+    repository: test/nvcf
+  sidecars:
+    repository: my-org/nvcf-core
+EOF
+
+render_values "$work_dir/partial-values.yaml"
+assert_sidecars "$work_dir/partial-values.yaml" nvcr.io my-org/nvcf-core "repository-only override"
+
+# ---------------------------------------------------------------------------
+# 4. Explicit empty values are treated as unset, not as an empty host/repo
+# ---------------------------------------------------------------------------
+write_env <<'EOF'
+global:
+  image:
+    registry: nvcr.io
+    repository: test/nvcf
+  sidecars:
+    hostname: ""
+    repository: ""
+EOF
+
+render_values "$work_dir/empty-values.yaml"
+assert_sidecars "$work_dir/empty-values.yaml" nvcr.io test/nvcf "explicit empty"
+
+echo "sidecar-registry-wiring: OK"

--- a/deploy/stacks/self-managed/tests/sidecar-registry-wiring.sh
+++ b/deploy/stacks/self-managed/tests/sidecar-registry-wiring.sh
@@ -82,7 +82,7 @@ assert_sidecars() {
 }
 
 # ---------------------------------------------------------------------------
-# 1. No override — the sidecars inherit global.image
+# 1. No override: the sidecars inherit global.image
 # ---------------------------------------------------------------------------
 write_env <<'EOF'
 global:
@@ -95,7 +95,7 @@ render_values "$work_dir/default-values.yaml"
 assert_sidecars "$work_dir/default-values.yaml" nvcr.io test/nvcf "no override"
 
 # ---------------------------------------------------------------------------
-# 2. Full override — global.sidecars redirects both host and repository
+# 2. Full override: global.sidecars redirects both host and repository
 # ---------------------------------------------------------------------------
 write_env <<'EOF'
 global:
@@ -111,7 +111,7 @@ render_values "$work_dir/override-values.yaml"
 assert_sidecars "$work_dir/override-values.yaml" private.nvcr.io my-org/nvcf-core "full override"
 
 # ---------------------------------------------------------------------------
-# 3. Partial override — an unset key falls back to global.image independently
+# 3. Partial override: an unset key falls back to global.image independently
 # ---------------------------------------------------------------------------
 write_env <<'EOF'
 global:


### PR DESCRIPTION
## Why

The self-managed stack renders the worker sidecar registry from `global.image` with no override hook:

```
NVCF_SIDECARS_HOSTNAME: {{ .Values.global.image.registry }}
NVCF_SIDECARS_REPOSITORY: {{ .Values.global.image.repository }}
```

(`deploy/stacks/self-managed/global.yaml.gotmpl:436-437`; the `NVCT_SIDECARS_*` equivalents were hardcoded the same way at `:519-520`). These env vars build the worker sidecar image URLs (`${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/<name>:<tag>`) consumed by `nvcf-api` / `nvct-api`.

Because the only knob is `global.image`, an operator who mirrors just the worker sidecars into a separate registry/org cannot point the sidecars there without also retargeting `global.image` — which drags every control-plane image to that registry and forces a full mirror. There is no supported way to keep control-plane images on the public catalog (`nvcr.io/nvidia/nvcf`) while sourcing worker sidecars from a different registry/org.

Resolves #1192.

## What changed

- `global.yaml.gotmpl`: derive the sidecar host/repository once and feed both the NVCF and NVCT env blocks, following the existing `dig … | default` override pattern (introduced by #898):

```
{{- $sidecarsHost := dig "global" "sidecars" "hostname" "" .Values | default .Values.global.image.registry }}
{{- $sidecarsRepo := dig "global" "sidecars" "repository" "" .Values | default .Values.global.image.repository }}
```

  wired into `NVCF_SIDECARS_HOSTNAME/REPOSITORY` and `NVCT_SIDECARS_HOSTNAME/REPOSITORY`.
- `base.yaml`: document the new `global.sidecars` block.
- `tests/sidecar-registry-wiring.sh`: new test, wired into `make test`.

Operator override:

```
global:
  sidecars:
    hostname: <registry>       # defaults to global.image.registry
    repository: <org/repo>     # defaults to global.image.repository
```

**Defaults are unchanged.** With `global.sidecars` unset, both env blocks render exactly as before from `global.image`, so mirror-everything and public-catalog installs are unaffected. An explicit `hostname: ""` / `repository: ""` is also treated as unset (falls back to `global.image`), matching the "explicit empty" handling in `image-override-wiring.sh`.

## Customer Release Notes

`feat(stack)`: The worker sidecar registry host and repository now take a `global.sidecars.{hostname,repository}` override in your environment file, so you can source the worker sidecars from a separate registry/org (for example a private NGC org) while control-plane images stay on `global.image`. Leave it unset to keep the current behavior — the sidecars continue to inherit `global.image`. Provide the matching sidecar pull credential separately.

## Testing

`deploy/stacks/self-managed/tests/sidecar-registry-wiring.sh` (new, passing) renders `global.yaml.gotmpl` through helmfile (`write-values` on the `nvct-api` release, whose shared template emits both the NVCF and NVCT env blocks) and asserts:

1. no override → all four `NVC[FT]_SIDECARS_*` keys inherit `global.image`;
2. full override (`global.sidecars.hostname` + `repository`) → all four resolve to the override;
3. repository-only override → `repository` uses the override, `hostname` falls back to `global.image.registry`;
4. explicit empty (`hostname: ""` / `repository: ""`) → treated as unset, falls back to `global.image`.

Local run:

```
sidecar-registry-wiring: OK
```

Render spot-check — with `global.sidecars: {hostname: private.nvcr.io, repository: my-org/nvcf-core}`:

```
NVCF_SIDECARS_HOSTNAME: private.nvcr.io
NVCF_SIDECARS_REPOSITORY: my-org/nvcf-core
NVCT_SIDECARS_HOSTNAME: private.nvcr.io
NVCT_SIDECARS_REPOSITORY: my-org/nvcf-core
```

and unset → falls back to the test's `global.image` (`nvcr.io` / `test/nvcf`).

## References

- Resolves #1192
- Follows the `dig … | default` override pattern from #898

## Notes for reviewers

- A single `global.sidecars` block intentionally feeds both NVCF and NVCT, since they share one worker sidecar registry.
- Credential provisioning is unchanged: the sidecar pull secret is supplied as today; only its entitlement needs to cover the chosen registry/org. No NEWT/GRAPES or credential-model change here.

## Related Pull Requests

None

## Dependencies

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable registry and repository settings for worker sidecar images.
  * Sidecars now inherit global image settings by default, with support for full or partial overrides.

* **Bug Fixes**
  * Improved registry and repository value wiring for NVCF and NVCT sidecars.

* **Tests**
  * Added automated coverage for default, overridden, partial, and explicitly empty registry configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->