### PR TITLE
feat(nvca): support per-function BYOO collector resource override

### DIFF
--- a/src/compute-plane-services/nvca/internal/miniservice/translate_workload.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/translate_workload.go
@@ -19,6 +19,7 @@ package mscontroller
 
 import (
 	"fmt"
+	"maps"
 
 	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/common"
 	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function"
@@ -51,7 +52,10 @@ func (r *Reconciler) translateWorkload(
 		InstanceTypeLabelSelectorKey: nodefeatures.UniformInstanceTypeLabelKey,
 		WorkloadResources:            corev1.ResourceRequirements{},
 		Tolerations:                  append([]corev1.Toleration(nil), r.cfg.Workload.Tolerations...),
-		OTelResources:                k8sutil.GetContainerResourcesBYOO(r.cfg),
+		OTelResources: mergeBYOOResources(
+			k8sutil.GetContainerResourcesBYOO(r.cfg),
+			ms.Spec.WorkloadConfig.GetBYOOResources(),
+		),
 		FluentbitResources:           k8sutil.GetContainerResourcesFluentBit(r.cfg),
 		FluentbitEnabled:             r.FeatureFlagFetcher.IsFeatureFlagEnabled(featureflag.BYOOFluentBit),
 		ClusterRegion:                r.ClusterRegion,
@@ -125,6 +129,40 @@ func (r *Reconciler) translateTaskWorkload(
 		return nil, err
 	}
 	return metaToClientObjs(objs), nil
+}
+
+// mergeBYOOResources overlays a per-workload BYOO collector resource override on top of
+// the cluster-level default. Only the resource keys present in the override are replaced,
+// so a function can bump e.g. memory while keeping the default CPU. A nil override returns
+// the base unchanged. As a safety net, any limit that ends up below its request is raised
+// to the request so the resulting container spec stays valid.
+func mergeBYOOResources(
+	base corev1.ResourceRequirements,
+	override *corev1.ResourceRequirements,
+) corev1.ResourceRequirements {
+	if override == nil {
+		return base
+	}
+	out := *base.DeepCopy()
+	ov := *override.DeepCopy()
+	if len(ov.Requests) > 0 {
+		if out.Requests == nil {
+			out.Requests = corev1.ResourceList{}
+		}
+		maps.Copy(out.Requests, ov.Requests)
+	}
+	if len(ov.Limits) > 0 {
+		if out.Limits == nil {
+			out.Limits = corev1.ResourceList{}
+		}
+		maps.Copy(out.Limits, ov.Limits)
+	}
+	for name, req := range out.Requests {
+		if lim, ok := out.Limits[name]; ok && req.Cmp(lim) > 0 {
+			out.Limits[name] = req.DeepCopy()
+		}
+	}
+	return out
 }
 
 func metaToClientObjs(mobjs []metav1.Object) (cobjs []client.Object) {

--- a/src/compute-plane-services/nvca/internal/miniservice/translate_workload_test.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/translate_workload_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	nvcav1alpha1 "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/v1alpha1"
@@ -114,4 +115,45 @@ func TestTranslateWorkloadLLMUsesCanonicalPylonArgs(t *testing.T) {
 	}
 	assert.Equal(t, []string{"--backend-connectivity=reverse"}, backendConnectivityArgs)
 	assert.Equal(t, []string{"--initial-input-tps=100"}, initialInputTPSArgs)
+}
+
+func TestMergeBYOOResources(t *testing.T) {
+	base := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+		},
+	}
+
+	t.Run("nil override returns base unchanged", func(t *testing.T) {
+		got := mergeBYOOResources(base, nil)
+		assert.Equal(t, base, got)
+	})
+
+	t.Run("memory-only override keeps default cpu", func(t *testing.T) {
+		override := &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("4Gi")},
+			Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("4Gi")},
+		}
+		got := mergeBYOOResources(base, override)
+		assert.Equal(t, "1", got.Requests.Cpu().String())
+		assert.Equal(t, "4Gi", got.Requests.Memory().String())
+		assert.Equal(t, "1", got.Limits.Cpu().String())
+		assert.Equal(t, "4Gi", got.Limits.Memory().String())
+		// base must not be mutated
+		assert.Equal(t, "2Gi", base.Limits.Memory().String())
+	})
+
+	t.Run("request above limit clamps limit up", func(t *testing.T) {
+		override := &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("4Gi")},
+		}
+		got := mergeBYOOResources(base, override)
+		assert.Equal(t, "4Gi", got.Requests.Memory().String())
+		assert.Equal(t, "4Gi", got.Limits.Memory().String())
+	})
 }

--- a/src/compute-plane-services/nvca/pkg/apis/nvca/v1alpha1/BUILD.bazel
+++ b/src/compute-plane-services/nvca/pkg/apis/nvca/v1alpha1/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
     deps = [
         "//src/compute-plane-services/nvca/pkg/apis/nvca/internal/compat",
         "//src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/common",
+        "//src/compute-plane-services/nvca/vendor/k8s.io/api/core/v1:core",
         "//src/compute-plane-services/nvca/vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
         "//src/compute-plane-services/nvca/vendor/k8s.io/apimachinery/pkg/runtime",
         "//src/compute-plane-services/nvca/vendor/k8s.io/apimachinery/pkg/runtime/schema",

--- a/src/compute-plane-services/nvca/pkg/apis/nvca/v1alpha1/miniservice_types.go
+++ b/src/compute-plane-services/nvca/pkg/apis/nvca/v1alpha1/miniservice_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 
 import (
 	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/common"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -58,6 +59,14 @@ type WorkloadConfig struct {
 	// FeatureFlags toggles per-workload behaviors, keyed by feature flag name.
 	// +optional
 	FeatureFlags map[string]bool `json:"featureFlags,omitempty"`
+
+	// BYOOResources overrides the BYOO OTel collector sidecar's CPU/memory for this
+	// workload. When set, it takes precedence over the cluster-level default at
+	// translate time (only the resource keys present are overridden). Intended for
+	// large-log / high-throughput functions whose collector needs more headroom than
+	// the cluster default.
+	// +optional
+	BYOOResources *corev1.ResourceRequirements `json:"byooResources,omitempty"`
 }
 
 // IsFeatureFlagEnabled reports whether the named feature flag is enabled.
@@ -66,6 +75,15 @@ func (c *WorkloadConfig) IsFeatureFlagEnabled(key string) bool {
 		return false
 	}
 	return c.FeatureFlags[key]
+}
+
+// GetBYOOResources returns the per-workload BYOO collector resource override, or nil
+// if none is configured. It is nil-safe so callers can use it on a nil WorkloadConfig.
+func (c *WorkloadConfig) GetBYOOResources() *corev1.ResourceRequirements {
+	if c == nil {
+		return nil
+	}
+	return c.BYOOResources
 }
 
 type LocalObjectReference struct {

--- a/src/compute-plane-services/nvca/pkg/apis/nvca/v1alpha1/zz_generated.deepcopy.go
+++ b/src/compute-plane-services/nvca/pkg/apis/nvca/v1alpha1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -211,6 +212,11 @@ func (in *WorkloadConfig) DeepCopyInto(out *WorkloadConfig) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.BYOOResources != nil {
+		in, out := &in.BYOOResources, &out.BYOOResources
+		*out = new(corev1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/src/compute-plane-services/nvca/pkg/featureflag/featureflag_workload.go
+++ b/src/compute-plane-services/nvca/pkg/featureflag/featureflag_workload.go
@@ -19,12 +19,17 @@ package featureflag
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/v1alpha1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 )
+
+// minBYOOMemoryBytes is the floor for a per-workload BYOO collector memory override.
+// A memory override below 1Gi is rejected.
+const minBYOOMemoryBytes = 1 << 30 // 1Gi
 
 const (
 	// WorkloadConfigConfigMapName is the fixed name of the ConfigMap a chart author may include
@@ -54,6 +59,9 @@ var workloadFeatureFlagKeys = map[string]struct{}{
 // DecodeWorkloadConfig decodes the workload config ConfigMap into a WorkloadConfig. The
 // config is read from the WorkloadConfigDataKey data key as a YAML document. Unrecognized
 // feature flags are dropped and logged as a warning. A nil ConfigMap yields a zero config.
+// A malformed or invalid byooResources override is a hard error: rather than silently
+// deploying the collector with resources the chart author did not ask for, decoding fails
+// so the misconfiguration surfaces at deploy time.
 func DecodeWorkloadConfig(ctx context.Context, log logr.Logger, cm *corev1.ConfigMap) (*v1alpha1.WorkloadConfig, error) {
 	if cm == nil {
 		return nil, nil
@@ -75,5 +83,28 @@ func DecodeWorkloadConfig(ctx context.Context, log logr.Logger, cm *corev1.Confi
 			delete(cfg.FeatureFlags, key)
 		}
 	}
+
+	if cfg.BYOOResources != nil {
+		if err := validateBYOOResources(cfg.BYOOResources); err != nil {
+			return nil, fmt.Errorf("invalid byooResources in ConfigMap %q: %w", WorkloadConfigConfigMapName, err)
+		}
+	}
 	return &cfg, nil
+}
+
+// validateBYOOResources rejects a per-workload BYOO collector resource override that
+// would be unsafe: every specified quantity must be positive, and any memory quantity
+// must be at least 1Gi.
+func validateBYOOResources(rr *corev1.ResourceRequirements) error {
+	for kind, list := range map[string]corev1.ResourceList{"requests": rr.Requests, "limits": rr.Limits} {
+		for name, q := range list {
+			if q.Sign() <= 0 {
+				return fmt.Errorf("%s.%s must be positive (got %q)", kind, name, q.String())
+			}
+			if name == corev1.ResourceMemory && q.CmpInt64(minBYOOMemoryBytes) < 0 {
+				return fmt.Errorf("%s.memory must be at least 1Gi (got %q)", kind, q.String())
+			}
+		}
+	}
+	return nil
 }

--- a/src/compute-plane-services/nvca/pkg/featureflag/featureflag_workload_test.go
+++ b/src/compute-plane-services/nvca/pkg/featureflag/featureflag_workload_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/v1alpha1"
 )
@@ -84,6 +85,48 @@ func TestDecodeWorkloadConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "valid byooResources override is kept",
+			cm: workloadConfigCM("byooResources:\n" +
+				"  requests:\n    cpu: \"1\"\n    memory: 4Gi\n" +
+				"  limits:\n    cpu: \"1\"\n    memory: 4Gi\n"),
+			want: &v1alpha1.WorkloadConfig{
+				BYOOResources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				},
+			},
+		},
+		{
+			name: "byooResources below 1Gi memory floor returns error",
+			cm: workloadConfigCM("byooResources:\n" +
+				"  limits:\n    memory: 512Mi\n"),
+			wantErr: true,
+		},
+		{
+			name: "byooResources with non-positive cpu returns error",
+			cm: workloadConfigCM("byooResources:\n" +
+				"  requests:\n    cpu: \"0\"\n    memory: 2Gi\n"),
+			wantErr: true,
+		},
+		{
+			name: "byooResources with malformed cpu returns error",
+			cm: workloadConfigCM("byooResources:\n" +
+				"  requests:\n    cpu: \"abc\"\n    memory: 2Gi\n"),
+			wantErr: true,
+		},
+		{
+			name: "byooResources with malformed memory returns error",
+			cm: workloadConfigCM("byooResources:\n" +
+				"  limits:\n    memory: \"notaquantity\"\n"),
+			wantErr: true,
+		},
+		{
 			name:    "invalid yaml returns error",
 			cm:      workloadConfigCM("featureFlags: [not-a-map"),
 			wantErr: true,
@@ -125,4 +168,77 @@ func TestWorkloadConfigIsFeatureFlagEnabled(t *testing.T) {
 	}
 	assert.True(t, cfg.IsFeatureFlagEnabled(StatusByWorkerReadiness))
 	assert.False(t, cfg.IsFeatureFlagEnabled("SomeOtherFlag"))
+}
+
+func TestWorkloadConfigGetBYOOResources(t *testing.T) {
+	var nilCfg *v1alpha1.WorkloadConfig
+	assert.Nil(t, nilCfg.GetBYOOResources())
+
+	empty := &v1alpha1.WorkloadConfig{}
+	assert.Nil(t, empty.GetBYOOResources())
+
+	rr := &corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("4Gi")},
+	}
+	cfg := &v1alpha1.WorkloadConfig{BYOOResources: rr}
+	assert.Equal(t, rr, cfg.GetBYOOResources())
+}
+
+func TestValidateBYOOResources(t *testing.T) {
+	tests := []struct {
+		name    string
+		rr      *corev1.ResourceRequirements
+		wantErr bool
+	}{
+		{
+			name: "valid requests and limits",
+			rr: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+		},
+		{
+			name: "memory exactly at 1Gi floor is valid",
+			rr: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
+			},
+		},
+		{
+			name: "memory below 1Gi floor is rejected",
+			rr: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero cpu is rejected",
+			rr: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("0")},
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative memory is rejected",
+			rr: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("-1Gi")},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateBYOOResources(tt.rr)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }


### PR DESCRIPTION
## TL;DR
Lets a Helm function size its BYOO OTel collector sidecar above the cluster default via the existing `nvcf-workload-config` ConfigMap. Large-log / high-throughput functions (e.g. Nemotron Ultra) can request more collector memory/CPU without a per-cluster "snowflake" override.

## Additional Details
Reuses the `nvcf-workload-config` ConfigMap channel (the same one that carries per-workload feature flags) rather than introducing a new config surface:

- **Type** (`v1alpha1.WorkloadConfig`): new optional `byooResources *corev1.ResourceRequirements` field, plus a nil-safe `GetBYOOResources()` accessor. Deepcopy updated accordingly.
- **Decode/validate** (`DecodeWorkloadConfig`): an invalid override is validated and, if bad, **dropped with a log warning** so the deploy falls back to the safe cluster default instead of failing. Rules: every specified quantity must be positive, and any memory quantity must be at least **1Gi** (perf testing showed the collector OOMs below ~1Gi under burst). There is no upper bound — 1Gi is only a floor.
- **Translate** (`translateWorkload`): the override is overlaid per resource key onto the cluster default (`OTelResources`), so a function can bump memory while keeping the default CPU. As a safety net, any limit left below its request is raised to the request to keep the pod spec valid.

Precedence: per-function `byooResources` → cluster `nvca.agentConfig.byooResources` → `icms-translate` default (1000m / 2Gi).

No CRD schema regen needed: the MiniService CRD uses `x-kubernetes-preserve-unknown-fields: true`.

## For the Reviewer
- Closely: `internal/miniservice/translate_workload.go` (`mergeBYOOResources` overlay + limit clamp) and `pkg/featureflag/featureflag_workload.go` (drop-with-warning behavior and the 1Gi floor).
- Open question: should we also add a sanity **upper** bound (e.g. reject > 64Gi to catch typos), or leave it floor-only?

## For QA
- `go test ./pkg/featureflag/... ./internal/miniservice/... ./pkg/apis/nvca/v1alpha1/...` (miniservice needs the version ldflag the build injects).
- New tests cover: decode keeps a valid override, drops sub-1Gi memory and non-positive CPU; `validateBYOOResources` boundaries; `GetBYOOResources` nil-safety; `mergeBYOOResources` nil passthrough, per-key overlay (no base mutation), and request>limit clamp.

## Issues
Relates to #345

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-workload CPU and memory overrides for BYOO OTel collectors.
  * Unspecified resource values continue using cluster defaults.
  * Resource limits are automatically raised to meet requested amounts.

* **Bug Fixes**
  * Invalid or malformed overrides now fall back to cluster defaults.
  * Added validation for insufficient memory and non-positive CPU values.
  * Overrides no longer modify shared cluster-level resource settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->