### PR TITLE
fix(self-managed): bump ESS, LLM, and NVCA versions

### DIFF
--- a/deploy/helm/cloud-functions/nvcf-api/values.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/values.yaml
@@ -242,9 +242,9 @@ api:
             go: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/nvcf-worker-utils-oss:1.0.4
           otel-container: dummy
           niclls-container: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/nvcf_worker_niclls:2.109.4
-          ess-agent-container: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/ess-agent:1.3.1
+          ess-agent-container: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/ess-agent:1.4.0
           otel-collector-container: dummy
-          llm-credential-manager-image: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/nvcf-worker-llm-credentials-oss:1.0.4
+          llm-credential-manager-image: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/nvcf-worker-llm-credentials-oss:1.1.1
           llm-router-client-image: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/pylon:0.10.0
         notary:
           turn:

--- a/deploy/helm/cloud-functions/tests/sidecar_release_artifacts_test.sh
+++ b/deploy/helm/cloud-functions/tests/sidecar_release_artifacts_test.sh
@@ -51,8 +51,8 @@ expected_annotations=(
   "release-artifact-init-container-image: \"${hostname}/${repository}/nvcf-worker-init-oss:1.2.0\""
   "release-artifact-utils-container-image-go-image: \"${hostname}/${repository}/nvcf-worker-utils-oss:1.0.4\""
   "release-artifact-niclls-container-image: \"${hostname}/${repository}/nvcf_worker_niclls:2.109.4\""
-  "release-artifact-ess-agent-container-image: \"${hostname}/${repository}/ess-agent:1.3.1\""
-  "release-artifact-llm-credential-manager-image: \"${hostname}/${repository}/nvcf-worker-llm-credentials-oss:1.0.4\""
+  "release-artifact-ess-agent-container-image: \"${hostname}/${repository}/ess-agent:1.4.0\""
+  "release-artifact-llm-credential-manager-image: \"${hostname}/${repository}/nvcf-worker-llm-credentials-oss:1.1.1\""
   "release-artifact-llm-router-client-image: \"${hostname}/${repository}/pylon:0.10.0\""
 )
 

--- a/deploy/stacks/nvcf-compute-plane/environments/base.yaml
+++ b/deploy/stacks/nvcf-compute-plane/environments/base.yaml
@@ -31,9 +31,9 @@ global:
   # NVCA Operator Configuration
   # =============================================================================
   nvcaOperator:
-    imageTag: "3.2.7"
+    imageTag: "3.2.12"
     selfManaged:
-      nvcaVersion: "3.2.7"
+      nvcaVersion: "3.2.12"
       otelCollector:
         # Self-hosted registries do not always mirror this optional image.
         # Enable it only after publishing the collector in global.image.

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/deployment.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/deployment.yaml
@@ -130,7 +130,7 @@ spec:
           - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTU3LjAtbnYtMC4xLjEifQ=="
           - --task-env-overrides-b64
           - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTU3LjAtbnYtMC4xLjEifQ=="
-        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.7
+        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.12
         imagePullPolicy: IfNotPresent
         securityContext:
           # Set here so openbao injection can copy it upon injection
@@ -176,7 +176,7 @@ spec:
             cpu: "1000m"
             memory: "4Gi"
       - name: nvca-mirror
-        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.7
+        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.12
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/pre-delete-cleanup-job.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/pre-delete-cleanup-job.yaml
@@ -52,7 +52,7 @@ spec:
         fsGroup: 1010
       containers:
       - name: cleanup
-        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.7
+        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.12
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/self-managed-nvcfbackend-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/self-managed-nvcfbackend-cm.yaml
@@ -20,7 +20,7 @@ metadata:
   name: nvcfbackend-self-managed
   namespace: nvca-operator
   annotations:
-    release-artifact-nvca-image: "nvcr.io/0651155215864979/ncp-dev/nvca:3.2.7"
+    release-artifact-nvca-image: "nvcr.io/0651155215864979/ncp-dev/nvca:3.2.12"
     release-artifact-nvcf-image-credential-helper-image: "nvcr.io/0651155215864979/ncp-dev/nvcf-image-credential-helper:0.10.2"
     release-artifact-samba-image: "nvcr.io/0651155215864979/ncp-dev/samba:1.0.5"
   labels:
@@ -37,7 +37,7 @@ data:
     clusterDescription: "ncp-local"
     clusterGroupName: "nvcf-default"
     ncaID: "nvcf-default"
-    nvcaVersion: "3.2.7"
+    nvcaVersion: "3.2.12"
     oAuthClientId: ""
     cloudProvider: "NCP"
     region: "us-west-1"

--- a/deploy/stacks/nvcf-compute-plane/tests/observability-profile.sh
+++ b/deploy/stacks/nvcf-compute-plane/tests/observability-profile.sh
@@ -91,7 +91,7 @@ for profile in default disabled control compute all; do
   esac
 done
 
-expected_nvca_version="3.2.7"
+expected_nvca_version="3.2.12"
 test "$(operator_image_tag "$work_dir/default.yaml")" = "$expected_nvca_version" ||
   fail "default operator image tag is not $expected_nvca_version"
 test "$(nvca_version "$work_dir/default.yaml")" = "$expected_nvca_version" ||


### PR DESCRIPTION
## TL;DR

Pin the self-managed release to ESS Agent `1.4.0`, worker LLM credentials `1.1.1`, and NVCA `3.2.12`.

## Why

The API chart still points at ESS Agent `1.3.1` and worker LLM credentials `1.0.4`. Those defaults predate the ESS assertion credential refresh work. The compute-plane stack also still pins the NVCA operator and backend to `3.2.7` even though `3.2.12` is released.

## What changed

- Updated the ESS Agent sidecar default to `1.4.0`.
- Updated the worker LLM credentials sidecar default to `1.1.1`.
- Updated the rendered release-artifact annotation test expectations for both images.
- Preserved the configurable sidecar hostname and repository placeholders.
- Updated the compute-plane NVCA operator and backend defaults to `3.2.12`.
- Updated the focused compute-plane assertion and regenerated the affected golden manifests.

## Customer Release Notes

Updated the self-managed NVCF worker ESS and LLM credential sidecars and the NVCA operator and backend versions.

## Plan Summary

This updates the `helm-nvcf-api` sidecar defaults and the separately deployed `nvcf-compute-plane` NVCA defaults. The compute-plane continues to use `helm-nvca-operator` chart `1.21.3`. This PR does not create a release tag.

## Usage

No configuration changes are required. Existing sidecar registry and repository overrides continue to apply.

## For the Reviewer

Review the sidecar defaults and rendered assertions under `deploy/helm/cloud-functions`, plus the NVCA defaults and generated manifests under `deploy/stacks/nvcf-compute-plane`.

## Testing

- `make test`
- `make lint`
- `make validate` (11 resources valid; 0 invalid, errors, or skipped)
- `make test-observability-profile`
- `make test-local` with the repository-pinned Helm `3.15.4` and Helmfile `1.1.9` (render matches golden)
- `git diff --check`

No additional QA is required for this version-only chart update.

## Notes

The self-managed stack currently consumes the published API chart version. Its chart-version pin can be advanced after this chart patch release is available.

## Issues

Relates to #1133

## References

- #1133

## Related Pull Requests

- #1134

## Dependencies

Updates existing NVCF component image versions only. No new third-party dependency, license review, NOTICE change, or package dependency is introduced. The NVCA release tag `src/compute-plane-services/nvca/v3.2.12` already exists.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated cloud function sidecar components to newer releases, including the ESS Agent and LLM credential manager.
  - Updated the NVCA Operator and self-managed NVCA components to version 3.2.12.
- **Tests**
  - Updated deployment validation checks to reflect the latest component versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->