### PR TITLE
fix(event-ledger): exclude /info from CORS preflight handling

### DIFF
--- a/src/control-plane-services/event-ledger/cmd/api/startup/info_test.go
+++ b/src/control-plane-services/event-ledger/cmd/api/startup/info_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/NVIDIA/nvcf/src/control-plane-services/event-ledger/cmd/api/service"
+	"github.com/NVIDIA/nvcf/src/control-plane-services/event-ledger/internal/middleware"
 )
 
 // TestRegisterUnauthenticatedRoutes_Info verifies GET /info returns the stamped
@@ -87,6 +88,38 @@ func TestRegisterUnauthenticatedRoutes_Info_RejectsNonGET(t *testing.T) {
 		http.MethodPut,
 		http.MethodPatch,
 		http.MethodDelete,
+		http.MethodOptions,
+	} {
+		t.Run(method, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequestWithContext(t.Context(), method, "/info", nil)
+			router.ServeHTTP(w, r)
+
+			assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+			assert.Equal(t, http.MethodGet, w.Header().Get("Allow"))
+			assert.Empty(t, w.Body.String())
+		})
+	}
+}
+
+// TestRegisterUnauthenticatedRoutes_Info_RejectsNonGET_WithCORSMiddleware
+// wires /info through middleware.EnableCORS the same way runService does, to
+// guard against regressions where the CORS preflight short-circuit swallows
+// OPTIONS /info before it reaches the go-lib handler's 405 enforcement
+// (see NVBug 6664046: OPTIONS /info returned 204 instead of 405 in staging
+// because the plain-router test above doesn't apply the production
+// middleware chain).
+func TestRegisterUnauthenticatedRoutes_Info_RejectsNonGET_WithCORSMiddleware(t *testing.T) {
+	router := mux.NewRouter()
+	router.Use(middleware.EnableCORS)
+	registerUnauthenticatedRoutes(router, &service.Server{}, func(h http.Handler) http.Handler { return h })
+
+	for _, method := range []string{
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodPatch,
+		http.MethodDelete,
+		http.MethodOptions,
 	} {
 		t.Run(method, func(t *testing.T) {
 			w := httptest.NewRecorder()

--- a/src/control-plane-services/event-ledger/cmd/api/startup/info_test.go
+++ b/src/control-plane-services/event-ledger/cmd/api/startup/info_test.go
@@ -105,10 +105,9 @@ func TestRegisterUnauthenticatedRoutes_Info_RejectsNonGET(t *testing.T) {
 // TestRegisterUnauthenticatedRoutes_Info_RejectsNonGET_WithCORSMiddleware
 // wires /info through middleware.EnableCORS the same way runService does, to
 // guard against regressions where the CORS preflight short-circuit swallows
-// OPTIONS /info before it reaches the go-lib handler's 405 enforcement
-// (see NVBug 6664046: OPTIONS /info returned 204 instead of 405 in staging
-// because the plain-router test above doesn't apply the production
-// middleware chain).
+// OPTIONS /info before it reaches the go-lib handler's 405 enforcement. The
+// plain-router test above does not apply the production middleware chain, so
+// it cannot catch this class of bug on its own.
 func TestRegisterUnauthenticatedRoutes_Info_RejectsNonGET_WithCORSMiddleware(t *testing.T) {
 	router := mux.NewRouter()
 	router.Use(middleware.EnableCORS)

--- a/src/control-plane-services/event-ledger/internal/middleware/cors.go
+++ b/src/control-plane-services/event-ledger/internal/middleware/cors.go
@@ -21,6 +21,14 @@ import "net/http"
 
 func EnableCORS(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// /info is a build-metadata endpoint, not a browser-facing API. It must
+		// enforce its own GET-only contract (405 for every other method,
+		// including OPTIONS) instead of being short-circuited as a CORS preflight.
+		if r.URL.Path == "/info" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 

--- a/src/control-plane-services/event-ledger/internal/middleware/cors_test.go
+++ b/src/control-plane-services/event-ledger/internal/middleware/cors_test.go
@@ -1,0 +1,64 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestEnableCORS_Preflight verifies OPTIONS requests to ordinary routes are
+// short-circuited with a 204 CORS preflight response.
+func TestEnableCORS_Preflight(t *testing.T) {
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+	})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodOptions, "/v1/ledger/versions/abc/instances/def", nil)
+	EnableCORS(next).ServeHTTP(w, r)
+
+	assert.False(t, nextCalled, "preflight OPTIONS should not reach the wrapped handler")
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.Equal(t, "GET, POST, DELETE, OPTIONS", w.Header().Get("Access-Control-Allow-Methods"))
+}
+
+// TestEnableCORS_InfoBypassesPreflight verifies /info is excluded from CORS
+// preflight handling so its own GET-only contract (405 for every other
+// method, including OPTIONS) is enforced by the wrapped handler.
+func TestEnableCORS_InfoBypassesPreflight(t *testing.T) {
+	for _, method := range []string{http.MethodOptions, http.MethodGet, http.MethodPost} {
+		t.Run(method, func(t *testing.T) {
+			nextCalled := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+			})
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequestWithContext(t.Context(), method, "/info", nil)
+			EnableCORS(next).ServeHTTP(w, r)
+
+			assert.True(t, nextCalled, "/info requests must reach the wrapped handler regardless of method")
+			assert.Empty(t, w.Header().Get("Access-Control-Allow-Methods"))
+		})
+	}
+}


### PR DESCRIPTION
## TL;DR

`OPTIONS /info` on event-ledger returned `204` instead of `405` because the global CORS preflight middleware intercepted every `OPTIONS` request, including `/info`, before it reached the version handler's GET-only enforcement. This scopes the CORS preflight short-circuit to skip `/info`.

## Additional Details

`/info` is a build-metadata endpoint, not browser-facing, so it doesn't need CORS preflight handling. The version handler's GET-only check (`r.Method != http.MethodGet`) already covers `OPTIONS` the same as every other non-GET method. CORS was just intercepting the request before it got there.

All other event-ledger routes keep their existing CORS behavior unchanged.

Added a regression test that wires `EnableCORS` the same way `runService` does. The existing test only exercised a bare router without the production middleware chain, which is why this slipped through.

## Testing

- `go test ./...` (event-ledger module) passes.
- `go build ./...` and `go vet ./...` are clean.
- Manual end-to-end test against a real `httptest.Server` confirms `OPTIONS /info` returns `405` with `Allow: GET`.
- Ran the service locally against the real Cassandra backend in the local k3d cluster:
  - `GET /info` returns `200`
  - `OPTIONS /info` returns `405` with `Allow: GET`
  - `POST /info` still returns `405`
  - `GET /health` is unaffected
  - `OPTIONS` on a real API route (`/v3/ledger/namespace/example/events`) still returns `204` with CORS headers

## References

Relates to #315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected `/info` method handling so unsupported requests return `405` with `Allow: GET` and an empty response body.
  * Ensured CORS processing does not override endpoint-specific validation for `/info`.
  * Preserved standard CORS preflight behavior for other routes.

* **Tests**
  * Added coverage for `/info` requests with CORS enabled, including `OPTIONS`, `GET`, and `POST` scenarios.
  * Added verification that regular routes continue to handle CORS preflight requests correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->