### PR TITLE
fix(icms): pin LLS migration image digest missed by the chart import

### DIFF
--- a/deploy/helm/icms/README.md
+++ b/deploy/helm/icms/README.md
@@ -86,6 +86,11 @@ Important settings to review before deployment:
 
 The default values include development-oriented placeholders. Override them before using the chart in any shared or production environment.
 
+When `sis.lls.hmacRotation.image.digest` is set, the chart renders both LLS
+workloads with `registry/repository@digest`; the digest takes precedence over
+the tag. `icms-api/values.versions.yaml` pins the multi-architecture OCI index
+for the configured migration-image tag.
+
 ## Remote Config RBAC
 
 `spring-cloud-kubernetes` (5.0.2, shipped in icms-service `1.2.x`) calls `listNamespacedConfigMap` without a `fieldSelector=metadata.name` filter and matches the target name in memory. Because the API request is unfiltered, the Role must grant `list`/`watch` on the configmaps collection itself, with no `resourceNames` scoping for those verbs, so the `sis-api` SA can read every ConfigMap in the namespace. Chart assumes none are sensitive; clusters that block broad namespace reads need a policy exception.

--- a/deploy/helm/icms/icms-api/templates/_helpers.tpl
+++ b/deploy/helm/icms/icms-api/templates/_helpers.tpl
@@ -158,6 +158,7 @@ vault.hashicorp.com/agent-inject-template-file-vault-secrets.json: "/vault/confi
 {{/*
 Derive the full image value
 Expects a dictionary with 'image' and 'name' keys
+An optional immutable digest pin takes precedence over tag.
 Usage: {{ include "sis.image.full" (dict "image" .Values.sis.lls.hmacRotation.image "name" "sis.lls.hmacRotation.image") }}
 */}}
 {{- define "sis.image.full" -}}
@@ -165,8 +166,12 @@ Usage: {{ include "sis.image.full" (dict "image" .Values.sis.lls.hmacRotation.im
 {{- $name := .name -}}
 {{- $registry := required (printf "A valid image registry is required for %s.registry" $name) $image.registry -}}
 {{- $repository := required (printf "A valid image repository is required for %s.repository" $name) $image.repository -}}
+{{- if $image.digest -}}
+{{- printf "%s/%s@%s" $registry $repository $image.digest -}}
+{{- else -}}
 {{- $tag := required (printf "A valid image tag is required for %s.tag" $name) $image.tag -}}
 {{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/deploy/helm/icms/icms-api/values.versions.yaml
+++ b/deploy/helm/icms/icms-api/values.versions.yaml
@@ -15,10 +15,10 @@
 
 # Supplemental Helm values override, layered on top of values.yaml.
 #
-# Pins image tags that Renovate auto-bumps. The chart's main values.yaml leaves
-# these tags empty so consumers publishing into their own registry supply the
-# tag themselves; this file carries the tag NVIDIA builds against, so an install
-# that layers it does not have to restate the version.
+# Pins image versions and digests that Renovate auto-bumps. The chart's main
+# values.yaml leaves these fields empty so consumers publishing into their own
+# registry supply them themselves; this file carries the version NVIDIA builds
+# against, so an install that layers it does not have to restate the version.
 #
 # Internal install: pass via an additional --values flag, for example:
 #   helm install icms-api icms-api -f icms-api/values.yaml \
@@ -27,5 +27,7 @@ sis:
   lls:
     hmacRotation:
       image:
+        # Multi-architecture OCI index digest for tag 0.16.3.
         # renovate: datasource=docker depName=nvcr.io/0651155215864979/ncp-dev/nvcf-openbao-migrations
         tag: "0.16.3"
+        digest: "sha256:6bb41be51d62c74b42f4d12af6581d343f6bc7205d02787a1958d994b91a998c"

--- a/deploy/helm/icms/icms-api/values.yaml
+++ b/deploy/helm/icms/icms-api/values.yaml
@@ -45,8 +45,12 @@ sis:
       image:
         # registry: must be supplied in additional values
         # repository: must be supplied in additional values
-        # tag: must be supplied in additional values (see icms-api/values.versions.yaml for the internal pin)
+        # tag or digest: must be supplied in additional values (see
+        # icms-api/values.versions.yaml for the immutable pin NVIDIA builds against)
         tag: ""
+        # Optional immutable manifest digest. When set, this takes precedence
+        # over `tag` while preserving `tag` for release automation and traceability.
+        digest: ""
         pullPolicy: IfNotPresent
       # OpenBao connection settings
       # When empty, baoService is derived from lls.namespace in templates (openbao-server.<namespace>.svc.cluster.local)


### PR DESCRIPTION
## Why

The `icms-api` chart was imported from the upstream `sis-colocated-deploy` chart
repo in #834 (merged 2026-08-17). The import was taken at roughly the upstream
`2.0.0`/`2.0.1` state, so the security fix released as upstream tag `2.0.2`
("fix(security): pin LLS migration image digest and record triage", 2026-08-14)
never landed here. `2.0.2` is still the newest upstream tag, so this is the only
gap of its kind.

The consequence is live: both LLS workloads rendered by this chart (the HMAC
rotation `CronJob` and the LLS migrations hook `Job`) resolve their image
through a mutable tag with `pullPolicy: IfNotPresent`. A registry compromise, a
tag move, or an unsafe operator override could run unreviewed code with OpenBao
access. Upstream closed that by pinning an immutable manifest digest; this repo
never got it.

Note that the `sis.image` helper for the main API container already supports a
digest here. Only `sis.image.full`, the helper used for the LLS workloads, was
left on the tag-only path.

## What changed

Four files, all under `deploy/helm/icms/`:

- `icms-api/templates/_helpers.tpl` - `sis.image.full` now prefers a configured
  digest and renders `registry/repository@digest`, falling back to the existing
  required-tag path when no digest is set. Without this the pin below is inert.
- `icms-api/values.yaml` - documents the optional `digest` field on the
  hmacRotation image and defaults it to `""`, so consumers publishing into their
  own registry keep today's tag-based behavior unchanged.
- `icms-api/values.versions.yaml` - pins the multi-architecture OCI index digest
  for migration image tag `0.16.3`. The tag is deliberately kept alongside the
  digest so Renovate and release automation retain a human-readable version.
- `README.md` - documents the digest-over-tag precedence.

No chart version bump: `Chart.yaml` carries `version: 0.0.0 # set by CI`.

## Deliberately not ported

Upstream `2.0.2` touched seven files. Three have no equivalent here and are out
of scope for this PR rather than being given an invented home:

- `.security-triage.yaml` - upstream's copy is scoped to the chart repo
  (`project: "sis-colocated-deploy"`, `visibility: Internal`). This repo's root
  `.security-triage.yaml` is a different document: `project: "nvcf"`,
  `visibility: Public`, covering the whole monorepo. The upstream entries added
  in `2.0.2` are triage notes citing internal merge requests and internal
  scanner finding IDs, which do not belong in a public repo's security file.
- `SECURITY.md` - upstream's is a chart threat model. This repo's root
  `SECURITY.md` is a vulnerability reporting policy. Different documents; there
  is no threat-model doc here to update.
- `renovate.json` - upstream extended its regex manager to capture
  `currentDigest` so Renovate bumps tag and digest together. Verified this repo
  has no Renovate config at all (no `renovate.json`, `.renovaterc*`, or
  `.github/renovate.json`), so there is nothing to extend. Consequence worth
  flagging: until Renovate is wired up here, the pinned digest will not
  auto-refresh when the tag moves, and will need a manual update.

## Verification

`helm lint` (helm v3.20.1):

```
$ helm lint icms-api
engine.go:214: [INFO] Missing required value: A valid image registry (.Values.sis.image.registry) is required!
engine.go:214: [INFO] Missing required value: A valid image repository (.Values.sis.image.repository) is required!
==> Linting icms-api
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

The chart requires `sis.image.registry`/`repository` and `sis.lls.enabled=true`
before the LLS workloads render, so rendering used this override:

```yaml
sis:
  image:
    registry: nvcr.io
    repository: example/icms-api
  lls:
    enabled: true
    hmacRotation:
      image:
        registry: nvcr.io
        repository: 0651155215864979/ncp-dev/nvcf-openbao-migrations
```

Digest lands in both LLS workloads:

```
$ helm template icms-api icms-api -f icms-api/values.yaml \
    -f icms-api/values.versions.yaml -f override.yaml \
    | grep -E '^kind:|nvcf-openbao-migrations'
...
kind: CronJob
              image: "nvcr.io/0651155215864979/ncp-dev/nvcf-openbao-migrations@sha256:6bb41be51d62c74b42f4d12af6581d343f6bc7205d02787a1958d994b91a998c"
kind: Job
          image: "nvcr.io/0651155215864979/ncp-dev/nvcf-openbao-migrations@sha256:6bb41be51d62c74b42f4d12af6581d343f6bc7205d02787a1958d994b91a998c"
```

Tag fallback is unchanged when no digest is set (no break for consumers using
their own registry):

```
$ helm template ... --set sis.lls.hmacRotation.image.tag=0.16.3   # no versions file
              image: "nvcr.io/0651155215864979/ncp-dev/nvcf-openbao-migrations:0.16.3"
          image: "nvcr.io/0651155215864979/ncp-dev/nvcf-openbao-migrations:0.16.3"
```

Digest wins when both are set:

```
$ helm template ... -f icms-api/values.versions.yaml --set sis.lls.hmacRotation.image.tag=9.9.9
              image: "nvcr.io/0651155215864979/ncp-dev/nvcf-openbao-migrations@sha256:6bb41be51d62c74b42f4d12af6581d343f6bc7205d02787a1958d994b91a998c"
```

Neither set still fails loudly rather than rendering a bare image name:

```
Error: execution error at (helm-nvcf-sis/templates/hook-lls-migrations.yaml:45:21):
A valid image tag is required for sis.lls.hmacRotation.image.tag
```

Digest string is now present in the repo, where it previously appeared nowhere:

```
$ grep -rn 6bb41be51d62c74b42f4d12af6581d343f6bc7205d02787a1958d994b91a998c .
deploy/helm/icms/icms-api/values.versions.yaml:33:        digest: "sha256:6bb41be51d62c74b42f4d12af6581d343f6bc7205d02787a1958d994b91a998c"
```

## Testing

Helm lint and template only. Chart-values change with no unit-testable code
path; the render assertions above cover digest precedence, tag fallback, and the
missing-both error case.

## References

Follows up #834.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring immutable image digests for LLS migration and HMAC rotation images.
  - Configured digests take precedence over image tags when both are provided.
  - Added support for pinned multi-architecture OCI image references.

- **Documentation**
  - Updated Helm configuration guidance for image tags, digests, and immutable version pinning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->