### PR TITLE
docs(cli): document stack paths for source builds

### DIFF
--- a/docs/dev/local-development.md
+++ b/docs/dev/local-development.md
@@ -5,7 +5,7 @@ Run a full NVCF self-hosted stack on your laptop using
 local-k3d tooling lives at `tools/ncp-local-cluster/` in this repo.
 
 <Info>
-This setup is for **local development only**. It uses fake GPUs, a single
+This setup is only for local development. It uses fake GPUs, a single
 Cassandra replica, and ephemeral storage. Do not use this for production
 workloads.
 </Info>
@@ -32,17 +32,17 @@ Four canonical flows are covered below: pick a topology from
 
 ## Topologies
 
-**Single-cluster** brings up one k3d cluster named `ncp-local`. Control
+Single-cluster topology: This brings up one k3d cluster named `ncp-local`. Control
 plane and compute plane share the cluster. The fastest path for
 function-lifecycle testing and basic install validation.
 
-**Multi-cluster** brings up `ncp-local-cp` plus `ncp-local-compute-N`
+Multi-cluster topology: This brings up `ncp-local-cp` plus `ncp-local-compute-N`
 (N=1 by default). Control plane lives on the cp cluster; compute plane on
 the compute cluster. Required when you need to exercise cross-cluster
 registration, the OIDC/JWKS discovery flow, or the `.test` hostname
 routing the cp Gateway exposes to compute workers.
 
-The two topologies are **mutually exclusive**: both claim host ports
+The two topologies cannot run at the same time. Both claim host ports
 8080/8443/4222. Destroy one before bringing up the other:
 
 ```bash
@@ -55,14 +55,21 @@ make -C tools/ncp-local-cluster destroy-multicluster
 
 ## Install paths
 
-**CLI** drives the install through `nvcf-cli self-hosted install
+CLI path: The CLI drives the install through `nvcf-cli self-hosted install
 --control-plane` (writes a control-plane profile YAML), `nvcf-cli init`
 (mints the admin JWT against the live api-keys service), and
-`nvcf-cli compute-plane register/install` (writes compute-plane values
-and applies them). The CLI manages URL block selection (in-cluster vs
-cross-cluster reachable) based on the kube contexts you pass.
+`nvcf-cli self-hosted compute-plane register` (writes compute-plane values),
+followed by `nvcf-cli self-hosted compute-plane install` (applies them). The
+CLI manages URL block selection (in-cluster vs cross-cluster reachable) based
+on the kube contexts you pass.
 
-**Helmfile** drives the install through split Make targets:
+Repository-built CLI binaries do not contain the stack OCI defaults injected
+into packaged releases. Pass
+`--control-plane-stack deploy/stacks/self-managed` and
+`--compute-plane-stack deploy/stacks/nvcf-compute-plane` in the CLI path. Use
+both directories from the same checkout.
+
+Helmfile path: Helmfile drives the install through split Make targets:
 `deploy/stacks/self-managed/Makefile` for control plane (`make template`,
 `make install`) and `deploy/stacks/nvcf-compute-plane/Makefile` for
 compute plane (`make register-cluster`, `make install`). The operator authors
@@ -82,7 +89,7 @@ the rationale.
 - `helmfile` >= 1.1.0, < 1.2.0 (Helmfile flows only)
 - `helm-diff` plugin (Helmfile flows only):
   `helm plugin install https://github.com/databus23/helm-diff`
-- An **NGC API key** with access to the NVCF chart and image registry.
+- An NGC API key with access to the NVCF chart and image registry.
 - `nvcf-cli` built from this repo:
 
   ```bash

--- a/docs/dev/local-development.md
+++ b/docs/dev/local-development.md
@@ -55,19 +55,41 @@ make -C tools/ncp-local-cluster destroy-multicluster
 
 ## Install paths
 
-CLI path: The CLI drives the install through `nvcf-cli self-hosted install
---control-plane` (writes a control-plane profile YAML), `nvcf-cli init`
-(mints the admin JWT against the live api-keys service), and
-`nvcf-cli self-hosted compute-plane register` (writes compute-plane values),
-followed by `nvcf-cli self-hosted compute-plane install` (applies them). The
-CLI manages URL block selection (in-cluster vs cross-cluster reachable) based
-on the kube contexts you pass.
+CLI path: The profile-and-values workflow installs the control plane, writes a
+control-plane profile, registers the compute plane, and installs the generated
+compute-plane values. For a repository-built CLI, run these commands from the
+repository root:
+
+```bash
+nvcf-cli self-hosted \
+  --control-plane-stack deploy/stacks/self-managed \
+  install --control-plane
+
+nvcf-cli init
+
+nvcf-cli self-hosted \
+  --compute-plane-stack deploy/stacks/nvcf-compute-plane \
+  compute-plane register \
+  --control-plane-profile deploy/stacks/self-managed/out/control-plane-profile.yaml \
+  --cluster-name <cluster-name> \
+  --kube-context <compute-plane-context>
+
+nvcf-cli self-hosted \
+  --compute-plane-stack deploy/stacks/nvcf-compute-plane \
+  compute-plane install \
+  --values deploy/stacks/nvcf-compute-plane/out/<cluster-name>-register-values.yaml \
+  --kube-context <compute-plane-context>
+```
+
+The alternative `self-hosted install --compute-plane` command registers the
+cluster itself before applying the compute-plane manifests. Do not run
+`cluster register` before that combined command. Use one compute-plane workflow
+or the other.
 
 Repository-built CLI binaries do not contain the stack OCI defaults injected
-into packaged releases. Pass
-`--control-plane-stack deploy/stacks/self-managed` and
-`--compute-plane-stack deploy/stacks/nvcf-compute-plane` in the CLI path. Use
-both directories from the same checkout.
+into packaged releases. The commands above pass the required stack explicitly.
+Use both stack directories from the same checkout. The CLI selects in-cluster
+or cross-cluster URLs from the kube contexts you pass.
 
 Helmfile path: Helmfile drives the install through split Make targets:
 `deploy/stacks/self-managed/Makefile` for control plane (`make template`,

--- a/docs/user/cli.md
+++ b/docs/user/cli.md
@@ -473,15 +473,30 @@ Use these commands to install and inspect self-hosted NVCF deployments. For the 
 | `self-hosted up --cluster-name <cluster-name> --nca-id <nca-id> --region <region>` | Run the local k3d fresh-install flow. |
 | `self-hosted status` | Show a deployment health summary. |
 | `self-hosted install --control-plane` | Run the control-plane installation primitive. |
-| `self-hosted install --compute-plane --cluster-name <cluster-name>` | Run the compute-plane installation primitive for a registered GPU cluster. |
+| `self-hosted install --compute-plane --cluster-name <cluster-name>` | Register a GPU cluster and install its compute-plane manifests in one command. |
+| `self-hosted compute-plane register` | Register a GPU cluster from a control-plane profile and write compute-plane values. |
+| `self-hosted compute-plane install --values <path>` | Install compute-plane manifests from values written by `compute-plane register`. |
 | `self-hosted uninstall --compute-plane --cluster-name <cluster-name>` | Remove compute-plane components for the GPU cluster. |
 | `self-hosted uninstall --control-plane` | Remove control-plane components. |
+
+Choose one compute-plane workflow:
+
+1. Run `self-hosted compute-plane register`, then run
+   `self-hosted compute-plane install` with the generated values file. This is
+   the profile-and-values workflow.
+2. Run `self-hosted install --compute-plane` to register the cluster and apply
+   the compute-plane manifests in one command.
+
+Do not run `cluster register` before `self-hosted install --compute-plane`. The
+combined install command performs registration itself.
 
 Bundle sources:
 
 - `--control-plane-stack` selects the control-plane stack bundle.
 - `--compute-plane-stack` selects the compute-plane stack bundle.
 - Both flags accept local paths, git URLs, and `oci://` references.
+- The control-plane and compute-plane sources must come from the same checkout
+  or release. Do not combine stack revisions.
 - Packaged binaries can include immutable OCI defaults injected by the release
   build. Repository builds require explicit stack flags.
 

--- a/docs/user/cli.md
+++ b/docs/user/cli.md
@@ -53,6 +53,21 @@ remote cache for this build:
 bazel build --remote_cache= //src/clis/nvcf-cli:nvcf-cli
 ```
 
+Repository builds do not embed the stack OCI defaults supplied to packaged CLI
+releases. Pass the matching stack paths when you run self-hosted commands from
+a source checkout:
+
+```bash
+nvcf-cli self-hosted \
+  --control-plane-stack deploy/stacks/self-managed \
+  --compute-plane-stack deploy/stacks/nvcf-compute-plane \
+  <subcommand>
+```
+
+Use both stacks from the same checkout. A command only needs the stack it
+operates on, but keeping both flags in a multi-plane workflow makes the source
+selection explicit.
+
 ### Download from NGC
 
 The CLI is available as a resource from NGC. See
@@ -462,11 +477,13 @@ Use these commands to install and inspect self-hosted NVCF deployments. For the 
 | `self-hosted uninstall --compute-plane --cluster-name <cluster-name>` | Remove compute-plane components for the GPU cluster. |
 | `self-hosted uninstall --control-plane` | Remove control-plane components. |
 
-Bundle source overrides:
+Bundle sources:
 
 - `--control-plane-stack` selects the control-plane stack bundle.
 - `--compute-plane-stack` selects the compute-plane stack bundle.
 - Both flags accept local paths, git URLs, and `oci://` references.
+- Packaged binaries can include immutable OCI defaults injected by the release
+  build. Repository builds require explicit stack flags.
 
 `self-hosted up` supports only a single local k3d cluster. It requires
 `--env local`, a current `k3d-*` kube context, and no split-context flags. For


### PR DESCRIPTION
## TL;DR

Document the explicit control-plane and compute-plane stack paths required by
repository-built `nvcf-cli` binaries. Packaged releases can carry injected OCI
defaults, but source builds intentionally do not.

## Additional Details

The source-build instructions previously led directly into self-hosted command
examples without explaining this build-time difference. The developer overview
also used the incomplete `nvcf-cli compute-plane` command prefix.

This change:

- shows both matching repository stack paths after the source-build steps;
- explains when packaged and source-built binaries differ;
- clarifies that each command only needs the stack it operates on; and
- corrects the profile-driven command prefix to
  `nvcf-cli self-hosted compute-plane`.

No CLI behavior, release default, chart source, or version pin changes.

## For the Reviewer

Please review the source-build note in `docs/user/cli.md` and the install-path
summary in `docs/dev/local-development.md` for consistency with the existing
single-cluster and multi-cluster CLI guides.

## For QA

QA is not needed for this documentation-only change.

Validation:

- `git diff --check`
- `npm_config_cache=<isolated-cache> ./tools/ci/check-docs`
  - Fern reported zero errors and one existing warning.
  - The version-sync check remained advisory because `imports.yaml` is absent
    from the public checkout.

## Issues

Closes #1202

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the local development setup is intended only for local use, including topology and port-conflict behavior.
  * Expanded CLI installation guidance with explicit control-plane and compute-plane stack paths.
  * Documented separate registration and installation workflows, combined installation options, and registration-order requirements.
  * Clarified that source-built CLI commands require matching stack sources from the same checkout or release.
  * Simplified NGC API key prerequisite instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->