### PR TITLE
test(bdd): guard multi-cluster NVCF gRPC mode

### DIFF
--- a/tests/bdd/fixtures_test.go
+++ b/tests/bdd/fixtures_test.go
@@ -216,6 +216,32 @@ func TestSelfManagedLocalBDDMultiFixtureWiresComputeReachableWorkerEndpoints(t *
 	}
 }
 
+func TestSelfManagedLocalBDDMultiFixtureUsesPlaintextNVCFGRPC(t *testing.T) {
+	const fixturePath = "fixtures/self-managed-local-bdd-multi.yaml"
+
+	fixtureBytes, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("read multi-cluster stack fixture: %v", err)
+	}
+	var fixture struct {
+		Addons struct {
+			LLM struct {
+				Gateway struct {
+					Auth struct {
+						GRPCInsecure bool `yaml:"grpcInsecure"`
+					} `yaml:"auth"`
+				} `yaml:"gateway"`
+			} `yaml:"llm"`
+		} `yaml:"addons"`
+	}
+	if err := yaml.Unmarshal(fixtureBytes, &fixture); err != nil {
+		t.Fatalf("parse multi-cluster stack fixture: %v", err)
+	}
+	if !fixture.Addons.LLM.Gateway.Auth.GRPCInsecure {
+		t.Fatal("multi-cluster stack fixture must use plaintext NVCF API gRPC")
+	}
+}
+
 func TestNVCTTaskSmokeUsesTaskSimpleSample(t *testing.T) {
 	for _, path := range []string{
 		"../../examples/task-samples/task-simple-sample/Dockerfile",


### PR DESCRIPTION
## Why

The local multi-cluster BDD fixture must enable plaintext gRPC for the NVCF API connection because the current NVCF API gRPC listener is plaintext. The fixture already carries this local-only setting, but retained environment drift showed that there was no focused test preventing it from being removed silently.

Relates to #1207.
Parent epic: #19.

## What changed

- Add a structural fixture test asserting `addons.llm.gateway.auth.grpcInsecure: true` in the local multi-cluster fixture.
- Leave stack defaults, deployed resources, worker transport, and QUIC PKI unchanged.

## Customer release notes

Not customer visible. Test coverage only.

## Plan summary

No resource or configuration changes. This guards existing local BDD fixture behavior while #1207 tracks server-side TLS support.

## Usage

Not applicable.

## Testing

- Mutation proof: removing the fixture key caused the new focused test to fail.
- `cd tests/bdd && go test -run TestSelfManagedLocalBDDMultiFixtureUsesPlaintextNVCFGRPC -count=1`
- `cd tests/bdd && go test -short ./...`
- The full short suite also passed in an isolated VM worktree.
- `tests/bdd/scripts/lint.sh` was attempted. The VM does not have `golangci-lint`; the local v2.11.4 binary fails during context loading before analysis because it is incompatible with the repository configuration.

## Related PRs

None.

## Dependencies

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that self-managed multi-cluster setups use plaintext gRPC communication for the NVCF API.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->