### PR TITLE
docs(ci): document the deploy-to-stg pull request label

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,9 @@ Commit with a DCO sign-off and a conventional commit message (see [Commit Messag
 - Push your branch and open a PR targeting `main`.
 - Use the [PR template](.github/PULL_REQUEST_TEMPLATE.md) when opening your pull request.
 - Reference the related issue in the PR description with `Fixes #123`.
+- To get a dev image built from your PR, label it `deploy-to-stg`. See
+  [the deploy-to-stg label](docs/dev/deploy-to-stg-label.md). This works only
+  for branches in this repository, not for fork PRs.
 - Someone will review your PR soon!
 
 ---

--- a/docs/dev/deploy-to-stg-label.md
+++ b/docs/dev/deploy-to-stg-label.md
@@ -1,0 +1,116 @@
+# The deploy-to-stg pull request label
+
+Add the `deploy-to-stg` label to a pull request and CI builds that PR's service
+image and pushes it to the internal NGC dev (ncp-dev) registry, so you can pull
+it into a cluster before the PR merges.
+
+Source of truth:
+[`.github/workflows/image-push-manual.yml`](../../.github/workflows/image-push-manual.yml).
+
+## How to use it
+
+1. Add the `deploy-to-stg` label to your PR. That builds and pushes once.
+2. Every later push to the PR rebuilds and pushes again.
+3. Remove the label to stop further builds.
+
+Reopening a PR that still carries the label also builds. Adding an unrelated
+label to a PR that already carries `deploy-to-stg` does not.
+
+Pull requests from forks are skipped. The workflow uses `pull_request`, not
+`pull_request_target`, so untrusted code never runs with the registry
+credentials, and the fork check runs in the first job.
+
+## Which service gets built
+
+A PR event carries no service name, so the workflow derives one. It diffs the
+PR's own changes against the merge base, takes the `src/<plane>/<service>`
+prefix of every changed file, and builds only when:
+
+- exactly one such subtree changed, and
+- that subtree has a `BUILD.bazel`.
+
+Anything else is skipped with a notice on the `resolve subtree` job. It does
+not fail the PR.
+
+If your PR touches more than one service, or you want to push from a ref
+without labeling a PR, run the workflow manually: Actions, `image-push
+(manual)`, Run workflow, and pass `service_path`, for example
+`src/invocation-plane-services/grpc-proxy`.
+
+## Where the image lands
+
+The registry base is the `NCP_DEV_REGISTRY` repository secret. The repository
+name under it comes from the Bazel `oci_image_index` target name:
+
+| Target name | Pushed repository |
+|---|---|
+| `image` | `<service>` |
+| `<component>_image` | `<service>-<component>`, underscores become hyphens |
+| `<name>-image` | `<name>`, used as is |
+
+Every `oci_image_index` target under the subtree is pushed, so a subtree with
+several images publishes several repositories.
+
+Each push gets two tags: `gh.<run-number>-<first 8 characters of the run's
+commit SHA>`, and `latest-dispatch`. Tags are always machine-derived; there is
+no way to pass one in. Images are multi-arch, linux/amd64 and linux/arm64.
+
+The exact destination is printed in the `push to ncp-dev` job log, on lines of
+the form `[push] <target> -> <repository>:<tag>`. The workflow does not post
+the image reference back to the PR.
+
+## What the workflow needs
+
+Permissions: `contents: read` and `packages: read`. The `packages` scope is
+what lets the job pull the private `ghcr.io/nvidia/nvcf/bazel-ci` container it
+runs in.
+
+Repository secrets:
+
+- `NGC_NCP_DEV_KEY`: NGC key with push access to the dev registry.
+- `NCP_DEV_REGISTRY`: registry base, host, tenant, and repository prefix.
+- `BAZEL_REMOTE_CACHE_TOKEN`: optional. Without it the build falls back to the
+  local disk cache and is slower.
+
+Repository variables: `BAZEL_CI_IMAGE`, `BAZEL_REMOTE_CACHE_ENDPOINT`,
+`BAZEL_REMOTE_CACHE_CA`.
+
+These runs only read the shared Bazel cache.
+[`tools/ci/bazel-cache-upload-mode`](../../tools/ci/bazel-cache-upload-mode)
+grants write access only to `merge_group` and pushes to `main`, so a PR build
+can never write to it.
+
+## When it does not work
+
+Nothing ran, or every job is skipped. Check the condition on `resolve subtree`.
+It skips when the PR is from a fork, when the label is not on the PR, or when
+the event was a `labeled` event for some other label.
+
+It ran but pushed nothing. Read the notice on `resolve subtree`. There are
+three:
+
+- no `src/<plane>/<service>` file changed,
+- the single subtree that changed has no `BUILD.bazel`,
+- more than one subtree changed, so pick one with `workflow_dispatch`.
+
+The push job failed:
+
+- `ERROR: set secrets NGC_NCP_DEV_KEY and NCP_DEV_REGISTRY`: repository
+  configuration, not your PR.
+- `ERROR: no such subtree`: bad `service_path` on a manual run. The error lists
+  the subtrees that own a Bazel module.
+- `ERROR: no oci_image_index targets under <path>`: the subtree has no image
+  target such as `go_oci_image` or `java_oci_image`.
+- `ERROR: bazel query failed`: a BUILD or package loading error in the subtree.
+  Reproduce it locally.
+
+A run that vanished mid-build was most likely superseded. PR runs are grouped
+by ref with `cancel-in-progress`, so a newer push cancels the older run. Manual
+runs are grouped by `service_path` and are not cancelled.
+
+## Charts
+
+There is no label for charts.
+[`.github/workflows/chart-push-manual.yml`](../../.github/workflows/chart-push-manual.yml)
+packages a chart from `deploy/helm/` and pushes it to the same dev registry. It
+is `workflow_dispatch` only.


### PR DESCRIPTION
## TL;DR

CI automation is moving fast and developers do not know how the `deploy-to-stg`
label works. This adds a short developer page for it, readable in under a
minute: what the label does, how to use it, where the image lands, and what to
check when it does not work.

## Additional Details

Everything in the page is taken from
`.github/workflows/image-push-manual.yml`, read end to end. Nothing is
described that is not in that file.

What the page covers:

- Trigger and lifecycle: `pull_request` on `labeled`, `synchronize`,
  `reopened`, plus `workflow_dispatch` with a `service_path` input. Label to
  start, every later push rebuilds, remove the label to stop.
- The two safety properties, because they are the ones people trip over:
  fork PRs are filtered in the `resolve` job, and the workflow uses
  `pull_request` rather than `pull_request_target` so untrusted code never runs
  with the registry credentials. Also the `labeled` guard, so an unrelated
  label on an already-labeled PR does not rebuild.
- Service resolution: three-dot diff against the merge base, one
  `src/<plane>/<service>` subtree, must have a `BUILD.bazel`. The three skip
  notices and what to do about each.
- Destination: the `NCP_DEV_REGISTRY` base plus a repository name derived from
  the `oci_image_index` target name, tagged
  `gh.<run-number>-<8-char SHA>` and `latest-dispatch`, multi-arch. Where to
  read the resolved destination in the job log.
- Configuration it depends on: `contents: read` and `packages: read`, the
  `NGC_NCP_DEV_KEY` and `NCP_DEV_REGISTRY` secrets, the optional remote-cache
  token, and the fact that these runs can only read the shared Bazel cache
  because `tools/ci/bazel-cache-upload-mode` grants writes to `merge_group` and
  `main` only. No secret values appear.
- Failure triage keyed to the literal error strings the workflow emits, plus
  the concurrency behaviour, which explains runs that disappear mid-build.
- One paragraph on the chart equivalent, `chart-push-manual.yml`, with a link.
  It is `workflow_dispatch` only, with no label. Not documented in depth.

### Placement

`docs/dev/deploy-to-stg-label.md`. `docs/AGENTS.md` and the documentation table
in `CONTRIBUTING.md` both define `docs/dev/` as the contributor and developer
workflow tree, published only if symlinked into a versioned tree. That matches
this page: it is for people working in the repo, not for customers, and it
sits next to `github-release-process.md`, `release-process.md`, and
`oss-dependency-scanning.md`.

There is no index or table of contents for `docs/dev/`, and its pages are not
in `fern/versions/dev.yml` (only `architecture.md` and `release-process.md`
are), so no Fern navigation change is needed and none was made. The one place a
developer would actually look is the pull request step in `CONTRIBUTING.md`, so
that step now carries a single bullet linking the page, with the note that the
label does not work for fork PRs.

### Not documented

`image-push-manual.yml` still opens with the comment
"Manual (workflow_dispatch) only; no image is pushed automatically", which the
`pull_request` trigger below it has since made stale. The page documents the
actual behaviour. Left the comment alone to keep this PR documentation-only;
worth a one-line follow-up.

## For the Reviewer

The page was re-read against the workflow line by line before pushing. Please
check the destination-repository table and the tag format in particular, since
those are the two things a developer will copy.

## For QA

Not applicable, documentation only. Verified ASCII-only, no bold, no emoji, no
em-dash, and that every linked path exists. `tools/ci/check-docs` could not run
to completion locally: `fern check` crashes with
`ReferenceError: crypto is not defined` on the local Node 18, which is
unrelated to this change and does not touch Fern navigation.

## Issues

NO-REF

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for obtaining development images through the `deploy-to-stg` pull request label.
  - Documented label behavior, supported branch types, manual triggering, image naming, permissions, caching, cancellations, and failure handling.
  - Clarified that fork-based pull requests are not supported for this workflow.
  - Added details about the separate chart-publishing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->