### PR TITLE
fix(storage): [backport v3.2] label model-cache init namespace for nvcf-unbound DNS injection

### DIFF
--- a/src/compute-plane-services/nvca/pkg/storage/cachebackend_samba.go
+++ b/src/compute-plane-services/nvca/pkg/storage/cachebackend_samba.go
@@ -154,8 +154,20 @@ func EnsureSambaModelCacheInfra(
 	}
 
 	rwSecret, roSecret := newSambaModelCacheSecrets()
+
+	// Ensure the namespace first and patch required labels onto it if it already
+	// exists. ensureCreated treats AlreadyExists as success without updating, so
+	// pre-existing namespaces (e.g. from a previous NVCA version that did not
+	// set WorkloadInstanceTypeLabel) must be patched explicitly.
+	ns := NewModelCacheInitNamespace()
+	if err := ensureCreated(ctx, c, ns); err != nil {
+		return false, fmt.Errorf("ensure samba model cache %T: %w", ns, err)
+	}
+	if err := ensureNamespaceLabels(ctx, c, ns); err != nil {
+		return false, fmt.Errorf("patch samba model cache %T labels: %w", ns, err)
+	}
+
 	objs := []client.Object{
-		NewModelCacheInitNamespace(),
 		rwSecret,
 		roSecret,
 		newSambaModelCacheDataPVC(cacheHandle, size),
@@ -188,6 +200,40 @@ func ensureCreated(ctx context.Context, c client.Client, obj client.Object) erro
 		return err
 	}
 	return nil
+}
+
+// ensureNamespaceLabels patches the labels from want onto the live namespace.
+// It is a no-op when all required labels are already present with the correct
+// values, so it is safe to call on every reconcile. NotFound is treated as a
+// no-op: the namespace was just created by ensureCreated with the correct
+// labels and does not need patching.
+func ensureNamespaceLabels(ctx context.Context, c client.Client, want *corev1.Namespace) error {
+	live := &corev1.Namespace{}
+	if err := c.Get(ctx, client.ObjectKey{Name: want.Name}, live); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	// Check whether all required labels are already present with correct values.
+	allPresent := true
+	for k, v := range want.Labels {
+		if live.Labels[k] != v {
+			allPresent = false
+			break
+		}
+	}
+	if allPresent {
+		return nil
+	}
+	patched := live.DeepCopy()
+	if patched.Labels == nil {
+		patched.Labels = make(map[string]string, len(want.Labels))
+	}
+	for k, v := range want.Labels {
+		patched.Labels[k] = v
+	}
+	return c.Patch(ctx, patched, client.MergeFrom(live))
 }
 
 // sambaModelCacheSelector is the unique pod selector for a handle's Samba server.

--- a/src/compute-plane-services/nvca/pkg/storage/cachebackend_samba_test.go
+++ b/src/compute-plane-services/nvca/pkg/storage/cachebackend_samba_test.go
@@ -290,7 +290,7 @@ func TestSambaModelCacheResourceName_LongHandleBounded(t *testing.T) {
 
 // TestEnsureNamespaceLabels_PatchesExistingNamespace verifies that
 // ensureNamespaceLabels adds missing labels to a namespace that already exists
-// without the required keys — the scenario that arises on clusters upgraded
+// without the required keys; the scenario that arises on clusters upgraded
 // from an NVCA version that did not set WorkloadInstanceTypeLabel.
 func TestEnsureNamespaceLabels_PatchesExistingNamespace(t *testing.T) {
 	ctx := context.Background()

--- a/src/compute-plane-services/nvca/pkg/storage/cachebackend_samba_test.go
+++ b/src/compute-plane-services/nvca/pkg/storage/cachebackend_samba_test.go
@@ -287,3 +287,56 @@ func TestSambaModelCacheResourceName_LongHandleBounded(t *testing.T) {
 	// Stable: same input yields same name.
 	assert.Equal(t, name, sambaModelCacheResourceName(long))
 }
+
+// TestEnsureNamespaceLabels_PatchesExistingNamespace verifies that
+// ensureNamespaceLabels adds missing labels to a namespace that already exists
+// without the required keys — the scenario that arises on clusters upgraded
+// from an NVCA version that did not set WorkloadInstanceTypeLabel.
+func TestEnsureNamespaceLabels_PatchesExistingNamespace(t *testing.T) {
+	ctx := context.Background()
+
+	// Existing namespace has only the managed-by label, no workload-instance-type.
+	existing := &corev1.Namespace{}
+	existing.Name = ModelCacheInitNamespace
+	existing.Labels = map[string]string{"app.kubernetes.io/managed-by": "nvca"}
+
+	c := sambaInfraClient(t, existing)
+
+	want := NewModelCacheInitNamespace()
+	require.NoError(t, ensureNamespaceLabels(ctx, c, want))
+
+	got := &corev1.Namespace{}
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: ModelCacheInitNamespace}, got))
+	for k, v := range want.Labels {
+		assert.Equal(t, v, got.Labels[k], "label %s must be patched onto existing namespace", k)
+	}
+	// Pre-existing labels must not be removed.
+	assert.Equal(t, "nvca", got.Labels["app.kubernetes.io/managed-by"])
+}
+
+// TestEnsureNamespaceLabels_NoopWhenLabelsPresent verifies that
+// ensureNamespaceLabels is a no-op (no patch call) when all required labels
+// are already present with the correct values.
+func TestEnsureNamespaceLabels_NoopWhenLabelsPresent(t *testing.T) {
+	ctx := context.Background()
+
+	want := NewModelCacheInitNamespace()
+	existing := want.DeepCopy()
+
+	patchCount := 0
+	sch := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(sch))
+	c := fake.NewClientBuilder().
+		WithScheme(sch).
+		WithObjects(existing).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+				patchCount++
+				return nil
+			},
+		}).
+		Build()
+
+	require.NoError(t, ensureNamespaceLabels(ctx, c, want))
+	assert.Equal(t, 0, patchCount, "Patch must not be called when all labels are already correct")
+}

--- a/src/compute-plane-services/nvca/pkg/storage/controller_modelcache.go
+++ b/src/compute-plane-services/nvca/pkg/storage/controller_modelcache.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	nvcav1new "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/v1"
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/types"
 )
 
 func NewModelCacheInitNamespace() *corev1.Namespace {
@@ -46,6 +47,14 @@ func NewModelCacheInitNamespace() *corev1.Namespace {
 	namespace.Name = ModelCacheInitNamespace
 	namespace.Labels = map[string]string{
 		"app.kubernetes.io/managed-by": "nvca",
+		// The nvcf-unbound Kyverno ClusterPolicy (add-unbound-dns) matches on
+		// this label to inject the cluster's nvcf-unbound nameserver into pods.
+		// Without it the model-cache writer job falls back to the kube-dns
+		// ClusterIP, which is unreachable on clusters where node-local-dns
+		// serves it from the host network (e.g. node-local-dns DaemonSet with
+		// hostNetwork=true binding the kube-dns VIP), causing DNS timeouts and
+		// a ~7m45s backoff before the deploy continues without a cache.
+		types.WorkloadInstanceTypeLabel: types.WorkloadInstanceTypeValueMiniService,
 	}
 	return namespace
 }

--- a/src/compute-plane-services/nvca/pkg/storage/controller_modelcache_test.go
+++ b/src/compute-plane-services/nvca/pkg/storage/controller_modelcache_test.go
@@ -27,7 +27,24 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/types"
 )
+
+// TestNewModelCacheInitNamespace_HasUnboundDNSLabel asserts that the namespace
+// carries the workload-instance-type label so the nvcf-unbound Kyverno policy
+// (add-unbound-dns) injects the cluster's nvcf-unbound nameserver into pods.
+// Without it the model-cache writer job falls back to the kube-dns ClusterIP,
+// which is unreachable on clusters running node-local-dns with hostNetwork=true.
+func TestNewModelCacheInitNamespace_HasUnboundDNSLabel(t *testing.T) {
+	ns := NewModelCacheInitNamespace()
+	assert.Equal(t, ModelCacheInitNamespace, ns.Name)
+	assert.Equal(t,
+		types.WorkloadInstanceTypeValueMiniService,
+		ns.Labels[types.WorkloadInstanceTypeLabel],
+		"workload-instance-type label must be present so add-unbound-dns injects nvcf-unbound nameservers",
+	)
+}
 
 func TestEnsureCacheMountOptionsConfigMap(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
## Customer Summary

Backport of #1116 to v3.2.

The model-cache writer job for helm-chart functions fails with DNS timeout on clusters running `node-local-dns` with `hostNetwork=true`, causing every model-attached helm deploy to stall ~7m45s and proceed without a cache.

## TL;DR

Cherry-picks three commits from #1116 onto `release-src/compute-plane-services/nvca/v3.2`:

1. `fix(storage)`: add `WorkloadInstanceTypeLabel=miniservice` to `NewModelCacheInitNamespace` so the Kyverno `add-unbound-dns` policy injects nvcf-unbound nameservers into the writer job pod.
2. `fix(storage)`: `ensureNamespaceLabels` — patch the label onto pre-existing namespaces on upgrade (clusters where `nvca-modelcache-init` already exists without the label).
3. `style(storage)`: replace em-dash with ASCII semicolon in test comment.

## Testing

All three commits cherry-picked cleanly. No conflicts.

## Tickets

Backport of #1116. Relates to NO-REF.