### PR TITLE
fix(cli): tolerate kubectl attach fallback diagnostics

### DIFF
--- a/src/clis/nvcf-cli/internal/openbao/client.go
+++ b/src/clis/nvcf-cli/internal/openbao/client.go
@@ -489,10 +489,9 @@ func (c *Client) executeKubectlRun(ctx context.Context, name string, args []stri
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if c.config.Debug {
-			logging.Debug("kubectl run failed with error: %s", err)
 			logging.Debug("kubectl raw output received (%s)", kubectlOutputMetadata(string(output)))
 		}
-		return "", fmt.Errorf("kubectl run failed: %s\nOutput: %s", err, string(output))
+		return "", fmt.Errorf("kubectl run failed: %w\nOutput: %s", err, string(output))
 	}
 
 	if c.config.Debug {

--- a/src/clis/nvcf-cli/internal/openbao/client.go
+++ b/src/clis/nvcf-cli/internal/openbao/client.go
@@ -490,23 +490,27 @@ func (c *Client) executeKubectlRun(ctx context.Context, name string, args []stri
 	if err != nil {
 		if c.config.Debug {
 			logging.Debug("kubectl run failed with error: %s", err)
-			logging.Debug("kubectl raw output:\n%s", string(output))
+			logging.Debug("kubectl raw output received (%s)", kubectlOutputMetadata(string(output)))
 		}
 		return "", fmt.Errorf("kubectl run failed: %s\nOutput: %s", err, string(output))
 	}
 
 	if c.config.Debug {
-		logging.Debug("kubectl raw output (length: %d bytes):\n%s", len(output), string(output))
+		logging.Debug("kubectl raw output received (%s)", kubectlOutputMetadata(string(output)))
 	}
 
 	// Filter out kubectl deletion messages and return only the actual command output
 	cleanOutput := c.filterKubectlOutput(string(output))
 
 	if c.config.Debug {
-		logging.Debug("kubectl filtered output (length: %d bytes):\n%s", len(cleanOutput), cleanOutput)
+		logging.Debug("kubectl filtered output produced (%s)", kubectlOutputMetadata(cleanOutput))
 	}
 
 	return strings.TrimSpace(cleanOutput), nil
+}
+
+func kubectlOutputMetadata(output string) string {
+	return fmt.Sprintf("%d bytes", len(output))
 }
 
 // filterKubectlOutput filters out kubectl messages and returns only the actual command output
@@ -542,6 +546,7 @@ func (c *Client) filterKubectlOutput(output string) string {
 		if strings.Contains(line, "All commands and output from this session will be recorded") ||
 			strings.Contains(line, "If you don't see a command prompt") ||
 			strings.HasPrefix(line, "Warning:") ||
+			strings.HasPrefix(line, "warning:") ||
 			strings.HasPrefix(line, "Error from server:") {
 			continue
 		}

--- a/src/clis/nvcf-cli/internal/openbao/client_test.go
+++ b/src/clis/nvcf-cli/internal/openbao/client_test.go
@@ -61,3 +61,45 @@ func TestFilterKubectlOutputPreservesPEMBlockWithKubectlNoise(t *testing.T) {
 	got := c.filterKubectlOutput("pod \"openbao-pki-root-ca\" deleted\n" + openBaoTestCertPEM + "pod \"openbao-pki-root-ca\" deleted\n")
 	assert.Equal(t, openBaoTestCertPEM[:len(openBaoTestCertPEM)-1], got)
 }
+
+func TestFilterKubectlOutputDropsLowercaseAttachFallbackAfterResponse(t *testing.T) {
+	c := NewClient(&Config{}, nil)
+	response := `{"data":{"certificate":"-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"}}`
+	tests := map[string]string{
+		"normal attach": response + "\npod \"openbao-pki-root-ca\" deleted\n",
+		"log fallback": response +
+			"\nwarning: couldn't attach to pod/openbao-pki-root-ca, falling back to streaming logs\n" +
+			"pod \"openbao-pki-root-ca\" deleted\n",
+	}
+
+	for name, output := range tests {
+		t.Run(name, func(t *testing.T) {
+			filtered := c.filterKubectlOutput(output)
+			got, err := rootCAPEMFromOpenBaoResponse(filtered)
+			require.NoError(t, err)
+			assert.Equal(t, openBaoTestCertPEM, got)
+		})
+	}
+}
+
+func TestRootCAPEMFromOpenBaoResponsePreservesCertificateErrors(t *testing.T) {
+	tests := map[string]string{
+		"malformed response":  "not-json",
+		"OpenBao error":       `{"errors":["permission denied"]}`,
+		"missing certificate": `{"data":{}}`,
+	}
+
+	for name, response := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := rootCAPEMFromOpenBaoResponse(response)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestKubectlOutputMetadataDoesNotExposeCertificate(t *testing.T) {
+	metadata := kubectlOutputMetadata(openBaoTestCertPEM)
+
+	assert.Equal(t, "59 bytes", metadata)
+	assert.NotContains(t, metadata, "CERTIFICATE")
+}

--- a/src/clis/nvcf-cli/internal/openbao/client_test.go
+++ b/src/clis/nvcf-cli/internal/openbao/client_test.go
@@ -18,8 +18,10 @@ limitations under the License.
 package openbao
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -102,4 +104,15 @@ func TestKubectlOutputMetadataDoesNotExposeCertificate(t *testing.T) {
 
 	assert.Equal(t, "59 bytes", metadata)
 	assert.NotContains(t, metadata, "CERTIFICATE")
+}
+
+func TestExecuteKubectlRunPreservesCommandError(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	c := NewClient(&Config{}, nil)
+	_, err := c.executeKubectlRun(context.Background(), "test", nil)
+	require.Error(t, err)
+
+	var execErr *exec.Error
+	require.ErrorAs(t, err, &execErr)
 }


### PR DESCRIPTION
## Summary

- filter lowercase kubectl attach fallback diagnostics without corrupting a valid exported profile
- keep command and certificate parsing failures visible while logging only output sizes in debug mode
- cover normal attach, log fallback, malformed response, OpenBao error, and missing-certificate paths

Fixes #1228

## Testing

- `go test ./internal/openbao -count=1`
- `go test ./... -count=1`
- `go build ./...`
- `git diff --check`

The repository Bazel target was not run locally because the host Bazel cache was inaccessible; the equivalent Go package, full-module, and build checks above passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command output filtering to remove additional lowercase warning and fallback noise.
  * Preserved certificate-related errors during command processing.
  * Prevented certificate contents from appearing in diagnostic output.

* **Security**
  * Debug logging now reports output sizes without exposing command output or certificate data.

* **Tests**
  * Added coverage for output filtering, certificate error handling, command failures, and sensitive-data redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->