### PR TITLE
fix(nvcf-cli): derive profile endpoints from stack domain

### DIFF
--- a/src/clis/nvcf-cli/cmd/self_hosted_control_plane.go
+++ b/src/clis/nvcf-cli/cmd/self_hosted_control_plane.go
@@ -112,7 +112,7 @@ func runControlPlaneProfileExport(c *cobra.Command, _ []string) error {
 		Env:                 selfHostedEnv,
 		ControlPlaneContext: selfHostedControlPlaneContext,
 		ComputePlaneContext: selfHostedComputePlaneContext,
-		ICMSURL:             resolveICMSURL(selfHostedICMSURL),
+		ICMSURL:             selfHostedICMSURL,
 		NATSURL:             selfHostedNATSURL,
 		SourceRootCA:        true,
 	})

--- a/src/clis/nvcf-cli/cmd/self_hosted_control_plane_profile.go
+++ b/src/clis/nvcf-cli/cmd/self_hosted_control_plane_profile.go
@@ -21,10 +21,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 
 	"nvcf-cli/internal/client"
 	"nvcf-cli/internal/openbao"
@@ -46,11 +50,19 @@ type controlPlaneProfileWriteRequest struct {
 	ComputePlaneContext string
 	ICMSURL             string
 	NATSURL             string
+	StackDomain         string
 	SourceRootCA        bool
 	RootCAPEM           string
 }
 
 func writeControlPlaneProfile(req controlPlaneProfileWriteRequest) (string, error) {
+	if req.StackDomain == "" {
+		domain, err := loadControlPlaneStackDomain(req.StackPath, req.Env)
+		if err != nil {
+			return "", err
+		}
+		req.StackDomain = domain
+	}
 	doc := buildControlPlaneProfile(req)
 	rootCAPEM := strings.TrimSpace(req.RootCAPEM)
 	if rootCAPEM == "" && req.SourceRootCA {
@@ -125,20 +137,17 @@ func applyControlPlaneRootCATrust(doc *controlplaneprofile.ControlPlaneProfile, 
 }
 
 func buildControlPlaneProfile(req controlPlaneProfileWriteRequest) controlplaneprofile.ControlPlaneProfile {
-	icmsURL := req.ICMSURL
-	if icmsURL == "" && req.Env == "local" {
-		icmsURL = "http://sis.localhost:8080"
-	}
+	icmsURL := resolveProfileICMSURL(req.ICMSURL, req.Env, req.StackDomain)
 	computeEndpoints := resolveRegisterEndpointValues(req.Env, req.ControlPlaneContext, req.ComputePlaneContext, icmsURL, req.NATSURL)
 	gatewayHTTP := resolveProfileGatewayHTTPURL(req.Env, icmsURL)
-	gatewayGRPC := resolveProfileGatewayGRPCURL(req.Env)
-	apiHost := firstNonEmpty(os.Getenv("API_HOST"), hostnameFromURL(gatewayHTTP))
+	gatewayGRPC := resolveProfileGatewayGRPCURL(req.Env, req.StackDomain)
+	apiHost := firstNonEmpty(os.Getenv("API_HOST"), viper.GetString("api_host"), hostnameFromURL(gatewayHTTP))
 	domain := domainFromHost(apiHost)
-	apiKeysHost := firstNonEmpty(os.Getenv("API_KEYS_HOST"), "api-keys."+domain)
-	invocationHost := firstNonEmpty(os.Getenv("INVOKE_HOST"), "invocation."+domain)
-	sisHost := firstNonEmpty(os.Getenv("NVCF_ICMS_HOST"), "sis."+domain)
-	revalHost := firstNonEmpty(os.Getenv("NVCF_REVAL_HOST"), "reval."+domain)
-	natsHost := firstNonEmpty(os.Getenv("NVCF_NATS_HOST"), "nats."+domain)
+	apiKeysHost := firstNonEmpty(os.Getenv("API_KEYS_HOST"), viper.GetString("api_keys_host"), "api-keys."+domain)
+	invocationHost := firstNonEmpty(os.Getenv("INVOKE_HOST"), viper.GetString("invoke_host"), "invocation."+domain)
+	sisHost := firstNonEmpty(os.Getenv("NVCF_ICMS_HOST"), viper.GetString("icms_host"), "sis."+domain)
+	revalHost := firstNonEmpty(os.Getenv("NVCF_REVAL_HOST"), viper.GetString("reval_host"), "reval."+domain)
+	natsHost := firstNonEmpty(os.Getenv("NVCF_NATS_HOST"), viper.GetString("nats_host"), "nats."+domain)
 
 	return controlplaneprofile.ControlPlaneProfile{
 		APIVersion: controlplaneprofile.APIVersion,
@@ -175,6 +184,65 @@ func buildControlPlaneProfile(req controlPlaneProfileWriteRequest) controlplanep
 	}
 }
 
+func loadControlPlaneStackDomain(stackPath, env string) (string, error) {
+	if stackPath == "" {
+		return "", nil
+	}
+	domain := ""
+	for _, name := range []string{"base.yaml", env + ".yaml"} {
+		path := filepath.Join(stackPath, "environments", name)
+		body, err := os.ReadFile(path)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return "", fmt.Errorf("reading control-plane stack values %q: %w", path, err)
+		}
+		var values struct {
+			Global struct {
+				Domain string `yaml:"domain"`
+			} `yaml:"global"`
+		}
+		if err := yaml.Unmarshal(body, &values); err != nil {
+			return "", fmt.Errorf("parsing control-plane stack values %q: %w", path, err)
+		}
+		if value := strings.TrimSpace(values.Global.Domain); value != "" {
+			domain = value
+		}
+	}
+	return domain, nil
+}
+
+func resolveProfileICMSURL(flagValue, env, stackDomain string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	if value := os.Getenv("NVCF_ICMS_URL"); value != "" {
+		return value
+	}
+	if value := os.Getenv("NVCF_SIS_URL"); value != "" {
+		return value
+	}
+	if cfg, err := client.LoadConfigWithoutAuth(); err == nil {
+		if cfg.ICMSURL != "" {
+			return cfg.ICMSURL
+		}
+		if viper.IsSet("base_http_url") && cfg.BaseHTTPURL != "" {
+			if derived, ok := deriveICMSFromAPI(cfg.BaseHTTPURL); ok {
+				return derived
+			}
+			return cfg.BaseHTTPURL
+		}
+	}
+	if stackDomain != "" {
+		return profileHTTPServiceURL(env, "sis", stackDomain)
+	}
+	if strings.EqualFold(env, "local") {
+		return "http://sis.localhost:8080"
+	}
+	return resolveICMSURL("")
+}
+
 // rewriteURLHost replaces the hostname (preserving scheme, port, path, and
 // query) of rawURL with newHost. Returns rawURL unchanged when it cannot be
 // parsed, has no host, or when newHost is empty.
@@ -203,7 +271,7 @@ func resolveProfileGatewayHTTPURL(env, icmsURL string) string {
 	if v := os.Getenv("NVCF_BASE_HTTP_URL"); v != "" {
 		return v
 	}
-	if cfg, err := client.LoadConfigWithoutAuth(); err == nil && cfg.BaseHTTPURL != "" && !(env == "local" && cfg.BaseHTTPURL == "https://api.nvcf.nvidia.com") {
+	if cfg, err := client.LoadConfigWithoutAuth(); err == nil && viper.IsSet("base_http_url") && cfg.BaseHTTPURL != "" {
 		return cfg.BaseHTTPURL
 	}
 	if icmsURL != "" {
@@ -212,17 +280,39 @@ func resolveProfileGatewayHTTPURL(env, icmsURL string) string {
 	return "http://api.localhost:8080"
 }
 
-func resolveProfileGatewayGRPCURL(env string) string {
+func resolveProfileGatewayGRPCURL(env, stackDomain string) string {
 	if v := os.Getenv("NVCF_BASE_GRPC_URL"); v != "" {
 		return v
 	}
 	if v := os.Getenv("NVCF_GRPC_URL"); v != "" {
 		return v
 	}
-	if cfg, err := client.LoadConfigWithoutAuth(); err == nil && cfg.BaseGRPCURL != "" && !(env == "local" && cfg.BaseGRPCURL == "grpc.nvcf.nvidia.com:443") {
+	if cfg, err := client.LoadConfigWithoutAuth(); err == nil && (viper.IsSet("grpc_url") || viper.IsSet("base_grpc_url")) && cfg.BaseGRPCURL != "" {
 		return cfg.BaseGRPCURL
 	}
+	if stackDomain != "" {
+		port := "443"
+		if strings.EqualFold(env, "local") {
+			port = "10081"
+		}
+		return net.JoinHostPort("grpc."+stackDomain, port)
+	}
+	if !strings.EqualFold(env, "local") {
+		if cfg, err := client.LoadConfigWithoutAuth(); err == nil && cfg.BaseGRPCURL != "" {
+			return cfg.BaseGRPCURL
+		}
+	}
 	return "grpc.localhost:10081"
+}
+
+func profileHTTPServiceURL(env, service, domain string) string {
+	scheme := "https"
+	host := service + "." + domain
+	if strings.EqualFold(env, "local") {
+		scheme = "http"
+		host = net.JoinHostPort(host, "8080")
+	}
+	return (&url.URL{Scheme: scheme, Host: host}).String()
 }
 
 func hostnameFromURL(rawURL string) string {

--- a/src/clis/nvcf-cli/cmd/self_hosted_control_plane_test.go
+++ b/src/clis/nvcf-cli/cmd/self_hosted_control_plane_test.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -143,6 +144,145 @@ func TestControlPlaneProfileExportCommandRecreatesProfileFromOpenBao(t *testing.
 	assert.Equal(t, controlplaneprofile.TrustModeBundle, result.Profile.TransportTLS.TrustMode)
 	assert.Equal(t, strings.TrimSpace(rootCA), strings.TrimSpace(result.Profile.TransportTLS.TrustBundlePEM))
 	assert.Equal(t, wantFingerprint, result.Profile.TransportTLS.TrustBundleFingerprint)
+	assert.Equal(t, "http://sis.localhost:8080", result.Profile.ControlPlane.Endpoints.ComputeReachable.ICMSURL)
+	assert.Equal(t, "http://reval.localhost:8080", result.Profile.ControlPlane.Endpoints.ComputeReachable.ReValURL)
+	assert.Equal(t, "nats://nats.localhost:4222", result.Profile.ControlPlane.Endpoints.ComputeReachable.NATSURL)
+}
+
+func TestControlPlaneProfileExportCommandUsesSelectedEnvironmentDomain(t *testing.T) {
+	stackDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(stackDir, "helmfile.d"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(stackDir, "environments"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stackDir, "environments", "base.yaml"), []byte("global:\n  domain: base.example.test\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(stackDir, "environments", "alpha.yaml"), []byte("global:\n  domain: alpha.example.test\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(stackDir, "environments", "beta.yaml"), []byte("global:\n  domain: beta.example.test\n"), 0o600))
+
+	for _, tc := range []struct {
+		env    string
+		domain string
+	}{
+		{env: "alpha", domain: "alpha.example.test"},
+		{env: "beta", domain: "beta.example.test"},
+	} {
+		t.Run(tc.env, func(t *testing.T) {
+			resetControlPlaneProfileValidateCommand(t)
+			resetViperForProfileTest(t)
+			for _, name := range []string{
+				"API_HOST",
+				"API_KEYS_HOST",
+				"INVOKE_HOST",
+				"NVCF_ICMS_HOST",
+				"NVCF_REVAL_HOST",
+				"NVCF_NATS_HOST",
+				"NVCF_BASE_HTTP_URL",
+				"NVCF_BASE_GRPC_URL",
+				"NVCF_GRPC_URL",
+				"NVCF_NATS_URL",
+			} {
+				t.Setenv(name, "")
+			}
+
+			prevFetch := fetchControlPlaneRootCAPEM
+			fetchControlPlaneRootCAPEM = func(context.Context, string) (string, error) {
+				return "", nil
+			}
+			t.Cleanup(func() { fetchControlPlaneRootCAPEM = prevFetch })
+
+			rootCmd.SetOut(&bytes.Buffer{})
+			rootCmd.SetErr(&bytes.Buffer{})
+			rootCmd.SetArgs([]string{
+				"self-hosted",
+				"--control-plane-stack", stackDir,
+				"--env", tc.env,
+				"control-plane", "profile", "export",
+				"--cluster-name", "control-plane",
+			})
+
+			require.NoError(t, rootCmd.Execute())
+			body, err := os.ReadFile(filepath.Join(stackDir, "out", controlPlaneProfileFileName))
+			require.NoError(t, err)
+			result, err := controlplaneprofile.ParseAndValidate(body, controlplaneprofile.ValidateOptions{Require: controlplaneprofile.RequireBoth})
+			require.NoError(t, err)
+
+			profile := result.Profile.ControlPlane
+			assert.Equal(t, "https://api."+tc.domain, profile.Gateway.HTTPURL)
+			assert.Equal(t, "grpc."+tc.domain+":443", profile.Gateway.GRPCURL)
+			assert.Equal(t, "api."+tc.domain, profile.Hosts.API)
+			assert.Equal(t, "api-keys."+tc.domain, profile.Hosts.APIKeys)
+			assert.Equal(t, "invocation."+tc.domain, profile.Hosts.Invocation)
+			assert.Equal(t, "sis."+tc.domain, profile.Hosts.SIS)
+			assert.Equal(t, "reval."+tc.domain, profile.Hosts.ReVal)
+			assert.Equal(t, "nats."+tc.domain, profile.Hosts.NATS)
+			assert.Equal(t, "https://sis."+tc.domain, profile.Endpoints.ComputeReachable.ICMSURL)
+			assert.Equal(t, "https://reval."+tc.domain, profile.Endpoints.ComputeReachable.ReValURL)
+			assert.Equal(t, "nats://nats."+tc.domain+":4222", profile.Endpoints.ComputeReachable.NATSURL)
+		})
+	}
+}
+
+func TestControlPlaneProfileExportCommandPrefersNamedConfigOverStackDomain(t *testing.T) {
+	resetControlPlaneProfileValidateCommand(t)
+	configureSelfHostedTestConfig(t, `
+base_http_url: https://gateway.config.example.test
+base_grpc_url: grpc.config.example.test:7443
+icms_url: https://sis-dial.config.example.test/custom/path
+api_host: api.config.example.test
+api_keys_host: api-keys.config.example.test
+invoke_host: invocation.config.example.test
+icms_host: sis.config.example.test
+`)
+	for _, name := range []string{
+		"API_HOST",
+		"API_KEYS_HOST",
+		"INVOKE_HOST",
+		"NVCF_ICMS_HOST",
+		"NVCF_REVAL_HOST",
+		"NVCF_NATS_HOST",
+		"NVCF_BASE_HTTP_URL",
+		"NVCF_BASE_GRPC_URL",
+		"NVCF_GRPC_URL",
+		"NVCF_NATS_URL",
+	} {
+		t.Setenv(name, "")
+	}
+
+	stackDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(stackDir, "helmfile.d"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(stackDir, "environments"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stackDir, "environments", "base.yaml"), []byte("global:\n  domain: base.example.test\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(stackDir, "environments", "qa.yaml"), []byte("global:\n  domain: stack.example.test\n"), 0o600))
+
+	prevFetch := fetchControlPlaneRootCAPEM
+	fetchControlPlaneRootCAPEM = func(context.Context, string) (string, error) {
+		return "", nil
+	}
+	t.Cleanup(func() { fetchControlPlaneRootCAPEM = prevFetch })
+
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"--config", viper.ConfigFileUsed(),
+		"self-hosted",
+		"--control-plane-stack", stackDir,
+		"--env", "qa",
+		"control-plane", "profile", "export",
+		"--cluster-name", "control-plane",
+	})
+
+	require.NoError(t, rootCmd.Execute())
+	body, err := os.ReadFile(filepath.Join(stackDir, "out", controlPlaneProfileFileName))
+	require.NoError(t, err)
+	result, err := controlplaneprofile.ParseAndValidate(body, controlplaneprofile.ValidateOptions{Require: controlplaneprofile.RequireBoth})
+	require.NoError(t, err)
+
+	profile := result.Profile.ControlPlane
+	assert.Equal(t, "https://gateway.config.example.test", profile.Gateway.HTTPURL)
+	assert.Equal(t, "grpc.config.example.test:7443", profile.Gateway.GRPCURL)
+	assert.Equal(t, "api.config.example.test", profile.Hosts.API)
+	assert.Equal(t, "api-keys.config.example.test", profile.Hosts.APIKeys)
+	assert.Equal(t, "invocation.config.example.test", profile.Hosts.Invocation)
+	assert.Equal(t, "sis.config.example.test", profile.Hosts.SIS)
+	assert.Equal(t, "https://sis.config.example.test/custom/path", profile.Endpoints.ComputeReachable.ICMSURL)
 }
 
 func TestParseControlPlaneProfileRequireModeAcceptsAny(t *testing.T) {

--- a/src/clis/nvcf-cli/cmd/self_hosted_test.go
+++ b/src/clis/nvcf-cli/cmd/self_hosted_test.go
@@ -178,10 +178,13 @@ func configureSelfHostedTestConfig(t *testing.T, body string) {
 	viper.AutomaticEnv()
 	t.Setenv("NVCF_ICMS_URL", "")
 	t.Setenv("NVCF_SIS_URL", "")
-	cfgFile = ""
 
 	configPath := filepath.Join(t.TempDir(), "nvcf-cli.yaml")
 	require.NoError(t, os.WriteFile(configPath, []byte(body), 0o600))
+	// Cobra's OnInitialize callback reruns initConfig for every Execute call.
+	// Keep it pinned to this fixture instead of letting it rediscover a
+	// developer's ~/.nvcf-cli.yaml during command tests.
+	cfgFile = configPath
 	viper.SetConfigFile(configPath)
 	require.NoError(t, viper.ReadInConfig())
 


### PR DESCRIPTION
## TL;DR

Derive exported self-hosted control-plane profile endpoints and Host overrides from the selected Helmfile environment's `global.domain` instead of unrelated CLI defaults.

## Additional Details

Profile export previously ignored the selected stack environment when choosing gateway, SIS, ReVal, NATS, and invocation addresses. That could produce a syntactically valid profile for the wrong deployment domain.

This change loads `environments/base.yaml` and `environments/<env>.yaml` with the environment overlay taking precedence, then uses the effective domain for profile endpoints. Explicit flags, environment variables, and named CLI config values retain precedence. Local-environment endpoint behavior is unchanged.

The command-test config helper is also pinned to its temporary fixture so Cobra initialization cannot rediscover a developer's home config during a test.

## For the Reviewer

Please focus on endpoint precedence in `self_hosted_control_plane_profile.go` and the alpha/beta environment coverage in `self_hosted_control_plane_test.go`.

## For QA

QA is recommended for a self-hosted environment whose deployment domain differs from CLI defaults.

Verified:

- `go test ./cmd -run 'ControlPlaneProfile|BuildControlPlaneProfile|RewriteURLHost' -count=1`
- `go test ./cmd -count=1`
- `go test ./... -count=1`
- `go build .`
- Exported a profile from a stack environment with a non-default domain, without `--nca-id` or endpoint overrides.
- `self-hosted control-plane profile validate --require both` accepted the result.
- `self-hosted compute-plane register --dry-run` selected the exported compute-reachable scope without mutating SIS or writing values.

A reachability-enabled dry run was not completed because the disposable validation host had no DNS record for the test deployment domain. No profile or cluster resources were hand-edited to bypass that prerequisite.

The repository Bazel target was attempted with and without remote cache, but local analysis did not make progress. The Go module tests and build above completed successfully.

## Issues

Fixes #1231

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Related Pull Requests

None.

## Dependencies

None. No license or NOTICE changes are required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Control-plane profile exports now automatically use the selected environment’s stack domain to generate service, gateway, HTTP, and gRPC URLs.
  * Profile exports can derive ICMS endpoints from available configuration sources, with explicitly configured values taking precedence.
  * Local and non-local environments now receive appropriate service ports and endpoint settings.
  * Gateway HTTP settings are applied only when a base HTTP URL is explicitly configured.

* **Bug Fixes**
  * Improved configuration handling to ensure profile exports consistently use the intended environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->