### PR TITLE
test(bdd): cover multi-cluster LLM routing

### DIFF
--- a/tests/bdd/features/multi-cluster-helmfile.feature
+++ b/tests/bdd/features/multi-cluster-helmfile.feature
@@ -260,6 +260,9 @@ Feature: Install a local multi-cluster NVCF stack with Helmfile
         """
       Then the command output should contain "bdd-echo"
 
+      # Keep the simulated GPU capacity available for the next scenario.
+      And I successfully undeploy the function selected by NVCF CLI
+
     @function-lifecycle @grpc
     Scenario: Operator creates, deploys, and invokes the gRPC Load Tester Supreme sample function
       Given I use NVCF CLI config "${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml"
@@ -293,3 +296,59 @@ Feature: Install a local multi-cluster NVCF stack with Helmfile
         {"message":"bdd-grpc-echo"}
         """
       Then the command output should contain "bdd-grpc-echo"
+
+      # Keep the simulated GPU capacity available for the LLM scenario.
+      And I successfully undeploy the function selected by NVCF CLI
+
+    # This fixed-response sample proves the multi-cluster LLM routing and
+    # request/response contract. It is not a token-generation capacity test.
+    # The compute fixture deliberately retains stargateQUICInsecure; secured
+    # split-cluster transport coverage remains a separate scenario.
+    # The scenario depends on the earlier control-plane install and compute
+    # registration scenarios and is not a standalone tag target.
+    @llm-function-type
+    Scenario: Operator creates, deploys, and invokes an LLM-type OpenAI-compatible sample function
+      Given I use NVCF CLI config "${REPO_ROOT}/tests/bdd/fixtures/nvcf-cli-local.yaml"
+
+      When I successfully create function "bdd-multi-openai-compatible-sample" from image "nvcr.io/${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM}/nvcf-openai-compatible-sample:local" with CLI options:
+        | option           | value                                                                                               |
+        | --function-type  | LLM                                                                                                 |
+        | --inference-url  | /v1/chat/completions                                                                                |
+        | --inference-port | 8000                                                                                                |
+        | --health-uri     | /health                                                                                             |
+        | --health-port    | 8000                                                                                                |
+        | --health-timeout | PT30S                                                                                               |
+        | --llm-model      | name=openai-compatible-sample,uris=/v1/chat/completions\|/v1/embeddings,routingMethod=round_robin |
+
+      And I successfully deploy the function selected by NVCF CLI with options:
+        | option          | value               |
+        | --gpu           | H100                |
+        | --instance-type | NCP.GPU.H100_1x     |
+        | --backend       | ncp-local-compute-1 |
+        | --regions       | us-west-1           |
+        | --min-instances | 1                   |
+        | --max-instances | 1                   |
+        | --timeout       | 900                 |
+
+      And I successfully generate a function API key with CLI options:
+        | option        | value                                                               |
+        | --description | bdd-multi-openai-compatible-sample                                  |
+        | --scopes      | invoke_function,list_functions,queue_details,list_functions_details |
+
+      When I successfully invoke model "openai-compatible-sample" at "/v1/chat/completions" with timeout "120" seconds:
+        """
+        {"messages":[{"role":"user","content":"bdd-multi-llm-echo"}]}
+        """
+      Then the command output should contain "chat.completion"
+      And the command output should contain "fixed 128-byte response"
+
+      # Authentication remains enforced at the LLM gateway in the split
+      # topology. Only the status code is captured for a stable assertion.
+      When I run command:
+        """
+        curl -s -o /dev/null -w "%{http_code}" -X POST http://llm.localhost:8080/v1/chat/completions -H "Content-Type: application/json" -d '{"model":"unauthenticated/check","messages":[]}'
+        """
+      Then the command exit code should be 0
+      And the command output should contain "401"
+
+      And I successfully undeploy the function selected by NVCF CLI

--- a/tests/bdd/features/multi-cluster-helmfile.feature
+++ b/tests/bdd/features/multi-cluster-helmfile.feature
@@ -346,7 +346,7 @@ Feature: Install a local multi-cluster NVCF stack with Helmfile
       # topology. Only the status code is captured for a stable assertion.
       When I run command:
         """
-        curl -s -o /dev/null -w "%{http_code}" -X POST http://llm.localhost:8080/v1/chat/completions -H "Content-Type: application/json" -d '{"model":"unauthenticated/check","messages":[]}'
+        curl -s --connect-timeout 5 --max-time 30 -o /dev/null -w "%{http_code}" -X POST http://llm.localhost:8080/v1/chat/completions -H "Content-Type: application/json" -H "traceparent: 00-00000000000000000000000000001019-0000000000001019-01" -d '{"model":"unauthenticated/check","messages":[]}'
         """
       Then the command exit code should be 0
       And the command output should contain "401"

--- a/tests/bdd/godog_test.go
+++ b/tests/bdd/godog_test.go
@@ -904,7 +904,10 @@ func TestMultiClusterHelmfileFeatureFileWiresToSteps(t *testing.T) {
 				`{"object":"chat.completion","choices":[{"message":{"content":"This is a fixed 128-byte response for routing and contract validation, not token-generation capacity."}}]}` +
 				"\n",
 		},
-		`curl -s --connect-timeout 5 --max-time 30 -o /dev/null -w "%{http_code}" -X POST http://llm.localhost:8080/v1/chat/completions -H "Content-Type: application/json" -H "traceparent: 00-00000000000000000000000000001019-0000000000001019-01" -d '{"model":"unauthenticated/check","messages":[]}'`: {
+		`curl -s --connect-timeout 5 --max-time 30 -o /dev/null -w "%{http_code}" -X POST ` +
+			`http://llm.localhost:8080/v1/chat/completions -H "Content-Type: application/json" ` +
+			`-H "traceparent: 00-00000000000000000000000000001019-0000000000001019-01" ` +
+			`-d '{"model":"unauthenticated/check","messages":[]}'`: {
 			ExitCode: 0,
 			Stdout:   "401",
 		},

--- a/tests/bdd/godog_test.go
+++ b/tests/bdd/godog_test.go
@@ -904,7 +904,7 @@ func TestMultiClusterHelmfileFeatureFileWiresToSteps(t *testing.T) {
 				`{"object":"chat.completion","choices":[{"message":{"content":"This is a fixed 128-byte response for routing and contract validation, not token-generation capacity."}}]}` +
 				"\n",
 		},
-		`curl -s -o /dev/null -w "%{http_code}" -X POST http://llm.localhost:8080/v1/chat/completions -H "Content-Type: application/json" -d '{"model":"unauthenticated/check","messages":[]}'`: {
+		`curl -s --connect-timeout 5 --max-time 30 -o /dev/null -w "%{http_code}" -X POST http://llm.localhost:8080/v1/chat/completions -H "Content-Type: application/json" -H "traceparent: 00-00000000000000000000000000001019-0000000000001019-01" -d '{"model":"unauthenticated/check","messages":[]}'`: {
 			ExitCode: 0,
 			Stdout:   "401",
 		},

--- a/tests/bdd/godog_test.go
+++ b/tests/bdd/godog_test.go
@@ -896,6 +896,18 @@ func TestMultiClusterHelmfileFeatureFileWiresToSteps(t *testing.T) {
 			ExitCode: 0,
 			Stdout:   "Function invocation completed!\n\nResponse:\n{\"message\":\"bdd-grpc-echo\"}\n",
 		},
+		"/usr/bin/nvcf-cli --config /repo-root-placeholder/tests/bdd/fixtures/nvcf-cli-local.yaml function invoke" +
+			" --inference-url /v1/chat/completions --model-name openai-compatible-sample" +
+			" --request-body '{\"messages\":[{\"role\":\"user\",\"content\":\"bdd-multi-llm-echo\"}]}' --timeout 120": {
+			ExitCode: 0,
+			Stdout: "Function invocation completed!\n\nResponse:\n" +
+				`{"object":"chat.completion","choices":[{"message":{"content":"This is a fixed 128-byte response for routing and contract validation, not token-generation capacity."}}]}` +
+				"\n",
+		},
+		`curl -s -o /dev/null -w "%{http_code}" -X POST http://llm.localhost:8080/v1/chat/completions -H "Content-Type: application/json" -d '{"model":"unauthenticated/check","messages":[]}'`: {
+			ExitCode: 0,
+			Stdout:   "401",
+		},
 		taskSmokeCommand: {
 			ExitCode: 0,
 			Stdout:   "Task bdd-nvct-task-smoke status: COMPLETED\n",
@@ -991,13 +1003,37 @@ func TestMultiClusterHelmfileFeatureFileWiresToSteps(t *testing.T) {
 		"--description bdd-grpc-load-tester-supreme") {
 		t.Fatal("gRPC sample function API key was not generated for the function service")
 	}
+	if !commandRanThatContainsAll(suite.Runner.(*fakeRunner).runs,
+		"function create --name bdd-multi-openai-compatible-sample",
+		"nvcf-openai-compatible-sample:local",
+		"--function-type LLM",
+		"--llm-model") {
+		t.Fatal("multi-cluster LLM sample function was not created with the LLM function type and model config")
+	}
+	if !commandRanThatContains(suite.Runner.(*fakeRunner).runs, "function invoke --inference-url /v1/chat/completions --model-name openai-compatible-sample") {
+		t.Fatal("multi-cluster LLM function invoke CLI command was never invoked")
+	}
+	if !commandRanThatContainsAll(suite.Runner.(*fakeRunner).runs,
+		"api-key generate --for function",
+		"--description bdd-multi-openai-compatible-sample") {
+		t.Fatal("multi-cluster LLM sample function API key was not generated for the function service")
+	}
+	cleanupCount := 0
+	for _, command := range suite.Runner.(*fakeRunner).runs {
+		if strings.Contains(command, "function delete --deployment-only") {
+			cleanupCount++
+		}
+	}
+	if cleanupCount != 3 {
+		t.Fatalf("function deployment cleanup commands = %d, want 3", cleanupCount)
+	}
 	if commandRanThatContains(suite.Runner.(*fakeRunner).runs, "api-key generate --description bdd-nvct-task-smoke") {
 		t.Fatal("NVCT task smoke should not use nvcf-cli api-key generate because it emits function resources")
 	}
 	if !commandRanExactly(suite.Runner.(*fakeRunner).runs, taskSmokeCommand) {
 		t.Fatal("NVCT task API smoke script was not invoked with the local instance type")
 	}
-	assertFunctionDeploymentsUseInstanceType(t, suite.Runner.(*fakeRunner).runs, "NCP.GPU.H100_1x", 2)
+	assertFunctionDeploymentsUseInstanceType(t, suite.Runner.(*fakeRunner).runs, "NCP.GPU.H100_1x", 3)
 }
 
 // TestSingleClusterHelmfileUpstreamImagesFeatureFileWiresToSteps runs the


### PR DESCRIPTION
## Why

The multi-cluster Helmfile BDD flow installs the LLM gateway and request
router, but it only invoked HTTP and gRPC echo workloads. That left the
split-cluster LLM routing contract untested and kept every simulated GPU
deployment active between scenarios.

## What changed

- Add a fixed-response OpenAI-compatible LLM scenario targeting the separate
  compute cluster.
- Verify the synchronous chat-completion envelope and unauthenticated gateway
  rejection.
- Bound the unauthenticated gateway probe with connection and total timeouts
  and a valid fixed `traceparent`.
- Undeploy each HTTP, gRPC, and LLM workload before the next scenario so the
  documented local capacity is reused.
- Extend the fake-runner wiring test to require the LLM create, API-key,
  invoke, and cleanup commands.

## Customer Release Notes

Not customer visible.

## Plan Summary

Not applicable.

## Usage

Not applicable.

## Testing

- `go test -run '^TestMultiClusterHelmfileFeatureFileWiresToSteps$' -count=1` passed.
- `go test -short -count=1 ./...` passed for `nvcf-bdd`, `dsl`, `harness`, and `steps`.
- `go vet ./...` and `git diff --check` passed.

The local `golangci-lint` run is blocked by an incompatible host toolchain: Go
1.27 export data cannot be decoded by the installed linter built with Go 1.26.

## Notes

The sample returns a fixed response. This validates routing, authentication,
cleanup, and request/response wiring; it does not measure token-generation
capacity or latency.

The compute fixture deliberately retains `stargateQUICInsecure: true`. Secured
split-cluster trust and invocation remain separate follow-up work blocked on
#1207 and #1075.

The live runner uses `StopOnFailure: true`, so a failed scenario stops the
suite and retains state for diagnostics. A retry can use the documented
`BDD_CLEANUP_MODE=stack-multi` pre-suite cleanup. A cross-cutting `After` hook
that deletes state on failure is intentionally outside this focused routing
coverage.

## References

Relates to #1019.

## Related Pull Requests

- #1075
- #1208

## Dependencies

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded multi-cluster validation to cover the complete lifecycle of OpenAI-compatible LLM functions, including creation, deployment, invocation, authentication, and undeployment.
  * Added checks for authenticated and unauthenticated gateway access, API-key generation, timeouts, and trace information.
  * Improved cleanup verification to ensure deployed sample functions are removed and simulated GPU capacity remains available for subsequent scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->