### PR TITLE
fix(admin-token-issuer-proxy): separate readiness from liveness

### DIFF
--- a/deploy/helm/admin-token-issuer-proxy/chart/Chart.yaml
+++ b/deploy/helm/admin-token-issuer-proxy/chart/Chart.yaml
@@ -18,4 +18,4 @@ name: helm-admin-token-issuer-proxy
 description: Admin Issuer Proxy service for minting admin-scoped JWTs from Vault/OpenBao
 type: application
 version: 0.0.0 # Chart version is managed by semantic-release
-appVersion: "1.0.2"
+appVersion: "1.1.0"

--- a/deploy/helm/admin-token-issuer-proxy/chart/values.yaml
+++ b/deploy/helm/admin-token-issuer-proxy/chart/values.yaml
@@ -39,7 +39,7 @@ adminIssuerProxy:
     pullPolicy: IfNotPresent
 
     # Image tag to use. Defaults to the appVersion from Chart.yaml if not specified.
-    tag: "1.0.2"
+    tag: "1.1.0"
 
   # List of image pull secrets for accessing private container registries.
   # Example:
@@ -182,10 +182,10 @@ adminIssuerProxy:
     periodSeconds: 30
 
   # Readiness probe configuration. Kubernetes uses this to determine if the pod should receive traffic.
-  # The probe checks the /healthz endpoint to verify the service is ready to handle requests.
+  # The probe checks /readyz so metadata initialization remains distinct from liveness.
   readinessProbe:
     httpGet:
-      path: /healthz
+      path: /readyz
       port: 8080
     # Wait time before the first probe is executed after container start
     initialDelaySeconds: 5

--- a/deploy/helm/admin-token-issuer-proxy/values.local.yaml
+++ b/deploy/helm/admin-token-issuer-proxy/values.local.yaml
@@ -17,4 +17,4 @@ adminIssuerProxy:
   image:
     registry: ""
     repository: ""
-    tag: "1.0.2"
+    tag: "1.1.0"


### PR DESCRIPTION
## What

- use the proxy's dependency-aware `/readyz` endpoint for Kubernetes readiness
- keep `/healthz` as the process liveness endpoint
- update the chart and local defaults to application v1.1.0

## Why

The admin token issuer proxy can start before API Keys has completed a cold
start. Application v1.1.0 keeps the process live while retrying transient
metadata failures, but it must not receive traffic until that metadata is
initialized.

Related to #1229.

## Validation

- `go test ./...` from `src/control-plane-services/admin-token-issuer-proxy`
- `helm lint deploy/helm/admin-token-issuer-proxy/chart ...`
- focused `helm template` assertions confirm image v1.1.0, liveness on
  `/healthz`, and readiness on `/readyz`
- clean k3d E2E on `linux/amd64` using the promoted v1.1.0 candidate image
  (`sha256:b23c2a375b36455b0b3b26790c29d1f4202145da4cfae2f8e681c1011d2e90b6`):
  - with the metadata Service deliberately unavailable across multiple
    accelerated liveness windows, `/healthz` remained 200, `/readyz` remained
    503, Kubernetes Ready remained false, and the pod had zero restarts
  - after the metadata backend became available, `/readyz` changed to 200 and
    the same pod became Ready with zero restarts

## Dependency

#1418 is merged and application v1.1.0 has been built and promoted to the
release staging lane. Final public catalog publication remains a downstream
self-managed-stack release gate; this chart change is required before that
stack can consume and publish the matching chart/image pair.

No third-party dependencies are added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment readiness checks by using the dedicated readiness endpoint, helping ensure traffic is only sent after required initialization is complete.

* **Chores**
  * Updated the deployed application version to 1.1.0 across Helm configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->