### PR TITLE
docs(llm): clarify body format contract

### DIFF
--- a/docs/user/llm-gateway.md
+++ b/docs/user/llm-gateway.md
@@ -58,6 +58,7 @@ Set `functionType` to `LLM` and define model routing metadata under `models[].ll
   "inferenceUrl": "/",
   "inferencePort": 8000,
   "functionType": "LLM",
+  "apiBodyFormat": "CUSTOM",
   "models": [
     {
       "name": "dummy-model",
@@ -70,6 +71,17 @@ Set `functionType` to `LLM` and define model routing metadata under `models[].ll
   ]
 }
 ```
+
+`apiBodyFormat` accepts `CUSTOM` and `PREDICT_V2`; if omitted, it defaults to
+`CUSTOM`. Use `CUSTOM` for OpenAI-compatible LLM functions. `OPENAI_CHAT` is
+not an accepted value and the create-function API rejects it with
+`400 Bad Request`.
+
+The body-format field does not select the LLM protocol or an OpenAI endpoint.
+`functionType: "LLM"` selects the LLM invocation path, and `llmConfig.uris`
+declares the OpenAI-compatible paths implemented by the container. The client
+request body is the native OpenAI-compatible body for the selected path; the
+gateway does not wrap it in a second NVCF envelope.
 
 `llmConfig.uris` declares the OpenAI-compatible paths the model supports. Supported LLM paths are:
 
@@ -128,6 +140,47 @@ curl -sS -X POST "http://${GATEWAY_ADDR}/v1/chat/completions" \
 ```
 
 When `stream` is `true`, the gateway relays server-sent events. When `stream` is false or omitted, the gateway returns the final JSON response from the upstream service.
+
+For a non-streaming request, the upstream container must return an
+OpenAI-compatible chat completion. For example:
+
+```json
+{
+  "id": "chatcmpl-example",
+  "object": "chat.completion",
+  "created": 1787745600,
+  "model": "dummy-model",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "NVCF routes GPU-backed inference workloads."
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 12,
+    "completion_tokens": 7,
+    "total_tokens": 19
+  }
+}
+```
+
+For streaming requests, the upstream container returns OpenAI-compatible SSE
+chunks and terminates with `data: [DONE]`. The gateway relays the upstream
+response; it does not synthesize model output or token usage.
+
+### Routing checks versus token-generation tests
+
+An echo or fixed-response workload is useful for verifying function creation,
+authentication, worker registration, routing, streaming transport, and
+failover. It does not generate tokens. Repeated or canned output from such a
+workload cannot measure model token throughput, time to first token, or
+token-generation latency. Capacity and latency claims require a genuine
+token-generating model, with input and output token counts recorded alongside
+concurrency, duration, error rate, throughput, and latency percentiles.
 
 ### Responses
 

--- a/src/clis/nvcf-cli/examples/create-llm-function-routing-method.json
+++ b/src/clis/nvcf-cli/examples/create-llm-function-routing-method.json
@@ -4,7 +4,7 @@
   "inferenceUrl": "/",
   "inferencePort": 8000,
   "functionType": "LLM",
-  "apiBodyFormat": "OPENAI_CHAT",
+  "apiBodyFormat": "CUSTOM",
   "health": {
     "protocol": "HTTP",
     "uri": "/health",

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/rest/function/management/FunctionManagementControllerTest.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/rest/function/management/FunctionManagementControllerTest.java
@@ -819,6 +819,69 @@ class FunctionManagementControllerTest {
     }
 
     @Test
+    void shouldRejectUnsupportedApiBodyFormatWithGenericProblemDetail() throws JacksonException {
+        var problem = postRawCreateFunctionExpectingBadRequest("""
+                {
+                  "name": "sample-llm-function",
+                  "containerImage": "nvcr.io/example/openai-compatible:latest",
+                  "inferenceUrl": "/",
+                  "functionType": "LLM",
+                  "apiBodyFormat": "OPENAI_CHAT",
+                  "models": [
+                    {
+                      "name": "dummy-model",
+                      "llmConfig": {
+                        "uris": ["/v1/chat/completions"]
+                      }
+                    }
+                  ]
+                }
+                """);
+
+        assertThat(problem.get("detail").asString()).isEqualTo("Failed to read request");
+    }
+
+    @Test
+    void shouldPreserveGenericMalformedRequestProblemDetail() throws JacksonException {
+        var problem = postRawCreateFunctionExpectingBadRequest("{");
+
+        assertThat(problem.get("detail").asString()).isEqualTo("Failed to read request");
+    }
+
+    @ParameterizedTest
+    @CsvSource({"CUSTOM,CUSTOM", "PREDICT_V2,PREDICT_V2", "OMITTED,CUSTOM"})
+    void shouldDeserializeSupportedAndDefaultApiBodyFormats(
+            String serializedValue, String expectedValue) throws JacksonException {
+        var apiBodyFormat = serializedValue.equals("OMITTED")
+                ? ""
+                : ", \"apiBodyFormat\": \"" + serializedValue + "\"";
+        var request = jsonMapper.readValue("""
+                {
+                  "name": "sample-function",
+                  "inferenceUrl": "/",
+                  "containerImage": "nvcr.io/example/openai-compatible:latest"%s
+                }
+                """.formatted(apiBodyFormat), CreateFunctionRequest.class);
+
+        assertThat(request.getApiBodyFormat().toString()).isEqualTo(expectedValue);
+    }
+
+    private ObjectNode postRawCreateFunctionExpectingBadRequest(String requestBody)
+            throws JacksonException {
+        var token = MOCK_OAUTH2_TOKEN_SERVER.getJwt(
+                TEST_CLIENT_SUBJECT, List.of(SCOPE_REGISTER_FUNCTION), 100);
+        var requestEntity = RequestEntity.post(URI.create("/v2/nvcf/functions"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .body(requestBody);
+
+        var responseEntity = testRestTemplate.exchange(requestEntity, String.class);
+
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        return jsonMapper.readValue(responseEntity.getBody(), ObjectNode.class);
+    }
+
+    @Test
     void shouldGetBadRequestOnInvalidUri() throws JacksonException {
         var validUri = "valid_uri";
         var invalidUri = "invalid uri";


### PR DESCRIPTION
## Why

The LLM function example used `OPENAI_CHAT`, but the create-function API accepts
`CUSTOM` and `PREDICT_V2`. Invocation still uses OpenAI-compatible paths, so the
example made a valid routing workflow fail before function creation.

## What changed

- Document the supported `apiBodyFormat` values and the `CUSTOM` default.
- Correct the CLI example to use `CUSTOM`.
- Explain that body format does not select the LLM protocol or invocation path.
- Document native OpenAI-compatible request, response, and streaming behavior.
- Distinguish echo routing checks from real token-generation performance tests.
- Cover supported values, defaulting, and generic HTTP 400 rejection of an
  unsupported value.

The Pull Request does not special-case `ApiBodyFormatEnum` in shared
deserialization error handling. A general improvement for deserialization
error details belongs in a separate change that treats fields consistently.

## Customer Release Notes

Clarified the LLM function body-format contract and corrected the CLI example.

## Plan Summary

Not applicable.

## Usage

Use `apiBodyFormat: "CUSTOM"` for OpenAI-compatible LLM functions.

## Testing

- Focused Bazel integration selection on Linux with JDK 25: 5 tests passed.
  The selection covered unsupported-value HTTP 400 handling, generic malformed
  JSON handling, `CUSTOM`, `PREDICT_V2`, and omitted-to-`CUSTOM` defaulting.
- `./tools/ci/check-docs`: completed with zero Fern errors.
- `jq empty src/clis/nvcf-cli/examples/create-llm-function-routing-method.json`
- `git diff --check`

No live deployment validation is required for this documentation and request
deserialization coverage change.

## Notes

The test host reserved the default mock-registry port, so the focused Bazel
run supplied an unused test-only mock port through the existing Spring
configuration override. No production configuration changed.

## Issues

Relates to #1227.

## References

- Review request: https://github.com/NVIDIA/nvcf/pull/1238#issuecomment-5431089693

## Related Pull Requests

None.

## Dependencies

None. No license or NOTICE changes are required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified supported LLM API body formats, including `CUSTOM` and `OPENAI_CHAT`.
  * Documented default behavior, validation errors, routing and endpoint semantics.
  * Added requirements for non-streaming JSON responses and streaming SSE termination.
  * Clarified gateway relay behavior and limitations when benchmarking token generation with echo or fixed-response workloads.

* **Examples**
  * Updated the LLM function routing example to use the `CUSTOM` API body format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->