### PR TITLE
fix(nvca): apply a delete timeout to helm uninstall and survive SIGTERM when stripping ICMS finalizers during teardown

### DIFF
--- a/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
+++ b/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
@@ -64,6 +64,14 @@ helmDefaults:
   createNamespace: true
   devel: true
   timeout: 900
+  # deleteWait/deleteTimeout govern `helm uninstall` (helmfile destroy), which
+  # is a separate code path from timeout/wait above (those only apply to
+  # install/upgrade). Without them, `helm uninstall` gets no --timeout flag at
+  # all and falls back to Helm's 5m hook-wait default, well under the
+  # nvca-operator pre-delete hook's ~10m worst-case cordon-and-drain budget
+  # (see deployments/nvca-operator/values.yaml gracefulShutdown.cleanupTimeoutSeconds).
+  deleteWait: true
+  deleteTimeout: 900
   wait: true
   waitForJobs: true
   diffArgs:

--- a/src/compute-plane-services/nvca/pkg/operator/cleanup/shutdown.go
+++ b/src/compute-plane-services/nvca/pkg/operator/cleanup/shutdown.go
@@ -139,6 +139,12 @@ func NewShutdownHandler(ctx context.Context, opts ShutdownHandlerOptions) http.H
 	}
 }
 
+// icmsFinalizerStripTimeout bounds the detached-context finalizer strip that
+// runs immediately after drainWorkloads, independent of the parent ctx's
+// cancellation deadline. See the comment at its call site in
+// RunShutdownCleanup for why this needs its own context.
+const icmsFinalizerStripTimeout = 30 * time.Second
+
 // RunShutdownCleanup performs the operator-managed cleanup used by both the
 // preStop /shutdown handler and the Helm pre-delete cleanup job.
 func RunShutdownCleanup(ctx context.Context, opts ShutdownHandlerOptions) ShutdownResponse {
@@ -191,6 +197,19 @@ func RunShutdownCleanup(ctx context.Context, opts ShutdownHandlerOptions) Shutdo
 			log.WithError(err).Warnf("Failed to count ICMS requests in namespace %s, proceeding with cleanup", requestsNS)
 		} else if requestCount > 0 {
 			drainWorkloads(ctx, opts.K8sClient, opts.DynamicClient, systemNS, requestsNS, requestCount, rolloutTimeout, drainTimeout)
+
+			// Strip ICMSRequest finalizers right after the drain wait, on a context
+			// detached from ctx's cancellation. The pre-delete Job's activeDeadlineSeconds
+			// can expire around this point in the worst case (poll + rollout + full drain
+			// wait leaves little margin), and kubelet's SIGTERM cancels ctx when that
+			// happens. A cancelled ctx would otherwise skip this deep inside
+			// CleanupBackendResources below, leaving requestsNS finalizer-blocked and
+			// stuck Terminating, which then deadlocks reinstall.
+			finalizerCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), icmsFinalizerStripTimeout)
+			if err := deleteICMSRequests(finalizerCtx, opts.DynamicClient, requestsNS); err != nil {
+				log.WithError(err).Warnf("failed to strip ICMS request finalizers in namespace %s", requestsNS)
+			}
+			cancel()
 		}
 
 		log.Infof("Cleaning up NVCFBackend %s/%s", nb.Namespace, nb.Name)

--- a/src/compute-plane-services/nvca/pkg/operator/cleanup/shutdown_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/cleanup/shutdown_test.go
@@ -624,6 +624,88 @@ func TestNewShutdownHandler_WithV1ICMSRequests(t *testing.T) {
 	assert.True(t, resp.Cleanup, "should trigger cleanup even with ICMS requests present")
 }
 
+func TestRunShutdownCleanup_StripsICMSRequestFinalizersAfterDrain(t *testing.T) {
+	ctx := context.Background()
+
+	sentinel := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              ShutdownSentinelConfigMapName,
+			Namespace:         "test-namespace",
+			Finalizers:        []string{SentinelFinalizer},
+			DeletionTimestamp: &metav1.Time{Time: time.Now()},
+		},
+	}
+	backend := &nvidiaiov1.NVCFBackend{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-backend",
+			Namespace:  "test-namespace",
+			Finalizers: []string{NVCAOperatorFinalizer},
+		},
+	}
+	agentConfig := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "agent-config",
+			Namespace: DefaultNVCASystemNamespace,
+		},
+		Data: map[string]string{
+			"config.yaml": "agent:\n  featureFlags: []",
+		},
+	}
+	replicas := int32(1)
+	nvcaDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: NVCAModuleName, Namespace: DefaultNVCASystemNamespace},
+		Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+		Status: appsv1.DeploymentStatus{
+			UpdatedReplicas:     1,
+			AvailableReplicas:   1,
+			UnavailableReplicas: 0,
+		},
+	}
+
+	k8sClient := fake.NewSimpleClientset(sentinel, agentConfig, nvcaDeployment)
+	nvcaClient := fakenvcaop.NewSimpleClientset(backend)
+
+	scheme := runtime.NewScheme()
+	icmsGVR := schema.GroupVersionResource{
+		Group:    "nvca.nvcf.nvidia.io",
+		Version:  "v2beta1",
+		Resource: "icmsrequests",
+	}
+	icmsRequest := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "nvca.nvcf.nvidia.io/v2beta1",
+			"kind":       "ICMSRequest",
+			"metadata": map[string]interface{}{
+				"name":       "sr-1",
+				"namespace":  DefaultNVCARequestsNamespace,
+				"finalizers": []interface{}{"nvca.finalizers.nvidia.io"},
+			},
+		},
+	}
+	dynamicClient := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{icmsGVR: "ICMSRequestList"}, icmsRequest)
+
+	// A drain timeout shorter than the fixed 5s poll interval in drainWorkloads
+	// forces the "timeout reached, proceeding with forced cleanup" branch on
+	// the very first loop iteration, which is the code path this test targets:
+	// the ICMSRequest still has its finalizer and is never observed as drained.
+	resp := RunShutdownCleanup(ctx, ShutdownHandlerOptions{
+		K8sClient:           k8sClient,
+		NVCAClient:          nvcaClient,
+		DynamicClient:       dynamicClient,
+		Namespace:           "test-namespace",
+		DrainTimeout:        1 * time.Millisecond,
+		RolloutTimeout:      1 * time.Millisecond,
+		SetGracefulShutdown: func(shutdown bool) {},
+	})
+
+	require.True(t, resp.Cleanup)
+	require.Empty(t, resp.Error)
+
+	_, err := dynamicClient.Resource(icmsGVR).Namespace(DefaultNVCARequestsNamespace).Get(ctx, "sr-1", metav1.GetOptions{})
+	assert.True(t, k8serrors.IsNotFound(err), "ICMSRequest should be deleted once its finalizer is stripped, even on the forced-cleanup (drain-timeout) path")
+}
+
 func TestNewShutdownHandler_MultipleBackends(t *testing.T) {
 	ctx := context.Background()
 

--- a/src/compute-plane-services/nvca/pkg/operator/cleanup/shutdown_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/cleanup/shutdown_test.go
@@ -703,7 +703,8 @@ func TestRunShutdownCleanup_StripsICMSRequestFinalizersAfterDrain(t *testing.T) 
 	require.Empty(t, resp.Error)
 
 	_, err := dynamicClient.Resource(icmsGVR).Namespace(DefaultNVCARequestsNamespace).Get(ctx, "sr-1", metav1.GetOptions{})
-	assert.True(t, k8serrors.IsNotFound(err), "ICMSRequest should be deleted once its finalizer is stripped, even on the forced-cleanup (drain-timeout) path")
+	assert.True(t, k8serrors.IsNotFound(err),
+		"ICMSRequest should be deleted once its finalizer is stripped, even on the forced-cleanup (drain-timeout) path")
 }
 
 func TestNewShutdownHandler_MultipleBackends(t *testing.T) {


### PR DESCRIPTION
## TL;DR
`helmfile destroy` on the compute-plane stack calls `helm uninstall` with no delete-specific timeout, so it falls back to Helm's 5-minute default while the `nvca-operator` pre-delete hook can legitimately take up to ~10 minutes to cordon-and-drain in-flight requests. This makes `make destroy` report failure on a teardown that actually succeeds, and can leave the requests namespace deadlocked against reinstall if the hook's own deadline is hit mid-drain. This PR adds the correct helmfile delete timeout and hardens the finalizer-strip step against a SIGTERM landing mid-drain.

## Additional Details
- `deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl`: `helmDefaults.timeout` only applies to install/upgrade in helmfile; the delete path (`helmfile destroy` / `helm uninstall`) reads separate `deleteWait`/`deleteTimeout` fields, which were never set. Added `deleteWait: true` and `deleteTimeout: 900` so `helm uninstall` gets a timeout budget that actually covers the pre-delete hook's worst case.
- `src/compute-plane-services/nvca/pkg/operator/cleanup/shutdown.go`: the pre-delete hook Job has its own `activeDeadlineSeconds` (~600s), and its worst-case internal budget (poll + rollout wait + full drain wait) leaves little margin before that deadline. If kubelet's SIGTERM lands around there, it cancels the cleanup process's context, and the step that strips the finalizer from any remaining in-flight-request custom resource — previously reached deep inside the later cleanup call, on that same context — fails silently. The CR is left finalizer-blocked, which keeps its namespace stuck `Terminating` and deadlocks a subsequent reinstall (`ServiceAccount` creation forbidden while the namespace terminates). The finalizer strip now runs immediately after the drain wait, on a context detached from the parent's cancellation (`context.WithoutCancel` + its own short timeout), so it survives that SIGTERM.
- No functional change to the normal (non-timeout) path; the later, now-redundant strip call is idempotent.

## For the Reviewer
- Closest attention: the reordering in `shutdown.go` (finalizer strip moved to run right after `drainWorkloads`, on a detached context) and the new `deleteWait`/`deleteTimeout` keys in `02-nvca.yaml.gotmpl`.
- `deleteWait`/`deleteTimeout` are new to this helmfile config; confirmed they're recognized helmfile v1.7.3 fields via `helmfile build` rather than silently-dropped typos.

## For QA
- `go build ./...` and `go test ./pkg/operator/cleanup/...` pass, including a new regression test (`TestRunShutdownCleanup_StripsICMSRequestFinalizersAfterDrain`) that forces the drain-timeout branch and asserts the CR is gone by the time cleanup returns.
- Live-simulated the exact SIGTERM-mid-drain race against a running self-managed cluster by building the pre-fix and post-fix `nvca-operator-cleanup` binaries and running each against a synthetic in-flight request with a SIGTERM sent mid-drain: pre-fix left the finalizer/CR in place after reporting "success"; post-fix removed it despite the same cancellation.
- QA on a real teardown (`make destroy` with an in-flight request present) recommended before merge, to confirm the helmfile-level timeout change end-to-end.

## Issues
NO-REF

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown cleanup reliability when workload draining reaches its timeout.
  * Ensured pending request resources are fully removed even if the pre-delete process is cancelled.
  * Extended uninstall handling to wait for cleanup hooks and allow sufficient time for deletion.

* **Tests**
  * Added coverage verifying forced cleanup successfully removes remaining finalizers and resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->