### PR TITLE
fix(event-ledger): verify Cassandra server certificates

### DIFF
--- a/src/control-plane-services/event-ledger/internal/config/cliargs.go
+++ b/src/control-plane-services/event-ledger/internal/config/cliargs.go
@@ -97,8 +97,10 @@ func (c *CliArgs) SetupDatabase() {
 	c.int("database.cassandra.num-conns", 2, "Connections per host", true)
 	c.string("database.cassandra.pub-key-b64", "", "Cassandra public key as base64-encoded string", true)
 	c.string("database.cassandra.priv-key-b64", "", "Cassandra private key as base64-encoded string", true)
+	c.string("database.cassandra.ca-cert-b64", "", "Cassandra CA certificate as base64-encoded string", true)
 	c.string("database.cassandra.pub-key-path", "", "Cassandra public key path", true)
 	c.string("database.cassandra.priv-key-path", "", "Cassandra private key path", true)
+	c.string("database.cassandra.ca-cert-path", "", "Cassandra CA certificate path", true)
 	c.bool("database.cassandra.insecure-skip-verify", false, "Insecurely skip certificate verification", true)
 }
 

--- a/src/control-plane-services/event-ledger/internal/config/config.go
+++ b/src/control-plane-services/event-ledger/internal/config/config.go
@@ -170,7 +170,7 @@ type DBConfig struct {
 	CassandraConfig CassandraConfig `mapstructure:"cassandra"`
 }
 
-type CassandraConfig struct {
+ok type CassandraConfig struct {
 	Hosts              []string `mapstructure:"hosts"`
 	Port               int      `mapstructure:"port"`
 	Keyspace           string   `mapstructure:"keyspace"`
@@ -180,8 +180,10 @@ type CassandraConfig struct {
 	NumConns           int      `mapstructure:"num-conns"`
 	PubKeyB64          string   `mapstructure:"pub-key-b64"`
 	PrivKeyB64         string   `mapstructure:"priv-key-b64"`
+	CACertB64          string   `mapstructure:"ca-cert-b64"`
 	PubKeyPath         string   `mapstructure:"pub-key-path"`
 	PrivKeyPath        string   `mapstructure:"priv-key-path"`
+	CACertPath         string   `mapstructure:"ca-cert-path"`
 	InsecureSkipVerify bool     `mapstructure:"insecure-skip-verify"`
 }
 

--- a/src/control-plane-services/event-ledger/internal/config/config.go
+++ b/src/control-plane-services/event-ledger/internal/config/config.go
@@ -170,7 +170,7 @@ type DBConfig struct {
 	CassandraConfig CassandraConfig `mapstructure:"cassandra"`
 }
 
-ok type CassandraConfig struct {
+type CassandraConfig struct {
 	Hosts              []string `mapstructure:"hosts"`
 	Port               int      `mapstructure:"port"`
 	Keyspace           string   `mapstructure:"keyspace"`

--- a/src/control-plane-services/event-ledger/internal/configutil/BUILD.bazel
+++ b/src/control-plane-services/event-ledger/internal/configutil/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "configutil",
@@ -11,4 +11,11 @@ alias(
     name = "go_default_library",
     actual = ":configutil",
     visibility = ["//src/control-plane-services/event-ledger:__subpackages__"],
+)
+
+go_test(
+    name = "configutil_test",
+    srcs = ["utils_test.go"],
+    embed = [":configutil"],
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/src/control-plane-services/event-ledger/internal/configutil/utils.go
+++ b/src/control-plane-services/event-ledger/internal/configutil/utils.go
@@ -19,29 +19,44 @@ package configutil
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"fmt"
 	"reflect"
 )
 
-func GetTLSConfigFromBase64(certBase64 string, keyBase64 string, insecureSkipVerify bool) (*tls.Config, error) {
-	certPem, err := base64.StdEncoding.DecodeString(certBase64)
+func GetTLSConfigFromBase64(certBase64 string, keyBase64 string, caCertBase64 string, insecureSkipVerify bool) (*tls.Config, error) {
+	certPEM, err := base64.StdEncoding.DecodeString(certBase64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode cert base64: %v", err)
+		return nil, fmt.Errorf("failed to decode cert base64: %w", err)
 	}
 
-	keyPem, err := base64.StdEncoding.DecodeString(keyBase64)
+	keyPEM, err := base64.StdEncoding.DecodeString(keyBase64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode key base64: %v", err)
+		return nil, fmt.Errorf("failed to decode key base64: %w", err)
 	}
 
-	cert, err := tls.X509KeyPair(certPem, keyPem)
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create key pair: %v", err)
+		return nil, fmt.Errorf("failed to create key pair: %w", err)
+	}
+
+	var rootCAs *x509.CertPool
+	if caCertBase64 != "" {
+		caCertPEM, err := base64.StdEncoding.DecodeString(caCertBase64)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode CA cert base64: %w", err)
+		}
+
+		rootCAs = x509.NewCertPool()
+		if !rootCAs.AppendCertsFromPEM(caCertPEM) {
+			return nil, fmt.Errorf("failed to parse CA certificate")
+		}
 	}
 
 	return &tls.Config{
 		Certificates:       []tls.Certificate{cert},
+		RootCAs:            rootCAs,
 		InsecureSkipVerify: insecureSkipVerify,
 	}, nil
 }

--- a/src/control-plane-services/event-ledger/internal/configutil/utils_test.go
+++ b/src/control-plane-services/event-ledger/internal/configutil/utils_test.go
@@ -1,0 +1,117 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configutil
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTLSConfigFromBase64LoadsRootCA(t *testing.T) {
+	clientCertPEM, clientKeyPEM, caCertPEM := generateCertificateChain(t)
+
+	tlsConfig, err := GetTLSConfigFromBase64(
+		base64.StdEncoding.EncodeToString(clientCertPEM),
+		base64.StdEncoding.EncodeToString(clientKeyPEM),
+		base64.StdEncoding.EncodeToString(caCertPEM),
+		false,
+	)
+
+	require.NoError(t, err)
+	require.False(t, tlsConfig.InsecureSkipVerify)
+	require.Len(t, tlsConfig.Certificates, 1)
+	require.NotNil(t, tlsConfig.RootCAs)
+	require.Len(t, tlsConfig.RootCAs.Subjects(), 1)
+}
+
+func TestGetTLSConfigFromBase64AllowsSystemRoots(t *testing.T) {
+	clientCertPEM, clientKeyPEM, _ := generateCertificateChain(t)
+
+	tlsConfig, err := GetTLSConfigFromBase64(
+		base64.StdEncoding.EncodeToString(clientCertPEM),
+		base64.StdEncoding.EncodeToString(clientKeyPEM),
+		"",
+		false,
+	)
+
+	require.NoError(t, err)
+	require.Nil(t, tlsConfig.RootCAs)
+}
+
+func TestGetTLSConfigFromBase64RejectsInvalidRootCA(t *testing.T) {
+	clientCertPEM, clientKeyPEM, _ := generateCertificateChain(t)
+
+	_, err := GetTLSConfigFromBase64(
+		base64.StdEncoding.EncodeToString(clientCertPEM),
+		base64.StdEncoding.EncodeToString(clientKeyPEM),
+		base64.StdEncoding.EncodeToString([]byte("not a certificate")),
+		false,
+	)
+
+	require.ErrorContains(t, err, "failed to parse CA certificate")
+}
+
+func generateCertificateChain(t *testing.T) ([]byte, []byte, []byte) {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	now := time.Now()
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             now.Add(-time.Minute),
+		NotAfter:              now.Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "test-client"},
+		NotBefore:    now.Add(-time.Minute),
+		NotAfter:     now.Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	clientCertDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	clientKeyDER, err := x509.MarshalECPrivateKey(clientKey)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientCertDER}),
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: clientKeyDER}),
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertDER})
+}

--- a/src/control-plane-services/event-ledger/internal/db_client/cassandra/BUILD.bazel
+++ b/src/control-plane-services/event-ledger/internal/db_client/cassandra/BUILD.bazel
@@ -41,11 +41,13 @@ alias(
 go_test(
     name = "cassandra_test",
     srcs = [
+        "common_test.go",
         "v2_resilience_test.go",
         "v2_test.go",
     ],
     embed = [":cassandra"],
     deps = [
+        "//src/control-plane-services/event-ledger/internal/config",
         "//src/control-plane-services/event-ledger/internal/data_access",
         "//src/control-plane-services/event-ledger/internal/observability/logging",
         "@com_github_gocql_gocql//:gocql",

--- a/src/control-plane-services/event-ledger/internal/db_client/cassandra/common.go
+++ b/src/control-plane-services/event-ledger/internal/db_client/cassandra/common.go
@@ -481,7 +481,32 @@ func NewCassandraProvider(logger *otelzap.Logger) *CassandraProvider {
 	return &CassandraProvider{logger: logger}
 }
 
+func validateCassandraTLSConfig(cassandraConfig config.CassandraConfig) error {
+	pathConfigured := cassandraConfig.PubKeyPath != "" ||
+		cassandraConfig.PrivKeyPath != "" ||
+		cassandraConfig.CACertPath != ""
+	base64Configured := cassandraConfig.PubKeyB64 != "" ||
+		cassandraConfig.PrivKeyB64 != "" ||
+		cassandraConfig.CACertB64 != ""
+
+	if pathConfigured && base64Configured {
+		return fmt.Errorf("cassandra TLS configuration cannot mix file paths and base64 values")
+	}
+	if pathConfigured && (cassandraConfig.PubKeyPath == "" || cassandraConfig.PrivKeyPath == "") {
+		return fmt.Errorf("cassandra TLS file configuration requires both pub-key-path and priv-key-path")
+	}
+	if base64Configured && (cassandraConfig.PubKeyB64 == "" || cassandraConfig.PrivKeyB64 == "") {
+		return fmt.Errorf("cassandra TLS base64 configuration requires both pub-key-b64 and priv-key-b64")
+	}
+
+	return nil
+}
+
 func (p *CassandraProvider) NewConnection(config config.DBConfig) (data_access.DBHandler, error) {
+	if err := validateCassandraTLSConfig(config.CassandraConfig); err != nil {
+		return nil, err
+	}
+
 	cluster := gocql.NewCluster()
 	cluster.Hosts = config.CassandraConfig.Hosts
 	cluster.Port = config.CassandraConfig.Port
@@ -523,8 +548,7 @@ func (p *CassandraProvider) NewConnection(config config.DBConfig) (data_access.D
 			config.CassandraConfig.InsecureSkipVerify,
 		)
 		if err != nil {
-			p.logger.Warn("failed to create tls config", zap.Error(err))
-			return nil, err
+			return nil, fmt.Errorf("create Cassandra TLS config: %w", err)
 		}
 		cluster.SslOpts = &gocql.SslOptions{
 			Config:                 sslOpts,

--- a/src/control-plane-services/event-ledger/internal/db_client/cassandra/common.go
+++ b/src/control-plane-services/event-ledger/internal/db_client/cassandra/common.go
@@ -510,17 +510,25 @@ func (p *CassandraProvider) NewConnection(config config.DBConfig) (data_access.D
 	}
 	if config.CassandraConfig.PubKeyPath != "" && config.CassandraConfig.PrivKeyPath != "" {
 		cluster.SslOpts = &gocql.SslOptions{
-			CertPath: config.CassandraConfig.PubKeyPath,
-			KeyPath:  config.CassandraConfig.PrivKeyPath,
+			CertPath:               config.CassandraConfig.PubKeyPath,
+			KeyPath:                config.CassandraConfig.PrivKeyPath,
+			CaPath:                 config.CassandraConfig.CACertPath,
+			EnableHostVerification: !config.CassandraConfig.InsecureSkipVerify,
 		}
 	} else if config.CassandraConfig.PubKeyB64 != "" && config.CassandraConfig.PrivKeyB64 != "" {
-		sslOpts, err := configutil.GetTLSConfigFromBase64(config.CassandraConfig.PubKeyB64, config.CassandraConfig.PrivKeyB64, config.CassandraConfig.InsecureSkipVerify)
+		sslOpts, err := configutil.GetTLSConfigFromBase64(
+			config.CassandraConfig.PubKeyB64,
+			config.CassandraConfig.PrivKeyB64,
+			config.CassandraConfig.CACertB64,
+			config.CassandraConfig.InsecureSkipVerify,
+		)
 		if err != nil {
 			p.logger.Warn("failed to create tls config", zap.Error(err))
 			return nil, err
 		}
 		cluster.SslOpts = &gocql.SslOptions{
-			Config: sslOpts,
+			Config:                 sslOpts,
+			EnableHostVerification: !config.CassandraConfig.InsecureSkipVerify,
 		}
 	}
 

--- a/src/control-plane-services/event-ledger/internal/db_client/cassandra/common_test.go
+++ b/src/control-plane-services/event-ledger/internal/db_client/cassandra/common_test.go
@@ -1,0 +1,116 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cassandra
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/nvcf/src/control-plane-services/event-ledger/internal/config"
+)
+
+func TestValidateCassandraTLSConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  config.CassandraConfig
+		wantErr string
+	}{
+		{
+			name: "no TLS configuration",
+		},
+		{
+			name: "file key pair uses system roots",
+			config: config.CassandraConfig{
+				PubKeyPath:  "client.crt",
+				PrivKeyPath: "client.key",
+			},
+		},
+		{
+			name: "file key pair uses custom CA",
+			config: config.CassandraConfig{
+				PubKeyPath:  "client.crt",
+				PrivKeyPath: "client.key",
+				CACertPath:  "ca.crt",
+			},
+		},
+		{
+			name: "base64 key pair uses system roots",
+			config: config.CassandraConfig{
+				PubKeyB64:  "client-cert",
+				PrivKeyB64: "client-key",
+			},
+		},
+		{
+			name: "base64 key pair uses custom CA",
+			config: config.CassandraConfig{
+				PubKeyB64:  "client-cert",
+				PrivKeyB64: "client-key",
+				CACertB64:  "ca-cert",
+			},
+		},
+		{
+			name: "CA path without client key pair",
+			config: config.CassandraConfig{
+				CACertPath: "ca.crt",
+			},
+			wantErr: "requires both pub-key-path and priv-key-path",
+		},
+		{
+			name: "base64 CA without client key pair",
+			config: config.CassandraConfig{
+				CACertB64: "ca-cert",
+			},
+			wantErr: "requires both pub-key-b64 and priv-key-b64",
+		},
+		{
+			name: "partial file key pair",
+			config: config.CassandraConfig{
+				PubKeyPath: "client.crt",
+			},
+			wantErr: "requires both pub-key-path and priv-key-path",
+		},
+		{
+			name: "partial base64 key pair",
+			config: config.CassandraConfig{
+				PrivKeyB64: "client-key",
+			},
+			wantErr: "requires both pub-key-b64 and priv-key-b64",
+		},
+		{
+			name: "mixed file and base64 configuration",
+			config: config.CassandraConfig{
+				PubKeyPath:  "client.crt",
+				PrivKeyPath: "client.key",
+				CACertB64:   "ca-cert",
+			},
+			wantErr: "cannot mix file paths and base64 values",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCassandraTLSConfig(tt.config)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
## TL;DR

Add configurable Cassandra CA certificates so Event Ledger can verify Cassandra server certificates instead of relying on `insecure-skip-verify`.

## Additional Details

Event Ledger currently supports a client certificate and private key but cannot load a Cassandra-specific CA trust bundle.

This change:

- adds `database.cassandra.ca-cert-b64` and `database.cassandra.ca-cert-path`
- loads base64-encoded CA certificates into `tls.Config.RootCAs`
- passes file-based CA certificates to gocql through `CaPath`
- explicitly configures gocql hostname verification
- preserves system-root behavior when no custom CA is configured
- returns an error when a configured CA cannot be decoded or parsed

Deployment configuration changes are maintained separately and should be rolled out only after an Event Ledger image containing this change is available.

## For the Reviewer

Please review:

- `internal/configutil/utils.go` for CA parsing and trust-pool construction
- `internal/db_client/cassandra/common.go` for gocql hostname-verification behavior
- `internal/configutil/utils_test.go` for custom-CA, system-root, and invalid-CA coverage

## For QA

Validation completed:

- `go test ./...`

The complete Event Ledger Go test suite passes locally.

Bazel validation was not run locally because Bazel is unavailable in the development environment; CI should run the added `configutil_test` target.

## Issues

NO-REF

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring Cassandra TLS with a custom CA certificate supplied as a file or Base64 value.
  - Added command-line options for selecting CA certificate sources.
  - Improved TLS settings to consistently apply certificate validation and host verification preferences.

- **Bug Fixes**
  - Added validation for incomplete or conflicting certificate and key configurations.
  - Improved error reporting for invalid certificates, keys, and CA data.
  - Preserved use of system trusted certificates when no custom CA is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->