### PR TITLE
fix(cloud-functions): delete deployment before function

### DIFF
--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/service/function/FunctionDeploymentService.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/service/function/FunctionDeploymentService.java
@@ -293,7 +293,29 @@ public class FunctionDeploymentService {
                 functionDeploymentLookupService.getDeploymentContextByVersionIdOrThrow(
                         functionVersionId)
                 .deployment();
+        return deleteFunctionDeployment(function, deployment, payloadBuilder, graceful);
+    }
+
+    // Deletes a function deployment when one exists. This is used by function deletion,
+    // which must also support deployments that were already deleted or never deployed.
+    public void deleteFunctionDeploymentIfPresent(
+            FunctionEntity function,
+            AuditEventPayload.Builder payloadBuilder) {
+        var versionId = function.getFunctionVersionId();
+        functionDeploymentLookupService.getDeploymentContextByVersionId(versionId)
+                .map(FunctionDeploymentContext::deployment)
+                .ifPresent(deployment -> deleteFunctionDeployment(function, deployment,
+                                                                   payloadBuilder, false));
+    }
+
+    private FunctionDto deleteFunctionDeployment(
+            FunctionEntity function,
+            FunctionDeploymentEntity deployment,
+            AuditEventPayload.Builder payloadBuilder,
+            boolean graceful) {
         var functionJsonBefore = jsonMapper.valueToTree(function);
+        var functionId = function.getFunctionId();
+        var functionVersionId = function.getFunctionVersionId();
 
         log.info(MESG_FUNCTION_OPERATION, functionId, functionVersionId, "Deleting deployment");
 
@@ -333,13 +355,9 @@ public class FunctionDeploymentService {
         return functionMapperService.toFunctionDto(function, Optional.empty(), Optional.empty());
     }
 
-    /**
-     * Forcefully deletes function's deployment which includes corresponding NATS queues,
-     * the Workers, and the entry from the functions_deployment_v2 table.
-     *
-     * @param functionVersionId Version id of the function whose deployment is to be deleted
-     */
-    public void forceDeleteFunctionDeployment(UUID functionVersionId) {
+    // Forcefully deletes function's deployment which includes corresponding NATS queues,
+    // the Workers, and the entry from the functions_deployment_v2 table.
+    private void forceDeleteFunctionDeployment(UUID functionVersionId) {
         deleteFunctionRequestQueue(functionVersionId);
         var deploymentOpt = functionDeploymentLookupService
                 .getDeploymentContextByVersionId(functionVersionId)

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/service/function/FunctionManagementService.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/service/function/FunctionManagementService.java
@@ -392,21 +392,20 @@ public class FunctionManagementService {
             throw new ForbiddenException(mesg);
         }
 
-        log.info(MESG_FUNCTION_OPERATION, functionId, functionVersionId, "Deleting");
+        log.info(MESG_FUNCTION_OPERATION, functionId, functionVersionId, "Deleting function");
 
-        // Delete vestiges of the function from various tables.
+        // If the function is currently deployed, then force delete -- the queue, the workers
+        // associated with the function, and the deployment. Also, audit the operation.
+        deploymentService.deleteFunctionDeploymentIfPresent(function, payloadBuilder);
+
+        // Delete the function.
         functionsRepository.delete(function);
 
-        // If the function is currently deployed, delete the queue, the Workers associated
-        // with the function, and the deployment.
-        deploymentService.forceDeleteFunctionDeployment(functionVersionId);
-
-        // Delete any secrets associated with the function
+        // Then, delete any secrets associated with the function.
         essService.deleteFunctionVersionSecrets(functionId, functionVersionId);
 
         // If there are no more versions of a function, we should delete the function-specific
-        // secrets path in ESS and also delete any remaining vestiges such as authorized parties
-        // for wildcard version from azps tables.
+        // secrets path in ESS.
         try {
             functionLookupService.lookupUsingFunctionIdOrThrow(functionId);
         } catch (NotFoundException ex) {
@@ -414,7 +413,7 @@ public class FunctionManagementService {
             essService.deleteFunctionSecrets(functionId);
         }
         functionAuditService.auditFunctionDelete(payloadBuilder, function);
-        log.info(MESG_FUNCTION_OPERATION, functionId, functionVersionId, "Deleted");
+        log.info(MESG_FUNCTION_OPERATION, functionId, functionVersionId, "Deleted function");
     }
 
     public FunctionDto updateFunction(

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/rest/function/management/FunctionManagementControllerTest.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/rest/function/management/FunctionManagementControllerTest.java
@@ -2049,6 +2049,24 @@ class FunctionManagementControllerTest {
     }
 
 
+    @Test
+    void deleteUndeployedFunction() {
+        testService.createTestFunctionEntity(TEST_FUNCTION_ID, TEST_VERSION_ID_1, TEST_NCA_ID,
+                                             TEST_FUNCTION_NAME);
+        var token = MOCK_OAUTH2_TOKEN_SERVER.getJwt(TEST_CLIENT_SUBJECT,
+                                                    List.of(SCOPE_DELETE_FUNCTION), 100);
+        var requestEntity = RequestEntity.delete(
+                        URI.create("/v2/nvcf/functions/" + TEST_FUNCTION_ID
+                                           + "/versions/" + TEST_VERSION_ID_1))
+                .header("Authorization", "Bearer " + token)
+                .build();
+
+        var responseEntity = testRestTemplate.exchange(requestEntity, Void.class);
+
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(functionsRepository.getByFunctionVersionId(TEST_VERSION_ID_1)).isEmpty();
+    }
+
     Stream<Arguments> deleteArgs() {
         var jwtCases = Stream.of(
                 Arguments.of(MOCK_OAUTH2_TOKEN_SERVER.getJwt(TEST_CLIENT_SUBJECT,


### PR DESCRIPTION
## TL;DR

Delete an existing function deployment before deleting the function record. This preserves deployment cleanup and records deployment deletion in the audit trail.

## Additional Details

Function deletion now checks for a deployment and deletes it first. The deployment cleanup removes the queue and workers, records the deployment audit event, and then allows function and secret cleanup to proceed. Function versions that were never deployed continue to delete successfully.

## For the Reviewer

Review the deletion sequence in `FunctionManagementService` and the optional deployment cleanup path in `FunctionDeploymentService`.

## For QA

- Added a controller regression test for deleting an undeployed function.
- Not run locally. The `nvcf-core:tests` target requires Docker.
- QA Needed: No

## Issues

Fixes #1251

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved function deletion handling for versions without deployments.
  * Function deletion now completes successfully and returns `204 No Content` when no deployment exists.
  * Deployment deletion is recorded in the operation audit trail.
  * Added clearer deletion activity logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->