### PR TITLE
fix(nvca): remove leftover intra-namespace egress NetworkPolicy from nvcf-backend at startup

### DIFF
--- a/docs/ngc-managed/cluster-management/configuration.md
+++ b/docs/ngc-managed/cluster-management/configuration.md
@@ -271,13 +271,13 @@ The NVCA operator requires outbound network connectivity to pull images, charts,
 | Policy Name | Description |
 | --- | --- |
 | allow-egress-gxcache | Allows egress traffic to the GX Cache namespace for caching operations (only relevant for NVIDIA managed clusters) |
-| allow-egress-internet-no- internal-no-api | Allows egress traffic to the public internet (0.0.0.0/0) but blocks traffic to common private IP ranges. Also allows DNS resolution via kube-dns. |
+| allow-egress-internet-no-internal-no-api | Allows egress traffic to the public internet (0.0.0.0/0) but blocks traffic to common private IP ranges. Also allows DNS resolution via kube-dns. |
 | allow-egress-intra-namespace | Allows pod-to-pod communication within the same namespace. Applied only to per-instance function namespaces (for example a MiniService's utils pod reaching its own inference pod), never to the shared `nvcf-backend` namespace. |
 | allow-egress-nvcf-cache | Allows egress traffic to NVCF cache services (only relevant for NVIDIA managed clusters) |
-| allow-egress-prometheus- nvcf-byoo | Allows egress traffic to Prometheus monitoring endpoints (only relevant for NVIDIA managed clusters) |
+| allow-egress-prometheus-nvcf-byoo | Allows egress traffic to Prometheus monitoring endpoints (only relevant for NVIDIA managed clusters) |
 | allow-ingress-monitoring | Allows ingress traffic for monitoring services. In per-instance function namespaces, also allows same-namespace ingress (paired with allow-egress-intra-namespace); never in the shared `nvcf-backend` namespace. |
 | allow-ingress-monitoring-dcgm | Allows ingress traffic for DCGM monitoring |
-| allow-ingress-monitoring- gxcache | Allows ingress traffic for GX Cache monitoring (only relevant for NVIDIA managed clusters) |
+| allow-ingress-monitoring-gxcache | Allows ingress traffic for GX Cache monitoring (only relevant for NVIDIA managed clusters) |
 
 ## Key Network Requirements
 

--- a/docs/ngc-managed/cluster-management/configuration.md
+++ b/docs/ngc-managed/cluster-management/configuration.md
@@ -275,7 +275,7 @@ The NVCA operator requires outbound network connectivity to pull images, charts,
 | allow-egress-intra-namespace | Allows pod-to-pod communication within the same namespace. Applied only to per-instance function namespaces (for example a MiniService's utils pod reaching its own inference pod), never to the shared `nvcf-backend` namespace. |
 | allow-egress-nvcf-cache | Allows egress traffic to NVCF cache services (only relevant for NVIDIA managed clusters) |
 | allow-egress-prometheus-nvcf-byoo | Allows egress traffic to Prometheus monitoring endpoints (only relevant for NVIDIA managed clusters) |
-| allow-ingress-monitoring | Allows ingress traffic for monitoring services. In per-instance function namespaces, also allows same-namespace ingress (paired with allow-egress-intra-namespace); never in the shared `nvcf-backend` namespace. |
+| allow-ingress-monitoring | Allows ingress from the `monitoring` namespace on supported monitoring ports. In per-instance function namespaces, also allows same-namespace ingress (paired with allow-egress-intra-namespace); same-namespace ingress is not added to the shared `nvcf-backend` namespace. |
 | allow-ingress-monitoring-dcgm | Allows ingress traffic for DCGM monitoring |
 | allow-ingress-monitoring-gxcache | Allows ingress traffic for GX Cache monitoring (only relevant for NVIDIA managed clusters) |
 

--- a/docs/ngc-managed/cluster-management/configuration.md
+++ b/docs/ngc-managed/cluster-management/configuration.md
@@ -272,9 +272,10 @@ The NVCA operator requires outbound network connectivity to pull images, charts,
 | --- | --- |
 | allow-egress-gxcache | Allows egress traffic to the GX Cache namespace for caching operations (only relevant for NVIDIA managed clusters) |
 | allow-egress-internet-no- internal-no-api | Allows egress traffic to the public internet (0.0.0.0/0) but blocks traffic to common private IP ranges. Also allows DNS resolution via kube-dns. |
+| allow-egress-intra-namespace | Allows pod-to-pod communication within the same namespace. Applied only to per-instance function namespaces (for example a MiniService's utils pod reaching its own inference pod), never to the shared `nvcf-backend` namespace. |
 | allow-egress-nvcf-cache | Allows egress traffic to NVCF cache services (only relevant for NVIDIA managed clusters) |
 | allow-egress-prometheus- nvcf-byoo | Allows egress traffic to Prometheus monitoring endpoints (only relevant for NVIDIA managed clusters) |
-| allow-ingress-monitoring | Allows ingress traffic for monitoring services |
+| allow-ingress-monitoring | Allows ingress traffic for monitoring services. In per-instance function namespaces, also allows same-namespace ingress (paired with allow-egress-intra-namespace); never in the shared `nvcf-backend` namespace. |
 | allow-ingress-monitoring-dcgm | Allows ingress traffic for DCGM monitoring |
 | allow-ingress-monitoring- gxcache | Allows ingress traffic for GX Cache monitoring (only relevant for NVIDIA managed clusters) |
 

--- a/docs/ngc-managed/cluster-management/configuration.md
+++ b/docs/ngc-managed/cluster-management/configuration.md
@@ -272,7 +272,6 @@ The NVCA operator requires outbound network connectivity to pull images, charts,
 | --- | --- |
 | allow-egress-gxcache | Allows egress traffic to the GX Cache namespace for caching operations (only relevant for NVIDIA managed clusters) |
 | allow-egress-internet-no- internal-no-api | Allows egress traffic to the public internet (0.0.0.0/0) but blocks traffic to common private IP ranges. Also allows DNS resolution via kube-dns. |
-| allow-egress-intra-namespace | Controls pod-to-pod communication within the same namespace. This policy is only applied to function namespaces and not to shared pod instance namespaces. |
 | allow-egress-nvcf-cache | Allows egress traffic to NVCF cache services (only relevant for NVIDIA managed clusters) |
 | allow-egress-prometheus- nvcf-byoo | Allows egress traffic to Prometheus monitoring endpoints (only relevant for NVIDIA managed clusters) |
 | allow-ingress-monitoring | Allows ingress traffic for monitoring services |

--- a/docs/user/cluster-management/configuration.md
+++ b/docs/user/cluster-management/configuration.md
@@ -284,7 +284,6 @@ The NVCA operator requires outbound network connectivity to pull images, charts,
 | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | allow-egress-gxcache                      | Allows egress traffic to the GX Cache namespace for caching operations (only relevant for NVIDIA managed clusters)                                         |
 | allow-egress-internet-no- internal-no-api | Allows egress traffic to the public internet (0.0.0.0/0) but blocks traffic to common private IP ranges. Also allows DNS resolution via kube-dns.          |
-| allow-egress-intra-namespace              | Controls pod-to-pod communication within the same namespace. This policy is only applied to function namespaces and not to shared pod instance namespaces. |
 | allow-egress-nvcf-cache                   | Allows egress traffic to NVCF cache services (only relevant for NVIDIA managed clusters)                                                                   |
 | allow-egress-prometheus- nvcf-byoo        | Allows egress traffic to Prometheus monitoring endpoints (only relevant for NVIDIA managed clusters)                                                       |
 | allow-ingress-monitoring                  | Allows ingress traffic for monitoring services                                                                                                             |

--- a/docs/user/cluster-management/configuration.md
+++ b/docs/user/cluster-management/configuration.md
@@ -283,13 +283,13 @@ The NVCA operator requires outbound network connectivity to pull images, charts,
 | Policy Name                               | Description                                                                                                                                                |
 | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | allow-egress-gxcache                      | Allows egress traffic to the GX Cache namespace for caching operations (only relevant for NVIDIA managed clusters)                                         |
-| allow-egress-internet-no- internal-no-api | Allows egress traffic to the public internet (0.0.0.0/0) but blocks traffic to common private IP ranges. Also allows DNS resolution via kube-dns.          |
+| allow-egress-internet-no-internal-no-api | Allows egress traffic to the public internet (0.0.0.0/0) but blocks traffic to common private IP ranges. Also allows DNS resolution via kube-dns.          |
 | allow-egress-intra-namespace              | Allows pod-to-pod communication within the same namespace. Applied only to per-instance function namespaces (for example a MiniService's utils pod reaching its own inference pod), never to the shared `nvcf-backend` namespace.  |
 | allow-egress-nvcf-cache                   | Allows egress traffic to NVCF cache services (only relevant for NVIDIA managed clusters)                                                                   |
-| allow-egress-prometheus- nvcf-byoo        | Allows egress traffic to Prometheus monitoring endpoints (only relevant for NVIDIA managed clusters)                                                       |
+| allow-egress-prometheus-nvcf-byoo         | Allows egress traffic to Prometheus monitoring endpoints (only relevant for NVIDIA managed clusters)                                                       |
 | allow-ingress-monitoring                  | Allows ingress traffic for monitoring services. In per-instance function namespaces, also allows same-namespace ingress (paired with allow-egress-intra-namespace); never in the shared `nvcf-backend` namespace. |
 | allow-ingress-monitoring-dcgm             | Allows ingress traffic for DCGM monitoring                                                                                                                 |
-| allow-ingress-monitoring- gxcache         | Allows ingress traffic for GX Cache monitoring (only relevant for NVIDIA managed clusters)                                                                 |
+| allow-ingress-monitoring-gxcache         | Allows ingress traffic for GX Cache monitoring (only relevant for NVIDIA managed clusters)                                                                 |
 
 ## Key Network Requirements
 

--- a/docs/user/cluster-management/configuration.md
+++ b/docs/user/cluster-management/configuration.md
@@ -287,7 +287,7 @@ The NVCA operator requires outbound network connectivity to pull images, charts,
 | allow-egress-intra-namespace              | Allows pod-to-pod communication within the same namespace. Applied only to per-instance function namespaces (for example a MiniService's utils pod reaching its own inference pod), never to the shared `nvcf-backend` namespace.  |
 | allow-egress-nvcf-cache                   | Allows egress traffic to NVCF cache services (only relevant for NVIDIA managed clusters)                                                                   |
 | allow-egress-prometheus-nvcf-byoo         | Allows egress traffic to Prometheus monitoring endpoints (only relevant for NVIDIA managed clusters)                                                       |
-| allow-ingress-monitoring                  | Allows ingress traffic for monitoring services. In per-instance function namespaces, also allows same-namespace ingress (paired with allow-egress-intra-namespace); never in the shared `nvcf-backend` namespace. |
+| allow-ingress-monitoring                  | Allows ingress from the `monitoring` namespace on supported monitoring ports. In per-instance function namespaces, also allows same-namespace ingress (paired with allow-egress-intra-namespace); same-namespace ingress is not added to the shared `nvcf-backend` namespace. |
 | allow-ingress-monitoring-dcgm             | Allows ingress traffic for DCGM monitoring                                                                                                                 |
 | allow-ingress-monitoring-gxcache         | Allows ingress traffic for GX Cache monitoring (only relevant for NVIDIA managed clusters)                                                                 |
 

--- a/docs/user/cluster-management/configuration.md
+++ b/docs/user/cluster-management/configuration.md
@@ -284,9 +284,10 @@ The NVCA operator requires outbound network connectivity to pull images, charts,
 | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | allow-egress-gxcache                      | Allows egress traffic to the GX Cache namespace for caching operations (only relevant for NVIDIA managed clusters)                                         |
 | allow-egress-internet-no- internal-no-api | Allows egress traffic to the public internet (0.0.0.0/0) but blocks traffic to common private IP ranges. Also allows DNS resolution via kube-dns.          |
+| allow-egress-intra-namespace              | Allows pod-to-pod communication within the same namespace. Applied only to per-instance function namespaces (for example a MiniService's utils pod reaching its own inference pod), never to the shared `nvcf-backend` namespace.  |
 | allow-egress-nvcf-cache                   | Allows egress traffic to NVCF cache services (only relevant for NVIDIA managed clusters)                                                                   |
 | allow-egress-prometheus- nvcf-byoo        | Allows egress traffic to Prometheus monitoring endpoints (only relevant for NVIDIA managed clusters)                                                       |
-| allow-ingress-monitoring                  | Allows ingress traffic for monitoring services                                                                                                             |
+| allow-ingress-monitoring                  | Allows ingress traffic for monitoring services. In per-instance function namespaces, also allows same-namespace ingress (paired with allow-egress-intra-namespace); never in the shared `nvcf-backend` namespace. |
 | allow-ingress-monitoring-dcgm             | Allows ingress traffic for DCGM monitoring                                                                                                                 |
 | allow-ingress-monitoring- gxcache         | Allows ingress traffic for GX Cache monitoring (only relevant for NVIDIA managed clusters)                                                                 |
 

--- a/src/compute-plane-services/nvca/internal/miniservice/reconcile_test.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/reconcile_test.go
@@ -766,7 +766,7 @@ rules:
 	netPolList := &netv1.NetworkPolicyList{}
 	err = r.Client.List(ctx, netPolList, client.InNamespace(ms.Spec.Namespace))
 	require.NoError(t, err)
-	assert.Len(t, netPolList.Items, 7)
+	assert.Len(t, netPolList.Items, 6)
 
 	// Check that initial resources were not created until after the utils pod's init containers complete.
 	err = r.Client.Get(ctx, client.ObjectKeyFromObject(ms), ms)
@@ -2661,7 +2661,7 @@ rules:
 	netPolList := &netv1.NetworkPolicyList{}
 	err = r.Client.List(ctx, netPolList, client.InNamespace(ms.Spec.Namespace))
 	require.NoError(t, err)
-	assert.Len(t, netPolList.Items, 7)
+	assert.Len(t, netPolList.Items, 6)
 
 	// Check that initial resources were not created until after the utils pod's init containers complete.
 	gotJob := &batchv1.Job{}

--- a/src/compute-plane-services/nvca/internal/miniservice/reconcile_test.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/reconcile_test.go
@@ -766,7 +766,7 @@ rules:
 	netPolList := &netv1.NetworkPolicyList{}
 	err = r.Client.List(ctx, netPolList, client.InNamespace(ms.Spec.Namespace))
 	require.NoError(t, err)
-	assert.Len(t, netPolList.Items, 6)
+	assert.Len(t, netPolList.Items, 7)
 
 	// Check that initial resources were not created until after the utils pod's init containers complete.
 	err = r.Client.Get(ctx, client.ObjectKeyFromObject(ms), ms)
@@ -2661,7 +2661,7 @@ rules:
 	netPolList := &netv1.NetworkPolicyList{}
 	err = r.Client.List(ctx, netPolList, client.InNamespace(ms.Spec.Namespace))
 	require.NoError(t, err)
-	assert.Len(t, netPolList.Items, 6)
+	assert.Len(t, netPolList.Items, 7)
 
 	// Check that initial resources were not created until after the utils pod's init containers complete.
 	gotJob := &batchv1.Job{}

--- a/src/compute-plane-services/nvca/internal/util/k8sutil/netpol.go
+++ b/src/compute-plane-services/nvca/internal/util/k8sutil/netpol.go
@@ -87,6 +87,9 @@ func EnsureNetworkPoliciesFunctionNamespace(
 	crClient client.Client,
 	extraNPs ...*netv1.NetworkPolicy,
 ) error {
+	var allExtraNPs []*netv1.NetworkPolicy
+	allExtraNPs = append(allExtraNPs, createIntraNamespaceEgressPolicy(namespace))
+	allExtraNPs = append(allExtraNPs, extraNPs...)
 	return ensureNetworkPolicies(ctx,
 		namespace,
 		nps,
@@ -94,7 +97,7 @@ func EnsureNetworkPoliciesFunctionNamespace(
 		k8sClient,
 		crClient,
 		true,
-		extraNPs...,
+		allExtraNPs...,
 	)
 }
 
@@ -123,12 +126,16 @@ func ensureNetworkPolicies(
 	ffFetcher featureflag.Fetcher,
 	k8sClient k8sclient.Interface,
 	crClient client.Client,
-	// cleanupLegacyIntraNamespaceEgress is true only for function namespaces
-	// (EnsureNetworkPoliciesFunctionNamespace), the only reconcile path that
-	// ever created AllowEgressIntraNamespaceNetworkPolicyName. Shared pod
-	// instance namespaces never owned that policy, so they must not delete a
-	// same-named policy they don't manage.
-	cleanupLegacyIntraNamespaceEgress bool,
+	// singleTenantNamespace is true for function namespaces (one MiniService
+	// or Helm release per namespace, via EnsureNetworkPoliciesFunctionNamespace).
+	// A same-namespace allow is safe there because only one tenant's pods ever
+	// live in the namespace, e.g. a MiniService's utils pod reaching its own
+	// inference pod on a different pod in the same namespace. It is false for
+	// the namespace shared across every container-function tenant on the
+	// cluster (nvcf-backend, via EnsureNetworkPoliciesSharedPodInstanceNamespace),
+	// where the same allow would let one customer's pod reach another
+	// customer's pod.
+	singleTenantNamespace bool,
 	extraNPs ...*netv1.NetworkPolicy,
 ) error {
 	log := core.GetLogger(ctx)
@@ -171,6 +178,19 @@ func ensureNetworkPolicies(
 		newNP.Namespace = namespace
 
 		switch newNP.Name {
+		case MonitoringIngressNetworkPolicyName:
+			if singleTenantNamespace {
+				snRule := netv1.NetworkPolicyIngressRule{
+					From: []netv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{K8sNameLabelKey: namespace},
+							},
+						},
+					},
+				}
+				newNP.Spec.Ingress = append(newNP.Spec.Ingress, snRule)
+			}
 		case EgressNVCFCacheNetworkPolicyNameKey:
 			// check if both container-caching & dns-proxy namespaces are present
 			var ccnsErr, pcnsErr error
@@ -219,50 +239,12 @@ func ensureNetworkPolicies(
 			errs = append(errs, err)
 		}
 	}
-	// Clean up the legacy unconditional intra-namespace egress policy this
-	// package used to create for every function namespace: combined with the
-	// same-namespace ingress rule this package used to add to
-	// MonitoringIngressNetworkPolicyName, it let any pod in a function
-	// namespace reach any other pod in that namespace on any port. Neither
-	// is created here anymore, but namespaces reconciled by an older build
-	// may still have this policy left over, so remove it explicitly. Scoped
-	// to function namespaces only; see cleanupLegacyIntraNamespaceEgress.
-	if cleanupLegacyIntraNamespaceEgress {
-		if _, wanted := newNetworkPolicies[AllowEgressIntraNamespaceNetworkPolicyName]; !wanted {
-			if err := deleteNetworkPolicyIfExists(ctx, namespace, AllowEgressIntraNamespaceNetworkPolicyName, k8sClient, crClient); err != nil {
-				errs = append(errs, err)
-			}
-		}
-	}
-
 	if err := errors.Join(errs...); err != nil {
 		return err
 	}
 
 	// Prune existing network policies that are not in the configmap and are custom network policies
 	return pruneCustomNetworkPolicies(ctx, namespace, k8sClient, crClient, newNetworkPolicies)
-}
-
-// deleteNetworkPolicyIfExists deletes the named NetworkPolicy in namespace,
-// treating "not found" as success.
-func deleteNetworkPolicyIfExists(ctx context.Context,
-	namespace string,
-	name string,
-	k8sClient k8sclient.Interface,
-	crClient client.Client,
-) error {
-	if crClient != nil {
-		np := &netv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
-		if err := crClient.Delete(ctx, np); err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("delete NetworkPolicy %s in namespace %s: %w", name, namespace, err)
-		}
-		return nil
-	}
-
-	if err := k8sClient.NetworkingV1().NetworkPolicies(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("delete NetworkPolicy %s in namespace %s: %w", name, namespace, err)
-	}
-	return nil
 }
 
 func pruneCustomNetworkPolicies(ctx context.Context,
@@ -401,6 +383,28 @@ func getValidNetworkPolicyNames(nps map[string]string) []string {
 	}
 
 	return validNps
+}
+
+func createIntraNamespaceEgressPolicy(namespace string) *netv1.NetworkPolicy {
+	return &netv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: AllowEgressIntraNamespaceNetworkPolicyName,
+		},
+		Spec: netv1.NetworkPolicySpec{
+			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeEgress},
+			Egress: []netv1.NetworkPolicyEgressRule{
+				{
+					To: []netv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{K8sNameLabelKey: namespace},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 func createOrUpdateNetworkPolicy(ctx context.Context,

--- a/src/compute-plane-services/nvca/internal/util/k8sutil/netpol.go
+++ b/src/compute-plane-services/nvca/internal/util/k8sutil/netpol.go
@@ -119,6 +119,23 @@ func EnsureNetworkPoliciesSharedPodInstanceNamespace(
 	)
 }
 
+// RemoveLegacyIntraNamespaceEgressPolicy deletes the allow-egress-intra-namespace
+// NetworkPolicy from the shared pod-instance namespace (nvcf-backend) if it still
+// exists from before this policy was scoped out of that namespace. It is meant to
+// be called once, at agent startup, rather than on every reconcile: the policy is
+// not custom-labeled, so the regular ensureNetworkPolicies prune loop never removes
+// it on its own, and clusters that already have it must be migrated explicitly.
+func RemoveLegacyIntraNamespaceEgressPolicy(ctx context.Context, namespace string, k8sClient k8sclient.Interface) error {
+	err := k8sClient.NetworkingV1().NetworkPolicies(namespace).Delete(
+		ctx, AllowEgressIntraNamespaceNetworkPolicyName, metav1.DeleteOptions{},
+	)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete legacy NetworkPolicy %s in namespace %s: %w",
+			AllowEgressIntraNamespaceNetworkPolicyName, namespace, err)
+	}
+	return nil
+}
+
 func ensureNetworkPolicies(
 	ctx context.Context,
 	namespace string,

--- a/src/compute-plane-services/nvca/internal/util/k8sutil/netpol.go
+++ b/src/compute-plane-services/nvca/internal/util/k8sutil/netpol.go
@@ -87,16 +87,13 @@ func EnsureNetworkPoliciesFunctionNamespace(
 	crClient client.Client,
 	extraNPs ...*netv1.NetworkPolicy,
 ) error {
-	var allExtraNPs []*netv1.NetworkPolicy
-	allExtraNPs = append(allExtraNPs, createIntraNamespaceEgressPolicy(namespace))
-	allExtraNPs = append(allExtraNPs, extraNPs...)
 	return ensureNetworkPolicies(ctx,
 		namespace,
 		nps,
 		ffFetcher,
 		k8sClient,
 		crClient,
-		allExtraNPs...,
+		extraNPs...,
 	)
 }
 
@@ -166,17 +163,6 @@ func ensureNetworkPolicies(
 		newNP.Namespace = namespace
 
 		switch newNP.Name {
-		case MonitoringIngressNetworkPolicyName:
-			snRule := netv1.NetworkPolicyIngressRule{
-				From: []netv1.NetworkPolicyPeer{
-					{
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{K8sNameLabelKey: namespace},
-						},
-					},
-				},
-			}
-			newNP.Spec.Ingress = append(newNP.Spec.Ingress, snRule)
 		case EgressNVCFCacheNetworkPolicyNameKey:
 			// check if both container-caching & dns-proxy namespaces are present
 			var ccnsErr, pcnsErr error
@@ -225,12 +211,51 @@ func ensureNetworkPolicies(
 			errs = append(errs, err)
 		}
 	}
+	// Clean up the legacy unconditional intra-namespace egress policy this
+	// package used to create for every function namespace: combined with the
+	// same-namespace ingress rule this package used to add to
+	// MonitoringIngressNetworkPolicyName, it let any pod in a function
+	// namespace reach any other pod in that namespace on any port. Neither
+	// is created here anymore, but namespaces reconciled by an older build
+	// may still have this policy left over, so remove it explicitly.
+	if _, wanted := newNetworkPolicies[AllowEgressIntraNamespaceNetworkPolicyName]; !wanted {
+		if err := deleteNetworkPolicyIfExists(ctx, namespace, AllowEgressIntraNamespaceNetworkPolicyName, k8sClient, crClient); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
 	if err := errors.Join(errs...); err != nil {
 		return err
 	}
 
 	// Prune existing network policies that are not in the configmap and are custom network policies
 	return pruneCustomNetworkPolicies(ctx, namespace, k8sClient, crClient, newNetworkPolicies)
+}
+
+// deleteNetworkPolicyIfExists deletes the named NetworkPolicy in namespace,
+// treating "not found" as success.
+func deleteNetworkPolicyIfExists(ctx context.Context,
+	namespace string,
+	name string,
+	k8sClient k8sclient.Interface,
+	crClient client.Client,
+) error {
+	log := core.GetLogger(ctx)
+
+	if crClient != nil {
+		np := &netv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+		if err := crClient.Delete(ctx, np); err != nil && !apierrors.IsNotFound(err) {
+			log.WithError(err).Errorf("delete NetworkPolicy %s in namespace %s", name, namespace)
+			return fmt.Errorf("delete NetworkPolicy %s in namespace %s: %v", name, namespace, err)
+		}
+		return nil
+	}
+
+	if err := k8sClient.NetworkingV1().NetworkPolicies(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		log.WithError(err).Errorf("delete NetworkPolicy %s in namespace %s", name, namespace)
+		return fmt.Errorf("delete NetworkPolicy %s in namespace %s: %v", name, namespace, err)
+	}
+	return nil
 }
 
 func pruneCustomNetworkPolicies(ctx context.Context,
@@ -369,28 +394,6 @@ func getValidNetworkPolicyNames(nps map[string]string) []string {
 	}
 
 	return validNps
-}
-
-func createIntraNamespaceEgressPolicy(namespace string) *netv1.NetworkPolicy {
-	return &netv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: AllowEgressIntraNamespaceNetworkPolicyName,
-		},
-		Spec: netv1.NetworkPolicySpec{
-			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeEgress},
-			Egress: []netv1.NetworkPolicyEgressRule{
-				{
-					To: []netv1.NetworkPolicyPeer{
-						{
-							NamespaceSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{K8sNameLabelKey: namespace},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
 }
 
 func createOrUpdateNetworkPolicy(ctx context.Context,

--- a/src/compute-plane-services/nvca/internal/util/k8sutil/netpol.go
+++ b/src/compute-plane-services/nvca/internal/util/k8sutil/netpol.go
@@ -93,6 +93,7 @@ func EnsureNetworkPoliciesFunctionNamespace(
 		ffFetcher,
 		k8sClient,
 		crClient,
+		true,
 		extraNPs...,
 	)
 }
@@ -111,6 +112,7 @@ func EnsureNetworkPoliciesSharedPodInstanceNamespace(
 		ffFetcher,
 		k8sClient,
 		crClient,
+		false,
 	)
 }
 
@@ -121,6 +123,12 @@ func ensureNetworkPolicies(
 	ffFetcher featureflag.Fetcher,
 	k8sClient k8sclient.Interface,
 	crClient client.Client,
+	// cleanupLegacyIntraNamespaceEgress is true only for function namespaces
+	// (EnsureNetworkPoliciesFunctionNamespace), the only reconcile path that
+	// ever created AllowEgressIntraNamespaceNetworkPolicyName. Shared pod
+	// instance namespaces never owned that policy, so they must not delete a
+	// same-named policy they don't manage.
+	cleanupLegacyIntraNamespaceEgress bool,
 	extraNPs ...*netv1.NetworkPolicy,
 ) error {
 	log := core.GetLogger(ctx)
@@ -217,10 +225,13 @@ func ensureNetworkPolicies(
 	// MonitoringIngressNetworkPolicyName, it let any pod in a function
 	// namespace reach any other pod in that namespace on any port. Neither
 	// is created here anymore, but namespaces reconciled by an older build
-	// may still have this policy left over, so remove it explicitly.
-	if _, wanted := newNetworkPolicies[AllowEgressIntraNamespaceNetworkPolicyName]; !wanted {
-		if err := deleteNetworkPolicyIfExists(ctx, namespace, AllowEgressIntraNamespaceNetworkPolicyName, k8sClient, crClient); err != nil {
-			errs = append(errs, err)
+	// may still have this policy left over, so remove it explicitly. Scoped
+	// to function namespaces only; see cleanupLegacyIntraNamespaceEgress.
+	if cleanupLegacyIntraNamespaceEgress {
+		if _, wanted := newNetworkPolicies[AllowEgressIntraNamespaceNetworkPolicyName]; !wanted {
+			if err := deleteNetworkPolicyIfExists(ctx, namespace, AllowEgressIntraNamespaceNetworkPolicyName, k8sClient, crClient); err != nil {
+				errs = append(errs, err)
+			}
 		}
 	}
 
@@ -240,20 +251,16 @@ func deleteNetworkPolicyIfExists(ctx context.Context,
 	k8sClient k8sclient.Interface,
 	crClient client.Client,
 ) error {
-	log := core.GetLogger(ctx)
-
 	if crClient != nil {
 		np := &netv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
 		if err := crClient.Delete(ctx, np); err != nil && !apierrors.IsNotFound(err) {
-			log.WithError(err).Errorf("delete NetworkPolicy %s in namespace %s", name, namespace)
-			return fmt.Errorf("delete NetworkPolicy %s in namespace %s: %v", name, namespace, err)
+			return fmt.Errorf("delete NetworkPolicy %s in namespace %s: %w", name, namespace, err)
 		}
 		return nil
 	}
 
 	if err := k8sClient.NetworkingV1().NetworkPolicies(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-		log.WithError(err).Errorf("delete NetworkPolicy %s in namespace %s", name, namespace)
-		return fmt.Errorf("delete NetworkPolicy %s in namespace %s: %v", name, namespace, err)
+		return fmt.Errorf("delete NetworkPolicy %s in namespace %s: %w", name, namespace, err)
 	}
 	return nil
 }

--- a/src/compute-plane-services/nvca/internal/util/k8sutil/netpol.go
+++ b/src/compute-plane-services/nvca/internal/util/k8sutil/netpol.go
@@ -119,6 +119,23 @@ func EnsureNetworkPoliciesSharedPodInstanceNamespace(
 	)
 }
 
+// RemoveLegacyIntraNamespaceEgressPolicy deletes the allow-egress-intra-namespace
+// NetworkPolicy from the shared pod-instance namespace (nvcf-backend) if it still
+// exists from before this policy was scoped out of that namespace. It is meant to
+// be called once, at agent startup, rather than on every reconcile: the policy is
+// not custom-labeled, so the regular ensureNetworkPolicies prune loop never removes
+// it on its own, and clusters that already have it must be migrated explicitly.
+func RemoveLegacyIntraNamespaceEgressPolicy(ctx context.Context, namespace string, k8sClient k8sclient.Interface) error {
+	err := k8sClient.NetworkingV1().NetworkPolicies(namespace).Delete(
+		ctx, AllowEgressIntraNamespaceNetworkPolicyName, metav1.DeleteOptions{},
+	)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete legacy NetworkPolicy %s in namespace %s: %w",
+			AllowEgressIntraNamespaceNetworkPolicyName, namespace, err)
+	}
+	return nil
+}
+
 func ensureNetworkPolicies(
 	ctx context.Context,
 	namespace string,
@@ -126,16 +143,16 @@ func ensureNetworkPolicies(
 	ffFetcher featureflag.Fetcher,
 	k8sClient k8sclient.Interface,
 	crClient client.Client,
-	// singleTenantNamespace is true for function namespaces (one MiniService
-	// or Helm release per namespace, via EnsureNetworkPoliciesFunctionNamespace).
-	// A same-namespace allow is safe there because only one tenant's pods ever
+	// isMiniServiceNamespace is true for function namespaces (one MiniService
+	// per namespace, via EnsureNetworkPoliciesFunctionNamespace). A
+	// same-namespace allow is safe there because only one tenant's pods ever
 	// live in the namespace, e.g. a MiniService's utils pod reaching its own
 	// inference pod on a different pod in the same namespace. It is false for
 	// the namespace shared across every container-function tenant on the
 	// cluster (nvcf-backend, via EnsureNetworkPoliciesSharedPodInstanceNamespace),
 	// where the same allow would let one customer's pod reach another
 	// customer's pod.
-	singleTenantNamespace bool,
+	isMiniServiceNamespace bool,
 	extraNPs ...*netv1.NetworkPolicy,
 ) error {
 	log := core.GetLogger(ctx)
@@ -179,7 +196,7 @@ func ensureNetworkPolicies(
 
 		switch newNP.Name {
 		case MonitoringIngressNetworkPolicyName:
-			if singleTenantNamespace {
+			if isMiniServiceNamespace {
 				snRule := netv1.NetworkPolicyIngressRule{
 					From: []netv1.NetworkPolicyPeer{
 						{

--- a/src/compute-plane-services/nvca/internal/util/k8sutil/netpol.go
+++ b/src/compute-plane-services/nvca/internal/util/k8sutil/netpol.go
@@ -119,23 +119,6 @@ func EnsureNetworkPoliciesSharedPodInstanceNamespace(
 	)
 }
 
-// RemoveLegacyIntraNamespaceEgressPolicy deletes the allow-egress-intra-namespace
-// NetworkPolicy from the shared pod-instance namespace (nvcf-backend) if it still
-// exists from before this policy was scoped out of that namespace. It is meant to
-// be called once, at agent startup, rather than on every reconcile: the policy is
-// not custom-labeled, so the regular ensureNetworkPolicies prune loop never removes
-// it on its own, and clusters that already have it must be migrated explicitly.
-func RemoveLegacyIntraNamespaceEgressPolicy(ctx context.Context, namespace string, k8sClient k8sclient.Interface) error {
-	err := k8sClient.NetworkingV1().NetworkPolicies(namespace).Delete(
-		ctx, AllowEgressIntraNamespaceNetworkPolicyName, metav1.DeleteOptions{},
-	)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("delete legacy NetworkPolicy %s in namespace %s: %w",
-			AllowEgressIntraNamespaceNetworkPolicyName, namespace, err)
-	}
-	return nil
-}
-
 func ensureNetworkPolicies(
 	ctx context.Context,
 	namespace string,

--- a/src/compute-plane-services/nvca/internal/util/k8sutil/netpol_test.go
+++ b/src/compute-plane-services/nvca/internal/util/k8sutil/netpol_test.go
@@ -259,6 +259,40 @@ func TestEnsureNetworkPoliciesCleansUpLegacyIntraNamespaceEgressPolicy(t *testin
 	assert.True(t, apierrors.IsNotFound(err), "leftover allow-egress-intra-namespace should be deleted on reconcile")
 }
 
+// TestEnsureNetworkPoliciesSharedPodInstanceNamespaceDoesNotDeleteUnownedPolicy
+// verifies that EnsureNetworkPoliciesSharedPodInstanceNamespace never owned
+// AllowEgressIntraNamespaceNetworkPolicyName (only
+// EnsureNetworkPoliciesFunctionNamespace ever created it), so it must not
+// delete a same-named policy in a shared pod instance namespace.
+func TestEnsureNetworkPoliciesSharedPodInstanceNamespaceDoesNotDeleteUnownedPolicy(t *testing.T) {
+	featureFlagFetcher := &featureflagmock.Fetcher{}
+	ctx := context.Background()
+	namespace := "test-namespace"
+	npCM := newNetworkPolicyConfigMap("nvca-system")
+	k8sClient := k8sfake.NewSimpleClientset(&netv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      AllowEgressIntraNamespaceNetworkPolicyName,
+			Namespace: namespace,
+		},
+		Spec: netv1.NetworkPolicySpec{
+			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeEgress},
+		},
+	})
+
+	err := EnsureNetworkPoliciesSharedPodInstanceNamespace(
+		ctx,
+		namespace,
+		npCM.Data,
+		featureFlagFetcher,
+		k8sClient,
+		nil,
+	)
+	require.NoError(t, err)
+
+	_, err = k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(ctx, AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
+	require.NoError(t, err, "shared pod instance namespace reconcile must not delete a policy it doesn't own")
+}
+
 func TestEnsureNetworkPoliciesWithCustomPolicies(t *testing.T) {
 	// Mock feature flag fetcher
 	featureFlagFetcher := &featureflagmock.Fetcher{

--- a/src/compute-plane-services/nvca/internal/util/k8sutil/netpol_test.go
+++ b/src/compute-plane-services/nvca/internal/util/k8sutil/netpol_test.go
@@ -217,14 +217,17 @@ func TestEnsureNetworkPoliciesFunctionNamespaceAllowsIntraNamespaceAccess(t *tes
 	)
 	require.NoError(t, err)
 
-	ingressNP, err := k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(ctx, MonitoringIngressNetworkPolicyName, metav1.GetOptions{})
+	ingressNP, err := k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(
+		ctx, MonitoringIngressNetworkPolicyName, metav1.GetOptions{})
 	require.NoError(t, err)
-	require.Len(t, ingressNP.Spec.Ingress, 2, "allow-ingress-monitoring should have the ConfigMap-defined rule plus the same-namespace rule")
+	require.Len(t, ingressNP.Spec.Ingress, 2,
+		"allow-ingress-monitoring should have the ConfigMap-defined rule plus the same-namespace rule")
 	sameNSRule := ingressNP.Spec.Ingress[1]
 	require.Len(t, sameNSRule.From, 1)
 	assert.Equal(t, namespace, sameNSRule.From[0].NamespaceSelector.MatchLabels[K8sNameLabelKey])
 
-	egressNP, err := k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(ctx, AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
+	egressNP, err := k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(
+		ctx, AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
 	require.NoError(t, err, "allow-egress-intra-namespace should be created for function namespaces")
 	require.Len(t, egressNP.Spec.Egress, 1)
 	require.Len(t, egressNP.Spec.Egress[0].To, 1)
@@ -254,14 +257,17 @@ func TestEnsureNetworkPoliciesSharedPodInstanceNamespaceDoesNotAllowIntraNamespa
 	)
 	require.NoError(t, err)
 
-	ingressNP, err := k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(ctx, MonitoringIngressNetworkPolicyName, metav1.GetOptions{})
+	ingressNP, err := k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(
+		ctx, MonitoringIngressNetworkPolicyName, metav1.GetOptions{})
 	require.NoError(t, err)
 	require.Len(t, ingressNP.Spec.Ingress, 1, "allow-ingress-monitoring should only have the ConfigMap-defined rule")
 	assert.Equal(t, "bar", ingressNP.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels["foo"])
 
-	_, err = k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(ctx, AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
+	_, err = k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(
+		ctx, AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
 	require.Error(t, err)
-	assert.True(t, apierrors.IsNotFound(err), "allow-egress-intra-namespace should not be created for the shared pod instance namespace")
+	assert.True(t, apierrors.IsNotFound(err),
+		"allow-egress-intra-namespace should not be created for the shared pod instance namespace")
 }
 
 // TestEnsureNetworkPoliciesSharedPodInstanceNamespaceDoesNotDeleteUnownedPolicy

--- a/src/compute-plane-services/nvca/internal/util/k8sutil/netpol_test.go
+++ b/src/compute-plane-services/nvca/internal/util/k8sutil/netpol_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
@@ -80,7 +81,7 @@ func TestEnsureNetworkPolicies(t *testing.T) {
 	require.NoError(t, err)
 	npList1, err := k8sClient.NetworkingV1().NetworkPolicies(namespace).List(ctx, metav1.ListOptions{})
 	require.NoError(t, err)
-	assert.Len(t, npList1.Items, 8)
+	assert.Len(t, npList1.Items, 7)
 	// Try again, no errors or updates.
 	err = EnsureNetworkPoliciesFunctionNamespace(
 		ctx,
@@ -93,7 +94,7 @@ func TestEnsureNetworkPolicies(t *testing.T) {
 	require.NoError(t, err)
 	npList2, err := k8sClient.NetworkingV1().NetworkPolicies(namespace).List(ctx, metav1.ListOptions{})
 	require.NoError(t, err)
-	assert.Len(t, npList2.Items, 8)
+	assert.Len(t, npList2.Items, 7)
 
 	// Ensure with ctrl client.
 	err = EnsureNetworkPoliciesFunctionNamespace(
@@ -108,7 +109,7 @@ func TestEnsureNetworkPolicies(t *testing.T) {
 	npList1 = &netv1.NetworkPolicyList{}
 	err = crClient.List(ctx, npList1, client.InNamespace(namespace))
 	require.NoError(t, err)
-	assert.Len(t, npList1.Items, 8)
+	assert.Len(t, npList1.Items, 7)
 	// Try again, no errors or updates.
 	err = EnsureNetworkPoliciesFunctionNamespace(
 		ctx,
@@ -122,7 +123,7 @@ func TestEnsureNetworkPolicies(t *testing.T) {
 	npList2 = &netv1.NetworkPolicyList{}
 	err = crClient.List(ctx, npList2, client.InNamespace(namespace))
 	require.NoError(t, err)
-	assert.Len(t, npList2.Items, 8)
+	assert.Len(t, npList2.Items, 7)
 
 	// No caching namespaces
 	k8sClient = k8sfake.NewSimpleClientset()
@@ -140,7 +141,7 @@ func TestEnsureNetworkPolicies(t *testing.T) {
 	require.NoError(t, err)
 	npList1, err = k8sClient.NetworkingV1().NetworkPolicies(namespace).List(ctx, metav1.ListOptions{})
 	require.NoError(t, err)
-	assert.Len(t, npList1.Items, 7)
+	assert.Len(t, npList1.Items, 6)
 
 	// Ensure with ctrl client.
 	err = EnsureNetworkPoliciesFunctionNamespace(
@@ -155,7 +156,7 @@ func TestEnsureNetworkPolicies(t *testing.T) {
 	npList1 = &netv1.NetworkPolicyList{}
 	err = crClient.List(ctx, npList1, client.InNamespace(namespace))
 	require.NoError(t, err)
-	assert.Len(t, npList1.Items, 7)
+	assert.Len(t, npList1.Items, 6)
 
 	// No feature flags.
 	featureFlagFetcher.EnabledFFs = nil
@@ -174,7 +175,7 @@ func TestEnsureNetworkPolicies(t *testing.T) {
 	require.NoError(t, err)
 	npList1, err = k8sClient.NetworkingV1().NetworkPolicies(namespace).List(ctx, metav1.ListOptions{})
 	require.NoError(t, err)
-	assert.Len(t, npList1.Items, 4)
+	assert.Len(t, npList1.Items, 3)
 
 	// Ensure with ctrl client.
 	err = EnsureNetworkPoliciesFunctionNamespace(
@@ -189,7 +190,73 @@ func TestEnsureNetworkPolicies(t *testing.T) {
 	npList1 = &netv1.NetworkPolicyList{}
 	err = crClient.List(ctx, npList1, client.InNamespace(namespace))
 	require.NoError(t, err)
-	assert.Len(t, npList1.Items, 4)
+	assert.Len(t, npList1.Items, 3)
+}
+
+// TestEnsureNetworkPoliciesDoesNotOpenIntraNamespaceAccess is a regression
+// test: allow-ingress-monitoring must not gain a same-namespace ingress
+// rule, and allow-egress-intra-namespace must not be created. Together
+// those two used to let any pod in a function namespace reach any other
+// pod in that namespace on any port.
+func TestEnsureNetworkPoliciesDoesNotOpenIntraNamespaceAccess(t *testing.T) {
+	featureFlagFetcher := &featureflagmock.Fetcher{}
+	ctx := context.Background()
+	namespace := "test-namespace"
+	npCM := newNetworkPolicyConfigMap("nvca-system")
+	k8sClient := k8sfake.NewSimpleClientset()
+
+	err := EnsureNetworkPoliciesFunctionNamespace(
+		ctx,
+		namespace,
+		npCM.Data,
+		featureFlagFetcher,
+		k8sClient,
+		nil,
+	)
+	require.NoError(t, err)
+
+	ingressNP, err := k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(ctx, MonitoringIngressNetworkPolicyName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, ingressNP.Spec.Ingress, 1, "allow-ingress-monitoring should only have the ConfigMap-defined rule")
+	assert.Equal(t, "bar", ingressNP.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels["foo"])
+
+	_, err = k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(ctx, AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
+	require.Error(t, err)
+	assert.True(t, apierrors.IsNotFound(err), "allow-egress-intra-namespace should not be created")
+}
+
+// TestEnsureNetworkPoliciesCleansUpLegacyIntraNamespaceEgressPolicy verifies
+// that a leftover allow-egress-intra-namespace policy from a pre-fix
+// reconcile gets deleted on the next reconcile, so already affected
+// namespaces self-heal rather than staying open forever.
+func TestEnsureNetworkPoliciesCleansUpLegacyIntraNamespaceEgressPolicy(t *testing.T) {
+	featureFlagFetcher := &featureflagmock.Fetcher{}
+	ctx := context.Background()
+	namespace := "test-namespace"
+	npCM := newNetworkPolicyConfigMap("nvca-system")
+	k8sClient := k8sfake.NewSimpleClientset(&netv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      AllowEgressIntraNamespaceNetworkPolicyName,
+			Namespace: namespace,
+		},
+		Spec: netv1.NetworkPolicySpec{
+			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeEgress},
+		},
+	})
+
+	err := EnsureNetworkPoliciesFunctionNamespace(
+		ctx,
+		namespace,
+		npCM.Data,
+		featureFlagFetcher,
+		k8sClient,
+		nil,
+	)
+	require.NoError(t, err)
+
+	_, err = k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(ctx, AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
+	require.Error(t, err)
+	assert.True(t, apierrors.IsNotFound(err), "leftover allow-egress-intra-namespace should be deleted on reconcile")
 }
 
 func TestEnsureNetworkPoliciesWithCustomPolicies(t *testing.T) {
@@ -230,7 +297,7 @@ func TestEnsureNetworkPoliciesWithCustomPolicies(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should have standard policies + custom policies
-	assert.Len(t, npList.Items, 10) // 8 standard + 2 custom
+	assert.Len(t, npList.Items, 9) // 7 standard + 2 custom
 
 	// Check that custom policies have the correct label
 	customPolicyCount := 0
@@ -289,7 +356,7 @@ func TestEnsureNetworkPoliciesCustomPolicyPruning(t *testing.T) {
 	// Verify custom policies exist
 	npList, err := k8sClient.NetworkingV1().NetworkPolicies(namespace).List(ctx, metav1.ListOptions{})
 	require.NoError(t, err)
-	assert.Len(t, npList.Items, 10) // 8 standard + 2 custom
+	assert.Len(t, npList.Items, 9) // 7 standard + 2 custom
 
 	// Now create a configmap without custom policies
 	npCMNoCustom := newNetworkPolicyConfigMap("nvca-system")
@@ -318,7 +385,7 @@ func TestEnsureNetworkPoliciesCustomPolicyPruning(t *testing.T) {
 	// Verify custom policies were pruned
 	npListAfter, err := k8sClient.NetworkingV1().NetworkPolicies(namespace).List(ctx, metav1.ListOptions{})
 	require.NoError(t, err)
-	assert.Len(t, npListAfter.Items, 8) // Only standard policies remain
+	assert.Len(t, npListAfter.Items, 7) // Only standard policies remain
 
 	// Verify no custom policies exist
 	for _, np := range npListAfter.Items {
@@ -656,7 +723,7 @@ func TestEnsureNetworkPoliciesCustomPolicyNameOverride(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should have standard policies + custom policies
-	assert.Len(t, npList.Items, 9) // 8 standard + 1 custom
+	assert.Len(t, npList.Items, 8) // 7 standard + 1 custom
 
 	// Verify the custom policy has the key name, not the YAML name
 	customPolicyFound := false
@@ -718,7 +785,7 @@ func TestPruneCustomNetworkPoliciesWithCRClient(t *testing.T) {
 	npList := &netv1.NetworkPolicyList{}
 	err = crClient.List(ctx, npList, client.InNamespace(namespace))
 	require.NoError(t, err)
-	assert.Len(t, npList.Items, 10) // 8 standard + 2 custom
+	assert.Len(t, npList.Items, 9) // 7 standard + 2 custom
 
 	// Now create a configmap without custom policies
 	npCMNoCustom := newNetworkPolicyConfigMap("nvca-system")
@@ -738,7 +805,7 @@ func TestPruneCustomNetworkPoliciesWithCRClient(t *testing.T) {
 	npListAfter := &netv1.NetworkPolicyList{}
 	err = crClient.List(ctx, npListAfter, client.InNamespace(namespace))
 	require.NoError(t, err)
-	assert.Len(t, npListAfter.Items, 8) // Only standard policies remain
+	assert.Len(t, npListAfter.Items, 7) // Only standard policies remain
 
 	// Verify no custom policies exist
 	for _, np := range npListAfter.Items {
@@ -849,8 +916,8 @@ spec:
 	err = crClient.List(ctx, npList, client.InNamespace(namespace))
 	require.NoError(t, err)
 
-	// Should have: 8 standard policies + 1 new custom policy + 1 standard policy we created manually
-	assert.Len(t, npList.Items, 10)
+	// Should have: 7 standard policies + 1 new custom policy + 1 standard policy we created manually
+	assert.Len(t, npList.Items, 9)
 
 	// Verify old custom policies were pruned
 	oldCustomPolicy1Exists := false

--- a/src/compute-plane-services/nvca/internal/util/k8sutil/netpol_test.go
+++ b/src/compute-plane-services/nvca/internal/util/k8sutil/netpol_test.go
@@ -289,7 +289,11 @@ func TestEnsureNetworkPoliciesSharedPodInstanceNamespaceDoesNotDeleteUnownedPoli
 	)
 	require.NoError(t, err)
 
-	_, err = k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(ctx, AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
+	_, err = k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(
+		ctx,
+		AllowEgressIntraNamespaceNetworkPolicyName,
+		metav1.GetOptions{},
+	)
 	require.NoError(t, err, "shared pod instance namespace reconcile must not delete a policy it doesn't own")
 }
 

--- a/src/compute-plane-services/nvca/internal/util/k8sutil/netpol_test.go
+++ b/src/compute-plane-services/nvca/internal/util/k8sutil/netpol_test.go
@@ -81,7 +81,7 @@ func TestEnsureNetworkPolicies(t *testing.T) {
 	require.NoError(t, err)
 	npList1, err := k8sClient.NetworkingV1().NetworkPolicies(namespace).List(ctx, metav1.ListOptions{})
 	require.NoError(t, err)
-	assert.Len(t, npList1.Items, 7)
+	assert.Len(t, npList1.Items, 8)
 	// Try again, no errors or updates.
 	err = EnsureNetworkPoliciesFunctionNamespace(
 		ctx,
@@ -94,7 +94,7 @@ func TestEnsureNetworkPolicies(t *testing.T) {
 	require.NoError(t, err)
 	npList2, err := k8sClient.NetworkingV1().NetworkPolicies(namespace).List(ctx, metav1.ListOptions{})
 	require.NoError(t, err)
-	assert.Len(t, npList2.Items, 7)
+	assert.Len(t, npList2.Items, 8)
 
 	// Ensure with ctrl client.
 	err = EnsureNetworkPoliciesFunctionNamespace(
@@ -109,7 +109,7 @@ func TestEnsureNetworkPolicies(t *testing.T) {
 	npList1 = &netv1.NetworkPolicyList{}
 	err = crClient.List(ctx, npList1, client.InNamespace(namespace))
 	require.NoError(t, err)
-	assert.Len(t, npList1.Items, 7)
+	assert.Len(t, npList1.Items, 8)
 	// Try again, no errors or updates.
 	err = EnsureNetworkPoliciesFunctionNamespace(
 		ctx,
@@ -123,7 +123,7 @@ func TestEnsureNetworkPolicies(t *testing.T) {
 	npList2 = &netv1.NetworkPolicyList{}
 	err = crClient.List(ctx, npList2, client.InNamespace(namespace))
 	require.NoError(t, err)
-	assert.Len(t, npList2.Items, 7)
+	assert.Len(t, npList2.Items, 8)
 
 	// No caching namespaces
 	k8sClient = k8sfake.NewSimpleClientset()
@@ -141,7 +141,7 @@ func TestEnsureNetworkPolicies(t *testing.T) {
 	require.NoError(t, err)
 	npList1, err = k8sClient.NetworkingV1().NetworkPolicies(namespace).List(ctx, metav1.ListOptions{})
 	require.NoError(t, err)
-	assert.Len(t, npList1.Items, 6)
+	assert.Len(t, npList1.Items, 7)
 
 	// Ensure with ctrl client.
 	err = EnsureNetworkPoliciesFunctionNamespace(
@@ -156,7 +156,7 @@ func TestEnsureNetworkPolicies(t *testing.T) {
 	npList1 = &netv1.NetworkPolicyList{}
 	err = crClient.List(ctx, npList1, client.InNamespace(namespace))
 	require.NoError(t, err)
-	assert.Len(t, npList1.Items, 6)
+	assert.Len(t, npList1.Items, 7)
 
 	// No feature flags.
 	featureFlagFetcher.EnabledFFs = nil
@@ -175,7 +175,7 @@ func TestEnsureNetworkPolicies(t *testing.T) {
 	require.NoError(t, err)
 	npList1, err = k8sClient.NetworkingV1().NetworkPolicies(namespace).List(ctx, metav1.ListOptions{})
 	require.NoError(t, err)
-	assert.Len(t, npList1.Items, 3)
+	assert.Len(t, npList1.Items, 4)
 
 	// Ensure with ctrl client.
 	err = EnsureNetworkPoliciesFunctionNamespace(
@@ -190,15 +190,17 @@ func TestEnsureNetworkPolicies(t *testing.T) {
 	npList1 = &netv1.NetworkPolicyList{}
 	err = crClient.List(ctx, npList1, client.InNamespace(namespace))
 	require.NoError(t, err)
-	assert.Len(t, npList1.Items, 3)
+	assert.Len(t, npList1.Items, 4)
 }
 
-// TestEnsureNetworkPoliciesDoesNotOpenIntraNamespaceAccess is a regression
-// test: allow-ingress-monitoring must not gain a same-namespace ingress
-// rule, and allow-egress-intra-namespace must not be created. Together
-// those two used to let any pod in a function namespace reach any other
-// pod in that namespace on any port.
-func TestEnsureNetworkPoliciesDoesNotOpenIntraNamespaceAccess(t *testing.T) {
+// TestEnsureNetworkPoliciesFunctionNamespaceAllowsIntraNamespaceAccess
+// verifies that function namespaces (one MiniService/Helm release per
+// namespace, single-tenant) still get the same-namespace ingress rule on
+// allow-ingress-monitoring and the allow-egress-intra-namespace policy. This
+// is required so a MiniService's utils pod can reach its own inference pod
+// running in a different pod in the same namespace; it's safe because only
+// one tenant's pods ever live in a function namespace.
+func TestEnsureNetworkPoliciesFunctionNamespaceAllowsIntraNamespaceAccess(t *testing.T) {
 	featureFlagFetcher := &featureflagmock.Fetcher{}
 	ctx := context.Background()
 	namespace := "test-namespace"
@@ -217,34 +219,32 @@ func TestEnsureNetworkPoliciesDoesNotOpenIntraNamespaceAccess(t *testing.T) {
 
 	ingressNP, err := k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(ctx, MonitoringIngressNetworkPolicyName, metav1.GetOptions{})
 	require.NoError(t, err)
-	require.Len(t, ingressNP.Spec.Ingress, 1, "allow-ingress-monitoring should only have the ConfigMap-defined rule")
-	assert.Equal(t, "bar", ingressNP.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels["foo"])
+	require.Len(t, ingressNP.Spec.Ingress, 2, "allow-ingress-monitoring should have the ConfigMap-defined rule plus the same-namespace rule")
+	sameNSRule := ingressNP.Spec.Ingress[1]
+	require.Len(t, sameNSRule.From, 1)
+	assert.Equal(t, namespace, sameNSRule.From[0].NamespaceSelector.MatchLabels[K8sNameLabelKey])
 
-	_, err = k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(ctx, AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
-	require.Error(t, err)
-	assert.True(t, apierrors.IsNotFound(err), "allow-egress-intra-namespace should not be created")
+	egressNP, err := k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(ctx, AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
+	require.NoError(t, err, "allow-egress-intra-namespace should be created for function namespaces")
+	require.Len(t, egressNP.Spec.Egress, 1)
+	require.Len(t, egressNP.Spec.Egress[0].To, 1)
+	assert.Equal(t, namespace, egressNP.Spec.Egress[0].To[0].NamespaceSelector.MatchLabels[K8sNameLabelKey])
 }
 
-// TestEnsureNetworkPoliciesCleansUpLegacyIntraNamespaceEgressPolicy verifies
-// that a leftover allow-egress-intra-namespace policy from a pre-fix
-// reconcile gets deleted on the next reconcile, so already affected
-// namespaces self-heal rather than staying open forever.
-func TestEnsureNetworkPoliciesCleansUpLegacyIntraNamespaceEgressPolicy(t *testing.T) {
+// TestEnsureNetworkPoliciesSharedPodInstanceNamespaceDoesNotAllowIntraNamespaceAccess
+// is a regression test: the namespace shared across every
+// container-function tenant (nvcf-backend) must not get the same-namespace
+// ingress rule on allow-ingress-monitoring, and must never get
+// allow-egress-intra-namespace. Combined, those two would let one tenant's
+// pod reach another tenant's pod on any port.
+func TestEnsureNetworkPoliciesSharedPodInstanceNamespaceDoesNotAllowIntraNamespaceAccess(t *testing.T) {
 	featureFlagFetcher := &featureflagmock.Fetcher{}
 	ctx := context.Background()
-	namespace := "test-namespace"
+	namespace := "nvcf-backend"
 	npCM := newNetworkPolicyConfigMap("nvca-system")
-	k8sClient := k8sfake.NewSimpleClientset(&netv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      AllowEgressIntraNamespaceNetworkPolicyName,
-			Namespace: namespace,
-		},
-		Spec: netv1.NetworkPolicySpec{
-			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeEgress},
-		},
-	})
+	k8sClient := k8sfake.NewSimpleClientset()
 
-	err := EnsureNetworkPoliciesFunctionNamespace(
+	err := EnsureNetworkPoliciesSharedPodInstanceNamespace(
 		ctx,
 		namespace,
 		npCM.Data,
@@ -254,9 +254,14 @@ func TestEnsureNetworkPoliciesCleansUpLegacyIntraNamespaceEgressPolicy(t *testin
 	)
 	require.NoError(t, err)
 
+	ingressNP, err := k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(ctx, MonitoringIngressNetworkPolicyName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, ingressNP.Spec.Ingress, 1, "allow-ingress-monitoring should only have the ConfigMap-defined rule")
+	assert.Equal(t, "bar", ingressNP.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels["foo"])
+
 	_, err = k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(ctx, AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
 	require.Error(t, err)
-	assert.True(t, apierrors.IsNotFound(err), "leftover allow-egress-intra-namespace should be deleted on reconcile")
+	assert.True(t, apierrors.IsNotFound(err), "allow-egress-intra-namespace should not be created for the shared pod instance namespace")
 }
 
 // TestEnsureNetworkPoliciesSharedPodInstanceNamespaceDoesNotDeleteUnownedPolicy
@@ -335,7 +340,7 @@ func TestEnsureNetworkPoliciesWithCustomPolicies(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should have standard policies + custom policies
-	assert.Len(t, npList.Items, 9) // 7 standard + 2 custom
+	assert.Len(t, npList.Items, 10) // 8 standard + 2 custom
 
 	// Check that custom policies have the correct label
 	customPolicyCount := 0
@@ -394,7 +399,7 @@ func TestEnsureNetworkPoliciesCustomPolicyPruning(t *testing.T) {
 	// Verify custom policies exist
 	npList, err := k8sClient.NetworkingV1().NetworkPolicies(namespace).List(ctx, metav1.ListOptions{})
 	require.NoError(t, err)
-	assert.Len(t, npList.Items, 9) // 7 standard + 2 custom
+	assert.Len(t, npList.Items, 10) // 8 standard + 2 custom
 
 	// Now create a configmap without custom policies
 	npCMNoCustom := newNetworkPolicyConfigMap("nvca-system")
@@ -423,7 +428,7 @@ func TestEnsureNetworkPoliciesCustomPolicyPruning(t *testing.T) {
 	// Verify custom policies were pruned
 	npListAfter, err := k8sClient.NetworkingV1().NetworkPolicies(namespace).List(ctx, metav1.ListOptions{})
 	require.NoError(t, err)
-	assert.Len(t, npListAfter.Items, 7) // Only standard policies remain
+	assert.Len(t, npListAfter.Items, 8) // Only standard policies remain
 
 	// Verify no custom policies exist
 	for _, np := range npListAfter.Items {
@@ -761,7 +766,7 @@ func TestEnsureNetworkPoliciesCustomPolicyNameOverride(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should have standard policies + custom policies
-	assert.Len(t, npList.Items, 8) // 7 standard + 1 custom
+	assert.Len(t, npList.Items, 9) // 8 standard + 1 custom
 
 	// Verify the custom policy has the key name, not the YAML name
 	customPolicyFound := false
@@ -823,7 +828,7 @@ func TestPruneCustomNetworkPoliciesWithCRClient(t *testing.T) {
 	npList := &netv1.NetworkPolicyList{}
 	err = crClient.List(ctx, npList, client.InNamespace(namespace))
 	require.NoError(t, err)
-	assert.Len(t, npList.Items, 9) // 7 standard + 2 custom
+	assert.Len(t, npList.Items, 10) // 8 standard + 2 custom
 
 	// Now create a configmap without custom policies
 	npCMNoCustom := newNetworkPolicyConfigMap("nvca-system")
@@ -843,7 +848,7 @@ func TestPruneCustomNetworkPoliciesWithCRClient(t *testing.T) {
 	npListAfter := &netv1.NetworkPolicyList{}
 	err = crClient.List(ctx, npListAfter, client.InNamespace(namespace))
 	require.NoError(t, err)
-	assert.Len(t, npListAfter.Items, 7) // Only standard policies remain
+	assert.Len(t, npListAfter.Items, 8) // Only standard policies remain
 
 	// Verify no custom policies exist
 	for _, np := range npListAfter.Items {
@@ -954,8 +959,8 @@ spec:
 	err = crClient.List(ctx, npList, client.InNamespace(namespace))
 	require.NoError(t, err)
 
-	// Should have: 7 standard policies + 1 new custom policy + 1 standard policy we created manually
-	assert.Len(t, npList.Items, 9)
+	// Should have: 8 standard policies + 1 new custom policy + 1 standard policy we created manually
+	assert.Len(t, npList.Items, 10)
 
 	// Verify old custom policies were pruned
 	oldCustomPolicy1Exists := false

--- a/src/compute-plane-services/nvca/pkg/nvca/backendk8scache.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/backendk8scache.go
@@ -745,14 +745,6 @@ func (b *BackendK8sCacheBuilder) Start(ctx context.Context) (*BackendK8sCache, <
 			}
 		}
 
-		// One-time migration for clusters that already had the intra-namespace
-		// egress policy in the shared pod-instance namespace before it was scoped
-		// out; ensureNetworkPolicies above does not remove it on its own.
-		if err := k8sutil.RemoveLegacyIntraNamespaceEgressPolicy(ctx, c.podInstanceNamespace, c.clients.K8s); err != nil {
-			return nil, nil, fmt.Errorf("remove legacy NetworkPolicy in namespace %s: %w",
-				c.podInstanceNamespace, err)
-		}
-
 		// add configMapInformers for Network Policy for k8s backend only
 		if err := addConfigMapInformers(ctx, c); err != nil {
 			return nil, nil, err

--- a/src/compute-plane-services/nvca/pkg/nvca/backendk8scache.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/backendk8scache.go
@@ -745,6 +745,14 @@ func (b *BackendK8sCacheBuilder) Start(ctx context.Context) (*BackendK8sCache, <
 			}
 		}
 
+		// One-time migration for clusters that already had the intra-namespace
+		// egress policy in the shared pod-instance namespace before it was scoped
+		// out; ensureNetworkPolicies above does not remove it on its own.
+		if err := k8sutil.RemoveLegacyIntraNamespaceEgressPolicy(ctx, c.podInstanceNamespace, c.clients.K8s); err != nil {
+			return nil, nil, fmt.Errorf("remove legacy NetworkPolicy in namespace %s: %w",
+				c.podInstanceNamespace, err)
+		}
+
 		// add configMapInformers for Network Policy for k8s backend only
 		if err := addConfigMapInformers(ctx, c); err != nil {
 			return nil, nil, err

--- a/src/compute-plane-services/nvca/pkg/nvca/backendk8scache.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/backendk8scache.go
@@ -747,10 +747,11 @@ func (b *BackendK8sCacheBuilder) Start(ctx context.Context) (*BackendK8sCache, <
 
 		// One-time migration for clusters that already had the intra-namespace
 		// egress policy in the shared pod-instance namespace before it was scoped
-		// out; ensureNetworkPolicies above does not remove it on its own.
+		// out; ensureNetworkPolicies above does not remove it on its own. Best
+		// effort: failing to remove a leftover policy should not block agent
+		// startup, since it does not affect the agent's ability to operate.
 		if err := k8sutil.RemoveLegacyIntraNamespaceEgressPolicy(ctx, c.podInstanceNamespace, c.clients.K8s); err != nil {
-			return nil, nil, fmt.Errorf("remove legacy NetworkPolicy in namespace %s: %w",
-				c.podInstanceNamespace, err)
+			log.WithError(err).Warnf("failed to remove legacy NetworkPolicy in namespace %s", c.podInstanceNamespace)
 		}
 
 		// add configMapInformers for Network Policy for k8s backend only

--- a/src/compute-plane-services/nvca/pkg/nvca/backendk8scache_test.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/backendk8scache_test.go
@@ -49,6 +49,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -700,6 +701,28 @@ func TestAutoPurgeWorkerDeletion(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, o)
 	}
+}
+
+func TestBackendK8sCacheStartRemovesLegacyIntraNamespaceEgressPolicy(t *testing.T) {
+	ctx, cancel := context.WithCancel(newTestContext())
+	t.Cleanup(cancel)
+
+	legacyNP := &netv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k8sutil.AllowEgressIntraNamespaceNetworkPolicyName,
+			Namespace: RequestsNamespace,
+		},
+	}
+
+	b := NewBackendk8sCacheBuilder().WithNamespaceLabels(labels.Set{"foo": "bar"})
+	clients := mockKubeClients(legacyNP)
+	bc, _, err := b.WithClients(clients).Start(ctx)
+	require.NoError(t, err)
+
+	_, err = bc.clients.K8s.NetworkingV1().NetworkPolicies(RequestsNamespace).Get(
+		ctx, k8sutil.AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{},
+	)
+	assert.True(t, apierrors.IsNotFound(err))
 }
 
 func TestCleanupFailedButNoInstances(t *testing.T) {

--- a/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_test.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_test.go
@@ -115,7 +115,14 @@ func TestK8sComputeBackendEnsureNetPolicy(t *testing.T) {
 		Start(ctx)
 	require.NoError(t, err)
 
-	checkNS := func(t *testing.T, namespace, expLabelVal string) {
+	// hasIntraNamespaceAccess is true for function namespaces (one
+	// MiniService/Helm release per namespace, single-tenant), where a
+	// same-namespace allow is safe and needed (e.g. the utils pod reaching
+	// its own inference pod on a different pod in the same namespace). It is
+	// false for the namespace shared across every container-function tenant
+	// (nvcf-backend), where the same allow would let one customer's pod
+	// reach another customer's pod.
+	checkNS := func(t *testing.T, namespace, expLabelVal string, hasIntraNamespaceAccess bool) {
 		t.Run(fmt.Sprintf("%s:%s", namespace, expLabelVal), func(t *testing.T) {
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
 				egressNP, err := clients.K8s.NetworkingV1().NetworkPolicies(namespace).Get(ctx,
@@ -133,21 +140,35 @@ func TestK8sComputeBackendEnsureNetPolicy(t *testing.T) {
 					assert.Equal(c, "0.0.0.0/0", peer1.IPBlock.CIDR)
 				}
 
-				// NVCA no longer creates an intra-namespace egress policy:
-				// combined with allow-ingress-monitoring's same-namespace
-				// ingress rule, it allowed any pod in a function namespace
-				// to reach any other pod in that namespace on any port.
-				_, err = clients.K8s.NetworkingV1().NetworkPolicies(namespace).Get(ctx, k8sutil.AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
-				assert.True(c, errors.IsNotFound(err), "allow-egress-intra-namespace should not be created")
+				// Check for the intra-namespace egress policy
+				if hasIntraNamespaceAccess {
+					intraEgressNP, err := clients.K8s.NetworkingV1().NetworkPolicies(namespace).Get(ctx, k8sutil.AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
+					if assert.NoError(c, err) {
+						assert.Equal(c, []netv1.PolicyType{"Egress"}, intraEgressNP.Spec.PolicyTypes)
+						if !assert.Len(c, intraEgressNP.Spec.Egress, 1) {
+							return
+						}
+						if !assert.Len(c, intraEgressNP.Spec.Egress[0].To, 1) {
+							return
+						}
+						peer := intraEgressNP.Spec.Egress[0].To[0]
+						assert.NotNil(c, peer.NamespaceSelector)
+						assert.Equal(c, namespace, peer.NamespaceSelector.MatchLabels[k8sutil.K8sNameLabelKey])
+					}
+				} else {
+					_, err := clients.K8s.NetworkingV1().NetworkPolicies(namespace).Get(ctx, k8sutil.AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
+					assert.True(c, errors.IsNotFound(err), "allow-egress-intra-namespace should not be created for the shared pod instance namespace")
+				}
 
 				ingressNP, err := clients.K8s.NetworkingV1().NetworkPolicies(namespace).Get(ctx,
 					k8sutil.MonitoringIngressNetworkPolicyName, metav1.GetOptions{})
 				if assert.NoError(c, err) {
 					assert.Equal(c, []netv1.PolicyType{"Ingress"}, ingressNP.Spec.PolicyTypes)
-					// Only the ConfigMap-defined rule should be present; NVCA
-					// no longer injects an unscoped same-namespace ingress
-					// rule here.
-					if !assert.Len(c, ingressNP.Spec.Ingress, 1) {
+					wantRules := 1
+					if hasIntraNamespaceAccess {
+						wantRules = 2
+					}
+					if !assert.Len(c, ingressNP.Spec.Ingress, wantRules) {
 						return
 					}
 					if !assert.Len(c, ingressNP.Spec.Ingress[0].From, 1) {
@@ -158,13 +179,20 @@ func TestK8sComputeBackendEnsureNetPolicy(t *testing.T) {
 						return
 					}
 					assert.Equal(c, expLabelVal, peer1.NamespaceSelector.MatchLabels["foo"])
+					if hasIntraNamespaceAccess {
+						peer2 := ingressNP.Spec.Ingress[1].From[0]
+						if !assert.NotNil(c, peer2.NamespaceSelector) {
+							return
+						}
+						assert.Equal(c, namespace, peer2.NamespaceSelector.MatchLabels[k8sutil.K8sNameLabelKey])
+					}
 				}
 			}, 5*time.Second, 200*time.Millisecond, "namespace: "+namespace)
 		})
 	}
 
-	checkNS(t, b.podInstanceNamespace, "bar")
-	checkNS(t, msNS.Name, "bar")
+	checkNS(t, b.podInstanceNamespace, "bar", false)
+	checkNS(t, msNS.Name, "bar", true)
 
 	// Update and make sure changes are propagated by the informer's event handler.
 	b.ForceSync(ctx)
@@ -186,8 +214,8 @@ spec:
 	require.NoError(t, err)
 	b.ForceSync(ctx)
 
-	checkNS(t, b.podInstanceNamespace, "baz")
-	checkNS(t, msNS.Name, "baz")
+	checkNS(t, b.podInstanceNamespace, "baz", false)
+	checkNS(t, msNS.Name, "baz", true)
 }
 
 func newHelmInstanceRBACConfigMap() *v1.ConfigMap {

--- a/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_test.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_test.go
@@ -115,7 +115,7 @@ func TestK8sComputeBackendEnsureNetPolicy(t *testing.T) {
 		Start(ctx)
 	require.NoError(t, err)
 
-	checkNS := func(t *testing.T, namespace, expLabelVal string, hasIntraEgressNP bool) {
+	checkNS := func(t *testing.T, namespace, expLabelVal string) {
 		t.Run(fmt.Sprintf("%s:%s", namespace, expLabelVal), func(t *testing.T) {
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
 				egressNP, err := clients.K8s.NetworkingV1().NetworkPolicies(namespace).Get(ctx,
@@ -133,28 +133,21 @@ func TestK8sComputeBackendEnsureNetPolicy(t *testing.T) {
 					assert.Equal(c, "0.0.0.0/0", peer1.IPBlock.CIDR)
 				}
 
-				// Check for the intra-namespace egress policy
-				if hasIntraEgressNP {
-					intraEgressNP, err := clients.K8s.NetworkingV1().NetworkPolicies(namespace).Get(ctx, k8sutil.AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
-					if assert.NoError(c, err) {
-						assert.Equal(c, []netv1.PolicyType{"Egress"}, intraEgressNP.Spec.PolicyTypes)
-						if !assert.Len(c, intraEgressNP.Spec.Egress, 1) {
-							return
-						}
-						if !assert.Len(c, intraEgressNP.Spec.Egress[0].To, 1) {
-							return
-						}
-						peer := intraEgressNP.Spec.Egress[0].To[0]
-						assert.NotNil(c, peer.NamespaceSelector)
-						assert.Equal(c, namespace, peer.NamespaceSelector.MatchLabels[k8sutil.K8sNameLabelKey])
-					}
-				}
+				// NVCA no longer creates an intra-namespace egress policy:
+				// combined with allow-ingress-monitoring's same-namespace
+				// ingress rule, it allowed any pod in a function namespace
+				// to reach any other pod in that namespace on any port.
+				_, err = clients.K8s.NetworkingV1().NetworkPolicies(namespace).Get(ctx, k8sutil.AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
+				assert.True(c, errors.IsNotFound(err), "allow-egress-intra-namespace should not be created")
 
 				ingressNP, err := clients.K8s.NetworkingV1().NetworkPolicies(namespace).Get(ctx,
 					k8sutil.MonitoringIngressNetworkPolicyName, metav1.GetOptions{})
 				if assert.NoError(c, err) {
 					assert.Equal(c, []netv1.PolicyType{"Ingress"}, ingressNP.Spec.PolicyTypes)
-					if !assert.Len(c, ingressNP.Spec.Ingress, 2) {
+					// Only the ConfigMap-defined rule should be present; NVCA
+					// no longer injects an unscoped same-namespace ingress
+					// rule here.
+					if !assert.Len(c, ingressNP.Spec.Ingress, 1) {
 						return
 					}
 					if !assert.Len(c, ingressNP.Spec.Ingress[0].From, 1) {
@@ -165,18 +158,13 @@ func TestK8sComputeBackendEnsureNetPolicy(t *testing.T) {
 						return
 					}
 					assert.Equal(c, expLabelVal, peer1.NamespaceSelector.MatchLabels["foo"])
-					peer2 := ingressNP.Spec.Ingress[1].From[0]
-					if !assert.NotNil(c, peer2.NamespaceSelector) {
-						return
-					}
-					assert.Equal(c, namespace, peer2.NamespaceSelector.MatchLabels[k8sutil.K8sNameLabelKey])
 				}
 			}, 5*time.Second, 200*time.Millisecond, "namespace: "+namespace)
 		})
 	}
 
-	checkNS(t, b.podInstanceNamespace, "bar", false)
-	checkNS(t, msNS.Name, "bar", true)
+	checkNS(t, b.podInstanceNamespace, "bar")
+	checkNS(t, msNS.Name, "bar")
 
 	// Update and make sure changes are propagated by the informer's event handler.
 	b.ForceSync(ctx)
@@ -198,8 +186,8 @@ spec:
 	require.NoError(t, err)
 	b.ForceSync(ctx)
 
-	checkNS(t, b.podInstanceNamespace, "baz", false)
-	checkNS(t, msNS.Name, "baz", true)
+	checkNS(t, b.podInstanceNamespace, "baz")
+	checkNS(t, msNS.Name, "baz")
 }
 
 func newHelmInstanceRBACConfigMap() *v1.ConfigMap {

--- a/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_test.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_test.go
@@ -142,7 +142,8 @@ func TestK8sComputeBackendEnsureNetPolicy(t *testing.T) {
 
 				// Check for the intra-namespace egress policy
 				if hasIntraNamespaceAccess {
-					intraEgressNP, err := clients.K8s.NetworkingV1().NetworkPolicies(namespace).Get(ctx, k8sutil.AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
+					intraEgressNP, err := clients.K8s.NetworkingV1().NetworkPolicies(namespace).Get(
+						ctx, k8sutil.AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
 					if assert.NoError(c, err) {
 						assert.Equal(c, []netv1.PolicyType{"Egress"}, intraEgressNP.Spec.PolicyTypes)
 						if !assert.Len(c, intraEgressNP.Spec.Egress, 1) {
@@ -156,8 +157,10 @@ func TestK8sComputeBackendEnsureNetPolicy(t *testing.T) {
 						assert.Equal(c, namespace, peer.NamespaceSelector.MatchLabels[k8sutil.K8sNameLabelKey])
 					}
 				} else {
-					_, err := clients.K8s.NetworkingV1().NetworkPolicies(namespace).Get(ctx, k8sutil.AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
-					assert.True(c, errors.IsNotFound(err), "allow-egress-intra-namespace should not be created for the shared pod instance namespace")
+					_, err := clients.K8s.NetworkingV1().NetworkPolicies(namespace).Get(
+						ctx, k8sutil.AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
+					assert.True(c, errors.IsNotFound(err),
+						"allow-egress-intra-namespace should not be created for the shared pod instance namespace")
 				}
 
 				ingressNP, err := clients.K8s.NetworkingV1().NetworkPolicies(namespace).Get(ctx,


### PR DESCRIPTION
## TL;DR
Adds a one-time startup cleanup that deletes the `allow-egress-intra-namespace` NetworkPolicy from the shared `nvcf-backend` namespace if it still exists. This is a follow-up to the base branch's fix, which stops the policy from being created in `nvcf-backend` going forward but does not remove copies that already exist on clusters that reconciled before that fix shipped.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
The base branch scopes `ensureNetworkPolicies` so `nvcf-backend` no longer gets the same-namespace ingress rule or the `allow-egress-intra-namespace` egress policy, since a same-namespace allow in that shared, multi-tenant namespace lets one customer's pod reach another customer's pod. That change only affects future reconciles: it stops new copies of the egress policy from being created, but the regular prune loop (`pruneCustomNetworkPolicies`) only deletes policies carrying a "custom policy" label, and this one never had it — so already-deployed clusters keep the stale policy object indefinitely, undoing part of the isolation fix.

This PR adds `k8sutil.RemoveLegacyIntraNamespaceEgressPolicy`, called once from the agent's existing startup bootstrap path in `backendk8scache.go`, scoped to a single hardcoded policy name in the shared `nvcf-backend` namespace only. It never touches MiniService/Helm per-instance namespaces, where the same policy is legitimate and retained.

Split into a separate PR from the base fix so the operational impact of an automated startup deletion (versus a manual/SBOM-driven remediation) can be evaluated on its own, independent of the underlying NetworkPolicy scoping fix.

## For the Reviewer
- `internal/util/k8sutil/netpol.go`: `RemoveLegacyIntraNamespaceEgressPolicy` — the only new function, a straightforward delete-if-exists.
- `pkg/nvca/backendk8scache.go`: call site, added right after the existing per-namespace `ensureNetworkPolicies` bootstrap loop at agent startup.
- Please weigh in on whether an automated startup delete is acceptable here, or whether this should instead be a manual/tooled remediation step outside NVCA.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
- `go build ./...`, `go vet ./...` — clean.
- `go test ./internal/util/k8sutil/... ./pkg/nvca/...` — all green.
- Not yet done: live verification against a cluster with a pre-existing `allow-egress-intra-namespace` policy in `nvcf-backend`, confirming the agent removes it on startup.

## Issues
NO-REF

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected network policy behavior so function-specific namespaces allow intended same-namespace communication.
  - Shared pod-instance namespaces no longer receive unintended intra-namespace access.
  - Improved monitoring access rules for Prometheus and related services.
  - Legacy network policy configuration is removed during startup when possible, with cleanup issues logged without blocking startup.

- **Documentation**
  - Clarified policy names, internet egress exclusions, monitoring behavior, and namespace applicability in cluster configuration guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->