### PR TITLE
fix(local-cluster): make destroy-all cleanup POSIX-portable

### DIFF
--- a/tools/ncp-local-cluster/Makefile
+++ b/tools/ncp-local-cluster/Makefile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: help clean build test test-coverage-html test-manual start stop destroy destroy-all-ncp-local status ensure-cluster ensure-context ensure-docker-config validate-compute-clusters print-compute-clusters start-control-plane deploy-control-plane-addons deploy-control-plane-endpoints build-and-deploy-control-plane-cluster destroy-control-plane start-compute-plane deploy-compute-plane-addons configure-compute-control-plane-dns deploy-compute-control-plane-endpoints build-and-deploy-compute-plane-cluster destroy-compute-plane build-and-deploy-multicluster destroy-multicluster test-multicluster-make setup-gateway-api setup-metallb check-gateway-api deploy-sample deploy-nginx wait-for-nginx wait-for-gateway validate-gateway cleanup-nginx wait-for-deployment validate-deployment cleanup-sample build-and-deploy-cluster build-csi-smb deploy-csi-smb wait-for-csi-smb build-fake-gpu-operator deploy-fake-gpu-operator wait-for-fake-gpu-operator deploy-prometheus-crds uninstall-prometheus-crds deploy-kube-state-metrics wait-for-kube-state-metrics uninstall-kube-state-metrics build-credential-provider-multiarch
+.PHONY: help clean build test test-coverage-html test-manual start stop destroy destroy-all-ncp-local status ensure-cluster ensure-context ensure-docker-config validate-compute-clusters print-compute-clusters start-control-plane deploy-control-plane-addons deploy-control-plane-endpoints build-and-deploy-control-plane-cluster destroy-control-plane start-compute-plane deploy-compute-plane-addons configure-compute-control-plane-dns deploy-compute-control-plane-endpoints build-and-deploy-compute-plane-cluster destroy-compute-plane build-and-deploy-multicluster destroy-multicluster test-destroy-all-ncp-local test-multicluster-make setup-gateway-api setup-metallb check-gateway-api deploy-sample deploy-nginx wait-for-nginx wait-for-gateway validate-gateway cleanup-nginx wait-for-deployment validate-deployment cleanup-sample build-and-deploy-cluster build-csi-smb deploy-csi-smb wait-for-csi-smb build-fake-gpu-operator deploy-fake-gpu-operator wait-for-fake-gpu-operator deploy-prometheus-crds uninstall-prometheus-crds deploy-kube-state-metrics wait-for-kube-state-metrics uninstall-kube-state-metrics build-credential-provider-multiarch
 
 # === Cluster Configuration ===
 CLUSTER_NAME := ncp-local
@@ -156,8 +156,8 @@ destroy-all-ncp-local: ## Discover and destroy every ncp-local* k3d cluster on t
 		echo "destroy-all-ncp-local requires jq; install it and retry." >&2; \
 		exit 1; \
 	}
-	@set -o pipefail; \
-	NAMES=$$(k3d cluster list -o json | jq -r '.[] | select(.name|startswith("ncp-local")) | .name'); \
+	@CLUSTERS_JSON=$$(k3d cluster list -o json) || exit $$?; \
+	NAMES=$$(printf '%s\n' "$$CLUSTERS_JSON" | jq -r '.[] | select(.name|startswith("ncp-local")) | .name') || exit $$?; \
 	if [ -z "$$NAMES" ]; then \
 		echo "No ncp-local* clusters present."; \
 		exit 0; \
@@ -297,6 +297,9 @@ destroy-multicluster: validate-compute-clusters ## Destroy the default control-p
 
 test-multicluster-make: ## Run dry Makefile tests for multi-cluster name derivation
 	@tests/test-multicluster-make.sh
+
+test-destroy-all-ncp-local: ## Run dry Makefile tests for host-wide local-cluster cleanup
+	@tests/test-destroy-all-ncp-local.sh
 
 # --- Load Balancer & Gateway API Setup ---
 setup-gateway-api:

--- a/tools/ncp-local-cluster/tests/test-destroy-all-ncp-local.sh
+++ b/tools/ncp-local-cluster/tests/test-destroy-all-ncp-local.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MAKE_SHELL="${MAKE_SHELL:-/bin/sh}"
+TEST_DIR="$(mktemp -d)"
+FAKE_BIN_DIR="$TEST_DIR/bin"
+DELETE_LOG="$TEST_DIR/deleted-clusters"
+OUTPUT_FILE="$TEST_DIR/output"
+
+cleanup() {
+  rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+
+  if [ "$actual" != "$expected" ]; then
+    fail "${label}: expected '${expected}', got '${actual}'"
+  fi
+}
+
+mkdir -p "$FAKE_BIN_DIR"
+
+cat >"$FAKE_BIN_DIR/k3d" <<'EOF'
+#!/bin/sh
+if [ "$#" -eq 4 ] && [ "$1" = "cluster" ] && [ "$2" = "list" ] && [ "$3" = "-o" ] && [ "$4" = "json" ]; then
+  printf '%s\n' "${FAKE_K3D_JSON:-[]}"
+  exit "${FAKE_K3D_LIST_EXIT:-0}"
+fi
+if [ "$#" -eq 3 ] && [ "$1" = "cluster" ] && [ "$2" = "delete" ]; then
+  printf '%s\n' "$3" >>"$DELETE_LOG"
+  exit 0
+fi
+echo "unexpected k3d arguments: $*" >&2
+exit 64
+EOF
+
+cat >"$FAKE_BIN_DIR/jq" <<'EOF'
+#!/bin/sh
+input="$(cat)"
+if [ "$#" -ne 2 ] || [ "$1" != "-r" ] || [ "$2" != '.[] | select(.name|startswith("ncp-local")) | .name' ]; then
+  echo "unexpected jq arguments: $*" >&2
+  exit 64
+fi
+if [ "$input" != "${FAKE_JQ_EXPECT_INPUT:-[]}" ]; then
+  echo "unexpected jq input: $input" >&2
+  exit 65
+fi
+if [ "${FAKE_JQ_EXIT:-0}" -ne 0 ]; then
+  exit "$FAKE_JQ_EXIT"
+fi
+printf '%b' "${FAKE_JQ_OUTPUT:-}"
+EOF
+
+chmod +x "$FAKE_BIN_DIR/k3d" "$FAKE_BIN_DIR/jq"
+
+run_make() {
+  PATH="$FAKE_BIN_DIR:$PATH" \
+    DELETE_LOG="$DELETE_LOG" \
+    make --no-print-directory -s -C "$ROOT_DIR" \
+      SHELL="$MAKE_SHELL" destroy-all-ncp-local
+}
+
+: >"$DELETE_LOG"
+if ! FAKE_K3D_JSON='[]' FAKE_JQ_EXPECT_INPUT='[]' run_make >"$OUTPUT_FILE" 2>&1; then
+  cat "$OUTPUT_FILE" >&2
+  fail "empty cluster inventory should succeed under $MAKE_SHELL"
+fi
+assert_eq "No ncp-local* clusters present." "$(cat "$OUTPUT_FILE")" "empty inventory output"
+assert_eq "" "$(cat "$DELETE_LOG")" "empty inventory deletion log"
+
+: >"$DELETE_LOG"
+cluster_json='[{"name":"ncp-local"},{"name":"unrelated"},{"name":"ncp-local-cp"}]'
+FAKE_K3D_JSON="$cluster_json" \
+  FAKE_JQ_EXPECT_INPUT="$cluster_json" \
+  FAKE_JQ_OUTPUT='ncp-local\nncp-local-cp\n' \
+  run_make >"$OUTPUT_FILE" 2>&1 || {
+    cat "$OUTPUT_FILE" >&2
+    fail "matching cluster inventory should succeed"
+  }
+assert_eq $'ncp-local\nncp-local-cp' "$(cat "$DELETE_LOG")" "deleted cluster names"
+
+: >"$DELETE_LOG"
+if FAKE_K3D_LIST_EXIT=23 FAKE_JQ_EXPECT_INPUT='[]' run_make >"$OUTPUT_FILE" 2>&1; then
+  cat "$OUTPUT_FILE" >&2
+  fail "k3d cluster list failure should propagate"
+fi
+assert_eq "" "$(cat "$DELETE_LOG")" "k3d failure deletion log"
+
+: >"$DELETE_LOG"
+if FAKE_K3D_JSON='[]' FAKE_JQ_EXPECT_INPUT='[]' FAKE_JQ_EXIT=24 run_make >"$OUTPUT_FILE" 2>&1; then
+  cat "$OUTPUT_FILE" >&2
+  fail "jq failure should propagate"
+fi
+assert_eq "" "$(cat "$DELETE_LOG")" "jq failure deletion log"
+
+echo "PASS: destroy-all-ncp-local Makefile tests"


### PR DESCRIPTION
## TL;DR

Make `destroy-all-ncp-local` work with POSIX `/bin/sh` implementations such as Dash while retaining failure detection for both inventory commands.

## Additional Details

The cleanup recipe used Bash-only `set -o pipefail` without selecting Bash, so it failed before inventory on common Debian and Ubuntu systems. The recipe now captures `k3d cluster list -o json` as a separately checked command, then passes that result to a separately checked `jq` selection. This preserves both failure paths without changing the repository-wide Make shell.

Focused fake-command coverage verifies:

- empty inventory succeeds under Dash
- only `ncp-local*` names are deleted
- `k3d cluster list` failures propagate
- `jq` failures propagate

## For the Reviewer

Please review the status handling in `tools/ncp-local-cluster/Makefile` and the controlled `k3d`/`jq` boundary coverage in `tests/test-destroy-all-ncp-local.sh`.

## For QA

QA is not needed. These are dry Makefile tests and do not create or destroy real clusters.

Passed:

- `MAKE_SHELL=/bin/sh make -C tools/ncp-local-cluster test-destroy-all-ncp-local` with `/bin/sh` resolving to Dash
- `make -C tools/ncp-local-cluster validate-compute-clusters`
- `make -C tools/ncp-local-cluster print-compute-clusters`
- `make -C tools/ncp-local-cluster test-multicluster-make`
- `bash -n tools/ncp-local-cluster/tests/test-destroy-all-ncp-local.sh`
- `shellcheck tools/ncp-local-cluster/tests/test-destroy-all-ncp-local.sh`
- `git diff --check`

## Issues

Fixes #1261

## Dependencies

None. No license or NOTICE changes.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved local cluster cleanup reliability by ensuring failures while discovering or filtering clusters are reported clearly.
  - Prevented cleanup operations from silently continuing when cluster-listing commands fail.

- **Tests**
  - Added integration coverage for empty inventories, matching clusters, deletion behavior, and command failures.
  - Added a dry-run test target for validating host-wide local cluster cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->