### PR TITLE
chore(http-invocation): bump nvcf-invocation-service chart image to v0.12.0

### DIFF
--- a/deploy/helm/http-invocation/nvcf-invocation-service/Chart.yaml
+++ b/deploy/helm/http-invocation/nvcf-invocation-service/Chart.yaml
@@ -19,4 +19,4 @@ description: A Helm chart for NVCF Invocation Service deployment
 
 type: application
 version: 0.0.0 # autoversioning enabled via release pipeline
-appVersion: "0.8.8"
+appVersion: "0.12.0"

--- a/deploy/helm/http-invocation/nvcf-invocation-service/values.yaml
+++ b/deploy/helm/http-invocation/nvcf-invocation-service/values.yaml
@@ -37,7 +37,7 @@ invocation:
     registry: "" # must be supplied
     repository: "" # must be supplied
     pullPolicy: IfNotPresent
-    tag: "0.8.8"
+    tag: "0.12.0"
 
   podAnnotations: {}
   podLabels: {}

--- a/deploy/helm/http-invocation/tests/image_tag_appversion_test.sh
+++ b/deploy/helm/http-invocation/tests/image_tag_appversion_test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verify the nvcf-invocation-service chart version contract:
+#   - values.yaml invocation.image.tag matches Chart.yaml appVersion,
+#   - the default render pins the Deployment image to that version,
+#   - an empty tag still resolves to appVersion through the chart helper.
+#
+# Assertions read the expected version from Chart.yaml rather than hardcoding
+# it, so a routine image bump does not require editing this test.
+set -euo pipefail
+
+chart_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../nvcf-invocation-service" && pwd)"
+registry="registry.example.test"
+repository="nvcf-invocation-service"
+
+app_version="$(yq -r '.appVersion' "${chart_root}/Chart.yaml")"
+values_tag="$(yq -r '.invocation.image.tag' "${chart_root}/values.yaml")"
+
+if [[ -z "${app_version}" || "${app_version}" == "null" ]]; then
+  echo "FAILED: Chart.yaml appVersion is empty" >&2
+  exit 1
+fi
+
+if [[ "${values_tag}" != "${app_version}" ]]; then
+  echo "FAILED: values.yaml invocation.image.tag (${values_tag}) does not match Chart.yaml appVersion (${app_version})" >&2
+  exit 1
+fi
+
+render() {
+  helm template inv "${chart_root}" \
+    --set-string invocation.image.registry="${registry}" \
+    --set-string invocation.image.repository="${repository}" \
+    "$@"
+}
+
+assert_image() {
+  local manifest="$1" expected="$2" label="$3" count
+  # awk, not grep -F: grep matches substrings, so a tag such as 0.12.0-rc1
+  # would still match 0.12.0 and hide a regression.
+  count="$(awk -v expected="\"${expected}\"" \
+    '$1 == "image:" && $2 == expected { n++ } END { print n + 0 }' "${manifest}")"
+  if [[ "${count}" -ne 1 ]]; then
+    echo "FAILED: expected exactly 1 ${expected} image in the ${label} render, got ${count}" >&2
+    exit 1
+  fi
+}
+
+manifest="$(mktemp)"
+fallback_manifest="$(mktemp)"
+trap 'rm -f "${manifest}" "${fallback_manifest}"' EXIT
+
+render > "${manifest}"
+assert_image "${manifest}" "${registry}/${repository}:${app_version}" "default"
+
+# helm upgrade --reuse-values carries the previous release's values forward but
+# never its Chart.yaml. An empty tag must still resolve through appVersion.
+render --set-string invocation.image.tag="" > "${fallback_manifest}"
+assert_image "${fallback_manifest}" "${registry}/${repository}:${app_version}" "empty-tag fallback"
+
+echo "image_tag_appversion_test.sh: chart image pins ${app_version} from Chart.yaml appVersion"

--- a/tools/ci/check-helm-charts
+++ b/tools/ci/check-helm-charts
@@ -44,6 +44,7 @@ chart_map=(
     "ess                      encrypted-secret-store/ess-api"
     "gateway-routes-vanity    gateway-routes/chart"
     "grpc-proxy               grpc-proxy/grpc-proxy"
+    "http-invocation          http-invocation/nvcf-invocation-service"
     "llm-api-gateway          llm-api-gateway/llm-api-gateway"
     "llm-request-router       llm-request-router/llm-request-router"
     "notary                   notary/nvcf-notary-service"

--- a/tools/ci/helm-validate-values/http-invocation.yaml
+++ b/tools/ci/helm-validate-values/http-invocation.yaml
@@ -1,0 +1,5 @@
+# CI-only values for helm lint/template validation.
+invocation:
+  image:
+    registry: example.com
+    repository: foo/bar/baz

--- a/tools/ci/test-check-helm-charts
+++ b/tools/ci/test-check-helm-charts
@@ -77,17 +77,20 @@ expect "missing values directory fails" 1 "values directory not found"
 
 fake_values_dir=""
 fake_chart_root=""
+fake_chart_count=0
 
-make_fake_tree() {  # sets $fake_values_dir and $fake_chart_root from the real chart_map
+make_fake_tree() {  # sets $fake_values_dir, $fake_chart_root, and $fake_chart_count from the real chart_map
     local stem rel
     fake_values_dir="$(mktemp -d)"
     fake_chart_root="$(mktemp -d)"
+    fake_chart_count=0
     while read -r stem rel; do
         [ -n "${stem}" ] || continue
         : >"${fake_values_dir}/${stem}.yaml"
         mkdir -p "${fake_chart_root}/${rel}"
         printf 'apiVersion: v2\nname: %s\nversion: 0.0.0\n' "${stem}" \
             >"${fake_chart_root}/${rel}/Chart.yaml"
+        fake_chart_count=$((fake_chart_count + 1))
     done < <(sed -n '/^chart_map=(/,/^)/p' "${script}" | sed -n 's/^ *"\(.*\)"$/\1/p')
     if [ ! -f "${fake_chart_root}/openbao/helm/Chart.yaml" ]; then
         printf 'FAIL fake tree: chart_map did not yield the expected entries\n'
@@ -124,7 +127,7 @@ run_with_fake_helm() {  # run_with_fake_helm -> sets $out and $rc
 make_fake_tree
 printf 'dependencies:\n  - name: openbao\n' >>"${fake_chart_root}/openbao/helm/Chart.yaml"
 run_with_fake_helm
-expect "fetched charts directory is removed" 0 "14 charts linted and rendered"
+expect "fetched charts directory is removed" 0 "${fake_chart_count} charts linted and rendered"
 if [ -e "${fake_chart_root}/openbao/helm/charts" ]; then
     printf 'FAIL created charts directory left behind\n'
     fail=1
@@ -141,7 +144,7 @@ printf 'dependencies:\n  - name: openbao\n' >>"${fake_chart_root}/openbao/helm/C
 mkdir -p "${fake_chart_root}/openbao/helm/charts/vendored-subchart"
 : >"${fake_chart_root}/openbao/helm/charts/vendored-0.1.0.tgz"
 run_with_fake_helm
-expect "existing charts directory run succeeds" 0 "14 charts linted and rendered"
+expect "existing charts directory run succeeds" 0 "${fake_chart_count} charts linted and rendered"
 if [ -e "${fake_chart_root}/openbao/helm/charts/fetched-0.1.0.tgz" ]; then
     printf 'FAIL fetched archive left in an existing charts directory\n'
     fail=1


### PR DESCRIPTION
## Why
The `nvcf-invocation-service` Helm chart's `values.yaml` `image.tag` and `Chart.yaml` `appVersion` were both still pinned at `0.8.8`, set at the chart migration commit (25d879e1). The service source on `main` has since released several tags, up through `src/invocation-plane-services/http-invocation/v0.12.0`, so the chart no longer reflects the latest available release.

Review feedback noted the bump landed with no test. The chart had no test coverage at all, and nothing asserted that `values.yaml` `invocation.image.tag` stays in sync with `Chart.yaml` `appVersion`, or that the `_helpers.tpl` fallback still resolves an empty tag to `appVersion`.

## What changed
- Bumped `deploy/helm/http-invocation/nvcf-invocation-service/values.yaml` `image.tag` from `0.8.8` to `0.12.0`.
- Bumped `deploy/helm/http-invocation/nvcf-invocation-service/Chart.yaml` `appVersion` from `0.8.8` to `0.12.0` to match.
- Added `deploy/helm/http-invocation/tests/image_tag_appversion_test.sh`, following the existing `deploy/helm/nvca-operator/tests/*_test.sh` convention. It asserts the `values.yaml` tag equals `Chart.yaml` `appVersion`, that the default render pins the Deployment image to that version, and that an empty tag still falls back to `appVersion` through the chart helper. The expected version is read from `Chart.yaml` rather than hardcoded, so a routine image bump does not require editing the test.
- Registered the chart with `tools/ci/check-helm-charts` by adding `tools/ci/helm-validate-values/http-invocation.yaml` and one `chart_map` entry. This chart was the only one under `deploy/helm/` with no CI values file, so it received no lint or render validation.

## Customer Release Notes
Not customer visible.

## Plan Summary
Deploying this chart change updates the `nvcf-invocation-service` container image tag from `0.8.8` to `0.12.0`. No other resources are affected. The test and CI values additions have no runtime effect.

## Usage
Run the chart test directly:

```sh
bash deploy/helm/http-invocation/tests/image_tag_appversion_test.sh
```

## Testing
- New chart test passes against this branch.
- Three negative checks confirm each assertion fails when it should: tag/appVersion drift, the helper pinning a wrong tag, and removal of the `| default .Chart.AppVersion` fallback.
- `tools/ci/check-helm-charts` passes, now covering 15 charts instead of 14.
- `tools/ci/test-check-helm-charts` passes.
- Verified no other files under `deploy/helm/http-invocation/` reference the old `0.8.8` tag.

No local cluster was used, so this is render-level validation only. A staging rollout is still recommended before promoting further.

## Notes
The review comment asked for the literal strings `:0.12.0` and `appVersion: "0.12.0"` in the assertions. The test reads the version from `Chart.yaml` instead. It guards the same contract without needing an edit on every future bump.

`tools/ci/check-helm-charts` is the wired-up validation path in this snapshot. The standalone `image_tag_appversion_test.sh` needs a `tools/ci/subproject-validations.yaml` entry on the internal side before it runs in CI.

## References
Closes #1267

## Related Pull Requests
None.

## Dependencies
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the invocation service deployment to version 0.12.0.
  * Aligned the default container image with the new service version.
  * Improved deployment configuration validation to ensure the application version and container image remain consistent across Helm-based installations.
  * Expanded automated checks to cover the invocation service and adapt as additional deployment charts are added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
