### PR TITLE
docs(release): add RELEASE.md documenting release process

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,12 +13,16 @@ authoritative behavior; this document summarizes it for contributors.
 ## Release Cadence
 
 Releases are commit-triggered, not calendar-triggered. There is no fixed
-weekly or monthly cadence.
+weekly or monthly cadence. On every push to `main`, the `service-release` job
+runs `./tools/ci/github-release auto`. Each subproject registered in
+[`tools/ci/github-release-subprojects.json`](tools/ci/github-release-subprojects.json)
+uses exactly one of two release models. They are mutually exclusive: the
+automation branches on a subproject's `dev_prerelease` flag and only ever
+runs one path for it, never both.
 
-On every push to `main`, the `service-release` job runs
-`./tools/ci/github-release auto`. For each subproject, this walks the commits
-since its last release tag and applies semantic-release-style analysis to
-decide whether to cut a new version:
+Semantic-release model (most subprojects, for example `src/clis/nvcf-cli`):
+walks the commits since the subproject's last release tag and decides
+whether to cut a new version.
 
 - Commits typed `feat`, `fix`, or `perf` (the "customer" commit types defined
   in [`CONTRIBUTING.md`](CONTRIBUTING.md#how-to-select-a-commit-type)) trigger
@@ -27,24 +31,32 @@ decide whether to cut a new version:
   or `revert` (the "foundational" types) do not trigger a release on their
   own.
 
-Some subprojects also publish a `-dev.N` prerelease tag on every push to
-`main`, independent of commit type. In practice this means prerelease tags
-land many times per day during active development, while stable tags land
-only when a release-worthy commit merges. For example, at the time of
+Dev-prerelease model (only `nvca` and the three Helm stacks under
+`deploy/stacks/`: `nvcf-compute-plane`, `self-managed`, and `observability`):
+a push to `main` never cuts a stable release, regardless of commit type. It
+only bumps a `-dev.N` prerelease tag off the stable base version recorded in
+the subproject's `VERSION` file. In practice this means dev prereleases land
+many times per day during active development; for example, at the time of
 writing, `src/compute-plane-services/nvca` had cut five `-dev.N` prereleases
-in a single day alongside its normal stable-tag history.
+in a single day. A stable release for one of these four subprojects is cut
+only when a commit lands on that subproject's release branch (see Branch
+Naming), which bumps the patch version automatically. Until a release branch
+exists for one of these subprojects, only dev prereleases accumulate; there
+is no stable-release path on `main` for them.
 
 Release notes are generated from commit messages (semantic-release
-conventions) and attached to the GitHub Release for each tag.
+conventions) and attached to the GitHub Release for each tag, dev
+prereleases included.
 
 ## Branch Naming
 
 - `main`: the active development branch. All pull requests target `main`,
   except hotfixes (see [`CONTRIBUTING.md`](CONTRIBUTING.md#step-2-create-a-branch)).
 - `release-<service-path>/vMAJOR.MINOR`: a maintenance branch for one
-  subproject's release train. Pushes to a branch matching `release-**/v*`
-  run the same release automation, scoped to that subproject, so patch fixes
-  on a maintenance train publish their own tags.
+  subproject's release train, used by the dev-prerelease release model (see
+  Release Cadence). Pushes to a branch matching `release-**/v*` run the same
+  release automation, scoped to that subproject, so patch fixes on a
+  maintenance train publish their own stable tags.
 
 Real examples from this repository:
 
@@ -55,19 +67,30 @@ Real examples from this repository:
 The separator between the service id and the version can vary by how a
 subproject registers its release metadata; for example
 `release-nvcf-cassandra-migrations-v0.10` uses a flattened id instead of a
-path segment. Check a subproject's entry in the release metadata consumed by
-`tools/ci/github-release` if you need the exact branch name it expects.
+path segment. That branch also predates this subproject's current
+configuration, which does not use the dev-prerelease model, so treat it as
+historical evidence of the naming pattern rather than a live example. Check
+a subproject's entry in
+[`tools/ci/github-release-subprojects.json`](tools/ci/github-release-subprojects.json)
+for its current release model and exact branch name.
 
 Tags follow the matching format `<service-path>/vMAJOR.MINOR.PATCH`, for
-example `src/clis/nvcf-cli/v1.15.11` and
-`src/compute-plane-services/nvca/v3.3.0-dev.184`.
+example `src/clis/nvcf-cli/v1.15.11` (semantic-release model) and
+`src/compute-plane-services/nvca/v3.3.0-dev.184` (dev-prerelease model).
 
 ## Who Can Trigger a Release
 
-Automatic: any contributor whose reviewed pull request merges to `main` has
-triggered a release for the subprojects their commits touch, as long as at
-least one commit is a `feat`, `fix`, or `perf` type. No separate release
-action is needed after merge.
+Automatic, semantic-release subprojects: any contributor whose reviewed pull
+request merges to `main` has triggered a release for the subprojects their
+commits touch, as long as at least one commit is a `feat`, `fix`, or `perf`
+type. No separate release action is needed after merge.
+
+Automatic, dev-prerelease subprojects (`nvca` and the three stacks under
+`deploy/stacks/`): merging any pull request to `main` only produces a dev
+prerelease tag, regardless of commit type. Triggering an actual stable
+release for one of these subprojects requires a commit to land on that
+subproject's release branch instead of `main`. See Manual below for who can
+create that branch in the first place.
 
 Manual: `.github/workflows/release-tags.yml` also accepts a
 `workflow_dispatch` trigger with three operations:
@@ -79,8 +102,18 @@ Manual: `.github/workflows/release-tags.yml` also accepts a
 - `self-managed-branch-cut`: the same branch-cut flow for the
   `nvcf-self-managed-stack` service.
 
-`workflow_dispatch` requires GitHub write access to the repository; there is
-no separate, smaller list of named release managers. Branch-cut operations
+Both branch-cut operations only work for a dev-prerelease subproject; the
+underlying `branch-cut` command refuses to run against a subproject that
+does not use that release model.
+
+`workflow_dispatch` requires GitHub write access to the repository. In this
+repository that access is granted through organization team membership, not
+a hand-maintained list: the `NVIDIA/nvcf-dev` team (the NVCF maintainers)
+holds write access, and `NVIDIA/nvcf-admin` holds admin access. In practice
+this means only NVCF maintainers can cut a release branch for `nvca` or one
+of the three stacks; an external contributor with a fix for an already-cut
+release branch needs a maintainer to either create the branch or merge a
+pull request that targets an existing one. Branch-cut operations
 additionally require the `NV_GITHUB_TOKEN` repository secret to be
 configured, because the default `GITHUB_TOKEN` cannot trigger CI on the
 generated version-bump pull request. Area ownership for review is defined in

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -110,12 +110,11 @@ underlying `branch-cut` command refuses to run against a subproject that
 does not use that release model.
 
 `workflow_dispatch` requires GitHub write access to the repository. In this
-repository that access is granted through organization team membership, not
-a hand-maintained list: the `NVIDIA/nvcf-dev` team (the NVCF maintainers)
-holds write access, and `NVIDIA/nvcf-admin` holds admin access. In practice
-this means only NVCF maintainers can cut a release branch for `nvca` or one
-of the three stacks; an external contributor with a fix for an already-cut
-release branch needs a maintainer to either create the branch or merge a
+repository that access is granted through organization team membership:
+maintainers (`NVIDIA/nvcf-dev` and `NVIDIA/nvcf-admin`) can cut a release
+branch for `nvca` or one of the three stacks; an external contributor with
+a fix for an already-cut release branch needs a maintainer to either create
+the branch or merge a
 pull request that targets an existing one. Branch-cut operations
 additionally require the `NV_GITHUB_TOKEN` repository secret to be
 configured, because the default `GITHUB_TOKEN` cannot trigger CI on the

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -112,7 +112,11 @@ does not use that release model.
 `workflow_dispatch` requires GitHub write access to the repository. In this
 repository that access is granted through organization team membership:
 maintainers (`NVIDIA/nvcf-dev` and `NVIDIA/nvcf-admin`) can cut a release
-branch for `nvca` or one of the three stacks; an external contributor with
+branch. Only `nvca` and `nvcf-self-managed-stack` have a dedicated
+`workflow_dispatch` operation; for `nvcf-compute-plane-stack` and
+`nvcf-observability-stack`, a maintainer runs
+`tools/ci/github-release branch-cut --service <id>` directly, since no CI
+job wires up that operation for them yet. An external contributor with
 a fix for an already-cut release branch needs a maintainer to either create
 the branch or merge a
 pull request that targets an existing one. Branch-cut operations

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,9 +20,10 @@ uses exactly one of two release models. They are mutually exclusive: the
 automation branches on a subproject's `dev_prerelease` flag and only ever
 runs one path for it, never both.
 
-Semantic-release model (most subprojects, for example `src/clis/nvcf-cli`):
-walks the commits since the subproject's last release tag and decides
-whether to cut a new version.
+### Semantic-release model
+
+Most subprojects, for example `src/clis/nvcf-cli`. Walks the commits since
+the subproject's last release tag and decides whether to cut a new version.
 
 - Commits typed `feat`, `fix`, or `perf` (the "customer" commit types defined
   in [`CONTRIBUTING.md`](CONTRIBUTING.md#how-to-select-a-commit-type)) trigger
@@ -31,10 +32,12 @@ whether to cut a new version.
   or `revert` (the "foundational" types) do not trigger a release on their
   own.
 
-Dev-prerelease model (only `nvca` and the three Helm stacks under
-`deploy/stacks/`: `nvcf-compute-plane`, `self-managed`, and `observability`):
-a push to `main` never cuts a stable release, regardless of commit type. It
-only bumps a `-dev.N` prerelease tag off the stable base version recorded in
+### Dev-prerelease model
+
+Only `nvca` and the three Helm stacks under `deploy/stacks/`:
+`nvcf-compute-plane`, `self-managed`, and `observability`. A push to `main`
+never cuts a stable release, regardless of commit type. It only bumps a
+`-dev.N` prerelease tag off the stable base version recorded in
 the subproject's `VERSION` file. In practice this means dev prereleases land
 many times per day during active development; for example, at the time of
 writing, `src/compute-plane-services/nvca` had cut five `-dev.N` prereleases

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -142,7 +142,19 @@ step tied to a version tag.
 
 ## Backport Policy
 
-No formal backport policy is documented in this repository today. A fix that
-needs to reach an already-cut maintenance branch has to be applied there
-directly (for example by cherry-picking the commit to the `release-*`
-branch), following the same commit and review conventions as `main`.
+Applies only to the four dev-prerelease subprojects (`nvca` and the three
+stacks under `deploy/stacks/`), since those are the only subprojects that
+cut release branches at all (see Release Cadence). Semantic-release
+subprojects have no maintenance branch to backport to; a fix for one of
+them ships by merging to `main` like any other change.
+
+Support window: for each of the four dev-prerelease subprojects, only the
+latest minor release train and the one before it (N and N-1) are
+maintained. A release branch older than N-1 is effectively end of life and
+does not receive further backports.
+
+Mechanism: a fix lands on `main` first. To reach a supported release
+branch, apply it there directly, for example by cherry-picking the commit
+to the `release-*` branch, following the same commit and review
+conventions as `main`. There is no automation that backports a commit for
+you.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,112 @@
+# Release Process
+
+NVCF is a monorepo. Each subproject under `src/`, `deploy/stacks/`, and
+`migrations/` (services, CLIs, Helm stacks, migration sets) is versioned and
+released independently. There is no single repo-wide release; releases happen
+per subproject, driven by commits that touch that subproject's path.
+
+The automation that implements this lives in
+[`.github/workflows/release-tags.yml`](.github/workflows/release-tags.yml) and
+[`tools/ci/github-release`](tools/ci/github-release). Read those files for the
+authoritative behavior; this document summarizes it for contributors.
+
+## Release Cadence
+
+Releases are commit-triggered, not calendar-triggered. There is no fixed
+weekly or monthly cadence.
+
+On every push to `main`, the `service-release` job runs
+`./tools/ci/github-release auto`. For each subproject, this walks the commits
+since its last release tag and applies semantic-release-style analysis to
+decide whether to cut a new version:
+
+- Commits typed `feat`, `fix`, or `perf` (the "customer" commit types defined
+  in [`CONTRIBUTING.md`](CONTRIBUTING.md#how-to-select-a-commit-type)) trigger
+  a new stable release tag for the subproject they touch.
+- Commits typed `docs`, `build`, `test`, `refactor`, `ci`, `chore`, `style`,
+  or `revert` (the "foundational" types) do not trigger a release on their
+  own.
+
+Some subprojects also publish a `-dev.N` prerelease tag on every push to
+`main`, independent of commit type. In practice this means prerelease tags
+land many times per day during active development, while stable tags land
+only when a release-worthy commit merges. For example, at the time of
+writing, `src/compute-plane-services/nvca` had cut five `-dev.N` prereleases
+in a single day alongside its normal stable-tag history.
+
+Release notes are generated from commit messages (semantic-release
+conventions) and attached to the GitHub Release for each tag.
+
+## Branch Naming
+
+- `main`: the active development branch. All pull requests target `main`,
+  except hotfixes (see [`CONTRIBUTING.md`](CONTRIBUTING.md#step-2-create-a-branch)).
+- `release-<service-path>/vMAJOR.MINOR`: a maintenance branch for one
+  subproject's release train. Pushes to a branch matching `release-**/v*`
+  run the same release automation, scoped to that subproject, so patch fixes
+  on a maintenance train publish their own tags.
+
+Real examples from this repository:
+
+- `release-src/compute-plane-services/nvca/v3.1`
+- `release-src/compute-plane-services/nvca/v3.2`
+- `release-deploy/stacks/self-managed/v0.7`
+
+The separator between the service id and the version can vary by how a
+subproject registers its release metadata; for example
+`release-nvcf-cassandra-migrations-v0.10` uses a flattened id instead of a
+path segment. Check a subproject's entry in the release metadata consumed by
+`tools/ci/github-release` if you need the exact branch name it expects.
+
+Tags follow the matching format `<service-path>/vMAJOR.MINOR.PATCH`, for
+example `src/clis/nvcf-cli/v1.15.11` and
+`src/compute-plane-services/nvca/v3.3.0-dev.184`.
+
+## Who Can Trigger a Release
+
+Automatic: any contributor whose reviewed pull request merges to `main` has
+triggered a release for the subprojects their commits touch, as long as at
+least one commit is a `feat`, `fix`, or `perf` type. No separate release
+action is needed after merge.
+
+Manual: `.github/workflows/release-tags.yml` also accepts a
+`workflow_dispatch` trigger with three operations:
+
+- `auto`: re-run the same automatic logic on demand, optionally scoped to one
+  service.
+- `branch-cut`: cut a new maintenance release branch and open the follow-up
+  version-bump pull request for the `nvca` service.
+- `self-managed-branch-cut`: the same branch-cut flow for the
+  `nvcf-self-managed-stack` service.
+
+`workflow_dispatch` requires GitHub write access to the repository; there is
+no separate, smaller list of named release managers. Branch-cut operations
+additionally require the `NV_GITHUB_TOKEN` repository secret to be
+configured, because the default `GITHUB_TOKEN` cannot trigger CI on the
+generated version-bump pull request. Area ownership for review is defined in
+[`.github/CODEOWNERS`](.github/CODEOWNERS).
+
+## Artifact Destinations
+
+GitHub tags and GitHub Releases are the primary release artifact, one per
+subproject version. Publishing is gated by two repository variables read in
+`release-tags.yml`: `NVCF_GITHUB_AUTO_TAGGING_ENABLED` and
+`NVCF_GITHUB_RELEASE_DRY_RUN`. These are configured in repository settings,
+not in source, so check their current values in the repository if you need
+to confirm whether tag and release publishing is live or running in dry-run
+preview mode at a given point in time.
+
+Container images are handled separately from the tag and release flow.
+[`.github/workflows/image-push-manual.yml`](.github/workflows/image-push-manual.yml)
+builds and pushes a multi-arch image for one service subtree to an internal
+NGC registry, either via manual `workflow_dispatch` or automatically for a
+pull request carrying the `deploy-to-stg` label. This path exists for
+pre-merge and staging testing; it is not an automatic per-release publish
+step tied to a version tag.
+
+## Backport Policy
+
+No formal backport policy is documented in this repository today. A fix that
+needs to reach an already-cut maintenance branch has to be applied there
+directly (for example by cherry-picking the commit to the `release-*`
+branch), following the same commit and review conventions as `main`.


### PR DESCRIPTION
## TL;DR
Add a root-level RELEASE.md, sibling to CONTRIBUTING.md, documenting the release process: cadence, branch and tag naming, who can trigger a release, artifact destinations, and backport policy.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
This repository has real, working release automation (`.github/workflows/release-tags.yml` and `tools/ci/github-release`), but nothing summarized it for a contributor unfamiliar with the workflow internals. RELEASE.md was written from the actual automation source, CONTRIBUTING.md, CODEOWNERS, current git tags, current release branches, and live GitHub Release history, not a generic template.

This is a pure documentation change (new RELEASE.md only), so no code tests apply. Verified with `git diff --check` for whitespace/formatting issues.

## For the Reviewer
Please confirm the described release cadence, branch-naming pattern, and artifact-destination behavior match current practice, since some of it (for example the live/dry-run state of GitHub auto-tagging, gated by repository variables) can change without a source change.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
N/A, documentation only.

## Issues
Closes #1284

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added release documentation covering independent subproject releases.
  - Described stable and prerelease schedules, branch and tag conventions, and automatic or manual release triggers.
  - Documented required permissions, secrets, artifact destinations, and separate image publishing.
  - Clarified backport handling for supported development release trains, including current and previous release tracks.
  - Documented project-specific branch-cut and release procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->