### PR TITLE
docs(agents): list verification commands in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,10 +360,10 @@ default; see `BAZEL.md` for the full command and flag reference, and use the
 nearest nested `AGENTS.md` for subtree-scoped commands.
 
 ```bash
-bazel test //src/clis/nvcf-cli/... --test_output=streamed  # fast, file-scoped: one package, streamed output
-bazel test //...                                            # full suite: broad or cross-cutting changes
-git diff --check                                            # docs-only: whitespace errors, conflict markers
-fern check                                                   # docs-only: validate Fern nav, links, and config
+bazel test //src/clis/nvcf-cli/... --test_output=streamed    # scoped: the package(s) you changed, streamed output
+bazel test //...                                              # full suite: broad or cross-cutting changes
+git diff --check HEAD                                         # docs-only: whitespace errors, conflict markers
+fern check                                                     # docs-only: validate Fern nav, links, and config
 ```
 
 ### Java Bazel test target contract

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,6 +353,19 @@ change, or refactor with full existing coverage).
 
 Prefer the repo-native test runner (`make test`, `go test`, `cargo test`, etc.). Run tests before committing. Check coverage requirements in the subtree `AGENTS.md` or CI config.
 
+### Verification commands
+
+Run these from the repo root before opening a PR. They are the general
+default; see `BAZEL.md` for the full command and flag reference, and use the
+nearest nested `AGENTS.md` for subtree-scoped commands.
+
+```bash
+bazel test //src/clis/nvcf-cli/... --test_output=streamed  # fast, file-scoped: one package, streamed output
+bazel test //...                                            # full suite: broad or cross-cutting changes
+git diff --check                                            # docs-only: whitespace errors, conflict markers
+fern check                                                   # docs-only: validate Fern nav, links, and config
+```
+
 ### Java Bazel test target contract
 
 The `manual` tag placement in `rules/java/defs.bzl` is intentional.


### PR DESCRIPTION
## TL;DR
Adds a "Verification commands" subsection to the `## Tests` section of root `AGENTS.md` with a fenced bash block of exact, copy-pasteable commands (with flags) to run before opening a PR: a fast file-scoped test command, the full test suite, and the documentation-only commands (`git diff --check`, `fern check`).

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
The existing `## Tests` section only gave generic guidance ("Prefer the repo-native test runner... Run tests before committing. Check coverage requirements in the subtree AGENTS.md or CI config.") with no literal command block. That makes contributors and coding agents reconstruct the exact commands from `BAZEL.md` and `CONTRIBUTING.md` each time instead of copy-pasting them from `AGENTS.md` itself.

The commands added are not new; they are copied verbatim from commands already documented and proven elsewhere in this repo:
- `bazel test //src/clis/nvcf-cli/... --test_output=streamed` and `bazel test //...` from `CONTRIBUTING.md` ("Step 4: Run Tests Locally") and `BAZEL.md` ("Day-to-day commands").
- `git diff --check` and `fern check` from `CONTRIBUTING.md` (documentation-only change path).

This is a pure documentation change to `AGENTS.md`. No tests were added because no code changed; the checklist box for "New or existing tests cover these changes" is left unchecked below for that reason. Validation performed: `git diff --check` on the change (clean) and a manual re-read of `CONTRIBUTING.md` and `BAZEL.md` to confirm every command in the new block matches an already-documented, working command.

## For the Reviewer
Please confirm the listed commands and flags are still current (in particular the `nvcf-cli` Bazel target path and the `fern check` invocation), and that the new subsection reads coherently as the concrete complement to the existing `## Tests` guidance.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
Not applicable; documentation-only change.

## Issues
Closes #1285

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the documented verification commands for pull requests.
  * Updated the scoped Bazel test description and formatting of command comments.
  * Added `HEAD` to the documented `git diff --check` command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->