### PR TITLE
ci(github-release): comment the shipped version on released pull requests

### DIFF
--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -63,6 +63,9 @@ jobs:
     permissions:
       contents: write
       packages: read
+      # Releases comment the version they shipped on the pull requests that went
+      # into them. Needed for the github.token fallback; a PAT carries its own.
+      pull-requests: write
     steps:
       # ref is the branch, not the pushed SHA. Two reasons, both about the gap
       # between when a push happens and when this job actually runs:

--- a/docs/dev/github-release-process.md
+++ b/docs/dev/github-release-process.md
@@ -108,6 +108,24 @@ src/compute-plane-services/nvca/v<X.Y.Z>-dev.N
 On a matching release branch, the workflow creates the next stable
 patch tag for that train.
 
+Every stable release the workflow creates from a version file comments
+the version it shipped on the pull requests that release covers, which
+is the note `@semantic-release/github` posts for the services it
+manages:
+
+```text
+This PR is included in version 3.2.14.
+```
+
+Dev prerelease tags stay silent, and a re-run over a release that
+already exists does not comment again. The commented range starts at
+the closest release tag reachable from the branch rather than the
+highest-sorting tag, because a release branch is cut with a synthetic
+root and never contained most default-branch tags. It covers every
+commit since that tag rather than only the tagged commit, because the
+workflow's concurrency group cancels queued runs and a superseded push
+is first tagged by the next run to finish.
+
 The self-managed stack is not in this auto-tag set until it has a
 monorepo version source. Its release config currently keeps default
 branch release tagging disabled.

--- a/tools/ci/github-release
+++ b/tools/ci/github-release
@@ -656,24 +656,28 @@ def release_url(slug, tag):
 
 
 def ancestor_service_tag(root, service):
-    """Newest service tag reachable from HEAD, by ancestry rather than by version sort.
+    """Closest service tag reachable from HEAD, by ancestry rather than by version sort.
 
     Release branches are cut with a synthetic root (see linear_release_branch_base),
     so the highest-sorting tag for a service can be a main-line tag that this branch
     never contained. Ancestry is what actually bounds the commits a release ships.
 
+    Every supported prefix is matched in a single describe so the closest tag wins.
+    Taking the first prefix to match instead would return a more distant tag whenever
+    a service's newest release used another of its prefixes, and the range would then
+    re-resolve commits an earlier release already covered.
+
     Called before the new tag is created, so HEAD itself is never the answer.
     """
+    matches = []
     for prefix in tag_prefixes(service, root):
-        tag = run(
-            ["git", "describe", "--tags", "--abbrev=0", "--match", f"{prefix}*", "HEAD"],
-            cwd=root,
-            capture=True,
-            check=False,
-        ).strip()
-        if tag:
-            return tag
-    return ""
+        matches.extend(["--match", f"{prefix}*"])
+    return run(
+        ["git", "describe", "--tags", "--abbrev=0", *matches, "HEAD"],
+        cwd=root,
+        capture=True,
+        check=False,
+    ).strip()
 
 
 def released_commits(root, since_tag):

--- a/tools/ci/github-release
+++ b/tools/ci/github-release
@@ -42,6 +42,10 @@ JAVA_COMPONENT_KINDS = (JAVA_FRAMEWORK_KIND, JAVA_SERVICE_KIND)
 # Framework commits quoted in dependency-triggered release notes. A service that
 # is many framework commits behind should still get readable notes.
 MAX_QUOTED_FRAMEWORK_COMMITS = 20
+# Commits resolved to pull requests when commenting a published release. Each one
+# costs an API call, so an unexpectedly wide range is truncated rather than left
+# to fan out. The cap is reported when it is hit.
+MAX_RELEASE_COMMENT_COMMITS = 50
 # Conventional Commit subject prefix, for example "fix(nv-boot)!: subject".
 COMMIT_SUBJECT_PATTERN = re.compile(r"^(?P<type>[a-zA-Z]+)(?:\([^)]*\))?(?P<breaking>!)?:")
 
@@ -619,18 +623,136 @@ def validate_version_file(root, service):
 
 
 def create_release(tag, title, notes, draft, dry_run):
+    """Create the GitHub release. True when this call created it, False otherwise."""
     if dry_run:
         print(f"[github-release] dry-run: would create GitHub release {tag}")
         print(notes)
-        return
+        return False
     view = subprocess.run(["gh", "release", "view", tag], text=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     if view.returncode == 0:
         print(f"[github-release] GitHub release {tag} already exists; leaving it unchanged")
-        return
+        return False
     cmd = ["gh", "release", "create", tag, "--verify-tag", "--title", title, "--notes", notes]
     if draft:
         cmd.append("--draft")
     run(cmd)
+    return True
+
+
+def repo_slug():
+    slug = os.environ.get("GITHUB_REPOSITORY", "").strip()
+    if slug:
+        return slug
+    return run(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+        capture=True,
+        check=False,
+    ).strip()
+
+
+def release_url(slug, tag):
+    server = os.environ.get("GITHUB_SERVER_URL", "https://github.com").rstrip("/")
+    return f"{server}/{slug}/releases/tag/{tag}"
+
+
+def ancestor_service_tag(root, service):
+    """Newest service tag reachable from HEAD, by ancestry rather than by version sort.
+
+    Release branches are cut with a synthetic root (see linear_release_branch_base),
+    so the highest-sorting tag for a service can be a main-line tag that this branch
+    never contained. Ancestry is what actually bounds the commits a release ships.
+
+    Called before the new tag is created, so HEAD itself is never the answer.
+    """
+    for prefix in tag_prefixes(service, root):
+        tag = run(
+            ["git", "describe", "--tags", "--abbrev=0", "--match", f"{prefix}*", "HEAD"],
+            cwd=root,
+            capture=True,
+            check=False,
+        ).strip()
+        if tag:
+            return tag
+    return ""
+
+
+def released_commits(root, since_tag):
+    """Commits a release covers, oldest bound exclusive.
+
+    More than one merge can land in a single release: the workflow's concurrency
+    group cancels queued runs, so a superseded push never gets a run of its own and
+    its commits are first tagged by the next run to finish. Resolving only HEAD
+    would drop those pull requests silently.
+    """
+    if not since_tag:
+        # Nothing bounds the range, and walking all of history would be thousands
+        # of API lookups. Only the tagged commit is resolved.
+        return [run(["git", "rev-parse", "--verify", "HEAD^{commit}"], cwd=root, capture=True).strip()]
+    raw = run(["git", "rev-list", f"{since_tag}..HEAD"], cwd=root, capture=True, check=False)
+    commits = [line.strip() for line in raw.splitlines() if line.strip()]
+    if len(commits) > MAX_RELEASE_COMMENT_COMMITS:
+        print(
+            f"[github-release] {len(commits)} commits since {since_tag}; "
+            f"only the newest {MAX_RELEASE_COMMENT_COMMITS} are resolved to pull requests"
+        )
+        return commits[:MAX_RELEASE_COMMENT_COMMITS]
+    return commits
+
+
+def pull_requests_for_commit(slug, sha):
+    raw = run(
+        ["gh", "api", f"repos/{slug}/commits/{sha}/pulls", "--jq", ".[].number"],
+        capture=True,
+        check=False,
+    )
+    return [line.strip() for line in raw.splitlines() if line.strip()]
+
+
+def comment_release_on_pull_requests(root, service, tag, version, since_tag):
+    """Post the "included in version" note on the pull requests a release shipped.
+
+    Services that publish from a VERSION file never run semantic-release, so nothing
+    posted the note that @semantic-release/github posts for the services it manages.
+    Release branches publish exclusively through this path, so without it a backport
+    merge gets no version feedback at all.
+
+    A failure here never fails the job. The tag, the push, and the GitHub release
+    have already succeeded; losing a courtesy comment must not mark a shipped
+    release as broken.
+    """
+    slug = repo_slug()
+    if not slug:
+        print("[github-release] WARNING: could not resolve the repository; skipping release comments")
+        return []
+
+    body = (
+        f"This PR is included in version {version}.\n"
+        "\n"
+        f"The release is available on [GitHub release]({release_url(slug, tag)})."
+    )
+    commented = []
+    for sha in released_commits(root, since_tag):
+        for number in pull_requests_for_commit(slug, sha):
+            if number in commented:
+                continue
+            result = subprocess.run(
+                ["gh", "pr", "comment", number, "--repo", slug, "--body", body],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+            if result.returncode != 0:
+                print(
+                    f"[github-release] WARNING: {service['id']}: could not comment {tag} on #{number}: "
+                    f"{(result.stdout or '').strip()}"
+                )
+                continue
+            commented.append(number)
+    if commented:
+        print(f"[github-release] {service['id']}: commented {tag} on {', '.join('#' + n for n in commented)}")
+    else:
+        print(f"[github-release] {service['id']}: no pull requests found for {tag}")
+    return commented
 
 
 def publish_tag_for_version(root, service, version, dry_run, draft, reason):
@@ -657,9 +779,16 @@ def publish_tag_for_version(root, service, version, dry_run, draft, reason):
         print(f"[github-release] {service['id']}: would create {tag} at HEAD")
         print(notes)
         return
+    # Resolved before tagging so HEAD's own tag cannot bound the range.
+    since_tag = ancestor_service_tag(root, service)
     run(["git", "tag", tag, "HEAD"], cwd=root)
     run(["git", "push", "origin", f"refs/tags/{tag}"], cwd=root)
-    create_release(tag, tag, notes, draft, dry_run=False)
+    created = create_release(tag, tag, notes, draft, dry_run=False)
+    # Only for a release this run actually created, so a re-run does not comment
+    # twice, and only for a stable version: dev prereleases are internal
+    # checkpoints, not something to announce on a pull request.
+    if created and not draft and re.fullmatch(STABLE_SEMVER_PATTERN, version):
+        comment_release_on_pull_requests(root, service, tag, version, since_tag)
 
 
 def java_ci_components(root):

--- a/tools/ci/test-github-release.py
+++ b/tools/ci/test-github-release.py
@@ -1062,6 +1062,26 @@ class GithubReleaseTest(unittest.TestCase):
                 "the version sort would have bounded the range with an unreachable tag",
             )
 
+    def test_ancestor_service_tag_prefers_the_closest_of_several_prefixes(self):
+        # Services carry legacy prefixes alongside the current one, and the newest
+        # release can sit on either. Taking the first prefix to match would reach
+        # past a closer tag and re-resolve commits an earlier release covered.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.nvca_repo_with_tag(root, "3.2.0")
+            self.commit_backport(root, "fix(nvca): released under the legacy prefix")
+            git(root, "tag", "nvca-v3.2.1")
+            self.commit_backport(root, "fix(nvca): not yet released")
+
+            self.assertEqual(
+                self.github_release.ancestor_service_tag(root, self.NVCA_SERVICE), "nvca-v3.2.1"
+            )
+            self.assertEqual(
+                self.github_release.tag_prefixes(self.NVCA_SERVICE, root),
+                ["src/compute-plane-services/nvca/v", "nvca-v"],
+                "the current prefix is checked first, so a closer legacy tag must still win",
+            )
+
     def test_released_commits_covers_every_merge_since_the_previous_tag(self):
         # The concurrency group cancels queued runs, so one tag can carry several
         # merges. All of them have to be resolved, not just HEAD.

--- a/tools/ci/test-github-release.py
+++ b/tools/ci/test-github-release.py
@@ -30,6 +30,24 @@ def git(root, *args):
     subprocess.run(["git", *args], cwd=root, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 
 
+class SubprocessShim:
+    """Stands in for the module's `subprocess`, intercepting only `gh` calls.
+
+    Every other attribute, `run` included, falls through to the real module so the
+    git plumbing under test keeps working.
+    """
+
+    def __init__(self, fake_run):
+        self._fake_run = fake_run
+
+    def __getattr__(self, name):
+        return getattr(subprocess, name)
+
+    @property
+    def run(self):
+        return self._fake_run
+
+
 @contextlib.contextmanager
 def chdir(path):
     old_cwd = os.getcwd()
@@ -977,6 +995,225 @@ class GithubReleaseTest(unittest.TestCase):
             )
             with chdir(root), self.assertRaisesRegex(SystemExit, "branch-cut requires release.dev_prerelease"):
                 self.github_release.branch_cut(args)
+
+
+    NVCA_SERVICE = {
+        "id": "nvca",
+        "path": "src/compute-plane-services/nvca",
+        "service_name": "nvca",
+        "legacy_tag_prefix": "nvca-v",
+        "version_file": "VERSION",
+        "dev_prerelease": True,
+    }
+
+    def stub_gh_comments(self, pull_requests, failing=()):
+        """Route `gh pr comment` to a recorder and stub the two API lookups.
+
+        Returns the list that collects (pull request number, comment body).
+        """
+        real_run = subprocess.run
+        posted = []
+
+        def fake_run(args, *rest, **kwargs):
+            if list(args[:3]) == ["gh", "pr", "comment"]:
+                number = args[3]
+                body = args[args.index("--body") + 1]
+                if number in failing:
+                    return subprocess.CompletedProcess(args, 1, stdout="pull request is locked")
+                posted.append((number, body))
+                return subprocess.CompletedProcess(args, 0, stdout="")
+            return real_run(args, *rest, **kwargs)
+
+        self.github_release.subprocess = SubprocessShim(fake_run)
+        self.github_release.repo_slug = lambda: "NVIDIA/nvcf"
+        self.github_release.pull_requests_for_commit = lambda slug, sha: pull_requests.get(sha, [])
+        return posted
+
+    def nvca_repo_with_tag(self, root, version="3.2.0"):
+        """Seed an nvca repo whose HEAD carries the service tag for `version`."""
+        self.init_repo(root)
+        self.write_nvca_version(root, version)
+        self.commit_all(root, "seed nvca")
+        git(root, "tag", f"src/compute-plane-services/nvca/v{version}")
+
+    def commit_backport(self, root, message):
+        (root / "src/compute-plane-services/nvca/README.md").write_text(f"{message}\n")
+        self.commit_all(root, message)
+        return self.github_release.run(["git", "rev-parse", "HEAD"], cwd=root, capture=True).strip()
+
+    def test_ancestor_service_tag_ignores_a_higher_tag_off_the_branch(self):
+        # A release branch must bound its range by what it actually contains. The
+        # highest-sorting tag can be a main-line tag the branch never had.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.nvca_repo_with_tag(root, "3.2.0")
+            self.commit_backport(root, "feat(nvca): main only")
+            git(root, "tag", "src/compute-plane-services/nvca/v3.3.0-dev.0")
+            git(root, "checkout", "-b", "release-src/compute-plane-services/nvca/v3.2", "HEAD~1")
+            self.commit_backport(root, "fix(nvca): backport")
+
+            self.assertEqual(
+                self.github_release.ancestor_service_tag(root, self.NVCA_SERVICE),
+                "src/compute-plane-services/nvca/v3.2.0",
+            )
+            self.assertEqual(
+                self.github_release.latest_service_tag(self.NVCA_SERVICE, root),
+                "src/compute-plane-services/nvca/v3.3.0-dev.0",
+                "the version sort would have bounded the range with an unreachable tag",
+            )
+
+    def test_released_commits_covers_every_merge_since_the_previous_tag(self):
+        # The concurrency group cancels queued runs, so one tag can carry several
+        # merges. All of them have to be resolved, not just HEAD.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.nvca_repo_with_tag(root)
+            first = self.commit_backport(root, "fix(nvca): first backport (#1249)")
+            second = self.commit_backport(root, "fix(nvca): second backport (#1250)")
+
+            commits = self.github_release.released_commits(root, "src/compute-plane-services/nvca/v3.2.0")
+            self.assertEqual(commits, [second, first])
+
+    def test_released_commits_without_a_previous_tag_resolves_only_head(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.init_repo(root)
+            self.write_nvca_version(root, "3.2.0")
+            self.commit_all(root, "seed nvca")
+            head = self.commit_backport(root, "fix(nvca): first ever release")
+
+            self.assertEqual(self.github_release.released_commits(root, ""), [head])
+
+    def test_released_commits_reports_a_truncated_range(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.nvca_repo_with_tag(root)
+            self.github_release.MAX_RELEASE_COMMENT_COMMITS = 2
+            for index in range(4):
+                self.commit_backport(root, f"fix(nvca): backport {index}")
+
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                commits = self.github_release.released_commits(root, "src/compute-plane-services/nvca/v3.2.0")
+
+            self.assertEqual(len(commits), 2)
+            self.assertIn("only the newest 2 are resolved", output.getvalue())
+
+    def test_comment_release_posts_once_per_pull_request(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.nvca_repo_with_tag(root)
+            first = self.commit_backport(root, "fix(nvca): first backport")
+            second = self.commit_backport(root, "fix(nvca): second backport")
+            # The same PR can own more than one commit in the range.
+            posted = self.stub_gh_comments({first: ["1249"], second: ["1250", "1249"]})
+
+            with contextlib.redirect_stdout(io.StringIO()):
+                commented = self.github_release.comment_release_on_pull_requests(
+                    root,
+                    self.NVCA_SERVICE,
+                    "src/compute-plane-services/nvca/v3.2.1",
+                    "3.2.1",
+                    "src/compute-plane-services/nvca/v3.2.0",
+                )
+
+            self.assertEqual(commented, ["1250", "1249"])
+            self.assertEqual([number for number, _body in posted], ["1250", "1249"])
+            body = posted[0][1]
+            self.assertIn("This PR is included in version 3.2.1.", body)
+            self.assertIn(
+                "https://github.com/NVIDIA/nvcf/releases/tag/src/compute-plane-services/nvca/v3.2.1",
+                body,
+            )
+
+    def test_comment_release_survives_a_failed_comment(self):
+        # The tag, the push, and the GitHub release already succeeded. A comment
+        # that cannot be posted must not turn a shipped release into a failure.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.nvca_repo_with_tag(root)
+            first = self.commit_backport(root, "fix(nvca): first backport")
+            posted = self.stub_gh_comments({first: ["1249", "1250"]}, failing=("1249",))
+
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                commented = self.github_release.comment_release_on_pull_requests(
+                    root,
+                    self.NVCA_SERVICE,
+                    "src/compute-plane-services/nvca/v3.2.1",
+                    "3.2.1",
+                    "src/compute-plane-services/nvca/v3.2.0",
+                )
+
+            self.assertEqual(commented, ["1250"])
+            self.assertEqual([number for number, _body in posted], ["1250"])
+            self.assertIn("could not comment", output.getvalue())
+
+    def test_create_release_reports_whether_it_created_the_release(self):
+        existing = {"seen": False}
+
+        def fake_run(args, *rest, **kwargs):
+            if list(args[:3]) == ["gh", "release", "view"]:
+                return subprocess.CompletedProcess(args, 0 if existing["seen"] else 1)
+            raise AssertionError(f"unexpected call: {args}")
+
+        self.github_release.subprocess = SubprocessShim(fake_run)
+        self.github_release.run = lambda *a, **k: ""
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertTrue(self.github_release.create_release("t", "t", "n", draft=False, dry_run=False))
+            existing["seen"] = True
+            self.assertFalse(self.github_release.create_release("t", "t", "n", draft=False, dry_run=False))
+            self.assertFalse(self.github_release.create_release("t", "t", "n", draft=False, dry_run=True))
+
+    def publish_and_capture_comments(self, version):
+        """Publish a tag for `version` from a release branch, recording any comments.
+
+        The repo is shaped like the real thing: a release branch holding the 3.2.x
+        line, with a higher dev tag on the default branch that this branch never
+        contained.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            remote = Path(tmp) / "remote.git"
+            root.mkdir()
+            subprocess.run(
+                ["git", "init", "--bare", "--initial-branch=main", str(remote)],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            self.nvca_repo_with_tag(root)
+            git(root, "remote", "add", "origin", str(remote))
+            git(root, "push", "origin", "HEAD")
+            self.commit_backport(root, "feat(nvca): default branch only")
+            git(root, "tag", "src/compute-plane-services/nvca/v3.3.0-dev.0")
+            git(root, "checkout", "-b", "release-src/compute-plane-services/nvca/v3.2", "HEAD~1")
+            self.commit_backport(root, "fix(nvca): backport")
+
+            comments = []
+            self.github_release.create_release = lambda *a, **k: True
+            self.github_release.comment_release_on_pull_requests = (
+                lambda root, service, tag, version, since_tag: comments.append((tag, version, since_tag))
+            )
+            with chdir(root), contextlib.redirect_stdout(io.StringIO()):
+                self.github_release.publish_tag_for_version(
+                    root, self.NVCA_SERVICE, version, dry_run=False, draft=False, reason="VERSION"
+                )
+            return comments
+
+    def test_publish_tag_comments_on_a_stable_release(self):
+        comments = self.publish_and_capture_comments("3.2.1")
+        self.assertEqual(
+            comments,
+            [("src/compute-plane-services/nvca/v3.2.1", "3.2.1", "src/compute-plane-services/nvca/v3.2.0")],
+            "the range must be bounded by the newest tag on this branch, not the highest tag overall",
+        )
+
+    def test_publish_tag_stays_quiet_for_a_dev_prerelease(self):
+        # Dev prereleases are internal checkpoints on the default branch, not
+        # something to announce on a pull request.
+        self.assertEqual(self.publish_and_capture_comments("3.3.0-dev.4"), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

A pull request that merges to `main` gets a comment naming the version it shipped in,
for example "This PR is included in version helm-nvca-operator-v1.21.7". That comment
comes from the `@semantic-release/github` plugin.

Subprojects configured with a `version_file` in `github-release-subprojects.json`
never run semantic-release. They publish through `publish_tag_for_version`, which
creates the tag and the GitHub release but posts nothing back to the pull request.
Release branches publish exclusively through that path, so a backport that merges to
a release branch gets no version feedback at all. Anyone tracking where a backport
landed has to search the tags by hand.

## What changed

`publish_tag_for_version` now posts the comment once the GitHub release is created.

Two gates keep it to official releases only:

- The version must be a stable `X.Y.Z`. Dev prereleases (`X.Y.Z-dev.N`) are internal
  checkpoints on the default branch and stay silent.
- `create_release` now reports whether this run created the release. A re-run over an
  existing release does not comment again.

The commit range is bounded by ancestry (`git describe`) rather than by the existing
version sort. Release branches are cut with a synthetic root in
`linear_release_branch_base`, so the highest-sorting tag for a service can be a
main-line tag the branch never contained; bounding by it would resolve the wrong
commits. The range then covers every commit since that tag rather than just HEAD,
because the workflow's concurrency group cancels queued runs: a superseded push never
gets a run of its own and its commits are first tagged by the next run to finish.
Resolving only HEAD would skip those pull requests silently. Ranges wider than 50
commits are truncated, and the truncation is logged rather than applied silently.

A comment that cannot be posted warns and continues. The tag, the push, and the
release have already succeeded by that point, and losing a courtesy comment must not
mark a shipped release as broken.

`release-tags.yml` gains `pull-requests: write` on the `service-release` job. The job
normally runs with a PAT that carries its own permissions, but the `github.token`
fallback needs the scope declared.

## Customer Release Notes

Not customer visible.

## Plan Summary

Not applicable.

## Usage

Not applicable. The comment is posted automatically by the existing
`release-tags` workflow.

## Testing

`python3 tools/ci/test-github-release.py` passes, 45 tests. Nine are new and cover
ancestry-bounded range selection, multi-merge ranges, the truncation notice,
per-pull-request deduplication, the comment body, survival of a failed comment, the
`create_release` return value, and both the stable and dev-prerelease gates.

Each new test was mutation-checked. Dropping the stable-version gate, bounding the
range by version sort instead of ancestry, and resolving only HEAD each fail the
suite.

No QA needed; this is CI-only and does not change any shipped artifact.

## Notes

Only the comment was missing. Tags and GitHub releases were already being created
correctly on release branches, so nothing about how versions are chosen changes here.

## References

Closes #1288

## Related Pull Requests

None

## Dependencies

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stable releases now automatically comment the shipped version on included pull requests.
  * Release comments identify relevant changes and avoid duplicate notifications.
  * Release creation reports whether a new release was successfully published.

* **Bug Fixes**
  * Commenting failures now produce warnings without interrupting releases.
  * Release processing limits commit lookups for reliable performance.

* **Documentation**
  * Clarified release comment behavior, including nearest-tag ranges and silent development prereleases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->