### PR TITLE
fix(pylon): preserve shared gRPC trust precedence

### DIFF
--- a/docs/user/llm-function-enablement.md
+++ b/docs/user/llm-function-enablement.md
@@ -37,27 +37,33 @@ Production deployments secure two independent worker-to-router paths:
 
 | Path | TLS identity | Pylon trust input |
 | --- | --- | --- |
-| gRPC registration and watches | The external HTTPS dial hostname, normally an NLB DNS name | Tonic's enabled system and public roots by default, or `--grpc-tls-ca-cert-path` for a private CA |
+| gRPC registration and watches | The external HTTPS dial hostname, normally an NLB DNS name | Enabled system and public roots, augmented by the gRPC override or the reverse-mode QUIC trust bundle |
 | QUIC reverse tunnel | The advertised request-router pod hostname | `--tls-cert-path` for the existing QUIC identity or trust input |
 
 The current production gRPC design uses a public ACM certificate on the NLB
 TLS listener. The NLB certificate covers the public gRPC dial hostname. An
-unmanaged Pylon process, or one using NVCA system trust mode, leaves
-`--grpc-tls-ca-cert-path` unset so Tonic uses its enabled system and public
-roots. NVCA bundle mode instead points the option at its merged CA file. That
-file includes system roots, so it also validates the public ACM chain.
+unmanaged Pylon process, or one using NVCA system trust mode, can leave both
+trust paths unset so Tonic uses its enabled system and public roots. In reverse
+mode, Pylon reuses `--tls-cert-path` as gRPC trust when the gRPC-specific
+override is unset. NVCA bundle mode points both options at its merged CA file.
+
+`--grpc-tls-ca-cert-path` or `STARGATE_GRPC_TLS_CA_CERT_PATH` is the optional
+gRPC-specific override. A configured custom bundle augments the enabled system
+and public roots. It does not replace them. In direct mode,
+`--tls-cert-path` is the Pylon QUIC server identity and is never treated as a
+gRPC CA bundle.
 
 A private-CA certificate on the NLB listener is a supported alternative. Give
 Pylon the CA bundle with `--grpc-tls-ca-cert-path <path>` or
 `STARGATE_GRPC_TLS_CA_CERT_PATH=<path>`. The input is a PEM bundle containing
-one or more public CA certificates. It does not disable certificate or
-hostname verification. Pylon reads the file once during startup. An unreadable
-path fails startup with the configured path in the error. Invalid PEM,
-untrusted chains, and hostname mismatches prevent the gRPC watch and
-registration connections. Replace or rotate the bundle with a rolling restart
-of the worker pods. The dial address must be an `https://` URI. A scheme-less
-`host:port` address preserves Pylon's existing plaintext HTTP behavior, even on
-port 443.
+the CA certificates required by the selected certificate chain, including a
+private root when applicable. It does not disable certificate or hostname
+verification. Pylon reads the file once during startup. An unreadable path
+fails startup with the configured path in the error. Invalid PEM, untrusted
+chains, and hostname mismatches prevent the gRPC watch and registration
+connections. Replace or rotate the bundle with a rolling restart of the worker
+pods. The dial address must be an `https://` URI. A scheme-less `host:port`
+address preserves Pylon's existing plaintext HTTP behavior, even on port 443.
 
 For gRPC, TLS SNI and hostname verification always use the external HTTPS dial
 hostname. After discovery, Pylon separately sends the concrete request-router

--- a/docs/user/runbooks/transport-tls-rotation.md
+++ b/docs/user/runbooks/transport-tls-rotation.md
@@ -20,19 +20,23 @@ closed, so an ordinary leaf renewal causes no traffic interruption.
 
 ## Scope
 
-Trust bundles do not reload yet. Pylon has two independent outbound trust
-inputs:
+Trust bundles do not reload yet. Pylon uses this outbound trust precedence:
 
-- `--grpc-tls-ca-cert-path` or `STARGATE_GRPC_TLS_CA_CERT_PATH` verifies the
-  Stargate gRPC HTTPS endpoint.
-- `--tls-cert-path` or `STARGATE_TLS_CERT_PATH` retains its existing QUIC
-  identity or trust meaning.
+- `--grpc-tls-ca-cert-path` or `STARGATE_GRPC_TLS_CA_CERT_PATH` is the optional
+  gRPC-specific override.
+- Reverse-mode Pylon otherwise reuses `--tls-cert-path` or
+  `STARGATE_TLS_CERT_PATH` for gRPC and QUIC trust.
+- When neither applies, gRPC HTTPS uses enabled system and public roots.
+
+Custom gRPC roots augment the enabled system and public roots. They do not
+replace them. Direct-mode Pylon uses `--tls-cert-path` as its QUIC server
+identity and never treats that identity as a gRPC CA bundle.
 
 Managed bundle mode explicitly points both settings at the same merged system
 and private CA file. This reuses CA roots only. It does not reuse or couple the
 gRPC NLB leaf certificate and the Kubernetes-internal QUIC leaf certificate.
-Pylon reads both trust bundles at startup, so changing the shared file requires
-a rolling restart of the worker pods.
+Pylon reads the selected trust inputs at startup, so changing the shared file
+requires a rolling restart of the worker pods.
 
 The current production gRPC design uses a public ACM certificate on the NLB TLS
 listener. It normally needs no custom gRPC CA bundle. A private-CA NLB listener

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/registration/grpc_endpoint.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/registration/grpc_endpoint.rs
@@ -80,7 +80,9 @@ impl StargateGrpcEndpoint {
         let mut endpoint = match (dial_uri.scheme_str(), grpc_tls_ca_cert_pem) {
             (Some("https"), Some(ca_cert_pem)) => Endpoint::from(dial_uri)
                 .tls_config(
-                    ClientTlsConfig::new().ca_certificate(Certificate::from_pem(ca_cert_pem)),
+                    ClientTlsConfig::new()
+                        .with_enabled_roots()
+                        .ca_certificate(Certificate::from_pem(ca_cert_pem)),
                 )
                 .context("configure custom CA for stargate gRPC endpoint")?,
             _ => Endpoint::new(dial_uri).context("configure stargate gRPC endpoint")?,

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/registration/tests.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/registration/tests.rs
@@ -54,9 +54,9 @@ use super::urls::infer_upstream_http_base_url;
 use super::*;
 
 const TEST_WAIT: Duration = Duration::from_secs(1);
-const TEST_ROUTER_AUTHORITY: &str =
-    "stargate-0.llm-request-router-headless.nvcf.svc.cluster.local:50071";
+const TEST_ROUTER_AUTHORITY: &str = "router-0.router-headless.example.invalid:50071";
 const DEFAULT_ROOT_TEST_DIAL_URL_ENV: &str = "PYLON_DEFAULT_ROOT_TEST_DIAL_URL";
+const CUSTOM_ROOT_TEST_CA_PATH_ENV: &str = "PYLON_CUSTOM_ROOT_TEST_CA_PATH";
 
 type TestWatchStream =
     Pin<Box<dyn Stream<Item = Result<WatchStargatesResponse, Status>> + Send + 'static>>;
@@ -632,6 +632,74 @@ async fn https_without_custom_ca_uses_configured_native_roots() {
     assert!(
         output.status.success(),
         "default-root child test failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("1 passed"),
+        "default-root child test did not run exactly one test:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn custom_grpc_ca_augments_configured_native_roots() {
+    if let (Ok(dial_url), Ok(custom_ca_path)) = (
+        std::env::var(DEFAULT_ROOT_TEST_DIAL_URL_ENV),
+        std::env::var(CUSTOM_ROOT_TEST_CA_PATH_ENV),
+    ) {
+        let custom_ca = std::fs::read(custom_ca_path).expect("custom CA file should be readable");
+        let endpoint = StargateGrpcEndpoint::new(dial_url, "")
+            .expect("default-root test endpoint should build");
+        endpoint
+            .channel_endpoint(Some(&custom_ca))
+            .expect("augmented-root test endpoint should configure")
+            .connect()
+            .await
+            .expect("native root should remain enabled beside the custom CA");
+        return;
+    }
+
+    let server_ca = TestCertificateAuthority::new("default-roots-test-ca");
+    let custom_ca = TestCertificateAuthority::new("custom-roots-test-ca");
+    let server = TestTlsControlPlane::spawn(&server_ca, "localhost").await;
+    let server_ca_file = tempfile::NamedTempFile::new().expect("CA file should be created");
+    std::fs::write(server_ca_file.path(), server_ca.pem()).expect("CA file should be written");
+    let custom_ca_file = tempfile::NamedTempFile::new().expect("CA file should be created");
+    std::fs::write(custom_ca_file.path(), custom_ca.pem()).expect("CA file should be written");
+    let test_binary = std::env::current_exe().expect("test binary path should resolve");
+    let dial_url = server.dial_url.clone();
+    let server_ca_path = server_ca_file.path().to_path_buf();
+    let custom_ca_path = custom_ca_file.path().to_path_buf();
+
+    let output = tokio::task::spawn_blocking(move || {
+        Command::new(test_binary)
+            .args([
+                "--exact",
+                "registration::tests::custom_grpc_ca_augments_configured_native_roots",
+                "--nocapture",
+            ])
+            .env(DEFAULT_ROOT_TEST_DIAL_URL_ENV, dial_url)
+            .env(CUSTOM_ROOT_TEST_CA_PATH_ENV, custom_ca_path)
+            .env("SSL_CERT_FILE", server_ca_path)
+            .env_remove("SSL_CERT_DIR")
+            .output()
+            .expect("augmented-root child test should run")
+    })
+    .await
+    .expect("augmented-root child test should join");
+
+    assert!(
+        output.status.success(),
+        "augmented-root child test failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("1 passed"),
+        "augmented-root child test did not run exactly one test:\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );

--- a/src/libraries/rust/stargate/crates/pylon/src/main.rs
+++ b/src/libraries/rust/stargate/crates/pylon/src/main.rs
@@ -59,7 +59,7 @@ struct Args {
     /// Path to the QUIC server identity in direct mode or trust anchor in reverse mode
     #[arg(long, env = "STARGATE_TLS_CERT_PATH", value_name = "PATH")]
     tls_cert_path: Option<String>,
-    /// Path to a PEM CA bundle used to verify Stargate gRPC HTTPS endpoints
+    /// Optional PEM CA bundle override used to verify Stargate gRPC HTTPS endpoints
     #[arg(long, env = "STARGATE_GRPC_TLS_CA_CERT_PATH", value_name = "PATH")]
     grpc_tls_ca_cert_path: Option<String>,
     /// Path to the QUIC server private key in direct mode

--- a/src/libraries/rust/stargate/crates/pylon/src/startup.rs
+++ b/src/libraries/rust/stargate/crates/pylon/src/startup.rs
@@ -551,6 +551,11 @@ fn registration_config_from_plan(
 fn load_grpc_tls_ca_cert(args: &Args) -> Result<Option<Vec<u8>>> {
     args.grpc_tls_ca_cert_path
         .as_ref()
+        .or_else(|| {
+            matches!(args.backend_connectivity, BackendConnectivity::Reverse)
+                .then_some(args.tls_cert_path.as_ref())
+                .flatten()
+        })
         .map(|path| {
             let pem = std::fs::read(path)
                 .with_context(|| format!("load gRPC TLS CA certificate from {path}"))?;
@@ -558,10 +563,14 @@ fn load_grpc_tls_ca_cert(args: &Args) -> Result<Option<Vec<u8>>> {
                 .collect::<std::result::Result<Vec<_>, _>>()
                 .with_context(|| format!("parse gRPC TLS CA certificate from {path}"))?;
             let mut root_store = rustls::RootCertStore::empty();
-            let (valid, _) = root_store.add_parsable_certificates(certificates);
+            let (valid, invalid) = root_store.add_parsable_certificates(certificates);
             ensure!(
                 valid > 0,
                 "gRPC TLS CA certificate file {path} contains no valid certificates"
+            );
+            ensure!(
+                invalid == 0,
+                "gRPC TLS CA certificate file {path} contains {invalid} invalid certificate(s)"
             );
             Ok(pem)
         })
@@ -1426,6 +1435,91 @@ mod tests {
     }
 
     #[test]
+    fn reverse_mode_reuses_quic_trust_when_grpc_override_is_unset() {
+        let root = tempfile::tempdir().expect("test directory should create");
+        let path = root.path().join("shared-ca.pem");
+        let mut params = rcgen::CertificateParams::default();
+        params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let key = rcgen::KeyPair::generate().expect("test CA key should generate");
+        let pem = params
+            .self_signed(&key)
+            .expect("test CA certificate should generate")
+            .pem()
+            .into_bytes();
+        std::fs::write(&path, &pem).expect("test CA should write");
+        let path = path.to_string_lossy().into_owned();
+        let (args, _) = startup(&[
+            "--backend-connectivity",
+            "reverse",
+            "--tls-cert-path",
+            &path,
+        ]);
+
+        assert_eq!(
+            load_grpc_tls_ca_cert(&args)
+                .expect("reverse-mode shared CA should load")
+                .as_deref(),
+            Some(pem.as_slice())
+        );
+    }
+
+    #[test]
+    fn grpc_ca_override_takes_precedence_over_reverse_quic_trust() {
+        let root = tempfile::tempdir().expect("test directory should create");
+        let shared_path = root.path().join("shared-ca.pem");
+        let override_path = root.path().join("grpc-ca.pem");
+        let ca_pem = |common_name: &str| {
+            let mut params = rcgen::CertificateParams::default();
+            params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+            params
+                .distinguished_name
+                .push(rcgen::DnType::CommonName, common_name);
+            let key = rcgen::KeyPair::generate().expect("test CA key should generate");
+            params
+                .self_signed(&key)
+                .expect("test CA certificate should generate")
+                .pem()
+                .into_bytes()
+        };
+        let shared_pem = ca_pem("shared-ca");
+        let override_pem = ca_pem("grpc-ca");
+        std::fs::write(&shared_path, shared_pem).expect("shared CA should write");
+        std::fs::write(&override_path, &override_pem).expect("gRPC CA should write");
+        let shared_path = shared_path.to_string_lossy().into_owned();
+        let override_path = override_path.to_string_lossy().into_owned();
+        let (args, _) = startup(&[
+            "--backend-connectivity",
+            "reverse",
+            "--tls-cert-path",
+            &shared_path,
+            "--grpc-tls-ca-cert-path",
+            &override_path,
+        ]);
+
+        assert_eq!(
+            load_grpc_tls_ca_cert(&args)
+                .expect("gRPC CA override should load")
+                .as_deref(),
+            Some(override_pem.as_slice())
+        );
+    }
+
+    #[test]
+    fn direct_mode_server_identity_is_not_loaded_as_grpc_trust() {
+        let root = tempfile::tempdir().expect("test directory should create");
+        let cert_path = root.path().join("server.pem");
+        std::fs::write(&cert_path, b"not a CA bundle").expect("server identity should write");
+        let cert_path = cert_path.to_string_lossy().into_owned();
+        let (args, _) = startup(&["--tls-cert-path", &cert_path]);
+
+        assert!(
+            load_grpc_tls_ca_cert(&args)
+                .expect("direct-mode server identity should be ignored for gRPC trust")
+                .is_none()
+        );
+    }
+
+    #[test]
     fn grpc_tls_ca_load_error_rejects_empty_and_malformed_bundles() {
         for (name, pem) in [
             ("empty", &b""[..]),
@@ -1446,6 +1540,33 @@ mod tests {
             assert!(message.contains("contains no valid certificates"));
             assert!(message.contains(&path));
         }
+    }
+
+    #[test]
+    fn grpc_tls_ca_load_error_rejects_partially_malformed_bundle() {
+        let root = tempfile::tempdir().expect("test directory should create");
+        let path = root.path().join("partially-malformed-grpc-ca.pem");
+        let mut params = rcgen::CertificateParams::default();
+        params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let key = rcgen::KeyPair::generate().expect("test CA key should generate");
+        let mut pem = params
+            .self_signed(&key)
+            .expect("test CA certificate should generate")
+            .pem()
+            .into_bytes();
+        pem.extend_from_slice(
+            b"-----BEGIN CERTIFICATE-----\ndGVzdA==\n-----END CERTIFICATE-----\n",
+        );
+        std::fs::write(&path, pem).expect("test CA should write");
+        let path = path.to_string_lossy().into_owned();
+        let (args, _) = startup(&["--grpc-tls-ca-cert-path", &path]);
+
+        let error = load_grpc_tls_ca_cert(&args)
+            .expect_err("a bundle with an ignored certificate should fail");
+        assert!(
+            error.to_string().contains("invalid certificate"),
+            "unexpected error: {error:#}"
+        );
     }
 
     #[test]

--- a/src/libraries/rust/stargate/docs/diagrams/registration-and-quic-flow.puml
+++ b/src/libraries/rust/stargate/docs/diagrams/registration-and-quic-flow.puml
@@ -29,7 +29,14 @@ box "Dynamo Instance" #fdf5e6
 end box
 
 == Registration Stream ==
-BackendCli -> Service: RegisterInferenceServer(stream open)\nmetadata: Authorization: Bearer <token>
+note over BackendCli,Service
+  HTTPS gRPC trust precedence:
+  1. gRPC-specific CA bundle override
+  2. reverse-mode QUIC trust bundle
+  3. enabled system and public roots
+  Custom roots augment system roots.
+end note
+BackendCli -> Service: TLS/h2 using dial-host SNI\nRegisterInferenceServer(stream open)\nHTTP/2 authority identifies router\nmetadata: Authorization: Bearer <token>
 
 Service -> NVCF: AuthLlmWorker(worker_token)
 NVCF --> Service: routing_key


### PR DESCRIPTION
## Why

PR #1282 adds the HTTPS client and optional gRPC CA input, but its first version treats that input as independent from the existing reverse-mode trust contract and replaces enabled roots when a custom bundle is present. The public issue contract requires reverse-mode fallback to `STARGATE_TLS_CERT_PATH`, while direct-mode server identities must remain isolated from client trust.

## What changed

- Use `STARGATE_GRPC_TLS_CA_CERT_PATH` as the optional gRPC-specific override.
- Reuse `STARGATE_TLS_CERT_PATH` for gRPC trust in reverse mode when the override is unset.
- Keep direct-mode QUIC server identities out of the gRPC CA store.
- Augment enabled system and public roots with custom CA certificates.
- Reject bundles that contain ignored or malformed certificates.
- Add hermetic precedence, isolation, root-augmentation, and malformed-bundle regressions.
- Update the public TLS guide, rotation runbook, and registration flow diagram.

TLS SNI and certificate verification continue to use the external dial hostname. The advertised Stargate identity remains the HTTP/2 authority used by the backend router.


<!-- nvcf-pr-before-after:start -->
## Before and after

```mermaid
flowchart LR
  subgraph Before
    B1{"gRPC override set?"}
    B1 -->|No| B2["Reverse-mode shared trust not reused"]
    B1 -->|Yes| B3["Custom roots replace enabled roots"]
    B2 --> B4["Private chain can fail"]
    B3 --> B5["Public chain can fail"]
    B6["Mixed valid and malformed bundle"] --> B7["Malformed certificate can be ignored"]
  end

  subgraph After
    A1{"gRPC override set?"}
    A1 -->|Yes| A2["Select gRPC CA override"]
    A1 -->|No| A3{"Reverse mode with shared trust?"}
    A3 -->|Yes| A4["Select reverse-mode trust bundle"]
    A3 -->|No| A5["Use enabled system and public roots"]
    A2 --> A6{"Every certificate valid?"}
    A4 --> A6
    A6 -->|No| A7["Reject startup"]
    A6 -->|Yes| A8["Augment enabled roots"]
    A5 --> A9["HTTPS gRPC channel"]
    A8 --> A9
    A10["Direct-mode server identity"] -->|Never a client CA| A9
    A11["Dial hostname"] -->|TLS SNI and verification| A9
    A12["Advertised router identity"] -->|HTTP/2 authority only| A9
  end

  Before --> After
```
<!-- nvcf-pr-before-after:end -->

## Customer Release Notes

Reverse-mode Pylon can reuse its existing transport trust bundle for HTTPS gRPC while retaining enabled system roots and an optional gRPC-specific override.

## Plan Summary

No Kubernetes resources or deployment topology change.

## Usage

Set `STARGATE_GRPC_TLS_CA_CERT_PATH` only when gRPC needs a different CA bundle. Reverse-mode Pylon otherwise reuses `STARGATE_TLS_CERT_PATH`. Restart Pylon after changing either trust file.

## Testing

- `cargo test --offline -p pylon-lib -p pylon` (66 Pylon unit, 1 CLI, 385 pylon-lib unit, 2 public API, and doc tests passed)
- `cargo clippy --offline -p pylon-lib -p pylon --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `./tools/ci/check-docs` (0 errors; existing version-sync advisory retained)
- `git diff --check`
- TruffleHog 3.95.2 on every changed file (0 verified and 0 unknown findings)

QA remains required in the final multi-cluster TLS matrix tracked by #1292.

## Notes

This Pull Request is intentionally based on `codex/pylon-grpc-custom-ca` and should land with or after #1282. It does not duplicate the HTTPS channel or managed bundle injection already implemented there.

## Issues

Relates to #1281
Relates to #1293

## References

- https://github.com/NVIDIA/nvcf/issues/1281
- https://github.com/NVIDIA/nvcf/issues/1293

## Related Pull Requests

- #1282

## Dependencies

No new or updated third-party dependencies. License and NOTICE content do not change.
