### PR TITLE
fix(nvca): backport intra-namespace NetworkPolicy isolation fix to 3.2 (#1256)

### DIFF
--- a/docs/ngc-managed/cluster-management/configuration.md
+++ b/docs/ngc-managed/cluster-management/configuration.md
@@ -271,13 +271,13 @@ The NVCA operator requires outbound network connectivity to pull images, charts,
 | Policy Name | Description |
 | --- | --- |
 | allow-egress-gxcache | Allows egress traffic to the GX Cache namespace for caching operations (only relevant for NVIDIA managed clusters) |
-| allow-egress-internet-no- internal-no-api | Allows egress traffic to the public internet (0.0.0.0/0) but blocks traffic to common private IP ranges. Also allows DNS resolution via kube-dns. |
-| allow-egress-intra-namespace | Controls pod-to-pod communication within the same namespace. This policy is only applied to function namespaces and not to shared pod instance namespaces. |
+| allow-egress-internet-no-internal-no-api | Allows egress traffic to the public internet (0.0.0.0/0) but blocks traffic to common private IP ranges. Also allows DNS resolution via kube-dns. |
+| allow-egress-intra-namespace | Allows pod-to-pod communication within the same namespace. Applied only to per-instance function namespaces (for example a MiniService's utils pod reaching its own inference pod), never to the shared `nvcf-backend` namespace. |
 | allow-egress-nvcf-cache | Allows egress traffic to NVCF cache services (only relevant for NVIDIA managed clusters) |
-| allow-egress-prometheus- nvcf-byoo | Allows egress traffic to Prometheus monitoring endpoints (only relevant for NVIDIA managed clusters) |
-| allow-ingress-monitoring | Allows ingress traffic for monitoring services |
+| allow-egress-prometheus-nvcf-byoo | Allows egress traffic to Prometheus monitoring endpoints (only relevant for NVIDIA managed clusters) |
+| allow-ingress-monitoring | Allows ingress from the `monitoring` namespace on supported monitoring ports. In per-instance function namespaces, also allows same-namespace ingress (paired with allow-egress-intra-namespace); same-namespace ingress is not added to the shared `nvcf-backend` namespace. |
 | allow-ingress-monitoring-dcgm | Allows ingress traffic for DCGM monitoring |
-| allow-ingress-monitoring- gxcache | Allows ingress traffic for GX Cache monitoring (only relevant for NVIDIA managed clusters) |
+| allow-ingress-monitoring-gxcache | Allows ingress traffic for GX Cache monitoring (only relevant for NVIDIA managed clusters) |
 
 ## Key Network Requirements
 

--- a/docs/user/cluster-management/configuration.md
+++ b/docs/user/cluster-management/configuration.md
@@ -283,13 +283,13 @@ The NVCA operator requires outbound network connectivity to pull images, charts,
 | Policy Name                               | Description                                                                                                                                                |
 | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | allow-egress-gxcache                      | Allows egress traffic to the GX Cache namespace for caching operations (only relevant for NVIDIA managed clusters)                                         |
-| allow-egress-internet-no- internal-no-api | Allows egress traffic to the public internet (0.0.0.0/0) but blocks traffic to common private IP ranges. Also allows DNS resolution via kube-dns.          |
-| allow-egress-intra-namespace              | Controls pod-to-pod communication within the same namespace. This policy is only applied to function namespaces and not to shared pod instance namespaces. |
+| allow-egress-internet-no-internal-no-api | Allows egress traffic to the public internet (0.0.0.0/0) but blocks traffic to common private IP ranges. Also allows DNS resolution via kube-dns.          |
+| allow-egress-intra-namespace              | Allows pod-to-pod communication within the same namespace. Applied only to per-instance function namespaces (for example a MiniService's utils pod reaching its own inference pod), never to the shared `nvcf-backend` namespace.  |
 | allow-egress-nvcf-cache                   | Allows egress traffic to NVCF cache services (only relevant for NVIDIA managed clusters)                                                                   |
-| allow-egress-prometheus- nvcf-byoo        | Allows egress traffic to Prometheus monitoring endpoints (only relevant for NVIDIA managed clusters)                                                       |
-| allow-ingress-monitoring                  | Allows ingress traffic for monitoring services                                                                                                             |
+| allow-egress-prometheus-nvcf-byoo         | Allows egress traffic to Prometheus monitoring endpoints (only relevant for NVIDIA managed clusters)                                                       |
+| allow-ingress-monitoring                  | Allows ingress from the `monitoring` namespace on supported monitoring ports. In per-instance function namespaces, also allows same-namespace ingress (paired with allow-egress-intra-namespace); same-namespace ingress is not added to the shared `nvcf-backend` namespace. |
 | allow-ingress-monitoring-dcgm             | Allows ingress traffic for DCGM monitoring                                                                                                                 |
-| allow-ingress-monitoring- gxcache         | Allows ingress traffic for GX Cache monitoring (only relevant for NVIDIA managed clusters)                                                                 |
+| allow-ingress-monitoring-gxcache         | Allows ingress traffic for GX Cache monitoring (only relevant for NVIDIA managed clusters)                                                                 |
 
 ## Key Network Requirements
 

--- a/src/compute-plane-services/nvca/internal/util/k8sutil/netpol.go
+++ b/src/compute-plane-services/nvca/internal/util/k8sutil/netpol.go
@@ -96,6 +96,7 @@ func EnsureNetworkPoliciesFunctionNamespace(
 		ffFetcher,
 		k8sClient,
 		crClient,
+		true,
 		allExtraNPs...,
 	)
 }
@@ -114,7 +115,25 @@ func EnsureNetworkPoliciesSharedPodInstanceNamespace(
 		ffFetcher,
 		k8sClient,
 		crClient,
+		false,
 	)
+}
+
+// RemoveLegacyIntraNamespaceEgressPolicy deletes the allow-egress-intra-namespace
+// NetworkPolicy from the shared pod-instance namespace (nvcf-backend) if it still
+// exists from before this policy was scoped out of that namespace. It is meant to
+// be called once, at agent startup, rather than on every reconcile: the policy is
+// not custom-labeled, so the regular ensureNetworkPolicies prune loop never removes
+// it on its own, and clusters that already have it must be migrated explicitly.
+func RemoveLegacyIntraNamespaceEgressPolicy(ctx context.Context, namespace string, k8sClient k8sclient.Interface) error {
+	err := k8sClient.NetworkingV1().NetworkPolicies(namespace).Delete(
+		ctx, AllowEgressIntraNamespaceNetworkPolicyName, metav1.DeleteOptions{},
+	)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete legacy NetworkPolicy %s in namespace %s: %w",
+			AllowEgressIntraNamespaceNetworkPolicyName, namespace, err)
+	}
+	return nil
 }
 
 func ensureNetworkPolicies(
@@ -124,6 +143,16 @@ func ensureNetworkPolicies(
 	ffFetcher featureflag.Fetcher,
 	k8sClient k8sclient.Interface,
 	crClient client.Client,
+	// isMiniServiceNamespace is true for function namespaces (one MiniService
+	// per namespace, via EnsureNetworkPoliciesFunctionNamespace). A
+	// same-namespace allow is safe there because only one tenant's pods ever
+	// live in the namespace, e.g. a MiniService's utils pod reaching its own
+	// inference pod on a different pod in the same namespace. It is false for
+	// the namespace shared across every container-function tenant on the
+	// cluster (nvcf-backend, via EnsureNetworkPoliciesSharedPodInstanceNamespace),
+	// where the same allow would let one customer's pod reach another
+	// customer's pod.
+	isMiniServiceNamespace bool,
 	extraNPs ...*netv1.NetworkPolicy,
 ) error {
 	log := core.GetLogger(ctx)
@@ -167,16 +196,18 @@ func ensureNetworkPolicies(
 
 		switch newNP.Name {
 		case MonitoringIngressNetworkPolicyName:
-			snRule := netv1.NetworkPolicyIngressRule{
-				From: []netv1.NetworkPolicyPeer{
-					{
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{K8sNameLabelKey: namespace},
+			if isMiniServiceNamespace {
+				snRule := netv1.NetworkPolicyIngressRule{
+					From: []netv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{K8sNameLabelKey: namespace},
+							},
 						},
 					},
-				},
+				}
+				newNP.Spec.Ingress = append(newNP.Spec.Ingress, snRule)
 			}
-			newNP.Spec.Ingress = append(newNP.Spec.Ingress, snRule)
 		case EgressNVCFCacheNetworkPolicyNameKey:
 			// check if both container-caching & dns-proxy namespaces are present
 			var ccnsErr, pcnsErr error

--- a/src/compute-plane-services/nvca/internal/util/k8sutil/netpol_test.go
+++ b/src/compute-plane-services/nvca/internal/util/k8sutil/netpol_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
@@ -190,6 +191,121 @@ func TestEnsureNetworkPolicies(t *testing.T) {
 	err = crClient.List(ctx, npList1, client.InNamespace(namespace))
 	require.NoError(t, err)
 	assert.Len(t, npList1.Items, 4)
+}
+
+// TestEnsureNetworkPoliciesFunctionNamespaceAllowsIntraNamespaceAccess
+// verifies that function namespaces (one MiniService/Helm release per
+// namespace, single-tenant) still get the same-namespace ingress rule on
+// allow-ingress-monitoring and the allow-egress-intra-namespace policy. This
+// is required so a MiniService's utils pod can reach its own inference pod
+// running in a different pod in the same namespace; it's safe because only
+// one tenant's pods ever live in a function namespace.
+func TestEnsureNetworkPoliciesFunctionNamespaceAllowsIntraNamespaceAccess(t *testing.T) {
+	featureFlagFetcher := &featureflagmock.Fetcher{}
+	ctx := context.Background()
+	namespace := "test-namespace"
+	npCM := newNetworkPolicyConfigMap("nvca-system")
+	k8sClient := k8sfake.NewSimpleClientset()
+
+	err := EnsureNetworkPoliciesFunctionNamespace(
+		ctx,
+		namespace,
+		npCM.Data,
+		featureFlagFetcher,
+		k8sClient,
+		nil,
+	)
+	require.NoError(t, err)
+
+	ingressNP, err := k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(
+		ctx, MonitoringIngressNetworkPolicyName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, ingressNP.Spec.Ingress, 2,
+		"allow-ingress-monitoring should have the ConfigMap-defined rule plus the same-namespace rule")
+	sameNSRule := ingressNP.Spec.Ingress[1]
+	require.Len(t, sameNSRule.From, 1)
+	assert.Equal(t, namespace, sameNSRule.From[0].NamespaceSelector.MatchLabels[K8sNameLabelKey])
+
+	egressNP, err := k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(
+		ctx, AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
+	require.NoError(t, err, "allow-egress-intra-namespace should be created for function namespaces")
+	require.Len(t, egressNP.Spec.Egress, 1)
+	require.Len(t, egressNP.Spec.Egress[0].To, 1)
+	assert.Equal(t, namespace, egressNP.Spec.Egress[0].To[0].NamespaceSelector.MatchLabels[K8sNameLabelKey])
+}
+
+// TestEnsureNetworkPoliciesSharedPodInstanceNamespaceDoesNotAllowIntraNamespaceAccess
+// is a regression test: the namespace shared across every
+// container-function tenant (nvcf-backend) must not get the same-namespace
+// ingress rule on allow-ingress-monitoring, and must never get
+// allow-egress-intra-namespace. Combined, those two would let one tenant's
+// pod reach another tenant's pod on any port.
+func TestEnsureNetworkPoliciesSharedPodInstanceNamespaceDoesNotAllowIntraNamespaceAccess(t *testing.T) {
+	featureFlagFetcher := &featureflagmock.Fetcher{}
+	ctx := context.Background()
+	namespace := "nvcf-backend"
+	npCM := newNetworkPolicyConfigMap("nvca-system")
+	k8sClient := k8sfake.NewSimpleClientset()
+
+	err := EnsureNetworkPoliciesSharedPodInstanceNamespace(
+		ctx,
+		namespace,
+		npCM.Data,
+		featureFlagFetcher,
+		k8sClient,
+		nil,
+	)
+	require.NoError(t, err)
+
+	ingressNP, err := k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(
+		ctx, MonitoringIngressNetworkPolicyName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, ingressNP.Spec.Ingress, 1, "allow-ingress-monitoring should only have the ConfigMap-defined rule")
+	assert.Equal(t, "bar", ingressNP.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels["foo"])
+
+	_, err = k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(
+		ctx, AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
+	require.Error(t, err)
+	assert.True(t, apierrors.IsNotFound(err),
+		"allow-egress-intra-namespace should not be created for the shared pod instance namespace")
+}
+
+// TestEnsureNetworkPoliciesSharedPodInstanceNamespaceDoesNotDeleteUnownedPolicy
+// verifies that EnsureNetworkPoliciesSharedPodInstanceNamespace never owned
+// AllowEgressIntraNamespaceNetworkPolicyName (only
+// EnsureNetworkPoliciesFunctionNamespace ever created it), so it must not
+// delete a same-named policy in a shared pod instance namespace.
+func TestEnsureNetworkPoliciesSharedPodInstanceNamespaceDoesNotDeleteUnownedPolicy(t *testing.T) {
+	featureFlagFetcher := &featureflagmock.Fetcher{}
+	ctx := context.Background()
+	namespace := "test-namespace"
+	npCM := newNetworkPolicyConfigMap("nvca-system")
+	k8sClient := k8sfake.NewSimpleClientset(&netv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      AllowEgressIntraNamespaceNetworkPolicyName,
+			Namespace: namespace,
+		},
+		Spec: netv1.NetworkPolicySpec{
+			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeEgress},
+		},
+	})
+
+	err := EnsureNetworkPoliciesSharedPodInstanceNamespace(
+		ctx,
+		namespace,
+		npCM.Data,
+		featureFlagFetcher,
+		k8sClient,
+		nil,
+	)
+	require.NoError(t, err)
+
+	_, err = k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(
+		ctx,
+		AllowEgressIntraNamespaceNetworkPolicyName,
+		metav1.GetOptions{},
+	)
+	require.NoError(t, err, "shared pod instance namespace reconcile must not delete a policy it doesn't own")
 }
 
 func TestEnsureNetworkPoliciesWithCustomPolicies(t *testing.T) {

--- a/src/compute-plane-services/nvca/pkg/nvca/backendk8scache.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/backendk8scache.go
@@ -741,6 +741,15 @@ func (b *BackendK8sCacheBuilder) Start(ctx context.Context) (*BackendK8sCache, <
 			}
 		}
 
+		// One-time migration for clusters that already had the intra-namespace
+		// egress policy in the shared pod-instance namespace before it was scoped
+		// out; ensureNetworkPolicies above does not remove it on its own. Best
+		// effort: failing to remove a leftover policy should not block agent
+		// startup, since it does not affect the agent's ability to operate.
+		if err := k8sutil.RemoveLegacyIntraNamespaceEgressPolicy(ctx, c.podInstanceNamespace, c.clients.K8s); err != nil {
+			log.WithError(err).Warnf("failed to remove legacy NetworkPolicy in namespace %s", c.podInstanceNamespace)
+		}
+
 		// add configMapInformers for Network Policy for k8s backend only
 		if err := addConfigMapInformers(ctx, c); err != nil {
 			return nil, nil, err

--- a/src/compute-plane-services/nvca/pkg/nvca/backendk8scache_test.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/backendk8scache_test.go
@@ -49,6 +49,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -700,6 +701,28 @@ func TestAutoPurgeWorkerDeletion(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, o)
 	}
+}
+
+func TestBackendK8sCacheStartRemovesLegacyIntraNamespaceEgressPolicy(t *testing.T) {
+	ctx, cancel := context.WithCancel(newTestContext())
+	t.Cleanup(cancel)
+
+	legacyNP := &netv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k8sutil.AllowEgressIntraNamespaceNetworkPolicyName,
+			Namespace: RequestsNamespace,
+		},
+	}
+
+	b := NewBackendk8sCacheBuilder().WithNamespaceLabels(labels.Set{"foo": "bar"})
+	clients := mockKubeClients(legacyNP)
+	bc, _, err := b.WithClients(clients).Start(ctx)
+	require.NoError(t, err)
+
+	_, err = bc.clients.K8s.NetworkingV1().NetworkPolicies(RequestsNamespace).Get(
+		ctx, k8sutil.AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{},
+	)
+	assert.True(t, apierrors.IsNotFound(err))
 }
 
 func TestCleanupFailedButNoInstances(t *testing.T) {

--- a/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_test.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_test.go
@@ -115,7 +115,14 @@ func TestK8sComputeBackendEnsureNetPolicy(t *testing.T) {
 		Start(ctx)
 	require.NoError(t, err)
 
-	checkNS := func(t *testing.T, namespace, expLabelVal string, hasIntraEgressNP bool) {
+	// hasIntraNamespaceAccess is true for function namespaces (one
+	// MiniService/Helm release per namespace, single-tenant), where a
+	// same-namespace allow is safe and needed (e.g. the utils pod reaching
+	// its own inference pod on a different pod in the same namespace). It is
+	// false for the namespace shared across every container-function tenant
+	// (nvcf-backend), where the same allow would let one customer's pod
+	// reach another customer's pod.
+	checkNS := func(t *testing.T, namespace, expLabelVal string, hasIntraNamespaceAccess bool) {
 		t.Run(fmt.Sprintf("%s:%s", namespace, expLabelVal), func(t *testing.T) {
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
 				egressNP, err := clients.K8s.NetworkingV1().NetworkPolicies(namespace).Get(ctx,
@@ -134,8 +141,9 @@ func TestK8sComputeBackendEnsureNetPolicy(t *testing.T) {
 				}
 
 				// Check for the intra-namespace egress policy
-				if hasIntraEgressNP {
-					intraEgressNP, err := clients.K8s.NetworkingV1().NetworkPolicies(namespace).Get(ctx, k8sutil.AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
+				if hasIntraNamespaceAccess {
+					intraEgressNP, err := clients.K8s.NetworkingV1().NetworkPolicies(namespace).Get(
+						ctx, k8sutil.AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
 					if assert.NoError(c, err) {
 						assert.Equal(c, []netv1.PolicyType{"Egress"}, intraEgressNP.Spec.PolicyTypes)
 						if !assert.Len(c, intraEgressNP.Spec.Egress, 1) {
@@ -148,13 +156,22 @@ func TestK8sComputeBackendEnsureNetPolicy(t *testing.T) {
 						assert.NotNil(c, peer.NamespaceSelector)
 						assert.Equal(c, namespace, peer.NamespaceSelector.MatchLabels[k8sutil.K8sNameLabelKey])
 					}
+				} else {
+					_, err := clients.K8s.NetworkingV1().NetworkPolicies(namespace).Get(
+						ctx, k8sutil.AllowEgressIntraNamespaceNetworkPolicyName, metav1.GetOptions{})
+					assert.True(c, errors.IsNotFound(err),
+						"allow-egress-intra-namespace should not be created for the shared pod instance namespace")
 				}
 
 				ingressNP, err := clients.K8s.NetworkingV1().NetworkPolicies(namespace).Get(ctx,
 					k8sutil.MonitoringIngressNetworkPolicyName, metav1.GetOptions{})
 				if assert.NoError(c, err) {
 					assert.Equal(c, []netv1.PolicyType{"Ingress"}, ingressNP.Spec.PolicyTypes)
-					if !assert.Len(c, ingressNP.Spec.Ingress, 2) {
+					wantRules := 1
+					if hasIntraNamespaceAccess {
+						wantRules = 2
+					}
+					if !assert.Len(c, ingressNP.Spec.Ingress, wantRules) {
 						return
 					}
 					if !assert.Len(c, ingressNP.Spec.Ingress[0].From, 1) {
@@ -165,11 +182,13 @@ func TestK8sComputeBackendEnsureNetPolicy(t *testing.T) {
 						return
 					}
 					assert.Equal(c, expLabelVal, peer1.NamespaceSelector.MatchLabels["foo"])
-					peer2 := ingressNP.Spec.Ingress[1].From[0]
-					if !assert.NotNil(c, peer2.NamespaceSelector) {
-						return
+					if hasIntraNamespaceAccess {
+						peer2 := ingressNP.Spec.Ingress[1].From[0]
+						if !assert.NotNil(c, peer2.NamespaceSelector) {
+							return
+						}
+						assert.Equal(c, namespace, peer2.NamespaceSelector.MatchLabels[k8sutil.K8sNameLabelKey])
 					}
-					assert.Equal(c, namespace, peer2.NamespaceSelector.MatchLabels[k8sutil.K8sNameLabelKey])
 				}
 			}, 5*time.Second, 200*time.Millisecond, "namespace: "+namespace)
 		})


### PR DESCRIPTION
…2 (#1256)

(cherry picked from commit 1ad86826799dec5f1b856c604f5e754dc204fb73)

## TL;DR
Backports #1256 to the `3.2` release branch: removes the two NVCA-owned NetworkPolicy rules that combined to let any pod in the shared `nvcf-backend` namespace reach any other pod in that namespace, on any port, plus the follow-up best-effort startup cleanup of any already-created copy of the leftover egress policy. Per-instance function/MiniService namespaces are unaffected — both rules stay there since they're needed for legitimate same-namespace pod-to-pod communication.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
Clean cherry-pick of `1ad86826` (the squashed `main` commit for #1256) onto `release-src/compute-plane-services/nvca/v3.2`:

(cherry picked from commit 1ad86826799dec5f1b856c604f5e754dc204fb73)

No conflicts, no 3.2-specific adjustments needed — `go build` and `go test` pass unmodified on this branch.

## For the Reviewer
- Single cherry-picked commit; see #1256 for the full design discussion and review history (including the earlier back-and-forth on whether the leftover-policy cleanup belongs in NVCA at all).
- `internal/util/k8sutil/netpol.go` and `pkg/nvca/backendk8scache.go` are the core of the change.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
- `go build ./...` — clean.
- `go test ./internal/util/k8sutil/... ./pkg/nvca/...` — all green.
- Not yet done: live verification against a 3.2 cluster.

## Issues
NO-REF

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
