### PR TITLE
build: default bazel builds to --stamp for accurate /info version reporting

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -63,9 +63,15 @@ try-import %workspace%/tools/bazel/internal.bazelrc
 # silently reintroduce the multi-thousand-action C++ protobuf compile.
 common --incompatible_enable_proto_toolchain_resolution
 
-# Stamping for OCI image tags. Default off; CI opts in with --stamp.
+# Stamping for OCI image tags. On by default so every build path (CI,
+# manual GitHub dispatch, local `bazel run //<svc>:push`) embeds a real
+# STABLE_VERSION/STABLE_GIT_COMMIT via tools/workspace_status.sh instead of
+# silently falling back to an empty/"unknown" value. workspace_status.sh
+# already resolves to "mr-<sha>" when NVCF_VERSION is unset, so this is safe
+# for dev builds; only CI's real release path sets NVCF_VERSION for a proper
+# semver stamp.
 build --workspace_status_command=./tools/workspace_status.sh
-build --nostamp
+build --stamp
 
 # Java baseline: Java 25 for the whole monorepo (nv-boot-parent and the Java
 # control-plane services). local_jdk is the approved runtime. The pinned
@@ -105,7 +111,6 @@ build --@rules_go//go/config:pure
 
 # ---- CI profile ----
 build:ci --jobs=32
-build:ci --stamp
 
 # ---- Remote cache profile ----
 # Two configs:


### PR DESCRIPTION
## TL;DR
Stamping was CI-only (`build:ci --stamp`), so any image built outside that profile got an unstamped binary whose `/info` endpoint reports an empty/"unknown" version and commit. Moves `--stamp` to the base `build` config so every build path gets it.

## Additional Details
Hits `image-push-manual.yml`'s manual `workflow_dispatch` builds and its `deploy-to-stg`-label-triggered PR builds (same code path), plus any plain local `bazel run //<svc>/...:push` outside CI. `tools/workspace_status.sh` already falls back to `mr-<sha>` when `NVCF_VERSION` is unset, it just never ran because these paths never passed `--stamp`.

Dropped the now-redundant `build:ci --stamp` line since `build:ci` inherits the new base default.

## For QA
Built `//src/clis/nvcf-cli:nvcf-cli` with a plain `bazel build` on `main`: `Version: dev`, `Git Commit: unknown`. Rebuilt with this branch's `.bazelrc`, same command: `Version: mr-dc5a10438`, `Git Commit: dc5a10438`, matching the branch's commit.

Also checked flag resolution across `--config=ci`, `--config=release`, `--config=debug`, `--config=remote`, `--config=remote-write`, and combinations - all resolve `--stamp` from the base `build` line. Grepped the repo for any other `--nostamp` and none was found.

## Issues
Relates to #315

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Builds now include OCI version metadata by default.
  * CI build configuration has been simplified to use the same stamping behavior as standard builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->