### PR TITLE
test(bdd): assert plaintext TLS rejection

### DIFF
--- a/tests/bdd/features/multi-cluster-helmfile-llm-registration-tls.feature
+++ b/tests/bdd/features/multi-cluster-helmfile-llm-registration-tls.feature
@@ -83,12 +83,15 @@ Feature: Register an LLM worker securely with every router in a local split-clus
       And the command output should contain "Verify return code: 0 (ok)"
       And the command output should contain "ALPN protocol: h2"
 
+      # grpcurl reports a client-side dial deadline when plaintext HTTP/2 is
+      # sent to this verified TLS listener. The trusted Watch below proves
+      # that the same endpoint remains healthy.
       When I run command:
         """
-        grpcurl -plaintext -max-time 5 -import-path src/libraries/rust/stargate/crates/proto/proto -proto stargate.proto 127.0.0.1:50071 stargate.StargateControlPlane/WatchStargates
+        /bin/bash -c 'set -u; output=$(grpcurl -plaintext -max-time 5 -import-path src/libraries/rust/stargate/crates/proto/proto -proto stargate.proto 127.0.0.1:50071 stargate.StargateControlPlane/WatchStargates 2>&1); rc=$?; if [ "$rc" -eq 0 ]; then printf "%s\n" "plaintext Watch unexpectedly succeeded" >&2; exit 1; fi; printf "%s\n" "$output" | bash tests/bdd/scripts/assert-grpcurl-plaintext-tls-rejection.sh'
         """
-      Then the command exit code should be 1
-      And the command output should contain "does not look like a TLS handshake"
+      Then the command exit code should be 0
+      And the command output should contain "plaintext-watch-rejected=tls-listener-timeout"
 
       # WatchStargates is a long-lived stream. Normalize grpcurl's deadline
       # exit after it prints the initial snapshot.

--- a/tests/bdd/features/multi-cluster-helmfile-llm-registration-tls.feature
+++ b/tests/bdd/features/multi-cluster-helmfile-llm-registration-tls.feature
@@ -88,6 +88,7 @@ Feature: Register an LLM worker securely with every router in a local split-clus
         grpcurl -plaintext -max-time 5 -import-path src/libraries/rust/stargate/crates/proto/proto -proto stargate.proto 127.0.0.1:50071 stargate.StargateControlPlane/WatchStargates
         """
       Then the command exit code should be 1
+      And the command output should contain "does not look like a TLS handshake"
 
       # WatchStargates is a long-lived stream. Normalize grpcurl's deadline
       # exit after it prints the initial snapshot.

--- a/tests/bdd/godog_test.go
+++ b/tests/bdd/godog_test.go
@@ -1278,6 +1278,9 @@ func TestMultiClusterHelmfileLLMRegistrationTLSFeatureFileWiresToSteps(t *testin
 	if !commandRanExactly(suite.Runner.(*fakeRunner).runs, tlsWatchCommand) {
 		t.Fatal("WatchStargates was not observed over the trusted TLS listener")
 	}
+	if !commandRanExactly(suite.Runner.(*fakeRunner).runs, plaintextWatchCommand) {
+		t.Fatal("plaintext WatchStargates rejection was not exercised")
+	}
 }
 
 // TestSingleClusterHelmfileUpstreamImagesFeatureFileWiresToSteps runs the

--- a/tests/bdd/godog_test.go
+++ b/tests/bdd/godog_test.go
@@ -1174,8 +1174,13 @@ func TestMultiClusterHelmfileLLMRegistrationTLSFeatureFileWiresToSteps(t *testin
 			`-servername llm-request-router.nvcf.svc.cluster.local -alpn h2 -verify_return_error ` +
 			`-CAfile <(kubectl --context k3d-ncp-local-cp get secret stargate-quic-tls -n nvcf ` +
 			`-o jsonpath="{.data.ca\.crt}" | base64 -d) </dev/null 2>&1'`
-		plaintextWatchCommand = "grpcurl -plaintext -max-time 5 -import-path src/libraries/rust/stargate/crates/proto/proto -proto stargate.proto 127.0.0.1:50071 stargate.StargateControlPlane/WatchStargates"
-		tlsWatchCommand       = `/bin/bash -c 'grpcurl -max-time 3 ` +
+		plaintextWatchCommand = `/bin/bash -c 'set -u; output=$(grpcurl -plaintext -max-time 5 ` +
+			`-import-path src/libraries/rust/stargate/crates/proto/proto -proto stargate.proto ` +
+			`127.0.0.1:50071 stargate.StargateControlPlane/WatchStargates 2>&1); rc=$?; ` +
+			`if [ "$rc" -eq 0 ]; then printf "%s\n" "plaintext Watch unexpectedly succeeded" >&2; ` +
+			`exit 1; fi; printf "%s\n" "$output" | ` +
+			`bash tests/bdd/scripts/assert-grpcurl-plaintext-tls-rejection.sh'`
+		tlsWatchCommand = `/bin/bash -c 'grpcurl -max-time 3 ` +
 			`-cacert <(kubectl --context k3d-ncp-local-cp get secret stargate-quic-tls -n nvcf ` +
 			`-o jsonpath="{.data.ca\.crt}" | base64 -d) ` +
 			`-authority llm-request-router.nvcf.svc.cluster.local ` +
@@ -1212,7 +1217,7 @@ func TestMultiClusterHelmfileLLMRegistrationTLSFeatureFileWiresToSteps(t *testin
 			ExitCode: 0,
 			Stdout:   "ALPN protocol: h2\nVerify return code: 0 (ok)\n",
 		},
-		plaintextWatchCommand: {ExitCode: 1, Stderr: "tls: first record does not look like a TLS handshake"},
+		plaintextWatchCommand: {ExitCode: 0, Stdout: "plaintext-watch-rejected=tls-listener-timeout\n"},
 		tlsWatchCommand: {
 			ExitCode: 0,
 			Stdout: `{

--- a/tests/bdd/plaintext_tls_rejection_script_test.go
+++ b/tests/bdd/plaintext_tls_rejection_script_test.go
@@ -1,0 +1,61 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bdd_tmp
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestPlaintextTLSRejectionAcceptsObservedGrpcurlDeadline(t *testing.T) {
+	cmd := exec.Command("bash", "scripts/assert-grpcurl-plaintext-tls-rejection.sh")
+	cmd.Stdin = strings.NewReader(
+		`Failed to dial target host "127.0.0.1:50443": context deadline exceeded`,
+	)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("classify grpcurl deadline: %v\n%s", err, output)
+	}
+	if got, want := strings.TrimSpace(string(output)), "plaintext-watch-rejected=tls-listener-timeout"; got != want {
+		t.Fatalf("normalized output = %q, want %q", got, want)
+	}
+}
+
+func TestPlaintextTLSRejectionRejectsUnrelatedGrpcurlFailures(t *testing.T) {
+	for name, diagnostic := range map[string]string{
+		"binary missing":     "bash: grpcurl: command not found",
+		"connection refused": "Failed to dial target host 127.0.0.1:50071: connection refused",
+		"proto import":       "Failed to process proto source files.: missing.proto does not reside in any import path",
+		"usage":              "flag provided but not defined: -bad-flag",
+	} {
+		t.Run(name, func(t *testing.T) {
+			cmd := exec.Command("bash", "scripts/assert-grpcurl-plaintext-tls-rejection.sh")
+			cmd.Stdin = strings.NewReader(diagnostic)
+
+			output, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("unrelated failure was accepted: %s", output)
+			}
+			if strings.Contains(string(output), "plaintext-watch-rejected=") {
+				t.Fatalf("unrelated failure emitted success marker: %s", output)
+			}
+		})
+	}
+}

--- a/tests/bdd/plaintext_tls_rejection_script_test.go
+++ b/tests/bdd/plaintext_tls_rejection_script_test.go
@@ -26,7 +26,7 @@ import (
 func TestPlaintextTLSRejectionAcceptsObservedGrpcurlDeadline(t *testing.T) {
 	cmd := exec.Command("bash", "scripts/assert-grpcurl-plaintext-tls-rejection.sh")
 	cmd.Stdin = strings.NewReader(
-		`Failed to dial target host "127.0.0.1:50443": context deadline exceeded`,
+		`Failed to dial target host "127.0.0.1:50071": context deadline exceeded`,
 	)
 
 	output, err := cmd.CombinedOutput()
@@ -38,12 +38,32 @@ func TestPlaintextTLSRejectionAcceptsObservedGrpcurlDeadline(t *testing.T) {
 	}
 }
 
+func TestPlaintextTLSRejectionRejectsSnapshotThenRPCDeadline(t *testing.T) {
+	cmd := exec.Command("bash", "scripts/assert-grpcurl-plaintext-tls-rejection.sh")
+	cmd.Stdin = strings.NewReader(`{
+  "stargates": []
+}
+ERROR:
+  Code: DeadlineExceeded
+  Message: context deadline exceeded`)
+
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("successful plaintext snapshot followed by RPC deadline was accepted: %s", output)
+	}
+	if strings.Contains(string(output), "plaintext-watch-rejected=") {
+		t.Fatalf("successful plaintext snapshot emitted success marker: %s", output)
+	}
+}
+
 func TestPlaintextTLSRejectionRejectsUnrelatedGrpcurlFailures(t *testing.T) {
 	for name, diagnostic := range map[string]string{
-		"binary missing":     "bash: grpcurl: command not found",
-		"connection refused": "Failed to dial target host 127.0.0.1:50071: connection refused",
-		"proto import":       "Failed to process proto source files.: missing.proto does not reside in any import path",
-		"usage":              "flag provided but not defined: -bad-flag",
+		"binary missing":            "bash: grpcurl: command not found",
+		"connection refused":        "Failed to dial target host 127.0.0.1:50071: connection refused",
+		"dial timeout plus output":  "Failed to dial target host \"127.0.0.1:50071\": context deadline exceeded\n{}",
+		"proto import":              "Failed to process proto source files.: missing.proto does not reside in any import path",
+		"usage":                     "flag provided but not defined: -bad-flag",
+		"wrong target dial timeout": "Failed to dial target host \"127.0.0.1:50443\": context deadline exceeded",
 	} {
 		t.Run(name, func(t *testing.T) {
 			cmd := exec.Command("bash", "scripts/assert-grpcurl-plaintext-tls-rejection.sh")

--- a/tests/bdd/scripts/assert-grpcurl-plaintext-tls-rejection.sh
+++ b/tests/bdd/scripts/assert-grpcurl-plaintext-tls-rejection.sh
@@ -2,19 +2,18 @@
 # SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Normalize the grpcurl 1.9.3 client-side diagnostic observed when plaintext
-# HTTP/2 is sent to a healthy TLS listener. Unexpected command, proto, usage,
-# binary, and endpoint failures remain errors instead of satisfying the test.
+# Normalize only the complete grpcurl 1.9.3 dial-stage diagnostic observed when
+# plaintext HTTP/2 is sent to the verified TLS listener. RPC stream deadlines,
+# additional output, and unrelated command or endpoint failures remain errors.
 
 set -euo pipefail
 
 diagnostic="$(cat)"
-case "${diagnostic}" in
-  *"context deadline exceeded"*)
-    printf '%s\n' 'plaintext-watch-rejected=tls-listener-timeout'
-    ;;
-  *)
-    printf '%s\n' 'plaintext Watch failed without the expected TLS-listener transport timeout' >&2
-    exit 1
-    ;;
-esac
+expected_diagnostic='Failed to dial target host "127.0.0.1:50071": context deadline exceeded'
+if [[ "${diagnostic}" == "${expected_diagnostic}" ]]; then
+  printf '%s\n' 'plaintext-watch-rejected=tls-listener-timeout'
+  exit 0
+fi
+
+printf '%s\n' 'plaintext Watch failed without the expected TLS-listener dial timeout' >&2
+exit 1

--- a/tests/bdd/scripts/assert-grpcurl-plaintext-tls-rejection.sh
+++ b/tests/bdd/scripts/assert-grpcurl-plaintext-tls-rejection.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Normalize the grpcurl 1.9.3 client-side diagnostic observed when plaintext
+# HTTP/2 is sent to a healthy TLS listener. Unexpected command, proto, usage,
+# binary, and endpoint failures remain errors instead of satisfying the test.
+
+set -euo pipefail
+
+diagnostic="$(cat)"
+case "${diagnostic}" in
+  *"context deadline exceeded"*)
+    printf '%s\n' 'plaintext-watch-rejected=tls-listener-timeout'
+    ;;
+  *)
+    printf '%s\n' 'plaintext Watch failed without the expected TLS-listener transport timeout' >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## TL;DR

Strengthens the plaintext rejection coverage in #1308 so it accepts only the complete client-observable `grpcurl` dial-stage timeout from the expected TLS listener. A successful plaintext Watch snapshot followed by the stream deadline cannot satisfy the check.

## Additional Details

- Runs the exact plaintext `WatchStargates` probe and requires the complete evidenced diagnostic: `Failed to dial target host "127.0.0.1:50071": context deadline exceeded`.
- Rejects JSON snapshots, RPC status output, additional output, wrong-target timeouts, missing-binary, connection-refused, proto/import, usage, and unexpected failures.
- Uses the adjacent verified OpenSSL handshake and successful trusted TLS Watch to establish that the tested endpoint is healthy and TLS-only.
- Adds focused red/green coverage for the successful-snapshot-plus-RPC-deadline false positive and focused rejection cases.
- This PR is stacked on the head branch of #1308 and should land there before #1308 merges.

### Before

```mermaid
flowchart LR
  A["TLS dial fails before any RPC"] --> C["Output contains context deadline exceeded"]
  B["Plaintext Watch returns JSON, then stream deadline"] --> C
  C --> D["Same rejection marker"]
  D --> E["False positive possible"]
```

### After

```mermaid
flowchart LR
  A["OpenSSL verifies certificate and ALPN h2"] --> B["Exact plaintext Watch command"]
  B --> C{"Complete dial-stage line for 127.0.0.1:50071 only?"}
  C -->|Yes| D["Stable TLS-listener rejection marker"]
  C -->|No| E["Test fails"]
  F["JSON, RPC status, extra output, or wrong target"] --> E
  D --> G["Trusted TLS Watch succeeds"]
  G --> H["Healthy TLS endpoint rejects plaintext"]
```

## For the Reviewer

Please review the exact diagnostic equality check and its focused red/green tests, plus the exact-command assertion in `godog_test.go`. The accepted line was reproduced with `grpcurl` 1.9.3 against a real local TLS listener on the BDD target port. The regression test proves a successful plaintext snapshot followed by `DeadlineExceeded` is rejected.

## For QA

- Real TLS-listener probe on port 50071: produced the complete expected dial line and normalized successfully.
- Successful plaintext snapshot followed by RPC `DeadlineExceeded`: rejected.
- Wrong-target, extra-output, missing-binary, connection-refused, proto/import, and usage cases: rejected.
- Focused diagnostic and secure-registration wiring tests: passed.
- `go test -short -count=1 ./...`: passed.
- `go vet ./...`: passed.
- Shell syntax and ShellCheck 0.11.0: passed.
- Configured lint excluding the two pre-existing `ST1005` findings in unchanged `dsl/manifests.go`: 0 issues.
- `git diff --check`, gofmt, DCO, and sensitive-string checks: passed.

No separate QA run is needed; the parent PR's live topology test remains the integration gate.

## Issues

Relates to #1305
Relates to #1292

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
