### PR TITLE
fix(ci): trust the checkout inside image-push-manual's bazel-ci container

### DIFF
--- a/.github/workflows/image-push-manual.yml
+++ b/.github/workflows/image-push-manual.yml
@@ -143,6 +143,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # actions/checkout runs on the runner host; this job's steps run inside
+      # the bazel-ci container, which mounts that checkout under a different
+      # UID. Since git 2.35.2 (CVE-2022-24765) git refuses to operate on a
+      # repo it does not own ("detected dubious ownership"), which makes
+      # workspace_status.sh's `git rev-parse --short HEAD` fail silently
+      # (stderr redirected) and fall back to the literal "unknown", landing
+      # in the built binary as `mr-unknown` instead of a real short SHA.
+      - name: Trust the checkout inside the container
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Resolve service name for cache keys
         id: svc
         env:


### PR DESCRIPTION
## TL;DR
event-ledger's manual-dispatch images embed `mr-unknown` instead of a real commit short SHA. Adds a step to trust the checkout inside the `bazel-ci` container so `git rev-parse` stops failing silently.

## Additional Details
`image-push-manual.yml`'s `push to ncp-dev` job runs inside `container: ghcr.io/nvidia/nvcf/bazel-ci`. `actions/checkout` clones on the runner host; the container then mounts that checkout under a different UID. Since git 2.35.2 (CVE-2022-24765), git refuses to operate on a repo it does not own ("detected dubious ownership"). `tools/workspace_status.sh`'s `git rev-parse --short HEAD 2>/dev/null || echo "unknown"` swallows that failure and silently falls back to the literal `"unknown"`, so the job log shows no error at all. This is on top of, not caused by, #1315's `--stamp` fix: that fix got stamping to actually run, which is what surfaced this second bug.

Added `git config --global --add safe.directory "$GITHUB_WORKSPACE"` right after Checkout in the `push` job.

## For QA
Verified on a live `workflow_dispatch` run against event-ledger (run https://github.com/NVIDIA/nvcf/actions/runs/33214488561, on a scratch branch with this same fix): pulled the pushed image, extracted the binary, `strings` shows `mr-0c4521cc` matching the real commit short SHA, with zero occurrences of `mr-unknown`. An equivalent dispatch before this fix (run 33207590871, post-#1315 merge) produced `mr-unknown`.

## Issues
Relates to #315

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.