### PR TITLE
feat(nvca): gate helm model caching behind a default-off feature flag (3.2)

### DIFF
--- a/src/compute-plane-services/nvca/internal/miniservice/reconcile_storagerequests_test.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/reconcile_storagerequests_test.go
@@ -97,6 +97,24 @@ func TestMakeStorageRequests_BackendHandling(t *testing.T) {
 		assert.Empty(t, sts, "cacheLaunchRequested gates durable backends like the ephemeral path")
 	})
 
+	t.Run("none backend emits no ModelCacheRequest", func(t *testing.T) {
+		// SelectHelmCacheBackend returns None when CachingSupport or the
+		// HelmModelCaching sub-gate is off; a valid cache spec must still
+		// produce no ModelCacheRequest.
+		icmsReq := &nvcav2beta1.ICMSRequest{}
+		icmsReq.Spec.Action = common.FunctionCreationAction
+		icmsReq.Spec.CreationMsgInfo.FunctionLaunchSpecification = &function.LaunchSpecification{
+			CacheLaunchSpecification: &common.CacheLaunchSpecification{
+				CacheArtifacts: true,
+				CacheHandle:    "h1",
+				CacheSize:      262144000,
+			},
+		}
+		sts, err := r.makeStorageRequests(icmsReq, nil, job, pvc, nvcastorage.HelmCacheBackendNone)
+		require.NoError(t, err)
+		assert.Empty(t, sts)
+	})
+
 	t.Run("ephemeral backend emits no ModelCacheRequest", func(t *testing.T) {
 		icmsReq := &nvcav2beta1.ICMSRequest{}
 		icmsReq.Spec.Action = common.FunctionCreationAction

--- a/src/compute-plane-services/nvca/pkg/featureflag/featureflag.go
+++ b/src/compute-plane-services/nvca/pkg/featureflag/featureflag.go
@@ -34,8 +34,13 @@ var (
 )
 
 var (
-	LogPosting                    = newFeatureFlag("LogPosting", newBool(false))
-	CachingSupport                = newFeatureFlag("CachingSupport", newBool(false))
+	LogPosting     = newFeatureFlag("LogPosting", newBool(false))
+	CachingSupport = newFeatureFlag("CachingSupport", newBool(false))
+	// HelmModelCaching gates model caching for Helm-based workloads. It is a
+	// sub-gate of CachingSupport: both must be on before a backend is selected
+	// in storage.SelectHelmCacheBackend. When off, no ModelCacheRequest is
+	// created and no ephemeral model-cache-init container is injected.
+	HelmModelCaching              = newFeatureFlag("HelmModelCaching", newBool(false))
 	NVMeshEncryption              = newFeatureFlag("NVMeshEncryption", newBool(false))
 	PeriodicInstanceStatusUpdate  = newFeatureFlag("PeriodicInstanceStatusUpdate", newBool(true))
 	HelmRBACEnforcement           = newFeatureFlag("HelmRBACEnforcement", newBool(true))

--- a/src/compute-plane-services/nvca/pkg/featureflag/featureflag_test.go
+++ b/src/compute-plane-services/nvca/pkg/featureflag/featureflag_test.go
@@ -103,6 +103,40 @@ func TestMaintenanceModeFeatureFlags(t *testing.T) {
 	assert.Equal(t, CordonAndDrainMaintenance, flag)
 }
 
+func TestHelmModelCachingFeatureFlag(t *testing.T) {
+	// parseFlags mutates package globals. Restore them via Cleanup so state
+	// cannot leak into other tests even if an assertion aborts this one.
+	origCaching, origHelm := CachingSupport.enabled, HelmModelCaching.enabled
+	t.Cleanup(func() {
+		CachingSupport.enabled, HelmModelCaching.enabled = origCaching, origHelm
+	})
+
+	// Helm model caching must be opted into. Enabled() prefers the override, so
+	// clear it to assert the declared default is what an unset flag reports.
+	HelmModelCaching.enabled = nil
+	require.NotNil(t, HelmModelCaching.defaultValue)
+	assert.False(t, *HelmModelCaching.defaultValue, "HelmModelCaching must default to off")
+	assert.False(t, HelmModelCaching.Enabled(), "the declared default must reach Enabled()")
+
+	_ = parseFlags(fmt.Sprintf("+%s", HelmModelCaching.Key))
+	assert.True(t, HelmModelCaching.Enabled())
+
+	_ = parseFlags(fmt.Sprintf("-%s", HelmModelCaching.Key))
+	assert.False(t, HelmModelCaching.Enabled())
+
+	// CachingSupport is the parent gate, but it must not imply the Helm
+	// sub-gate. Clear the child override first, so this covers an unset child
+	// rather than one explicitly disabled just above.
+	HelmModelCaching.enabled = nil
+	_ = parseFlags(fmt.Sprintf("+%s", CachingSupport.Key))
+	assert.True(t, CachingSupport.Enabled())
+	assert.False(t, HelmModelCaching.Enabled())
+
+	flag, err := Get(HelmModelCaching.Key)
+	require.NoError(t, err)
+	assert.Equal(t, HelmModelCaching, flag)
+}
+
 func TestHelmAllowCPUNodesFeatureFlag(t *testing.T) {
 	// Reset flags to defaults
 	_ = parseFlags("-HelmAllowCPUNodes,-HelmResourceConstraints")

--- a/src/compute-plane-services/nvca/pkg/storage/cachebackend.go
+++ b/src/compute-plane-services/nvca/pkg/storage/cachebackend.go
@@ -30,14 +30,15 @@ import (
 )
 
 // HelmCacheBackend identifies the storage backend selected for the Helm model
-// cache. The backend is resolved from the CachingSupport gate plus the storage
-// classes available in the cluster, replacing the old HelmCachingSupport flag.
+// cache. The backend is resolved from the CachingSupport and HelmModelCaching
+// gates plus the storage classes available in the cluster.
 // The type and values live in pkg/types so metrics can share them; they are
 // aliased here for the storage-facing API.
 type HelmCacheBackend = nvcatypes.HelmCacheBackend
 
 const (
-	// HelmCacheBackendNone means caching is disabled (CachingSupport off).
+	// HelmCacheBackendNone means caching is disabled (CachingSupport or
+	// HelmModelCaching off).
 	HelmCacheBackendNone = nvcatypes.HelmCacheBackendNone
 	// HelmCacheBackendNVMesh uses NVMesh 3.x cross-namespace PV sharing
 	// (the existing doModelCacheNVMesh path).
@@ -64,9 +65,10 @@ const (
 )
 
 // SelectHelmCacheBackend resolves the Helm model-cache storage backend. All
-// caching is gated on CachingSupport; the mechanism is then chosen by which
-// storage class the cluster provides, falling back to Samba (when
-// HelmSharedStorage is enabled) and finally to a per-pod ephemeral cache:
+// caching is gated on CachingSupport plus the HelmModelCaching sub-gate; the
+// mechanism is then chosen by which storage class the cluster provides,
+// falling back to Samba (when HelmSharedStorage is enabled) and finally to a
+// per-pod ephemeral cache:
 //
 //  1. nvcf-sc-30 present    -> NVMesh 3.x installed      -> NVMesh
 //  2. nvcf-miniservice-sc present  -> operator shared storage   -> SharedFS
@@ -77,7 +79,8 @@ func SelectHelmCacheBackend(
 	c client.Client,
 	ff featureflag.Fetcher,
 ) (HelmCacheBackend, error) {
-	if !ff.IsFeatureFlagEnabled(featureflag.CachingSupport) {
+	if !ff.IsFeatureFlagEnabled(featureflag.CachingSupport) ||
+		!ff.IsFeatureFlagEnabled(featureflag.HelmModelCaching) {
 		return HelmCacheBackendNone, nil
 	}
 

--- a/src/compute-plane-services/nvca/pkg/storage/cachebackend_test.go
+++ b/src/compute-plane-services/nvca/pkg/storage/cachebackend_test.go
@@ -47,9 +47,13 @@ func cacheBackendClient(t *testing.T, scs ...*storagev1.StorageClass) *fake.Clie
 }
 
 func TestSelectHelmCacheBackend(t *testing.T) {
-	cachingOnly := []*featureflag.FeatureFlag{featureflag.CachingSupport}
+	cachingOnly := []*featureflag.FeatureFlag{
+		featureflag.CachingSupport,
+		featureflag.HelmModelCaching,
+	}
 	cachingAndSamba := []*featureflag.FeatureFlag{
 		featureflag.CachingSupport,
+		featureflag.HelmModelCaching,
 		&featureflag.HelmSharedStorage.FeatureFlag,
 	}
 
@@ -63,6 +67,20 @@ func TestSelectHelmCacheBackend(t *testing.T) {
 			name:  "caching disabled -> none",
 			flags: nil,
 			// nvcf-sc-30 present but caching off: still none.
+			storageClasses: []*storagev1.StorageClass{storageClass(NVMeshStorageClassName)},
+			want:           HelmCacheBackendNone,
+		},
+		{
+			name:  "HelmModelCaching off -> none",
+			flags: []*featureflag.FeatureFlag{featureflag.CachingSupport},
+			// CachingSupport on and nvcf-sc-30 present, but the Helm sub-gate
+			// is off: no backend is selected.
+			storageClasses: []*storagev1.StorageClass{storageClass(NVMeshStorageClassName)},
+			want:           HelmCacheBackendNone,
+		},
+		{
+			name:           "CachingSupport off, HelmModelCaching on -> none",
+			flags:          []*featureflag.FeatureFlag{featureflag.HelmModelCaching},
 			storageClasses: []*storagev1.StorageClass{storageClass(NVMeshStorageClassName)},
 			want:           HelmCacheBackendNone,
 		},


### PR DESCRIPTION
## Why

Backport of #1332 to the nvca 3.2 release line.

Helm model caching is gated only by `CachingSupport`, a broad shared gate.
There is no way to enable caching support on a cluster while keeping the Helm
model-cache path off, and no way to turn that path off on its own when it
misbehaves on a cluster.

## What changed

Adds a `HelmModelCaching` feature flag, default off, as a sub-gate of
`CachingSupport`. `storage.SelectHelmCacheBackend` returns
`HelmCacheBackendNone` unless both flags are enabled.

`SelectHelmCacheBackend` is the single choke point: it is called once per
reconcile in `internal/miniservice/reconcile.go`, and its result drives both
caching branches. `makeStorageRequests` only creates a `ModelCacheRequest` for
the NVMesh, SharedFS, and Samba backends, and the ephemeral `model-cache-init`
container injection is gated on the Ephemeral backend. Returning `None`
disables both, so no other call sites needed changes.

Default off means existing clusters see no behavior change until the flag is
added to their feature gate list.

## Differences from the main PR

Re-applied by hand rather than cherry-picked. This branch predates two changes
that landed on main, so the merge commit does not apply cleanly:

- `SelectHelmCacheBackend` on main takes a `modelCacheStorageClass` argument and
  its Samba fallback also requires the block class to exist. Here the signature
  is unchanged, so the doc comment keeps this branch's wording.
- `TestSelectHelmCacheBackend_SambaClassLookupError` does not exist on this
  branch, so it needed no flag update.

The gate itself, the flag declaration, and all new tests are identical to
#1332.

## Customer Release Notes

Helm model caching is now controlled by a dedicated `HelmModelCaching` feature
flag, disabled by default, in addition to the existing `CachingSupport` flag.
Enable both to use the Helm model cache.

## Plan Summary

Not applicable.

## Usage

Add the flag to the cluster's feature gate list alongside `CachingSupport`:

```
CachingSupport,HelmModelCaching
```

## Testing

- `go build ./...` is clean and `go test ./pkg/storage/... ./pkg/featureflag/... ./internal/miniservice/...` passes on this branch.
- `gofmt -l` reports nothing for the five changed files. Two other files on this branch (`pkg/nvca/backendk8scache_test.go`, `internal/miniservice/status_byoo_test.go`) are flagged by `gofmt` but are pre-existing and untouched here.

Tests carried over from #1332:
- `TestHelmModelCachingFeatureFlag`: asserts the declared default is off and
  reaches `Enabled()`, covers the `+`/`-` parse round trip, and asserts
  `CachingSupport` alone does not imply the sub-gate. Globals are restored with
  `t.Cleanup`.
- `TestSelectHelmCacheBackend`: two cases with `nvcf-sc-30` present so the
  assertion is about the gate rather than a missing storage class, one for each
  flag off alone.
- `TestMakeStorageRequests_BackendHandling`: a `HelmCacheBackendNone` case with
  a valid cache spec, asserting no `ModelCacheRequest` is emitted.

QA: not required. Behavior is unchanged for any cluster that does not set the
new flag.

## Notes

Per the nvca `AGENTS.md`, `release-x.y` branches take bugfixes only. This is a
`feat` by commit type but is behavior-neutral by default, so it is being
backported deliberately rather than by that convention.

## Issues

Relates to #1331

## Related Pull Requests

- #1332 (main)

## Dependencies

None