### PR TITLE
fix(charts): bump chart versions for released services

### DIFF
--- a/deploy/helm/cloud-functions/nvcf-api/Chart.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/Chart.yaml
@@ -19,4 +19,4 @@ description: A Helm chart for NVCF API deployment
 
 type: application
 version: 0.0.0 # autoversioning enabled via release pipeline
-appVersion: "1.12.6"
+appVersion: "1.16.3"

--- a/deploy/helm/cloud-functions/nvcf-api/values.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/values.yaml
@@ -33,7 +33,7 @@ api:
     # This sets the pull policy for images.
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "1.12.6"
+    tag: "1.16.3"
 
   # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   # imagePullSecrets:

--- a/deploy/helm/event-ledger/Chart.yaml
+++ b/deploy/helm/event-ledger/Chart.yaml
@@ -21,4 +21,4 @@ type: application
 
 version: 0.0.0 # autoversioning enabled via release pipeline
 
-appVersion: "0.1.1"
+appVersion: "0.13.3"

--- a/deploy/helm/event-ledger/values.yaml
+++ b/deploy/helm/event-ledger/values.yaml
@@ -37,7 +37,7 @@ eventLedger:
     # Image name is chart-owned and appended to registry/repository.
     name: "nvcf-event-ledger"
     pullPolicy: IfNotPresent
-    tag: "0.1.1"
+    tag: "0.13.3"
     digest: ""
 
   imagePullSecrets: []

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.0.4"
+appVersion: "3.3.0-dev.203"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.207"
+appVersion: "3.3.0-dev.209"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.224"
+appVersion: "3.3.0-dev.225"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.220"
+appVersion: "3.3.0-dev.221"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.225"
+appVersion: "3.3.0-dev.226"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.203"
+appVersion: "3.3.0-dev.204"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0"
+appVersion: "3.3.1"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.227"
+appVersion: "3.3.0-dev.229"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.223"
+appVersion: "3.3.0-dev.224"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.218"
+appVersion: "3.3.0-dev.219"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.222"
+appVersion: "3.3.0-dev.223"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.221"
+appVersion: "3.3.0-dev.222"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.226"
+appVersion: "3.3.0-dev.227"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.216"
+appVersion: "3.3.0-dev.217"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.206"
+appVersion: "3.3.0-dev.207"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.214"
+appVersion: "3.3.0-dev.215"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.217"
+appVersion: "3.3.0-dev.218"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.210"
+appVersion: "3.3.0-dev.212"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.229"
+appVersion: "3.3.0-dev.230"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.205"
+appVersion: "3.3.0-dev.206"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.204"
+appVersion: "3.3.0-dev.205"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.209"
+appVersion: "3.3.0-dev.210"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.230"
+appVersion: "3.3.0"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.215"
+appVersion: "3.3.0-dev.216"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.1"
+appVersion: "3.3.2"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.219"
+appVersion: "3.3.0-dev.220"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.212"
+appVersion: "3.3.0-dev.213"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.3.0-dev.213"
+appVersion: "3.3.0-dev.214"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0


### PR DESCRIPTION
Opened by `.github/workflows/chart-version-bump.yml` when `src/compute-plane-services/nvca/v3.3.2` was published.

The released tag carries the version, so this is a direct update rather than a lookup of the newest published image.

Merging this does not move the self-managed stack. A chart version reaches the stack only once the chart itself is released, and publishing that chart release is what triggers `stack-pin-bump.yml`.

Release notes: https://github.com/NVIDIA/nvcf/releases/tag/src/compute-plane-services/nvca/v3.3.2


If this pull request sits unmerged, later service releases add their bumps to the same branch, so merging it applies all of them.

Github commit:
fix(charts): bump chart versions for released services