### PR TITLE
docs(self-managed): inventory optional ModelExpress artifacts in the manifest

### DIFF
--- a/docs/user/manifest.md
+++ b/docs/user/manifest.md
@@ -211,6 +211,7 @@ The following tables list the complete artifact inventory.
 | `ebs-csi-driver` | `supported` | Optional | Provides Amazon EBS persistent volumes for EKS clusters. | `https://kubernetes-sigs.github.io/aws-ebs-csi-driver` | [Upstream](https://github.com/kubernetes-sigs/aws-ebs-csi-driver) |
 | `gpu-operator` | `supported` | Required | Manages NVIDIA GPU software on Kubernetes nodes. | `https://helm.ngc.nvidia.com/nvidia` | [Upstream](https://github.com/NVIDIA/gpu-operator) |
 | `helm-nvca-operator` | `1.12.7` | Required | Deploys the NVCA operator and compute-plane integration. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvca-operator:1.12.7` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/nvca-operator) |
+| `modelexpress` | `supported` | Optional | Distributes model weights peer-to-peer between Dynamo workers to reduce scale-out cold starts. Installed separately from the compute-plane stack. | `https://helm.ngc.nvidia.com/nvidia/ai-dynamo` | [Upstream](https://github.com/ai-dynamo/modelexpress) |
 | `nvcf-container-cache` | `0.25.22` | Optional | Deploys container image caching on GPU cluster nodes. | `https://helm.ngc.nvidia.com/nvidia/nvcf/nvcf-container-cache:0.25.22` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/container-cache) |
 
 ### Compute plane services and images
@@ -220,6 +221,7 @@ The following tables list the complete artifact inventory.
 | `ess-agent` | `1.3.1` | Required | Injects encrypted application secrets into function workloads. | `nvcr.io/nvidia/nvcf/ess-agent:1.3.1` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/compute-plane-services/ess-agent) |
 | `gpu-operator-validator` | `supported` | Required | Validates GPU Operator components on GPU nodes. | `https://catalog.ngc.nvidia.com/orgs/nvidia/teams/cloud-native/containers/gpu-operator-validator` | [Upstream](https://github.com/NVIDIA/gpu-operator) |
 | `k8s-device-plugin` | `supported` | Required | Advertises NVIDIA GPU resources to Kubernetes. | `https://catalog.ngc.nvidia.com/orgs/nvidia/teams/k8s/containers/device-plugin` | [Upstream](https://github.com/NVIDIA/k8s-device-plugin) |
+| `modelexpress-server` | `supported` | Optional | Serves model weights to Dynamo workers over NIXL RDMA transports. | `https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/modelexpress-server` | [Upstream](https://github.com/ai-dynamo/modelexpress) |
 | `nvca` | `3.0.3` | Required | Registers GPU clusters and orchestrates deployments in-cluster. | `nvcr.io/nvidia/nvcf/nvca:3.0.3` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/compute-plane-services/nvca) |
 | `nvca-operator` | `3.0.3` | Required | Reconciles NVCA resources and compute-plane configuration. | `nvcr.io/nvidia/nvcf/nvca-operator:3.0.3` |  |
 | `nvcf-container-cache` | `v1.1.36` | Optional | Caches container image layers on GPU cluster nodes. | `nvcr.io/nvidia/nvcf/nvcf-container-cache:v1.1.36` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/container-cache) |

--- a/docs/version-catalog/main.yaml
+++ b/docs/version-catalog/main.yaml
@@ -598,6 +598,14 @@ manifest:
       requirement: optional
       description: Provides SMB persistent volumes for supported deployments.
       upstream_url: https://github.com/kubernetes-csi/csi-driver-smb
+    - name: modelexpress
+      version: supported
+      distribution: https://helm.ngc.nvidia.com/nvidia/ai-dynamo
+      plane: compute
+      kind: chart
+      requirement: optional
+      description: Distributes model weights peer-to-peer between Dynamo workers to reduce scale-out cold starts. Installed separately from the compute-plane stack.
+      upstream_url: https://github.com/ai-dynamo/modelexpress
     - artifact_id: nvca
       plane: compute
       kind: service-image
@@ -655,6 +663,14 @@ manifest:
       requirement: required
       description: Advertises NVIDIA GPU resources to Kubernetes.
       upstream_url: https://github.com/NVIDIA/k8s-device-plugin
+    - name: modelexpress-server
+      version: supported
+      distribution: https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/modelexpress-server
+      plane: compute
+      kind: service-image
+      requirement: optional
+      description: Serves model weights to Dynamo workers over NIXL RDMA transports.
+      upstream_url: https://github.com/ai-dynamo/modelexpress
     - artifact_id: pylon
       plane: compute
       kind: service-image


### PR DESCRIPTION
## TL;DR

Adds the ModelExpress chart and server image to the generated software inventory
as optional compute-plane add-ons.

## Additional Details

Catalog entries only. No generator source or test changes, and
`docs/user/image-mirroring.md` is untouched.

Both entries use `version: supported` rather than an exact tag, matching the
seven existing entries in the catalog that do the same. ModelExpress installs
outside the compute-plane stack, so there is no pinned version for the manifest
to track. The tested combination, chart 0.5.1 with server 0.4.0, is recorded in
the guide and the sample instead, where a reader acting on it will see it.

## For the Reviewer

The generated `manifest.md` here was produced by hand, because the generator
needs `imports.yaml`, which is absent from the public mirror by design. Please
treat CI's regenerated output as authoritative and flag any difference.

## For QA

Manifest generation in CI.

## Issues

Closes #1352

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added optional Modelexpress Helm chart and server image entries to the compute-plane inventory.
  * Documented supported versions, distribution locations, descriptions, and upstream repository details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->