### PR TITLE
fix(nats): add self-managed regional placement tag

### DIFF
--- a/deploy/helm/nats/scripts/test-render-auth-callout.sh
+++ b/deploy/helm/nats/scripts/test-render-auth-callout.sh
@@ -73,6 +73,9 @@ assert_contains "$default_render" "- nats-nkeys"
 assert_contains "$default_render" "- nats-auth-callout-nkeys"
 # The post-install hook from the previous design must be gone.
 assert_not_contains "$default_render" "nats-auth-callout-secrets-json-hook"
+assert_contains "$default_render" '"server_tags": ['
+assert_contains "$default_render" '"dc:ncp",'
+assert_contains "$default_render" '"aws-region:ncp"'
 
 no_create_render="$tmpdir/no-create.yaml"
 render --set nats.authCallout.createNkeySecret=false > "$no_create_render"

--- a/deploy/helm/nats/values.yaml
+++ b/deploy/helm/nats/values.yaml
@@ -120,6 +120,7 @@ nats:
     merge:
       server_tags:
         - "dc:ncp"
+        - "aws-region:ncp"
       # Auth callout delegates authentication to an external service (nvcf-nats-auth-callout-service).
       # The AUTH account holds the auth callout service's NKey identity.
       # The APP account is the default for authenticated clients (NVCA, workers).

--- a/deploy/stacks/self-managed/Makefile
+++ b/deploy/stacks/self-managed/Makefile
@@ -19,6 +19,7 @@ test:
 	@tests/image-override-wiring.sh
 	@tests/sidecar-registry-wiring.sh
 	@tests/api-env-wiring.sh
+	@tests/nats-placement-tags.sh
 
 test-published-charts:
 	@: "$${NVCF_PUBLISHED_CHART_REGISTRY:?NVCF_PUBLISHED_CHART_REGISTRY is required}"

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -201,6 +201,13 @@ accounts:
 # These static global values are processed in the values template
 nats:
   enabled: true
+  # The control plane places request-queue streams by its logical NCP region.
+  # Keep both tags so NATS can host shared and region-scoped streams.
+  config:
+    merge:
+      server_tags:
+        - "dc:ncp"
+        - "aws-region:ncp"
   # Image overrides for the NATS config reloader. The reloader is not
   # republished under the public nvidia/nvcf catalog, so it defaults to its
   # upstream source, docker.io/natsio/nats-server-config-reloader:0.23.0.

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -199,6 +199,7 @@ openbao:
       {{- end }}
 
 nats:
+  {{- $natsServerTags := dig "nats" "config" "merge" "server_tags" (list "dc:ncp" "aws-region:ncp") .Values }}
   {{- if .Values.global.imagePullSecrets }}
   global:
     image:
@@ -246,13 +247,16 @@ nats:
         {{- end }}
   {{- end }}
 
-  {{- if .Values.global.storageClass }}
   config:
+    merge:
+      server_tags:
+        {{- toYaml $natsServerTags | nindent 8 }}
+    {{- if .Values.global.storageClass }}
     jetstream:
       fileStore:
         pvc:
           storageClassName: {{ .Values.global.storageClass }}
-  {{- end }}
+    {{- end }}
 
   {{- with dig "nats" "podDisruptionBudget" dict .Values }}
   podDisruptionBudget:

--- a/deploy/stacks/self-managed/tests/nats-placement-tags.sh
+++ b/deploy/stacks/self-managed/tests/nats-placement-tags.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+work_dir="$(mktemp -d)"
+test_stack_dir="$work_dir/self-managed"
+environment_name="nats-placement-tags-test"
+environment_file="$test_stack_dir/environments/$environment_name.yaml"
+secrets_file="$test_stack_dir/secrets/$environment_name-secrets.yaml"
+values_file="$work_dir/nats-values.yaml"
+trap 'rm -rf "$work_dir"' EXIT
+
+fail() {
+  echo "nats-placement-tags: $*" >&2
+  exit 1
+}
+
+mkdir -p "$test_stack_dir"
+cp -R "$stack_dir"/. "$test_stack_dir"
+printf '{}\n' >"$secrets_file"
+
+write_values() {
+  HELMFILE_ENV="$environment_name" \
+    HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" \
+    helmfile \
+      --file "$test_stack_dir/helmfile.d/01-dependencies.yaml.gotmpl" \
+      --environment default \
+      --state-values-set ingress.gatewayApi.controllerNamespace=envoy-gateway-system \
+      --state-values-set ingress.gatewayApi.gateways.shared.name=shared-gw \
+      --state-values-set ingress.gatewayApi.gateways.shared.namespace=envoy-gateway-system \
+      --state-values-set ingress.gatewayApi.gateways.grpc.name=grpc-gw \
+      --state-values-set ingress.gatewayApi.gateways.grpc.namespace=envoy-gateway-system \
+      --selector name=nats \
+      write-values \
+      --output-file-template "$values_file" >/dev/null
+}
+
+cat >"$environment_file" <<'EOF'
+global:
+  image:
+    registry: nvcr.io
+    repository: nvidia/nvcf
+nats:
+  enabled: true
+EOF
+
+write_values
+
+tags="$(yq -r '.nats.config.merge.server_tags | join(",")' "$values_file")"
+[[ "$tags" == "dc:ncp,aws-region:ncp" ]] ||
+  fail "expected dc:ncp,aws-region:ncp, got ${tags:-<none>}"
+
+cat >>"$environment_file" <<'EOF'
+  config:
+    merge:
+      server_tags:
+        - dc:custom
+        - aws-region:custom
+EOF
+
+write_values
+
+tags="$(yq -r '.nats.config.merge.server_tags | join(",")' "$values_file")"
+[[ "$tags" == "dc:custom,aws-region:custom" ]] ||
+  fail "expected environment tag override, got ${tags:-<none>}"
+
+echo "nats-placement-tags: OK"


### PR DESCRIPTION
## TL;DR

Add the logical NCP region tag required for JetStream to place region-scoped request queues on the bundled self-managed NATS cluster.

## Additional Details

The stack supplied `dc:ncp` but not `aws-region:ncp`. Regional request-queue streams select the latter tag, so their placement could fail even though NATS was healthy.

The NATS chart now includes both tags by default. The self-managed stack passes the tag list to the currently released chart and still permits environment overrides. Focused tests cover the chart render, default stack values, and custom stack tags.

## Customer Release Notes

Self-managed NATS now accepts region-scoped function request queues for the default NCP region.

## Plan Summary

The NATS server configuration gains one bounded placement tag. No pods, storage, or resource requests change.

## Usage

No operator action is required. Existing environments can replace the default tag list through `nats.config.merge.server_tags`.

## For the Reviewer

Please focus on the Helmfile value merge and the environment override case in `nats-placement-tags.sh`.

## For QA

QA needed: no additional manual QA beyond the final BDD integration run.

Tests run:

- `make test` in `deploy/helm/nats`
- `deploy/stacks/self-managed/tests/nats-placement-tags.sh`
- Shell syntax checks
- `git diff --check`

The first chart test attempt identified a missing local Helm repository. Adding the repository declared in `Chart.yaml` resolved the prerequisite, and the suite passed.

## Notes

The autoscaler smoke in #1363 exercises the regional request-queue path after this PR is available on `main`.

## Issues

Closes #1365

## Related Pull Requests

- #1363

## Dependencies

No new or updated third-party dependencies. NOTICE is unchanged.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable NATS placement tags for logical and AWS-region identifiers.
  * Supports environment-level overrides for placement tags.
  * Retained JetStream persistent storage-class settings alongside the new configuration.

* **Tests**
  * Added validation for default placement tags and custom environment overrides.
  * Helm rendering checks now confirm the expected default server tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->