### PR TITLE
fix(invocation): configure metrics exposure

### DIFF
--- a/deploy/helm/http-invocation/nvcf-invocation-service/templates/configmap-env.yaml
+++ b/deploy/helm/http-invocation/nvcf-invocation-service/templates/configmap-env.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.invocation.env }}
+{{- if or .Values.invocation.env .Values.invocation.metrics.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -24,6 +24,15 @@ metadata:
 data:
   {{- range $key, $value := .Values.invocation.env }}
   {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- if .Values.invocation.metrics.enabled }}
+  APP_CONFIG: "/etc/nvcf-invocation/settings.yaml"
+  APP_CONFIG_YAML: |
+    server:
+      metrics:
+        exporters:
+          - exporter: prometheus
+            endpoint: http://{{ .Values.invocation.metrics.bindAddress }}:{{ .Values.invocation.metrics.port }}
   {{- end }}
   {{- with .Values.invocation.tracing.baggageAttributeAllowlist }}
   SERVER__TRACING__BAGGAGE_ATTRIBUTE_ALLOWLIST: {{ join "," . | quote }}

--- a/deploy/helm/http-invocation/nvcf-invocation-service/templates/deployment.yaml
+++ b/deploy/helm/http-invocation/nvcf-invocation-service/templates/deployment.yaml
@@ -32,8 +32,8 @@ spec:
         {{- with .Values.invocation.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- if .Values.invocation.env }}
-        checksum/config-env: {{ dict "env" .Values.invocation.env "tracing" .Values.invocation.tracing | toYaml | sha256sum }}
+        {{- if or .Values.invocation.env .Values.invocation.metrics.enabled }}
+        checksum/config-env: {{ dict "env" .Values.invocation.env "metrics" .Values.invocation.metrics "tracing" .Values.invocation.tracing | toYaml | sha256sum }}
         {{- end }}
       labels:
         {{- include "nvcf-invocation-service.selectorLabels" . | nindent 8 }}
@@ -48,6 +48,14 @@ spec:
       volumes:
         {{- with .Values.invocation.volumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.invocation.metrics.enabled }}
+        - name: app-config
+          configMap:
+            name: {{ include "nvcf-invocation-service.fullname" . }}-env
+            items:
+              - key: APP_CONFIG_YAML
+                path: settings.yaml
         {{- end }}
         - name: vault-config-templates
           configMap:
@@ -65,6 +73,11 @@ spec:
             {{- with .Values.invocation.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- if .Values.invocation.metrics.enabled }}
+            - name: app-config
+              mountPath: /etc/nvcf-invocation
+              readOnly: true
+            {{- end }}
             - name: vault-config-templates
               mountPath: /vault/config/templates
               readOnly: true
@@ -73,7 +86,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-          {{- if .Values.invocation.env }}
+          {{- if or .Values.invocation.env .Values.invocation.metrics.enabled }}
           envFrom:
             - configMapRef:
                 name: {{ include "nvcf-invocation-service.fullname" . }}-env
@@ -83,6 +96,11 @@ spec:
             - name: {{ .name }}
               containerPort: {{ .containerPort }}
               protocol: {{ .protocol }}
+            {{- end }}
+            {{- if .Values.invocation.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.invocation.metrics.port }}
+              protocol: TCP
             {{- end }}
           resources:
             {{- toYaml .Values.invocation.resources | nindent 12 }}

--- a/deploy/helm/http-invocation/nvcf-invocation-service/templates/servicemonitor.yaml
+++ b/deploy/helm/http-invocation/nvcf-invocation-service/templates/servicemonitor.yaml
@@ -13,27 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: Service
+{{- if and .Values.invocation.metrics.enabled .Values.invocation.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
 metadata:
-  name: invocation
+  name: {{ include "nvcf-invocation-service.fullname" . }}-metrics
   namespace: {{ include "nvcf-invocation-service.namespace" . }}
   labels:
     {{- include "nvcf-invocation-service.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.invocation.service.type }}
-  ports:
-    {{- range .Values.invocation.service.ports }}
-    - port: {{ .port }}
-      targetPort: {{ .targetPort }}
-      protocol: {{ .protocol }}
-      name: {{ .name }}
-    {{- end }}
-    {{- if .Values.invocation.metrics.enabled }}
-    - name: metrics
-      port: {{ .Values.invocation.metrics.port }}
-      targetPort: metrics
-      protocol: TCP
-    {{- end }}
+  endpoints:
+    - interval: {{ .Values.invocation.metrics.serviceMonitor.interval | quote }}
+      path: {{ .Values.invocation.metrics.serviceMonitor.path | quote }}
+      port: metrics
+  namespaceSelector:
+    matchNames:
+      - {{ include "nvcf-invocation-service.namespace" . }}
   selector:
-    {{- include "nvcf-invocation-service.selectorLabels" . | nindent 4 }}
+    matchLabels:
+      {{- include "nvcf-invocation-service.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/http-invocation/nvcf-invocation-service/templates/validation.yaml
+++ b/deploy/helm/http-invocation/nvcf-invocation-service/templates/validation.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if and .Values.invocation.metrics.serviceMonitor.enabled (not .Values.invocation.metrics.enabled) }}
+{{- fail "invocation.metrics.enabled must be true when invocation.metrics.serviceMonitor.enabled is true" }}
+{{- end }}
+{{- if .Values.invocation.metrics.enabled }}
+{{- if not .Values.invocation.metrics.bindAddress }}
+{{- fail "invocation.metrics.bindAddress is required when invocation.metrics.enabled is true" }}
+{{- end }}
+{{- $metricsPortText := toString .Values.invocation.metrics.port }}
+{{- if or (not (regexMatch `^[0-9]+$` $metricsPortText)) (lt (int $metricsPortText) 1) (gt (int $metricsPortText) 65535) }}
+{{- fail "invocation.metrics.port must be an integer between 1 and 65535 when invocation.metrics.enabled is true" }}
+{{- end }}
+{{- if hasKey .Values.invocation.env "APP_CONFIG" }}
+{{- fail "invocation.env.APP_CONFIG is reserved when invocation.metrics.enabled is true" }}
+{{- end }}
+{{- if hasKey .Values.invocation.env "APP_CONFIG_YAML" }}
+{{- fail "invocation.env.APP_CONFIG_YAML is reserved when invocation.metrics.enabled is true" }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/http-invocation/nvcf-invocation-service/values.yaml
+++ b/deploy/helm/http-invocation/nvcf-invocation-service/values.yaml
@@ -60,10 +60,18 @@ invocation:
         port: 8080
         targetPort: 8080
         protocol: TCP
-      - name: metrics
-        port: 41337
-        targetPort: 41337
-        protocol: TCP
+
+  # Metrics collection remains active inside the invocation process. This
+  # setting controls whether the Prometheus listener is bound to the pod
+  # network and exposed through the Service.
+  metrics:
+    enabled: false
+    bindAddress: 0.0.0.0
+    port: 41337
+    serviceMonitor:
+      enabled: false
+      interval: 30s
+      path: /metrics
 
   resources:
     limits:
@@ -116,9 +124,6 @@ invocation:
   ports:
     - name: http
       containerPort: 8080
-      protocol: TCP
-    - name: metrics
-      containerPort: 41337
       protocol: TCP
 
   env:

--- a/deploy/helm/http-invocation/tests/metrics_config_test.sh
+++ b/deploy/helm/http-invocation/tests/metrics_config_test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+chart_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../nvcf-invocation-service" && pwd)"
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+
+fail() {
+  echo "metrics_config_test.sh: $*" >&2
+  exit 1
+}
+
+render() {
+  local output_file="$1"
+  shift
+  helm template invocation-service "$chart_root" \
+    --namespace nvcf \
+    --set-string invocation.image.registry=registry.example.test \
+    --set-string invocation.image.repository=nvcf-invocation-service \
+    "$@" >"$output_file"
+}
+
+assert_yq_eq() {
+  local file="$1"
+  local expression="$2"
+  local expected="$3"
+  local actual
+
+  actual="$(yq ea -r "$expression" "$file")"
+  [[ "$actual" == "$expected" ]] ||
+    fail "expected $expression to equal '$expected', got '$actual'"
+}
+
+default_manifest="$work_dir/default.yaml"
+enabled_manifest="$work_dir/enabled.yaml"
+custom_manifest="$work_dir/custom.yaml"
+monitor_manifest="$work_dir/monitor.yaml"
+validation_error="$work_dir/validation-error.txt"
+reserved_env_error="$work_dir/reserved-env-error.txt"
+port_validation_error="$work_dir/port-validation-error.txt"
+
+render "$default_manifest"
+assert_yq_eq \
+  "$default_manifest" \
+  '[select(.kind == "Service") | .spec.ports[] | select(.name == "metrics")] | length' \
+  0
+assert_yq_eq \
+  "$default_manifest" \
+  '[select(.kind == "Deployment") | .spec.template.spec.containers[].ports[] | select(.name == "metrics")] | length' \
+  0
+assert_yq_eq \
+  "$default_manifest" \
+  'select(.kind == "ConfigMap" and .metadata.name == "invocation-service-helm-nvcf-invocation-service-env") | .data.APP_CONFIG // "absent"' \
+  absent
+assert_yq_eq \
+  "$default_manifest" \
+  '[select(.kind == "ServiceMonitor")] | length' \
+  0
+
+render "$enabled_manifest" --set invocation.metrics.enabled=true
+assert_yq_eq \
+  "$enabled_manifest" \
+  'select(.kind == "ConfigMap" and .metadata.name == "invocation-service-helm-nvcf-invocation-service-env") | .data.APP_CONFIG' \
+  /etc/nvcf-invocation/settings.yaml
+assert_yq_eq \
+  "$enabled_manifest" \
+  'select(.kind == "ConfigMap" and .metadata.name == "invocation-service-helm-nvcf-invocation-service-env") | .data.APP_CONFIG_YAML | from_yaml | .server.metrics.exporters[0].endpoint' \
+  http://0.0.0.0:41337
+assert_yq_eq \
+  "$enabled_manifest" \
+  'select(.kind == "Deployment") | .spec.template.spec.containers[] | select(.name == "helm-nvcf-invocation-service") | .volumeMounts[] | select(.name == "app-config") | .mountPath' \
+  /etc/nvcf-invocation
+assert_yq_eq \
+  "$enabled_manifest" \
+  'select(.kind == "Service") | .spec.ports[] | select(.name == "metrics") | .port' \
+  41337
+
+render "$custom_manifest" \
+  --set invocation.metrics.enabled=true \
+  --set-string invocation.metrics.bindAddress=127.0.0.2 \
+  --set invocation.metrics.port=4242
+assert_yq_eq \
+  "$custom_manifest" \
+  'select(.kind == "ConfigMap" and .metadata.name == "invocation-service-helm-nvcf-invocation-service-env") | .data.APP_CONFIG_YAML | from_yaml | .server.metrics.exporters[0].endpoint' \
+  http://127.0.0.2:4242
+assert_yq_eq \
+  "$custom_manifest" \
+  'select(.kind == "Deployment") | .spec.template.spec.containers[] | select(.name == "helm-nvcf-invocation-service") | .ports[] | select(.name == "metrics") | .containerPort' \
+  4242
+
+render "$monitor_manifest" \
+  --set invocation.metrics.enabled=true \
+  --set invocation.metrics.serviceMonitor.enabled=true
+assert_yq_eq \
+  "$monitor_manifest" \
+  'select(.kind == "ServiceMonitor") | .spec.endpoints[0].port' \
+  metrics
+assert_yq_eq \
+  "$monitor_manifest" \
+  'select(.kind == "ServiceMonitor") | .spec.endpoints[0].path' \
+  /metrics
+
+if helm template invocation-service "$chart_root" \
+  --namespace nvcf \
+  --set-string invocation.image.registry=registry.example.test \
+  --set-string invocation.image.repository=nvcf-invocation-service \
+  --set invocation.metrics.serviceMonitor.enabled=true \
+  >/dev/null 2>"$validation_error"; then
+  fail "expected ServiceMonitor without metrics exposure to fail"
+fi
+grep -Fq \
+  'invocation.metrics.enabled must be true when invocation.metrics.serviceMonitor.enabled is true' \
+  "$validation_error" || fail "missing ServiceMonitor validation error"
+
+if helm template invocation-service "$chart_root" \
+  --namespace nvcf \
+  --set-string invocation.image.registry=registry.example.test \
+  --set-string invocation.image.repository=nvcf-invocation-service \
+  --set invocation.metrics.enabled=true \
+  --set-string invocation.env.APP_CONFIG=/tmp/custom.yaml \
+  >/dev/null 2>"$reserved_env_error"; then
+  fail "expected metrics exposure with a reserved APP_CONFIG override to fail"
+fi
+grep -Fq \
+  'invocation.env.APP_CONFIG is reserved when invocation.metrics.enabled is true' \
+  "$reserved_env_error" || fail "missing reserved APP_CONFIG validation error"
+
+for invalid_port in 0 65536 invalid; do
+  if helm template invocation-service "$chart_root" \
+    --namespace nvcf \
+    --set-string invocation.image.registry=registry.example.test \
+    --set-string invocation.image.repository=nvcf-invocation-service \
+    --set invocation.metrics.enabled=true \
+    --set-string invocation.metrics.port="$invalid_port" \
+    >/dev/null 2>"$port_validation_error"; then
+    fail "expected invalid metrics port '$invalid_port' to fail"
+  fi
+  grep -Fq \
+    'invocation.metrics.port must be an integer between 1 and 65535 when invocation.metrics.enabled is true' \
+    "$port_validation_error" || fail "missing metrics port validation error for '$invalid_port'"
+done
+
+echo "metrics_config_test.sh: invocation metrics exposure is configurable"

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -570,6 +570,12 @@ invocation:
   {{- . | nindent 2 }}
   {{- end }}
 
+  metrics:
+    enabled: {{ or (eq (dig "observability" "profile" "disabled" .Values) "control") (eq (dig "observability" "profile" "disabled" .Values) "all") }}
+    # The observability stack owns the shared ServiceMonitor resources.
+    serviceMonitor:
+      enabled: false
+
   env:
     # Observability
     {{- if .Values.global.observability.tracing.enabled }}

--- a/deploy/stacks/self-managed/tests/invocation-tracing-baggage.sh
+++ b/deploy/stacks/self-managed/tests/invocation-tracing-baggage.sh
@@ -84,16 +84,53 @@ invocation:
 EOF
 }
 
+write_disabled_environment() {
+  cat >"$environment_file" <<'EOF'
+global:
+  image:
+    registry: nvcr.io
+    repository: test/nvcf
+observability:
+  profile: disabled
+EOF
+}
+
 default_values="$work_dir/default-values.yaml"
 configured_values="$work_dir/configured-values.yaml"
 changed_values="$work_dir/changed-values.yaml"
+disabled_values="$work_dir/disabled-values.yaml"
 default_render="$work_dir/default-render.yaml"
 configured_render="$work_dir/configured-render.yaml"
 changed_render="$work_dir/changed-render.yaml"
+disabled_render="$work_dir/disabled-render.yaml"
 
 write_default_environment
 render_invocation_values "$default_values" >/dev/null
 render_chart "$default_values" "$default_render"
+assert_yq_eq \
+  "$default_values" \
+  '.invocation.metrics.enabled' \
+  true
+assert_yq_eq \
+  "$default_values" \
+  '.invocation.metrics.serviceMonitor.enabled' \
+  false
+assert_yq_eq \
+  "$default_render" \
+  'select(.kind == "ConfigMap" and .metadata.name == "invocation-service-env") | .data.APP_CONFIG' \
+  /etc/nvcf-invocation/settings.yaml
+assert_yq_eq \
+  "$default_render" \
+  'select(.kind == "ConfigMap" and .metadata.name == "invocation-service-env") | .data.APP_CONFIG_YAML | from_yaml | .server.metrics.exporters[0].endpoint' \
+  http://0.0.0.0:41337
+assert_yq_eq \
+  "$default_render" \
+  'select(.kind == "Deployment" and .metadata.name == "invocation-service") | .spec.template.spec.containers[] | select(.name == "helm-nvcf-invocation-service") | .volumeMounts[] | select(.name == "app-config") | .mountPath' \
+  /etc/nvcf-invocation
+assert_yq_eq \
+  "$default_render" \
+  'select(.kind == "Deployment" and .metadata.name == "invocation-service") | .spec.template.spec.volumes[] | select(.name == "token") | .projected.sources[0].serviceAccountToken.audience' \
+  http://openbao-server.vault-system.svc.cluster.local:8200
 assert_yq_eq \
   "$default_render" \
   'select(.kind == "ConfigMap" and .metadata.name == "invocation-service-env") | .data."SERVER__TRACING__BAGGAGE_ATTRIBUTE_ALLOWLIST" // "absent"' \
@@ -126,5 +163,21 @@ fi
 if [ "$configured_checksum" = "$changed_checksum" ]; then
   fail "deployment checksum did not change when the baggage allowlist changed"
 fi
+
+write_disabled_environment
+render_invocation_values "$disabled_values" >/dev/null
+render_chart "$disabled_values" "$disabled_render"
+assert_yq_eq \
+  "$disabled_values" \
+  '.invocation.metrics.enabled' \
+  false
+assert_yq_eq \
+  "$disabled_render" \
+  'select(.kind == "ConfigMap" and .metadata.name == "invocation-service-env") | .data.APP_CONFIG // "absent"' \
+  absent
+assert_yq_eq \
+  "$disabled_render" \
+  '[select(.kind == "Service" and .metadata.name == "invocation") | .spec.ports[] | select(.name == "metrics")] | length' \
+  0
 
 echo "invocation-tracing-baggage: all checks passed"


### PR DESCRIPTION
## TL;DR

Expose invocation metrics through explicit Helm values for the listener address, port, and optional ServiceMonitor. Enable the endpoint only for self-managed profiles that deploy control-plane observability.

## Additional Details

The invocation process falls back to a loopback-only Prometheus listener when no application settings file is mounted. A Kubernetes Service can declare port 41337 in that state, but other pods cannot reach it.

The invocation chart now owns the full metrics configuration:

- `invocation.metrics.enabled` controls the listener, container port, and Service port.
- `invocation.metrics.bindAddress` and `invocation.metrics.port` configure the Prometheus endpoint.
- `invocation.metrics.serviceMonitor.enabled` can create a chart-local ServiceMonitor when desired.
- Reserved application-config environment variables are validated to avoid conflicting configuration sources.

The self-managed stack enables the endpoint for the `control` and `all` observability profiles. Its central observability release continues to own the shared ServiceMonitor.

## Customer Release Notes

Invocation metrics exposure can now be configured through the Helm chart, allowing self-managed autoscaling and Prometheus scraping to reach the endpoint in cluster.

## Plan Summary

When enabled, the invocation Deployment gains a generated ConfigMap volume, a metrics container port, and a matching Service port. The optional ServiceMonitor remains disabled in the self-managed stack because the observability stack already supplies one.

## Usage

```yaml
invocation:
  metrics:
    enabled: true
    bindAddress: 0.0.0.0
    port: 41337
    serviceMonitor:
      enabled: false
```

## For the Reviewer

Please review the ownership split between the invocation chart and self-managed observability values. The listener configuration belongs to the invocation chart; the self-managed stack only chooses when to enable it.

## For QA

QA is still needed as part of #1363's final k3d smoke-test run.

Tests run:

- `deploy/helm/http-invocation/tests/metrics_config_test.sh`
- `deploy/helm/http-invocation/tests/image_tag_appversion_test.sh`
- `deploy/stacks/self-managed/tests/invocation-tracing-baggage.sh`
- `helm lint deploy/helm/http-invocation/nvcf-invocation-service --set-string invocation.image.registry=registry.example.test --set-string invocation.image.repository=nvcf-invocation-service`
- Shell syntax checks for the changed test scripts
- `git diff --check`

## Notes

The self-managed stack currently pins the published invocation chart at version 1.5.6. This PR tests the stack values against the chart source in this repository, but the stack will not consume these new values until the updated chart is released and its pin is advanced. That release/pin update is intentionally separate from this source change.

## Issues

Closes #1366

## Related Pull Requests

- #1363

## Dependencies

No new or updated third-party dependencies. No license review or NOTICE update is required.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Prometheus metrics for the invocation service, including bind address and port.
  * Added optional ServiceMonitor support for automated metrics scraping.
  * Added automatic application configuration mounting when metrics are enabled.
  * Metrics endpoints are exposed only when configured, including through supported observability profiles.

* **Bug Fixes**
  * Added validation for incomplete metrics settings and conflicting application configuration overrides.

* **Tests**
  * Added coverage for customized, enabled, disabled, ServiceMonitor, and invalid metrics configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->