### PR TITLE
fix(llm-routing): keep plaintext gRPC independent of QUIC trust

### DIFF
--- a/src/compute-plane-services/nvca/internal/miniservice/controller_test.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/controller_test.go
@@ -511,8 +511,7 @@ func assertHelmLLMTransportTLS(
 	assert.NotNil(t, findWorkloadVolume(utilsPod.Spec, transporttls.MergedCertsVolumeName))
 	assert.Equal(t, transporttls.SystemCertFile,
 		findWorkloadEnvValue(llmWorker, transporttls.CertPathEnv))
-	assert.Equal(t, transporttls.SystemCertFile,
-		findWorkloadEnvValue(llmWorker, transporttls.GrpcTLSCACertPathEnv))
+	assert.Empty(t, findWorkloadEnvValue(llmWorker, transporttls.GrpcTLSCACertPathEnv))
 	assert.NotNil(t, findWorkloadVolumeMount(llmWorker, transporttls.MergedCertsVolumeName))
 
 	trustConfigMap := &corev1.ConfigMap{}

--- a/src/compute-plane-services/nvca/internal/miniservice/transport_tls_test.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/transport_tls_test.go
@@ -131,8 +131,7 @@ func TestPrepareTransportTLSForWorkloadsInjectsPodLLMWorker(t *testing.T) {
 	expectedBundlePath := "/nvcf/transport-tls/ca-certificates.crt"
 	assert.Equal(t, expectedBundlePath,
 		findWorkloadEnvValue(llmWorker, transporttls.CertPathEnv))
-	assert.Equal(t, expectedBundlePath,
-		findWorkloadEnvValue(llmWorker, transporttls.GrpcTLSCACertPathEnv))
+	assert.Empty(t, findWorkloadEnvValue(llmWorker, transporttls.GrpcTLSCACertPathEnv))
 	mount := findWorkloadVolumeMount(llmWorker, "nvcf-trust-merged-certs")
 	require.NotNil(t, mount)
 	assert.Equal(t, "/nvcf/transport-tls", mount.MountPath)

--- a/src/compute-plane-services/nvca/internal/transporttls/transport_tls.go
+++ b/src/compute-plane-services/nvca/internal/transporttls/transport_tls.go
@@ -168,11 +168,26 @@ func InjectIntoPodSpec(podSpec *corev1.PodSpec, cfg nvcaconfig.TransportTLSConfi
 		ReadOnly:  true,
 	})
 	installedBundleFile := cfg.InstalledBundleMountPath + "/" + InstalledBundleFile
-	k8sutil.AddEnvsToContainer(llmWorker,
-		corev1.EnvVar{Name: CertPathEnv, Value: installedBundleFile},
-		corev1.EnvVar{Name: GrpcTLSCACertPathEnv, Value: installedBundleFile},
-	)
+	envs := []corev1.EnvVar{{Name: CertPathEnv, Value: installedBundleFile}}
+	if llmWorkerUsesHTTPSRegistration(llmWorker) {
+		envs = append(envs, corev1.EnvVar{Name: GrpcTLSCACertPathEnv, Value: installedBundleFile})
+	}
+	k8sutil.AddEnvsToContainer(llmWorker, envs...)
 	return nil
+}
+
+func llmWorkerUsesHTTPSRegistration(container *corev1.Container) bool {
+	for _, arg := range container.Args {
+		if address, found := strings.CutPrefix(strings.TrimSpace(arg), "--stargate-address="); found {
+			return strings.HasPrefix(strings.TrimSpace(address), "https://")
+		}
+	}
+	for _, env := range container.Env {
+		if env.Name == "LLM_REQUEST_ROUTER_ADDRESS" || env.Name == "STARGATE_ADDRESS" {
+			return strings.HasPrefix(strings.TrimSpace(env.Value), "https://")
+		}
+	}
+	return false
 }
 
 func validateInstalledBundleMountConflict(container *corev1.Container, mountPath string) error {

--- a/src/compute-plane-services/nvca/internal/transporttls/transport_tls_test.go
+++ b/src/compute-plane-services/nvca/internal/transporttls/transport_tls_test.go
@@ -198,6 +198,7 @@ func TestInjectIntoPodSpecOnlyMutatesLLMWorker(t *testing.T) {
 			{
 				Name:      function.LLMWorkerContainerName,
 				Image:     "nvcr.io/nvcf/llm-worker:test",
+				Args:      []string{"--stargate-address=https://stargate.example.test:50071"},
 				Resources: llmWorkerResources,
 			},
 			{Name: "inference", Image: "nvcr.io/customer/inference:test"},
@@ -234,6 +235,112 @@ func TestInjectIntoPodSpecOnlyMutatesLLMWorker(t *testing.T) {
 		assert.Empty(t, findTestEnvValue(container, CertPathEnv), name)
 		assert.Empty(t, findTestEnvValue(container, GrpcTLSCACertPathEnv), name)
 		assert.Nil(t, findTestVolumeMount(container, MergedCertsVolumeName), name)
+	}
+}
+
+func TestInjectIntoPodSpecOmitsGrpcCAForPlaintextRouter(t *testing.T) {
+	podSpec := &corev1.PodSpec{
+		InitContainers: []corev1.Container{testWorkerInitContainer()},
+		Containers: []corev1.Container{{
+			Name:  function.LLMWorkerContainerName,
+			Image: "nvcr.io/nvcf/llm-worker:test",
+			Args:  []string{"--stargate-address=http://stargate.example.test:50071"},
+		}},
+	}
+
+	err := InjectIntoPodSpec(podSpec, NormalizeConfig(nvcaconfig.TransportTLSConfig{
+		TrustMode:              nvcaconfig.TrustModeBundle,
+		TrustBundleFingerprint: testRootFingerprint,
+		TrustBundlePEM:         testRootCertPEM,
+	}))
+	require.NoError(t, err)
+
+	llmWorker := findTestContainer(podSpec, function.LLMWorkerContainerName)
+	require.NotNil(t, llmWorker)
+	assert.Equal(t, SystemCertFile, findTestEnvValue(llmWorker, CertPathEnv))
+	assert.Empty(t, findTestEnvValue(llmWorker, GrpcTLSCACertPathEnv))
+}
+
+func TestInjectIntoPodSpecPreservesExplicitGrpcCAForPlaintextRouter(t *testing.T) {
+	podSpec := &corev1.PodSpec{
+		InitContainers: []corev1.Container{testWorkerInitContainer()},
+		Containers: []corev1.Container{{
+			Name:  function.LLMWorkerContainerName,
+			Image: "nvcr.io/nvcf/llm-worker:test",
+			Args:  []string{"--stargate-address=http://stargate.example.test:50071"},
+			Env: []corev1.EnvVar{{
+				Name:  GrpcTLSCACertPathEnv,
+				Value: "/custom/grpc-ca.pem",
+			}},
+		}},
+	}
+
+	err := InjectIntoPodSpec(podSpec, NormalizeConfig(nvcaconfig.TransportTLSConfig{
+		TrustMode:              nvcaconfig.TrustModeBundle,
+		TrustBundleFingerprint: testRootFingerprint,
+		TrustBundlePEM:         testRootCertPEM,
+	}))
+	require.NoError(t, err)
+
+	llmWorker := findTestContainer(podSpec, function.LLMWorkerContainerName)
+	require.NotNil(t, llmWorker)
+	assert.Equal(t, "/custom/grpc-ca.pem", findTestEnvValue(llmWorker, GrpcTLSCACertPathEnv))
+}
+
+func TestLLMWorkerUsesHTTPSRegistration(t *testing.T) {
+	tests := []struct {
+		name      string
+		container corev1.Container
+		want      bool
+	}{
+		{
+			name:      "https argument",
+			container: corev1.Container{Args: []string{"--stargate-address=https://router.example.test:50071"}},
+			want:      true,
+		},
+		{
+			name:      "http argument",
+			container: corev1.Container{Args: []string{"--stargate-address=http://router.example.test:50071"}},
+		},
+		{
+			name: "https current environment",
+			container: corev1.Container{Env: []corev1.EnvVar{{
+				Name:  "LLM_REQUEST_ROUTER_ADDRESS",
+				Value: " https://router.example.test:50071 ",
+			}}},
+			want: true,
+		},
+		{
+			name: "https legacy environment",
+			container: corev1.Container{Env: []corev1.EnvVar{{
+				Name:  "STARGATE_ADDRESS",
+				Value: "https://router.example.test:50071",
+			}}},
+			want: true,
+		},
+		{
+			name: "scheme-less environment",
+			container: corev1.Container{Env: []corev1.EnvVar{{
+				Name:  "LLM_REQUEST_ROUTER_ADDRESS",
+				Value: "router.example.test:50071",
+			}}},
+		},
+		{
+			name: "argument takes precedence over environment",
+			container: corev1.Container{
+				Args: []string{"--stargate-address=http://router.example.test:50071"},
+				Env: []corev1.EnvVar{{
+					Name:  "LLM_REQUEST_ROUTER_ADDRESS",
+					Value: "https://router.example.test:50071",
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, llmWorkerUsesHTTPSRegistration(&tt.container))
+		})
 	}
 }
 
@@ -331,7 +438,7 @@ func TestInjectIntoPodSpecUsesConfiguredInstalledBundleMountPath(t *testing.T) {
 	require.NotNil(t, mount)
 	assert.Equal(t, "/nvcf/transport-tls", mount.MountPath)
 	assert.Equal(t, "/nvcf/transport-tls/ca-certificates.crt", findTestEnvValue(llmWorker, CertPathEnv))
-	assert.Equal(t, "/nvcf/transport-tls/ca-certificates.crt", findTestEnvValue(llmWorker, GrpcTLSCACertPathEnv))
+	assert.Empty(t, findTestEnvValue(llmWorker, GrpcTLSCACertPathEnv))
 
 	installContainer := findTestInitContainer(podSpec, InstallContainerName)
 	require.NotNil(t, installContainer)
@@ -435,7 +542,7 @@ func TestInjectIntoPodSpecCoexistsWithAdmissionCertificateMounts(t *testing.T) {
 	assert.Equal(t, "/webhook/certs", findTestVolumeMount(llmWorker, "webhook-certs").MountPath)
 	assert.Equal(t, "/nvcf/transport-tls", findTestVolumeMount(llmWorker, MergedCertsVolumeName).MountPath)
 	assert.Equal(t, "/nvcf/transport-tls/ca-certificates.crt", findTestEnvValue(llmWorker, CertPathEnv))
-	assert.Equal(t, "/nvcf/transport-tls/ca-certificates.crt", findTestEnvValue(llmWorker, GrpcTLSCACertPathEnv))
+	assert.Empty(t, findTestEnvValue(llmWorker, GrpcTLSCACertPathEnv))
 	assert.NotNil(t, findTestVolume(&pod.Spec, TrustBundleVolumeName))
 	assert.NotNil(t, findTestVolume(&pod.Spec, MergedCertsVolumeName))
 	assert.NotNil(t, findTestInitContainer(&pod.Spec, InstallContainerName))

--- a/src/compute-plane-services/nvca/pkg/nvca/transport_tls_test.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/transport_tls_test.go
@@ -99,8 +99,7 @@ func TestCreatePodArtifactInstancesTransportTLSBundleInjectsOnlyLLMWorker(t *tes
 	expectedBundlePath := "/nvcf/transport-tls/ca-certificates.crt"
 	assert.Equal(t, expectedBundlePath,
 		findTransportTLSEnvValue(llmWorker, transporttls.CertPathEnv))
-	assert.Equal(t, expectedBundlePath,
-		findTransportTLSEnvValue(llmWorker, transporttls.GrpcTLSCACertPathEnv))
+	assert.Empty(t, findTransportTLSEnvValue(llmWorker, transporttls.GrpcTLSCACertPathEnv))
 	mount := findTransportTLSVolumeMount(llmWorker, "nvcf-trust-merged-certs")
 	require.NotNil(t, mount)
 	assert.Equal(t, "/nvcf/transport-tls", mount.MountPath)

--- a/src/libraries/rust/stargate/crates/pylon/src/startup.rs
+++ b/src/libraries/rust/stargate/crates/pylon/src/startup.rs
@@ -549,10 +549,16 @@ fn registration_config_from_plan(
 }
 
 fn load_grpc_tls_ca_cert(args: &Args) -> Result<Option<Vec<u8>>> {
+    // Reverse QUIC always uses tls_cert_path as its trust anchor. Reuse that
+    // bundle for gRPC only when the registration seed explicitly uses HTTPS;
+    // treating it as a gRPC CA for an HTTP seed prevents Pylon from connecting.
+    let reuse_reverse_quic_trust =
+        matches!(args.backend_connectivity, BackendConnectivity::Reverse)
+            && args.stargate_address.trim().starts_with("https://");
     args.grpc_tls_ca_cert_path
         .as_ref()
         .or_else(|| {
-            matches!(args.backend_connectivity, BackendConnectivity::Reverse)
+            reuse_reverse_quic_trust
                 .then_some(args.tls_cert_path.as_ref())
                 .flatten()
         })
@@ -1435,7 +1441,7 @@ mod tests {
     }
 
     #[test]
-    fn reverse_mode_reuses_quic_trust_when_grpc_override_is_unset() {
+    fn reverse_mode_reuses_quic_trust_for_https_when_grpc_override_is_unset() {
         let root = tempfile::tempdir().expect("test directory should create");
         let path = root.path().join("shared-ca.pem");
         let mut params = rcgen::CertificateParams::default();
@@ -1451,6 +1457,8 @@ mod tests {
         let (args, _) = startup(&[
             "--backend-connectivity",
             "reverse",
+            "--stargate-address",
+            "https://stargate.example.test:50071",
             "--tls-cert-path",
             &path,
         ]);
@@ -1460,6 +1468,28 @@ mod tests {
                 .expect("reverse-mode shared CA should load")
                 .as_deref(),
             Some(pem.as_slice())
+        );
+    }
+
+    #[test]
+    fn reverse_mode_does_not_reuse_quic_trust_for_plaintext_grpc() {
+        let root = tempfile::tempdir().expect("test directory should create");
+        let path = root.path().join("quic-ca.pem");
+        std::fs::write(&path, b"not a gRPC CA bundle").expect("QUIC trust should write");
+        let path = path.to_string_lossy().into_owned();
+        let (args, _) = startup(&[
+            "--backend-connectivity",
+            "reverse",
+            "--stargate-address",
+            "http://stargate.example.test:50071",
+            "--tls-cert-path",
+            &path,
+        ]);
+
+        assert!(
+            load_grpc_tls_ca_cert(&args)
+                .expect("plaintext gRPC should not load the QUIC trust bundle")
+                .is_none()
         );
     }
 


### PR DESCRIPTION
## TL;DR

Keep the reverse-QUIC trust bundle out of plaintext Stargate gRPC registration while preserving verified HTTPS registration.

## Additional Details

Pylon reverse mode uses `STARGATE_TLS_CERT_PATH` as its QUIC trust anchor. NVCA also injected the same bundle through `STARGATE_GRPC_TLS_CA_CERT_PATH`. Current Pylon releases then attempted to load that gRPC CA even when `--stargate-address` used explicit HTTP, preventing worker registration.

This PR fixes both ends of that contract:

- NVCA injects the merged bundle as a gRPC CA only for an HTTPS request-router address.
- Pylon falls back to the reverse-QUIC trust bundle only for an HTTPS registration seed.
- An explicit gRPC CA retains precedence.
- Reverse QUIC continues using its existing trust input.

The paired changes belong together because either change alone still leaves the current released counterpart applying the CA to plaintext registration.

## Customer Release Notes

Self-managed LLM workers can register over explicit plaintext in-cluster gRPC while continuing to authenticate reverse QUIC independently.

## Plan Summary

No Kubernetes resources or public API shapes change. Worker environment injection becomes scheme-aware.

## Usage

No operator action is required. HTTPS endpoints continue to use the configured trust bundle. Explicit HTTP and scheme-less development endpoints remain plaintext.

## For the Reviewer

Please review the address-precedence behavior in `llmWorkerUsesHTTPSRegistration` and the Pylon fallback ordering in `load_grpc_tls_ca_cert`.

## For QA

QA needed: publish and consume both component artifacts through #1362, then run the final self-managed BDD integration.

Tests run:

- `go test ./internal/transporttls` with the required NVCA linker flag
- `go test ./pkg/nvca -run TestCreatePodArtifactInstancesTransportTLSBundleInjectsOnlyLLMWorker` with the required linker flag
- `go test ./internal/miniservice` with Kubernetes 1.34 envtest assets and the required linker flag
- `golangci-lint --new-from-rev=origin/main` for the affected NVCA packages
- `cargo test -p pylon`
- `cargo clippy -p pylon --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Notes

The NVCA `make test` wrapper requires an ignored `.env` file that is absent from the public checkout, so the affected packages were run directly with the documented linker and envtest settings.

Package-wide NVCA lint still reports three existing `goconst` findings in unrelated MiniService files. Linting only changes from `origin/main` reports zero issues.

## Issues

Closes #1367

## Related Pull Requests

- #1363
- Blocked release-consumption follow-up: #1362

## Dependencies

No new or updated third-party dependencies. NOTICE is unchanged.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS configuration for LLM workers using plaintext router registration.
  * gRPC CA certificates are now provided only when HTTPS registration is detected.
  * Explicitly configured certificate paths remain supported.
  * Prevented QUIC trust bundles from being incorrectly reused as gRPC CA certificates for HTTP registration.
  * Added coverage for HTTPS detection across command-line and environment-based settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->