### PR TITLE
fix(stack): preserve invocation environment overrides

### DIFF
--- a/deploy/stacks/self-managed/Makefile
+++ b/deploy/stacks/self-managed/Makefile
@@ -15,6 +15,7 @@ test:
 	@tests/llm-pki-release.sh
 	@tests/check-llm-pki-issuer.sh
 	@tests/pdb-value-wiring.sh
+	@tests/invocation-env-wiring.sh
 	@tests/invocation-tracing-baggage.sh
 	@tests/image-override-wiring.sh
 	@tests/sidecar-registry-wiring.sh

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -509,7 +509,8 @@ ess:
 
 invocation:
   env:
-    NATS_PROPERTIES__REGION: local
+    # Keep request subjects aligned with the API and worker consumers.
+    NATS_PROPERTIES__REGION: ncp
   podDisruptionBudget:
     enabled: false
     maxUnavailable: 1

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -555,6 +555,25 @@ api:
     {{- toYaml $apiEnv | nindent 4 }}
 
 invocation:
+  {{- $configuredInvocationEnv := dig "invocation" "env" dict .Values }}
+  {{- if not (kindIs "map" $configuredInvocationEnv) }}
+  {{- fail "invocation.env must be a map" }}
+  {{- end }}
+  {{- $invocationEnv := dict }}
+  {{- if .Values.global.observability.tracing.enabled }}
+  {{- $_ := set $invocationEnv "SERVER__TRACING__ENDPOINT_IP" (printf "%s://%s" .Values.global.observability.tracing.collectorProtocol .Values.global.observability.tracing.collectorEndpoint) }}
+  {{- $_ := set $invocationEnv "SERVER__TRACING__ENDPOINT_PORT" .Values.global.observability.tracing.collectorPort }}
+  {{- else }}
+  {{- $_ := set $invocationEnv "SERVER__ENVFILTER_DIRECTIVE" "otel::tracing=off,otel=off,server=trace,info" }}
+  {{- end }}
+  {{- if .Values.rateLimiter.enabled }}
+  {{- $_ := set $invocationEnv "RATE_LIMIT_ENABLED" "true" }}
+  {{- $_ := set $invocationEnv "RATE_LIMIT_ADDRESS" "http://ratelimiter.nvcf.svc.cluster.local:7777" }}
+  {{- end }}
+  {{- with $invocationWorkerBaseURL }}
+  {{- $_ := set $invocationEnv "WORKER_STREAM_PROPERTIES__SELF_ADDRESS" . }}
+  {{- end }}
+  {{- $invocationEnv = mergeOverwrite $invocationEnv (deepCopy $configuredInvocationEnv) }}
   fullnameOverride: invocation-service
   {{- if .Values.global.imagePullSecrets }}
   imagePullSecrets:
@@ -571,20 +590,7 @@ invocation:
   {{- end }}
 
   env:
-    # Observability
-    {{- if .Values.global.observability.tracing.enabled }}
-    SERVER__TRACING__ENDPOINT_IP: "{{ .Values.global.observability.tracing.collectorProtocol }}://{{ .Values.global.observability.tracing.collectorEndpoint }}"
-    SERVER__TRACING__ENDPOINT_PORT: {{ .Values.global.observability.tracing.collectorPort }}
-    {{- else }}
-    SERVER__ENVFILTER_DIRECTIVE: "otel::tracing=off,otel=off,server=trace,info"
-    {{- end }}
-    {{- if .Values.rateLimiter.enabled }}
-    RATE_LIMIT_ENABLED: "true"
-    RATE_LIMIT_ADDRESS: "http://ratelimiter.nvcf.svc.cluster.local:7777"
-    {{- end }}
-    {{- with $invocationWorkerBaseURL }}
-    WORKER_STREAM_PROPERTIES__SELF_ADDRESS: {{ . | quote }}
-    {{- end }}
+    {{- toYaml $invocationEnv | nindent 4 }}
   {{- with dig "invocation" "tracing" "baggageAttributeAllowlist" nil .Values }}
   tracing:
     baggageAttributeAllowlist:

--- a/deploy/stacks/self-managed/tests/invocation-env-wiring.sh
+++ b/deploy/stacks/self-managed/tests/invocation-env-wiring.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+work_dir="$(mktemp -d)"
+test_stack_dir="$work_dir/self-managed"
+environment_name="invocation-env-wiring-test"
+environment_file="$test_stack_dir/environments/$environment_name.yaml"
+secrets_file="$test_stack_dir/secrets/$environment_name-secrets.yaml"
+trap 'rm -rf "$work_dir"' EXIT
+
+fail() {
+  echo "invocation-env-wiring: $*" >&2
+  exit 1
+}
+
+mkdir -p "$test_stack_dir"
+cp -R "$stack_dir"/. "$test_stack_dir"
+printf '{}\n' >"$secrets_file"
+
+write_environment() {
+  cat >"$environment_file"
+}
+
+render_invocation_values() {
+  local output_file="$1"
+
+  HELMFILE_ENV="$environment_name" \
+    HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" \
+    helmfile \
+      --file "$test_stack_dir/helmfile.d/02-core.yaml.gotmpl" \
+      --environment default \
+      --state-values-set ingress.gatewayApi.controllerNamespace=envoy-gateway-system \
+      --state-values-set ingress.gatewayApi.gateways.shared.name=shared-gw \
+      --state-values-set ingress.gatewayApi.gateways.shared.namespace=envoy-gateway-system \
+      --state-values-set ingress.gatewayApi.gateways.grpc.name=grpc-gw \
+      --state-values-set ingress.gatewayApi.gateways.grpc.namespace=envoy-gateway-system \
+      --selector name=invocation-service \
+      write-values \
+      --output-file-template "$output_file"
+}
+
+assert_yq_eq() {
+  local file="$1"
+  local expression="$2"
+  local expected="$3"
+  local actual
+
+  actual="$(yq ea -r "$expression" "$file")"
+  [[ "$actual" == "$expected" ]] ||
+    fail "expected $expression to equal '$expected', got '$actual'"
+}
+
+default_values="$work_dir/default-values.yaml"
+custom_values="$work_dir/custom-values.yaml"
+invalid_values="$work_dir/invalid-values.yaml"
+invalid_log="$work_dir/invalid.log"
+
+write_environment <<'EOF'
+global:
+  image:
+    registry: nvcr.io
+    repository: test/nvcf
+EOF
+
+render_invocation_values "$default_values" >/dev/null
+assert_yq_eq \
+  "$default_values" \
+  '.invocation.env.NATS_PROPERTIES__REGION' \
+  ncp
+assert_yq_eq \
+  "$default_values" \
+  '.invocation.env.RATE_LIMIT_ENABLED' \
+  true
+assert_yq_eq \
+  "$default_values" \
+  '.invocation.env.SERVER__ENVFILTER_DIRECTIVE' \
+  otel::tracing=off,otel=off,server=trace,info
+
+write_environment <<'EOF'
+global:
+  image:
+    registry: nvcr.io
+    repository: test/nvcf
+invocation:
+  env:
+    CUSTOM_INVOCATION_ENV: retained
+    NATS_PROPERTIES__REGION: example-region
+    SERVER__ENVFILTER_DIRECTIVE: custom-filter
+EOF
+
+render_invocation_values "$custom_values" >/dev/null
+assert_yq_eq \
+  "$custom_values" \
+  '.invocation.env.CUSTOM_INVOCATION_ENV' \
+  retained
+assert_yq_eq \
+  "$custom_values" \
+  '.invocation.env.NATS_PROPERTIES__REGION' \
+  example-region
+assert_yq_eq \
+  "$custom_values" \
+  '.invocation.env.SERVER__ENVFILTER_DIRECTIVE' \
+  custom-filter
+assert_yq_eq \
+  "$custom_values" \
+  '.invocation.env.RATE_LIMIT_ADDRESS' \
+  http://ratelimiter.nvcf.svc.cluster.local:7777
+
+write_environment <<'EOF'
+global:
+  image:
+    registry: nvcr.io
+    repository: test/nvcf
+invocation:
+  env: invalid
+EOF
+
+if render_invocation_values "$invalid_values" >"$invalid_log" 2>&1; then
+  fail "expected a non-map invocation.env value to fail"
+fi
+grep -Fq 'invocation.env must be a map' "$invalid_log" ||
+  fail "missing invocation.env validation error"
+
+echo "invocation-env-wiring: all checks passed"


### PR DESCRIPTION
## TL;DR

Preserve self-managed `invocation.env` values during global values rendering and declare the current working request-queue region (`ncp`) explicitly.

## Additional Details

The base environment declares invocation settings under `invocation.env`, but `global.yaml.gotmpl` previously rebuilt the entire environment from tracing, rate-limiter, and worker-stream entries. It did not merge the configured map. `NATS_PROPERTIES__REGION: local` was therefore silently discarded, and invocation continued using its application fallback of `ncp`.

The template now builds the stack-owned defaults first and merges configured environment values afterward. Explicit environment values take precedence while unrelated generated settings remain present. A non-map `invocation.env` now fails with a direct validation message.

The checked-in region changes from the ineffective `local` declaration to `ncp`. This preserves current runtime behavior and keeps invocation request subjects aligned with the API and worker consumers.

## Customer Release Notes

Self-managed invocation environment overrides are now applied consistently, including explicit request-queue region configuration.

## Plan Summary

No Kubernetes resources, sizing, storage, or deployment order change. The invocation ConfigMap receives the corrected merged environment.

## Usage

Environment-specific invocation settings can be supplied through the existing map:

```yaml
invocation:
  env:
    CUSTOM_INVOCATION_ENV: value
```

Changing `NATS_PROPERTIES__REGION` requires the API, workers, and NATS placement configuration to use the same logical region.

## For the Reviewer

Please focus on merge precedence in `global.yaml.gotmpl`: stack-generated defaults are the base, and explicit `invocation.env` values are the final override.

## For QA

No separate QA run is needed for this configuration-only fix. Automated rendering tests cover the default, a custom override, generated-value preservation, and invalid input.

Tests run:

- `make test` from `deploy/stacks/self-managed`
- `bash -n deploy/stacks/self-managed/tests/invocation-env-wiring.sh`
- `git diff --check`

## Notes

This PR is independent of #1370. That PR makes the bundled NATS server eligible for both request-stream creators; this PR fixes environment-value propagation without changing the active region.

## Issues

Closes #1378

## Related Pull Requests

- #1370
- #1363

## Dependencies

No new or updated third-party dependencies. No license review or NOTICE update is required.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected invocation service routing to align requests with API and worker consumers.
  * Improved invocation environment configuration, including tracing, rate limiting, and worker settings.
  * Preserved valid custom environment values while rejecting invalid configuration formats.

* **Tests**
  * Added integration coverage for default, customized, and invalid invocation environment configurations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->