### PR TITLE
fix(stack): bump self-managed stack chart pins

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
@@ -108,7 +108,7 @@ releases:
 
   # --- NVCF NCP Dependencies ---
   - name: nats
-    version: 0.7.1
+    version: 0.8.1
     condition: nats.enabled # From defaults.yaml or env overrides
     namespace: nats-system
     <<: *dependency # Inherits base values from the dependency template

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -71,7 +71,7 @@ releases:
       - template: service
 
   - name: invocation-service
-    version: 1.5.6
+    version: 1.6.0
     namespace: nvcf
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -168,7 +168,7 @@ releases:
     {{- $llmRequestRouterChartPath := dig "addons" "llm" "requestRouter" "chartPath" "" .Values }}
     chart: {{ $llmRequestRouterChartPath | default "nvcf/helm-nvcf-llm-request-router" | quote }}
     {{- if not $llmRequestRouterChartPath }}
-    version: 1.12.1
+    version: 1.12.2
     {{- end }}
     namespace: nvcf
     condition: addons.llm.enabled


### PR DESCRIPTION
Opened by `.github/workflows/stack-pin-bump.yml` when `deploy/helm/http-invocation/v1.6.0` was published.

The released tag carries the version, so this is a direct pin update rather than a lookup of the newest published chart.

Release notes: https://github.com/NVIDIA/nvcf/releases/tag/deploy/helm/http-invocation/v1.6.0

If this pull request sits unmerged, later chart releases add their bumps to the same branch, so merging it applies all of them.

Github commit:
fix(stack): pin http-invocation/v1.6.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the invocation service to version 1.6.0.
  * Updated the default language model request router to version 1.12.2.
  * Updated the NATS service dependency to version 0.8.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->