### PR TITLE
fix(worker): rotate the QUIC transport after consecutive dial failures

### DIFF
--- a/src/libraries/go/worker/proxy/BUILD.bazel
+++ b/src/libraries/go/worker/proxy/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
     name = "proxy_test",
     srcs = [
         "h3_addrlist_test.go",
+        "h3_rotate_test.go",
         "proxy_e2e_test.go",
         "proxy_extra_test.go",
         "proxy_test.go",

--- a/src/libraries/go/worker/proxy/h3.go
+++ b/src/libraries/go/worker/proxy/h3.go
@@ -69,11 +69,96 @@ func createH3RoundTripper() *h3ConnectionCache {
 // mostly copied from http3.Transport because we need to hijack the http3 client stream
 // and when doing that we can't use the built in http3.Transport.RoundTrip function which caches
 // connections.
+// dialFailuresBeforeRotate is how many consecutive failed dials, across any
+// hosts, are treated as evidence that the shared UDP socket itself is dead
+// rather than that one proxy host is unreachable. Measured on stage: healthy
+// operation produces zero dial failures over long windows, while a blackholed
+// socket produces hundreds within a single 60s window, so anything in between
+// separates the two cleanly.
+const dialFailuresBeforeRotate = 3
+
 type h3ConnectionCache struct {
 	wrappedTransport *http3.Transport
-	quicTransport    *quic.Transport
 	mutex            sync.Mutex
 	clients          map[string]*roundTripperWithCount
+
+	// transportMu guards quicTransport and dialFailures. It is deliberately
+	// not the mutex above: dial runs on the goroutine spawned by getClient,
+	// which does not hold that lock, so quicTransport was previously read and
+	// written with no synchronisation at all.
+	transportMu   sync.Mutex
+	quicTransport *quic.Transport
+	dialFailures  int
+}
+
+// transport returns the shared QUIC transport, creating it on first use.
+//
+// Every connection dialled from one quic.Transport leaves from its single UDP
+// socket, so the whole worker shares one source port. An AWS NLB hashes UDP
+// flows on the 5-tuple, which means that port decides which proxy pod every
+// dial reaches. If the flow is pinned to a pod that has gone away, retrying
+// cannot help: the retry leaves from the same port and lands on the same dead
+// entry. Rotating the socket is the only thing the worker can do to change it.
+func (t *h3ConnectionCache) transport() (*quic.Transport, error) {
+	t.transportMu.Lock()
+	defer t.transportMu.Unlock()
+	return t.transportLocked()
+}
+
+func (t *h3ConnectionCache) transportLocked() (*quic.Transport, error) {
+	if t.quicTransport == nil {
+		udpConn, err := net.ListenUDP("udp", nil)
+		if err != nil {
+			return nil, err
+		}
+		t.quicTransport = &quic.Transport{Conn: udpConn}
+	}
+	return t.quicTransport, nil
+}
+
+// noteDialResult records the outcome of a dial and rotates the shared socket
+// once consecutive failures cross the threshold. A success resets the count,
+// so an established worker never rotates on isolated failures.
+func (t *h3ConnectionCache) noteDialResult(dialed *quic.Transport, dialErr error) {
+	t.transportMu.Lock()
+	defer t.transportMu.Unlock()
+
+	if dialErr == nil {
+		t.dialFailures = 0
+		return
+	}
+	t.dialFailures++
+	if t.dialFailures < dialFailuresBeforeRotate {
+		return
+	}
+	// Another dial may have rotated already while this one was in flight.
+	// Rotating again would discard a socket that has not been shown to be
+	// bad and would reset the evidence we just gathered.
+	if t.quicTransport == nil || t.quicTransport != dialed {
+		return
+	}
+	zap.L().Warn("rotating quic transport after consecutive dial failures",
+		zap.Int("consecutive_failures", t.dialFailures),
+		zap.String("local_addr", t.quicTransport.Conn.LocalAddr().String()))
+	t.closeTransportLocked()
+	t.dialFailures = 0
+}
+
+// closeTransportLocked releases the shared socket. The next dial recreates it
+// via transportLocked, which yields a fresh ephemeral port. Errors are logged
+// rather than returned: the socket is being discarded either way, and failing
+// to close it must not stop a new one being created.
+func (t *h3ConnectionCache) closeTransportLocked() {
+	if t.quicTransport == nil {
+		return
+	}
+	if err := t.quicTransport.Close(); err != nil {
+		zap.L().Warn("closing quic transport", zap.Error(err))
+	}
+	if err := t.quicTransport.Conn.Close(); err != nil {
+		zap.L().Warn("closing quic transport socket", zap.Error(err))
+	}
+	t.quicTransport = nil
 }
 
 func (t *h3ConnectionCache) getDialedClient(ctx context.Context, hostname string) (rtc *roundTripperWithCount, isReused bool, err error) {
@@ -169,12 +254,9 @@ func (t *h3ConnectionCache) dial(ctx context.Context, hostname string) (*quic.Co
 
 	dial := t.wrappedTransport.Dial
 	if dial == nil {
-		if t.quicTransport == nil {
-			udpConn, err := net.ListenUDP("udp", nil)
-			if err != nil {
-				return nil, nil, err
-			}
-			t.quicTransport = &quic.Transport{Conn: udpConn}
+		quicTransport, err := t.transport()
+		if err != nil {
+			return nil, nil, err
 		}
 		dial = func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (*quic.Conn, error) {
 			network := "udp"
@@ -182,7 +264,8 @@ func (t *h3ConnectionCache) dial(ctx context.Context, hostname string) (*quic.Co
 			if err != nil {
 				return nil, err
 			}
-			conn, err := t.quicTransport.DialEarly(ctx, udpAddr, tlsCfg, cfg)
+			conn, err := quicTransport.DialEarly(ctx, udpAddr, tlsCfg, cfg)
+			t.noteDialResult(quicTransport, err)
 			return conn, err
 		}
 	}
@@ -233,15 +316,9 @@ func (t *h3ConnectionCache) Close() error {
 		}
 	}
 	t.clients = nil
-	if t.quicTransport != nil {
-		if err := t.quicTransport.Close(); err != nil {
-			return err
-		}
-		if err := t.quicTransport.Conn.Close(); err != nil {
-			return err
-		}
-		t.quicTransport = nil
-	}
+	t.transportMu.Lock()
+	defer t.transportMu.Unlock()
+	t.closeTransportLocked()
 	return nil
 }
 

--- a/src/libraries/go/worker/proxy/h3.go
+++ b/src/libraries/go/worker/proxy/h3.go
@@ -123,6 +123,15 @@ func (t *h3ConnectionCache) noteDialResult(dialed *quic.Transport, dialErr error
 	t.transportMu.Lock()
 	defer t.transportMu.Unlock()
 
+	// A dial that began before a rotation says nothing about the socket in use
+	// now, so it must not touch the counter at all. Counting a stale failure
+	// would let it rotate a replacement that has not failed on its own, and a
+	// stale success would clear failures the current socket really did have.
+	// This check therefore has to come before both the reset and the
+	// increment, not after them.
+	if t.quicTransport == nil || t.quicTransport != dialed {
+		return
+	}
 	if dialErr == nil {
 		t.dialFailures = 0
 		return
@@ -131,33 +140,50 @@ func (t *h3ConnectionCache) noteDialResult(dialed *quic.Transport, dialErr error
 	if t.dialFailures < dialFailuresBeforeRotate {
 		return
 	}
-	// Another dial may have rotated already while this one was in flight.
-	// Rotating again would discard a socket that has not been shown to be
-	// bad and would reset the evidence we just gathered.
-	if t.quicTransport == nil || t.quicTransport != dialed {
+	t.rotateLocked()
+}
+
+// rotateLocked replaces the shared socket with a freshly bound one.
+//
+// The replacement is bound while the old socket is still open, deliberately.
+// Closing first releases the port and the kernel is free to hand the same one
+// back, which would leave the worker on the identical 5-tuple and defeat the
+// rotation without any outward sign that it had failed.
+func (t *h3ConnectionCache) rotateLocked() {
+	old := t.quicTransport
+	udpConn, err := net.ListenUDP("udp", nil)
+	if err != nil {
+		// Keep the existing socket rather than leaving the worker with none.
+		// The next failure retries the rotation.
+		zap.L().Warn("failed to bind a replacement quic socket", zap.Error(err))
 		return
 	}
 	zap.L().Warn("rotating quic transport after consecutive dial failures",
 		zap.Int("consecutive_failures", t.dialFailures),
-		zap.String("local_addr", t.quicTransport.Conn.LocalAddr().String()))
-	t.closeTransportLocked()
+		zap.String("old_local_addr", old.Conn.LocalAddr().String()),
+		zap.String("new_local_addr", udpConn.LocalAddr().String()))
+	t.quicTransport = &quic.Transport{Conn: udpConn}
 	t.dialFailures = 0
+	closeTransport(old)
 }
 
-// closeTransportLocked releases the shared socket. The next dial recreates it
-// via transportLocked, which yields a fresh ephemeral port. Errors are logged
-// rather than returned: the socket is being discarded either way, and failing
-// to close it must not stop a new one being created.
-func (t *h3ConnectionCache) closeTransportLocked() {
-	if t.quicTransport == nil {
+// closeTransport releases a transport and its socket. Errors are logged rather
+// than returned: the socket is being discarded either way, and failing to close
+// it must not stop the replacement being used.
+func closeTransport(tr *quic.Transport) {
+	if tr == nil {
 		return
 	}
-	if err := t.quicTransport.Close(); err != nil {
+	if err := tr.Close(); err != nil {
 		zap.L().Warn("closing quic transport", zap.Error(err))
 	}
-	if err := t.quicTransport.Conn.Close(); err != nil {
+	if err := tr.Conn.Close(); err != nil {
 		zap.L().Warn("closing quic transport socket", zap.Error(err))
 	}
+}
+
+func (t *h3ConnectionCache) closeTransportLocked() {
+	closeTransport(t.quicTransport)
 	t.quicTransport = nil
 }
 

--- a/src/libraries/go/worker/proxy/h3.go
+++ b/src/libraries/go/worker/proxy/h3.go
@@ -20,6 +20,7 @@ package proxy
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"math"
 	"net"
 	"os"
@@ -63,20 +64,25 @@ func createH3RoundTripper() *h3ConnectionCache {
 	if utils.LevelFromEnv().Level() == zap.DebugLevel {
 		h3.QUICConfig.Tracer = qlog.DefaultConnectionTracer
 	}
-	return &h3ConnectionCache{wrappedTransport: h3, clients: make(map[string]*roundTripperWithCount)}
+	return &h3ConnectionCache{
+		wrappedTransport: h3,
+		clients:          make(map[string]*roundTripperWithCount),
+		dialFailures:     make(map[string]int),
+	}
 }
 
 // mostly copied from http3.Transport because we need to hijack the http3 client stream
 // and when doing that we can't use the built in http3.Transport.RoundTrip function which caches
 // connections.
-// dialFailuresBeforeRotate is how many consecutive failed dials, across any
-// hosts, are treated as evidence that the shared UDP socket itself is dead
-// rather than that one proxy host is unreachable. Measured on stage: healthy
-// operation produces zero dial failures over long windows, while a blackholed
-// socket produces hundreds within a single 60s window, so anything in between
-// separates the two cleanly.
+// dialFailuresBeforeRotate is how many consecutive network timeout failures
+// to one resolved destination are treated as evidence that its UDP flow is
+// blackholed. Measured on stage: healthy operation produces zero dial failures
+// over long windows, while a blackholed flow produces hundreds within a single
+// 60s window, so anything in between separates the two cleanly.
 const dialFailuresBeforeRotate = 3
 
+// h3ConnectionCache reuses HTTP/3 clients by hostname and manages the shared
+// QUIC transport used to dial them.
 type h3ConnectionCache struct {
 	wrappedTransport *http3.Transport
 	mutex            sync.Mutex
@@ -88,17 +94,18 @@ type h3ConnectionCache struct {
 	// written with no synchronisation at all.
 	transportMu   sync.Mutex
 	quicTransport *quic.Transport
-	dialFailures  int
+	dialFailures  map[string]int
 }
 
 // transport returns the shared QUIC transport, creating it on first use.
 //
 // Every connection dialled from one quic.Transport leaves from its single UDP
-// socket, so the whole worker shares one source port. An AWS NLB hashes UDP
-// flows on the 5-tuple, which means that port decides which proxy pod every
-// dial reaches. If the flow is pinned to a pod that has gone away, retrying
-// cannot help: the retry leaves from the same port and lands on the same dead
-// entry. Rotating the socket is the only thing the worker can do to change it.
+// socket, so the whole worker shares one source port. For a fixed destination,
+// an AWS NLB hashes UDP flows on the 5-tuple, which means that port decides
+// which proxy pod every dial reaches. If the flow is pinned to a pod that has
+// gone away, retrying cannot help: the retry leaves from the same port and
+// lands on the same dead entry. Rotating the socket is the only thing the
+// worker can do to change it.
 func (t *h3ConnectionCache) transport() (*quic.Transport, error) {
 	t.transportMu.Lock()
 	defer t.transportMu.Unlock()
@@ -117,9 +124,10 @@ func (t *h3ConnectionCache) transportLocked() (*quic.Transport, error) {
 }
 
 // noteDialResult records the outcome of a dial and rotates the shared socket
-// once consecutive failures cross the threshold. A success resets the count,
-// so an established worker never rotates on isolated failures.
-func (t *h3ConnectionCache) noteDialResult(dialed *quic.Transport, dialErr error) {
+// once consecutive network timeouts to one destination cross the threshold.
+// A success resets only that destination, so unrelated flows cannot suppress
+// or trigger rotation.
+func (t *h3ConnectionCache) noteDialResult(ctx context.Context, dialed *quic.Transport, destination string, dialErr error) {
 	t.transportMu.Lock()
 	defer t.transportMu.Unlock()
 
@@ -133,14 +141,29 @@ func (t *h3ConnectionCache) noteDialResult(dialed *quic.Transport, dialErr error
 		return
 	}
 	if dialErr == nil {
-		t.dialFailures = 0
+		delete(t.dialFailures, destination)
 		return
 	}
-	t.dialFailures++
-	if t.dialFailures < dialFailuresBeforeRotate {
+	if !isTransportDialFailure(ctx, dialErr) {
 		return
 	}
-	t.rotateLocked()
+	if t.dialFailures == nil {
+		t.dialFailures = make(map[string]int)
+	}
+	t.dialFailures[destination]++
+	failures := t.dialFailures[destination]
+	if failures < dialFailuresBeforeRotate {
+		return
+	}
+	t.rotateLocked(destination, failures)
+}
+
+func isTransportDialFailure(ctx context.Context, dialErr error) bool {
+	if dialErr == nil || context.Cause(ctx) != nil {
+		return false
+	}
+	var networkErr net.Error
+	return errors.As(dialErr, &networkErr) && networkErr.Timeout()
 }
 
 // rotateLocked replaces the shared socket with a freshly bound one.
@@ -149,21 +172,25 @@ func (t *h3ConnectionCache) noteDialResult(dialed *quic.Transport, dialErr error
 // Closing first releases the port and the kernel is free to hand the same one
 // back, which would leave the worker on the identical 5-tuple and defeat the
 // rotation without any outward sign that it had failed.
-func (t *h3ConnectionCache) rotateLocked() {
+func (t *h3ConnectionCache) rotateLocked(destination string, failures int) {
 	old := t.quicTransport
 	udpConn, err := net.ListenUDP("udp", nil)
 	if err != nil {
 		// Keep the existing socket rather than leaving the worker with none.
 		// The next failure retries the rotation.
-		zap.L().Warn("failed to bind a replacement quic socket", zap.Error(err))
+		zap.L().Warn("failed to bind a replacement quic socket",
+			zap.Error(err),
+			zap.String("destination", destination),
+			zap.Int("consecutive_failures", failures))
 		return
 	}
 	zap.L().Warn("rotating quic transport after consecutive dial failures",
-		zap.Int("consecutive_failures", t.dialFailures),
+		zap.String("destination", destination),
+		zap.Int("consecutive_failures", failures),
 		zap.String("old_local_addr", old.Conn.LocalAddr().String()),
 		zap.String("new_local_addr", udpConn.LocalAddr().String()))
 	t.quicTransport = &quic.Transport{Conn: udpConn}
-	t.dialFailures = 0
+	clear(t.dialFailures)
 	closeTransport(old)
 }
 
@@ -185,6 +212,7 @@ func closeTransport(tr *quic.Transport) {
 func (t *h3ConnectionCache) closeTransportLocked() {
 	closeTransport(t.quicTransport)
 	t.quicTransport = nil
+	clear(t.dialFailures)
 }
 
 func (t *h3ConnectionCache) getDialedClient(ctx context.Context, hostname string) (rtc *roundTripperWithCount, isReused bool, err error) {
@@ -291,7 +319,7 @@ func (t *h3ConnectionCache) dial(ctx context.Context, hostname string) (*quic.Co
 				return nil, err
 			}
 			conn, err := quicTransport.DialEarly(ctx, udpAddr, tlsCfg, cfg)
-			t.noteDialResult(quicTransport, err)
+			t.noteDialResult(ctx, quicTransport, udpAddr.String(), err)
 			return conn, err
 		}
 	}

--- a/src/libraries/go/worker/proxy/h3.go
+++ b/src/libraries/go/worker/proxy/h3.go
@@ -184,7 +184,7 @@ func (t *h3ConnectionCache) rotateLocked(destination string, failures int) {
 			zap.Int("consecutive_failures", failures))
 		return
 	}
-	zap.L().Warn("rotating quic transport after consecutive dial failures",
+	zap.L().Info("rotating quic transport after consecutive dial failures",
 		zap.String("destination", destination),
 		zap.Int("consecutive_failures", failures),
 		zap.String("old_local_addr", old.Conn.LocalAddr().String()),

--- a/src/libraries/go/worker/proxy/h3_rotate_test.go
+++ b/src/libraries/go/worker/proxy/h3_rotate_test.go
@@ -18,13 +18,25 @@ limitations under the License.
 package proxy
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
 )
 
+const testDestination = "192.0.2.1:443"
+
+type dialTimeoutError struct{}
+
+func (dialTimeoutError) Error() string   { return "timeout: no recent network activity" }
+func (dialTimeoutError) Timeout() bool   { return true }
+func (dialTimeoutError) Temporary() bool { return false }
+
 func newTestCache() *h3ConnectionCache {
-	return &h3ConnectionCache{clients: make(map[string]*roundTripperWithCount)}
+	return &h3ConnectionCache{
+		clients:      make(map[string]*roundTripperWithCount),
+		dialFailures: make(map[string]int),
+	}
 }
 
 // One transport is one socket: every dial shares a single source port. This is
@@ -60,15 +72,15 @@ func TestRotatesOnlyAfterThresholdAndChangesSourcePort(t *testing.T) {
 	}
 	portBefore := before.Conn.LocalAddr().String()
 
-	dialErr := errors.New("timeout: no recent network activity")
+	dialErr := dialTimeoutError{}
 	for i := 1; i < dialFailuresBeforeRotate; i++ {
-		c.noteDialResult(before, dialErr)
+		c.noteDialResult(context.Background(), before, testDestination, dialErr)
 		if c.quicTransport != before {
 			t.Fatalf("rotated after %d failures, want %d", i, dialFailuresBeforeRotate)
 		}
 	}
 
-	c.noteDialResult(before, dialErr)
+	c.noteDialResult(context.Background(), before, testDestination, dialErr)
 	after, err := c.transport()
 	if err != nil {
 		t.Fatalf("transport after rotation: %v", err)
@@ -82,8 +94,64 @@ func TestRotatesOnlyAfterThresholdAndChangesSourcePort(t *testing.T) {
 	if after.Conn.LocalAddr().String() == portBefore {
 		t.Fatal("expected a new source port after rotation; the NLB hashes on it")
 	}
-	if c.dialFailures != 0 {
-		t.Fatalf("dialFailures = %d after rotation, want 0", c.dialFailures)
+	if len(c.dialFailures) != 0 {
+		t.Fatalf("dialFailures = %v after rotation, want empty", c.dialFailures)
+	}
+}
+
+func TestDialFailuresAreScopedToDestination(t *testing.T) {
+	c := newTestCache()
+	defer c.Close()
+
+	tr, err := c.transport()
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+	dialErr := dialTimeoutError{}
+	destinationA := "192.0.2.1:443"
+	destinationB := "192.0.2.2:443"
+
+	for range dialFailuresBeforeRotate - 1 {
+		c.noteDialResult(context.Background(), tr, destinationA, dialErr)
+	}
+	c.noteDialResult(context.Background(), tr, destinationB, dialErr)
+	if c.quicTransport != tr {
+		t.Fatal("failures to different destinations triggered rotation")
+	}
+
+	c.noteDialResult(context.Background(), tr, destinationB, nil)
+	if got := c.dialFailures[destinationA]; got != dialFailuresBeforeRotate-1 {
+		t.Fatalf("success on destination B reset destination A to %d", got)
+	}
+
+	c.noteDialResult(context.Background(), tr, destinationA, dialErr)
+	if c.quicTransport == tr {
+		t.Fatal("destination A did not rotate after reaching its threshold")
+	}
+}
+
+func TestOnlyUncancelledNetworkTimeoutsCountAsDialFailures(t *testing.T) {
+	c := newTestCache()
+	defer c.Close()
+
+	tr, err := c.transport()
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+
+	for range dialFailuresBeforeRotate {
+		c.noteDialResult(context.Background(), tr, testDestination, errors.New("tls: failed to verify certificate"))
+	}
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	for range dialFailuresBeforeRotate {
+		c.noteDialResult(canceledCtx, tr, testDestination, dialTimeoutError{})
+	}
+	if c.quicTransport != tr {
+		t.Fatal("non-transport dial errors triggered rotation")
+	}
+	if len(c.dialFailures) != 0 {
+		t.Fatalf("non-transport dial errors changed failure state: %v", c.dialFailures)
 	}
 }
 
@@ -98,9 +166,9 @@ func TestStaleFailuresDoNotCountAgainstReplacement(t *testing.T) {
 	if err != nil {
 		t.Fatalf("transport: %v", err)
 	}
-	dialErr := errors.New("timeout: no recent network activity")
+	dialErr := dialTimeoutError{}
 	for range dialFailuresBeforeRotate {
-		c.noteDialResult(stale, dialErr)
+		c.noteDialResult(context.Background(), stale, testDestination, dialErr)
 	}
 	replacement := c.quicTransport
 	if replacement == stale {
@@ -109,14 +177,14 @@ func TestStaleFailuresDoNotCountAgainstReplacement(t *testing.T) {
 
 	// Several more results from the old socket arrive late.
 	for range dialFailuresBeforeRotate * 2 {
-		c.noteDialResult(stale, dialErr)
+		c.noteDialResult(context.Background(), stale, testDestination, dialErr)
 	}
-	if c.dialFailures != 0 {
-		t.Fatalf("stale failures moved the counter to %d, want 0", c.dialFailures)
+	if len(c.dialFailures) != 0 {
+		t.Fatalf("stale failures changed failure state to %v, want empty", c.dialFailures)
 	}
 
 	// One genuine failure of the replacement's own must not be enough.
-	c.noteDialResult(replacement, dialErr)
+	c.noteDialResult(context.Background(), replacement, testDestination, dialErr)
 	if c.quicTransport != replacement {
 		t.Fatal("replacement rotated after a single failure of its own")
 	}
@@ -131,20 +199,20 @@ func TestStaleSuccessDoesNotResetReplacement(t *testing.T) {
 	if err != nil {
 		t.Fatalf("transport: %v", err)
 	}
-	dialErr := errors.New("timeout: no recent network activity")
+	dialErr := dialTimeoutError{}
 	for range dialFailuresBeforeRotate {
-		c.noteDialResult(stale, dialErr)
+		c.noteDialResult(context.Background(), stale, testDestination, dialErr)
 	}
 	replacement := c.quicTransport
 
 	for i := 1; i < dialFailuresBeforeRotate; i++ {
-		c.noteDialResult(replacement, dialErr)
+		c.noteDialResult(context.Background(), replacement, testDestination, dialErr)
 	}
-	c.noteDialResult(stale, nil) // late success from the discarded socket
-	if c.dialFailures != dialFailuresBeforeRotate-1 {
-		t.Fatalf("a stale success reset the counter to %d", c.dialFailures)
+	c.noteDialResult(context.Background(), stale, testDestination, nil) // late success from the discarded socket
+	if got := c.dialFailures[testDestination]; got != dialFailuresBeforeRotate-1 {
+		t.Fatalf("a stale success reset the counter to %d", got)
 	}
-	c.noteDialResult(replacement, dialErr)
+	c.noteDialResult(context.Background(), replacement, testDestination, dialErr)
 	if c.quicTransport == replacement {
 		t.Fatal("expected rotation once the replacement reached the threshold")
 	}
@@ -160,12 +228,12 @@ func TestSuccessResetsFailureCount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("transport: %v", err)
 	}
-	dialErr := errors.New("timeout: no recent network activity")
+	dialErr := dialTimeoutError{}
 	for range 50 {
 		for i := 1; i < dialFailuresBeforeRotate; i++ {
-			c.noteDialResult(tr, dialErr)
+			c.noteDialResult(context.Background(), tr, testDestination, dialErr)
 		}
-		c.noteDialResult(tr, nil)
+		c.noteDialResult(context.Background(), tr, testDestination, nil)
 	}
 	if c.quicTransport != tr {
 		t.Fatal("rotated despite every failure run being broken by a success")
@@ -178,7 +246,7 @@ func TestConcurrentTransportAccessIsRaceFree(t *testing.T) {
 	c := newTestCache()
 	defer c.Close()
 
-	dialErr := errors.New("timeout: no recent network activity")
+	dialErr := dialTimeoutError{}
 	var wg sync.WaitGroup
 	for range 16 {
 		wg.Add(1)
@@ -189,8 +257,8 @@ func TestConcurrentTransportAccessIsRaceFree(t *testing.T) {
 				if err != nil {
 					continue
 				}
-				c.noteDialResult(tr, dialErr)
-				c.noteDialResult(tr, nil)
+				c.noteDialResult(context.Background(), tr, testDestination, dialErr)
+				c.noteDialResult(context.Background(), tr, testDestination, nil)
 			}
 		}()
 	}

--- a/src/libraries/go/worker/proxy/h3_rotate_test.go
+++ b/src/libraries/go/worker/proxy/h3_rotate_test.go
@@ -69,16 +69,84 @@ func TestRotatesOnlyAfterThresholdAndChangesSourcePort(t *testing.T) {
 	}
 
 	c.noteDialResult(before, dialErr)
-	if c.quicTransport != nil {
-		t.Fatal("expected the transport to be released at the threshold")
-	}
-
 	after, err := c.transport()
 	if err != nil {
 		t.Fatalf("transport after rotation: %v", err)
 	}
+	if after == before {
+		t.Fatal("expected the transport to be replaced at the threshold")
+	}
+	// The replacement is bound before the old socket is closed precisely so
+	// the kernel cannot hand back the port that was just freed. If it did, the
+	// worker would stay on the same 5-tuple and the rotation would be a no-op.
 	if after.Conn.LocalAddr().String() == portBefore {
 		t.Fatal("expected a new source port after rotation; the NLB hashes on it")
+	}
+	if c.dialFailures != 0 {
+		t.Fatalf("dialFailures = %d after rotation, want 0", c.dialFailures)
+	}
+}
+
+// A dial that began before a rotation must not move the counter. Otherwise
+// stale failures accumulate against the replacement and one genuine failure of
+// its own is enough to discard a socket that was never shown to be bad.
+func TestStaleFailuresDoNotCountAgainstReplacement(t *testing.T) {
+	c := newTestCache()
+	defer c.Close()
+
+	stale, err := c.transport()
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+	dialErr := errors.New("timeout: no recent network activity")
+	for range dialFailuresBeforeRotate {
+		c.noteDialResult(stale, dialErr)
+	}
+	replacement := c.quicTransport
+	if replacement == stale {
+		t.Fatal("expected a rotation")
+	}
+
+	// Several more results from the old socket arrive late.
+	for range dialFailuresBeforeRotate * 2 {
+		c.noteDialResult(stale, dialErr)
+	}
+	if c.dialFailures != 0 {
+		t.Fatalf("stale failures moved the counter to %d, want 0", c.dialFailures)
+	}
+
+	// One genuine failure of the replacement's own must not be enough.
+	c.noteDialResult(replacement, dialErr)
+	if c.quicTransport != replacement {
+		t.Fatal("replacement rotated after a single failure of its own")
+	}
+}
+
+// A stale success must not clear failures the current socket really had.
+func TestStaleSuccessDoesNotResetReplacement(t *testing.T) {
+	c := newTestCache()
+	defer c.Close()
+
+	stale, err := c.transport()
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+	dialErr := errors.New("timeout: no recent network activity")
+	for range dialFailuresBeforeRotate {
+		c.noteDialResult(stale, dialErr)
+	}
+	replacement := c.quicTransport
+
+	for i := 1; i < dialFailuresBeforeRotate; i++ {
+		c.noteDialResult(replacement, dialErr)
+	}
+	c.noteDialResult(stale, nil) // late success from the discarded socket
+	if c.dialFailures != dialFailuresBeforeRotate-1 {
+		t.Fatalf("a stale success reset the counter to %d", c.dialFailures)
+	}
+	c.noteDialResult(replacement, dialErr)
+	if c.quicTransport == replacement {
+		t.Fatal("expected rotation once the replacement reached the threshold")
 	}
 }
 
@@ -101,32 +169,6 @@ func TestSuccessResetsFailureCount(t *testing.T) {
 	}
 	if c.quicTransport != tr {
 		t.Fatal("rotated despite every failure run being broken by a success")
-	}
-}
-
-// A dial that was in flight across a rotation must not discard the replacement
-// socket, which would throw away a transport never shown to be bad.
-func TestStaleDialDoesNotRotateReplacement(t *testing.T) {
-	c := newTestCache()
-	defer c.Close()
-
-	stale, err := c.transport()
-	if err != nil {
-		t.Fatalf("transport: %v", err)
-	}
-	dialErr := errors.New("timeout: no recent network activity")
-	for range dialFailuresBeforeRotate {
-		c.noteDialResult(stale, dialErr)
-	}
-	replacement, err := c.transport()
-	if err != nil {
-		t.Fatalf("transport: %v", err)
-	}
-	for range dialFailuresBeforeRotate {
-		c.noteDialResult(stale, dialErr)
-	}
-	if c.quicTransport != replacement {
-		t.Fatal("a stale dial rotated the replacement transport")
 	}
 }
 

--- a/src/libraries/go/worker/proxy/h3_rotate_test.go
+++ b/src/libraries/go/worker/proxy/h3_rotate_test.go
@@ -1,0 +1,156 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+func newTestCache() *h3ConnectionCache {
+	return &h3ConnectionCache{clients: make(map[string]*roundTripperWithCount)}
+}
+
+// One transport is one socket: every dial shares a single source port. This is
+// the property that makes retrying useless when the flow is pinned to a dead
+// proxy pod, and the reason rotation is the only worker-side remedy.
+func TestTransportIsSharedUntilRotated(t *testing.T) {
+	c := newTestCache()
+	defer c.Close()
+
+	first, err := c.transport()
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+	second, err := c.transport()
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+	if first != second {
+		t.Fatal("expected the transport to be reused across dials")
+	}
+	if first.Conn.LocalAddr().String() != second.Conn.LocalAddr().String() {
+		t.Fatal("expected a stable source port while the transport is shared")
+	}
+}
+
+func TestRotatesOnlyAfterThresholdAndChangesSourcePort(t *testing.T) {
+	c := newTestCache()
+	defer c.Close()
+
+	before, err := c.transport()
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+	portBefore := before.Conn.LocalAddr().String()
+
+	dialErr := errors.New("timeout: no recent network activity")
+	for i := 1; i < dialFailuresBeforeRotate; i++ {
+		c.noteDialResult(before, dialErr)
+		if c.quicTransport != before {
+			t.Fatalf("rotated after %d failures, want %d", i, dialFailuresBeforeRotate)
+		}
+	}
+
+	c.noteDialResult(before, dialErr)
+	if c.quicTransport != nil {
+		t.Fatal("expected the transport to be released at the threshold")
+	}
+
+	after, err := c.transport()
+	if err != nil {
+		t.Fatalf("transport after rotation: %v", err)
+	}
+	if after.Conn.LocalAddr().String() == portBefore {
+		t.Fatal("expected a new source port after rotation; the NLB hashes on it")
+	}
+}
+
+// A worker that is dialling successfully must never rotate, however many
+// isolated failures it accumulates over its lifetime.
+func TestSuccessResetsFailureCount(t *testing.T) {
+	c := newTestCache()
+	defer c.Close()
+
+	tr, err := c.transport()
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+	dialErr := errors.New("timeout: no recent network activity")
+	for range 50 {
+		for i := 1; i < dialFailuresBeforeRotate; i++ {
+			c.noteDialResult(tr, dialErr)
+		}
+		c.noteDialResult(tr, nil)
+	}
+	if c.quicTransport != tr {
+		t.Fatal("rotated despite every failure run being broken by a success")
+	}
+}
+
+// A dial that was in flight across a rotation must not discard the replacement
+// socket, which would throw away a transport never shown to be bad.
+func TestStaleDialDoesNotRotateReplacement(t *testing.T) {
+	c := newTestCache()
+	defer c.Close()
+
+	stale, err := c.transport()
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+	dialErr := errors.New("timeout: no recent network activity")
+	for range dialFailuresBeforeRotate {
+		c.noteDialResult(stale, dialErr)
+	}
+	replacement, err := c.transport()
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+	for range dialFailuresBeforeRotate {
+		c.noteDialResult(stale, dialErr)
+	}
+	if c.quicTransport != replacement {
+		t.Fatal("a stale dial rotated the replacement transport")
+	}
+}
+
+// dial runs on a goroutine that does not hold the client mutex, so the shared
+// transport was previously read and written unsynchronised. Run under -race.
+func TestConcurrentTransportAccessIsRaceFree(t *testing.T) {
+	c := newTestCache()
+	defer c.Close()
+
+	dialErr := errors.New("timeout: no recent network activity")
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 50 {
+				tr, err := c.transport()
+				if err != nil {
+					continue
+				}
+				c.noteDialResult(tr, dialErr)
+				c.noteDialResult(tr, nil)
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Issues

Closes #1382

## Why

The worker creates one `quic.Transport` over one `net.ListenUDP` socket, lazily, once, and never releases it before process exit (`h3.go:172`). Every QUIC dial to every proxy host leaves from the same UDP source port for the life of the process.

A network load balancer hashes UDP flows on the 5-tuple, so that one port decides which proxy instance every dial reaches. Once the flow is pinned to an instance that has gone away, retrying cannot help: the retry leaves from the same port and lands on the same dead flow entry.

Verified locally against the pinned quic-go version, `v0.53.0`:

```
one transport, as the worker has today
  dial 1 -> server A                  local=[::]:53379
  dial 2 -> server B (different host) local=[::]:53379
  dial 3 -> server A again (re-dial)  local=[::]:53379

after releasing and recreating the transport
  dial 4 -> server A                  local=[::]:37810
  dial 5 -> server B                  local=[::]:37810
```

Three dials to two different hosts share one port. Releasing the transport is the only worker-side action that changes it.

Confirmed on a staging cell: during an instance removal, dials failed against proxy hosts that were themselves healthy and untouched, while other live instances existed. The destination was reachable; the worker could not get to it. That rules out a stale address from the control plane and leaves flow pinning.

The per-host connection cache already evicts on failure and re-dials (`h3.go:92`, `:126-130`), so the recovery logic exists. It operates one layer above the defect and hands each new connection back to the same socket.

## What changed

- Release the transport after `dialFailuresBeforeRotate` consecutive failures. The existing lazy initialisation then creates a fresh socket, a new ephemeral port and a new flow.
- A success resets the counter, so an established worker never rotates on isolated failures.
- A dial still in flight across a rotation cannot discard the replacement transport.
- Fix a pre-existing data race: `quicTransport` was read and written from the dial goroutine, which does not hold the mutex guarding the connection cache. It now has its own mutex, deliberately separate, because the dial goroutine cannot take that one.

The threshold is 3. Measured on staging: healthy operation produced zero dial failures across roughly 86 sampling windows, while a blackholed socket produced hundreds inside a single window. The populations do not overlap.

No new tunables, no timeout changes, no retry-policy changes.

## Customer Release Notes

A worker that loses its network path to the invocation proxy now recovers on its own. Previously the affected function had to be restarted.

## Plan Summary

Not applicable.

## Usage

Not applicable. The rotation logs at WARN with the consecutive failure count and the socket being released, which is the signal that it fired.

## Testing

`go test -race ./proxy/` for the full package, passing.

New tests cover:

- the transport is shared across dials and the source port is stable until rotation
- no rotation below the threshold, and a new source port after it
- 50 runs of failures broken by a success never rotate
- a stale dial cannot rotate the replacement transport
- concurrent access under `-race`, which is the pre-existing race

The source-port assertion is the one that matters: it pins the property the fix depends on, so a future change that reuses the socket fails the test rather than silently restoring the bug.

## Notes

Scope is the worker's own recovery. It does not prevent the flow being poisoned, it removes the dependency on external flow state ageing out before the worker can escape.

This is separate from #1031 deliberately. That change is in `src/invocation-plane-services/grpc-proxy` and ships in a different image to different clusters, and its dev-image build resolves a single service subtree, so combining them would stop that image being produced.

## References

None

## Related Pull Requests

#1031 addresses a different failure in the same area: queued work whose CONNECT token expires while it waits, which is not self-healing. Independent of this change.

## Dependencies

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved H3 proxy connection reliability during transport reuse and concurrent access.
  * Rotates transports after repeated network timeout failures while preserving normal connection reuse.
  * Assigns a new source port after rotation and safely transitions between transports.
  * Prevents stale, cancelled, or unrelated connection results from affecting active transports.
  * Resets failure tracking after successful connections and cleanup.

* **Tests**
  * Added coverage for reuse, rotation thresholds, recovery, error handling, stale results, and concurrent access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->