### PR TITLE
fix(ci): refresh accumulated stack pins from main

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -155,6 +155,9 @@ jobs:
       - name: Run release helper tests
         run: python3 tools/ci/test-github-release.py
 
+      - name: Test stack pin branch refresh
+        run: bash tools/ci/test-prepare-stack-pin-branch
+
       - name: Check Go toolchain declarations agree
         run: tools/ci/check-go-version
 

--- a/.github/workflows/stack-pin-bump.yml
+++ b/.github/workflows/stack-pin-bump.yml
@@ -49,6 +49,10 @@ jobs:
           # would carry whatever the stack looked like then onto a branch cut
           # from today's main.
           ref: ${{ github.event.repository.default_branch }}
+          # The shared bump branch can predate new release metadata. Its pin
+          # commits must be rebased onto the complete default-branch history
+          # before the resolver runs there.
+          fetch-depth: 0
 
       - uses: actions/setup-go@v5
         with:
@@ -86,6 +90,7 @@ jobs:
         if: steps.tag.outputs.applies == 'true'
         env:
           BRANCH: chore/stack-pin-bumps
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           # The bump is applied ON the pull request branch, not on the default
@@ -94,15 +99,11 @@ jobs:
           # a bump for the same pin, and a swallowed stash conflict either drops
           # that earlier bump or commits conflict markers. Starting here also
           # makes the tool idempotent: it sees the existing value and reports
-          # "already <version>".
+          # "already <version>". Refreshing from the default branch first keeps
+          # new release metadata available without dropping accumulated pins.
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin "${BRANCH}" || true
-          if git rev-parse --verify -q "origin/${BRANCH}" >/dev/null; then
-            git checkout -B "${BRANCH}" "origin/${BRANCH}"
-          else
-            git checkout -B "${BRANCH}"
-          fi
+          tools/ci/prepare-stack-pin-branch "${BRANCH}" "${BASE_BRANCH}"
 
       - name: Apply the bump
         id: bump

--- a/tools/ci/prepare-stack-pin-branch
+++ b/tools/ci/prepare-stack-pin-branch
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+branch="${1:?usage: prepare-stack-pin-branch <branch> <base-branch>}"
+base_branch="${2:?usage: prepare-stack-pin-branch <branch> <base-branch>}"
+
+git check-ref-format --branch "${branch}" >/dev/null
+git check-ref-format --branch "${base_branch}" >/dev/null
+
+git fetch origin "+refs/heads/${base_branch}:refs/remotes/origin/${base_branch}"
+set +e
+git ls-remote --exit-code --heads origin "refs/heads/${branch}" >/dev/null
+branch_status=$?
+set -e
+
+case "${branch_status}" in
+  0)
+    git fetch origin "+refs/heads/${branch}:refs/remotes/origin/${branch}"
+    git checkout -B "${branch}" "origin/${branch}"
+    git rebase "origin/${base_branch}"
+    ;;
+  2)
+    git checkout -B "${branch}" "origin/${base_branch}"
+    ;;
+  *)
+    echo "failed to check whether origin/${branch} exists" >&2
+    exit "${branch_status}"
+    ;;
+esac

--- a/tools/ci/test-prepare-stack-pin-branch
+++ b/tools/ci/test-prepare-stack-pin-branch
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+work_dir="$(mktemp -d)"
+trap 'rm -rf -- "${work_dir}"' EXIT
+
+remote="${work_dir}/remote.git"
+seed="${work_dir}/seed"
+runner="${work_dir}/runner"
+
+git init --bare --initial-branch=main "${remote}" >/dev/null
+git clone "${remote}" "${seed}" >/dev/null 2>&1
+git -C "${seed}" config user.name "Test User"
+git -C "${seed}" config user.email "test@example.com"
+git -C "${seed}" switch -c main >/dev/null 2>&1
+printf 'metadata=old\n' > "${seed}/metadata"
+git -C "${seed}" add metadata
+git -C "${seed}" commit -m "ci: seed release metadata" >/dev/null
+git -C "${seed}" push -u origin main >/dev/null 2>&1
+
+git -C "${seed}" switch -c chore/stack-pin-bumps >/dev/null 2>&1
+printf 'pin=nats-0.8.1\n' > "${seed}/pins"
+git -C "${seed}" add pins
+git -C "${seed}" commit -m "fix(stack): accumulate first pin" >/dev/null
+git -C "${seed}" push -u origin chore/stack-pin-bumps >/dev/null 2>&1
+
+git -C "${seed}" switch main >/dev/null 2>&1
+printf 'metadata=current\n' > "${seed}/metadata"
+git -C "${seed}" add metadata
+git -C "${seed}" commit -m "ci: register another chart" >/dev/null
+git -C "${seed}" push origin main >/dev/null 2>&1
+
+git clone --branch main "${remote}" "${runner}" >/dev/null 2>&1
+git -C "${runner}" config user.name "Test User"
+git -C "${runner}" config user.email "test@example.com"
+
+(
+  cd "${runner}"
+  "${script_dir}/prepare-stack-pin-branch" chore/stack-pin-bumps main >/dev/null
+
+  test "$(git branch --show-current)" = "chore/stack-pin-bumps"
+  test "$(tr -d '\n' < metadata)" = "metadata=current"
+  test "$(tr -d '\n' < pins)" = "pin=nats-0.8.1"
+  git merge-base --is-ancestor origin/main HEAD
+  test -z "$(git rev-list --merges origin/main..HEAD)"
+  git log --format=%s origin/main..HEAD | grep -Fx "fix(stack): accumulate first pin" >/dev/null
+
+  "${script_dir}/prepare-stack-pin-branch" chore/new-stack-pin-bumps main >/dev/null
+  test "$(git branch --show-current)" = "chore/new-stack-pin-bumps"
+  test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
+)
+
+echo "prepare-stack-pin-branch tests passed"


### PR DESCRIPTION
## TL;DR

Refresh the shared stack-pin branch from current `main` before applying each chart release so accumulated pin commits do not hide newly merged release metadata.

## Additional Details

The invocation chart `v1.6.0` release exposed a split-brain workflow state. The stack audit passed on current `main`, but the workflow then switched to the older `chore/stack-pin-bumps` branch. The resolver failed there because that branch predated the invocation chart release metadata from #1386.

This change extracts the branch preparation into a small helper. An existing pin branch is fetched and rebased onto the current default branch before the resolver runs. A missing branch starts directly from the current default branch. Rebase conflicts and remote lookup failures remain loud, and the existing force-with-lease protects against concurrent updates.

A git-backed regression test verifies that previously accumulated pins survive the refresh, new metadata is present, history remains linear, and a missing branch starts at the current base.

Customer release notes: Not customer visible.

Plan summary: Not applicable.

Usage: Not applicable.

Notes: After merge, rerun the invocation `v1.6.0` stack-pin workflow and confirm #1381 gains the invocation pin alongside its existing NATS and request-router pins.

Related pull requests: #1381, #1386.

Dependencies: None. No license review or NOTICE update is required.

## For the Reviewer

Please focus on the fetch/rebase behavior in `tools/ci/prepare-stack-pin-branch` and the force-with-lease assumptions in `.github/workflows/stack-pin-bump.yml`.

## For QA

QA is not needed beyond CI and the post-merge rerun of the failed invocation pin workflow.

Tests run:

- `bash tools/ci/test-prepare-stack-pin-branch`
- `bash -n tools/ci/prepare-stack-pin-branch tools/ci/test-prepare-stack-pin-branch`
- `shellcheck tools/ci/prepare-stack-pin-branch tools/ci/test-prepare-stack-pin-branch`
- `python3 tools/ci/test-github-release.py` (47 tests passed)
- `go test -C tools/stack-pin-resolver ./...`
- Ruby YAML parsing for both changed workflows
- `git diff --check`

The standalone local license-header checker was also attempted. In this OSS snapshot it exits before checking files because its empty arrays trigger an existing `unbound variable` error. Every changed file carries the required SPDX header, and repository CI remains the authoritative check.

## Issues

Closes #1387

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated branch refreshes so existing branches are rebased onto the latest default branch while preserving changes.
  * Ensured new branches start cleanly from the latest default branch.
  * Added clearer failure handling when branch preparation encounters Git errors.

* **Tests**
  * Added integration coverage for branch creation, rebasing, history preservation, and linear ancestry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->