### PR TITLE
test(stack): remove pinned router version assertion

### DIFF
--- a/deploy/stacks/self-managed/tests/llm-router-split-cluster.sh
+++ b/deploy/stacks/self-managed/tests/llm-router-split-cluster.sh
@@ -270,11 +270,8 @@ default_source_release="$(HELMFILE_ENV="$default_source_environment_name" \
     --selector name=llm-request-router \
     list --skip-charts --output json)"
 default_source_chart="$(jq -r '.[0].chart // ""' <<<"$default_source_release")"
-default_source_version="$(jq -r '.[0].version // ""' <<<"$default_source_release")"
 test "$default_source_chart" = 'nvcf/helm-nvcf-llm-request-router' ||
   fail "expected default request-router chart, got ${default_source_chart:-missing}"
-test "$default_source_version" = '1.12.1' ||
-  fail "expected default request-router version 1.12.1, got ${default_source_version:-missing}"
 
 default_source_values="$work_dir/default-source-router-values.yaml"
 HELMFILE_ENV="$default_source_environment_name" \


### PR DESCRIPTION
## TL;DR

Remove the exact llm-request-router chart-version assertion from the self-managed Helmfile render suite. Stack pin automation can now update the chart version without failing a test that does not validate behavior.

## Additional Details

The test still verifies that the default configuration resolves the expected published chart and continues to render its values contract. Chart pin values remain validated by the Helmfile configuration and release workflow.

Related PR: https://github.com/NVIDIA/nvcf/pull/1381

## For the Reviewer

Review `deploy/stacks/self-managed/tests/llm-router-split-cluster.sh`. The change removes only the unused resolved-version value and its exact-version assertion.

## For QA

QA is not needed for this test-only change.

Validated with:

- `bash deploy/stacks/self-managed/tests/llm-router-split-cluster.sh`
- `make -C deploy/stacks/self-managed test`

## Issues

Closes #1389

## Dependencies

None.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the self-managed deployment to use newer NATS, invocation service, and LLM request router charts.
  * Improved deployment validation by focusing on the expected default request router selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->