### PR TITLE
fix(llm-routing): align worker Pylon with router transport

### DIFF
--- a/deploy/helm/cloud-functions/nvcf-api/values.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/values.yaml
@@ -245,7 +245,7 @@ api:
           ess-agent-container: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/ess-agent:1.4.0
           otel-collector-container: dummy
           llm-credential-manager-image: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/nvcf-worker-llm-credentials-oss:1.1.1
-          llm-router-client-image: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/pylon:0.14.1
+          llm-router-client-image: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/pylon:0.14.3
         notary:
           turn:
             enabled: true

--- a/deploy/helm/cloud-functions/tests/sidecar_release_artifacts_test.sh
+++ b/deploy/helm/cloud-functions/tests/sidecar_release_artifacts_test.sh
@@ -53,7 +53,7 @@ expected_annotations=(
   "release-artifact-niclls-container-image: \"${hostname}/${repository}/nvcf_worker_niclls:2.109.4\""
   "release-artifact-ess-agent-container-image: \"${hostname}/${repository}/ess-agent:1.4.0\""
   "release-artifact-llm-credential-manager-image: \"${hostname}/${repository}/nvcf-worker-llm-credentials-oss:1.1.1\""
-  "release-artifact-llm-router-client-image: \"${hostname}/${repository}/pylon:0.14.1\""
+  "release-artifact-llm-router-client-image: \"${hostname}/${repository}/pylon:0.14.3\""
 )
 
 for annotation in "${expected_annotations[@]}"; do

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -441,7 +441,7 @@ natsAuthCalloutService:
 {{- else if $legacyPylonImageConfigured }}
 {{- $effectivePylonImage = $legacyPylonImage }}
 {{- else if $llmEnabled }}
-{{- $effectivePylonImage = printf "%s/%s/pylon:0.14.1" $sidecarsHost $sidecarsRepo }}
+{{- $effectivePylonImage = printf "%s/%s/pylon:0.14.3" $sidecarsHost $sidecarsRepo }}
 {{- end }}
 {{- $stackApiRemoteConfigData := dict }}
 {{- $stackNvcfRemoteConfig := dict }}

--- a/deploy/stacks/self-managed/tests/api-env-wiring.sh
+++ b/deploy/stacks/self-managed/tests/api-env-wiring.sh
@@ -139,7 +139,7 @@ assert_yaml_value "$explicit_manifest" \
   'select(.kind == "ConfigMap" and .data."nvcf-api.yaml" != null) | .data."nvcf-api.yaml" | from_yaml | .nvcf.sidecars.retained-setting' \
   keep-inside-sidecars "rendered nested sidecar remote config"
 
-# With no explicit value, the enabled LLM addon derives Pylon 0.14.1 from the
+# With no explicit value, the enabled LLM addon derives Pylon 0.14.3 from the
 # effective worker-sidecar registry rather than the control-plane image path.
 write_environment <<'EOF'
 global:
@@ -157,7 +157,7 @@ EOF
 default_values="$work_dir/default-values.yaml"
 render_api_values "$default_values" >/dev/null
 assert_yaml_value "$default_values" "$remote_pylon_expression" \
-  registry.example.test/team/sidecars/pylon:0.14.1 "computed Pylon default"
+  registry.example.test/team/sidecars/pylon:0.14.3 "computed Pylon default"
 
 # Local BDD fixtures rely on the same computed default after their registry
 # paths are configured. They must not carry unresolved fixture placeholders
@@ -174,8 +174,8 @@ for fixture_name in self-managed-local-bdd.yaml self-managed-local-bdd-multi.yam
   fixture_pylon_image="$(yq -r "$remote_pylon_expression" "$fixture_values")"
   [[ "$fixture_pylon_image" != *REPLACE_WITH_* ]] ||
     fail "$fixture_name Pylon property retained an unresolved fixture placeholder"
-  [[ "$fixture_pylon_image" == nvcr.io/sample-org/sample-team/pylon:0.14.1 ]] ||
-    fail "$fixture_name Pylon property: expected computed 0.14.1 image, got $fixture_pylon_image"
+  [[ "$fixture_pylon_image" == nvcr.io/sample-org/sample-team/pylon:0.14.3 ]] ||
+    fail "$fixture_name Pylon property: expected computed 0.14.3 image, got $fixture_pylon_image"
 done
 
 # The deprecated env key remains accepted for one compatibility window, but


### PR DESCRIPTION
## TL;DR

Align the default LLM worker Pylon image with the Pylon 0.14.3 plaintext gRPC trust fix so a self-managed LLM worker registers with the current request router.

## Additional Details

The self-managed stack uses API remote configuration to select the LLM worker sidecar. Its previous Pylon 0.14.1 default reused QUIC trust for the plaintext gRPC registration seed and left the router with no eligible inference candidates. This updates both default sources to 0.14.3, while preserving explicit operator overrides, and extends the existing chart and stack rendering regressions.

## For the Reviewer

Review the matching default in deploy/helm/cloud-functions/nvcf-api/values.yaml and deploy/stacks/self-managed/global.yaml.gotmpl. Explicit configured and legacy image paths are intentionally unchanged.

## For QA

Ran:
- make -C deploy/helm/cloud-functions lint
- make -C deploy/helm/cloud-functions test
- bash deploy/stacks/self-managed/tests/api-env-wiring.sh

The full self-managed test suite has a separate stale 1.12.1 pin assertion fixed by related PR #1393.

## Issues

Fixes #1392

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the default LLM router sidecar image to version 0.14.3.
  * Updated deployment configuration and validation checks to reflect the new default version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->