### PR TITLE
feat(stack): surface api-keys service env in self-managed stack

### DIFF
--- a/deploy/stacks/self-managed/Makefile
+++ b/deploy/stacks/self-managed/Makefile
@@ -20,6 +20,7 @@ test:
 	@tests/image-override-wiring.sh
 	@tests/sidecar-registry-wiring.sh
 	@tests/api-env-wiring.sh
+	@tests/apikeys-env-wiring.sh
 	@tests/nats-placement-tags.sh
 
 test-published-charts:

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -505,6 +505,12 @@ rateLimiter:
 # Set enabled: true for any service running more than one replica.
 
 apikeys:
+  # Operator-set api-keys service env, deep-merged over the chart defaults
+  # (AWS_REGION / SPRING_PROFILES_ACTIVE). Set NVCF_NCA_ID to the NCA the
+  # api-keys service authorizes keys against. Leave unset to keep the chart
+  # defaults only.
+  # env:
+  #   NVCF_NCA_ID: "nca-xxxxxxxx"
   podDisruptionBudget:
     enabled: false
     maxUnavailable: 1

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -508,7 +508,8 @@ apikeys:
   # Operator-set api-keys service env, deep-merged over the chart defaults
   # (AWS_REGION / SPRING_PROFILES_ACTIVE). Set NVCF_NCA_ID to the NCA the
   # api-keys service authorizes keys against. Leave unset to keep the chart
-  # defaults only.
+  # defaults only. Non-secret configuration only -- secrets belong in
+  # secrets/<env>-secrets.yaml.
   # env:
   #   NVCF_NCA_ID: "nca-xxxxxxxx"
   podDisruptionBudget:

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -286,6 +286,10 @@ apikeys:
   startupProbe:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with dig "apikeys" "env" dict .Values }}
+  env:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 
 natsAuthCalloutService:
   {{- if .Values.global.imagePullSecrets }}

--- a/deploy/stacks/self-managed/tests/apikeys-env-wiring.sh
+++ b/deploy/stacks/self-managed/tests/apikeys-env-wiring.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Test that apikeys.env threads from environments/<env>.yaml through
+# global.yaml.gotmpl into the api-keys release values. NVCF_NCA_ID is
+# operator-specific config (the NCA the api-keys service authorizes keys
+# against) and must be settable from the plain env file, not only the secrets
+# file. When apikeys.env is unset the stack emits no override, so the chart
+# default env (AWS_REGION / SPRING_PROFILES_ACTIVE) stands and existing installs
+# render byte-identical.
+set -euo pipefail
+
+stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+work_dir="$(mktemp -d)"
+test_stack_dir="$work_dir/self-managed"
+environment_name="apikeys-env-wiring-test"
+environment_file="$test_stack_dir/environments/$environment_name.yaml"
+secrets_file="$test_stack_dir/secrets/$environment_name-secrets.yaml"
+trap 'rm -rf "$work_dir"' EXIT
+
+fail() {
+  echo "apikeys-env-wiring: $*" >&2
+  exit 1
+}
+
+mkdir -p "$test_stack_dir"
+cp -R "$stack_dir"/. "$test_stack_dir"
+printf '{}\n' >"$secrets_file"
+
+write_environment() {
+  cat >"$environment_file"
+}
+
+render_apikeys_values() {
+  local output_file="$1"
+
+  HELMFILE_ENV="$environment_name" \
+    HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" \
+    helmfile \
+      --file "$test_stack_dir/helmfile.d/02-core.yaml.gotmpl" \
+      --environment default \
+      --state-values-set ingress.gatewayApi.controllerNamespace=envoy-gateway-system \
+      --state-values-set ingress.gatewayApi.gateways.shared.name=shared-gw \
+      --state-values-set ingress.gatewayApi.gateways.shared.namespace=envoy-gateway-system \
+      --state-values-set ingress.gatewayApi.gateways.grpc.name=grpc-gw \
+      --state-values-set ingress.gatewayApi.gateways.grpc.namespace=envoy-gateway-system \
+      --selector name=api-keys \
+      write-values \
+      --output-file-template "$output_file"
+}
+
+assert_yaml_value() {
+  local input_file="$1" expression="$2" want="$3" label="$4" got
+  got="$(yq -r "$expression" "$input_file")"
+  [[ "$got" == "$want" ]] ||
+    fail "$label: expected $want, got ${got:-<none>}"
+}
+
+# 1. Default: apikeys.env unset. The stack forwards no env override, so the
+#    api-keys chart default env stands and nothing is emitted for the release.
+write_environment <<'EOF'
+global:
+  image:
+    registry: nvcr.io
+    repository: nvidia/nvcf
+EOF
+
+default_values="$work_dir/apikeys-default-values.yaml"
+render_apikeys_values "$default_values" >/dev/null
+assert_yaml_value "$default_values" '.apikeys.env' null \
+  "default: apikeys.env must not be emitted when unset in the env file"
+
+# 2. Override: NVCF_NCA_ID in environments/<env>.yaml reaches the release as
+#    apikeys.env, alongside any other operator-supplied keys. Helm deep-merges
+#    this over the chart default env at template time.
+write_environment <<'EOF'
+global:
+  image:
+    registry: nvcr.io
+    repository: nvidia/nvcf
+apikeys:
+  env:
+    NVCF_NCA_ID: "nca-test-1234"
+    CUSTOM_APIKEYS_ENV: configured
+EOF
+
+override_values="$work_dir/apikeys-override-values.yaml"
+render_apikeys_values "$override_values" >/dev/null
+assert_yaml_value "$override_values" '.apikeys.env.NVCF_NCA_ID' nca-test-1234 \
+  "override: NVCF_NCA_ID must reach the api-keys release values"
+assert_yaml_value "$override_values" '.apikeys.env.CUSTOM_APIKEYS_ENV' configured \
+  "override: arbitrary api-keys env keys must reach the release values"
+
+echo "apikeys-env-wiring: OK"


### PR DESCRIPTION
## Summary

Surface the `api-keys` service environment (`apikeys.env`, e.g. `NVCF_NCA_ID`) in the self-managed stack so it can be set from `environments/<env>.yaml`, instead of only via the secrets file or a patched `global.yaml.gotmpl`. When `apikeys.env` is unset the stack emits nothing, so existing deployments are unchanged.

## Additional Details

The `api-keys` release only receives `../global.yaml.gotmpl` + `../secrets/<env>-secrets.yaml` as chart values; the plain environment file reaches a release only where `global.yaml.gotmpl` re-emits it via `dig … .Values`. The `apikeys:` block wires `image`, `podDisruptionBudget`, and `startupProbe` but had no passthrough for `apikeys.env`, so `apikeys.env.NVCF_NCA_ID` set in `environments/<env>.yaml` was read into `.Values` but silently dropped. `NVCF_NCA_ID` is deployment-specific config an operator running the stack for their own tenant must set (it is the NCA the api-keys service authorizes keys against).

This adds the missing stack passthrough. No chart change.

- `deploy/stacks/self-managed/global.yaml.gotmpl` — add a `dig`-based `apikeys.env` passthrough in the `apikeys:` block, mirroring the existing `podDisruptionBudget` / `startupProbe` passthroughs.
- `deploy/stacks/self-managed/environments/base.yaml` — document the knob with a commented `apikeys.env` example.

Example — set the operator's NCA:

```yaml
# environments/<env>.yaml
apikeys:
  env:
    NVCF_NCA_ID: "nca-xxxxxxxx"
```

Helm deep-merges the release values over the chart's `values.yaml`, so `NVCF_NCA_ID` lands in the env ConfigMap alongside the chart defaults (`AWS_REGION` / `SPRING_PROFILES_ACTIVE`) without clobbering them.

## For the Reviewer

- Backward-compatible: the `with dig "apikeys" "env" dict .Values` emits nothing when unset, so an unset flag renders byte-identical and the chart default env still applies.
- This is the same `dig … .Values` shape already used in the same `apikeys:` block for `podDisruptionBudget` and `startupProbe` — add the knob, forward only when the operator supplies it.

## For QA

**Automated test (`make test`).** Added `deploy/stacks/self-managed/tests/apikeys-env-wiring.sh`, wired into the offline `make test` target next to `api-env-wiring.sh`. It follows the existing value-wiring pattern (`pdb-value-wiring.sh` / `api-env-wiring.sh`): it renders the `api-keys` release values with `helmfile write-values` and asserts, via `yq`, that (a) `apikeys.env` is **absent** by default (no override emitted), and (b) `apikeys.env.NVCF_NCA_ID` (plus an arbitrary `CUSTOM_APIKEYS_ENV` key) is threaded through when the environment file sets `apikeys.env.*`.

**Manual render.** Also rendered the real `api-keys` chart env ConfigMap with `helm template … --show-only templates/configmap-env.yaml`:

- **Case A — default (`apikeys.env` unset):** the ConfigMap carries the chart defaults only — `AWS_REGION` + `SPRING_PROFILES_ACTIVE` — confirming byte-identical behavior when the knob is unset.
- **Case B — override (`apikeys.env.NVCF_NCA_ID` set):** the ConfigMap carries `AWS_REGION` + `SPRING_PROFILES_ACTIVE` + `NVCF_NCA_ID`, confirming the deep-merge adds the operator value without clobbering the defaults (and changes the `checksum/config-env` annotation so the pod rolls on change).

## Issues

Fixes #1356

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for DCO compliance.
- [x] New or existing tests cover these changes. <!-- added tests/apikeys-env-wiring.sh (offline `make test`); also validated via helm template of the env ConfigMap (default vs override) -->
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional environment variable overrides for the API keys service.
  * Overrides can be configured per environment, including custom values and `NVCF_NCA_ID`.
  * Default chart behavior is preserved when no overrides are configured.
  * Added configuration guidance for securely managing environment-specific secrets.

* **Tests**
  * Added integration coverage for configured and unset environment override scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->