### PR TITLE
fix(nvcf-cli): preserve dialable profile endpoints

### DIFF
--- a/src/clis/nvcf-cli/cmd/self_hosted_control_plane_profile.go
+++ b/src/clis/nvcf-cli/cmd/self_hosted_control_plane_profile.go
@@ -148,6 +148,11 @@ func buildControlPlaneProfile(req controlPlaneProfileWriteRequest) controlplanep
 	sisHost := firstNonEmpty(os.Getenv("NVCF_ICMS_HOST"), viper.GetString("icms_host"), "sis."+domain)
 	revalHost := firstNonEmpty(os.Getenv("NVCF_REVAL_HOST"), viper.GetString("reval_host"), "reval."+domain)
 	natsHost := firstNonEmpty(os.Getenv("NVCF_NATS_HOST"), viper.GetString("nats_host"), "nats."+domain)
+	if strings.EqualFold(req.Env, "local") {
+		computeEndpoints.ICMSServiceURL = rewriteURLHost(computeEndpoints.ICMSServiceURL, sisHost)
+		computeEndpoints.ReValServiceURL = rewriteURLHost(computeEndpoints.ReValServiceURL, revalHost)
+		computeEndpoints.NATSURL = rewriteURLHost(computeEndpoints.NATSURL, natsHost)
+	}
 
 	return controlplaneprofile.ControlPlaneProfile{
 		APIVersion: controlplaneprofile.APIVersion,
@@ -163,9 +168,9 @@ func buildControlPlaneProfile(req controlPlaneProfileWriteRequest) controlplanep
 					NATSURL:  "nats://nats.nats-system.svc.cluster.local:4222",
 				},
 				ComputeReachable: controlplaneprofile.EndpointScope{
-					ICMSURL:  rewriteURLHost(computeEndpoints.ICMSServiceURL, sisHost),
-					ReValURL: rewriteURLHost(computeEndpoints.ReValServiceURL, revalHost),
-					NATSURL:  rewriteURLHost(computeEndpoints.NATSURL, natsHost),
+					ICMSURL:  computeEndpoints.ICMSServiceURL,
+					ReValURL: computeEndpoints.ReValServiceURL,
+					NATSURL:  computeEndpoints.NATSURL,
 				},
 			},
 			Gateway: controlplaneprofile.Gateway{
@@ -247,10 +252,8 @@ func resolveProfileICMSURL(flagValue, env, stackDomain string) string {
 // query) of rawURL with newHost. Returns rawURL unchanged when it cannot be
 // parsed, has no host, or when newHost is empty.
 //
-// This lets buildControlPlaneProfile project bare-ELB URLs back through the
-// canonical sis./reval./nats. service prefix that the gateway HTTPRoutes
-// match. For local k3d (rawURL already has sis./reval./nats. prefixes equal
-// to newHost) this is effectively a no-op.
+// Local split-cluster resolution can produce cross-cluster service names that
+// must be normalized to the local gateway routing hosts before export.
 func rewriteURLHost(rawURL, newHost string) string {
 	if rawURL == "" || newHost == "" {
 		return rawURL

--- a/src/clis/nvcf-cli/cmd/self_hosted_control_plane_test.go
+++ b/src/clis/nvcf-cli/cmd/self_hosted_control_plane_test.go
@@ -282,7 +282,7 @@ icms_host: sis.config.example.test
 	assert.Equal(t, "api-keys.config.example.test", profile.Hosts.APIKeys)
 	assert.Equal(t, "invocation.config.example.test", profile.Hosts.Invocation)
 	assert.Equal(t, "sis.config.example.test", profile.Hosts.SIS)
-	assert.Equal(t, "https://sis.config.example.test/custom/path", profile.Endpoints.ComputeReachable.ICMSURL)
+	assert.Equal(t, "https://sis-dial.config.example.test/custom/path", profile.Endpoints.ComputeReachable.ICMSURL)
 }
 
 func TestParseControlPlaneProfileRequireModeAcceptsAny(t *testing.T) {
@@ -375,21 +375,17 @@ func TestBuildControlPlaneProfile_LocalK3DKeepsServicePrefixedHosts(t *testing.T
 	assert.Equal(t, "nats://nats.localhost:4222", got.ControlPlane.Endpoints.ComputeReachable.NATSURL)
 }
 
-func TestBuildControlPlaneProfile_BareELBProjectsServicePrefixes(t *testing.T) {
-	// Simulate GATEWAY_ADDR-routed EKS where icms_url is a bare ELB hostname:
-	// the emitted hosts and computeReachable URLs must carry the canonical
-	// sis./reval./nats. service prefixes that the gateway HTTPRoutes match.
+func TestBuildControlPlaneProfile_GatewayOnlyDNSKeepsDialURLsSeparateFromRoutingHosts(t *testing.T) {
+	// The gateway is the only resolvable name. Service names are routing values
+	// sent through Host headers or TLS SNI and must not replace dial URL hosts.
 	resetViperForProfileTest(t)
-	t.Setenv("API_HOST", "")
+	t.Setenv("API_HOST", "api.routes.customer.example.test")
 	t.Setenv("API_KEYS_HOST", "")
 	t.Setenv("INVOKE_HOST", "")
 	t.Setenv("NVCF_ICMS_HOST", "")
 	t.Setenv("NVCF_REVAL_HOST", "")
 	t.Setenv("NVCF_NATS_HOST", "")
-	// In the bare-ELB topology the operator's base_http_url points at the same
-	// gateway ELB. Force resolveProfileGatewayHTTPURL to use it so the test
-	// does not pick up an unrelated default like https://api.nvcf.nvidia.com.
-	t.Setenv("NVCF_BASE_HTTP_URL", "http://abc123.elb.us-east-1.amazonaws.com")
+	t.Setenv("NVCF_BASE_HTTP_URL", "https://gateway.customer.example.test")
 	t.Setenv("NVCF_BASE_GRPC_URL", "")
 
 	prevEnv := selfHostedEnv
@@ -397,22 +393,24 @@ func TestBuildControlPlaneProfile_BareELBProjectsServicePrefixes(t *testing.T) {
 	selfHostedEnv = "qa"
 
 	got := buildControlPlaneProfile(controlPlaneProfileWriteRequest{
-		ClusterName: "nvcf-cp-qa",
+		ClusterName: "control-plane",
 		NCAID:       "nvcf-default",
-		Region:      "us-east-1",
+		Region:      "us-west-1",
 		Env:         "qa",
-		ICMSURL:     "http://abc123.elb.us-east-1.amazonaws.com",
+		ICMSURL:     "https://gateway.customer.example.test",
+		NATSURL:     "tls://gateway.customer.example.test:4222",
+		StackDomain: "routes.customer.example.test",
 	})
 
-	assert.Equal(t, "abc123.elb.us-east-1.amazonaws.com", got.ControlPlane.Hosts.API)
-	assert.Equal(t, "api-keys.abc123.elb.us-east-1.amazonaws.com", got.ControlPlane.Hosts.APIKeys)
-	assert.Equal(t, "sis.abc123.elb.us-east-1.amazonaws.com", got.ControlPlane.Hosts.SIS)
-	assert.Equal(t, "reval.abc123.elb.us-east-1.amazonaws.com", got.ControlPlane.Hosts.ReVal)
-	assert.Equal(t, "nats.abc123.elb.us-east-1.amazonaws.com", got.ControlPlane.Hosts.NATS)
-	assert.Equal(t, "invocation.abc123.elb.us-east-1.amazonaws.com", got.ControlPlane.Hosts.Invocation)
-	assert.Equal(t, "http://sis.abc123.elb.us-east-1.amazonaws.com", got.ControlPlane.Endpoints.ComputeReachable.ICMSURL)
-	assert.Equal(t, "http://reval.abc123.elb.us-east-1.amazonaws.com", got.ControlPlane.Endpoints.ComputeReachable.ReValURL)
-	assert.Equal(t, "nats://nats.abc123.elb.us-east-1.amazonaws.com:4222", got.ControlPlane.Endpoints.ComputeReachable.NATSURL)
+	assert.Equal(t, "api.routes.customer.example.test", got.ControlPlane.Hosts.API)
+	assert.Equal(t, "api-keys.routes.customer.example.test", got.ControlPlane.Hosts.APIKeys)
+	assert.Equal(t, "sis.routes.customer.example.test", got.ControlPlane.Hosts.SIS)
+	assert.Equal(t, "reval.routes.customer.example.test", got.ControlPlane.Hosts.ReVal)
+	assert.Equal(t, "nats.routes.customer.example.test", got.ControlPlane.Hosts.NATS)
+	assert.Equal(t, "invocation.routes.customer.example.test", got.ControlPlane.Hosts.Invocation)
+	assert.Equal(t, "https://gateway.customer.example.test", got.ControlPlane.Endpoints.ComputeReachable.ICMSURL)
+	assert.Equal(t, "https://gateway.customer.example.test", got.ControlPlane.Endpoints.ComputeReachable.ReValURL)
+	assert.Equal(t, "tls://gateway.customer.example.test:4222", got.ControlPlane.Endpoints.ComputeReachable.NATSURL)
 }
 
 func TestWriteControlPlaneProfileSourcesOpenBaoRootCA(t *testing.T) {


### PR DESCRIPTION
## Why

Control-plane profile export treated the per-service routing names as the DNS
hosts for ICMS, ReVal, and NATS endpoint URLs. Shared-gateway deployments may
resolve only the configured gateway, so compute-plane registration failed its
reachability checks before registration.

## What changed

- Preserve configured ICMS, ReVal, and NATS dial URLs for non-local profiles.
- Keep per-service HTTP Host and TLS SNI routing names in
  `controlPlane.hosts.*`.
- Retain local split-cluster endpoint normalization.
- Add a custom-domain regression where the gateway is the only resolvable
  endpoint name and explicit endpoint overrides remain unchanged.

## Customer Release Notes

Control-plane profile exports now preserve configured gateway addresses for
compute-plane connectivity while continuing to emit per-service routing hosts.

## Plan Summary

Not applicable.

## Usage

Not applicable.

## Testing

- `go test ./cmd -run 'ControlPlaneProfile|BuildControlPlaneProfile|RewriteURLHost' -count=1`
- `go test ./... -count=1`
- `go build -buildvcs=false -o /tmp/nvcf-rank2-bin/nvcf-cli .`
- `bazel test //src/clis/nvcf-cli/... --cache_test_results=no --test_output=errors` (21/21 tests passed in a disposable checkout; Gazelle bootstrap used local-only `GOFLAGS=-buildvcs=false` for this VM's VCS-stamping layout)
- `bazel build //src/clis/nvcf-cli:nvcf-cli`
- `nvcf-cli self-hosted --env qa control-plane profile validate --file <fixture> --require both`
- `nvcf-cli self-hosted --env qa compute-plane register --dry-run --control-plane-profile <fixture> --cluster-name gpu-a --kube-context fixture-compute`

The dry-run used a local shared-gateway fixture and read-only Kubernetes
responses. It passed endpoint reachability, OIDC discovery, and JWKS retrieval,
then skipped SIS mutation and values writes. QA is recommended against a
deployed shared-gateway topology.

## Notes

No external cluster, release, secret, or other shared resource was changed.
This corrects an endpoint contract and does not change the documented component
topology, observability, or existing diagrams.

## References

Fixes #1397

## Related Pull Requests

- Follow-up to #1234

## Dependencies

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved self-hosted control-plane profile generation for local environments by correctly normalizing compute-plane service URLs.
  * Preserved resolved endpoint URLs in non-local environments for more reliable connectivity.
  * Improved handling of gateway-only DNS configurations, keeping routing hosts and compute-reachable URLs distinct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Disposable k3d integration verification

Status: **PASS**. This was an actual disposable two-cluster k3d run, separate
from the earlier local HTTP fixture. The control-plane stack converged, profile
export and validation passed, and compute-plane registration dry-run completed
through endpoint reachability, OIDC discovery, and JWKS retrieval. Both k3d
clusters were destroyed after the run.

The clusters were created with the repository-prescribed workflow:

```sh
make -C tools/ncp-local-cluster build-and-deploy-multicluster \
  CONTROL_PLANE_DOMAIN=control-plane.integration.test \
  COMPUTE_CLUSTER_COUNT=1

HELMFILE_ENV=gateway-k3d helmfile \
  --environment default \
  --kube-context k3d-ncp-local-cp \
  sync
```

The public catalog did not contain every image tag named by the current stack
defaults, so the disposable deployment used the documented public v0.6.1 image
set and currently published chart versions. Those test-only pins were not added
to this PR.

The compute cluster intentionally resolved only the bare gateway. Route-only
service names returned NXDOMAIN. Routing through the gateway produced HTTP 401
from SIS (reachable, authentication required), HTTP 404 from the ReVal root
path (reachable), and a successful NATS TCP connection:

```sh
kubectl --context k3d-ncp-local-compute-1 run route-probe \
  --image=curlimages/curl:8.12.1 --restart=Never --rm -i -- \
  sh -c 'curl --noproxy "*" -o /dev/null -w "%{http_code}\n" \
    -H "Host: sis.control-plane.integration.test" \
    http://gateway.127.0.0.1.nip.io:8080; \
  curl --noproxy "*" -o /dev/null -w "%{http_code}\n" \
    -H "Host: reval.control-plane.integration.test" \
    http://gateway.127.0.0.1.nip.io:8080'

kubectl --context k3d-ncp-local-compute-1 run nats-probe \
  --image=busybox:1.36 --restart=Never --rm -i -- \
  sh -c 'nslookup gateway.127.0.0.1.nip.io; \
    nc -z -w 5 gateway.127.0.0.1.nip.io 4222; \
    ! nslookup sis.control-plane.integration.test; \
    ! nslookup reval.control-plane.integration.test; \
    ! nslookup nats.control-plane.integration.test'
```

Profile export and validation:

```sh
NVCF_BASE_HTTP_URL=http://gateway.127.0.0.1.nip.io:8080 \
NVCF_BASE_GRPC_URL=gateway.127.0.0.1.nip.io:10081 \
API_HOST=api.control-plane.integration.test \
API_KEYS_HOST=api-keys.control-plane.integration.test \
INVOKE_HOST=invocation.control-plane.integration.test \
NVCF_ICMS_HOST=sis.control-plane.integration.test \
NVCF_REVAL_HOST=reval.control-plane.integration.test \
NVCF_NATS_HOST=nats.control-plane.integration.test \
nvcf-cli --config "${CLI_CONFIG}" self-hosted \
  --env gateway-k3d \
  --control-plane-stack "${CONTROL_STACK}" \
  --compute-plane-stack "${COMPUTE_STACK}" \
  --control-plane-context k3d-ncp-local-cp \
  --compute-plane-context k3d-ncp-local-compute-1 \
  --icms-url http://gateway.127.0.0.1.nip.io:8080 \
  --nats-url nats://gateway.127.0.0.1.nip.io:4222 \
  --non-interactive --plain control-plane profile export \
  --cluster-name gateway-integration-cp --region us-west-1

nvcf-cli self-hosted control-plane profile validate \
  --file "${PROFILE}" --require both
```

Result:

```yaml
computeReachable:
  icmsURL: http://gateway.127.0.0.1.nip.io:8080
  revalURL: http://gateway.127.0.0.1.nip.io:8080
  natsURL: nats://gateway.127.0.0.1.nip.io:4222
hosts:
  sis: sis.control-plane.integration.test
  reval: reval.control-plane.integration.test
  nats: nats.control-plane.integration.test
```

The final positive registration used an isolated HOME/XDG directory and an
empty CLI config, so no configured endpoint could override the generated
profile:

```sh
HOME="${CLEAN_HOME}" XDG_CONFIG_HOME="${CLEAN_XDG}" \
KUBECONFIG="${KUBECONFIG}" \
nvcf-cli --config "${EMPTY_CONFIG}" self-hosted \
  --env gateway-k3d \
  --control-plane-stack "${CONTROL_STACK}" \
  --compute-plane-stack "${COMPUTE_STACK}" \
  --control-plane-context k3d-ncp-local-cp \
  --compute-plane-context k3d-ncp-local-compute-1 \
  --token "${ADMIN_JWT}" --non-interactive --plain \
  compute-plane register --dry-run \
  --control-plane-profile "${PROFILE}" \
  --cluster-name gateway-integration-compute \
  --kube-context k3d-ncp-local-compute-1 \
  --region us-west-1
```

Result: exit 0; `endpointScope: compute-reachable`; OIDC discovery succeeded;
JWKS retrieval returned 462 bytes; `sisMutation: skipped`; and
`valuesWrite: skipped`.

For the controlled negative, only the three `computeReachable` URL hosts were
changed to `sis.`, `reval.`, and `nats.control-plane.integration.test`; a hash
comparison confirmed `hosts.*` was otherwise identical. The same registration
command exited 1 with DNS lookup failures for the SIS and ReVal dial URLs.

Cleanup completed with:

```sh
make -C tools/ncp-local-cluster destroy-multicluster \
  CONTROL_PLANE_DOMAIN=control-plane.integration.test \
  COMPUTE_CLUSTER_COUNT=1
```

### Before

```mermaid
flowchart LR
    C[Compute registration] -->|dial sis, reval, nats service names| D[DNS]
    D -->|NXDOMAIN: names are routing values only| X[Reachability fails]
    H[controlPlane.hosts service names] -. Host or SNI .-> G[Shared gateway]
```

### After

```mermaid
flowchart LR
    C[Compute registration] -->|dial bare configured gateway| G[Shared gateway]
    G -->|Host or SNI from controlPlane.hosts| R[SIS, ReVal, and NATS routes]
    G -->|reachable URL| O[OIDC and JWKS registration flow]
```
