### PR TITLE
fix(nvca): validate transport TLS before workload rendering

### DIFF
--- a/src/compute-plane-services/nvca/internal/miniservice/transport_tls.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/transport_tls.go
@@ -44,6 +44,9 @@ func (r *Reconciler) prepareTransportTLSForWorkloads(
 		return nil
 	}
 	cfg := transporttls.NormalizeConfig(*r.cfg.Workload.TransportTLS)
+	if err := transporttls.ValidateConfig(cfg); err != nil {
+		return reconcile.TerminalError(err)
+	}
 	if cfg.TrustMode != transporttls.TrustModeBundle {
 		return nil
 	}
@@ -60,9 +63,6 @@ func (r *Reconciler) prepareTransportTLSForWorkloads(
 		return nil
 	}
 
-	if err := transporttls.ValidateConfig(cfg); err != nil {
-		return reconcile.TerminalError(err)
-	}
 	if err := r.ensureTransportTLSConfigMap(ctx, ms, cfg); err != nil {
 		return err
 	}

--- a/src/compute-plane-services/nvca/internal/miniservice/transport_tls_test.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/transport_tls_test.go
@@ -356,6 +356,139 @@ func TestPrepareTransportTLSForWorkloadsReturnsTerminalErrorForInvalidConfig(t *
 	}
 }
 
+func TestPrepareTransportTLSForWorkloadsRejectsInvalidConfigWithoutPodSpecs(t *testing.T) {
+	tests := []struct {
+		name           string
+		mutateWorkload func(*nvcaconfig.WorkloadConfig)
+		wantErr        string
+	}{
+		{
+			name: "missing bundle",
+			mutateWorkload: func(cfg *nvcaconfig.WorkloadConfig) {
+				cfg.TransportTLS.TrustBundlePEM = ""
+			},
+			wantErr: "trustBundlePem is required",
+		},
+		{
+			name: "malformed PEM",
+			mutateWorkload: func(cfg *nvcaconfig.WorkloadConfig) {
+				cfg.TransportTLS.TrustBundlePEM = "not a PEM bundle"
+			},
+			wantErr: "trustBundlePem is invalid",
+		},
+		{
+			name: "private key PEM",
+			mutateWorkload: func(cfg *nvcaconfig.WorkloadConfig) {
+				cfg.TransportTLS.TrustBundlePEM = "-----BEGIN PRIVATE KEY-----\nAQID\n-----END PRIVATE KEY-----"
+			},
+			wantErr: "PEM block type \"PRIVATE KEY\" is not supported",
+		},
+		{
+			name: "reserved fingerprint key",
+			mutateWorkload: func(cfg *nvcaconfig.WorkloadConfig) {
+				cfg.TransportTLS.TrustBundleKey = transporttls.TrustBundleFingerprintKey
+			},
+			wantErr: "must not use reserved key",
+		},
+		{
+			name: "malformed fingerprint",
+			mutateWorkload: func(cfg *nvcaconfig.WorkloadConfig) {
+				cfg.TransportTLS.TrustBundleFingerprint = "sha256:not-a-digest"
+			},
+			wantErr: "must match sha256:<64 lowercase hex characters>",
+		},
+		{
+			name: "mismatched fingerprint",
+			mutateWorkload: func(cfg *nvcaconfig.WorkloadConfig) {
+				cfg.TransportTLS.TrustBundleFingerprint =
+					"sha256:0000000000000000000000000000000000000000000000000000000000000000"
+			},
+			wantErr: "does not match transportTls.trustBundlePem",
+		},
+		{
+			name: "bundle with insecure QUIC",
+			mutateWorkload: func(cfg *nvcaconfig.WorkloadConfig) {
+				cfg.StargateQUICInsecure = true
+			},
+			wantErr: "workload.stargateQUICInsecure=true cannot be used with workload.transportTLS.trustMode=bundle",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := newTestContext()
+			ms := &nvcav1alpha1.MiniService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "llm-miniservice",
+					Namespace: "worker-ns",
+					UID:       k8stypes.UID("llm-miniservice-uid"),
+				},
+				Spec: nvcav1alpha1.MiniServiceSpec{Namespace: "worker-ns"},
+			}
+			crClient, _ := newFakeClient(mgrScheme, ms)
+			workloadCfg := nvcaconfig.WorkloadConfig{
+				TransportTLS: &nvcaconfig.TransportTLSConfig{
+					TrustMode:                nvcaconfig.TrustModeBundle,
+					TrustBundleConfigMapName: "nvcf-transport-trust-bundle",
+					TrustBundleKey:           "nvcf-ca-bundle.pem",
+					TrustBundleFingerprint:   testTransportTLSRootFingerprint,
+					TrustBundlePEM:           testTransportTLSRootCertPEM,
+					InstalledBundleMountPath: "/nvcf/transport-tls",
+				},
+			}
+			tt.mutateWorkload(&workloadCfg)
+			r := &Reconciler{Client: crClient, cfg: nvcaconfig.Config{Workload: workloadCfg}}
+
+			err := r.prepareTransportTLSForWorkloads(ctx, ms, nil)
+
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, reconcile.TerminalError(nil)),
+				"invalid static transport TLS config should fail terminally without rendered pod specs")
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestPrepareTransportTLSForWorkloadsAllowsValidConfigWithoutPodSpecs(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *nvcaconfig.TransportTLSConfig
+	}{
+		{name: "transport TLS unset"},
+		{
+			name: "system trust",
+			cfg:  &nvcaconfig.TransportTLSConfig{TrustMode: nvcaconfig.TrustModeSystem},
+		},
+		{
+			name: "secure bundle",
+			cfg: &nvcaconfig.TransportTLSConfig{
+				TrustMode:              nvcaconfig.TrustModeBundle,
+				TrustBundleFingerprint: testTransportTLSRootFingerprint,
+				TrustBundlePEM:         testTransportTLSRootCertPEM,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := newTestContext()
+			ms := &nvcav1alpha1.MiniService{
+				ObjectMeta: metav1.ObjectMeta{Name: "no-pod-miniservice"},
+				Spec:       nvcav1alpha1.MiniServiceSpec{Namespace: "worker-ns"},
+			}
+			crClient, _ := newFakeClient(mgrScheme, ms)
+			r := &Reconciler{
+				Client: crClient,
+				cfg:    nvcaconfig.Config{Workload: nvcaconfig.WorkloadConfig{TransportTLS: tt.cfg}},
+			}
+
+			err := r.prepareTransportTLSForWorkloads(ctx, ms, nil)
+
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestPrepareTransportTLSForWorkloadsRejectsQUICInsecureTerminal(t *testing.T) {
 	ctx := newTestContext()
 	ms := &nvcav1alpha1.MiniService{

--- a/src/compute-plane-services/nvca/pkg/nvca/transport_tls.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/transport_tls.go
@@ -37,11 +37,11 @@ func (c K8sComputeBackend) prepareTransportTLSForPod(ctx context.Context, pod *c
 		return nil
 	}
 	cfg := transporttls.NormalizeConfig(*c.bk8s.cfg.Workload.TransportTLS)
-	if cfg.TrustMode != transporttls.TrustModeBundle || !transporttls.PodSpecHasLLMWorker(&pod.Spec) {
-		return nil
-	}
 	if err := transporttls.ValidateConfig(cfg); err != nil {
 		return nvcaerrors.TerminalError(err)
+	}
+	if cfg.TrustMode != transporttls.TrustModeBundle || !transporttls.PodSpecHasLLMWorker(&pod.Spec) {
+		return nil
 	}
 	if err := c.ensureTransportTLSConfigMap(ctx, pod.Namespace, cfg); err != nil {
 		return err

--- a/src/compute-plane-services/nvca/pkg/nvca/transport_tls_test.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/transport_tls_test.go
@@ -193,6 +193,33 @@ func TestCreatePodArtifactInstancesTransportTLSBundleRejectsMismatchedFingerprin
 	assert.True(t, apierrors.IsNotFound(getErr))
 }
 
+func TestCreatePodArtifactInstancesTransportTLSBundleRejectsInvalidConfigWithoutLLMWorker(t *testing.T) {
+	ctx := newTestContext()
+	clients := makeMockKubeClients()
+	kb := newTransportTLSTestBackend(clients, nvcaconfig.TransportTLSConfig{
+		TrustMode:                nvcaconfig.TrustModeBundle,
+		TrustBundleConfigMapName: "nvcf-transport-trust-bundle",
+		TrustBundleKey:           "nvcf-ca-bundle.pem",
+		TrustBundleFingerprint:   "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		TrustBundlePEM:           testTransportRootCertPEM,
+	})
+	pod := newTransportTLSTestPod()
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == function.LLMWorkerContainerName {
+			pod.Spec.Containers[i].Name = "non-llm-worker"
+		}
+	}
+
+	_, err := kb.CreatePodArtifactInstances(ctx, pod, newTransportTLSTestRequest(), transportTLSTestMutator)
+
+	require.Error(t, err)
+	assert.True(t, nvcaerrors.IsTerminal(err), "invalid static transport TLS config should fail before pod inspection")
+	assert.Contains(t, err.Error(), "trustBundleFingerprint does not match transportTls.trustBundlePem")
+	pods, listErr := clients.K8s.CoreV1().Pods(RequestsNamespace).List(ctx, metav1.ListOptions{})
+	require.NoError(t, listErr)
+	assert.Empty(t, pods.Items)
+}
+
 func TestCreatePodArtifactInstancesTransportTLSBundleRejectsInvalidConfigMapMetadata(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/nvcaagent_reconcile.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/nvcaagent_reconcile.go
@@ -53,6 +53,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/clustervalidator"
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/transporttls"
 	nvidiaiov1 "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvcf/v1"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/featureflag"
 	nvcaoperatorerrors "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/operator/internal/errors"
@@ -1441,20 +1442,30 @@ func (bc *BackendK8sCache) getAgentConfigToMerge(ctx context.Context) (nvcaconfi
 	if err != nil {
 		return nvcaconfig.Config{}, false, err
 	}
-	if !foundOperatorCfg {
-		return mergeCfg, foundMergeCfg, nil
-	}
-	if mergeCfg.Workload.TransportTLS != nil {
+	if foundOperatorCfg && mergeCfg.Workload.TransportTLS != nil {
 		return nvcaconfig.Config{}, false,
-			fmt.Errorf("agent-config-merge and %s both configure workload.transportTLS", nvcaOperatorConfigMapName)
+			nvcaoperatorerrors.FatalError(
+				fmt.Errorf("agent-config-merge and %s both configure workload.transportTLS", nvcaOperatorConfigMapName))
 	}
 
-	mergeCfg.Workload.TransportTLS = operatorCfg.Workload.TransportTLS
-	if err := mergeCfg.Validate(); err != nil {
+	if foundOperatorCfg {
+		mergeCfg.Workload.TransportTLS = operatorCfg.Workload.TransportTLS
+	}
+	if err := validateAgentConfigToMerge(mergeCfg); err != nil {
 		return nvcaconfig.Config{}, false,
 			nvcaoperatorerrors.FatalError(fmt.Errorf("invalid combined NVCA agent configuration: %w", err))
 	}
-	return mergeCfg, true, nil
+	return mergeCfg, foundMergeCfg || foundOperatorCfg, nil
+}
+
+func validateAgentConfigToMerge(cfg nvcaconfig.Config) error {
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+	if cfg.Workload.TransportTLS == nil {
+		return nil
+	}
+	return transporttls.ValidateConfig(transporttls.NormalizeConfig(*cfg.Workload.TransportTLS))
 }
 
 func (bc *BackendK8sCache) getRawAgentConfigToMerge(ctx context.Context) (nvcaconfig.Config, bool, error) {

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/nvcaagent_reconcile_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/nvcaagent_reconcile_test.go
@@ -5177,8 +5177,8 @@ func TestSetupAgentConfigConfigMapMergesTransportTLSFromAgentConfigMergeConfigMa
 				TrustMode:                nvcaconfig.TrustModeBundle,
 				TrustBundleConfigMapName: "nvcf-transport-trust-bundle",
 				TrustBundleKey:           "nvcf-ca-bundle.pem",
-				TrustBundleFingerprint:   "sha256:9a7814909424061a68756ee5c26aa1a1491b8d20a7b813fb24fa7e73b2fa1c93",
-				TrustBundlePEM:           "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n",
+				TrustBundleFingerprint:   "sha256:95b3dc7dfd3212a6f02c644527f0a65890a9a9c80acf7551be6aa89b1f98fe86",
+				TrustBundlePEM:           transportTrustTestPEM,
 			},
 		},
 	}
@@ -5219,10 +5219,9 @@ func TestSetupAgentConfigConfigMapMergesTransportTLSFromAgentConfigMergeConfigMa
 	assert.Equal(t, nvcaconfig.TrustModeBundle, gotCfg.Workload.TransportTLS.TrustMode)
 	assert.Equal(t, "nvcf-transport-trust-bundle", gotCfg.Workload.TransportTLS.TrustBundleConfigMapName)
 	assert.Equal(t, "nvcf-ca-bundle.pem", gotCfg.Workload.TransportTLS.TrustBundleKey)
-	assert.Equal(t, "sha256:9a7814909424061a68756ee5c26aa1a1491b8d20a7b813fb24fa7e73b2fa1c93",
+	assert.Equal(t, "sha256:95b3dc7dfd3212a6f02c644527f0a65890a9a9c80acf7551be6aa89b1f98fe86",
 		gotCfg.Workload.TransportTLS.TrustBundleFingerprint)
-	assert.Equal(t, "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n",
-		gotCfg.Workload.TransportTLS.TrustBundlePEM)
+	assert.Equal(t, transportTrustTestPEM, gotCfg.Workload.TransportTLS.TrustBundlePEM)
 }
 
 func TestGetChartDefaultAgentConfig(t *testing.T) {

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/transport_tls_config_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/transport_tls_config_test.go
@@ -167,6 +167,7 @@ func TestGetAgentConfigToMerge_RejectsTransportTLSSourceConflict(t *testing.T) {
 
 	_, _, err = bc.getAgentConfigToMerge(ctx)
 	require.Error(t, err)
+	assert.True(t, nvcaoperatorerrors.IsFatal(err), "invalid static source conflict must not be requeued")
 	assert.Contains(t, err.Error(), "both configure workload.transportTLS")
 }
 
@@ -197,6 +198,90 @@ func TestGetRawAgentConfigToMerge_MalformedIsFatal(t *testing.T) {
 	assert.False(t, found)
 	assert.True(t, nvcaoperatorerrors.IsFatal(err))
 	assert.Contains(t, err.Error(), "invalid agent-config-merge")
+}
+
+func TestGetAgentConfigToMerge_RejectsInvalidDirectMergeTransportTLSAsFatal(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutateCfg func(*nvcaconfig.TransportTLSConfig)
+		wantErr   string
+	}{
+		{
+			name: "missing bundle",
+			mutateCfg: func(cfg *nvcaconfig.TransportTLSConfig) {
+				cfg.TrustBundlePEM = ""
+			},
+			wantErr: "trustBundlePem is required",
+		},
+		{
+			name: "malformed PEM",
+			mutateCfg: func(cfg *nvcaconfig.TransportTLSConfig) {
+				cfg.TrustBundlePEM = "not a PEM bundle"
+			},
+			wantErr: "trustBundlePem is invalid",
+		},
+		{
+			name: "private key PEM",
+			mutateCfg: func(cfg *nvcaconfig.TransportTLSConfig) {
+				cfg.TrustBundlePEM = "-----BEGIN PRIVATE KEY-----\nAQID\n-----END PRIVATE KEY-----"
+			},
+			wantErr: "PEM block type \"PRIVATE KEY\" is not supported",
+		},
+		{
+			name: "reserved fingerprint key",
+			mutateCfg: func(cfg *nvcaconfig.TransportTLSConfig) {
+				cfg.TrustBundleKey = transporttls.TrustBundleFingerprintKey
+			},
+			wantErr: "must not use reserved key",
+		},
+		{
+			name: "malformed fingerprint",
+			mutateCfg: func(cfg *nvcaconfig.TransportTLSConfig) {
+				cfg.TrustBundleFingerprint = "sha256:not-a-digest"
+			},
+			wantErr: "must match sha256:<64 lowercase hex characters>",
+		},
+		{
+			name: "mismatched fingerprint",
+			mutateCfg: func(cfg *nvcaconfig.TransportTLSConfig) {
+				cfg.TrustBundleFingerprint =
+					"sha256:0000000000000000000000000000000000000000000000000000000000000000"
+			},
+			wantErr: "does not match transportTls.trustBundlePem",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := newTestContext()
+			clients := mockKubeClientsForIntegrationTests()
+			bc := &BackendK8sCache{clients: clients, operatorNamespace: NVCAOperatorNamespace}
+			transportTLSCfg := nvcaconfig.TransportTLSConfig{
+				TrustMode:                nvcaconfig.TrustModeBundle,
+				TrustBundleConfigMapName: "nvcf-transport-trust-bundle",
+				TrustBundleKey:           "nvcf-ca-bundle.pem",
+				TrustBundleFingerprint:   "sha256:95b3dc7dfd3212a6f02c644527f0a65890a9a9c80acf7551be6aa89b1f98fe86",
+				TrustBundlePEM:           transportTrustTestPEM,
+				InstalledBundleMountPath: "/nvcf/transport-tls",
+			}
+			tt.mutateCfg(&transportTLSCfg)
+			mergeConfigData, err := nvcaconfig.EncodeConfig(nvcaconfig.Config{
+				Workload: nvcaconfig.WorkloadConfig{TransportTLS: &transportTLSCfg},
+			})
+			require.NoError(t, err)
+			_, err = clients.K8s.CoreV1().ConfigMaps(NVCAOperatorNamespace).Create(ctx, &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: agentConfigMergeConfigMapName},
+				Data:       map[string]string{agentConfigFile: string(mergeConfigData)},
+			}, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			_, _, err = bc.getAgentConfigToMerge(ctx)
+
+			require.Error(t, err)
+			assert.True(t, nvcaoperatorerrors.IsFatal(err), "invalid static agent configuration must not be requeued")
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
 }
 
 func TestGetAgentConfigToMerge_RejectsBundleWithQUICInsecureAsFatal(t *testing.T) {


### PR DESCRIPTION
## TL;DR

Apply the full NVCA transport TLS validator to the final combined agent configuration and before workload-specific early exits.

## Additional Details

- Validate direct agent configuration and operator-provided trust data after they are combined.
- Reject malformed or incomplete bundle trust and bundle trust paired with insecure QUIC as terminal static configuration errors.
- Validate before no-pod and non-LLM early returns.
- Preserve unset transport TLS, system trust, valid secure bundles, and legitimate no-pod behavior.

## For the Reviewer

Please focus on the validation ordering in `internal/miniservice/transport_tls.go`, `pkg/nvca/transport_tls.go`, and `pkg/operator/reconcile/nvcaagent_reconcile.go`.

## For QA

Is QA Needed? Yes. Verify that Secret-backed bundle trust combined with direct `stargateQUICInsecure: true` is rejected before workload creation, and that a valid secure bundle still produces healthy workloads without insecure QUIC flags.

## Issues

Relates to #1400

## Related Pull Requests

- v3.2 backport: #1402

## Dependencies

None. No dependency, license, or NOTICE changes.

## Testing

- Focused RED/GREEN regressions for direct merge, Secret-backed combination, no-pod MiniService, and non-LLM pod paths
- Full affected Go package suites with envtest and required linker flags
- Bazel tests for all four affected packages
- Bazel builds for the NVCA and NVCA operator binaries
- `git diff --check`

`make lint-go` could not start in the clean checkout because the local-only `.env` file is absent; Bazel analysis, compilation, tests, and binary builds passed.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transport TLS configurations are now validated consistently before processing continues.
  * Invalid certificates, bundles, fingerprints, reserved keys, and insecure trust settings now produce clear terminal errors, even when TLS injection is skipped.
  * Conflicting transport TLS definitions are reported as fatal configuration errors.
  * Valid unset, system-trust, and secure bundle configurations continue to work when no workload specification is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Verification

### Automated checks

The reviewed commit `e09b65e71e901615b3f78861f18945835e638bf4` passed:

```sh
bazel test \
  //src/compute-plane-services/nvca/internal/miniservice:miniservice_test \
  //src/compute-plane-services/nvca/internal/transporttls:transporttls_test \
  //src/compute-plane-services/nvca/pkg/nvca:nvca_test \
  //src/compute-plane-services/nvca/pkg/operator/reconcile:reconcile_test
bazel build \
  //src/compute-plane-services/nvca/cmd/nvca:nvca \
  //src/compute-plane-services/nvca/cmd/nvca-operator:nvca-operator
git diff --check origin/main...HEAD
```

Result: all four Bazel test targets passed, both binaries built, and the diff check was clean.

### Disposable live k3d validation

The repository-prescribed local workflow was used on a newly created disposable cluster:

```sh
make -C tools/ncp-local-cluster build-and-deploy-cluster
(cd tests/bdd && go test -run '^TestSingleClusterHelmfileLLMPKI$' -timeout 90m -v)
bazel run --stamp --define VERSION=main-e09b65e //src/compute-plane-services/nvca/cmd/nvca-operator:image_load
bazel run --stamp --define VERSION=main-e09b65e //src/compute-plane-services/nvca/cmd/nvca:image_load
k3d image import --cluster ncp-local local.test/nvcf/nvca-operator:main-e09b65e local.test/nvcf/nvca:main-e09b65e
kubectl --context k3d-ncp-local -n nvca-operator logs deployment/nvca-operator -c nvca-operator
kubectl --context k3d-ncp-local -n nvca-system get configmap agent-config
kubectl --context k3d-ncp-local -n nvca-system get deployment nvca
```

The full PKI BDD installed the stack, issuers/certificates, profile, registration, compute plane, and operator, then created and deployed the LLM function. It reported 3/4 scenarios and 67/75 steps passing (7 skipped). The only failing step was invocation, which returned HTTP 404 `no_eligible_candidates`; invocation success is therefore not claimed. The independent transport-TLS matrix below used locally loaded images built from the reviewed commit; both operator and agent reported version `mr-e09b65e7`.

For each negative row, the final source ConfigMaps were applied, generated `nvca-system/agent-config` and the `nvca-system/nvca` Deployment were removed, and the exact operator was restarted. All 7/7 invalid cases terminated reconciliation before either generated artifact reappeared:

| Configuration | Live result |
| --- | --- |
| Secret-backed CA bundle plus direct `stargateQUICInsecure: true` | Rejected with the bundle/insecure fatal error |
| `trustMode: bundle` without a bundle | Rejected: bundle PEM required |
| Malformed PEM | Rejected: bundle PEM invalid |
| Private-key PEM | Rejected: PEM block type unsupported |
| Reserved bundle key `fingerprint` | Rejected: reserved key |
| Malformed fingerprint | Rejected: expected `sha256:` plus 64 lowercase hex characters |
| Fingerprint not matching the CA bundle | Rejected: fingerprint mismatch |

The cluster's public CA ConfigMap supplied a valid PEM for positive and fingerprint cases; no credentials or private key material were used.

Positive live results:

- System trust generated agent configuration and the exact operator/agent became healthy.
- A Secret-backed bundle with insecure QUIC disabled generated `trustMode: bundle` plus a matching SHA-256 fingerprint, and the exact operator/agent became healthy.
- A direct-container non-LLM function deployed successfully and reached a 2/2 Running workload pod.
- A disposable Helm chart containing a regular worker but no `llm-worker` passed ReVal, reached MiniService `Running`, had all pods Running, and completed CLI deployment.
- A Service-only zero-pod chart was rejected by ReVal before NVCA with `provided helm chart service "no-pod" has no port 8000 matching selected pod specs`. No live NVCA result is claimed for that platform-inaccessible path; the focused no-pod regression passed in the exact commit checks above.

Live k3d status: transport-TLS negative and positive coverage passed. Application invocation remains unverified because of the unrelated `no_eligible_candidates` response described above.

### Validation flow

```mermaid
flowchart LR
  subgraph Before
    A[Direct merge or Secret-backed trust] --> B[Workload-specific rendering]
    B --> C{Pod specs / LLM worker?}
    C -->|No| D[Early return bypasses validation]
    C -->|Yes| E[Late TLS validation]
  end
  subgraph After
    F[Direct merge + Secret-backed trust] --> G[Validate final merged config]
    G --> H[Validate before runtime early returns]
    H --> I{Pod specs / LLM worker?}
    I -->|No| J[Valid no-op]
    I -->|Yes| K[Render workload]
  end
```