### PR TITLE
fix(nvca): validate transport TLS before workload rendering

### DIFF
--- a/src/compute-plane-services/nvca/internal/miniservice/transport_tls.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/transport_tls.go
@@ -37,6 +37,9 @@ func (r *Reconciler) prepareTransportTLSForWorkloads(
 	ms *nvcav1alpha1.MiniService,
 	objs []client.Object,
 ) error {
+	if err := transporttls.ValidateWorkloadConfig(r.cfg.Workload); err != nil {
+		return reconcile.TerminalError(err)
+	}
 	if r.cfg.Workload.TransportTLS == nil {
 		return nil
 	}
@@ -55,10 +58,6 @@ func (r *Reconciler) prepareTransportTLSForWorkloads(
 	}
 	if len(podSpecs) == 0 {
 		return nil
-	}
-
-	if err := transporttls.ValidateConfig(cfg); err != nil {
-		return reconcile.TerminalError(err)
 	}
 	if err := r.ensureTransportTLSConfigMap(ctx, ms, cfg); err != nil {
 		return err

--- a/src/compute-plane-services/nvca/internal/miniservice/transport_tls_test.go
+++ b/src/compute-plane-services/nvca/internal/miniservice/transport_tls_test.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/transporttls"
 	nvcav1alpha1 "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/v1alpha1"
 )
 
@@ -551,4 +552,137 @@ func findWorkloadEnvValue(container *corev1.Container, name string) string {
 		}
 	}
 	return ""
+}
+
+func TestPrepareTransportTLSForWorkloadsRejectsInvalidConfigWithoutPodSpecs(t *testing.T) {
+	tests := []struct {
+		name           string
+		mutateWorkload func(*nvcaconfig.WorkloadConfig)
+		wantErr        string
+	}{
+		{
+			name: "missing bundle",
+			mutateWorkload: func(cfg *nvcaconfig.WorkloadConfig) {
+				cfg.TransportTLS.TrustBundlePEM = ""
+			},
+			wantErr: "trustBundlePem is required",
+		},
+		{
+			name: "malformed PEM",
+			mutateWorkload: func(cfg *nvcaconfig.WorkloadConfig) {
+				cfg.TransportTLS.TrustBundlePEM = "not a PEM bundle"
+			},
+			wantErr: "trustBundlePem is invalid",
+		},
+		{
+			name: "private key PEM",
+			mutateWorkload: func(cfg *nvcaconfig.WorkloadConfig) {
+				cfg.TransportTLS.TrustBundlePEM = "-----BEGIN PRIVATE KEY-----\nAQID\n-----END PRIVATE KEY-----"
+			},
+			wantErr: "PEM block type \"PRIVATE KEY\" is not supported",
+		},
+		{
+			name: "reserved fingerprint key",
+			mutateWorkload: func(cfg *nvcaconfig.WorkloadConfig) {
+				cfg.TransportTLS.TrustBundleKey = transporttls.TrustBundleFingerprintKey
+			},
+			wantErr: "must not use reserved key",
+		},
+		{
+			name: "malformed fingerprint",
+			mutateWorkload: func(cfg *nvcaconfig.WorkloadConfig) {
+				cfg.TransportTLS.TrustBundleFingerprint = "sha256:not-a-digest"
+			},
+			wantErr: "must match sha256:<64 lowercase hex characters>",
+		},
+		{
+			name: "mismatched fingerprint",
+			mutateWorkload: func(cfg *nvcaconfig.WorkloadConfig) {
+				cfg.TransportTLS.TrustBundleFingerprint =
+					"sha256:0000000000000000000000000000000000000000000000000000000000000000"
+			},
+			wantErr: "does not match transportTls.trustBundlePem",
+		},
+		{
+			name: "bundle with insecure QUIC",
+			mutateWorkload: func(cfg *nvcaconfig.WorkloadConfig) {
+				cfg.StargateQUICInsecure = true
+			},
+			wantErr: "workload.stargateQUICInsecure=true cannot be used with workload.transportTLS.trustMode=bundle",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := newTestContext()
+			ms := &nvcav1alpha1.MiniService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "llm-miniservice",
+					Namespace: "worker-ns",
+					UID:       k8stypes.UID("llm-miniservice-uid"),
+				},
+				Spec: nvcav1alpha1.MiniServiceSpec{Namespace: "worker-ns"},
+			}
+			crClient, _ := newFakeClient(mgrScheme, ms)
+			workloadCfg := nvcaconfig.WorkloadConfig{
+				TransportTLS: &nvcaconfig.TransportTLSConfig{
+					TrustMode:                nvcaconfig.TrustModeBundle,
+					TrustBundleConfigMapName: "nvcf-transport-trust-bundle",
+					TrustBundleKey:           "nvcf-ca-bundle.pem",
+					TrustBundleFingerprint:   testTransportTLSRootFingerprint,
+					TrustBundlePEM:           testTransportTLSRootCertPEM,
+					InstalledBundleMountPath: "/nvcf/transport-tls",
+				},
+			}
+			tt.mutateWorkload(&workloadCfg)
+			r := &Reconciler{Client: crClient, cfg: nvcaconfig.Config{Workload: workloadCfg}}
+
+			err := r.prepareTransportTLSForWorkloads(ctx, ms, nil)
+
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, reconcile.TerminalError(nil)),
+				"invalid static transport TLS config should fail terminally without rendered pod specs")
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestPrepareTransportTLSForWorkloadsAllowsValidConfigWithoutPodSpecs(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *nvcaconfig.TransportTLSConfig
+	}{
+		{name: "transport TLS unset"},
+		{
+			name: "system trust",
+			cfg:  &nvcaconfig.TransportTLSConfig{TrustMode: nvcaconfig.TrustModeSystem},
+		},
+		{
+			name: "secure bundle",
+			cfg: &nvcaconfig.TransportTLSConfig{
+				TrustMode:              nvcaconfig.TrustModeBundle,
+				TrustBundleFingerprint: testTransportTLSRootFingerprint,
+				TrustBundlePEM:         testTransportTLSRootCertPEM,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := newTestContext()
+			ms := &nvcav1alpha1.MiniService{
+				ObjectMeta: metav1.ObjectMeta{Name: "no-pod-miniservice"},
+				Spec:       nvcav1alpha1.MiniServiceSpec{Namespace: "worker-ns"},
+			}
+			crClient, _ := newFakeClient(mgrScheme, ms)
+			r := &Reconciler{
+				Client: crClient,
+				cfg:    nvcaconfig.Config{Workload: nvcaconfig.WorkloadConfig{TransportTLS: tt.cfg}},
+			}
+
+			err := r.prepareTransportTLSForWorkloads(ctx, ms, nil)
+
+			require.NoError(t, err)
+		})
+	}
 }

--- a/src/compute-plane-services/nvca/internal/transporttls/transport_tls.go
+++ b/src/compute-plane-services/nvca/internal/transporttls/transport_tls.go
@@ -75,6 +75,19 @@ func NormalizeConfig(cfg nvcaconfig.TransportTLSConfig) nvcaconfig.TransportTLSC
 	return cfg
 }
 
+// ValidateWorkloadConfig validates transport trust before workload-specific
+// rendering can bypass it.
+func ValidateWorkloadConfig(workload nvcaconfig.WorkloadConfig) error {
+	if workload.TransportTLS == nil {
+		return nil
+	}
+	cfg := NormalizeConfig(*workload.TransportTLS)
+	if workload.StargateQUICInsecure && cfg.TrustMode == TrustModeBundle {
+		return fmt.Errorf("workload.stargateQUICInsecure=true cannot be used with workload.transportTLS.trustMode=bundle; set workload.stargateQUICInsecure=false or use trustMode=system")
+	}
+	return ValidateConfig(cfg)
+}
+
 func ValidateConfig(cfg nvcaconfig.TransportTLSConfig) error {
 	switch cfg.TrustMode {
 	case TrustModeSystem:

--- a/src/compute-plane-services/nvca/pkg/nvca/transport_tls.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/transport_tls.go
@@ -30,15 +30,15 @@ import (
 )
 
 func (c K8sComputeBackend) prepareTransportTLSForPod(ctx context.Context, pod *corev1.Pod) error {
+	if err := transporttls.ValidateWorkloadConfig(c.bk8s.cfg.Workload); err != nil {
+		return nvcaerrors.TerminalError(err)
+	}
 	if c.bk8s.cfg.Workload.TransportTLS == nil {
 		return nil
 	}
 	cfg := transporttls.NormalizeConfig(*c.bk8s.cfg.Workload.TransportTLS)
 	if cfg.TrustMode != transporttls.TrustModeBundle || !transporttls.PodSpecHasLLMWorker(&pod.Spec) {
 		return nil
-	}
-	if err := transporttls.ValidateConfig(cfg); err != nil {
-		return nvcaerrors.TerminalError(err)
 	}
 	if err := c.ensureTransportTLSConfigMap(ctx, pod.Namespace, cfg); err != nil {
 		return err

--- a/src/compute-plane-services/nvca/pkg/nvca/transport_tls_test.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/transport_tls_test.go
@@ -156,6 +156,33 @@ func TestCreatePodArtifactInstancesTransportTLSBundleRejectsMismatchedFingerprin
 	assert.True(t, apierrors.IsNotFound(getErr))
 }
 
+func TestCreatePodArtifactInstancesTransportTLSBundleRejectsInvalidConfigWithoutLLMWorker(t *testing.T) {
+	ctx := newTestContext()
+	clients := makeMockKubeClients()
+	kb := newTransportTLSTestBackend(clients, nvcaconfig.TransportTLSConfig{
+		TrustMode:                nvcaconfig.TrustModeBundle,
+		TrustBundleConfigMapName: "nvcf-transport-trust-bundle",
+		TrustBundleKey:           "nvcf-ca-bundle.pem",
+		TrustBundleFingerprint:   "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		TrustBundlePEM:           testTransportRootCertPEM,
+	})
+	pod := newTransportTLSTestPod()
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == function.LLMWorkerContainerName {
+			pod.Spec.Containers[i].Name = "non-llm-worker"
+		}
+	}
+
+	_, err := kb.CreatePodArtifactInstances(ctx, pod, newTransportTLSTestRequest(), transportTLSTestMutator)
+
+	require.Error(t, err)
+	assert.True(t, nvcaerrors.IsTerminal(err), "invalid static transport TLS config should fail before pod inspection")
+	assert.Contains(t, err.Error(), "trustBundleFingerprint does not match transportTls.trustBundlePem")
+	pods, listErr := clients.K8s.CoreV1().Pods(RequestsNamespace).List(ctx, metav1.ListOptions{})
+	require.NoError(t, listErr)
+	assert.Empty(t, pods.Items)
+}
+
 func TestCreatePodArtifactInstancesTransportTLSBundleRejectsInvalidConfigMapMetadata(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/nvcaagent_reconcile.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/nvcaagent_reconcile.go
@@ -53,6 +53,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/clustervalidator"
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/transporttls"
 	nvidiaiov1 "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvcf/v1"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/featureflag"
 	nvcaoperatorerrors "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/operator/internal/errors"
@@ -1428,16 +1429,20 @@ func (bc *BackendK8sCache) getAgentConfigToMerge(ctx context.Context) (nvcaconfi
 	if err != nil {
 		return nvcaconfig.Config{}, false, err
 	}
-	if !foundOperatorCfg {
-		return mergeCfg, foundMergeCfg, nil
-	}
-	if mergeCfg.Workload.TransportTLS != nil {
-		return nvcaconfig.Config{}, false,
-			fmt.Errorf("agent-config-merge and %s both configure workload.transportTLS", nvcaOperatorConfigMapName)
-	}
+	if foundOperatorCfg {
+		if mergeCfg.Workload.TransportTLS != nil {
+			return nvcaconfig.Config{}, false,
+				nvcaoperatorerrors.FatalError(
+					fmt.Errorf("agent-config-merge and %s both configure workload.transportTLS", nvcaOperatorConfigMapName))
+		}
 
-	mergeCfg.Workload.TransportTLS = operatorCfg.Workload.TransportTLS
-	return mergeCfg, true, nil
+		mergeCfg.Workload.TransportTLS = operatorCfg.Workload.TransportTLS
+	}
+	if err := transporttls.ValidateWorkloadConfig(mergeCfg.Workload); err != nil {
+		return nvcaconfig.Config{}, false,
+			nvcaoperatorerrors.FatalError(fmt.Errorf("invalid combined NVCA agent configuration: %w", err))
+	}
+	return mergeCfg, foundMergeCfg || foundOperatorCfg, nil
 }
 
 func (bc *BackendK8sCache) getRawAgentConfigToMerge(ctx context.Context) (nvcaconfig.Config, bool, error) {

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/nvcaagent_reconcile_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/nvcaagent_reconcile_test.go
@@ -5162,8 +5162,8 @@ func TestSetupAgentConfigConfigMapMergesTransportTLSFromAgentConfigMergeConfigMa
 				TrustMode:                nvcaconfig.TrustModeBundle,
 				TrustBundleConfigMapName: "nvcf-transport-trust-bundle",
 				TrustBundleKey:           "nvcf-ca-bundle.pem",
-				TrustBundleFingerprint:   "sha256:9a7814909424061a68756ee5c26aa1a1491b8d20a7b813fb24fa7e73b2fa1c93",
-				TrustBundlePEM:           "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n",
+				TrustBundleFingerprint:   "sha256:95b3dc7dfd3212a6f02c644527f0a65890a9a9c80acf7551be6aa89b1f98fe86",
+				TrustBundlePEM:           transportTrustTestPEM,
 			},
 		},
 	}
@@ -5204,10 +5204,9 @@ func TestSetupAgentConfigConfigMapMergesTransportTLSFromAgentConfigMergeConfigMa
 	assert.Equal(t, nvcaconfig.TrustModeBundle, gotCfg.Workload.TransportTLS.TrustMode)
 	assert.Equal(t, "nvcf-transport-trust-bundle", gotCfg.Workload.TransportTLS.TrustBundleConfigMapName)
 	assert.Equal(t, "nvcf-ca-bundle.pem", gotCfg.Workload.TransportTLS.TrustBundleKey)
-	assert.Equal(t, "sha256:9a7814909424061a68756ee5c26aa1a1491b8d20a7b813fb24fa7e73b2fa1c93",
+	assert.Equal(t, "sha256:95b3dc7dfd3212a6f02c644527f0a65890a9a9c80acf7551be6aa89b1f98fe86",
 		gotCfg.Workload.TransportTLS.TrustBundleFingerprint)
-	assert.Equal(t, "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n",
-		gotCfg.Workload.TransportTLS.TrustBundlePEM)
+	assert.Equal(t, transportTrustTestPEM, gotCfg.Workload.TransportTLS.TrustBundlePEM)
 }
 
 func TestGetChartDefaultAgentConfig(t *testing.T) {

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/transport_tls_config_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/transport_tls_config_test.go
@@ -28,6 +28,7 @@ import (
 	nvidiaiov1 "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvcf/v1"
 	nvcabelister "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/client/listers/nvcf/v1"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/operator/cleanup"
+	nvcaoperatorerrors "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/operator/internal/errors"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/operator/internal/kubeclients"
 	nvcaopotel "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/operator/otel"
 	nvcaoptypes "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/operator/types"
@@ -166,6 +167,7 @@ func TestGetAgentConfigToMerge_RejectsTransportTLSSourceConflict(t *testing.T) {
 
 	_, _, err = bc.getAgentConfigToMerge(ctx)
 	require.Error(t, err)
+	assert.True(t, nvcaoperatorerrors.IsFatal(err), "invalid static source conflict must not be requeued")
 	assert.Contains(t, err.Error(), "both configure workload.transportTLS")
 }
 
@@ -832,4 +834,152 @@ type testResourceEventHandlerRegistration struct {
 
 func (r testResourceEventHandlerRegistration) HasSynced() bool {
 	return r.synced
+}
+
+func TestGetAgentConfigToMerge_RejectsInvalidDirectMergeTransportTLSAsFatal(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutateCfg func(*nvcaconfig.TransportTLSConfig)
+		wantErr   string
+	}{
+		{
+			name: "missing bundle",
+			mutateCfg: func(cfg *nvcaconfig.TransportTLSConfig) {
+				cfg.TrustBundlePEM = ""
+			},
+			wantErr: "trustBundlePem is required",
+		},
+		{
+			name: "malformed PEM",
+			mutateCfg: func(cfg *nvcaconfig.TransportTLSConfig) {
+				cfg.TrustBundlePEM = "not a PEM bundle"
+			},
+			wantErr: "trustBundlePem is invalid",
+		},
+		{
+			name: "private key PEM",
+			mutateCfg: func(cfg *nvcaconfig.TransportTLSConfig) {
+				cfg.TrustBundlePEM = "-----BEGIN PRIVATE KEY-----\nAQID\n-----END PRIVATE KEY-----"
+			},
+			wantErr: "PEM block type \"PRIVATE KEY\" is not supported",
+		},
+		{
+			name: "reserved fingerprint key",
+			mutateCfg: func(cfg *nvcaconfig.TransportTLSConfig) {
+				cfg.TrustBundleKey = transporttls.TrustBundleFingerprintKey
+			},
+			wantErr: "must not use reserved key",
+		},
+		{
+			name: "malformed fingerprint",
+			mutateCfg: func(cfg *nvcaconfig.TransportTLSConfig) {
+				cfg.TrustBundleFingerprint = "sha256:not-a-digest"
+			},
+			wantErr: "must match sha256:<64 lowercase hex characters>",
+		},
+		{
+			name: "mismatched fingerprint",
+			mutateCfg: func(cfg *nvcaconfig.TransportTLSConfig) {
+				cfg.TrustBundleFingerprint =
+					"sha256:0000000000000000000000000000000000000000000000000000000000000000"
+			},
+			wantErr: "does not match transportTls.trustBundlePem",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := newTestContext()
+			clients := mockKubeClientsForIntegrationTests()
+			bc := &BackendK8sCache{clients: clients, operatorNamespace: NVCAOperatorNamespace}
+			transportTLSCfg := nvcaconfig.TransportTLSConfig{
+				TrustMode:                nvcaconfig.TrustModeBundle,
+				TrustBundleConfigMapName: "nvcf-transport-trust-bundle",
+				TrustBundleKey:           "nvcf-ca-bundle.pem",
+				TrustBundleFingerprint:   "sha256:95b3dc7dfd3212a6f02c644527f0a65890a9a9c80acf7551be6aa89b1f98fe86",
+				TrustBundlePEM:           transportTrustTestPEM,
+				InstalledBundleMountPath: "/nvcf/transport-tls",
+			}
+			tt.mutateCfg(&transportTLSCfg)
+			mergeConfigData, err := nvcaconfig.EncodeConfig(nvcaconfig.Config{
+				Workload: nvcaconfig.WorkloadConfig{TransportTLS: &transportTLSCfg},
+			})
+			require.NoError(t, err)
+			_, err = clients.K8s.CoreV1().ConfigMaps(NVCAOperatorNamespace).Create(ctx, &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: agentConfigMergeConfigMapName},
+				Data:       map[string]string{agentConfigFile: string(mergeConfigData)},
+			}, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			_, _, err = bc.getAgentConfigToMerge(ctx)
+
+			require.Error(t, err)
+			assert.True(t, nvcaoperatorerrors.IsFatal(err), "invalid static agent configuration must not be requeued")
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestGetAgentConfigToMerge_RejectsBundleWithQUICInsecureAsFatal(t *testing.T) {
+	ctx := newTestContext()
+	clients := mockKubeClientsForIntegrationTests()
+	bc := &BackendK8sCache{clients: clients, operatorNamespace: NVCAOperatorNamespace}
+
+	_, err := clients.K8s.CoreV1().ConfigMaps(NVCAOperatorNamespace).Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: agentConfigMergeConfigMapName},
+		Data: map[string]string{agentConfigFile: `workload:
+  stargateQUICInsecure: true
+  transportTLS:
+    trustMode: bundle
+`},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, _, err = bc.getAgentConfigToMerge(ctx)
+	require.Error(t, err)
+	assert.True(t, nvcaoperatorerrors.IsFatal(err), "invalid static agent configuration must not be requeued")
+	assert.Contains(t, err.Error(), "workload.stargateQUICInsecure=true cannot be used with workload.transportTLS.trustMode=bundle")
+}
+
+func TestGetAgentConfigToMerge_RejectsSecretBundleWithQUICInsecureAsFatal(t *testing.T) {
+	ctx := newTestContext()
+	clients := mockKubeClientsForIntegrationTests()
+	bc := &BackendK8sCache{clients: clients, operatorNamespace: NVCAOperatorNamespace}
+
+	_, err := clients.K8s.CoreV1().ConfigMaps(NVCAOperatorNamespace).Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: agentConfigMergeConfigMapName},
+		Data: map[string]string{agentConfigFile: `workload:
+  stargateQUICInsecure: true
+`},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+	createTransportTrustSource(t, ctx, clients)
+
+	_, _, err = bc.getAgentConfigToMerge(ctx)
+	require.Error(t, err)
+	assert.True(t, nvcaoperatorerrors.IsFatal(err), "invalid combined operator configuration must not be requeued")
+	assert.Contains(t, err.Error(), "workload.stargateQUICInsecure=true cannot be used with workload.transportTLS.trustMode=bundle")
+}
+
+func TestGetAgentConfigToMerge_AllowsSystemWithQUICInsecure(t *testing.T) {
+	ctx := newTestContext()
+	clients := mockKubeClientsForIntegrationTests()
+	bc := &BackendK8sCache{clients: clients, operatorNamespace: NVCAOperatorNamespace}
+
+	_, err := clients.K8s.CoreV1().ConfigMaps(NVCAOperatorNamespace).Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: agentConfigMergeConfigMapName},
+		Data: map[string]string{agentConfigFile: `workload:
+  stargateQUICInsecure: true
+  transportTLS:
+    trustMode: system
+`},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	cfg, found, err := bc.getAgentConfigToMerge(ctx)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.True(t, cfg.Workload.StargateQUICInsecure)
+	require.NotNil(t, cfg.Workload.TransportTLS)
+	assert.Equal(t, nvcaconfig.TrustModeSystem, cfg.Workload.TransportTLS.TrustMode)
 }


### PR DESCRIPTION
## TL;DR

Backport final and pre-render NVCA transport TLS validation to the v3.2 release branch.

## Additional Details

- Validate direct agent configuration and operator-provided trust data after they are combined.
- Add a release-local workload validator because v3.2 predates the shared workload validation introduced on main; no vendor files are changed.
- Reject malformed or incomplete bundle trust and bundle trust paired with insecure QUIC as terminal static configuration errors.
- Validate before no-pod and non-LLM early returns while preserving valid configurations.

## For the Reviewer

Please focus on `internal/transporttls.ValidateWorkloadConfig` and its use at the final operator configuration boundary and before workload-specific rendering exits.

## For QA

Is QA Needed? Yes. Repeat the Secret-backed bundle plus direct `stargateQUICInsecure: true` rejection on an NVCA v3.2 build, then verify a valid secure bundle still creates healthy workloads without insecure QUIC flags.

## Issues

Relates to #1400

## Related Pull Requests

- Main fix: #1401

## Dependencies

None. No dependency, vendor, license, or NOTICE changes.

## Testing

- Independent focused RED/GREEN regressions on the v3.2 release branch
- Full affected Go package suites with envtest and required linker flags
- Bazel tests for all four affected packages
- Bazel builds for the NVCA and NVCA operator binaries
- `git diff --check`

`make lint-go` could not start in the clean checkout because the local-only `.env` file is absent; Bazel analysis, compilation, tests, and binary builds passed.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Verification

### Automated checks

The reviewed commit `caa4fbd7e6283cb6491a70acf4b005f8f7e01122` passed independently on the release branch:

```sh
bazel test \
  //src/compute-plane-services/nvca/internal/miniservice:miniservice_test \
  //src/compute-plane-services/nvca/internal/transporttls:transporttls_test \
  //src/compute-plane-services/nvca/pkg/nvca:nvca_test \
  //src/compute-plane-services/nvca/pkg/operator/reconcile:reconcile_test
bazel build \
  //src/compute-plane-services/nvca/cmd/nvca:nvca \
  //src/compute-plane-services/nvca/cmd/nvca-operator:nvca-operator
git diff --check origin/release-src/compute-plane-services/nvca/v3.2...HEAD
```

Result: all four Bazel test targets passed, both binaries built, and the diff check was clean.

### Disposable live k3d validation

The release branch was tested on a separately rebuilt disposable cluster through the repository workflow:

```sh
make -C tools/ncp-local-cluster build-and-deploy-cluster
cp deploy/stacks/observability/environments/local.yaml deploy/stacks/observability/environments/local-bdd.yaml
(cd tests/bdd && go test -run '^TestSingleClusterHelmfile$' -timeout 90m -v)
bazel run --stamp --define VERSION=v32-caa4fbd //src/compute-plane-services/nvca/cmd/nvca-operator:image_load
bazel run --stamp --define VERSION=v32-caa4fbd //src/compute-plane-services/nvca/cmd/nvca:image_load
k3d image import --cluster ncp-local local.test/nvcf/nvca-operator:v32-caa4fbd local.test/nvcf/nvca:v32-caa4fbd
kubectl --context k3d-ncp-local -n nvca-operator logs deployment/nvca-operator -c nvca-operator
kubectl --context k3d-ncp-local -n nvca-system get configmap agent-config
kubectl --context k3d-ncp-local -n nvca-system get deployment nvca
```

The release BDD installed the full control plane, registered the cluster, installed the compute plane, and rolled out the operator. It reported 3/4 scenarios and 39/45 steps passing (5 skipped). Its sample-function deployment stopped at API validation because the branch's hard-coded `NCP.GPU.H100_8x` was not present in the live generated catalog; invocation was not reached and is not claimed.

Two unrelated release-harness issues required disposable-only runtime adjustments before loading the reviewed images: the Bazel-loaded operator image's configured `/tini` command is absent, so the Deployment invoked `/usr/bin/nvca-operator` and `/usr/bin/nvca-mirror` directly; and a disabled-telemetry init container referenced an unavailable pinned image, so that init container was removed. No repository files or pushed commits were changed by these adjustments. The exact operator and agent then reported version `mr-caa4fbd7` and became healthy.

For each negative row, the final source ConfigMaps were applied, generated `nvca-system/agent-config` and the `nvca-system/nvca` Deployment were removed, and the exact operator was restarted. All 7/7 invalid cases terminated reconciliation before either generated artifact reappeared:

| Configuration | Live result |
| --- | --- |
| Secret-backed CA bundle plus direct `stargateQUICInsecure: true` | Rejected with the bundle/insecure fatal error |
| `trustMode: bundle` without a bundle | Rejected: bundle PEM required |
| Malformed PEM | Rejected: bundle PEM invalid |
| Private-key PEM | Rejected: PEM block type unsupported |
| Reserved bundle key `fingerprint` | Rejected: reserved key |
| Malformed fingerprint | Rejected: expected `sha256:` plus 64 lowercase hex characters |
| Fingerprint not matching the CA bundle | Rejected: fingerprint mismatch |

The cluster's public CA ConfigMap supplied a valid PEM for positive and fingerprint cases; no credentials or private key material were used.

Positive live results:

- System trust generated agent configuration and the exact operator/agent became healthy.
- A Secret-backed bundle with insecure QUIC disabled generated `trustMode: bundle` plus a matching SHA-256 fingerprint, and the exact operator/agent became healthy.
- A direct-container non-LLM function used a live-catalog instance type, completed CLI deployment, and reached a 2/2 Running workload pod.
- A disposable Helm chart containing a regular worker but no `llm-worker` passed ReVal, reached MiniService `Running`, had the worker and utility pods Running, and completed CLI deployment.
- A Service-only zero-pod chart passed ReVal and the exact agent's validation, rendered one Service, and progressed through installation to `Starting` without a transport-TLS error. Because it intentionally has no application pod or endpoint, application-health completion is not claimed; the focused no-pod regression also passed in the exact commit checks above.

Live k3d status: transport-TLS negative and positive coverage passed. Application invocation remains unverified because the baseline BDD stopped at the unrelated catalog mismatch described above.

### Validation flow

```mermaid
flowchart LR
  subgraph Before
    A[Direct merge or Secret-backed trust] --> B[Workload-specific rendering]
    B --> C{Pod specs / LLM worker?}
    C -->|No| D[Early return bypasses validation]
    C -->|Yes| E[Late TLS validation]
  end
  subgraph After
    F[Direct merge + Secret-backed trust] --> G[Validate final merged config]
    G --> H[Validate before runtime early returns]
    H --> I{Pod specs / LLM worker?}
    I -->|No| J[Valid no-op]
    I -->|Yes| K[Render workload]
  end
```