### PR TITLE
fix(stack): bump self-managed stack chart pins

### DIFF
--- a/deploy/stacks/nvcf-compute-plane/Makefile
+++ b/deploy/stacks/nvcf-compute-plane/Makefile
@@ -60,7 +60,7 @@ include Makefile.dist
 -include helmfile-docker.mk
 
 # --- Development-Only Targets ---
-.PHONY: dist clean-dist ensure-helm ensure-helmfile ensure-binaries render-local test-observability-profile test-register-cluster test-kube-context test-nvca-entrypoints test-local generate-golden
+.PHONY: dist clean-dist ensure-helm ensure-helmfile ensure-binaries render-local test-observability-profile test-register-cluster test-kube-context test-compare-golden test-nvca-entrypoints test-local generate-golden
 
 # --- Binary Management (Development Only) ---
 ensure-helm:
@@ -181,7 +181,10 @@ test-kube-context:
 test-nvca-entrypoints: render-local
 	@tests/nvca-entrypoints.sh "$(DIST_DIR)/out"
 
-test-local: test-observability-profile test-register-cluster test-kube-context test-nvca-entrypoints
+test-compare-golden:
+	@tests/test-compare-golden.sh
+
+test-local: test-observability-profile test-register-cluster test-kube-context test-compare-golden test-nvca-entrypoints
 	@tests/verify-golden.sh "$(GOLDEN_LOCAL_DIR)" "$(DIST_DIR)/out"
 
 generate-golden: render-local

--- a/deploy/stacks/nvcf-compute-plane/environments/base.yaml
+++ b/deploy/stacks/nvcf-compute-plane/environments/base.yaml
@@ -31,9 +31,9 @@ global:
   # NVCA Operator Configuration
   # =============================================================================
   nvcaOperator:
-    imageTag: "3.3.2"
+    imageTag: "3.5.2"
     selfManaged:
-      nvcaVersion: "3.3.2"
+      nvcaVersion: "3.5.2"
       otelCollector:
         # Self-hosted registries do not always mirror this optional image.
         # Enable it only after publishing the collector in global.image.

--- a/deploy/stacks/nvcf-compute-plane/environments/base.yaml
+++ b/deploy/stacks/nvcf-compute-plane/environments/base.yaml
@@ -31,7 +31,6 @@ global:
   # NVCA Operator Configuration
   # =============================================================================
   nvcaOperator:
-    imageTag: "3.5.2"
     selfManaged:
       nvcaVersion: "3.5.2"
       otelCollector:

--- a/deploy/stacks/nvcf-compute-plane/helmfile.d/01-dependencies.yaml.gotmpl
+++ b/deploy/stacks/nvcf-compute-plane/helmfile.d/01-dependencies.yaml.gotmpl
@@ -49,7 +49,7 @@ releases:
     # defaults below match the managed SBOM template.
     condition: addons.kaiScheduler.enabled
     chart: kai-scheduler/kai-scheduler
-    version: v0.16.7
+    version: v0.17.1
     namespace: kai-scheduler
     values:
       - ../global.yaml.gotmpl
@@ -389,7 +389,7 @@ releases:
     # (NVIDIA/nvcf#1269).
     condition: addons.dynamoOperator.enabled
     chart: nvidia-ai-dynamo/dynamo-platform
-    version: 1.4.1
+    version: 1.4.2
     namespace: dynamo-system
     needs:
       - grove-system/grove-operator

--- a/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
+++ b/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
@@ -166,7 +166,7 @@ releases:
     # Released chart from nvca-operator-deploy. Compute-plane base values own
     # the operator and NVCA versions used by this stack.
     chart: nvcf/helm-nvca-operator
-    version: 1.21.8
+    version: 1.22.1
     namespace: nvca-operator
     values:
       - ../global.yaml.gotmpl

--- a/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
+++ b/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
@@ -163,10 +163,10 @@ helmDefaults:
 releases:
 
   - name: nvca-operator
-    # Released chart from nvca-operator-deploy. Compute-plane base values own
-    # the operator and NVCA versions used by this stack.
+    # The chart appVersion owns the operator image version. Compute-plane base
+    # values own the NVCA application version used by this stack.
     chart: nvcf/helm-nvca-operator
-    version: 1.22.1
+    version: 1.22.2
     namespace: nvca-operator
     values:
       - ../global.yaml.gotmpl

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/component-serviceaccount.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/component-serviceaccount.yaml
@@ -23,10 +23,10 @@ metadata:
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
     nvidia.com/dynamo-component-pod: "true"
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/deployment.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/deployment.yaml
@@ -9,10 +9,10 @@ metadata:
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
     control-plane: controller-manager
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -31,11 +31,11 @@ spec:
         app.kubernetes.io/instance: dynamo-operator
       annotations:
         kubectl.kubernetes.io/default-container: manager
-        checksum/config: 0c8ea1834ecd65a5dc13c7eb06542616828dfea7bbb5819416745500c0322362
+        checksum/config: 2c980230ddc059b0f682a4b8cbf766c66289c03ce4deaf8793cb1d7a789374aa
     spec:
       initContainers:
       - name: crd-apply
-        image: nvcr.io/nvidia/ai-dynamo/kubernetes-operator:1.4.1
+        image: nvcr.io/nvidia/ai-dynamo/kubernetes-operator:1.4.2
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
@@ -45,14 +45,14 @@ spec:
         command: ["/crd-apply"]
         args:
           - "--crds-dir=/opt/dynamo-operator/crds/"
-          - "--version=1.4.1"
+          - "--version=1.4.2"
           - "--conversion-webhook-service-name=dynamo-operator-webhook-service"
           - "--conversion-webhook-service-namespace=dynamo-system"
       containers:
       - args:
         - --config=/etc/dynamo-operator/config.yaml
-        - --operator-version=1.4.1
-        - "--operator-image=nvcr.io/nvidia/ai-dynamo/kubernetes-operator:1.4.1"
+        - --operator-version=1.4.2
+        - "--operator-image=nvcr.io/nvidia/ai-dynamo/kubernetes-operator:1.4.2"
         - "--operator-image-pull-policy=IfNotPresent"
         command:
         - /manager
@@ -68,7 +68,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         imagePullPolicy: "IfNotPresent"
-        image: nvcr.io/nvidia/ai-dynamo/kubernetes-operator:1.4.1
+        image: nvcr.io/nvidia/ai-dynamo/kubernetes-operator:1.4.2
         livenessProbe:
           httpGet:
             path: /healthz

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/epp.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/epp.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: dynamo-operator-epp
   labels:
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 rules:
 # Gateway API inference resources

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/gpu-discovery-rbac.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/gpu-discovery-rbac.yaml
@@ -8,10 +8,10 @@ kind: ClusterRole
 metadata:
   name: dynamo-operator-dynamo-system-gpu-discovery
   labels:
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: [""]
@@ -27,10 +27,10 @@ kind: ClusterRoleBinding
 metadata:
   name: dynamo-operator-dynamo-system-gpu-discovery
   labels:
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/leader-election-rbac.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/leader-election-rbac.yaml
@@ -22,10 +22,10 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -69,10 +69,10 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/manager-rbac.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/manager-rbac.yaml
@@ -20,10 +20,10 @@ kind: ClusterRole
 metadata:
   name: dynamo-operator-manager-role
   labels:
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -545,10 +545,10 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -570,10 +570,10 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -594,10 +594,10 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -619,10 +619,10 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -656,10 +656,10 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -680,10 +680,10 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -704,10 +704,10 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -728,10 +728,10 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -752,10 +752,10 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/metrics-auth-rbac.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/metrics-auth-rbac.yaml
@@ -8,10 +8,10 @@ metadata:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,10 +36,10 @@ metadata:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/metrics-service.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/metrics-service.yaml
@@ -9,10 +9,10 @@ metadata:
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
     control-plane: controller-manager
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/operator-config.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/operator-config.yaml
@@ -20,10 +20,10 @@ kind: ConfigMap
 metadata:
   name: dynamo-operator-config
   labels:
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/planner.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/planner.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: dynamo-operator-planner
   labels:
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: ["nvidia.com"]

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/profiling-job-rbac.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/profiling-job-rbac.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: dynamo-operator-dgdr-profiling
   labels:
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: dgdr-profiling
 rules:
@@ -42,10 +42,10 @@ kind: ClusterRoleBinding
 metadata:
   name: dynamo-operator-dgdr-profiling
   labels:
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: dgdr-profiling
 roleRef:

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/serviceaccount.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/serviceaccount.yaml
@@ -22,10 +22,10 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/topology-label-rbac.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/topology-label-rbac.yaml
@@ -8,10 +8,10 @@ kind: ClusterRole
 metadata:
   name: dynamo-operator-dynamo-system-topology-label
   labels:
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: [""]
@@ -24,10 +24,10 @@ kind: ClusterRoleBinding
 metadata:
   name: dynamo-operator-dynamo-system-topology-label
   labels:
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/webhook-configuration.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/webhook-configuration.yaml
@@ -25,10 +25,10 @@ metadata:
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
     nvidia.com/dynamo-operator-namespace: dynamo-system
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 webhooks:
 - admissionReviewVersions:
@@ -128,10 +128,10 @@ metadata:
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
     nvidia.com/dynamo-operator-namespace: dynamo-system
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 webhooks:
 - admissionReviewVersions:

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/webhook-rbac.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/webhook-rbac.yaml
@@ -10,10 +10,10 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -47,10 +47,10 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -72,10 +72,10 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -107,10 +107,10 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/webhook-service.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-dynamo-operator/dynamo-platform/charts/dynamo-operator/templates/webhook-service.yaml
@@ -9,10 +9,10 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    helm.sh/chart: dynamo-operator-1.4.1
+    helm.sh/chart: dynamo-operator-1.4.2
     app.kubernetes.io/name: dynamo-operator
     app.kubernetes.io/instance: dynamo-operator
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   ports:

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/default-queue.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/default-queue.yaml
@@ -8,6 +8,7 @@ metadata:
     name: default-parent-queue
     annotations:
         helm.sh/resource-policy: keep
+        argocd.argoproj.io/sync-options: Prune=false
 spec:
     resources:
         cpu:
@@ -30,6 +31,7 @@ metadata:
     name: default-queue
     annotations:
         helm.sh/resource-policy: keep
+        argocd.argoproj.io/sync-options: Prune=false
 spec:
     parentQueue: default-parent-queue
     resources:

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/default-shard.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/default-shard.yaml
@@ -8,8 +8,10 @@ metadata:
   name: default
   annotations:
     helm.sh/resource-policy: keep
+    argocd.argoproj.io/sync-options: Prune=false
 spec:
   partitionLabelValue: ""
+  goMemLimitRatio: 0.9
   placementStrategy:
     gpu: binpack
     cpu: binpack

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/hooks/post/kai-config-deployer/configmap.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/hooks/post/kai-config-deployer/configmap.yaml
@@ -52,7 +52,7 @@ data:
           image:
             name: binder
             repository: ghcr.io/kai-scheduler/kai-scheduler
-            tag: v0.16.7
+            tag: v0.17.1
             pullPolicy: IfNotPresent
           resources:
             limits:
@@ -69,7 +69,7 @@ data:
           image:
             name: resourcereservation
             repository: ghcr.io/kai-scheduler/kai-scheduler
-            tag: v0.16.7
+            tag: v0.17.1
             pullPolicy: IfNotPresent
     
       podGrouper:
@@ -78,7 +78,7 @@ data:
           image:
             name: podgrouper
             repository: ghcr.io/kai-scheduler/kai-scheduler
-            tag: v0.16.7
+            tag: v0.17.1
             pullPolicy: IfNotPresent
           resources:
             limits:
@@ -87,6 +87,11 @@ data:
             requests:
               cpu: 50m
               memory: 512Mi
+          podDisruptionBudget:
+            enabled: true
+            maxUnavailable: 1
+        args:
+          genericKartaFallback: true
     
       podGroupController:
         service:
@@ -94,7 +99,7 @@ data:
           image:
             name: podgroupcontroller
             repository: ghcr.io/kai-scheduler/kai-scheduler
-            tag: v0.16.7
+            tag: v0.17.1
             pullPolicy: IfNotPresent
           resources:
             limits:
@@ -110,7 +115,7 @@ data:
           image:
             name: queuecontroller
             repository: ghcr.io/kai-scheduler/kai-scheduler
-            tag: v0.16.7
+            tag: v0.17.1
             pullPolicy: IfNotPresent
           resources:
             limits:
@@ -126,7 +131,7 @@ data:
           image:
             name: admission
             repository: ghcr.io/kai-scheduler/kai-scheduler
-            tag: v0.16.7
+            tag: v0.17.1
             pullPolicy: IfNotPresent
           resources:
             limits:
@@ -154,7 +159,7 @@ data:
           image:
             name: nodescaleadjuster
             repository: ghcr.io/kai-scheduler/kai-scheduler
-            tag: v0.16.7
+            tag: v0.17.1
             pullPolicy: IfNotPresent
           resources:
             limits:
@@ -168,7 +173,7 @@ data:
           scalingPodImage:
             name: scalingpod
             repository: ghcr.io/kai-scheduler/kai-scheduler
-            tag: v0.16.7
+            tag: v0.17.1
             pullPolicy: IfNotPresent
     
       scheduler:
@@ -177,7 +182,7 @@ data:
           image:
             name: scheduler
             repository: ghcr.io/kai-scheduler/kai-scheduler
-            tag: v0.16.7
+            tag: v0.17.1
             pullPolicy: IfNotPresent
           resources:
             limits:
@@ -186,6 +191,9 @@ data:
             requests:
               cpu: 500m
               memory: 3Gi
+          podDisruptionBudget:
+            enabled: true
+            maxUnavailable: 1
         schedulerService:
           port: 8080
     
@@ -194,7 +202,7 @@ data:
           image:
             name: numa-placement-exporter
             repository: ghcr.io/kai-scheduler/kai-scheduler
-            tag: v0.16.7
+            tag: v0.17.1
             pullPolicy: IfNotPresent
           resources:
             limits:

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/hooks/post/kai-config-deployer/job.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/hooks/post/kai-config-deployer/job.yaml
@@ -23,7 +23,7 @@ spec:
         - name: nvcr-pull-secret
       containers:
       - name: deployer
-        image: "ghcr.io/kai-scheduler/kai-scheduler/crd-upgrader:v0.16.7"
+        image: "ghcr.io/kai-scheduler/kai-scheduler/crd-upgrader:v0.17.1"
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/hooks/post/post-delete-job.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/hooks/post/post-delete-job.yaml
@@ -10,6 +10,8 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-delete-policy": hook-succeeded
+    argocd.argoproj.io/hook: PostDelete
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
 spec:
   template:
     metadata:
@@ -22,7 +24,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: deleter
-          image: "ghcr.io/kai-scheduler/kai-scheduler/crd-upgrader:v0.16.7"
+          image: "ghcr.io/kai-scheduler/kai-scheduler/crd-upgrader:v0.17.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/hooks/pre/crd-upgrader.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/hooks/pre/crd-upgrader.yaml
@@ -23,7 +23,7 @@ spec:
         - name: nvcr-pull-secret
       containers:
       - name: upgrader
-        image: "ghcr.io/kai-scheduler/kai-scheduler/crd-upgrader:v0.16.7"
+        image: "ghcr.io/kai-scheduler/kai-scheduler/crd-upgrader:v0.17.1"
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/hooks/pre/topology-migration/job.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/hooks/pre/topology-migration/job.yaml
@@ -22,7 +22,7 @@ spec:
         - name: nvcr-pull-secret
       containers:
       - name: migration
-        image: "ghcr.io/kai-scheduler/kai-scheduler/crd-upgrader:v0.16.7"
+        image: "ghcr.io/kai-scheduler/kai-scheduler/crd-upgrader:v0.17.1"
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/rbac/binder.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/rbac/binder.yaml
@@ -83,8 +83,9 @@ rules:
   - resource.k8s.io
   resources:
   - resourceclaims
-  - resourceclaims/status
   verbs:
+  - create
+  - delete
   - get
   - list
   - patch
@@ -97,6 +98,16 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceclaims/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - scheduling.run.ai
   resources:

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/rbac/podgrouper.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/rbac/podgrouper.yaml
@@ -286,6 +286,7 @@ rules:
   - distributedworkloads
   - inferenceworkloads
   - interactiveworkloads
+  - kartas
   - runaijobs
   - trainingworkloads
   verbs:

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/rbac/post-delete-binding.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/rbac/post-delete-binding.yaml
@@ -11,6 +11,8 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-delete-policy": hook-succeeded
+    argocd.argoproj.io/hook: PostDelete
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
 subjects:
   - kind: ServiceAccount
     name: post-delete-cleanup

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/rbac/post-delete-clusterrole.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/rbac/post-delete-clusterrole.yaml
@@ -11,6 +11,8 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-delete-policy": hook-succeeded
+    argocd.argoproj.io/hook: PostDelete
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
 rules:
 - apiGroups:
   - apps

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/services/operator.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/services/operator.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: kai-operator
       containers:
       - name: operator
-        image: ghcr.io/kai-scheduler/kai-scheduler/operator:v0.16.7
+        image: ghcr.io/kai-scheduler/kai-scheduler/operator:v0.17.1
         imagePullPolicy: IfNotPresent
         resources:
             limits:
@@ -51,7 +51,7 @@ spec:
         - name: MS_REPOSITORY
           value: ghcr.io/kai-scheduler/kai-scheduler
         - name: MS_TAG
-          value: v0.16.7
+          value: v0.17.1
         ports:
         - containerPort: 8080
           name: metrics

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/services/post-delete-serviceaccount.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/services/post-delete-serviceaccount.yaml
@@ -12,3 +12,5 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-delete-policy": hook-succeeded
+    argocd.argoproj.io/hook: PostDelete
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/services/resourcereservation-namespace.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/services/resourcereservation-namespace.yaml
@@ -8,3 +8,4 @@ metadata:
   name: kai-resource-reservation
   annotations:
     helm.sh/resource-policy: keep
+    argocd.argoproj.io/sync-options: Prune=false

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/services/resourcereservation-serviceaccount.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/01-dependencies.yaml-kai-scheduler/kai-scheduler/templates/services/resourcereservation-serviceaccount.yaml
@@ -2,7 +2,6 @@
 # Source: kai-scheduler/templates/services/resourcereservation-serviceaccount.yaml
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
-
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/agent-config-merge-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/agent-config-merge-cm.yaml
@@ -21,10 +21,10 @@ metadata:
   name: agent-config-merge
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.1
+    helm.sh/chart: helm-nvca-operator-1.22.2
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/version: "3.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml:  |2

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/agent-config-merge-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/agent-config-merge-cm.yaml
@@ -21,7 +21,7 @@ metadata:
   name: agent-config-merge
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.21.8
+    helm.sh/chart: helm-nvca-operator-1.22.1
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.3.2"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/chart-defaults-nvcfbackend-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/chart-defaults-nvcfbackend-cm.yaml
@@ -21,7 +21,7 @@ metadata:
   name: nvcfbackend-chart-defaults
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.21.8
+    helm.sh/chart: helm-nvca-operator-1.22.1
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.3.2"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/chart-defaults-nvcfbackend-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/chart-defaults-nvcfbackend-cm.yaml
@@ -21,10 +21,10 @@ metadata:
   name: nvcfbackend-chart-defaults
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.1
+    helm.sh/chart: helm-nvca-operator-1.22.2
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/version: "3.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   cluster-dto.yaml: |

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/crds/nvidia.io_nvcfbackends_crd.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/crds/nvidia.io_nvcfbackends_crd.yaml
@@ -20,10 +20,10 @@ kind: CustomResourceDefinition
 metadata:
   name: nvcfbackends.nvcf.nvidia.io
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.1
+    helm.sh/chart: helm-nvca-operator-1.22.2
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/version: "3.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   group: nvcf.nvidia.io

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/crds/nvidia.io_nvcfbackends_crd.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/crds/nvidia.io_nvcfbackends_crd.yaml
@@ -20,7 +20,7 @@ kind: CustomResourceDefinition
 metadata:
   name: nvcfbackends.nvcf.nvidia.io
   labels:
-    helm.sh/chart: helm-nvca-operator-1.21.8
+    helm.sh/chart: helm-nvca-operator-1.22.1
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.3.2"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/custom-annotations-configmap.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/custom-annotations-configmap.yaml
@@ -21,10 +21,10 @@ metadata:
   name: nvca-namespace-pod-annotations
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.1
+    helm.sh/chart: helm-nvca-operator-1.22.2
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/version: "3.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   annotations: "{}"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/custom-annotations-configmap.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/custom-annotations-configmap.yaml
@@ -21,7 +21,7 @@ metadata:
   name: nvca-namespace-pod-annotations
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.21.8
+    helm.sh/chart: helm-nvca-operator-1.22.1
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.3.2"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/custom-network-policies-configmap.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/custom-network-policies-configmap.yaml
@@ -21,9 +21,9 @@ metadata:
   name: nvcf-custom-network-policies
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.1
+    helm.sh/chart: helm-nvca-operator-1.22.2
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/version: "3.5.2"
     app.kubernetes.io/managed-by: Helm
 data:

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/custom-network-policies-configmap.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/custom-network-policies-configmap.yaml
@@ -21,7 +21,7 @@ metadata:
   name: nvcf-custom-network-policies
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.21.8
+    helm.sh/chart: helm-nvca-operator-1.22.1
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.3.2"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/deployment.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/deployment.yaml
@@ -21,7 +21,7 @@ metadata:
   name: nvca-operator
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.21.8
+    helm.sh/chart: helm-nvca-operator-1.22.1
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.3.2"
@@ -130,7 +130,7 @@ spec:
           - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTU3LjAtbnYtMC4yLjEifQ=="
           - --task-env-overrides-b64
           - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTU3LjAtbnYtMC4yLjEifQ=="
-        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.3.2
+        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.5.2
         imagePullPolicy: IfNotPresent
         securityContext:
           # Set here so openbao injection can copy it upon injection
@@ -176,7 +176,7 @@ spec:
             cpu: "1000m"
             memory: "4Gi"
       - name: nvca-mirror
-        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.3.2
+        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.5.2
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/deployment.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/deployment.yaml
@@ -21,10 +21,10 @@ metadata:
   name: nvca-operator
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.1
+    helm.sh/chart: helm-nvca-operator-1.22.2
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/version: "3.5.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/gpu-profiling-config-configmap.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/gpu-profiling-config-configmap.yaml
@@ -25,7 +25,7 @@ metadata:
   name: nvca-gpu-profiling-config
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.21.8
+    helm.sh/chart: helm-nvca-operator-1.22.1
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.3.2"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/gpu-profiling-config-configmap.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/gpu-profiling-config-configmap.yaml
@@ -25,10 +25,10 @@ metadata:
   name: nvca-gpu-profiling-config
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.1
+    helm.sh/chart: helm-nvca-operator-1.22.2
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/version: "3.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   functionIds: ""

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
@@ -21,7 +21,7 @@ metadata:
   name: nvcfbackend-helm-managed
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.21.8
+    helm.sh/chart: helm-nvca-operator-1.22.1
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.3.2"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
@@ -21,9 +21,9 @@ metadata:
   name: nvcfbackend-helm-managed
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.1
+    helm.sh/chart: helm-nvca-operator-1.22.2
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/version: "3.5.2"
     app.kubernetes.io/managed-by: Helm
 data: {}

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/ngc-service-key.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/ngc-service-key.yaml
@@ -20,10 +20,10 @@ kind: Secret
 metadata:
   name: ngc-service-key
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.1
+    helm.sh/chart: helm-nvca-operator-1.22.2
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/version: "3.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   ngcServiceKey: ZHVtbXktYXBpLWtleQ==

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/ngc-service-key.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/ngc-service-key.yaml
@@ -20,7 +20,7 @@ kind: Secret
 metadata:
   name: ngc-service-key
   labels:
-    helm.sh/chart: helm-nvca-operator-1.21.8
+    helm.sh/chart: helm-nvca-operator-1.22.1
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.3.2"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/operator-config-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/operator-config-cm.yaml
@@ -20,7 +20,7 @@ metadata:
   name: nvca-operator-config
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.21.8
+    helm.sh/chart: helm-nvca-operator-1.22.1
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.3.2"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/operator-config-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/operator-config-cm.yaml
@@ -20,10 +20,10 @@ metadata:
   name: nvca-operator-config
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.1
+    helm.sh/chart: helm-nvca-operator-1.22.2
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/version: "3.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/pre-delete-cleanup-job.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/pre-delete-cleanup-job.yaml
@@ -21,10 +21,10 @@ metadata:
   name: nvca-operator-pre-delete-cleanup
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.1
+    helm.sh/chart: helm-nvca-operator-1.22.2
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/version: "3.5.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cleanup
   annotations:

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/pre-delete-cleanup-job.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/pre-delete-cleanup-job.yaml
@@ -21,7 +21,7 @@ metadata:
   name: nvca-operator-pre-delete-cleanup
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.21.8
+    helm.sh/chart: helm-nvca-operator-1.22.1
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.3.2"
@@ -52,7 +52,7 @@ spec:
         fsGroup: 1010
       containers:
       - name: cleanup
-        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.3.2
+        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.5.2
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/pre-delete-cleanup-rbac.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/pre-delete-cleanup-rbac.yaml
@@ -21,7 +21,7 @@ metadata:
   name: nvca-operator-pre-delete-cleanup
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.21.8
+    helm.sh/chart: helm-nvca-operator-1.22.1
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.3.2"
@@ -39,7 +39,7 @@ kind: ClusterRole
 metadata:
   name: nvca-operator-pre-delete-cleanup
   labels:
-    helm.sh/chart: helm-nvca-operator-1.21.8
+    helm.sh/chart: helm-nvca-operator-1.22.1
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.3.2"
@@ -140,7 +140,7 @@ kind: ClusterRoleBinding
 metadata:
   name: nvca-operator-pre-delete-cleanup
   labels:
-    helm.sh/chart: helm-nvca-operator-1.21.8
+    helm.sh/chart: helm-nvca-operator-1.22.1
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.3.2"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/pre-delete-cleanup-rbac.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/pre-delete-cleanup-rbac.yaml
@@ -21,10 +21,10 @@ metadata:
   name: nvca-operator-pre-delete-cleanup
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.1
+    helm.sh/chart: helm-nvca-operator-1.22.2
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/version: "3.5.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cleanup
   annotations:
@@ -39,10 +39,10 @@ kind: ClusterRole
 metadata:
   name: nvca-operator-pre-delete-cleanup
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.1
+    helm.sh/chart: helm-nvca-operator-1.22.2
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/version: "3.5.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cleanup
   annotations:
@@ -140,10 +140,10 @@ kind: ClusterRoleBinding
 metadata:
   name: nvca-operator-pre-delete-cleanup
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.1
+    helm.sh/chart: helm-nvca-operator-1.22.2
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/version: "3.5.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cleanup
   annotations:

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/rbac_allowed_extra_types.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/rbac_allowed_extra_types.yaml
@@ -19,10 +19,10 @@ kind: ClusterRole
 metadata:
   name: nvca-operator-allowed-extra-types
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.1
+    helm.sh/chart: helm-nvca-operator-1.22.2
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/version: "3.5.2"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: ["foo.com"]
@@ -71,10 +71,10 @@ kind: ClusterRoleBinding
 metadata:
   name: nvca-operator-allowed-extra-types
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.1
+    helm.sh/chart: helm-nvca-operator-1.22.2
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/version: "3.5.2"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/rbac_allowed_extra_types.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/rbac_allowed_extra_types.yaml
@@ -19,7 +19,7 @@ kind: ClusterRole
 metadata:
   name: nvca-operator-allowed-extra-types
   labels:
-    helm.sh/chart: helm-nvca-operator-1.21.8
+    helm.sh/chart: helm-nvca-operator-1.22.1
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.3.2"
@@ -71,7 +71,7 @@ kind: ClusterRoleBinding
 metadata:
   name: nvca-operator-allowed-extra-types
   labels:
-    helm.sh/chart: helm-nvca-operator-1.21.8
+    helm.sh/chart: helm-nvca-operator-1.22.1
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.3.2"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/role.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/role.yaml
@@ -20,7 +20,7 @@ kind: ClusterRole
 metadata:
   name: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.21.8
+    helm.sh/chart: helm-nvca-operator-1.22.1
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.3.2"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/role.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/role.yaml
@@ -20,10 +20,10 @@ kind: ClusterRole
 metadata:
   name: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.1
+    helm.sh/chart: helm-nvca-operator-1.22.2
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/version: "3.5.2"
     app.kubernetes.io/managed-by: Helm
   finalizers:
     - nvca.nvcf.nvidia.io/operator-cleanup

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/role_binding.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/role_binding.yaml
@@ -20,7 +20,7 @@ kind: ClusterRoleBinding
 metadata:
   name: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.21.8
+    helm.sh/chart: helm-nvca-operator-1.22.1
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.3.2"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/role_binding.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/role_binding.yaml
@@ -20,10 +20,10 @@ kind: ClusterRoleBinding
 metadata:
   name: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.1
+    helm.sh/chart: helm-nvca-operator-1.22.2
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/version: "3.5.2"
     app.kubernetes.io/managed-by: Helm
   finalizers:
     - nvca.nvcf.nvidia.io/operator-cleanup

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/sa.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/sa.yaml
@@ -21,9 +21,9 @@ metadata:
   name: nvca-operator
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.1
+    helm.sh/chart: helm-nvca-operator-1.22.2
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/version: "3.5.2"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: false

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/sa.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/sa.yaml
@@ -21,7 +21,7 @@ metadata:
   name: nvca-operator
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.21.8
+    helm.sh/chart: helm-nvca-operator-1.22.1
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.3.2"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/self-managed-nvcfbackend-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/self-managed-nvcfbackend-cm.yaml
@@ -24,10 +24,10 @@ metadata:
     release-artifact-nvcf-image-credential-helper-image: "nvcr.io/0651155215864979/ncp-dev/nvcf-image-credential-helper:0.10.2"
     release-artifact-samba-image: "nvcr.io/0651155215864979/ncp-dev/samba:1.0.5"
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.1
+    helm.sh/chart: helm-nvca-operator-1.22.2
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/version: "3.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   cluster-dto.yaml: |

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/self-managed-nvcfbackend-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/self-managed-nvcfbackend-cm.yaml
@@ -20,11 +20,11 @@ metadata:
   name: nvcfbackend-self-managed
   namespace: nvca-operator
   annotations:
-    release-artifact-nvca-image: "nvcr.io/0651155215864979/ncp-dev/nvca:3.3.2"
+    release-artifact-nvca-image: "nvcr.io/0651155215864979/ncp-dev/nvca:3.5.2"
     release-artifact-nvcf-image-credential-helper-image: "nvcr.io/0651155215864979/ncp-dev/nvcf-image-credential-helper:0.10.2"
     release-artifact-samba-image: "nvcr.io/0651155215864979/ncp-dev/samba:1.0.5"
   labels:
-    helm.sh/chart: helm-nvca-operator-1.21.8
+    helm.sh/chart: helm-nvca-operator-1.22.1
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.3.2"
@@ -37,7 +37,7 @@ data:
     clusterDescription: "ncp-local"
     clusterGroupName: "nvcf-default"
     ncaID: "nvcf-default"
-    nvcaVersion: "3.3.2"
+    nvcaVersion: "3.5.2"
     oAuthClientId: ""
     cloudProvider: "NCP"
     region: "us-west-1"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/shutdown-sentinel.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/shutdown-sentinel.yaml
@@ -21,10 +21,10 @@ metadata:
   name: nvca-operator-shutdown-sentinel
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.1
+    helm.sh/chart: helm-nvca-operator-1.22.2
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/version: "3.5.2"
     app.kubernetes.io/managed-by: Helm
   finalizers:
     - nvca.nvcf.nvidia.io/operator-cleanup

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/shutdown-sentinel.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/shutdown-sentinel.yaml
@@ -21,7 +21,7 @@ metadata:
   name: nvca-operator-shutdown-sentinel
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.21.8
+    helm.sh/chart: helm-nvca-operator-1.22.1
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
     app.kubernetes.io/version: "3.3.2"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/storage-capabilities-configmap.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/storage-capabilities-configmap.yaml
@@ -20,10 +20,10 @@ metadata:
   name: nvcf-storage-capabilities
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.1
+    helm.sh/chart: helm-nvca-operator-1.22.2
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/version: "3.5.2"
     app.kubernetes.io/managed-by: Helm
 data:
   storage-provider-capabilities.yaml: |

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/storage-capabilities-configmap.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/storage-capabilities-configmap.yaml
@@ -1,0 +1,92 @@
+---
+# Source: helm-nvca-operator/templates/storage-capabilities-configmap.yaml
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nvcf-storage-capabilities
+  namespace: nvca-operator
+  labels:
+    helm.sh/chart: helm-nvca-operator-1.22.1
+    app.kubernetes.io/name: nvca-operator
+    app.kubernetes.io/instance: nvca-operator
+    app.kubernetes.io/version: "3.3.2"
+    app.kubernetes.io/managed-by: Helm
+data:
+  storage-provider-capabilities.yaml: |
+    # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+    # SPDX-License-Identifier: Apache-2.0
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    #     http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+
+    # NVCA owns this catalog and installs it with the NVCA chart. Each entry is
+    # named by exact CSI provisioner and records the PVC access modes qualified end to end in an
+    # NVCF cache workflow. Nothing else is declared: NVCA derives how caching runs
+    # from these modes.
+    #
+    #   ReadWriteMany              one shared claim; readers mount it read-only
+    #   ReadWriteOnce+ReadOnlyMany writer takes the claim; readers get their own
+    #
+    # An access mode a driver merely accepts is not a qualification. A claim that
+    # binds is not either. An empty accessModes list means nothing is qualified
+    # yet, so caching stays off for that driver, and a provisioner absent from this
+    # file is unsupported. Enabling a backend is an edit here, backed by a
+    # qualification run.
+    apiVersion: storage.nvcf.nvidia.com/v1alpha1
+    kind: StorageCapabilityCatalog
+    drivers:
+      - name: nvmesh-csi.excelero.com
+        provider: nvmesh
+        # Encrypted caches are qualified on NVMesh, through a derived StorageClass
+        # and a per-sharing-domain Secret.
+        encryptionSupported: true
+        accessModes:
+          - ReadWriteOnce
+          - ReadOnlyMany
+        # The reader PV is XFS on the same filesystem as the writer, so it needs
+        # nouuid and norecovery or the mount fails outright.
+        readerMountOptions:
+          - ro
+          - norecovery
+          - nouuid
+      - name: csi.weka.io
+        provider: weka
+        # Fresh ReadWriteMany and ReadOnlyMany claims were tested, but a cache
+        # workflow was not, so nothing is qualified yet.
+        accessModes: []
+        readerMountOptions: []
+      - name: fss.csi.oraclecloud.com
+        provider: ociFss
+        # A ReadWriteMany claim was tested; its readers used read-only Pod mounts,
+        # which is not evidence for a ReadOnlyMany claim. No cache workflow was
+        # qualified.
+        accessModes: []
+        readerMountOptions: []
+      - name: lustre.csi.oraclecloud.com
+        provider: ociLustre
+        # No PVC access mode has been qualified in an NVCF cache workflow.
+        accessModes: []
+        readerMountOptions: []

--- a/deploy/stacks/nvcf-compute-plane/tests/compare-golden.sh
+++ b/deploy/stacks/nvcf-compute-plane/tests/compare-golden.sh
@@ -6,7 +6,9 @@ actual_dir="${2:?actual manifest directory is required}"
 work_dir="$(mktemp -d)"
 trap 'rm -rf "$work_dir"' EXIT
 
-# Paths are compared verbatim. The Makefile renders with an explicit
+# Paths are compared verbatim. File hashes ignore trailing whitespace because
+# Helm charts can emit whitespace-only template lines that do not change the
+# rendered Kubernetes object. The Makefile renders with an explicit
 # --output-dir-template of <helmfile>-<release>, so directory names no longer
 # carry helmfile's default {{ .State.AbsPathSHA1 }} component and are identical
 # on every machine. Normalising the hash away here would hide a regression if
@@ -18,7 +20,8 @@ index_tree() {
   find "$root_dir" -type f -print |
     while IFS= read -r file; do
       relative_path="${file#"$root_dir"/}"
-      printf '%s  %s\n' "$(git hash-object "$file")" "$relative_path"
+      normalized_hash="$(sed 's/[[:space:]]*$//' "$file" | git hash-object --stdin)"
+      printf '%s  %s\n' "$normalized_hash" "$relative_path"
     done |
     sort >"$output_file"
 }

--- a/deploy/stacks/nvcf-compute-plane/tests/observability-profile.sh
+++ b/deploy/stacks/nvcf-compute-plane/tests/observability-profile.sh
@@ -91,9 +91,14 @@ for profile in default disabled control compute all; do
   esac
 done
 
-expected_nvca_version="3.3.2"
-test "$(operator_image_tag "$work_dir/default.yaml")" = "$expected_nvca_version" ||
-  fail "default operator image tag is not $expected_nvca_version"
+expected_operator_version="$(yq -r '.global.nvcaOperator.imageTag' "$stack_dir/environments/base.yaml")"
+expected_nvca_version="$(yq -r '.global.nvcaOperator.selfManaged.nvcaVersion' "$stack_dir/environments/base.yaml")"
+[[ -n "$expected_operator_version" && "$expected_operator_version" != "null" ]] ||
+  fail "could not read the default NVCA operator version"
+[[ -n "$expected_nvca_version" && "$expected_nvca_version" != "null" ]] ||
+  fail "could not read the default NVCA version"
+test "$(operator_image_tag "$work_dir/default.yaml")" = "$expected_operator_version" ||
+  fail "default operator image tag is not $expected_operator_version"
 test "$(nvca_version "$work_dir/default.yaml")" = "$expected_nvca_version" ||
   fail "default NVCA version is not $expected_nvca_version"
 

--- a/deploy/stacks/nvcf-compute-plane/tests/observability-profile.sh
+++ b/deploy/stacks/nvcf-compute-plane/tests/observability-profile.sh
@@ -91,14 +91,11 @@ for profile in default disabled control compute all; do
   esac
 done
 
-expected_operator_version="$(yq -r '.global.nvcaOperator.imageTag' "$stack_dir/environments/base.yaml")"
 expected_nvca_version="$(yq -r '.global.nvcaOperator.selfManaged.nvcaVersion' "$stack_dir/environments/base.yaml")"
-[[ -n "$expected_operator_version" && "$expected_operator_version" != "null" ]] ||
-  fail "could not read the default NVCA operator version"
 [[ -n "$expected_nvca_version" && "$expected_nvca_version" != "null" ]] ||
   fail "could not read the default NVCA version"
-test "$(operator_image_tag "$work_dir/default.yaml")" = "$expected_operator_version" ||
-  fail "default operator image tag is not $expected_operator_version"
+test -z "$(operator_image_tag "$work_dir/default.yaml")" ||
+  fail "default operator image tag should be supplied by the chart appVersion"
 test "$(nvca_version "$work_dir/default.yaml")" = "$expected_nvca_version" ||
   fail "default NVCA version is not $expected_nvca_version"
 

--- a/deploy/stacks/nvcf-compute-plane/tests/test-compare-golden.sh
+++ b/deploy/stacks/nvcf-compute-plane/tests/test-compare-golden.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+
+expected_dir="$work_dir/expected"
+actual_dir="$work_dir/actual"
+mkdir -p "$expected_dir/nested" "$actual_dir/nested"
+
+printf 'key: value\n\n' >"$expected_dir/nested/manifest.yaml"
+printf 'key: value  \n \t\n' >"$actual_dir/nested/manifest.yaml"
+"$script_dir/compare-golden.sh" "$expected_dir" "$actual_dir"
+
+printf 'key: changed\n' >"$actual_dir/nested/manifest.yaml"
+if "$script_dir/compare-golden.sh" "$expected_dir" "$actual_dir" >/dev/null; then
+  echo "expected semantic content changes to fail golden comparison" >&2
+  exit 1
+fi
+
+echo "compare-golden: all checks passed"

--- a/deploy/stacks/observability/charts/nvcf-otel-collector/values.yaml
+++ b/deploy/stacks/observability/charts/nvcf-otel-collector/values.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 collectorName: nvcf-observability
-image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.129.1
+image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.160.0
 imagePullSecrets: []
 
 targetAllocatorRbac:

--- a/deploy/stacks/observability/environments/base.yaml
+++ b/deploy/stacks/observability/environments/base.yaml
@@ -28,7 +28,7 @@ metricsBackend:
     clientPrivateKeyPath: ""
 
 prometheusOperatorCrds:
-  version: "30.0.0"
+  version: "31.0.1"
   values:
     crds:
       alertmanagerconfigs:
@@ -53,7 +53,7 @@ prometheusOperatorCrds:
         enabled: false
 
 opentelemetryOperator:
-  version: "0.114.1"
+  version: "0.122.0"
   admissionWebhooks:
     certManager:
       enabled: false
@@ -62,11 +62,11 @@ opentelemetryOperator:
   manager:
     collectorImage:
       repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
-      tag: "0.129.1"
+      tag: "0.160.0"
 
 collector:
   collectorName: nvcf-observability
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.129.1
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.160.0
   targetAllocator:
     allocationStrategy: consistent-hashing
     prometheusCR:
@@ -101,7 +101,7 @@ collector:
             - prometheusremotewrite
 
 victoriaMetrics:
-  version: "0.38.0"
+  version: "0.45.0"
   server:
     retentionPeriod: "1"
     persistentVolume:

--- a/deploy/stacks/observability/helmfile.d/01-observability.yaml.gotmpl
+++ b/deploy/stacks/observability/helmfile.d/01-observability.yaml.gotmpl
@@ -139,7 +139,7 @@ releases:
   {{- if $prometheusOperatorCrdsEnabled }}
   - name: prometheus-operator-crds
     chart: nvcf/prometheus-operator-crds
-    version: {{ dig "prometheusOperatorCrds" "version" "30.0.0" .Values | quote }}
+    version: {{ dig "prometheusOperatorCrds" "version" "31.0.1" .Values | quote }}
     namespace: {{ dig "prometheusOperatorCrds" "namespace" $observabilityNamespace .Values }}
     values:
       - {{- toYaml (dig "prometheusOperatorCrds" "values" dict .Values) | nindent 8 }}
@@ -150,7 +150,7 @@ releases:
   {{- if $opentelemetryOperatorEnabled }}
   - name: opentelemetry-operator
     chart: nvcf/opentelemetry-operator
-    version: {{ dig "opentelemetryOperator" "version" "0.114.1" .Values | quote }}
+    version: {{ dig "opentelemetryOperator" "version" "0.122.0" .Values | quote }}
     namespace: {{ dig "opentelemetryOperator" "namespace" $observabilityNamespace .Values }}
     {{- if $prometheusOperatorCrdsEnabled }}
     needs:
@@ -183,7 +183,7 @@ releases:
   {{- if $victoriaMetricsEnabled }}
   - name: victoria-metrics
     chart: nvcf/victoria-metrics-single
-    version: {{ dig "victoriaMetrics" "version" "0.38.0" .Values | quote }}
+    version: {{ dig "victoriaMetrics" "version" "0.45.0" .Values | quote }}
     namespace: {{ $victoriaMetricsNamespace }}
     values:
       - ../values/victoria-metrics.yaml.gotmpl

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -193,8 +193,6 @@ api:
 # global.workerEndpoints.essServiceURL; NVCT_ESS_WORKER_BASE_URL stays on it.
 nvctApi:
   essBaseURL: ""
-  image:
-    tag: "1.65.0"
 
 # Image overrides for the API account-bootstrap job. alpine-k8s is not
 # republished under the public nvidia/nvcf catalog, so it defaults to its
@@ -346,10 +344,6 @@ addons:
       replicaCount: 3
       # Set only for source-tree validation. Empty uses the released OCI chart.
       chartPath: ""
-      # Chart 1.13.2 otherwise defaults to Stargate 0.15.1, which predates the
-      # shutdown-drain arguments rendered by that chart.
-      image:
-        tag: "0.16.2"
       readiness:
         warmupMs: 60000
       workload:
@@ -564,8 +558,6 @@ invocation:
     maxUnavailable: 1
 
 adminIssuerProxy:
-  image:
-    tag: "1.1.1"
   podDisruptionBudget:
     enabled: false
     maxUnavailable: 1

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -157,6 +157,8 @@ observability:
 
 # Defaults consumed only for the control and all observability profiles.
 functionAutoscaler:
+  image:
+    tag: "1.21.0"
   region: local
   cassandra:
     contactPoints: cassandra.cassandra-system.svc.cluster.local
@@ -174,7 +176,7 @@ functionAutoscaler:
 # API environment entries are merged over the stack defaults. Remote config is
 # passed to the API chart and overrides its packaged application profile. When
 # the LLM addon is enabled, the stack defaults the Pylon image from
-# global.sidecars (or global.image) at version 0.14.1.
+# global.sidecars (or global.image) at version 0.16.2.
 api:
   env: {}
   # In-cluster ESS base URL for the API's own ESS calls. Empty defaults to
@@ -191,17 +193,19 @@ api:
 # global.workerEndpoints.essServiceURL; NVCT_ESS_WORKER_BASE_URL stays on it.
 nvctApi:
   essBaseURL: ""
+  image:
+    tag: "1.65.0"
 
 # Image overrides for the API account-bootstrap job. alpine-k8s is not
 # republished under the public nvidia/nvcf catalog, so it defaults to its
-# upstream source, docker.io/alpine/k8s:1.36.1. Leave these unset unless you
+# upstream source, docker.io/alpine/k8s:1.37.0. Leave these unset unless you
 # have mirrored the image into your own registry, in which case set registry
 # and repository together:
 #   accountBootstrap:
 #     image:
 #       registry: <your-registry>
 #       repository: <your-repository>/alpine-k8s
-#       tag: "1.36.1"
+#       tag: "1.37.0"
 
 accounts:
   limits:
@@ -222,14 +226,14 @@ nats:
         - "aws-region:ncp"
   # Image overrides for the NATS config reloader. The reloader is not
   # republished under the public nvidia/nvcf catalog, so it defaults to its
-  # upstream source, docker.io/natsio/nats-server-config-reloader:0.23.0.
+  # upstream source, docker.io/natsio/nats-server-config-reloader:0.24.0.
   # Leave these unset unless you have mirrored the image into your own
   # registry, in which case set registry and repository together:
   # reloader:
   #   image:
   #     registry: <your-registry>
   #     repository: <your-repository>/nats-server-config-reloader
-  #     tag: "0.23.0"
+  #     tag: "0.24.0"
   # PDB: the upstream NATS chart enables a disruption budget by default.
   # Override here to disable it or adjust the minAvailable threshold.
   podDisruptionBudget:
@@ -255,10 +259,9 @@ cassandra:
   resourcesPreset: "xlarge"
   migrations:
     image:
-      # 0.17.1 and later drop tables used by the published function autoscaler.
-      # Keep this explicit because the pinned published Cassandra chart defaults
-      # to an incompatible migration image.
-      tag: 0.17.0
+      # 0.17.3 includes the current NVCT task schema while preserving the
+      # legacy tables required by the published function autoscaler 1.21.0.
+      tag: 0.17.3
   # Image overrides for the Cassandra server and dynamicSeedDiscovery containers.
   # The default image name is `cassandra` under global.image.repository.
   # Override here when pulling from a registry that uses a different path or tag.
@@ -292,6 +295,8 @@ certManager:
 openbao:
   enabled: true
   migrations:
+    image:
+      tag: "0.19.1"
     issuerDiscovery:
       enabled: false
   injector:
@@ -341,6 +346,10 @@ addons:
       replicaCount: 3
       # Set only for source-tree validation. Empty uses the released OCI chart.
       chartPath: ""
+      # Chart 1.13.2 otherwise defaults to Stargate 0.15.1, which predates the
+      # shutdown-drain arguments rendered by that chart.
+      image:
+        tag: "0.16.2"
       readiness:
         warmupMs: 60000
       workload:
@@ -452,7 +461,7 @@ addons:
       # certPath: /etc/stargate/tls/tls.crt
       # keyPath: /etc/stargate/tls/tls.key
       # Image defaults to ${global.image.registry}/${global.image.repository}/nvcf-openbao-migrations.
-      # tag falls back to openbao.migrations.image.tag and then 0.16.2 if
+      # tag falls back to openbao.migrations.image.tag and then 0.19.1 if
       # neither location is set.
       # image:
       #   registry: ""
@@ -555,6 +564,8 @@ invocation:
     maxUnavailable: 1
 
 adminIssuerProxy:
+  image:
+    tag: "1.1.1"
   podDisruptionBudget:
     enabled: false
     maxUnavailable: 1

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -157,8 +157,6 @@ observability:
 
 # Defaults consumed only for the control and all observability profiles.
 functionAutoscaler:
-  image:
-    tag: "1.21.0"
   region: local
   cassandra:
     contactPoints: cassandra.cassandra-system.svc.cluster.local

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -293,8 +293,6 @@ certManager:
 openbao:
   enabled: true
   migrations:
-    image:
-      tag: "0.19.1"
     issuerDiscovery:
       enabled: false
   injector:

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -1040,7 +1040,9 @@ llmRequestRouter:
   image:
     registry: {{ .Values.global.image.registry }}
     repository: {{ .Values.global.image.repository }}/stargate
-    tag: {{ dig "addons" "llm" "requestRouter" "image" "tag" "0.16.2" .Values | quote }}
+    {{- with dig "addons" "llm" "requestRouter" "image" "tag" nil .Values }}
+    tag: {{ . | quote }}
+    {{- end }}
   {{- /*
   Backend routing follows the LLM addon rather than being separately opted into.
   A worker holds one registration stream and one reverse tunnel per replica, and

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -212,7 +212,7 @@ nats:
     image:
       registry: {{ .Values.global.image.registry }}
       repository: {{ .Values.global.image.repository }}/nats-server
-      tag: 2.11.17-alpine3.22
+      tag: 2.14.6-alpine3.22
   # The config reloader is not republished under the public nvidia/nvcf
   # catalog, so it defaults to its upstream Docker Hub source and a
   # public-catalog install needs no override. If you mirror the image into
@@ -222,7 +222,7 @@ nats:
     image:
       registry: {{ dig "nats" "reloader" "image" "registry" "" .Values | default "docker.io" }}
       repository: {{ dig "nats" "reloader" "image" "repository" "" .Values | default "natsio/nats-server-config-reloader" }}
-      tag: {{ dig "nats" "reloader" "image" "tag" "" .Values | default "0.23.0" | quote }}
+      tag: {{ dig "nats" "reloader" "image" "tag" "" .Values | default "0.24.0" | quote }}
   natsBox:
     container:
       image:
@@ -451,7 +451,7 @@ natsAuthCalloutService:
 {{- else if $legacyPylonImageConfigured }}
 {{- $effectivePylonImage = $legacyPylonImage }}
 {{- else if $llmEnabled }}
-{{- $effectivePylonImage = printf "%s/%s/pylon:0.15.1" $sidecarsHost $sidecarsRepo }}
+{{- $effectivePylonImage = printf "%s/%s/pylon:0.16.2" $sidecarsHost $sidecarsRepo }}
 {{- end }}
 {{- $stackApiRemoteConfigData := dict }}
 {{- $stackNvcfRemoteConfig := dict }}
@@ -499,7 +499,7 @@ api:
     image:
       registry: {{ dig "api" "accountBootstrap" "image" "registry" "" .Values | default "docker.io" }}
       repository: {{ dig "api" "accountBootstrap" "image" "repository" "" .Values | default "alpine/k8s" }}
-      tag: {{ dig "api" "accountBootstrap" "image" "tag" "" .Values | default "1.36.1" | quote }}
+      tag: {{ dig "api" "accountBootstrap" "image" "tag" "" .Values | default "1.37.0" | quote }}
       pullPolicy: IfNotPresent
 
     registryCredentials: []
@@ -632,6 +632,9 @@ nvctApi:
   image:
     registry: {{ .Values.global.image.registry }}
     repository: {{ .Values.global.image.repository }}/nvct-service-oss
+    {{- with dig "nvctApi" "image" "tag" nil .Values }}
+    tag: {{ . | quote }}
+    {{- end }}
 
   env:
     NVCT_SIDECARS_HOSTNAME: {{ $sidecarsHost }}
@@ -825,6 +828,9 @@ adminIssuerProxy:
   image:
     registry: {{ .Values.global.image.registry }}
     repository: {{ .Values.global.image.repository }}/admin-token-issuer-proxy
+    {{- with dig "adminIssuerProxy" "image" "tag" nil .Values }}
+    tag: {{ . | quote }}
+    {{- end }}
   {{- with include "nvcf.nodeSelector" (dict "type" "controlplane" "selectors" .Values.global.nodeSelectors) }}
   {{- . | nindent 2 }}
   {{- end }}
@@ -852,6 +858,10 @@ stateMetrics:
   image:
     registry: {{ .Values.global.image.registry }}
     repository: {{ .Values.global.image.repository }}/nvcf-state-metrics-service
+  {{- with dig "stateMetrics" "resources" dict .Values }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with include "nvcf.nodeSelector" (dict "type" "controlplane" "selectors" .Values.global.nodeSelectors) }}
   {{- . | nindent 2 }}
   {{- end }}
@@ -1030,6 +1040,7 @@ llmRequestRouter:
   image:
     registry: {{ .Values.global.image.registry }}
     repository: {{ .Values.global.image.repository }}/stargate
+    tag: {{ dig "addons" "llm" "requestRouter" "image" "tag" "0.16.2" .Values | quote }}
   {{- /*
   Backend routing follows the LLM addon rather than being separately opted into.
   A worker holds one registration stream and one reverse tunnel per replica, and
@@ -1215,7 +1226,7 @@ llmRequestRouter:
   {{- /* Provisioning reuses the OpenBao migrations image. Prefer an explicit
        PKI tag, then the OpenBao migrations tag, and finally the compatible
        stack default so a normal environment need not duplicate chart values. */ -}}
-  {{- $pkiImageTag := dig "addons" "llm" "pki" "image" "tag" (dig "openbao" "migrations" "image" "tag" "" .Values) .Values | default "0.16.2" }}
+  {{- $pkiImageTag := dig "addons" "llm" "pki" "image" "tag" (dig "openbao" "migrations" "image" "tag" "" .Values) .Values | default "0.19.1" }}
   pki:
     enabled: true
     namespace: {{ dig "addons" "llm" "pki" "namespace" "vault-system" .Values | quote }}
@@ -1333,12 +1344,12 @@ vanityGateway:
 {{- $vanityBackend := merge (deepCopy (dig "ingress" "gatewayApi" "routes" "vanityGateway" "backend" dict .Values)) (dict "name" "vanity-gateway" "namespace" "nvcf" "port" 8080) }}
 {{- $essBackend := merge (deepCopy (dig "ingress" "gatewayApi" "routes" "ess" "backend" dict .Values)) (dict "name" "ess-api" "namespace" "ess" "port" 8080) }}
 {{- $apiKeysBackend := merge (deepCopy (dig "ingress" "gatewayApi" "routes" "apiKeys" "backend" dict .Values)) (dict "name" "api-keys" "namespace" "api-keys" "port" 8080) }}
-{{/* openbao-migrations image tag: 0.16.2 is the floor. An operator may pin a
+{{/* openbao-migrations image tag: 0.19.1 is the floor. An operator may pin a
      newer tag via addons.nvcfUi.openbaoMigrations.image.tag, but anything older
-     than the floor is ignored (the migrations job needs >= 0.16.2). */}}
-{{- $nvcfUiOpenbaoMigrationsTag := "0.16.2" }}
+     than the floor is ignored (the migrations job needs >= 0.19.1). */}}
+{{- $nvcfUiOpenbaoMigrationsTag := "0.19.1" }}
 {{- $nvcfUiMigrationsTagOverride := dig "addons" "nvcfUi" "openbaoMigrations" "image" "tag" "" .Values }}
-{{- if and $nvcfUiMigrationsTagOverride (semverCompare ">=0.16.2" $nvcfUiMigrationsTagOverride) }}
+{{- if and $nvcfUiMigrationsTagOverride (semverCompare ">=0.19.1" $nvcfUiMigrationsTagOverride) }}
 {{- $nvcfUiOpenbaoMigrationsTag = $nvcfUiMigrationsTagOverride }}
 {{- end }}
 nvcfUi:

--- a/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
@@ -162,7 +162,7 @@ releases:
 {{- end }}
 
   - name: cassandra
-    version: 0.20.2
+    version: 0.20.3
     condition: cassandra.enabled # From defaults.yaml or env overrides
     namespace: cassandra-system
     <<: *dependency # Inherits base values from the dependency template

--- a/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
@@ -120,7 +120,7 @@ releases:
     <<: *dependency
 
   - name: openbao-server # this name MUST not change
-    version: 0.32.1
+    version: 0.32.2
     condition: openbao.enabled # From defaults.yaml or env overrides
     namespace: vault-system
     <<: *dependency # Inherits base values from the dependency template

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -57,7 +57,7 @@ releases:
     condition: icms.enabled
 
   - name: api
-    version: 1.25.4
+    version: 1.25.5
     namespace: nvcf
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -57,7 +57,7 @@ releases:
     condition: icms.enabled
 
   - name: api
-    version: 1.25.3
+    version: 1.25.4
     namespace: nvcf
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -58,7 +58,7 @@ releases:
     condition: icms.enabled
 
   - name: api
-    version: 1.25.5
+    version: 1.25.6
     namespace: nvcf
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -67,7 +67,7 @@ releases:
       - ess/ess-api
 
   - name: nvct-api
-    version: 1.5.2
+    version: 1.5.3
     namespace: nvcf
     inherit:
       - template: service
@@ -194,7 +194,7 @@ releases:
       release-group: services
 
   - name: vanity-gateway
-    version: 0.4.0
+    version: 0.4.1
     namespace: nvcf
     condition: addons.vanityGateway.enabled
     inherit:

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -169,7 +169,7 @@ releases:
     {{- $llmRequestRouterChartPath := dig "addons" "llm" "requestRouter" "chartPath" "" .Values }}
     chart: {{ $llmRequestRouterChartPath | default "nvcf/helm-nvcf-llm-request-router" | quote }}
     {{- if not $llmRequestRouterChartPath }}
-    version: 1.13.0
+    version: 1.13.1
     {{- end }}
     namespace: nvcf
     condition: addons.llm.enabled

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -183,7 +183,7 @@ releases:
 
   - name: llm-api-gateway
     chart: nvcf/helm-nvcf-llm-api-gateway
-    version: 1.4.2
+    version: 1.4.3
     namespace: nvcf
     condition: addons.llm.enabled
     values:

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -81,7 +81,7 @@ releases:
       - nvcf/api
 
   - name: grpc-proxy
-    version: 1.7.1
+    version: 1.7.2
     namespace: nvcf
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -44,7 +44,7 @@ releases:
 
   # --- NVCF Services ---
   - name: api-keys
-    version: 1.6.0
+    version: 1.7.0
     namespace: api-keys
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -169,7 +169,7 @@ releases:
     {{- $llmRequestRouterChartPath := dig "addons" "llm" "requestRouter" "chartPath" "" .Values }}
     chart: {{ $llmRequestRouterChartPath | default "nvcf/helm-nvcf-llm-request-router" | quote }}
     {{- if not $llmRequestRouterChartPath }}
-    version: 1.12.2
+    version: 1.13.0
     {{- end }}
     namespace: nvcf
     condition: addons.llm.enabled

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -169,7 +169,7 @@ releases:
     {{- $llmRequestRouterChartPath := dig "addons" "llm" "requestRouter" "chartPath" "" .Values }}
     chart: {{ $llmRequestRouterChartPath | default "nvcf/helm-nvcf-llm-request-router" | quote }}
     {{- if not $llmRequestRouterChartPath }}
-    version: 1.13.1
+    version: 1.13.2
     {{- end }}
     namespace: nvcf
     condition: addons.llm.enabled

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -50,7 +50,7 @@ releases:
       - template: service
 
   - name: sis
-    version: 2.0.0
+    version: 2.1.0
     namespace: sis
     inherit:
       - template: service
@@ -89,7 +89,7 @@ releases:
 
   - name: ratelimiter
     chart: nvcf/helm-nvcf-rate-limiter
-    version: 1.1.0
+    version: 1.2.0
     namespace: nvcf
     condition: rateLimiter.enabled
     values:
@@ -100,13 +100,13 @@ releases:
       - nvcf/api
 
   - name: ess-api
-    version: 1.7.2
+    version: 1.8.0
     namespace: ess
     inherit:
       - template: service
 
   - name: notary-service
-    version: 1.4.2
+    version: 1.5.0
     namespace: nvcf
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -114,7 +114,7 @@ releases:
 
   - name: admin-issuer-proxy
     chart: nvcf/helm-admin-token-issuer-proxy
-    version: 1.5.1
+    version: 1.5.2
     namespace: api-keys
     values:
       - ../global.yaml.gotmpl

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -101,7 +101,7 @@ releases:
       - nvcf/api
 
   - name: ess-api
-    version: 1.8.0
+    version: 1.8.1
     namespace: ess
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -218,7 +218,7 @@ releases:
     {{- $gatewayRoutesChartPath := dig "ingress" "gatewayApi" "chartPath" "" .Values }}
     chart: {{ $gatewayRoutesChartPath | default "nvcf/nvcf-gateway-routes" | quote }}
     {{- if not $gatewayRoutesChartPath }}
-    version: 1.17.0
+    version: 1.18.0
     {{- end }}
     needs:
       - nvcf/notary-service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -57,7 +57,7 @@ releases:
     condition: icms.enabled
 
   - name: api
-    version: 1.25.1
+    version: 1.25.3
     namespace: nvcf
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -107,7 +107,7 @@ releases:
       - template: service
 
   - name: notary-service
-    version: 1.5.0
+    version: 1.5.1
     namespace: nvcf
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -170,7 +170,7 @@ releases:
     {{- $llmRequestRouterChartPath := dig "addons" "llm" "requestRouter" "chartPath" "" .Values }}
     chart: {{ $llmRequestRouterChartPath | default "nvcf/helm-nvcf-llm-request-router" | quote }}
     {{- if not $llmRequestRouterChartPath }}
-    version: 1.13.2
+    version: 1.13.3
     {{- end }}
     namespace: nvcf
     condition: addons.llm.enabled

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -44,7 +44,8 @@ releases:
 
   # --- NVCF Services ---
   - name: api-keys
-    version: 1.7.0
+    # 1.7.0 currently references an unpublished api-keys service image.
+    version: 1.6.0
     namespace: api-keys
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -44,8 +44,7 @@ releases:
 
   # --- NVCF Services ---
   - name: api-keys
-    # 1.7.0 currently references an unpublished api-keys service image.
-    version: 1.6.0
+    version: 1.7.0
     namespace: api-keys
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
@@ -68,7 +68,7 @@ releases:
 
   {{- if $functionAutoscalerEnabled }}
   - name: function-autoscaler
-    version: 0.2.1
+    version: 0.3.0
     namespace: nvcf
     inherit:
       - template: functionAutoscaler

--- a/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
@@ -68,7 +68,7 @@ releases:
 
   {{- if $functionAutoscalerEnabled }}
   - name: function-autoscaler
-    version: 0.3.0
+    version: 0.3.1
     namespace: nvcf
     inherit:
       - template: functionAutoscaler

--- a/deploy/stacks/self-managed/tests/api-env-wiring.sh
+++ b/deploy/stacks/self-managed/tests/api-env-wiring.sh
@@ -139,7 +139,7 @@ assert_yaml_value "$explicit_manifest" \
   'select(.kind == "ConfigMap" and .data."nvcf-api.yaml" != null) | .data."nvcf-api.yaml" | from_yaml | .nvcf.sidecars.retained-setting' \
   keep-inside-sidecars "rendered nested sidecar remote config"
 
-# With no explicit value, the enabled LLM addon derives Pylon 0.15.1 from the
+# With no explicit value, the enabled LLM addon derives Pylon 0.16.2 from the
 # effective worker-sidecar registry rather than the control-plane image path.
 write_environment <<'EOF'
 global:
@@ -157,7 +157,7 @@ EOF
 default_values="$work_dir/default-values.yaml"
 render_api_values "$default_values" >/dev/null
 assert_yaml_value "$default_values" "$remote_pylon_expression" \
-  registry.example.test/team/sidecars/pylon:0.15.1 "computed Pylon default"
+  registry.example.test/team/sidecars/pylon:0.16.2 "computed Pylon default"
 
 # Local BDD fixtures rely on the same computed default after their registry
 # paths are configured. They must not carry unresolved fixture placeholders
@@ -174,8 +174,8 @@ for fixture_name in self-managed-local-bdd.yaml self-managed-local-bdd-multi.yam
   fixture_pylon_image="$(yq -r "$remote_pylon_expression" "$fixture_values")"
   [[ "$fixture_pylon_image" != *REPLACE_WITH_* ]] ||
     fail "$fixture_name Pylon property retained an unresolved fixture placeholder"
-  [[ "$fixture_pylon_image" == nvcr.io/sample-org/sample-team/pylon:0.15.1 ]] ||
-    fail "$fixture_name Pylon property: expected computed 0.15.1 image, got $fixture_pylon_image"
+  [[ "$fixture_pylon_image" == nvcr.io/sample-org/sample-team/pylon:0.16.2 ]] ||
+    fail "$fixture_name Pylon property: expected computed 0.16.2 image, got $fixture_pylon_image"
 done
 
 # The deprecated env key remains accepted for one compatibility window, but

--- a/deploy/stacks/self-managed/tests/cassandra-autoscaler-published-compatibility.sh
+++ b/deploy/stacks/self-managed/tests/cassandra-autoscaler-published-compatibility.sh
@@ -20,10 +20,10 @@ autoscaler_manifest="$work_dir/function-autoscaler.yaml"
 autoscaler_release="$work_dir/function-autoscaler-release.json"
 # These literals are the compatibility contract under test. Review and advance
 # them together only after the autoscaler no longer uses the removed tables.
-cassandra_chart_version=0.20.2
-autoscaler_chart_version=0.2.1
-migrations_image_version=0.17.0
-autoscaler_image_version=1.19.0
+cassandra_chart_version=0.20.3
+autoscaler_chart_version=0.3.0
+migrations_image_version=0.17.3
+autoscaler_image_version=1.21.0
 trap 'rm -rf "$work_dir"' EXIT
 
 fail() {

--- a/deploy/stacks/self-managed/tests/cassandra-autoscaler-published-compatibility.sh
+++ b/deploy/stacks/self-managed/tests/cassandra-autoscaler-published-compatibility.sh
@@ -21,9 +21,8 @@ autoscaler_release="$work_dir/function-autoscaler-release.json"
 # These literals are the compatibility contract under test. Review and advance
 # them together only after the autoscaler no longer uses the removed tables.
 cassandra_chart_version=0.20.3
-autoscaler_chart_version=0.3.0
+autoscaler_chart_version=0.3.1
 migrations_image_version=0.17.3
-autoscaler_image_version=1.21.0
 trap 'rm -rf "$work_dir"' EXIT
 
 fail() {
@@ -124,6 +123,12 @@ test "$(yq -r '.[0].chart' "$autoscaler_release")" = \
 test "$(yq -r '.[0].version' "$autoscaler_release")" = \
   "$autoscaler_chart_version" ||
   fail "observability Helmfile did not select function autoscaler $autoscaler_chart_version"
+
+autoscaler_chart="oci://${NVCF_PUBLISHED_CHART_REGISTRY}/${NVCF_PUBLISHED_CHART_REPOSITORY}/helm-nvcf-function-autoscaler"
+autoscaler_image_version="$(helm show chart "$autoscaler_chart" \
+  --version "$autoscaler_chart_version" | yq -r '.appVersion // ""')"
+test -n "$autoscaler_image_version" ||
+  fail "published function autoscaler chart has no appVersion"
 
 autoscaler_image="$(yq ea -r '
   select(.kind == "Deployment" and .metadata.name == "function-autoscaler") |

--- a/deploy/stacks/self-managed/tests/ess-base-url-wiring.sh
+++ b/deploy/stacks/self-managed/tests/ess-base-url-wiring.sh
@@ -65,6 +65,9 @@ assert_value() {
 
 public_url="https://ess.example.test"
 incluster_url="http://ess-api.ess.svc.cluster.local:8080"
+expected_nvct_image_tag="$(yq -r '.nvctApi.image.tag' "$stack_dir/environments/base.yaml")"
+[[ -n "$expected_nvct_image_tag" && "$expected_nvct_image_tag" != "null" ]] ||
+  fail "could not read the default NVCT image tag"
 
 # ---------------------------------------------------------------------------
 # 1. Default: essServiceURL set, no essBaseURL override. Both the self base URL
@@ -89,6 +92,8 @@ assert_value "$default_values" '.nvctApi.env.NVCT_ESS_BASE_URL' "$public_url" \
   "default: NVCT_ESS_BASE_URL tracks essServiceURL"
 assert_value "$default_values" '.nvctApi.env.NVCT_ESS_WORKER_BASE_URL' "$public_url" \
   "default: NVCT_ESS_WORKER_BASE_URL tracks essServiceURL"
+assert_value "$default_values" '.nvctApi.image.tag' "$expected_nvct_image_tag" \
+  "default: NVCT image tag tracks the base environment"
 
 # ---------------------------------------------------------------------------
 # 2. Override: essServiceURL is the public URL for workers; essBaseURL points

--- a/deploy/stacks/self-managed/tests/ess-base-url-wiring.sh
+++ b/deploy/stacks/self-managed/tests/ess-base-url-wiring.sh
@@ -65,9 +65,6 @@ assert_value() {
 
 public_url="https://ess.example.test"
 incluster_url="http://ess-api.ess.svc.cluster.local:8080"
-expected_nvct_image_tag="$(yq -r '.nvctApi.image.tag' "$stack_dir/environments/base.yaml")"
-[[ -n "$expected_nvct_image_tag" && "$expected_nvct_image_tag" != "null" ]] ||
-  fail "could not read the default NVCT image tag"
 
 # ---------------------------------------------------------------------------
 # 1. Default: essServiceURL set, no essBaseURL override. Both the self base URL
@@ -92,8 +89,8 @@ assert_value "$default_values" '.nvctApi.env.NVCT_ESS_BASE_URL' "$public_url" \
   "default: NVCT_ESS_BASE_URL tracks essServiceURL"
 assert_value "$default_values" '.nvctApi.env.NVCT_ESS_WORKER_BASE_URL' "$public_url" \
   "default: NVCT_ESS_WORKER_BASE_URL tracks essServiceURL"
-assert_value "$default_values" '.nvctApi.image.tag' "$expected_nvct_image_tag" \
-  "default: NVCT image tag tracks the base environment"
+assert_value "$default_values" '.nvctApi.image.tag' null \
+  "default: NVCT image tag is supplied by the chart"
 
 # ---------------------------------------------------------------------------
 # 2. Override: essServiceURL is the public URL for workers; essBaseURL points

--- a/deploy/stacks/self-managed/tests/gateway-routes-local-chart.sh
+++ b/deploy/stacks/self-managed/tests/gateway-routes-local-chart.sh
@@ -34,8 +34,8 @@ test "$default_chart" = 'nvcf/nvcf-gateway-routes' || {
   echo "gateway-routes-local-chart: expected default chart, got ${default_chart:-missing}" >&2
   exit 1
 }
-test "$default_version" = '1.17.0' || {
-  echo "gateway-routes-local-chart: expected default version 1.17.0, got ${default_version:-missing}" >&2
+test "$default_version" = '1.18.0' || {
+  echo "gateway-routes-local-chart: expected default version 1.18.0, got ${default_version:-missing}" >&2
   exit 1
 }
 

--- a/deploy/stacks/self-managed/tests/gateway-routes-published-chart.sh
+++ b/deploy/stacks/self-managed/tests/gateway-routes-published-chart.sh
@@ -11,7 +11,7 @@ stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 work_dir="$(mktemp -d)"
 published_manifest="$work_dir/gateway-routes.yaml"
 published_release="$work_dir/gateway-routes-release.json"
-published_version=1.17.0
+published_version=1.18.0
 gateway_namespace=gateway
 trap 'rm -rf "$work_dir"' EXIT
 

--- a/deploy/stacks/self-managed/tests/llm-router-local-chart.sh
+++ b/deploy/stacks/self-managed/tests/llm-router-local-chart.sh
@@ -51,9 +51,13 @@ test "$backend_repository" = "$main_repository" || {
 }
 
 main_tag="$(yq -r '.llmRequestRouter.image.tag // ""' "$values_file")"
-expected_main_tag="$(yq -r '.addons.llm.requestRouter.image.tag // ""' "$stack_dir/environments/base.yaml")"
-test "$main_tag" = "$expected_main_tag" || {
-  echo "llm-router-local-chart: expected main router tag $expected_main_tag, got ${main_tag:-missing}" >&2
+test -z "$main_tag" || {
+  echo "llm-router-local-chart: expected main router tag to inherit the chart default, got $main_tag" >&2
+  exit 1
+}
+expected_main_tag="$(yq -r '.llmRequestRouter.image.tag' "$stack_dir/../../helm/llm-request-router/llm-request-router/values.yaml")"
+test -n "$expected_main_tag" && test "$expected_main_tag" != "null" || {
+  echo "llm-router-local-chart: local chart has no default main router tag" >&2
   exit 1
 }
 

--- a/deploy/stacks/self-managed/tests/llm-router-local-chart.sh
+++ b/deploy/stacks/self-managed/tests/llm-router-local-chart.sh
@@ -51,8 +51,9 @@ test "$backend_repository" = "$main_repository" || {
 }
 
 main_tag="$(yq -r '.llmRequestRouter.image.tag // ""' "$values_file")"
-test -z "$main_tag" || {
-  echo "llm-router-local-chart: expected main router tag to inherit the chart default, got $main_tag" >&2
+expected_main_tag="$(yq -r '.addons.llm.requestRouter.image.tag // ""' "$stack_dir/environments/base.yaml")"
+test "$main_tag" = "$expected_main_tag" || {
+  echo "llm-router-local-chart: expected main router tag $expected_main_tag, got ${main_tag:-missing}" >&2
   exit 1
 }
 
@@ -67,8 +68,7 @@ helm template llm-request-router "$stack_dir/../../helm/llm-request-router/llm-r
   --values "$values_file" >"$local_manifest"
 
 main_registry="$(yq -r '.llmRequestRouter.image.registry' "$values_file")"
-chart_app_version="$(yq -r '.appVersion' "$stack_dir/../../helm/llm-request-router/llm-request-router/Chart.yaml")"
-expected_stargate_image="${main_registry:+${main_registry}/}${main_repository}:${chart_app_version}"
+expected_stargate_image="${main_registry:+${main_registry}/}${main_repository}:${expected_main_tag}"
 main_image="$(yq ea -r \
   'select(.kind == "Deployment" and .metadata.name == "llm-request-router" and .metadata.namespace == "nvcf") | .spec.template.spec.containers[0].image' \
   "$local_manifest")"

--- a/deploy/stacks/self-managed/tests/llm-router-published-chart.sh
+++ b/deploy/stacks/self-managed/tests/llm-router-published-chart.sh
@@ -11,7 +11,7 @@ stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 work_dir="$(mktemp -d)"
 published_manifest="$work_dir/llm-request-router.yaml"
 published_release="$work_dir/llm-request-router-release.json"
-published_version=1.13.2
+published_version=1.13.3
 expected_stargate_image="${NVCF_PUBLISHED_CHART_REGISTRY}/${NVCF_PUBLISHED_CHART_REPOSITORY}/stargate:0.16.2"
 trap 'rm -rf "$work_dir"' EXIT
 

--- a/deploy/stacks/self-managed/tests/llm-router-published-chart.sh
+++ b/deploy/stacks/self-managed/tests/llm-router-published-chart.sh
@@ -11,8 +11,8 @@ stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 work_dir="$(mktemp -d)"
 published_manifest="$work_dir/llm-request-router.yaml"
 published_release="$work_dir/llm-request-router-release.json"
-published_version=1.12.2
-expected_stargate_image="${NVCF_PUBLISHED_CHART_REGISTRY}/${NVCF_PUBLISHED_CHART_REPOSITORY}/stargate:0.14.1"
+published_version=1.13.2
+expected_stargate_image="${NVCF_PUBLISHED_CHART_REGISTRY}/${NVCF_PUBLISHED_CHART_REPOSITORY}/stargate:0.16.2"
 trap 'rm -rf "$work_dir"' EXIT
 
 fail() {

--- a/deploy/stacks/self-managed/tests/observability-autoscaler.sh
+++ b/deploy/stacks/self-managed/tests/observability-autoscaler.sh
@@ -52,6 +52,33 @@ test "$(release_count compute function-autoscaler)" = "0" ||
 test "$(release_count disabled function-autoscaler)" = "0" ||
   fail "disabled profile installed the function autoscaler"
 
+test_stack_dir="$work_dir/self-managed"
+cp -R "$stack_dir" "$test_stack_dir"
+cp "$test_stack_dir/secrets/secrets.yaml.template" \
+  "$test_stack_dir/secrets/base-secrets.yaml"
+
+HELMFILE_ENV=base HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" helmfile \
+  --file "$test_stack_dir/helmfile.d/03-observability.yaml.gotmpl" \
+  --environment default \
+  "${state_values[@]}" \
+  --state-values-set observability.profile=control \
+  --state-values-set-string stateMetrics.resources.requests.cpu=100m \
+  --state-values-set-string stateMetrics.resources.requests.memory=128Mi \
+  --state-values-set-string stateMetrics.resources.limits.cpu=500m \
+  --state-values-set-string stateMetrics.resources.limits.memory=512Mi \
+  --selector name=state-metrics \
+  write-values \
+  --output-file-template "$work_dir/state-metrics-values.yaml" >/dev/null
+
+for assertion in \
+  '.stateMetrics.resources.requests.cpu == "100m"' \
+  '.stateMetrics.resources.requests.memory == "128Mi"' \
+  '.stateMetrics.resources.limits.cpu == "500m"' \
+  '.stateMetrics.resources.limits.memory == "512Mi"'; do
+  yq -e "$assertion" "$work_dir/state-metrics-values.yaml" >/dev/null ||
+    fail "state-metrics resource override was not passed to the chart: $assertion"
+done
+
 write_autoscaler_values() {
   local output_file="$1"
   shift
@@ -71,9 +98,11 @@ write_autoscaler_values "$work_dir/autoscaler-values.yaml"
 
 autoscaler_values="$work_dir/autoscaler-values.yaml"
 autoscaler_tag="$(yq -r '.functionautoscaler.image.tag // ""' "$autoscaler_values")"
-if [[ -n "$autoscaler_tag" ]]; then
-  fail "stack duplicated the function autoscaler chart-owned image tag"
-fi
+expected_autoscaler_tag="$(yq -r '.functionAutoscaler.image.tag // ""' "$stack_dir/environments/base.yaml")"
+[[ -n "$expected_autoscaler_tag" ]] ||
+  fail "base environment does not pin the function autoscaler image"
+test "$autoscaler_tag" = "$expected_autoscaler_tag" ||
+  fail "rendered autoscaler image tag is $autoscaler_tag, expected $expected_autoscaler_tag"
 for expected in \
   'CASSANDRA__CONTACT_POINTS: cassandra.cassandra-system.svc.cluster.local' \
   'CASSANDRA__IS_DEVELOPMENT: "false"' \
@@ -93,13 +122,8 @@ helm template function-autoscaler "$repo_dir/deploy/helm/function-autoscaler" \
   >"$work_dir/autoscaler-manifests.yaml"
 
 autoscaler_manifests="$work_dir/autoscaler-manifests.yaml"
-# Read from the chart itself rather than hardcoding the pin, so this check
-# does not need updating every time the autoscaler appVersion is bumped.
-autoscaler_app_version="$(yq -r '.appVersion' "$repo_dir/deploy/helm/function-autoscaler/Chart.yaml")"
-[[ -n "$autoscaler_app_version" && "$autoscaler_app_version" != "null" ]] ||
-  fail "could not read function-autoscaler chart appVersion"
-grep -q "image: nvcr.io/YOUR_ORG/YOUR_TEAM/nvcf-function-autoscaler:${autoscaler_app_version}" "$autoscaler_manifests" ||
-  fail "self-managed stack did not pin the autoscaler image to the chart's appVersion ($autoscaler_app_version)"
+grep -q "image: nvcr.io/YOUR_ORG/YOUR_TEAM/nvcf-function-autoscaler:${expected_autoscaler_tag}" "$autoscaler_manifests" ||
+  fail "self-managed stack did not pin the autoscaler image to $expected_autoscaler_tag"
 test "$(grep -c '^kind: ConfigMap$' "$autoscaler_manifests")" = "2" ||
   fail "autoscaler chart did not render only its env and Vault template ConfigMaps"
 grep -q 'name: function-autoscaler-env' "$autoscaler_manifests" ||

--- a/deploy/stacks/self-managed/tests/observability-autoscaler.sh
+++ b/deploy/stacks/self-managed/tests/observability-autoscaler.sh
@@ -98,11 +98,11 @@ write_autoscaler_values "$work_dir/autoscaler-values.yaml"
 
 autoscaler_values="$work_dir/autoscaler-values.yaml"
 autoscaler_tag="$(yq -r '.functionautoscaler.image.tag // ""' "$autoscaler_values")"
-expected_autoscaler_tag="$(yq -r '.functionAutoscaler.image.tag // ""' "$stack_dir/environments/base.yaml")"
+test -z "$autoscaler_tag" ||
+  fail "stack values should let the function autoscaler chart supply the image tag"
+expected_autoscaler_tag="$(yq -r '.appVersion // ""' "$repo_dir/deploy/helm/function-autoscaler/Chart.yaml")"
 [[ -n "$expected_autoscaler_tag" ]] ||
-  fail "base environment does not pin the function autoscaler image"
-test "$autoscaler_tag" = "$expected_autoscaler_tag" ||
-  fail "rendered autoscaler image tag is $autoscaler_tag, expected $expected_autoscaler_tag"
+  fail "function autoscaler chart does not define an appVersion"
 for expected in \
   'CASSANDRA__CONTACT_POINTS: cassandra.cassandra-system.svc.cluster.local' \
   'CASSANDRA__IS_DEVELOPMENT: "false"' \
@@ -123,7 +123,7 @@ helm template function-autoscaler "$repo_dir/deploy/helm/function-autoscaler" \
 
 autoscaler_manifests="$work_dir/autoscaler-manifests.yaml"
 grep -q "image: nvcr.io/YOUR_ORG/YOUR_TEAM/nvcf-function-autoscaler:${expected_autoscaler_tag}" "$autoscaler_manifests" ||
-  fail "self-managed stack did not pin the autoscaler image to $expected_autoscaler_tag"
+  fail "function autoscaler chart did not default the image to $expected_autoscaler_tag"
 test "$(grep -c '^kind: ConfigMap$' "$autoscaler_manifests")" = "2" ||
   fail "autoscaler chart did not render only its env and Vault template ConfigMaps"
 grep -q 'name: function-autoscaler-env' "$autoscaler_manifests" ||

--- a/deploy/stacks/self-managed/tests/openbao-published-chart.sh
+++ b/deploy/stacks/self-managed/tests/openbao-published-chart.sh
@@ -53,6 +53,12 @@ HELMFILE_ENV="$environment_name" \
     --output-file-template "$openbao_values" >/dev/null
 
 test -s "$openbao_values" || fail "helmfile wrote no OpenBao values"
+test "$(yq -r '.openbao.migrations.image.tag // ""' "$openbao_values")" = "" ||
+  fail "stack values should let the OpenBao chart supply the migrations image tag"
+expected_migrations_image="$(yq -r '
+  .openbao.migrations.image |
+  "\(.registry)/\(.repository):0.19.1"
+' "$openbao_values")"
 
 HELMFILE_ENV="$environment_name" \
   HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" \
@@ -106,5 +112,13 @@ password="$(yq -r '
 ' "$published_manifest")"
 test "$password" = "$expected_password" ||
   fail "published OpenBao chart did not preserve DEFAULT_CASSANDRA_PASSWORD"
+
+migrations_image="$(yq -r '
+  .spec.template.spec.containers[] |
+  select(.name == "bao-migrations") |
+  .image
+' "$published_manifest")"
+test "$migrations_image" = "$expected_migrations_image" ||
+  fail "published OpenBao chart rendered migrations image $migrations_image, expected $expected_migrations_image"
 
 echo "openbao-published-chart: all checks passed"

--- a/tests/bdd/features/single-cluster-helmfile-llm-pki.feature
+++ b/tests/bdd/features/single-cluster-helmfile-llm-pki.feature
@@ -34,7 +34,7 @@ Feature: Install a local single-cluster NVCF stack with PKI-secured LLM transpor
         | addons.llm.pki.enabled                         | true                                                                      |
         | addons.llm.pki.dnsNames[0]                     | llm-request-router.nvcf.svc.cluster.local                                |
         | addons.llm.pki.allowedDomains                  | nvcf.svc.cluster.local                                                    |
-        | addons.llm.pki.image.tag                       | 0.16.2                                                                    |
+        | addons.llm.pki.image.tag                       | 0.19.1                                                                    |
         | observability.profile                          | disabled                                                                  |
       And I copy the file "tests/bdd/fixtures/nvcf-compute-plane-local-bdd.yaml" to "deploy/stacks/nvcf-compute-plane/environments/local-bdd-pki.yaml"
       And I update yaml file "deploy/stacks/nvcf-compute-plane/environments/local-bdd-pki.yaml" with keys:
@@ -75,7 +75,7 @@ Feature: Install a local single-cluster NVCF stack with PKI-secured LLM transpor
         | llm-request-router.nvcf.svc.cluster.local          |
         | name: NVCF_SERVICE_PKI_ALLOWED_DOMAINS              |
         | value: "nvcf.svc.cluster.local"                   |
-        | nvcf-openbao-migrations:0.16.2                     |
+        | nvcf-openbao-migrations:0.19.1                     |
       # A colocated worker uses the in-cluster h2c Service directly. The
       # dedicated HTTPS identity and route belong only to an explicitly
       # enabled remote-worker ingress.

--- a/tests/bdd/features/single-cluster-helmfile-upstream-images.feature
+++ b/tests/bdd/features/single-cluster-helmfile-upstream-images.feature
@@ -32,13 +32,13 @@ Feature: Install a local single-cluster stack with upstream supporting images
           image:
             registry: {{ .Values.global.image.registry }}
             repository: {{ .Values.global.image.repository }}/nats-server-config-reloader
-            tag: "0.23.0"
+            tag: "0.24.0"
       ---
         reloader:
           image:
             registry: docker.io
             repository: natsio/nats-server-config-reloader
-            tag: "0.23.0"
+            tag: "0.24.0"
       """
     And I substitute a block in file "deploy/stacks/self-managed/global.yaml.gotmpl":
       """
@@ -46,14 +46,14 @@ Feature: Install a local single-cluster stack with upstream supporting images
           image:
             registry: {{ .Values.global.image.registry }}
             repository: {{ .Values.global.image.repository }}/alpine-k8s
-            tag: 1.36.1
+            tag: 1.37.0
             pullPolicy: IfNotPresent
       ---
         accountBootstrap:
           image:
             registry: docker.io
             repository: alpine/k8s
-            tag: "1.36.1"
+            tag: "1.37.0"
             pullPolicy: IfNotPresent
       """
     And a single-cluster ncp-local cluster is running
@@ -78,7 +78,7 @@ Feature: Install a local single-cluster stack with upstream supporting images
     # the same rendered release.
     Then the rendered manifests in "deploy/stacks/self-managed/out" under directories matching "*-nats" should contain:
       | text                                                               |
-      | docker.io/natsio/nats-server-config-reloader:0.23.0                |
+      | docker.io/natsio/nats-server-config-reloader:0.24.0                |
       | # Source: helm-nvcf-nats/templates/nkey-secret.yaml                |
 
     # Cassandra initialization currently uses its migrations image. Selecting
@@ -89,7 +89,7 @@ Feature: Install a local single-cluster stack with upstream supporting images
 
     And the rendered manifests in "deploy/stacks/self-managed/out" under directories matching "*-api" should contain:
       | text                             |
-      | docker.io/alpine/k8s:1.36.1      |
+      | docker.io/alpine/k8s:1.37.0      |
 
     # Keep this focused on the releases that own or exercise the overrides.
     # A full local stack install also starts unrelated service images that may
@@ -120,4 +120,4 @@ Feature: Install a local single-cluster stack with upstream supporting images
       kubectl get statefulset nats -n nats-system -o 'jsonpath={.spec.template.spec.containers[?(@.name=="reloader")].image}'
       """
     Then the command exit code should be 0
-    And the command output should contain "docker.io/natsio/nats-server-config-reloader:0.23.0"
+    And the command output should contain "docker.io/natsio/nats-server-config-reloader:0.24.0"

--- a/tests/bdd/fixtures/self-managed-local-bdd-multi.yaml
+++ b/tests/bdd/fixtures/self-managed-local-bdd-multi.yaml
@@ -42,6 +42,17 @@ global:
 observability:
   profile: disabled
 
+# The published chart defaults target production-sized nodes. Keep the local
+# split-cluster fixture schedulable after the core services are placed.
+stateMetrics:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
 cassandra:
   replicaCount: 1
   resourcesPreset: "large"

--- a/tests/bdd/fixtures/self-managed-local-bdd.yaml
+++ b/tests/bdd/fixtures/self-managed-local-bdd.yaml
@@ -35,6 +35,17 @@ global:
 observability:
   profile: disabled
 
+# The published chart defaults target production-sized nodes. Keep the local
+# single-cluster fixture schedulable after the core services are placed.
+stateMetrics:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
 cassandra:
   replicaCount: 1
   resourcesPreset: "large"

--- a/tests/bdd/godog_test.go
+++ b/tests/bdd/godog_test.go
@@ -1592,7 +1592,7 @@ func TestSingleClusterHelmfileUpstreamImagesFeatureFileWiresToSteps(t *testing.T
 	t.Setenv("SAMPLE_NGC_ORG", "test-org")
 	t.Setenv("SAMPLE_NGC_TEAM", "test-team")
 	t.Setenv("REPO_ROOT", "/repo-root-placeholder")
-	upstreamReloader := "docker.io/natsio/nats-server-config-reloader:0.23.0"
+	upstreamReloader := "docker.io/natsio/nats-server-config-reloader:0.24.0"
 	suite := newWiringSuite(t, newFakeRunner(map[string]harness.Result{
 		"k3d cluster get ncp-local-cp": {ExitCode: 1},
 		"helm list --all-namespaces --kube-context k3d-ncp-local -o json": {
@@ -1803,13 +1803,13 @@ func seedUpstreamImageStackInputs(t *testing.T, repoRoot string) {
     image:
       registry: {{ .Values.global.image.registry }}
       repository: {{ .Values.global.image.repository }}/nats-server-config-reloader
-      tag: "0.23.0"
+      tag: "0.24.0"
 api:
   accountBootstrap:
     image:
       registry: {{ .Values.global.image.registry }}
       repository: {{ .Values.global.image.repository }}/alpine-k8s
-      tag: 1.36.1
+      tag: 1.37.0
       pullPolicy: IfNotPresent
 `
 	if err := os.WriteFile(filepath.Join(stackDir, "global.yaml.gotmpl"), []byte(global), 0o644); err != nil {
@@ -1823,10 +1823,10 @@ func seedUpstreamImageRenderOutput(t *testing.T, repoRoot string) {
 	t.Helper()
 	manifests := map[string]string{
 		"01-nats/templates/nats.yaml": `# Source: helm-nvcf-nats/templates/nkey-secret.yaml
-image: docker.io/natsio/nats-server-config-reloader:0.23.0
+image: docker.io/natsio/nats-server-config-reloader:0.24.0
 `,
 		"02-cassandra/templates/cassandra.yaml": "image: nvcf-cassandra-migrations:latest\n",
-		"03-api/templates/api.yaml":             "image: docker.io/alpine/k8s:1.36.1\n",
+		"03-api/templates/api.yaml":             "image: docker.io/alpine/k8s:1.37.0\n",
 	}
 	root := filepath.Join(repoRoot, "deploy", "stacks", "self-managed", "out")
 	for relativePath, body := range manifests {
@@ -1855,7 +1855,7 @@ env:
     value: "true"
   - name: NVCF_SERVICE_PKI_ALLOWED_DOMAINS
     value: "nvcf.svc.cluster.local"
-image: nvcr.io/test-org/test-team/nvcf-openbao-migrations:0.16.2
+image: nvcr.io/test-org/test-team/nvcf-openbao-migrations:0.19.1
 `
 	filePath := filepath.Join(repoRoot, "deploy", "stacks", "self-managed", "out", "01-pki", "templates", "pki.yaml")
 	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {


### PR DESCRIPTION
Opened by `.github/workflows/stack-pin-bump.yml` when `deploy/helm/openbao/v0.32.2` was published.

The released tag carries the version, so this is a direct pin update rather than a lookup of the newest published chart.

Release notes: https://github.com/NVIDIA/nvcf/releases/tag/deploy/helm/openbao/v0.32.2

If this pull request sits unmerged, later chart releases add their bumps to the same branch, so merging it applies all of them.

Github commit:
fix(stack): pin openbao/v0.32.2