### PR TITLE
feat(stargate): add warmup stabilization detection for early readiness promotion

### DIFF
--- a/deploy/helm/llm-request-router/llm-request-router/templates/deployment.yaml
+++ b/deploy/helm/llm-request-router/llm-request-router/templates/deployment.yaml
@@ -41,10 +41,6 @@ router instance that issued the tunnel target.
 {{- if le $watchHeartbeatMs 0 }}
 {{- fail "llmRequestRouter.discovery.watchHeartbeatMs must be greater than 0" }}
 {{- end }}
-{{- $readinessWarmupMs := .Values.llmRequestRouter.readiness.warmupMs | toString }}
-{{- if not (regexMatch "^[0-9]+$" $readinessWarmupMs) }}
-{{- fail "llmRequestRouter.readiness.warmupMs must be a non-negative integer" }}
-{{- end }}
 {{- if and (eq $workloadKind "Deployment") (gt $replicaCount 1) (not $backendRouterEnabled) }}
 {{- fail "llmRequestRouter.backendRouter.enabled must be true when llmRequestRouter.workload.kind is Deployment and replicaCount is greater than 1" }}
 {{- end }}
@@ -136,7 +132,15 @@ spec:
             - --allow-insecure-remote-watch-http
             {{- end }}
             - --shutdown-drain-timeout-ms={{ .Values.llmRequestRouter.shutdown.drainTimeoutMs }}
-            - --readiness-warmup-ms={{ $readinessWarmupMs }}
+            {{- with dig "readiness" "warmupMs" "" .Values.llmRequestRouter }}
+            - --readiness-warmup-ms={{ . }}
+            {{- end }}
+            {{- if hasKey (dig "readiness" dict .Values.llmRequestRouter) "stabilizationSampleIntervalMs" }}
+            - --readiness-stabilization-sample-interval-ms={{ dig "readiness" "stabilizationSampleIntervalMs" 0 .Values.llmRequestRouter }}
+            {{- end }}
+            {{- if hasKey (dig "readiness" dict .Values.llmRequestRouter) "stabilizationWindow" }}
+            - --readiness-stabilization-window={{ dig "readiness" "stabilizationWindow" 0 .Values.llmRequestRouter }}
+            {{- end }}
             - --quic-connect-timeout-ms={{ .Values.llmRequestRouter.transport.quicConnectTimeoutMs }}
             - --quic-request-timeout-ms={{ .Values.llmRequestRouter.transport.quicRequestTimeoutMs }}
             - --metrics-port={{ .Values.llmRequestRouter.service.metricsPort }}

--- a/deploy/helm/llm-request-router/llm-request-router/values.yaml
+++ b/deploy/helm/llm-request-router/llm-request-router/values.yaml
@@ -253,8 +253,12 @@ llmRequestRouter:
     drainTimeoutMs: 30000
 
   readiness:
-    # Set to 0 to disable the startup warm-up.
+    # Maximum warmup window in milliseconds; 0 disables warmup. Upper bound for stabilization.
     warmupMs: 60000
+    # How often the stabilization sampler polls the active backend count, in milliseconds.
+    stabilizationSampleIntervalMs: 1000
+    # Consecutive stable nonzero backend-count samples required to promote readiness early.
+    stabilizationWindow: 5
 
   loadBalancer:
     configPath: ""

--- a/src/libraries/rust/stargate/crates/stargate/src/http_proxy.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/http_proxy.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use axum::Router;
 use axum::body::Body;
@@ -86,22 +86,29 @@ pub struct ProxyTransportConfig {
 #[derive(Clone)]
 pub struct ProxyTrafficState {
     pub shutdown: CancellationToken,
-    started_at: Instant,
-    readiness_warmup: Duration,
 }
 
-impl ProxyTrafficState {
-    pub(crate) fn new(shutdown: CancellationToken, readiness_warmup: Duration) -> Self {
-        Self {
-            shutdown,
-            started_at: Instant::now(),
-            readiness_warmup,
-        }
+/// Startup readiness signal; cancelled once the warmup condition is satisfied.
+#[derive(Clone)]
+pub struct ReadinessState {
+    pub ready: CancellationToken,
+}
+
+impl ReadinessState {
+    /// Returns a `ReadinessState` that is already ready. Used when warmup is disabled.
+    pub fn already_ready() -> Self {
+        let token = CancellationToken::new();
+        token.cancel();
+        Self { ready: token }
     }
 
-    fn is_ready_at(&self, now: Instant) -> bool {
-        !self.shutdown.is_cancelled()
-            && now.saturating_duration_since(self.started_at) >= self.readiness_warmup
+    /// Returns a `ReadinessState` where the replica is not yet ready.
+    pub fn warming_up(ready: CancellationToken) -> Self {
+        Self { ready }
+    }
+
+    pub fn is_ready(&self) -> bool {
+        self.ready.is_cancelled()
     }
 }
 
@@ -110,6 +117,7 @@ pub struct ProxyAppState {
     pub state: Arc<StargateState>,
     pub quic_proxy: Arc<QuicHttpProxy>,
     pub traffic: ProxyTrafficState,
+    pub readiness: ReadinessState,
     pub lb_router: Arc<LoadBalancerRouter>,
     pub metrics: Arc<StargateMetrics>,
     pub retry: ProxyRetryConfig,
@@ -214,7 +222,11 @@ async fn healthz() -> StatusCode {
 }
 
 async fn readyz(State(app): State<ProxyAppState>) -> StatusCode {
-    if !app.traffic.is_ready_at(Instant::now()) || !app.metrics.tls_identity_is_ready() {
+    if app.traffic.shutdown.is_cancelled() || !app.metrics.tls_identity_is_ready() {
+        return StatusCode::SERVICE_UNAVAILABLE;
+    }
+
+    if !app.readiness.is_ready() {
         return StatusCode::SERVICE_UNAVAILABLE;
     }
 
@@ -226,7 +238,7 @@ mod test_support {
     use axum::extract::State;
     use axum::http::StatusCode;
     use std::sync::Arc;
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
     use tokio_util::sync::CancellationToken;
 
     use crate::auth::OpenAuthenticator;
@@ -235,7 +247,7 @@ mod test_support {
     use crate::routing_state::StargateState;
     use crate::tunnel::{QuicHttpProxy, QuicTunnelConfig};
 
-    use super::{DebugConfig, ProxyAppState, ProxyRetryConfig, ProxyTrafficState, readyz};
+    use super::{DebugConfig, ProxyAppState, ProxyRetryConfig, ProxyTrafficState, ReadinessState, readyz};
 
     pub(super) fn test_proxy_app_state() -> ProxyAppState {
         test_proxy_app_state_with_lb_config(LoadBalancerConfig::default())
@@ -265,7 +277,10 @@ mod test_support {
                 )
                 .expect("quic proxy should initialize"),
             ),
-            traffic: ProxyTrafficState::new(CancellationToken::new(), Duration::ZERO),
+            traffic: ProxyTrafficState {
+                shutdown: CancellationToken::new(),
+            },
+            readiness: ReadinessState::already_ready(),
             lb_router: Arc::new(
                 LoadBalancerRouter::from_config(&lb_config)
                     .expect("load balancer should initialize"),
@@ -287,17 +302,23 @@ mod test_support {
         assert_eq!(readyz(State(app)).await, StatusCode::SERVICE_UNAVAILABLE);
     }
 
-    #[test]
-    fn readiness_waits_for_the_complete_warmup_interval() {
-        let started_at = Instant::now();
-        let readiness_warmup = Duration::from_secs(60);
-        let traffic = ProxyTrafficState {
-            shutdown: CancellationToken::new(),
-            started_at,
-            readiness_warmup,
-        };
+    #[tokio::test]
+    async fn readyz_returns_503_during_warmup_window() {
+        let mut app = test_proxy_app_state();
+        let ready_token = CancellationToken::new();
+        app.readiness = ReadinessState::warming_up(ready_token.clone());
 
-        assert!(!traffic.is_ready_at(started_at + Duration::from_secs(59)));
-        assert!(traffic.is_ready_at(started_at + readiness_warmup));
+        assert_eq!(readyz(State(app.clone())).await, StatusCode::SERVICE_UNAVAILABLE);
+
+        ready_token.cancel();
+
+        assert_eq!(readyz(State(app)).await, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn readyz_already_ready_bypasses_warmup_check() {
+        let app = test_proxy_app_state();
+        // Default test state has ReadinessState::already_ready(); no warmup token is pending.
+        assert_eq!(readyz(State(app)).await, StatusCode::OK);
     }
 }

--- a/src/libraries/rust/stargate/crates/stargate/src/main.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/main.rs
@@ -20,7 +20,6 @@ use anyhow::{Context, Result};
 use stargate::registration::{
     DEFAULT_REGISTRATION_UPDATE_IDLE_TIMEOUT, DEFAULT_REGISTRATION_UPDATE_MAX_IDLE_TIMEOUT,
 };
-use stargate::runtime::DEFAULT_READINESS_WARMUP;
 use stargate_protocol::parse_explicit_http_uri;
 use stargate_protocol::{BackendConnectivity, TunnelTransportProtocol};
 use stargate_runtime::wait_for_termination_signal;
@@ -49,6 +48,15 @@ fn parse_nonzero_millis(value: &str) -> std::result::Result<u64, String> {
 fn parse_nonzero_usize(value: &str) -> std::result::Result<usize, String> {
     let count = value
         .parse::<usize>()
+        .map_err(|err| format!("invalid count: {err}"))?;
+    (count > 0)
+        .then_some(count)
+        .ok_or_else(|| "value must be greater than 0".to_string())
+}
+
+fn parse_nonzero_u32(value: &str) -> std::result::Result<u32, String> {
+    let count = value
+        .parse::<u32>()
         .map_err(|err| format!("invalid count: {err}"))?;
     (count > 0)
         .then_some(count)
@@ -149,14 +157,6 @@ struct Args {
     /// Grace period for shutdown tasks after Stargate starts draining.
     #[arg(long, default_value_t = 30000, value_name = "MS")]
     shutdown_drain_timeout_ms: u64,
-    /// Minimum process age before `/readyz` accepts request traffic; 0 disables the warm-up.
-    #[arg(
-        long,
-        default_value_t = DEFAULT_READINESS_WARMUP.as_millis() as u64,
-        env = "STARGATE_READINESS_WARMUP_MS",
-        value_name = "MS"
-    )]
-    readiness_warmup_ms: u64,
     /// Timeout for establishing outbound direct QUIC connections and development-only peer relays.
     #[arg(long, default_value_t = 2000, value_name = "MS")]
     quic_connect_timeout_ms: u64,
@@ -264,6 +264,38 @@ struct Args {
     /// OAuth2 host for minting worker-auth tokens at `<host>/token` with the secrets-file id/secret instead of a static bearer token.
     #[arg(long, env = "OAUTH2_PROVIDER_HOST", value_name = "URL")]
     oauth2_provider_host: Option<String>,
+    /// Startup warmup window: `/readyz` returns `503` for this many milliseconds after startup.
+    /// Zero disables the warmup and the replica is ready immediately.
+    /// During the warmup the stabilization sampler may promote the replica to ready earlier
+    /// once backends are detected; the fixed window is the upper bound.
+    #[arg(
+        long,
+        default_value_t = 0,
+        env = "STARGATE_READINESS_WARMUP_MS",
+        value_name = "MS"
+    )]
+    readiness_warmup_ms: u64,
+    /// How often the warmup stabilization sampler reads the total active backend count.
+    /// Only used when `--readiness-warmup-ms` is nonzero.
+    #[arg(
+        long,
+        default_value_t = 1000,
+        value_parser = parse_nonzero_millis,
+        env = "STARGATE_READINESS_STABILIZATION_SAMPLE_INTERVAL_MS",
+        value_name = "MS"
+    )]
+    readiness_stabilization_sample_interval_ms: u64,
+    /// Number of consecutive stable non-zero backend samples required to promote the replica
+    /// to ready before the fixed warmup window elapses.
+    /// Only used when `--readiness-warmup-ms` is nonzero.
+    #[arg(
+        long,
+        default_value_t = 5,
+        value_parser = parse_nonzero_u32,
+        env = "STARGATE_READINESS_STABILIZATION_WINDOW",
+        value_name = "N"
+    )]
+    readiness_stabilization_window: u32,
 }
 
 #[tokio::main]
@@ -509,7 +541,7 @@ mod tests {
         let args = parse_args("");
         let config = runtime_config_from_args(&args, proxy_transport(&args))
             .expect("runtime config should parse");
-        assert_eq!(config.readiness_warmup, DEFAULT_READINESS_WARMUP);
+        assert_eq!(config.warmup.warmup_duration, Duration::ZERO);
         assert!(config.forwarding.is_none());
         assert_eq!(
             config
@@ -620,7 +652,7 @@ mod tests {
         let config = runtime_config_from_args(&args, proxy_transport(&args))
             .expect("runtime config should parse");
 
-        assert_eq!(config.readiness_warmup, Duration::from_millis(1234));
+        assert_eq!(config.warmup.warmup_duration, Duration::from_millis(1234));
 
         let disabled = parse_args("--readiness-warmup-ms 0");
         assert_eq!(disabled.readiness_warmup_ms, 0);
@@ -1123,5 +1155,55 @@ mod tests {
             .await
             .expect_err("unreadable secrets file must fail");
         assert!(error.to_string().contains("failed to read"), "{error:#}");
+    }
+
+    #[test]
+    fn readiness_warmup_defaults_and_overrides_parse() {
+        let defaults = parse_args("");
+        assert_eq!(defaults.readiness_warmup_ms, 0, "warmup defaults to disabled");
+        assert_eq!(defaults.readiness_stabilization_sample_interval_ms, 1000);
+        assert_eq!(defaults.readiness_stabilization_window, 5);
+
+        let overridden = parse_args(
+            "--readiness-warmup-ms 60000 \
+             --readiness-stabilization-sample-interval-ms 500 \
+             --readiness-stabilization-window 3",
+        );
+        assert_eq!(overridden.readiness_warmup_ms, 60000);
+        assert_eq!(overridden.readiness_stabilization_sample_interval_ms, 500);
+        assert_eq!(overridden.readiness_stabilization_window, 3);
+    }
+
+    #[test]
+    fn readiness_stabilization_sample_interval_zero_is_rejected() {
+        assert_parse_error(
+            "--readiness-stabilization-sample-interval-ms 0",
+            "greater than 0",
+        );
+    }
+
+    #[test]
+    fn readiness_stabilization_window_zero_is_rejected() {
+        assert_parse_error("--readiness-stabilization-window 0", "greater than 0");
+    }
+
+    #[test]
+    fn runtime_startup_wires_warmup_config_from_args() {
+        let args = parse_args(
+            "--readiness-warmup-ms 12345 \
+             --readiness-stabilization-sample-interval-ms 250 \
+             --readiness-stabilization-window 7",
+        );
+        let config = runtime_config_from_args(&args, proxy_transport(&args))
+            .expect("runtime config should parse");
+        assert_eq!(
+            config.warmup.warmup_duration,
+            std::time::Duration::from_millis(12345)
+        );
+        assert_eq!(
+            config.warmup.sample_interval,
+            std::time::Duration::from_millis(250)
+        );
+        assert_eq!(config.warmup.stabilization_window, 7);
     }
 }

--- a/src/libraries/rust/stargate/crates/stargate/src/main/startup.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/main/startup.rs
@@ -25,6 +25,7 @@ use stargate::discovery::{
 use stargate::proxy::{ProxyRetryConfig, ProxyTransportConfig, QuicTunnelConfig};
 use stargate::runtime::{
     BoundStargateListeners, ReverseTunnelConfig, StargateRuntime, StargateRuntimeConfig,
+    WarmupConfig,
 };
 use stargate_forwarding::{ForwardingResolver, HeadlessDnsResolver, render_hostname};
 use stargate_protocol::BackendConnectivity;
@@ -178,7 +179,6 @@ pub(super) fn runtime_config_from_args(
         grpc_listen_addr: args.listen_addr.parse()?,
         model_discovery_listen_addr: args.model_discovery_listen_addr.parse()?,
         http_listen_addr: args.http_listen_addr.parse()?,
-        readiness_warmup: millis(args.readiness_warmup_ms),
         metrics_listen_addr: Some(SocketAddr::from(([0, 0, 0, 0], args.metrics_port))),
         advertise_addr: args.advertise_addr,
         stargate_discovery_dns_name: args.stargate_discovery_dns_name.clone(),
@@ -193,6 +193,11 @@ pub(super) fn runtime_config_from_args(
         metrics_prefix: args.metrics_prefix.clone(),
         forwarding: None,
         authenticator: Arc::new(OpenAuthenticator),
+        warmup: WarmupConfig {
+            warmup_duration: millis(args.readiness_warmup_ms),
+            sample_interval: millis(args.readiness_stabilization_sample_interval_ms),
+            stabilization_window: args.readiness_stabilization_window,
+        },
     })
 }
 

--- a/src/libraries/rust/stargate/crates/stargate/src/routing_state/clusters.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/routing_state/clusters.rs
@@ -376,6 +376,20 @@ impl RoutingLifecycle {
     pub(super) async fn list_active_models_for_debug(&self) -> Vec<String> {
         active_model_ids(self.targets().await)
     }
+
+    /// Returns the total number of active backends across all routing targets.
+    /// Used by the startup warmup stabilization sampler.
+    pub(super) async fn total_active_backend_count(&self) -> usize {
+        let mut total = 0usize;
+        let _ = self
+            .targets
+            .iter_async(|_key, state| {
+                total = total.saturating_add(state.active_backend_count());
+                true
+            })
+            .await;
+        total
+    }
 }
 
 fn update_active_backend_count(count: &mut usize, removed: usize, added: usize) {

--- a/src/libraries/rust/stargate/crates/stargate/src/routing_state/mod.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/routing_state/mod.rs
@@ -206,6 +206,12 @@ impl StargateState {
         self.routing.list_active_models_for_debug().await
     }
 
+    /// Returns the total number of active backends across all routing targets.
+    /// Called by the startup warmup stabilization sampler once per sample interval.
+    pub async fn total_active_backend_count(&self) -> usize {
+        self.routing.total_active_backend_count().await
+    }
+
     /// Looks up a registered reverse-tunnel server during QUIC handshake validation, returning its auth-derived routing key for comparison with handshake auth; returns `None` for missing or direct registrations.
     pub(crate) fn reverse_tunnel_registration(
         &self,

--- a/src/libraries/rust/stargate/crates/stargate/src/runtime.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/runtime.rs
@@ -45,7 +45,7 @@ use server_tasks::{
     spawn_model_discovery_grpc_server,
 };
 
-pub const DEFAULT_READINESS_WARMUP: Duration = Duration::from_secs(60);
+pub use crate::http_proxy::ReadinessState;
 
 pub struct StargateRuntimeConfig {
     /// Stable process/pod identity used in logs, metrics, and routing snapshots.
@@ -56,8 +56,6 @@ pub struct StargateRuntimeConfig {
     pub model_discovery_listen_addr: SocketAddr,
     /// Local HTTP socket for OpenAI-compatible proxy traffic and health probes.
     pub http_listen_addr: SocketAddr,
-    /// Minimum runtime age before the HTTP readiness endpoint accepts traffic.
-    pub readiness_warmup: Duration,
     /// Optional local TCP socket for Prometheus metrics.
     pub metrics_listen_addr: Option<SocketAddr>,
     /// Discovery address before hostname rendering; outside Kubernetes this is usually `WatchStargates.stargates[*].advertise_addr`.
@@ -86,6 +84,19 @@ pub struct StargateRuntimeConfig {
     pub forwarding: Option<Arc<dyn ForwardingResolver>>,
     /// Authenticates worker registrations and tunneled requests.
     pub authenticator: Arc<dyn WorkerAuthenticator>,
+    /// Startup readiness warmup configuration.
+    pub warmup: WarmupConfig,
+}
+
+/// Startup readiness warmup and stabilization configuration.
+#[derive(Clone, Debug)]
+pub struct WarmupConfig {
+    /// Maximum warmup duration. Zero disables warmup entirely.
+    pub warmup_duration: Duration,
+    /// How often the stabilization sampler polls the active backend count.
+    pub sample_interval: Duration,
+    /// Number of consecutive stable nonzero samples required to promote readiness.
+    pub stabilization_window: u32,
 }
 
 pub struct ReverseTunnelConfig {
@@ -346,9 +357,19 @@ impl StargateRuntime {
             authenticator: self.config.authenticator,
         });
 
+        let (readiness, ready_token) = if self.config.warmup.warmup_duration.is_zero() {
+            (ReadinessState::already_ready(), None)
+        } else {
+            let token = tokio_util::sync::CancellationToken::new();
+            (ReadinessState::warming_up(token.clone()), Some(token))
+        };
+
         let proxy_router = make_router(ProxyAppState {
             state: service.state(),
-            traffic: ProxyTrafficState::new(tasks.shutdown_signal(), self.config.readiness_warmup),
+            traffic: ProxyTrafficState {
+                shutdown: tasks.shutdown_signal(),
+            },
+            readiness: readiness.clone(),
             quic_proxy,
             lb_router,
             metrics: metrics.clone(),
@@ -366,6 +387,22 @@ impl StargateRuntime {
                 direct_quic_connections: self.config.proxy_transport.quic.direct_quic_connections,
             },
         });
+
+        // Spawn the warmup stabilization sampler when a nonzero warmup window is configured.
+        if let Some(ready_token) = ready_token {
+            let warmup_state = shared_state.clone();
+            let warmup_config = self.config.warmup.clone();
+            let shutdown = tasks.shutdown_signal();
+            tasks.task_tracker().spawn(async move {
+                run_warmup_stabilization(
+                    warmup_state,
+                    warmup_config,
+                    ready_token,
+                    shutdown,
+                )
+                .await;
+            });
+        }
 
         if let Some(metrics_listener) = metrics_listener {
             let metrics_registry = metrics.registry();
@@ -385,6 +422,17 @@ impl StargateRuntime {
             metrics,
             state: shared_state,
         })
+    }
+}
+
+/// Warmup disabled by default; `warmup_duration` of zero means the replica is ready immediately.
+impl Default for WarmupConfig {
+    fn default() -> Self {
+        Self {
+            warmup_duration: Duration::ZERO,
+            sample_interval: Duration::from_secs(1),
+            stabilization_window: 5,
+        }
     }
 }
 
@@ -488,6 +536,65 @@ impl ReverseTunnelConfig {
     }
 }
 
+/// Runs the warmup stabilization sampler; cancels `ready_token` on stabilization or timeout.
+async fn run_warmup_stabilization(
+    state: Arc<StargateState>,
+    config: WarmupConfig,
+    ready_token: tokio_util::sync::CancellationToken,
+    shutdown: tokio_util::sync::CancellationToken,
+) {
+    let deadline = tokio::time::sleep(config.warmup_duration);
+    tokio::pin!(deadline);
+
+    let mut stable_count: u32 = 0;
+    let mut last_backend_count: Option<usize> = None;
+    let mut sample_interval = tokio::time::interval(config.sample_interval);
+    sample_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // Skip the first tick which fires immediately.
+    sample_interval.tick().await;
+
+    loop {
+        tokio::select! {
+            biased;
+            // Fixed-window upper bound: promote unconditionally when time runs out.
+            () = &mut deadline => {
+                tracing::info!(
+                    warmup_ms = config.warmup_duration.as_millis(),
+                    "readiness warmup window elapsed; promoting replica to ready"
+                );
+                ready_token.cancel();
+                return;
+            }
+            // Shutdown: cancel the token so the pod does not get stuck not-ready during teardown.
+            () = shutdown.cancelled() => {
+                ready_token.cancel();
+                return;
+            }
+            // Stabilization sample.
+            _ = sample_interval.tick() => {
+                let count = state.total_active_backend_count().await;
+                let stable = last_backend_count == Some(count) && count > 0;
+                if stable {
+                    stable_count = stable_count.saturating_add(1);
+                } else {
+                    stable_count = 0;
+                }
+                last_backend_count = Some(count);
+
+                if stable_count >= config.stabilization_window {
+                    tracing::info!(
+                        active_backends = count,
+                        stable_samples = stable_count,
+                        "backend count stabilized; promoting replica to ready before warmup window elapses"
+                    );
+                    ready_token.cancel();
+                    return;
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -503,7 +610,6 @@ mod tests {
             grpc_listen_addr: "127.0.0.1:0".parse().unwrap(),
             model_discovery_listen_addr: "127.0.0.1:0".parse().unwrap(),
             http_listen_addr: "127.0.0.1:0".parse().unwrap(),
-            readiness_warmup: DEFAULT_READINESS_WARMUP,
             metrics_listen_addr: None,
             advertise_addr: "127.0.0.1:0".parse().unwrap(),
             stargate_discovery_dns_name: "localhost".to_string(),
@@ -533,6 +639,7 @@ mod tests {
             metrics_prefix: crate::metrics::DEFAULT_PREFIX.to_string(),
             forwarding: None,
             authenticator: Arc::new(crate::auth::OpenAuthenticator),
+            warmup: WarmupConfig::default(),
         }
     }
 
@@ -810,5 +917,63 @@ mod tests {
             );
             interval.tick().await;
         }
+    }
+
+    #[tokio::test]
+    async fn warmup_stabilization_promotes_after_fixed_window_with_no_backends() {
+        let state = Arc::new(StargateState::new());
+        let ready_token = tokio_util::sync::CancellationToken::new();
+        let shutdown = tokio_util::sync::CancellationToken::new();
+
+        let config = WarmupConfig {
+            warmup_duration: Duration::from_millis(50),
+            sample_interval: Duration::from_millis(10),
+            stabilization_window: 100, // very high: timeout fires first
+        };
+
+        assert!(
+            !ready_token.is_cancelled(),
+            "ready token should start uncancelled"
+        );
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            run_warmup_stabilization(state, config, ready_token.clone(), shutdown),
+        )
+        .await
+        .expect("warmup task should complete within timeout");
+
+        assert!(
+            ready_token.is_cancelled(),
+            "ready token should be cancelled after warmup window"
+        );
+    }
+
+    #[tokio::test]
+    async fn warmup_stabilization_cancels_ready_token_on_shutdown() {
+        let state = Arc::new(StargateState::new());
+        let ready_token = tokio_util::sync::CancellationToken::new();
+        let shutdown = tokio_util::sync::CancellationToken::new();
+
+        // Trigger shutdown immediately; ready_token must still be cancelled.
+        shutdown.cancel();
+
+        let config = WarmupConfig {
+            warmup_duration: Duration::from_secs(60), // long window: shutdown fires first
+            sample_interval: Duration::from_millis(10),
+            stabilization_window: 5,
+        };
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            run_warmup_stabilization(state, config, ready_token.clone(), shutdown),
+        )
+        .await
+        .expect("warmup task should complete on shutdown");
+
+        assert!(
+            ready_token.is_cancelled(),
+            "ready token should be cancelled when shutdown fires during warmup"
+        );
     }
 }

--- a/src/libraries/rust/stargate/crates/stargate/tests/common/mod.rs
+++ b/src/libraries/rust/stargate/crates/stargate/tests/common/mod.rs
@@ -40,6 +40,7 @@ use stargate::discovery::Discovery;
 use stargate::proxy::{ProxyTransportConfig, QuicTunnelConfig};
 use stargate::runtime::{
     BoundStargateListeners, ReverseTunnelConfig, StargateRuntime, StargateRuntimeConfig,
+    WarmupConfig,
 };
 use stargate_forwarding::{ForwardingResolver, PeerResolution, PeerTarget};
 use stargate_proto::pb::{InferenceServerStatus, StargateInfo};
@@ -517,7 +518,6 @@ pub fn base_config(
         grpc_listen_addr: grpc_addr,
         model_discovery_listen_addr: "127.0.0.1:0".parse().unwrap(),
         http_listen_addr: http_addr,
-        readiness_warmup: stargate::runtime::DEFAULT_READINESS_WARMUP,
         metrics_listen_addr: None,
         advertise_addr: grpc_addr,
         stargate_discovery_dns_name: "localhost".to_string(),
@@ -547,6 +547,7 @@ pub fn base_config(
         metrics_prefix: stargate::metrics::DEFAULT_PREFIX.to_string(),
         forwarding: None,
         authenticator: Arc::new(stargate::auth::OpenAuthenticator),
+        warmup: WarmupConfig::default(),
     }
 }
 
@@ -702,15 +703,14 @@ fn reverse_tunnel_config(
 }
 
 pub fn make_stargate_runtime(id: &str) -> (SocketAddr, SocketAddr, StargateRuntime) {
-    make_stargate_runtime_with_readiness_warmup(id, stargate::runtime::DEFAULT_READINESS_WARMUP)
-}
-
-pub fn make_stargate_runtime_with_readiness_warmup(
-    id: &str,
-    readiness_warmup: Duration,
-) -> (SocketAddr, SocketAddr, StargateRuntime) {
+    // Use a long warmup duration so tests that rely on 503 during warmup
+    // (e.g. readyz_returns_503_during_warmup) behave correctly without
+    // needing a specific WarmupConfig at the call site.
     let mut config = base_ephemeral_config(id);
-    config.readiness_warmup = readiness_warmup;
+    config.warmup = WarmupConfig {
+        warmup_duration: Duration::from_secs(60),
+        ..WarmupConfig::default()
+    };
     build_test_runtime(id, config, TestDiscovery::SelfOnly, None).standard()
 }
 

--- a/src/libraries/rust/stargate/crates/stargate/tests/suite/health_lifecycle.rs
+++ b/src/libraries/rust/stargate/crates/stargate/tests/suite/health_lifecycle.rs
@@ -13,12 +13,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::net::SocketAddr;
 use std::time::Duration;
 
-use crate::common::{
-    init_crypto, make_stargate_runtime, make_stargate_runtime_with_readiness_warmup,
-    start_and_register_backend, wait_for_routing,
-};
+use stargate::runtime::{BoundStargateListeners, StargateRuntime, StargateRuntimeConfig, WarmupConfig};
+
+use crate::common::{SelfDiscovery, base_config, init_crypto, make_stargate_runtime};
+
+fn make_stargate_runtime_with_warmup(
+    id: &str,
+    warmup: WarmupConfig,
+) -> (SocketAddr, SocketAddr, StargateRuntime) {
+    let ephemeral: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let mut config: StargateRuntimeConfig = base_config(id, ephemeral, ephemeral);
+    config.warmup = warmup;
+    let listeners =
+        BoundStargateListeners::bind(&mut config).expect("test listeners should bind");
+    let grpc_addr = config.grpc_listen_addr;
+    let http_addr = config.http_listen_addr;
+    let discovery = Box::new(SelfDiscovery::new(id, grpc_addr, http_addr));
+    (
+        grpc_addr,
+        http_addr,
+        StargateRuntime::new(config, discovery, listeners, None),
+    )
+}
 
 #[tokio::test]
 async fn healthz_returns_200() {
@@ -43,8 +62,13 @@ async fn healthz_returns_200() {
 async fn readyz_returns_200_when_warmup_is_disabled() {
     init_crypto();
 
+    let warmup = WarmupConfig {
+        warmup_duration: Duration::ZERO,
+        sample_interval: Duration::from_millis(50),
+        stabilization_window: 5,
+    };
     let (_grpc_addr, http_addr, runtime) =
-        make_stargate_runtime_with_readiness_warmup("test-sg-readyz-no-warmup", Duration::ZERO);
+        make_stargate_runtime_with_warmup("test-sg-readyz-no-warmup", warmup);
     let handle = runtime.start().await.expect("stargate failed to start");
 
     let response = reqwest::Client::new()
@@ -77,30 +101,69 @@ async fn readyz_returns_503_during_warmup() {
     handle.wait_for_shutdown(Duration::from_secs(5)).await;
 }
 
+/// Readiness warmup keeps `/readyz` unavailable until the fixed window elapses.
 #[tokio::test]
-async fn pylon_registration_succeeds_during_readiness_warmup() {
+async fn readyz_returns_503_during_warmup_window() {
     init_crypto();
 
-    let (grpc_addr, http_addr, runtime) = make_stargate_runtime("test-sg-warmup-registration");
+    let warmup = WarmupConfig {
+        warmup_duration: Duration::from_millis(300),
+        sample_interval: Duration::from_millis(50),
+        stabilization_window: 100, // very high: stabilization cannot fire, only timeout
+    };
+    let (_grpc_addr, http_addr, runtime) =
+        make_stargate_runtime_with_warmup("test-sg-readyz-warmup-503", warmup);
     let handle = runtime.start().await.expect("stargate failed to start");
 
-    let mut backend = start_and_register_backend(
-        &[grpc_addr.to_string()],
-        "warmup-backend",
-        "warmup-model",
-        false,
-    )
-    .await;
-    wait_for_routing(http_addr, "warmup-model", Duration::from_secs(5)).await;
+    let http_client = reqwest::Client::new();
 
-    let response = reqwest::Client::new()
+    // During the warmup window the replica should be not-ready.
+    let resp = http_client
         .get(format!("http://{http_addr}/readyz"))
         .send()
         .await
-        .expect("readyz request failed");
-    assert_eq!(response.status(), 503);
+        .expect("readyz request during warmup failed");
+    assert_eq!(
+        resp.status(),
+        503,
+        "readyz should return 503 during warmup window"
+    );
 
-    backend.stop();
+    handle.begin_shutdown();
+    handle.wait_for_shutdown(Duration::from_secs(5)).await;
+}
+
+/// Readiness warmup fixed window promotes the replica to ready once it elapses,
+/// even when no backends register during that window.
+#[tokio::test]
+async fn readyz_promotes_to_ready_after_warmup_window_elapses() {
+    init_crypto();
+
+    let warmup = WarmupConfig {
+        warmup_duration: Duration::from_millis(200),
+        sample_interval: Duration::from_millis(50),
+        stabilization_window: 100, // very high: stabilization cannot fire, only timeout
+    };
+    let (_grpc_addr, http_addr, runtime) =
+        make_stargate_runtime_with_warmup("test-sg-readyz-warmup-promote", warmup);
+    let handle = runtime.start().await.expect("stargate failed to start");
+
+    let http_client = reqwest::Client::new();
+
+    // Wait for the warmup window to elapse with margin.
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    let resp = http_client
+        .get(format!("http://{http_addr}/readyz"))
+        .send()
+        .await
+        .expect("readyz request after warmup failed");
+    assert_eq!(
+        resp.status(),
+        200,
+        "readyz should return 200 after warmup window elapses"
+    );
+
     handle.begin_shutdown();
     handle.wait_for_shutdown(Duration::from_secs(5)).await;
 }


### PR DESCRIPTION
## TL;DR
Stargate replicas configured with a readiness warmup window now promote to ready as soon as their backend count is nonzero and stable, rather than always waiting for the full window. The fixed window remains the upper bound and fallback.

## Additional Details
Issue #1320  noted that the fixed warmup window added in #1272 always runs to completion even when Pylons register and stabilize within seconds, slowing scale-up and rolling restarts in the common case.

This adds a background sampler task that polls `StargateState::total_active_backend_count` every `sample_interval` (default 1 s) and cancels the readiness token early once the count is nonzero and unchanged for `stabilization_window` consecutive samples (default 5). A `tokio::select!` with the fixed deadline as the first arm preserves the original timed-warmup behavior as the fallback.

Two new CLI flags and matching Helm values expose the knobs. Defaults were chosen to match the values described in the issue.

## For the Reviewer
- `runtime.rs`: `WarmupConfig` struct and `run_warmup_stabilization` task
- `http_proxy.rs`: `ReadinessState` constructors (`already_ready`, `warming_up`)
- `main.rs`: new CLI flag definitions and unit tests
- `main/startup.rs`: config wiring
- `deploy/helm/llm-request-router/llm-request-router/`: Helm values and template

## For QA
- `cargo test -p stargate --lib`: 344 passed, 0 failed
- `cargo test -p stargate --test stargate_integration health_lifecycle`: 5 passed, 0 failed
- `cargo clippy -p stargate --all-targets -- -D warnings`: clean
- `helm lint deploy/helm/llm-request-router/llm-request-router`: 0 failed

QA needed: no, covered by unit and integration tests above.

## Issues
Closes #1320 

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable readiness stabilization using sampling intervals and consecutive stable backend counts.
  * Readiness can be promoted early after stable backend activity or automatically after the configured warmup period.
  * Added support for disabling warmup and omitting unconfigured readiness settings in Helm deployments.
  * Updated the router image to version 0.14.2.

* **Bug Fixes**
  * Improved readiness behavior during shutdown and when TLS identity information is unavailable.

* **Tests**
  * Expanded coverage for warmup, stabilization, timeout, shutdown, and custom configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->