### PR TITLE
fix(self-managed): consume NVCA transport TLS validation

### DIFF
--- a/deploy/stacks/nvcf-compute-plane/environments/base.yaml
+++ b/deploy/stacks/nvcf-compute-plane/environments/base.yaml
@@ -31,9 +31,9 @@ global:
   # NVCA Operator Configuration
   # =============================================================================
   nvcaOperator:
-    imageTag: "3.2.12"
+    imageTag: "3.2.19"
     selfManaged:
-      nvcaVersion: "3.2.12"
+      nvcaVersion: "3.2.19"
       otelCollector:
         # Self-hosted registries do not always mirror this optional image.
         # Enable it only after publishing the collector in global.image.

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/deployment.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/deployment.yaml
@@ -130,7 +130,7 @@ spec:
           - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTU3LjAtbnYtMC4xLjEifQ=="
           - --task-env-overrides-b64
           - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTU3LjAtbnYtMC4xLjEifQ=="
-        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.12
+        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.19
         imagePullPolicy: IfNotPresent
         securityContext:
           # Set here so openbao injection can copy it upon injection
@@ -176,7 +176,7 @@ spec:
             cpu: "1000m"
             memory: "4Gi"
       - name: nvca-mirror
-        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.12
+        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.19
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/pre-delete-cleanup-job.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/pre-delete-cleanup-job.yaml
@@ -52,7 +52,7 @@ spec:
         fsGroup: 1010
       containers:
       - name: cleanup
-        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.12
+        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.2.19
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/self-managed-nvcfbackend-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/self-managed-nvcfbackend-cm.yaml
@@ -20,7 +20,7 @@ metadata:
   name: nvcfbackend-self-managed
   namespace: nvca-operator
   annotations:
-    release-artifact-nvca-image: "nvcr.io/0651155215864979/ncp-dev/nvca:3.2.12"
+    release-artifact-nvca-image: "nvcr.io/0651155215864979/ncp-dev/nvca:3.2.19"
     release-artifact-nvcf-image-credential-helper-image: "nvcr.io/0651155215864979/ncp-dev/nvcf-image-credential-helper:0.10.2"
     release-artifact-samba-image: "nvcr.io/0651155215864979/ncp-dev/samba:1.0.5"
   labels:
@@ -37,7 +37,7 @@ data:
     clusterDescription: "ncp-local"
     clusterGroupName: "nvcf-default"
     ncaID: "nvcf-default"
-    nvcaVersion: "3.2.12"
+    nvcaVersion: "3.2.19"
     oAuthClientId: ""
     cloudProvider: "NCP"
     region: "us-west-1"

--- a/deploy/stacks/nvcf-compute-plane/tests/observability-profile.sh
+++ b/deploy/stacks/nvcf-compute-plane/tests/observability-profile.sh
@@ -91,7 +91,7 @@ for profile in default disabled control compute all; do
   esac
 done
 
-expected_nvca_version="3.2.12"
+expected_nvca_version="3.2.19"
 test "$(operator_image_tag "$work_dir/default.yaml")" = "$expected_nvca_version" ||
   fail "default operator image tag is not $expected_nvca_version"
 test "$(nvca_version "$work_dir/default.yaml")" = "$expected_nvca_version" ||


### PR DESCRIPTION
## Customer Summary
Self-hosted compute-plane deployments now consume NVCA 3.2.19, which includes transport TLS validation before workload rendering.

## TL;DR
Bump the self-managed NVCA operator and agent from 3.2.12 to the first 3.2 release containing the merged transport TLS validation backport, [NVIDIA/nvcf#1402](https://github.com/NVIDIA/nvcf/pull/1402).

## Additional Details
- Updates `global.nvcaOperator.imageTag` and `global.nvcaOperator.selfManaged.nvcaVersion` in the compute-plane base environment.
- Updates local golden manifests and the observability-profile version assertion.
- NVCA release tag: `src/compute-plane-services/nvca/v3.2.19`.

## For the Reviewer
Please verify that the operator image tag, self-managed NVCA image tag, and `nvcaVersion` remain synchronized at 3.2.19.

## For QA
QA Needed: Yes.

1. Deploy the self-hosted compute-plane stack with NVCA 3.2.19.
2. Configure a Secret-backed transport TLS bundle.
3. Set `workload.stargateQUICInsecure=true` through `agentConfig.mergeConfig`.
4. Verify reconciliation rejects the conflicting insecure transport before workload rendering and does not produce a worker with `--quic-insecure`.
5. Verify the valid Secret-backed TLS configuration still reconciles successfully.

Local checks: `make test-observability-profile`, `make test-self-managed-nvca-image-reference`, `helm lint deploy/helm/nvca-operator/nvca-operator`, `bash -n deploy/stacks/nvcf-compute-plane/tests/observability-profile.sh`, and `git diff --check` pass. The full golden render reached Helmfile but could not pull the internal OCI chart without registry credentials.

## Issues
NO-REF

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] Commit includes DCO sign-off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the NVCA Operator and self-managed NVCA components to version 3.2.19.
  * Updated observability validation to reflect the new component version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->