### PR TITLE
fix(cloud-functions): accept per-model routing expressions

### DIFF
--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/function/management/dto/CreateFunctionRequest.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/function/management/dto/CreateFunctionRequest.java
@@ -341,8 +341,10 @@ public class CreateFunctionRequest {
                     throw new BadRequestException(MESG_MISSING_LLM_MODEL_URIS);
                 }
                 if (isLlmFunction) {
-                    LlmConfigValidator.validateRoutingMethod(
-                            model.getName(), model.getLlmConfig().getRoutingMethod());
+                    // Persist the normalized expression (canonical algorithm spelling).
+                    model.getLlmConfig().setRoutingMethod(
+                            LlmConfigValidator.validateAndNormalizeRoutingMethod(
+                                    model.getName(), model.getLlmConfig().getRoutingMethod()));
                     LlmConfigValidator.validateTokenRateLimit(
                             model.getName(), model.getLlmConfig().getTokenRateLimit());
                 }

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/function/management/dto/LlmConfigValidator.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/function/management/dto/LlmConfigValidator.java
@@ -6,58 +6,120 @@ package com.nvidia.nvcf.rest.function.management.dto;
 
 import com.nvidia.boot.exceptions.BadRequestException;
 import jakarta.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
-import java.util.Set;
+import java.util.Map;
 import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 /**
- * Rejects invalid {@code llmConfig} routingMethod/tokenRateLimit at create/update, so callers
- * get a 400 up front instead of a late failure at invocation.
+ * Format-only validation for {@code llmConfig} fields at create/update, so callers get a 400 up
+ * front instead of a late failure at invocation.
+ *
+ * <p>routingMethod carries a routing expression: an algorithm token optionally followed by
+ * {@code ;key=value} tuning parameters (a profile of RFC 8941 Item with Parameters). This layer
+ * checks format only and normalizes the algorithm token to the router's canonical spelling. The
+ * router is the semantic authority: it rejects unknown methods, unknown or incompatible
+ * parameters, and invalid values at request time, so a well-formed expression persists even when
+ * it is semantically wrong.
  */
 @Slf4j
 public final class LlmConfigValidator {
 
     private LlmConfigValidator() {}
 
-    // Stargate LoadBalancerAlgorithm values; keep in sync. Blank = router default.
-    private static final Set<String> VALID_ROUTING_METHODS = Set.of(
-            "power-of-two",
-            "wait-and-widen",
-            "round-robin",
-            "random",
-            "pulsar",
-            "pulsar-wait-and-widen",
-            // Deprecated Stargate aliases retained for existing deployments.
-            "groq-multiregion",
-            "pulsar-multiregion");
+    private static final int MAX_ROUTING_METHOD_LENGTH = 1024;
+
+    // Router LoadBalancerAlgorithm canonical spellings; keep this alias map in sync with the
+    // router's serde aliases. Aliases are normalized away at write time so newly persisted
+    // expressions converge on canonical names. Unknown methods are kept as typed.
+    private static final Map<String, String> ALGORITHM_ALIASES = Map.of(
+            "power-of-two", "power-of-n",
+            "powerof2", "power-of-n",
+            "powerofn", "power-of-n",
+            "groq-multiregion", "wait-and-widen",
+            "pulsar-multiregion", "pulsar-wait-and-widen");
+
+    // RFC 8941 token: (ALPHA / "*") *(tchar / ":" / "/").
+    private static final Pattern ALGORITHM_TOKEN_PATTERN =
+            Pattern.compile("[A-Za-z*][!#$%&'*+.^_`|~0-9A-Za-z:/-]*");
+    private static final Pattern PARAMETER_PATTERN =
+            Pattern.compile("([a-z][a-z0-9_]*)=(.+)", Pattern.DOTALL);
+    private static final Pattern INTEGER_VALUE_PATTERN = Pattern.compile("-?\\d{1,15}");
+    private static final Pattern DECIMAL_VALUE_PATTERN = Pattern.compile("-?\\d{1,12}\\.\\d{1,3}");
+    // Quoted string: printable ASCII except '"' and '\', with only \" and \\ escapes.
+    private static final Pattern STRING_VALUE_PATTERN =
+            Pattern.compile("\"(?:[\\x20\\x21\\x23-\\x5B\\x5D-\\x7E]|\\\\[\"\\\\])*\"");
 
     // Comma-separated '<positiveInteger>-<unit>' entries, no unit repeated.
     private static final Pattern TOKEN_RATE_LIMIT_PATTERN = Pattern.compile(
             "^(?!.*-([SMHDW]).*-\\1)[1-9]\\d*-[SMHDW](,\\s*[1-9]\\d*-[SMHDW])*$");
 
     private static final String MESG_INVALID_ROUTING_METHOD =
-            "Invalid request: 'llmConfig.routingMethod' for model '%s' is invalid; supported "
-                    + "values are [power-of-two, wait-and-widen, round-robin, random, pulsar, "
-                    + "pulsar-wait-and-widen, groq-multiregion, pulsar-multiregion]";
+            "Invalid request: 'llmConfig.routingMethod' for model '%s' is invalid: %s";
+    private static final String REASON_TOO_LONG =
+            "expression exceeds " + MAX_ROUTING_METHOD_LENGTH + " characters";
+    private static final String REASON_COMMA = "commas are not allowed in a routing expression";
+    private static final String REASON_UNTERMINATED_STRING = "unterminated quoted string";
+    private static final String REASON_INVALID_ALGORITHM =
+            "the algorithm name before the first ';' must be a bare token";
+    private static final String REASON_MALFORMED_PARAMETER =
+            "malformed parameter '%s'; expected key=value with a lowercase snake_case key";
+    private static final String REASON_INVALID_VALUE =
+            "parameter '%s' value must be an integer, decimal, token, or quoted string";
+    private static final String REASON_BOOLEAN_SYNTAX =
+            "parameter '%s' must use =true or =false, not '?' boolean syntax";
+    private static final String REASON_DUPLICATE_PARAMETER = "duplicate parameter '%s'";
+
     private static final String MESG_INVALID_TOKEN_RATE_LIMIT =
             "Invalid request: 'llmConfig.tokenRateLimit' for model '%s' is invalid; expected "
                     + "comma-separated '<positiveInteger>-<unit>' entries with unit in [S, M, H, D, W] "
                     + "(for example '100000-S' or '10-M,5-S')";
 
-    /** Rejects a routingMethod that is not one of the supported router algorithms. */
-    public static void validateRoutingMethod(String modelName, @Nullable String routingMethod) {
+    /**
+     * Validates the routing expression's format and returns it with the algorithm token
+     * normalized to canonical spelling and optional whitespace after ';' removed. Blank input is
+     * returned unchanged. Never checks whether the method or parameters exist or apply.
+     */
+    public static String validateAndNormalizeRoutingMethod(
+            String modelName, @Nullable String routingMethod) {
         if (StringUtils.isBlank(routingMethod)) {
-            return;
+            return routingMethod;
         }
-        // Match the router: lowercase, '_' -> '-'.
-        var normalized = routingMethod.trim().toLowerCase(Locale.ROOT).replace('_', '-');
-        if (!VALID_ROUTING_METHODS.contains(normalized)) {
-            var mesg = MESG_INVALID_ROUTING_METHOD.formatted(modelName);
-            log.error(mesg);
-            throw new BadRequestException(mesg);
+        var raw = routingMethod.trim();
+        if (raw.length() > MAX_ROUTING_METHOD_LENGTH) {
+            throw invalidRoutingMethod(modelName, REASON_TOO_LONG);
         }
+        if (raw.indexOf(',') >= 0) {
+            throw invalidRoutingMethod(modelName, REASON_COMMA);
+        }
+        var segments = splitOutsideStrings(modelName, raw);
+        var algorithm = segments.get(0);
+        if (!ALGORITHM_TOKEN_PATTERN.matcher(algorithm).matches()) {
+            throw invalidRoutingMethod(modelName, REASON_INVALID_ALGORITHM);
+        }
+        var normalized = new StringBuilder(normalizeAlgorithm(algorithm));
+        var seenKeys = new HashSet<String>();
+        for (var segment : segments.subList(1, segments.size())) {
+            // RFC 8941 allows spaces after ';' only; anything else is part of the parameter.
+            var parameter = StringUtils.stripStart(segment, " ");
+            var matcher = PARAMETER_PATTERN.matcher(parameter);
+            if (!matcher.matches()) {
+                throw invalidRoutingMethod(
+                        modelName, REASON_MALFORMED_PARAMETER.formatted(parameter));
+            }
+            var key = matcher.group(1);
+            var value = matcher.group(2);
+            if (!seenKeys.add(key)) {
+                throw invalidRoutingMethod(modelName, REASON_DUPLICATE_PARAMETER.formatted(key));
+            }
+            validateParameterValue(modelName, key, value);
+            normalized.append(';').append(key).append('=').append(value);
+        }
+        return normalized.toString();
     }
 
     /** Rejects a tokenRateLimit that is not '<positiveInteger>-<unit>' fragments. */
@@ -70,5 +132,60 @@ public final class LlmConfigValidator {
             log.error(mesg);
             throw new BadRequestException(mesg);
         }
+    }
+
+    /** Splits on top-level ';' only; a ';' inside a quoted string stays in its segment. */
+    private static List<String> splitOutsideStrings(String modelName, String raw) {
+        var segments = new ArrayList<String>();
+        var current = new StringBuilder();
+        var inString = false;
+        for (var i = 0; i < raw.length(); i++) {
+            var c = raw.charAt(i);
+            if (inString) {
+                current.append(c);
+                if (c == '\\' && i + 1 < raw.length()) {
+                    current.append(raw.charAt(++i));
+                } else if (c == '"') {
+                    inString = false;
+                }
+            } else if (c == ';') {
+                segments.add(current.toString());
+                current.setLength(0);
+            } else {
+                if (c == '"') {
+                    inString = true;
+                }
+                current.append(c);
+            }
+        }
+        if (inString) {
+            throw invalidRoutingMethod(modelName, REASON_UNTERMINATED_STRING);
+        }
+        segments.add(current.toString());
+        return segments;
+    }
+
+    private static void validateParameterValue(String modelName, String key, String value) {
+        if (value.charAt(0) == '?') {
+            throw invalidRoutingMethod(modelName, REASON_BOOLEAN_SYNTAX.formatted(key));
+        }
+        var isValidValue = STRING_VALUE_PATTERN.matcher(value).matches()
+                || INTEGER_VALUE_PATTERN.matcher(value).matches()
+                || DECIMAL_VALUE_PATTERN.matcher(value).matches()
+                || ALGORITHM_TOKEN_PATTERN.matcher(value).matches();
+        if (!isValidValue) {
+            throw invalidRoutingMethod(modelName, REASON_INVALID_VALUE.formatted(key));
+        }
+    }
+
+    private static String normalizeAlgorithm(String algorithm) {
+        var lowered = algorithm.toLowerCase(Locale.ROOT).replace('_', '-');
+        return ALGORITHM_ALIASES.getOrDefault(lowered, lowered);
+    }
+
+    private static BadRequestException invalidRoutingMethod(String modelName, String reason) {
+        var mesg = MESG_INVALID_ROUTING_METHOD.formatted(modelName, reason);
+        log.error(mesg);
+        return new BadRequestException(mesg);
     }
 }

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/function/management/dto/LlmConfigValidator.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/function/management/dto/LlmConfigValidator.java
@@ -32,6 +32,9 @@ public final class LlmConfigValidator {
     private LlmConfigValidator() {}
 
     private static final int MAX_ROUTING_METHOD_LENGTH = 1024;
+    // The richest real algorithm config is under 20 tunable fields; 32 leaves headroom while
+    // keeping audit lines and canonicalization work bounded.
+    private static final int MAX_PARAMETER_COUNT = 32;
 
     // Router LoadBalancerAlgorithm canonical spellings; keep this alias map in sync with the
     // router's serde aliases. Aliases are normalized away at write time so newly persisted
@@ -43,9 +46,13 @@ public final class LlmConfigValidator {
             "groq-multiregion", "wait-and-widen",
             "pulsar-multiregion", "pulsar-wait-and-widen");
 
-    // RFC 8941 token: (ALPHA / "*") *(tchar / ":" / "/").
+    // RFC 8941 token: (ALPHA / "*") *(tchar / ":" / "/"). Used for parameter values only.
     private static final Pattern ALGORITHM_TOKEN_PATTERN =
             Pattern.compile("[A-Za-z*][!#$%&'*+.^_`|~0-9A-Za-z:/-]*");
+    // Algorithm names are checked after normalization, so this accepts any historical spelling
+    // (uppercase, underscores) while keeping persisted names to the shape Stargate has ever used.
+    private static final Pattern NORMALIZED_ALGORITHM_PATTERN =
+            Pattern.compile("[a-z][a-z0-9-]*");
     private static final Pattern PARAMETER_PATTERN =
             Pattern.compile("([a-z][a-z0-9_]*)=(.+)", Pattern.DOTALL);
     private static final Pattern INTEGER_VALUE_PATTERN = Pattern.compile("-?\\d{1,15}");
@@ -65,7 +72,12 @@ public final class LlmConfigValidator {
     private static final String REASON_COMMA = "commas are not allowed in a routing expression";
     private static final String REASON_UNTERMINATED_STRING = "unterminated quoted string";
     private static final String REASON_INVALID_ALGORITHM =
-            "the algorithm name before the first ';' must be a bare token";
+            "the algorithm name before the first ';' must start with a letter and contain only "
+                    + "letters, digits, hyphens, or underscores";
+    private static final String REASON_TOO_MANY_PARAMETERS =
+            "expression exceeds " + MAX_PARAMETER_COUNT + " parameters";
+    private static final String REASON_SEMICOLON_IN_STRING =
+            "parameter '%s' quoted string must not contain ';'";
     private static final String REASON_MALFORMED_PARAMETER =
             "malformed parameter '%s'; expected key=value with a lowercase snake_case key";
     private static final String REASON_INVALID_VALUE =
@@ -97,11 +109,14 @@ public final class LlmConfigValidator {
             throw invalidRoutingMethod(modelName, REASON_COMMA);
         }
         var segments = splitOutsideStrings(modelName, raw);
-        var algorithm = segments.get(0);
-        if (!ALGORITHM_TOKEN_PATTERN.matcher(algorithm).matches()) {
+        if (segments.size() - 1 > MAX_PARAMETER_COUNT) {
+            throw invalidRoutingMethod(modelName, REASON_TOO_MANY_PARAMETERS);
+        }
+        var algorithm = normalizeAlgorithm(segments.get(0));
+        if (!NORMALIZED_ALGORITHM_PATTERN.matcher(algorithm).matches()) {
             throw invalidRoutingMethod(modelName, REASON_INVALID_ALGORITHM);
         }
-        var normalized = new StringBuilder(normalizeAlgorithm(algorithm));
+        var normalized = new StringBuilder(algorithm);
         var seenKeys = new HashSet<String>();
         for (var segment : segments.subList(1, segments.size())) {
             // RFC 8941 allows spaces after ';' only; anything else is part of the parameter.
@@ -168,6 +183,11 @@ public final class LlmConfigValidator {
     private static void validateParameterValue(String modelName, String key, String value) {
         if (value.charAt(0) == '?') {
             throw invalidRoutingMethod(modelName, REASON_BOOLEAN_SYNTAX.formatted(key));
+        }
+        // Quoted strings must not carry ';' so a naive top-level split on ';' stays correct for
+        // every downstream consumer (router, CLI, log tooling).
+        if (STRING_VALUE_PATTERN.matcher(value).matches() && value.indexOf(';') >= 0) {
+            throw invalidRoutingMethod(modelName, REASON_SEMICOLON_IN_STRING.formatted(key));
         }
         var isValidValue = STRING_VALUE_PATTERN.matcher(value).matches()
                 || INTEGER_VALUE_PATTERN.matcher(value).matches()

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/service/function/FunctionLlmService.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/service/function/FunctionLlmService.java
@@ -403,9 +403,9 @@ public class FunctionLlmService {
                     llmConfig.setTokenRateLimit(llmConfigUpdate.tokenRateLimit());
                 }
                 if (llmConfigUpdate.routingMethod() != null) {
-                    LlmConfigValidator.validateRoutingMethod(
-                            modelUpdate.modelName(), llmConfigUpdate.routingMethod());
-                    llmConfig.setRoutingMethod(llmConfigUpdate.routingMethod());
+                    llmConfig.setRoutingMethod(
+                            LlmConfigValidator.validateAndNormalizeRoutingMethod(
+                                    modelUpdate.modelName(), llmConfigUpdate.routingMethod()));
                 }
                 updated = true;
                 break;

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/rest/function/management/dto/LlmConfigValidatorTest.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/rest/function/management/dto/LlmConfigValidatorTest.java
@@ -4,12 +4,14 @@
  */
 package com.nvidia.nvcf.rest.function.management.dto;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.nvidia.boot.exceptions.BadRequestException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -18,33 +20,94 @@ class LlmConfigValidatorTest {
     private static final String MODEL = "meta/llama-3.1-8b-instruct";
 
     @ParameterizedTest
-    @ValueSource(strings = {
-        "power-of-two", "wait-and-widen", "round-robin", "random", "pulsar",
-        "pulsar-wait-and-widen", "groq-multiregion", "pulsar-multiregion",
-        // Router normalizes case and '_' to '-', so these are accepted too.
-        "Power-Of-Two", "power_of_two", "wait_and_widen", "pulsar_wait_and_widen",
-        "groq_multiregion", "pulsar_multiregion", "  pulsar  "
-    })
-    void validRoutingMethodsAccepted(String routingMethod) {
-        assertThatCode(() -> LlmConfigValidator.validateRoutingMethod(MODEL, routingMethod))
-                .doesNotThrowAnyException();
+    @CsvSource(textBlock = """
+            # method-only values, canonical spellings kept
+            pulsar                                  | pulsar
+            random                                  | random
+            round-robin                             | round-robin
+            wait-and-widen                          | wait-and-widen
+            pulsar-wait-and-widen                   | pulsar-wait-and-widen
+            power-of-n                              | power-of-n
+            # spelling variants normalize to the router's canonical names
+            round_robin                             | round-robin
+            Power-Of-Two                            | power-of-n
+            power_of_two                            | power-of-n
+            powerOf2                                | power-of-n
+            groq-multiregion                        | wait-and-widen
+            groq_multiregion                        | wait-and-widen
+            pulsar-multiregion                      | pulsar-wait-and-widen
+            '  pulsar  '                            | pulsar
+            # expressions with parameters; space after ';' is dropped
+            pulsar;seed=stable-a                    | pulsar;seed=stable-a
+            'pulsar; seed=stable-a'                 | pulsar;seed=stable-a
+            power_of_two;sample_count=4             | power-of-n;sample_count=4
+            pulsar;seed=stable-a;n=2                | pulsar;seed=stable-a;n=2
+            pulsar;consider_kv_free_tokens=true     | pulsar;consider_kv_free_tokens=true
+            wait-and-widen;next_bucket_unlock_factor=0.25 | wait-and-widen;next_bucket_unlock_factor=0.25
+            pulsar;seed="stable a"                  | pulsar;seed="stable a"
+            pulsar;n=-7                             | pulsar;n=-7
+            # format-only: unknown methods and parameters persist by design
+            fastest                                 | fastest
+            pulsar;widen=2                          | pulsar;widen=2
+            fastest;seed=x                          | fastest;seed=x
+            """, delimiter = '|')
+    void wellFormedRoutingMethodsNormalized(String routingMethod, String expected) {
+        assertThat(LlmConfigValidator.validateAndNormalizeRoutingMethod(MODEL, routingMethod))
+                .isEqualTo(expected);
     }
 
     @ParameterizedTest
     @NullAndEmptySource
     @ValueSource(strings = {"   "})
-    void blankRoutingMethodAccepted(String routingMethod) {
-        assertThatCode(() -> LlmConfigValidator.validateRoutingMethod(MODEL, routingMethod))
-                .doesNotThrowAnyException();
+    void blankRoutingMethodReturnedUnchanged(String routingMethod) {
+        assertThatCode(() -> {
+            var result = LlmConfigValidator.validateAndNormalizeRoutingMethod(
+                    MODEL, routingMethod);
+            assertThat(result).isEqualTo(routingMethod);
+        }).doesNotThrowAnyException();
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"weighted", "sticky", "not-a-method", "round robin", "power-of-3"})
-    void invalidRoutingMethodsRejected(String routingMethod) {
-        assertThatThrownBy(() -> LlmConfigValidator.validateRoutingMethod(MODEL, routingMethod))
+    @ValueSource(strings = {
+        "round robin",                  // whitespace inside the algorithm token
+        "9lives",                       // token must start with a letter
+        "pulsar ;seed=x",               // space before ';'
+        "pulsar;seed = x",              // space around '='
+        "pulsar;;n=2",                  // empty parameter
+        "pulsar;n=2;",                  // trailing ';'
+        "pulsar;n=2;n=3",               // duplicate key
+        "pulsar;Seed=x",                // uppercase key
+        "pulsar;flag",                  // valueless parameter
+        "pulsar;n=",                    // empty value
+        "pulsar;b=?1",                  // SFV boolean syntax
+        "pulsar;f=0.1234",              // more than 3 fractional digits
+        "pulsar;s=\"unterminated",      // unterminated quoted string
+        "pul,sar",                      // comma in token
+        "pulsar;s=\"a,b\"",             // comma inside a quoted string
+        "pulsar;s=a b",                 // whitespace inside a bare value
+    })
+    void malformedRoutingMethodsRejected(String routingMethod) {
+        assertThatThrownBy(
+                () -> LlmConfigValidator.validateAndNormalizeRoutingMethod(MODEL, routingMethod))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessageContaining("routingMethod")
                 .hasMessageContaining(MODEL);
+    }
+
+    @Test
+    void oversizedRoutingMethodRejected() {
+        var oversized = "pulsar;seed=" + "a".repeat(1024);
+        assertThatThrownBy(
+                () -> LlmConfigValidator.validateAndNormalizeRoutingMethod(MODEL, oversized))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("1024");
+    }
+
+    @Test
+    void quotedStringMayContainSemicolon() {
+        assertThat(LlmConfigValidator.validateAndNormalizeRoutingMethod(
+                MODEL, "pulsar;seed=\"a;b\""))
+                .isEqualTo("pulsar;seed=\"a;b\"");
     }
 
     @ParameterizedTest

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/rest/function/management/dto/LlmConfigValidatorTest.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/rest/function/management/dto/LlmConfigValidatorTest.java
@@ -84,7 +84,10 @@ class LlmConfigValidatorTest {
         "pulsar;s=\"unterminated",      // unterminated quoted string
         "pul,sar",                      // comma in token
         "pulsar;s=\"a,b\"",             // comma inside a quoted string
+        "pulsar;s=\"a;b\"",             // semicolon inside a quoted string
         "pulsar;s=a b",                 // whitespace inside a bare value
+        "pulsar/v2",                    // algorithm charset is [a-z0-9-] after normalization
+        "*pulsar",                      // algorithm must start with a letter
     })
     void malformedRoutingMethodsRejected(String routingMethod) {
         assertThatThrownBy(
@@ -104,10 +107,18 @@ class LlmConfigValidatorTest {
     }
 
     @Test
-    void quotedStringMayContainSemicolon() {
-        assertThat(LlmConfigValidator.validateAndNormalizeRoutingMethod(
-                MODEL, "pulsar;seed=\"a;b\""))
-                .isEqualTo("pulsar;seed=\"a;b\"");
+    void parameterCountCappedAt32() {
+        var atCap = new StringBuilder("pulsar");
+        for (var i = 0; i < 32; i++) {
+            atCap.append(";p").append(i).append("=1");
+        }
+        assertThat(LlmConfigValidator.validateAndNormalizeRoutingMethod(MODEL, atCap.toString()))
+                .isEqualTo(atCap.toString());
+        var overCap = atCap + ";p32=1";
+        assertThatThrownBy(
+                () -> LlmConfigValidator.validateAndNormalizeRoutingMethod(MODEL, overCap))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("32 parameters");
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## TL;DR

Function owners can persist per-model routing expressions such as
`pulsar;seed=stable-a;n=2` in `llmConfig.routingMethod`. The API now validates
format only and normalizes the algorithm token to the router's canonical
spelling; the router stays the semantic authority and rejects invalid
expressions at request time.

## Additional Details

The routing method allow-list is replaced by grammar validation (a profile of
RFC 8941 Item with Parameters): algorithm token, optional `;key=value`
parameters, values as integer, decimal, token, or quoted string, no commas, no
duplicate keys, 1024-byte cap. Well-formed but semantically wrong expressions
persist by design, so the validator and the router cannot drift on semantics.
Write-time normalization (lowercase, underscore to hyphen, alias map) converges
newly persisted values on canonical algorithm names; the deprecated
multiregion aliases normalize to their replacements.

Do not merge until the router-side expression support has rolled out:
persisted expressions reach the router verbatim, and routers without the
parser reject those models' requests. Sequencing is tracked on the parent
issue.

## For the Reviewer

The grammar and its profile rules are the review core:
`LlmConfigValidator.validateAndNormalizeRoutingMethod` and its parameterized
test table. The two call sites now persist the returned normalized value.

## For QA

`bazel test //src/control-plane-services/cloud-functions/nvcf-core:tests`:
LlmConfigValidatorTest passes fully (all parameterized cases). The target
overall fails locally without Docker because unrelated Testcontainers
integration tests need it; CI provides Docker.

## Issues

Relates to #536

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
