### PR TITLE
feat(load-tests): add LLM API gateway k6 tests

### DIFF
--- a/examples/load-tests/README.md
+++ b/examples/load-tests/README.md
@@ -10,6 +10,9 @@ Many of the function tests target the [Load Tester Supreme](../function-samples/
 functions/                  NVCF function load tests
   definitions/              Protocol buffer definitions (gRPC)
   test-configs/             k6 configuration files
+llm-gateway/                LLM API gateway load tests
+  lib/                      Shared helpers and custom metrics
+  test-configs/             k6 configuration files
 tasks/                      NVCT task load tests
   test-configs/             k6 configuration files
   *.sh                      Cleanup and counting helpers
@@ -45,6 +48,13 @@ tasks/                      NVCT task load tests
 | `k6_regression_test_config.json` | Regression testing scenarios. |
 | `k6_sse_streaming_test_config.json` | Server-sent events streaming configuration. |
 | `k6_scratch_test_config.json` | Development/scratch config. |
+
+## LLM API Gateway Tests
+
+`llm-gateway/` holds tests that exercise the OpenAI-compatible gateway the way a customer
+does, so traffic flows through the request router and the router client sidecar on the
+worker. They target a configurable gateway URL and label every metric with the target, so
+runs against different deployments stay comparable. See `llm-gateway/README.md`.
 
 ## NVCT Task Tests
 

--- a/examples/load-tests/llm-gateway/README.md
+++ b/examples/load-tests/llm-gateway/README.md
@@ -9,7 +9,9 @@ directly. Everything here goes through the OpenAI-compatible gateway surface.
 
 ## Scripts
 
-One script per gateway endpoint, so a failure points at a single handler.
+Scripts are grouped by endpoint and workflow, so a failure points at a single handler.
+Chat completions has separate streaming and non-streaming scripts, and one script covers
+the three health endpoints.
 
 | Script | Endpoint | Notes |
 |--------|----------|-------|
@@ -20,7 +22,7 @@ One script per gateway endpoint, so a failure points at a single handler.
 | `gateway_health_test.js` | `GET /healthz`, `/readyz`, `/info` | Gateway process health. Never reaches the router or a worker. |
 
 These are the only routes the gateway registers. Handlers for audio transcription,
-translation, and speech to speech exist in the source but are not wired into a route, so
+translation, and speech-to-speech exist in the source but are not wired into a route, so
 they are not covered here.
 
 ## Test configs
@@ -40,7 +42,7 @@ Start with the smoke config. Confirm wiring and a clean baseline before ramping.
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `TOKEN` | Yes | Bearer token with permission to invoke the function. |
-| `LLM_GATEWAY_URL` | Yes | Base URL of the gateway to test. No trailing slash needed. |
+| `LLM_GATEWAY_URL` | Yes | Base URL of the gateway to test. Must use https, because the bearer token is sent on every request. No trailing slash needed. |
 | `LLM_FUNCTION_ID` | Yes | Function ID. The gateway requires it as a model prefix. |
 | `LLM_MODEL_NAME` | Yes | Model name as declared on the function. |
 | `LLM_REGION` | No | Free-form label applied to every metric. Defaults to `default`. |
@@ -120,12 +122,14 @@ serve. A 404 usually means the routing target was not found. Which of these a de
 produces changes over time, so the counter deliberately records the code instead of
 special-casing a particular failure.
 
-```
+```bash
 k6 run ... --summary-export summary.json   # http_errors carries the status tag
 ```
 
-Thresholds gate on the overall failure rate and the 95th percentile latency. Individual
-status codes do not abort a run, so hitting the rate limiter does not end a test early.
+Thresholds gate on the check pass rate, the overall failure rate, and the 95th percentile
+latency. The check threshold catches responses that succeed at the HTTP layer but are still
+wrong, such as a 200 carrying a malformed body. Individual status codes do not abort a run,
+so hitting the rate limiter does not end a test early.
 
 ## Before reading any numbers
 

--- a/examples/load-tests/llm-gateway/README.md
+++ b/examples/load-tests/llm-gateway/README.md
@@ -1,0 +1,155 @@
+# LLM API Gateway Load Tests
+
+[k6](https://grafana.com/docs/k6/latest/) load tests that hit the LLM API gateway the way a
+customer does. Traffic follows the full invocation path: gateway, request router, and the
+router client sidecar on the worker.
+
+These differ from the tests in `../functions/`, which target NVCF function endpoints
+directly. Everything here goes through the OpenAI-compatible gateway surface.
+
+## Scripts
+
+One script per gateway endpoint, so a failure points at a single handler.
+
+| Script | Endpoint | Notes |
+|--------|----------|-------|
+| `chat_completions_test.js` | `POST /v1/chat/completions` | Non-streaming completion. |
+| `chat_completions_stream_test.js` | `POST /v1/chat/completions` | Streaming completion, `stream: true`. |
+| `responses_test.js` | `POST /v1/responses` | Responses API. |
+| `embeddings_test.js` | `POST /v1/embeddings` | Embeddings. |
+| `gateway_health_test.js` | `GET /healthz`, `/readyz`, `/info` | Gateway process health. Never reaches the router or a worker. |
+
+These are the only routes the gateway registers. Handlers for audio transcription,
+translation, and speech to speech exist in the source but are not wired into a route, so
+they are not covered here.
+
+## Test configs
+
+| Config | Description |
+|--------|-------------|
+| `k6_llm_smoke_config.json` | 2 requests per second for 30 seconds. Run this first to confirm wiring. |
+| `k6_llm_breakpoint_config.json` | Ramping arrival rate, 5 to 50 requests per second over 9 minutes. |
+
+Both use an open workload model (arrival rate, not virtual users), so queueing shows up as
+latency rather than the load generator throttling itself.
+
+Start with the smoke config. Confirm wiring and a clean baseline before ramping.
+
+## Environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `TOKEN` | Yes | Bearer token with permission to invoke the function. |
+| `LLM_GATEWAY_URL` | Yes | Base URL of the gateway to test. No trailing slash needed. |
+| `LLM_FUNCTION_ID` | Yes | Function ID. The gateway requires it as a model prefix. |
+| `LLM_MODEL_NAME` | Yes | Model name as declared on the function. |
+| `LLM_REGION` | No | Free-form label applied to every metric. Defaults to `default`. |
+| `LLM_INSECURE_SKIP_TLS_VERIFY` | No | Set to `true` when addressing an ingress directly. |
+| `LLM_REQUEST_TIMEOUT_MS` | No | Request timeout in milliseconds. Defaults to 300000. |
+
+The model sent to the gateway is built as `${LLM_FUNCTION_ID}/${LLM_MODEL_NAME}`. A bare
+model name is rejected with a 400.
+
+The timeout default is deliberately well above the k6 default of 60 seconds. A queued
+request that outlives the timeout is recorded as a failed request, which reports saturation
+as breakage.
+
+## Running
+
+Smoke test first:
+
+```bash
+k6 run llm-gateway/chat_completions_test.js \
+  --config llm-gateway/test-configs/k6_llm_smoke_config.json \
+  -e TOKEN=$TOKEN \
+  -e LLM_GATEWAY_URL=$LLM_GATEWAY_URL \
+  -e LLM_FUNCTION_ID=$LLM_FUNCTION_ID \
+  -e LLM_MODEL_NAME=$LLM_MODEL_NAME
+```
+
+Then a breakpoint run:
+
+```bash
+k6 run llm-gateway/chat_completions_test.js \
+  --config llm-gateway/test-configs/k6_llm_breakpoint_config.json \
+  -e TOKEN=$TOKEN \
+  -e LLM_GATEWAY_URL=$LLM_GATEWAY_URL \
+  -e LLM_FUNCTION_ID=$LLM_FUNCTION_ID \
+  -e LLM_MODEL_NAME=$LLM_MODEL_NAME \
+  -e LLM_REGION=primary
+```
+
+Scripts import from `lib/common.js` using a relative path, so run them from the
+`examples/load-tests` directory as shown.
+
+## Choosing a target
+
+Two independent things get called region, and mixing them up produces confusing results.
+
+Client location is where the load generator runs. Locally that is your machine. On k6 Cloud
+it is the configured load zone.
+
+Serving location is the gateway and router that handle the request. `LLM_GATEWAY_URL`
+selects this.
+
+The two interact whenever the published gateway name is backed by anycast routing, because
+then the serving location is chosen by the client location. Running from several client
+locations and getting healthy results does not mean the matching serving locations were
+exercised. Point `LLM_GATEWAY_URL` at a specific ingress when the question is about one
+deployment.
+
+Addressing an ingress directly usually means the certificate will not match the address you
+dialed, so set `LLM_INSECURE_SKIP_TLS_VERIFY=true` for those runs. Prefer a hostname over a
+literal IP so DNS can spread load across all availability zone nodes.
+
+Set `LLM_REGION` to label each run. Every metric carries it, so results from separate runs
+stay attributable.
+
+To drive traffic from other client locations, add a `cloud` block with load zones to a copy
+of a config and run `k6 cloud` instead of `k6 run`. The configs under
+`../functions/test-configs/` show the block format.
+
+## Metrics
+
+Beyond the k6 defaults, every non-200 response increments `http_errors`, tagged with
+`status`, `endpoint`, and `region`.
+
+The breakdown by status code is the useful part, so read it rather than a single total. A
+429 is the rate limiter and is not a capacity finding. A 503 is the gateway declining to
+serve. A 404 usually means the routing target was not found. Which of these a deployment
+produces changes over time, so the counter deliberately records the code instead of
+special-casing a particular failure.
+
+```
+k6 run ... --summary-export summary.json   # http_errors carries the status tag
+```
+
+Thresholds gate on the overall failure rate and the 95th percentile latency. Individual
+status codes do not abort a run, so hitting the rate limiter does not end a test early.
+
+## Before reading any numbers
+
+Check the deployment first. A function deployed with `minInstances: 1`, `maxInstances: 1`,
+and `maxRequestConcurrency: 1` admits one request at a time, so a load test measures a
+one-slot queue rather than the stack. Raise the instance count and request concurrency
+before running a breakpoint test.
+
+Three more limits worth knowing:
+
+- Deployments may enforce per-user and per-account rate limiting. Expect 429s under load
+  unless the account is exempted. They are counted separately for this reason.
+- If the gateway does not cache invocation auth, every request pays the full auth path, and
+  that can saturate before anything downstream does. Read a latency knee with that in mind
+  rather than attributing it to the router or the worker.
+- The streaming test reports time to last token. k6 buffers the whole event stream, so time
+  to first token needs a k6 binary built with
+  [xk6-sse](https://github.com/phymbert/xk6-sse). The build command is in `../README.md`.
+
+A worker deployed in a different location than the gateway handling the request adds a
+network hop, which shows up as higher latency. That is topology, not a gateway regression.
+
+## Further reading
+
+- [NVCF HTTP load testing guide](https://docs.nvidia.com/nvcf/http-load-testing): k6 install
+  steps and the local run workflow.
+- [k6 documentation](https://grafana.com/docs/k6/latest/).

--- a/examples/load-tests/llm-gateway/chat_completions_stream_test.js
+++ b/examples/load-tests/llm-gateway/chat_completions_stream_test.js
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { check } from 'k6'
+import http from 'k6/http'
+
+import {
+  baseUrl,
+  classify,
+  modelId,
+  params,
+  skipTlsVerify,
+  thresholds,
+} from './lib/common.js'
+
+const ENDPOINT = '/v1/chat/completions'
+
+export const options = {
+  insecureSkipTLSVerify: skipTlsVerify(),
+  thresholds: thresholds,
+}
+
+// k6 buffers the whole server-sent-event stream before returning, so
+// http_req_duration here is time to last token, not time to first token.
+// Measuring time to first token needs a k6 binary built with xk6-sse.
+export default function () {
+  const payload = JSON.stringify({
+    model: modelId(),
+    messages: [{ role: 'user', content: 'What should I see in Paris?' }],
+    temperature: 0.2,
+    top_p: 0.7,
+    max_tokens: 256,
+    stream: true,
+  })
+
+  const response = http.post(
+    baseUrl() + ENDPOINT,
+    payload,
+    params(ENDPOINT, { 'Accept': 'text/event-stream' })
+  )
+  classify(response, ENDPOINT)
+
+  check(response, {
+    'status is 200': (r) => r.status === 200,
+    'body is an event stream': (r) => r.status === 200 && String(r.body).includes('data:'),
+    'stream terminated': (r) => r.status === 200 && String(r.body).includes('[DONE]'),
+  })
+}

--- a/examples/load-tests/llm-gateway/chat_completions_test.js
+++ b/examples/load-tests/llm-gateway/chat_completions_test.js
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { check } from 'k6'
+import http from 'k6/http'
+
+import {
+  baseUrl,
+  classify,
+  modelId,
+  params,
+  skipTlsVerify,
+  thresholds,
+} from './lib/common.js'
+
+const ENDPOINT = '/v1/chat/completions'
+
+export const options = {
+  insecureSkipTLSVerify: skipTlsVerify(),
+  thresholds: thresholds,
+}
+
+export default function () {
+  const payload = JSON.stringify({
+    model: modelId(),
+    messages: [{ role: 'user', content: 'What should I see in Paris?' }],
+    temperature: 0.2,
+    top_p: 0.7,
+    max_tokens: 256,
+    stream: false,
+  })
+
+  const response = http.post(baseUrl() + ENDPOINT, payload, params(ENDPOINT))
+  classify(response, ENDPOINT)
+
+  check(response, {
+    'status is 200': (r) => r.status === 200,
+    'has completion choice': (r) => {
+      if (r.status !== 200) {
+        return false
+      }
+      try {
+        const choices = r.json('choices')
+        return Array.isArray(choices) && choices.length > 0
+      } catch (err) {
+        return false
+      }
+    },
+  })
+}

--- a/examples/load-tests/llm-gateway/embeddings_test.js
+++ b/examples/load-tests/llm-gateway/embeddings_test.js
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { check } from 'k6'
+import http from 'k6/http'
+
+import {
+  baseUrl,
+  classify,
+  modelId,
+  params,
+  skipTlsVerify,
+  thresholds,
+} from './lib/common.js'
+
+const ENDPOINT = '/v1/embeddings'
+
+export const options = {
+  insecureSkipTLSVerify: skipTlsVerify(),
+  thresholds: thresholds,
+}
+
+export default function () {
+  const payload = JSON.stringify({
+    model: modelId(),
+    input: 'What should I see in Paris?',
+    encoding_format: 'float',
+  })
+
+  const response = http.post(baseUrl() + ENDPOINT, payload, params(ENDPOINT))
+  classify(response, ENDPOINT)
+
+  check(response, {
+    'status is 200': (r) => r.status === 200,
+    'has embedding data': (r) => {
+      if (r.status !== 200) {
+        return false
+      }
+      try {
+        const data = r.json('data')
+        return Array.isArray(data) && data.length > 0
+      } catch (err) {
+        return false
+      }
+    },
+  })
+}

--- a/examples/load-tests/llm-gateway/gateway_health_test.js
+++ b/examples/load-tests/llm-gateway/gateway_health_test.js
@@ -31,6 +31,7 @@ export default function () {
   for (const endpoint of ENDPOINTS) {
     const response = http.get(baseUrl() + endpoint, {
       timeout: requestTimeoutMs,
+      redirects: 0,
       tags: { endpoint: endpoint, region: region },
     })
     classify(response, endpoint)

--- a/examples/load-tests/llm-gateway/gateway_health_test.js
+++ b/examples/load-tests/llm-gateway/gateway_health_test.js
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { check } from 'k6'
+import http from 'k6/http'
+
+import { baseUrl, classify, region, requestTimeoutMs, skipTlsVerify, thresholds } from './lib/common.js'
+
+const ENDPOINTS = ['/healthz', '/readyz', '/info']
+
+export const options = {
+  insecureSkipTLSVerify: skipTlsVerify(),
+  thresholds: thresholds,
+}
+
+// These endpoints never reach the router or a worker. They isolate gateway
+// process health from the rest of the invocation path.
+export default function () {
+  for (const endpoint of ENDPOINTS) {
+    const response = http.get(baseUrl() + endpoint, {
+      timeout: requestTimeoutMs,
+      tags: { endpoint: endpoint, region: region },
+    })
+    classify(response, endpoint)
+
+    check(response, {
+      [`${endpoint} is 200`]: (r) => r.status === 200,
+    })
+  }
+}

--- a/examples/load-tests/llm-gateway/lib/common.js
+++ b/examples/load-tests/llm-gateway/lib/common.js
@@ -26,7 +26,13 @@ export function baseUrl() {
   if (!__ENV.LLM_GATEWAY_URL) {
     throw new Error('LLM_GATEWAY_URL is required, for example https://gateway.example.com')
   }
-  return __ENV.LLM_GATEWAY_URL.replace(/\/$/, '')
+  const url = __ENV.LLM_GATEWAY_URL.replace(/\/$/, '')
+  // params() attaches TOKEN as a bearer header, so plaintext would put a
+  // credential on the wire.
+  if (!url.startsWith('https://')) {
+    throw new Error(`LLM_GATEWAY_URL must use https, got "${url}"`)
+  }
+  return url
 }
 
 // Needed when addressing an ingress directly, because it serves a certificate
@@ -76,6 +82,9 @@ export function classify(response, endpoint) {
 }
 
 export const thresholds = {
+  // Catches responses that are not failures at the HTTP layer but are still
+  // wrong, for example a 200 carrying a malformed body.
+  'checks': ['rate>0.99'],
   'http_req_failed': ['rate<0.01'],
   'http_req_duration{expected_response:true}': ['p(95)<5000'],
 }

--- a/examples/load-tests/llm-gateway/lib/common.js
+++ b/examples/load-tests/llm-gateway/lib/common.js
@@ -57,6 +57,10 @@ export const requestTimeoutMs = Number(__ENV.LLM_REQUEST_TIMEOUT_MS || 300000)
 export function params(endpoint, extraHeaders) {
   return {
     timeout: requestTimeoutMs,
+    // Never follow a redirect. Go preserves Authorization across a same-host
+    // redirect, including an https to http downgrade, and a 3xx from this
+    // gateway is a finding rather than something to chase transparently.
+    redirects: 0,
     headers: Object.assign(
       {
         'Authorization': `Bearer ${__ENV.TOKEN}`,

--- a/examples/load-tests/llm-gateway/lib/common.js
+++ b/examples/load-tests/llm-gateway/lib/common.js
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Counter } from 'k6/metrics'
+
+// Label only. Set it to whatever identifies the target, for example a region
+// name, so results from separate runs stay attributable. It does not select an
+// endpoint; LLM_GATEWAY_URL does that.
+export const region = __ENV.LLM_REGION || 'default'
+
+export const httpErrors = new Counter('http_errors')
+
+export function baseUrl() {
+  if (!__ENV.LLM_GATEWAY_URL) {
+    throw new Error('LLM_GATEWAY_URL is required, for example https://gateway.example.com')
+  }
+  return __ENV.LLM_GATEWAY_URL.replace(/\/$/, '')
+}
+
+// Needed when addressing an ingress directly, because it serves a certificate
+// for the published gateway name rather than the address you dialed.
+export function skipTlsVerify() {
+  return String(__ENV.LLM_INSECURE_SKIP_TLS_VERIFY || '').toLowerCase() === 'true'
+}
+
+export function modelId() {
+  const functionId = __ENV.LLM_FUNCTION_ID
+  const modelName = __ENV.LLM_MODEL_NAME
+  if (!functionId || !modelName) {
+    throw new Error('LLM_FUNCTION_ID and LLM_MODEL_NAME are required')
+  }
+  return `${functionId}/${modelName}`
+}
+
+// k6 defaults to a 60s request timeout. Under a ramp that turns saturation into
+// recorded request failures, which reads as breakage rather than queueing.
+export const requestTimeoutMs = Number(__ENV.LLM_REQUEST_TIMEOUT_MS || 300000)
+
+export function params(endpoint, extraHeaders) {
+  return {
+    timeout: requestTimeoutMs,
+    headers: Object.assign(
+      {
+        'Authorization': `Bearer ${__ENV.TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      extraHeaders || {}
+    ),
+    tags: { endpoint: endpoint, region: region },
+  }
+}
+
+// Records every non-200 by status code. Deliberately generic: the interesting
+// failure changes over time, so let the codes speak rather than special-casing.
+export function classify(response, endpoint) {
+  if (response.status === 200) {
+    return
+  }
+  httpErrors.add(1, {
+    endpoint: endpoint,
+    region: region,
+    status: String(response.status),
+  })
+}
+
+export const thresholds = {
+  'http_req_failed': ['rate<0.01'],
+  'http_req_duration{expected_response:true}': ['p(95)<5000'],
+}

--- a/examples/load-tests/llm-gateway/responses_test.js
+++ b/examples/load-tests/llm-gateway/responses_test.js
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { check } from 'k6'
+import http from 'k6/http'
+
+import {
+  baseUrl,
+  classify,
+  modelId,
+  params,
+  skipTlsVerify,
+  thresholds,
+} from './lib/common.js'
+
+const ENDPOINT = '/v1/responses'
+
+export const options = {
+  insecureSkipTLSVerify: skipTlsVerify(),
+  thresholds: thresholds,
+}
+
+export default function () {
+  const payload = JSON.stringify({
+    model: modelId(),
+    input: 'What should I see in Paris?',
+    max_output_tokens: 256,
+    temperature: 0.2,
+    top_p: 0.7,
+    stream: false,
+  })
+
+  const response = http.post(baseUrl() + ENDPOINT, payload, params(ENDPOINT))
+  classify(response, ENDPOINT)
+
+  check(response, {
+    'status is 200': (r) => r.status === 200,
+    'has output': (r) => {
+      if (r.status !== 200) {
+        return false
+      }
+      try {
+        return r.json('output') !== undefined || r.json('output_text') !== undefined
+      } catch (err) {
+        return false
+      }
+    },
+  })
+}

--- a/examples/load-tests/llm-gateway/responses_test.js
+++ b/examples/load-tests/llm-gateway/responses_test.js
@@ -52,7 +52,10 @@ export default function () {
         return false
       }
       try {
-        return r.json('output') !== undefined || r.json('output_text') !== undefined
+        const output = r.json('output')
+        const outputText = r.json('output_text')
+        return (output !== undefined && output !== null) ||
+          (outputText !== undefined && outputText !== null)
       } catch (err) {
         return false
       }

--- a/examples/load-tests/llm-gateway/test-configs/k6_llm_breakpoint_config.json
+++ b/examples/load-tests/llm-gateway/test-configs/k6_llm_breakpoint_config.json
@@ -1,0 +1,27 @@
+{
+  "scenarios": {
+    "breakpoint": {
+      "executor": "ramping-arrival-rate",
+      "startRate": 5,
+      "timeUnit": "1s",
+      "preAllocatedVUs": 50,
+      "maxVUs": 500,
+      "startTime": "0s",
+      "gracefulStop": "30s",
+      "stages": [
+        {
+          "duration": "2m",
+          "target": 25
+        },
+        {
+          "duration": "2m",
+          "target": 50
+        },
+        {
+          "duration": "5m",
+          "target": 50
+        }
+      ]
+    }
+  }
+}

--- a/examples/load-tests/llm-gateway/test-configs/k6_llm_smoke_config.json
+++ b/examples/load-tests/llm-gateway/test-configs/k6_llm_smoke_config.json
@@ -1,0 +1,13 @@
+{
+  "scenarios": {
+    "smoke": {
+      "executor": "constant-arrival-rate",
+      "rate": 2,
+      "timeUnit": "1s",
+      "duration": "30s",
+      "preAllocatedVUs": 5,
+      "maxVUs": 20,
+      "gracefulStop": "10s"
+    }
+  }
+}


### PR DESCRIPTION
## Why

The k6 tests under `examples/load-tests` target NVCF function endpoints directly. None of them exercise the OpenAI-compatible LLM API gateway, so the gateway, the request router, and the router client sidecar on the worker have no load coverage. This adds tests that hit the gateway the way a customer does, so a run traverses that whole path.

## What changed

New `examples/load-tests/llm-gateway/` with one script per registered gateway route.

| Script | Endpoint |
|--------|----------|
| `chat_completions_test.js` | `POST /v1/chat/completions` |
| `chat_completions_stream_test.js` | `POST /v1/chat/completions` with `stream: true` |
| `responses_test.js` | `POST /v1/responses` |
| `embeddings_test.js` | `POST /v1/embeddings` |
| `gateway_health_test.js` | `GET /healthz`, `/readyz`, `/info` |

Those are the only routes the gateway registers. The audio and speech to speech handlers exist in the source but are not wired into a route, so they are not covered.

Shared logic lives in `lib/common.js`: target resolution, payload headers, request timeout, and custom metrics. Two configs are included, a smoke config and a ramping arrival rate config.

Three decisions worth reviewing:

1. The gateway is selected by `LLM_GATEWAY_URL` and every metric is labelled via `LLM_REGION`. When a published gateway name is backed by anycast routing, the serving deployment is chosen by client location, so one URL cannot show which deployment needs capacity. The README separates client location from serving location, because exercising several client locations does not exercise the matching serving deployments.
2. Every non-200 increments `http_errors` tagged with its status code. An earlier revision special-cased particular failures, including a counter keyed on 404 plus an error string. That broke immediately in testing: the gateway surfaces router candidate loss as 503, so the counter read zero while the condition was occurring. Recording the code keeps the script useful as behaviour moves. Thresholds gate on overall failure rate and p95 latency, so hitting the rate limiter does not abort a ramp.
3. The request timeout defaults to 300000 ms. k6 defaults to 60 seconds, which under a ramp records queued requests as failures and reports saturation as breakage. The existing `supreme_http_test.js` raises its timeout for the same reason.

Payloads are built with `JSON.stringify`, matching `supreme_http_test.js`. The existing `oai_compatible_llm_load_test.js` builds its payload with a template literal that emits invalid JSON (unquoted model value and two trailing commas). That is not fixed here to keep this change scoped.

## Customer Release Notes

Not customer visible.

## Plan Summary

Not applicable.

## Usage

```bash
k6 run llm-gateway/chat_completions_test.js \
  --config llm-gateway/test-configs/k6_llm_smoke_config.json \
  -e TOKEN=$TOKEN \
  -e LLM_GATEWAY_URL=$LLM_GATEWAY_URL \
  -e LLM_FUNCTION_ID=$LLM_FUNCTION_ID \
  -e LLM_MODEL_NAME=$LLM_MODEL_NAME
```

Run from `examples/load-tests`, since scripts import `lib/common.js` by relative path.

## Testing

Run against a live deployment. All five scripts pass with every check green, including `/v1/responses` and `/v1/embeddings`. Targeting an ingress directly with `LLM_INSECURE_SKIP_TLS_VERIFY=true` works, and omitting `LLM_GATEWAY_URL` fails with a clear message.

Load behaviour was exercised with `chat_completions_test.js` against a single region: a 9 minute ramp to 50 requests per second (21,299 requests), then a 5 minute ramp to 2000 requests per second (283,210 requests). p95 latency went from 105 ms to 137 ms across that range with no capacity ceiling reached, which also confirms the timeout and threshold choices behave sensibly under real load.

These files are themselves tests, so no separate unit tests are added. No QA needed.

## Notes

The README states that a function deployed with `maxInstances: 1` and `maxRequestConcurrency: 1` caps throughput well below the breakpoint ramp, so the deployment needs scaling before results are meaningful. The existing load tests do not document this either.

The streaming script reports time to last token. k6 buffers the whole event stream, so time to first token would need a k6 binary built with xk6-sse.

## References

Closes #1426

## Related Pull Requests

None

## Dependencies

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added load tests for chat completions, streaming chat completions, responses, embeddings, and gateway health endpoints.
  - Added smoke and breakpoint workload configurations for validating performance under different traffic levels.
  - Added shared configuration for endpoint selection, TLS, timeouts, response validation, metrics, and thresholds.
  - Added validation for malformed successful responses and a 99% check-pass-rate threshold.

- **Documentation**
  - Documented how to run gateway load tests, configure workloads, select targets, interpret metrics, and account for streaming latency limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
