### PR TITLE
feat(llm-api-gateway): cache invocation auth responses

### DIFF
--- a/src/invocation-plane-services/llm-api-gateway/cmd/llm-api-gateway/main.go
+++ b/src/invocation-plane-services/llm-api-gateway/cmd/llm-api-gateway/main.go
@@ -62,9 +62,9 @@ func main() {
 		zlog.Fatal().Err(err).Msg("failed to initialize inference provider")
 	}
 
-	var authClient *nvcf.GRPCClient
+	var authClient nvcf.Client
 	if cfg.NVCF.GRPCAddr != "" {
-		authClient, err = nvcf.NewClient(nvcf.Config{
+		grpcAuthClient, err := nvcf.NewClient(nvcf.Config{
 			Addr:               cfg.NVCF.GRPCAddr,
 			SecretsPath:        cfg.NVCF.SecretsPath,
 			OAuth2ProviderHost: cfg.NVCF.OAuth2ProviderHost,
@@ -74,6 +74,7 @@ func main() {
 		if err != nil {
 			zlog.Fatal().Err(err).Msg("failed to initialize nvcf grpc auth client")
 		}
+		authClient = nvcf.NewCachedClient(grpcAuthClient)
 	}
 
 	e, err := server.New(cfg, inferenceProvider, authClient)

--- a/src/invocation-plane-services/llm-api-gateway/nvcf/BUILD.bazel
+++ b/src/invocation-plane-services/llm-api-gateway/nvcf/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "nvcf",
     srcs = [
+        "auth_cache.go",
         "client.go",
         "types.go",
     ],
@@ -33,6 +34,7 @@ go_library(
         "@org_golang_google_grpc//credentials/insecure",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",
+        "@org_golang_x_sync//singleflight",
     ],
 )
 
@@ -44,7 +46,10 @@ alias(
 
 go_test(
     name = "nvcf_test",
-    srcs = ["client_test.go"],
+    srcs = [
+        "auth_cache_test.go",
+        "client_test.go",
+    ],
     embed = [":nvcf"],
     deps = [
         "//src/invocation-plane-services/llm-api-gateway/nvcf/pb",

--- a/src/invocation-plane-services/llm-api-gateway/nvcf/auth_cache.go
+++ b/src/invocation-plane-services/llm-api-gateway/nvcf/auth_cache.go
@@ -1,0 +1,147 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvcf
+
+import (
+	"context"
+	"crypto/sha256"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	// authCacheTTL bounds how long a positive auth response is reused. Token
+	// revocation, function unpublish, and model spec changes take up to this
+	// long to be observed.
+	authCacheTTL = 60 * time.Second
+	// authCacheMaxEntries bounds memory, not hit rate. Eviction past the cap
+	// removes expired entries first, then arbitrary ones.
+	authCacheMaxEntries = 1024
+)
+
+// authCacheKey must include every AuthLlmInvokeRequest field. If the RPC
+// gains an input, it must join this key or a cached response could be served
+// for a request the upstream would answer differently.
+type authCacheKey struct {
+	// tokenHash keeps raw bearer tokens out of process memory dumps.
+	tokenHash  [sha256.Size]byte
+	routingKey string
+}
+
+type authCacheEntry struct {
+	resp      *InvocationAuthResponse
+	expiresAt time.Time
+}
+
+// cachedClient caches positive AuthorizeInvocation responses. Errors and
+// denials are never cached: they propagate to the caller and the next request
+// retries upstream. There is no explicit invalidation; entries expire on TTL
+// only, matching the invocation auth cache in http-invocation.
+type cachedClient struct {
+	inner      Client
+	ttl        time.Duration
+	maxEntries int
+
+	// group collapses concurrent misses for the same key into one upstream
+	// call. The first caller's context governs the shared call, so its
+	// cancellation fails all waiters; they retry on their next request.
+	group singleflight.Group
+
+	mu      sync.Mutex
+	entries map[authCacheKey]authCacheEntry
+}
+
+// NewCachedClient wraps inner with the auth response cache. inner must be
+// non-nil.
+func NewCachedClient(inner Client) Client {
+	return newCachedClient(inner, authCacheTTL, authCacheMaxEntries)
+}
+
+func newCachedClient(inner Client, ttl time.Duration, maxEntries int) Client {
+	if ttl <= 0 || maxEntries <= 0 {
+		return inner
+	}
+	return &cachedClient{
+		inner:      inner,
+		ttl:        ttl,
+		maxEntries: maxEntries,
+		entries:    make(map[authCacheKey]authCacheEntry),
+	}
+}
+
+func (c *cachedClient) AuthorizeInvocation(
+	ctx context.Context,
+	clientAuthorizationToken string,
+	functionID string,
+) (*InvocationAuthResponse, error) {
+	key := authCacheKey{
+		tokenHash:  sha256.Sum256([]byte(clientAuthorizationToken)),
+		routingKey: functionID,
+	}
+
+	c.mu.Lock()
+	entry, ok := c.entries[key]
+	c.mu.Unlock()
+	if ok && time.Now().Before(entry.expiresAt) {
+		return entry.resp.clone(), nil
+	}
+
+	flightKey := string(key.tokenHash[:]) + key.routingKey
+	value, err, _ := c.group.Do(flightKey, func() (any, error) {
+		resp, err := c.inner.AuthorizeInvocation(ctx, clientAuthorizationToken, functionID)
+		if err != nil {
+			return nil, err
+		}
+		c.store(key, resp)
+		return resp, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	// Clone for every caller, including the one that ran the upstream call:
+	// the stored response is shared and must never be handed out directly.
+	return value.(*InvocationAuthResponse).clone(), nil
+}
+
+func (c *cachedClient) store(key authCacheKey, resp *InvocationAuthResponse) {
+	now := time.Now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if len(c.entries) >= c.maxEntries {
+		for k, e := range c.entries {
+			if !now.Before(e.expiresAt) {
+				delete(c.entries, k)
+			}
+		}
+		for k := range c.entries {
+			if len(c.entries) < c.maxEntries {
+				break
+			}
+			delete(c.entries, k)
+		}
+	}
+
+	c.entries[key] = authCacheEntry{resp: resp, expiresAt: now.Add(c.ttl)}
+}
+
+func (c *cachedClient) Close() error {
+	return c.inner.Close()
+}

--- a/src/invocation-plane-services/llm-api-gateway/nvcf/auth_cache_test.go
+++ b/src/invocation-plane-services/llm-api-gateway/nvcf/auth_cache_test.go
@@ -1,0 +1,252 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvcf
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type fakeAuthClient struct {
+	calls   atomic.Int64
+	respond func(token, routingKey string) (*InvocationAuthResponse, error)
+	// block, when non-nil, is closed by the test to release in-flight calls.
+	block chan struct{}
+}
+
+func (f *fakeAuthClient) AuthorizeInvocation(
+	_ context.Context,
+	token string,
+	routingKey string,
+) (*InvocationAuthResponse, error) {
+	f.calls.Add(1)
+	if f.block != nil {
+		<-f.block
+	}
+	if f.respond != nil {
+		return f.respond(token, routingKey)
+	}
+	return authResponseFor(routingKey), nil
+}
+
+func (f *fakeAuthClient) Close() error { return nil }
+
+func authResponseFor(routingKey string) *InvocationAuthResponse {
+	priority := uint32(2)
+	return &InvocationAuthResponse{
+		RoutingKey:   routingKey,
+		ClientAuthID: "client-auth-id",
+		ProjectID:    "project-id",
+		AuthContext:  map[string]string{"ncaId": "nca-" + routingKey},
+		RateLimitKey: "nca-" + routingKey,
+		ModelSpecs: map[string]ModelSpec{
+			"model": {URIs: []string{"uri-1"}, TokenRateLimit: "10", RoutingMethod: "rr"},
+		},
+		Priority: &priority,
+	}
+}
+
+func TestCachedClient_AuthorizeInvocation_CacheBehavior(t *testing.T) {
+	errDenied := errors.New("denied")
+
+	tests := []struct {
+		name string
+		run  func(t *testing.T, fake *fakeAuthClient, client Client)
+		want int64 // expected upstream calls
+	}{
+		{
+			name: "hit within ttl makes one upstream call",
+			run: func(t *testing.T, _ *fakeAuthClient, client Client) {
+				for range 3 {
+					if _, err := client.AuthorizeInvocation(context.Background(), "token", "fn"); err != nil {
+						t.Fatalf("unexpected error: %v", err)
+					}
+				}
+			},
+			want: 1,
+		},
+		{
+			name: "different routing keys are separate entries",
+			run: func(t *testing.T, _ *fakeAuthClient, client Client) {
+				for _, fn := range []string{"fn-a", "fn-b", "fn-a"} {
+					if _, err := client.AuthorizeInvocation(context.Background(), "token", fn); err != nil {
+						t.Fatalf("unexpected error: %v", err)
+					}
+				}
+			},
+			want: 2,
+		},
+		{
+			name: "different tokens are separate entries",
+			run: func(t *testing.T, _ *fakeAuthClient, client Client) {
+				for _, token := range []string{"token-a", "token-b", "token-a"} {
+					if _, err := client.AuthorizeInvocation(context.Background(), token, "fn"); err != nil {
+						t.Fatalf("unexpected error: %v", err)
+					}
+				}
+			},
+			want: 2,
+		},
+		{
+			name: "errors are not cached",
+			run: func(t *testing.T, fake *fakeAuthClient, client Client) {
+				fake.respond = func(string, string) (*InvocationAuthResponse, error) {
+					return nil, errDenied
+				}
+				if _, err := client.AuthorizeInvocation(context.Background(), "token", "fn"); !errors.Is(err, errDenied) {
+					t.Fatalf("want denied error, got %v", err)
+				}
+				fake.respond = nil
+				if _, err := client.AuthorizeInvocation(context.Background(), "token", "fn"); err != nil {
+					t.Fatalf("unexpected error after recovery: %v", err)
+				}
+			},
+			want: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeAuthClient{}
+			client := newCachedClient(fake, time.Minute, authCacheMaxEntries)
+			tt.run(t, fake, client)
+			if got := fake.calls.Load(); got != tt.want {
+				t.Fatalf("upstream calls = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCachedClient_AuthorizeInvocation_ExpiryRefetches(t *testing.T) {
+	fake := &fakeAuthClient{}
+	client := newCachedClient(fake, 10*time.Millisecond, authCacheMaxEntries)
+
+	if _, err := client.AuthorizeInvocation(context.Background(), "token", "fn"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	time.Sleep(20 * time.Millisecond)
+	if _, err := client.AuthorizeInvocation(context.Background(), "token", "fn"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := fake.calls.Load(); got != 2 {
+		t.Fatalf("upstream calls = %d, want 2", got)
+	}
+}
+
+func TestCachedClient_AuthorizeInvocation_ConcurrentMissesCollapse(t *testing.T) {
+	fake := &fakeAuthClient{block: make(chan struct{})}
+	client := newCachedClient(fake, time.Minute, authCacheMaxEntries)
+
+	const concurrency = 16
+	var wg sync.WaitGroup
+	errs := make(chan error, concurrency)
+	for range concurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := client.AuthorizeInvocation(context.Background(), "token", "fn")
+			errs <- err
+		}()
+	}
+
+	// Give the goroutines time to pile onto the in-flight call, then release.
+	time.Sleep(50 * time.Millisecond)
+	close(fake.block)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if got := fake.calls.Load(); got != 1 {
+		t.Fatalf("upstream calls = %d, want 1", got)
+	}
+}
+
+func TestCachedClient_AuthorizeInvocation_HitsShareNoMutableState(t *testing.T) {
+	fake := &fakeAuthClient{}
+	client := newCachedClient(fake, time.Minute, authCacheMaxEntries)
+
+	first, err := client.AuthorizeInvocation(context.Background(), "token", "fn")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	first.AuthContext["ncaId"] = "tampered"
+	first.ModelSpecs["model"].URIs[0] = "tampered"
+	*first.Priority = 99
+
+	second, err := client.AuthorizeInvocation(context.Background(), "token", "fn")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if second.AuthContext["ncaId"] != "nca-fn" {
+		t.Fatalf("AuthContext leaked mutation: %q", second.AuthContext["ncaId"])
+	}
+	if second.ModelSpecs["model"].URIs[0] != "uri-1" {
+		t.Fatalf("ModelSpecs leaked mutation: %q", second.ModelSpecs["model"].URIs[0])
+	}
+	if *second.Priority != 2 {
+		t.Fatalf("Priority leaked mutation: %d", *second.Priority)
+	}
+}
+
+func TestCachedClient_AuthorizeInvocation_ZeroTTLIsPassThrough(t *testing.T) {
+	fake := &fakeAuthClient{}
+	client := newCachedClient(fake, 0, authCacheMaxEntries)
+
+	for range 3 {
+		if _, err := client.AuthorizeInvocation(context.Background(), "token", "fn"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if got := fake.calls.Load(); got != 3 {
+		t.Fatalf("upstream calls = %d, want 3", got)
+	}
+}
+
+func TestCachedClient_AuthorizeInvocation_EvictionKeepsMapBounded(t *testing.T) {
+	const maxEntries = 8
+	fake := &fakeAuthClient{}
+	client := newCachedClient(fake, time.Minute, maxEntries)
+
+	for i := range maxEntries * 3 {
+		routingKey := fmt.Sprintf("fn-%d", i)
+		if _, err := client.AuthorizeInvocation(context.Background(), "token", routingKey); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	cached, ok := client.(*cachedClient)
+	if !ok {
+		t.Fatalf("expected *cachedClient, got %T", client)
+	}
+	cached.mu.Lock()
+	size := len(cached.entries)
+	cached.mu.Unlock()
+	if size > maxEntries {
+		t.Fatalf("cache size = %d, want <= %d", size, maxEntries)
+	}
+}

--- a/src/invocation-plane-services/llm-api-gateway/nvcf/types.go
+++ b/src/invocation-plane-services/llm-api-gateway/nvcf/types.go
@@ -17,6 +17,11 @@ limitations under the License.
 
 package nvcf
 
+import (
+	"maps"
+	"slices"
+)
+
 type ModelSpec struct {
 	URIs           []string
 	TokenRateLimit string
@@ -33,6 +38,29 @@ type InvocationAuthResponse struct {
 	// Priority is the caller priority resolved by NVCF API, or nil when no
 	// priority config applies. Lower value is higher priority, 0 is highest.
 	Priority *uint32
+}
+
+// clone returns a copy that shares no mutable state with the receiver, so a
+// cached response cannot be altered by one request in a way that leaks into
+// another.
+func (r *InvocationAuthResponse) clone() *InvocationAuthResponse {
+	if r == nil {
+		return nil
+	}
+	out := *r
+	out.AuthContext = maps.Clone(r.AuthContext)
+	if r.ModelSpecs != nil {
+		out.ModelSpecs = make(map[string]ModelSpec, len(r.ModelSpecs))
+		for name, spec := range r.ModelSpecs {
+			spec.URIs = slices.Clone(spec.URIs)
+			out.ModelSpecs[name] = spec
+		}
+	}
+	if r.Priority != nil {
+		priority := *r.Priority
+		out.Priority = &priority
+	}
+	return &out
 }
 
 func deriveRateLimitKey(authContext map[string]string) string {


### PR DESCRIPTION
## Why

llm-api-gateway calls NVCF API (`AuthLlmInvocation`) on every request that
carries a routing key, with no caching of the result. Auth traffic scales 1:1
with request arrival rate, each call runs function lookup queries on the
control plane database, and the blocking call adds its full latency to
time-to-first-token on every streaming request. Under load, auth latency
inflates first and requests fail once the call exceeds its timeout.

## What changed

A caching decorator around the nvcf client stores positive auth responses for
60s, keyed by a hash of the bearer token plus the routing key, bounded to 1024
entries. Concurrent identical misses collapse into one upstream call via
singleflight. Errors and denials are never cached, so revocations take effect
within one TTL and failures retry immediately. Hits return a copy so no two
requests share mutable state. The middleware and gRPC client are unchanged;
main.go wraps the client at wiring time.

Wiring now passes a nil interface when `NVCF_GRPC_ADDR` is unset, so the auth
middleware disables itself as intended instead of receiving a typed-nil
client.

## Customer Release Notes

Repeated invocations with the same API key and function reuse the
authorization result for up to 60 seconds, reducing per-request latency.
Token revocations take up to 60 seconds to apply.

## Plan Summary

Not applicable

## Usage

Not applicable

## Testing

`go test ./...` and `go test -race ./nvcf/...` pass locally;
`bazel test //src/invocation-plane-services/llm-api-gateway/nvcf/...` passes.
New tests cover cache hits, TTL expiry, error passthrough, concurrent miss
collapsing, key isolation, mutation isolation, and the entry cap.

## Notes

Cache hit/miss metrics land in a follow-up PR. TTL and capacity are package
constants, matching the existing outbound token cache in the same package.

## References

Closes #1427

## Related Pull Requests

None

## Dependencies

None (golang.org/x/sync was already a direct dependency)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved authorization response times by reusing recently validated credentials.
  - Reduced duplicate authorization requests when multiple requests arrive simultaneously.

- **Reliability**
  - Authorization failures and denied requests are retried normally rather than reusing unsuccessful results.
  - Responses are isolated between requests to prevent unintended data changes.

- **Testing**
  - Added coverage for expiration, concurrent requests, retry behavior, and cache capacity limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->