### PR TITLE
fix(nvca): stop the event dispatcher panicking on a closed channel

### DIFF
--- a/src/compute-plane-services/nvca/pkg/nvca/agent.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/agent.go
@@ -790,7 +790,17 @@ func (a *Agent) startEventProcessDispatchers(ctx context.Context, events <-chan 
 		for {
 			select {
 			// Pull from the ticker queue and push to the event-specific queue.
-			case ev := <-events:
+			case ev, open := <-events:
+				// A closed channel yields a nil event immediately and forever.
+				// Without this the dispatcher dereferences that nil, panicking
+				// the agent, and spins on the closed channel until it does.
+				if !open {
+					log.Info("Event channel closed, stopping event dispatcher")
+					return
+				}
+				if ev == nil {
+					continue
+				}
 				if queue, ok := a.resourceEventWorkerQueues[ev.Kind]; ok {
 					if ev.ObjectMetaKey != "" {
 						queue.Add(ev.ObjectMetaKey)

--- a/src/compute-plane-services/nvca/pkg/nvca/agent_test.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/agent_test.go
@@ -2709,6 +2709,12 @@ func TestEventDispatcherSurvivesClosedChannel(t *testing.T) {
 
 	a.startEventProcessDispatchers(ctx, events)
 
+	// A nil event on an open channel must be skipped rather than dereferenced.
+	// The channel is unbuffered, so the send below only completes once the
+	// dispatcher has received this one: if it panicked or returned here, the
+	// next send would block and this test would fail rather than pass silently.
+	events <- nil
+
 	// A live event still reaches its queue.
 	events <- &core.Event{Kind: "Pod", ObjectMetaKey: "ns/name"}
 	assert.Eventually(t, func() bool {
@@ -2716,10 +2722,12 @@ func TestEventDispatcherSurvivesClosedChannel(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond, "a dispatched event should be queued")
 
 	// Closing the channel must stop the dispatcher, not panic it. Before the
-	// fix this panicked the test binary rather than failing it.
+	// fix this panicked the test binary rather than failing it. A dispatcher
+	// spinning on the closed channel would enqueue continuously, so assert the
+	// queue never grows instead of sampling it once after a sleep.
 	close(events)
-	time.Sleep(100 * time.Millisecond)
-
-	assert.Equal(t, 1, a.resourceEventWorkerQueues["Pod"].Len(),
+	assert.Never(t, func() bool {
+		return a.resourceEventWorkerQueues["Pod"].Len() != 1
+	}, 250*time.Millisecond, 10*time.Millisecond,
 		"a closed channel must not enqueue anything further")
 }

--- a/src/compute-plane-services/nvca/pkg/nvca/agent_test.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/agent_test.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	nvcaauth "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/auth"
@@ -2684,4 +2685,41 @@ func TestStartReadinessNotSetOnICMSRegistrationFailure(t *testing.T) {
 		assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode,
 			"readiness endpoint should return 503 when Start() fails before arming readiness")
 	}
+}
+
+// TestEventDispatcherSurvivesClosedChannel covers a shutdown crash. The
+// dispatcher used a single-value receive, so once the event channel closed it
+// received a nil event immediately and forever: it dereferenced that nil and
+// panicked the agent, and spun on the closed channel until it did. The panic
+// was observed after "Self-destruct sequence completed", where the dispatcher
+// outlives the shutdown that closed its channel.
+func TestEventDispatcherSurvivesClosedChannel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan *core.Event)
+	a := &Agent{
+		metrics: nvcametrics.NewDefaultMetrics("cluster", "backend", "backend", "test"),
+		resourceEventWorkerQueues: map[string]workqueue.Interface{
+			"Pod": workqueue.New(),
+		},
+	}
+	defer a.resourceEventWorkerQueues["Pod"].ShutDown()
+	ctx = nvcametrics.WithMetrics(ctx, a.metrics)
+
+	a.startEventProcessDispatchers(ctx, events)
+
+	// A live event still reaches its queue.
+	events <- &core.Event{Kind: "Pod", ObjectMetaKey: "ns/name"}
+	assert.Eventually(t, func() bool {
+		return a.resourceEventWorkerQueues["Pod"].Len() == 1
+	}, 2*time.Second, 10*time.Millisecond, "a dispatched event should be queued")
+
+	// Closing the channel must stop the dispatcher, not panic it. Before the
+	// fix this panicked the test binary rather than failing it.
+	close(events)
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(t, 1, a.resourceEventWorkerQueues["Pod"].Len(),
+		"a closed channel must not enqueue anything further")
 }


### PR DESCRIPTION
## Why

`Agent.startEventProcessDispatchers` received events with a single-value
receive. A closed channel yields the zero value immediately and forever, so
once the event channel closed the dispatcher dereferenced a nil `*core.Event`
and panicked, and span on the closed channel until it did.

In a live agent this is a process panic, not a lost event. It surfaced in a
test run immediately after `Self-destruct sequence completed`, where the
dispatcher goroutine outlives the shutdown that closed its channel. It
presents as a rare, unrelated-looking test flake, which is how it went
unnoticed.

## What changed

Two-value receive: return when the channel closes, skip a nil event rather
than dereferencing it. Twelve lines in `agent.go`.

## Customer Release Notes

Fixed a rare NVCA agent crash during shutdown.

## Plan Summary

Not applicable.

## Usage

Not applicable.

## Testing

`TestEventDispatcherSurvivesClosedChannel` asserts a live event still reaches
its queue, then closes the channel and requires the dispatcher to stop
quietly.

The test was verified to catch the defect: with the fix reverted it panics the
test binary, and with the fix applied it passes. `go build ./...` and
`go test ./pkg/nvca/...` are clean.

QA: not required.

## Notes

Found while chasing what looked like a flake in an unrelated storage change.
Split out here because it is independent of that work and worth merging on its
own.

## Issues

Closes #1431

## Related Pull Requests

None

## Dependencies

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event-processing stability when event channels close unexpectedly.
  - Prevented nil or invalid events from causing crashes, hangs, or repeated processing.
  - Ensured active events continue to be handled normally while shutdown completes safely.

- **Tests**
  - Added regression coverage for nil events, live event processing, and closed channels.
  - Verified that no additional work is queued after the event channel closes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->