### PR TITLE
fix(cli): validate shared gateway service routes

### DIFF
--- a/src/clis/nvcf-cli/cmd/self_hosted_compute_plane.go
+++ b/src/clis/nvcf-cli/cmd/self_hosted_compute_plane.go
@@ -257,6 +257,7 @@ func runSelfHostedComputePlaneRegister(c *cobra.Command, _ []string) error {
 	registrationICMSURL := computePlaneRegisterICMSURL(validation.Profile, selected)
 	if err := computePlaneRegisterReachabilityCheck(c.Context(), reachability.CheckRequest{
 		TargetClusterName: computePlaneRegisterClusterName,
+		GatewayHTTPURL:    validation.Profile.ControlPlane.Gateway.HTTPURL,
 		ICMSURL:           registrationICMSURL,
 		ReValURL:          selected.Endpoints.ReValURL,
 		NATSURL:           selected.Endpoints.NATSURL,

--- a/src/clis/nvcf-cli/cmd/self_hosted_compute_plane_test.go
+++ b/src/clis/nvcf-cli/cmd/self_hosted_compute_plane_test.go
@@ -21,6 +21,8 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -361,6 +363,7 @@ func TestComputePlaneRegisterDryRunRunsReachabilityCheck(t *testing.T) {
 
 	require.NoError(t, rootCmd.Execute())
 	assert.Equal(t, "gpu-a", got.TargetClusterName)
+	assert.Equal(t, "https://api.example.test", got.GatewayHTTPURL)
 	assert.Equal(t, "https://sis.example.test", got.ICMSURL)
 	assert.Equal(t, "https://reval.example.test", got.ReValURL)
 	assert.Equal(t, "tls://nats.example.test:4222", got.NATSURL)
@@ -430,6 +433,134 @@ func TestComputePlaneRegisterDryRunStopsOnReachabilityFailure(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, assert.AnError)
 	assert.Equal(t, 0, fetchCalls, "identity discovery must not run after reachability failure")
+}
+
+func TestComputePlaneRegisterDryRunRejectsMissingSharedGatewayHostsBeforeIdentity(t *testing.T) {
+	resetComputePlaneFlags(t)
+
+	profileFile := writeTestControlPlaneProfile(t, "cp-cluster")
+	updateTestControlPlaneProfile(t, profileFile, func(profile *controlplaneprofile.ControlPlaneProfile) {
+		profile.ControlPlane.Endpoints.ComputeReachable.ICMSURL = profile.ControlPlane.Gateway.HTTPURL
+		profile.ControlPlane.Endpoints.ComputeReachable.ReValURL = profile.ControlPlane.Gateway.HTTPURL
+		profile.ControlPlane.Hosts.SIS = ""
+		profile.ControlPlane.Hosts.ReVal = ""
+	})
+
+	fetchCalls := 0
+	prevFetcher := fetchClusterIdentity
+	t.Cleanup(func() { fetchClusterIdentity = prevFetcher })
+	fetchClusterIdentity = func(context.Context, string) (string, string, string, error) {
+		fetchCalls++
+		return "", "", "", nil
+	}
+
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"self-hosted", "compute-plane", "register",
+		"--dry-run",
+		"--control-plane-profile", profileFile,
+		"--cluster-name", "gpu-a",
+	})
+
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.icmsURL")
+	assert.Contains(t, err.Error(), "controlPlane.hosts.sis")
+	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.revalURL")
+	assert.Contains(t, err.Error(), "controlPlane.hosts.reval")
+	assert.Equal(t, 0, fetchCalls, "identity discovery must not run after profile validation failure")
+}
+
+func TestComputePlaneRegisterDryRunRejectsNotFoundBeforeIdentity(t *testing.T) {
+	resetComputePlaneFlags(t)
+	selfHostedEnv = "prd"
+	computePlaneRegisterReachabilityCheck = reachability.Check
+
+	server := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(server.Close)
+	selfHostedICMSURL = server.URL
+
+	profileFile := writeTestControlPlaneProfile(t, "cp-cluster")
+	updateTestControlPlaneProfile(t, profileFile, func(profile *controlplaneprofile.ControlPlaneProfile) {
+		profile.ControlPlane.Gateway.HTTPURL = server.URL
+		profile.ControlPlane.Endpoints.ComputeReachable.ICMSURL = server.URL
+		profile.ControlPlane.Endpoints.ComputeReachable.ReValURL = server.URL
+	})
+
+	fetchCalls := 0
+	prevFetcher := fetchClusterIdentity
+	t.Cleanup(func() { fetchClusterIdentity = prevFetcher })
+	fetchClusterIdentity = func(context.Context, string) (string, string, string, error) {
+		fetchCalls++
+		return "", "", "", nil
+	}
+
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"self-hosted", "compute-plane", "register",
+		"--dry-run",
+		"--control-plane-profile", profileFile,
+		"--cluster-name", "gpu-a",
+	})
+
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.icmsURL")
+	assert.Contains(t, err.Error(), "/health")
+	assert.Contains(t, err.Error(), "controlPlane.hosts.sis")
+	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.revalURL")
+	assert.Contains(t, err.Error(), "/info")
+	assert.Contains(t, err.Error(), "controlPlane.hosts.reval")
+	assert.Contains(t, err.Error(), "status 404")
+	assert.Equal(t, 0, fetchCalls, "identity discovery must not run after HTTP reachability failure")
+}
+
+func TestComputePlaneRegisterDryRunAcceptsValidServiceRoutes(t *testing.T) {
+	resetComputePlaneFlags(t)
+	selfHostedEnv = "prd"
+	computePlaneRegisterReachabilityCheck = reachability.Check
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			w.WriteHeader(http.StatusOK)
+		case "/info":
+			w.WriteHeader(http.StatusUnauthorized)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	selfHostedICMSURL = server.URL
+
+	profileFile := writeTestControlPlaneProfile(t, "cp-cluster")
+	updateTestControlPlaneProfile(t, profileFile, func(profile *controlplaneprofile.ControlPlaneProfile) {
+		profile.ControlPlane.Gateway.HTTPURL = server.URL
+		profile.ControlPlane.Endpoints.ComputeReachable.ICMSURL = server.URL
+		profile.ControlPlane.Endpoints.ComputeReachable.ReValURL = server.URL
+	})
+
+	prevFetcher := fetchClusterIdentity
+	t.Cleanup(func() { fetchClusterIdentity = prevFetcher })
+	fetchClusterIdentity = func(context.Context, string) (string, string, string, error) {
+		return "https://k8s.example/issuer", `{"keys":[]}`, "psat", nil
+	}
+
+	var stdout bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"self-hosted", "compute-plane", "register",
+		"--dry-run",
+		"--control-plane-profile", profileFile,
+		"--cluster-name", "gpu-a",
+	})
+
+	require.NoError(t, rootCmd.Execute())
+	assert.Contains(t, stdout.String(), "dryRun: true")
+	assert.Contains(t, stdout.String(), "sisMutation: skipped")
 }
 
 func TestComputePlaneRegisterCallsSISAfterValidation(t *testing.T) {
@@ -977,6 +1108,16 @@ func writeTestControlPlaneProfile(t *testing.T, controlPlaneCluster string) stri
 		},
 	}))
 	return path
+}
+
+func updateTestControlPlaneProfile(t *testing.T, path string, update func(*controlplaneprofile.ControlPlaneProfile)) {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var profile controlplaneprofile.ControlPlaneProfile
+	require.NoError(t, yaml.Unmarshal(body, &profile))
+	update(&profile)
+	require.NoError(t, controlplaneprofile.WriteFile(path, profile))
 }
 
 func writeComputePlaneStack(t *testing.T) string {

--- a/src/clis/nvcf-cli/cmd/self_hosted_control_plane_test.go
+++ b/src/clis/nvcf-cli/cmd/self_hosted_control_plane_test.go
@@ -79,6 +79,31 @@ func TestControlPlaneProfileValidateCommandFailsWithFieldErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.natsURL")
 }
 
+func TestControlPlaneProfileValidateCommandRejectsMissingSharedGatewayHosts(t *testing.T) {
+	doc := strings.ReplaceAll(validControlPlaneProfileYAML(), "https://sis.nvcf-cp.internal", "https://gateway.nvcf-cp.internal")
+	doc = strings.ReplaceAll(doc, "https://reval.nvcf-cp.internal", "https://gateway.nvcf-cp.internal")
+	doc = strings.Replace(doc, "    httpURL: https://api.nvcf-cp.internal", "    httpURL: https://gateway.nvcf-cp.internal", 1)
+	doc = removeLine(doc, "    sis: sis.nvcf-cp.internal")
+	doc = removeLine(doc, "    reval: reval.nvcf-cp.internal")
+	path := writeControlPlaneProfileFixture(t, doc)
+	resetControlPlaneProfileValidateCommand(t)
+
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"self-hosted", "control-plane", "profile", "validate",
+		"--file", path,
+		"--require", "compute-reachable",
+	})
+
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.icmsURL")
+	assert.Contains(t, err.Error(), "controlPlane.hosts.sis")
+	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.revalURL")
+	assert.Contains(t, err.Error(), "controlPlane.hosts.reval")
+}
+
 func TestControlPlaneProfileValidateCommandHelpShowsAnyRequireMode(t *testing.T) {
 	resetControlPlaneProfileValidateCommand(t)
 

--- a/src/clis/nvcf-cli/internal/selfhosted/controlplaneprofile/profile.go
+++ b/src/clis/nvcf-cli/internal/selfhosted/controlplaneprofile/profile.go
@@ -289,9 +289,9 @@ func (v *validator) validateHosts() {
 
 func (v *validator) validateNoDNSHostHeaders() {
 	cp := v.doc.ControlPlane
-	requireHostForGatewayURL(v.add, "controlPlane.gateway.httpURL", cp.Gateway.HTTPURL, "controlPlane.hosts.api", cp.Hosts.API)
-	requireHostForGatewayURL(v.add, "controlPlane.endpoints.computeReachable.icmsURL", cp.Endpoints.ComputeReachable.ICMSURL, "controlPlane.hosts.sis", cp.Hosts.SIS)
-	requireHostForGatewayURL(v.add, "controlPlane.endpoints.computeReachable.revalURL", cp.Endpoints.ComputeReachable.ReValURL, "controlPlane.hosts.reval", cp.Hosts.ReVal)
+	requireHostForGatewayURL(v.add, "controlPlane.gateway.httpURL", cp.Gateway.HTTPURL, "", "controlPlane.hosts.api", cp.Hosts.API)
+	requireHostForGatewayURL(v.add, "controlPlane.endpoints.computeReachable.icmsURL", cp.Endpoints.ComputeReachable.ICMSURL, cp.Gateway.HTTPURL, "controlPlane.hosts.sis", cp.Hosts.SIS)
+	requireHostForGatewayURL(v.add, "controlPlane.endpoints.computeReachable.revalURL", cp.Endpoints.ComputeReachable.ReValURL, cp.Gateway.HTTPURL, "controlPlane.hosts.reval", cp.Hosts.ReVal)
 }
 
 // validateManagementTLS validates managementTls only when it is provided. An
@@ -498,7 +498,7 @@ func validateHost(add func(string, string), field, value string, required bool) 
 	}
 }
 
-func requireHostForGatewayURL(add func(string, string), urlField, rawURL, hostField, hostValue string) {
+func requireHostForGatewayURL(add func(string, string), urlField, rawURL, gatewayHTTPURL, hostField, hostValue string) {
 	if rawURL == "" {
 		return
 	}
@@ -506,9 +506,17 @@ func requireHostForGatewayURL(add func(string, string), urlField, rawURL, hostFi
 	if err != nil || u.Host == "" {
 		return
 	}
-	if isNoDNSGatewayHost(u.Hostname()) && strings.TrimSpace(hostValue) == "" {
-		add(hostField, fmt.Sprintf("required as Host header when %s uses a gateway address", urlField))
+	if isGatewayURL(u, gatewayHTTPURL) && strings.TrimSpace(hostValue) == "" {
+		add(hostField, fmt.Sprintf("required when %s uses a shared gateway address; set %s to the service Host header", urlField, hostField))
 	}
+}
+
+func isGatewayURL(endpoint *url.URL, gatewayHTTPURL string) bool {
+	if isNoDNSGatewayHost(endpoint.Hostname()) {
+		return true
+	}
+	gateway, err := url.Parse(gatewayHTTPURL)
+	return err == nil && gateway.Hostname() != "" && strings.EqualFold(endpoint.Hostname(), gateway.Hostname())
 }
 
 func isNoDNSGatewayHost(host string) bool {

--- a/src/clis/nvcf-cli/internal/selfhosted/controlplaneprofile/profile_test.go
+++ b/src/clis/nvcf-cli/internal/selfhosted/controlplaneprofile/profile_test.go
@@ -76,6 +76,30 @@ func TestValidateNoDNSGatewayAddressRequiresHostHeader(t *testing.T) {
 	assert.Contains(t, err.Error(), "Host header")
 }
 
+func TestValidateSharedGatewayHostnameRequiresServiceHostHeaders(t *testing.T) {
+	doc := strings.ReplaceAll(validControlPlaneProfileYAML(), "https://sis.nvcf-cp.internal", "https://gateway.nvcf-cp.internal")
+	doc = strings.ReplaceAll(doc, "https://reval.nvcf-cp.internal", "https://gateway.nvcf-cp.internal")
+	doc = strings.Replace(doc, "    httpURL: https://api.nvcf-cp.internal", "    httpURL: https://gateway.nvcf-cp.internal", 1)
+	doc = strings.Replace(doc, "    sis: sis.nvcf-cp.internal\n", "", 1)
+	doc = strings.Replace(doc, "    reval: reval.nvcf-cp.internal\n", "", 1)
+
+	_, err := ParseAndValidate([]byte(doc), ValidateOptions{Require: RequireComputeReachable})
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "controlPlane.hosts.sis")
+	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.icmsURL")
+	assert.Contains(t, err.Error(), "controlPlane.hosts.reval")
+	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.revalURL")
+}
+
+func TestValidateDirectServiceHostnamesDoNotRequireHostOverrides(t *testing.T) {
+	doc := strings.Replace(validControlPlaneProfileYAML(), "    sis: sis.nvcf-cp.internal\n", "", 1)
+	doc = strings.Replace(doc, "    reval: reval.nvcf-cp.internal\n", "", 1)
+
+	_, err := ParseAndValidate([]byte(doc), ValidateOptions{Require: RequireComputeReachable})
+	require.NoError(t, err)
+}
+
 func TestValidateEndpointScopeReportsUnusableWhenPresentURLInvalid(t *testing.T) {
 	v := validator{}
 

--- a/src/clis/nvcf-cli/internal/selfhosted/reachability/reachability.go
+++ b/src/clis/nvcf-cli/internal/selfhosted/reachability/reachability.go
@@ -30,6 +30,7 @@ import (
 
 type CheckRequest struct {
 	TargetClusterName string
+	GatewayHTTPURL    string
 	ICMSURL           string
 	ReValURL          string
 	NATSURL           string
@@ -64,18 +65,22 @@ func (e *CheckError) Error() string {
 
 func Check(ctx context.Context, req CheckRequest) error {
 	var problems []string
-	problems = append(problems, validateHTTPService("controlPlane.endpoints.computeReachable.icmsURL", req.ICMSURL, "controlPlane.hosts.sis", req.SISHost)...)
-	problems = append(problems, validateHTTPService("controlPlane.endpoints.computeReachable.revalURL", req.ReValURL, "controlPlane.hosts.reval", req.ReValHost)...)
+	problems = append(problems, validateHTTPService("controlPlane.endpoints.computeReachable.icmsURL", req.ICMSURL, req.GatewayHTTPURL, "controlPlane.hosts.sis", req.SISHost)...)
+	problems = append(problems, validateHTTPService("controlPlane.endpoints.computeReachable.revalURL", req.ReValURL, req.GatewayHTTPURL, "controlPlane.hosts.reval", req.ReValHost)...)
 	problems = append(problems, validateNATSServiceShape(req.NATSURL)...)
 	if len(problems) == 0 && req.ProbeHTTP {
 		client := req.HTTPClient
 		if client == nil {
 			client = &http.Client{Timeout: 10 * time.Second}
 		}
-		if err := probeHTTP(ctx, client, req.ICMSURL, req.SISHost); err != nil {
+		probeClient := *client
+		probeClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+		if err := probeHTTP(ctx, &probeClient, req.ICMSURL, "/health", req.SISHost, "controlPlane.hosts.sis"); err != nil {
 			problems = append(problems, fmt.Sprintf("controlPlane.endpoints.computeReachable.icmsURL: %v", err))
 		}
-		if err := probeHTTP(ctx, client, req.ReValURL, req.ReValHost); err != nil {
+		if err := probeHTTP(ctx, &probeClient, req.ReValURL, "/info", req.ReValHost, "controlPlane.hosts.reval"); err != nil {
 			problems = append(problems, fmt.Sprintf("controlPlane.endpoints.computeReachable.revalURL: %v", err))
 		}
 	}
@@ -85,7 +90,7 @@ func Check(ctx context.Context, req CheckRequest) error {
 	return nil
 }
 
-func validateHTTPService(urlField, rawURL, hostField, hostHeader string) []string {
+func validateHTTPService(urlField, rawURL, gatewayHTTPURL, hostField, hostHeader string) []string {
 	var problems []string
 	if strings.TrimSpace(rawURL) == "" {
 		return []string{urlField + ": required"}
@@ -97,8 +102,8 @@ func validateHTTPService(urlField, rawURL, hostField, hostHeader string) []strin
 	if u.Scheme != "http" && u.Scheme != "https" {
 		problems = append(problems, urlField+": scheme must be http or https")
 	}
-	if isGatewayAddress(u.Hostname()) && strings.TrimSpace(hostHeader) == "" {
-		problems = append(problems, fmt.Sprintf("%s: required as Host header when %s uses a gateway address", hostField, urlField))
+	if isGatewayAddress(u.Hostname(), gatewayHTTPURL) && strings.TrimSpace(hostHeader) == "" {
+		problems = append(problems, fmt.Sprintf("%s: required when %s uses a shared gateway address; set %s to the service Host header", hostField, urlField, hostField))
 	}
 	return problems
 }
@@ -117,8 +122,14 @@ func validateNATSServiceShape(rawURL string) []string {
 	return nil
 }
 
-func probeHTTP(ctx context.Context, client *http.Client, rawURL, hostHeader string) error {
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+func probeHTTP(ctx context.Context, client *http.Client, rawURL, probePath, hostHeader, hostField string) error {
+	probeURL, err := url.Parse(rawURL)
+	if err != nil {
+		return err
+	}
+	probeURL.Path = strings.TrimRight(probeURL.Path, "/") + probePath
+	probeURL.RawPath = ""
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, probeURL.String(), nil)
 	if err != nil {
 		return err
 	}
@@ -131,18 +142,22 @@ func probeHTTP(ctx context.Context, client *http.Client, rawURL, hostHeader stri
 	}
 	defer resp.Body.Close()
 	_, _ = io.Copy(io.Discard, resp.Body)
-	if resp.StatusCode >= http.StatusInternalServerError {
-		return fmt.Errorf("status %d", resp.StatusCode)
+	if (resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices) && resp.StatusCode != http.StatusUnauthorized {
+		return fmt.Errorf("status %d from %s; verify the endpoint routes %s to the service and set %s to the required Host header when using a shared gateway", resp.StatusCode, probePath, probePath, hostField)
 	}
 	return nil
 }
 
-func isGatewayAddress(host string) bool {
+func isGatewayAddress(host, gatewayHTTPURL string) bool {
 	if host == "" {
 		return false
 	}
 	if net.ParseIP(host) != nil {
 		return true
 	}
-	return strings.EqualFold(host, "localhost")
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	gateway, err := url.Parse(gatewayHTTPURL)
+	return err == nil && gateway.Hostname() != "" && strings.EqualFold(host, gateway.Hostname())
 }

--- a/src/clis/nvcf-cli/internal/selfhosted/reachability/reachability_test.go
+++ b/src/clis/nvcf-cli/internal/selfhosted/reachability/reachability_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,6 +44,36 @@ func TestCheckRequiresHostHeaderForGatewayAddress(t *testing.T) {
 	assert.Contains(t, err.Error(), "controlPlane.hosts.reval")
 }
 
+func TestCheckRequiresHostHeadersForSharedGatewayHostname(t *testing.T) {
+	err := Check(context.Background(), CheckRequest{
+		TargetClusterName: "gpu-a",
+		GatewayHTTPURL:    "https://gateway.example.test",
+		ICMSURL:           "https://gateway.example.test",
+		ReValURL:          "https://gateway.example.test",
+		NATSURL:           "tls://nats.example.test:4222",
+		ProbeHTTP:         false,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "controlPlane.hosts.sis")
+	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.icmsURL")
+	assert.Contains(t, err.Error(), "controlPlane.hosts.reval")
+	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.revalURL")
+}
+
+func TestCheckAllowsDirectServiceHostnamesWithoutHostOverrides(t *testing.T) {
+	err := Check(context.Background(), CheckRequest{
+		TargetClusterName: "gpu-a",
+		GatewayHTTPURL:    "https://gateway.example.test",
+		ICMSURL:           "https://sis.example.test",
+		ReValURL:          "https://reval.example.test",
+		NATSURL:           "tls://nats.example.test:4222",
+		ProbeHTTP:         false,
+	})
+
+	require.NoError(t, err)
+}
+
 func TestCheckErrorIncludesClusterNameWithoutProblems(t *testing.T) {
 	err := (&CheckError{TargetClusterName: "gpu-a"}).Error()
 
@@ -52,9 +83,18 @@ func TestCheckErrorIncludesClusterNameWithoutProblems(t *testing.T) {
 
 func TestCheckProbesICMSAndReValWithHostHeaders(t *testing.T) {
 	var gotHosts []string
+	var gotPaths []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotHosts = append(gotHosts, r.Host)
-		w.WriteHeader(http.StatusUnauthorized)
+		gotPaths = append(gotPaths, r.URL.Path)
+		switch r.URL.Path {
+		case "/health":
+			w.WriteHeader(http.StatusOK)
+		case "/info":
+			w.WriteHeader(http.StatusUnauthorized)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
 	}))
 	t.Cleanup(server.Close)
 
@@ -71,6 +111,81 @@ func TestCheckProbesICMSAndReValWithHostHeaders(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"sis.example.test", "reval.example.test"}, gotHosts)
+	assert.ElementsMatch(t, []string{"/health", "/info"}, gotPaths)
+}
+
+func TestCheckReportsNotFoundWithEndpointAndCorrectiveAction(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(server.Close)
+
+	err := Check(context.Background(), CheckRequest{
+		TargetClusterName: "gpu-a",
+		ICMSURL:           server.URL,
+		ReValURL:          server.URL,
+		NATSURL:           "tls://nats.example.test:4222",
+		SISHost:           "sis.example.test",
+		ReValHost:         "reval.example.test",
+		HTTPClient:        server.Client(),
+		ProbeHTTP:         true,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.icmsURL")
+	assert.Contains(t, err.Error(), "/health")
+	assert.Contains(t, err.Error(), "controlPlane.hosts.sis")
+	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.revalURL")
+	assert.Contains(t, err.Error(), "/info")
+	assert.Contains(t, err.Error(), "controlPlane.hosts.reval")
+	assert.Contains(t, err.Error(), "status 404")
+}
+
+func TestCheckRejectsRedirectStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusFound)
+	}))
+	t.Cleanup(server.Close)
+
+	err := Check(context.Background(), CheckRequest{
+		TargetClusterName: "gpu-a",
+		ICMSURL:           server.URL,
+		ReValURL:          server.URL,
+		NATSURL:           "tls://nats.example.test:4222",
+		SISHost:           "sis.example.test",
+		ReValHost:         "reval.example.test",
+		HTTPClient:        server.Client(),
+		ProbeHTTP:         true,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status 302")
+}
+
+func TestCheckDoesNotFollowRedirectToUnrelatedSuccess(t *testing.T) {
+	var loginRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/login" {
+			loginRequests.Add(1)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.Redirect(w, r, "/login", http.StatusFound)
+	}))
+	t.Cleanup(server.Close)
+
+	err := Check(context.Background(), CheckRequest{
+		TargetClusterName: "gpu-a",
+		ICMSURL:           server.URL,
+		ReValURL:          server.URL,
+		NATSURL:           "tls://nats.example.test:4222",
+		SISHost:           "sis.example.test",
+		ReValHost:         "reval.example.test",
+		HTTPClient:        server.Client(),
+		ProbeHTTP:         true,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status 302")
+	assert.Zero(t, loginRequests.Load(), "reachability probes must not follow redirects away from the service route")
 }
 
 func TestCheckReportsHTTPProbeFailure(t *testing.T) {


### PR DESCRIPTION
## Why

Self-managed control-plane profiles can route SIS and ReVal through one shared gateway hostname. Missing Host overrides and permissive root probes could make invalid routes appear reachable.

## What changed

- Require SIS and ReVal Host overrides when compute-reachable endpoints use the shared HTTP gateway hostname.
- Preserve direct service DNS endpoints without Host overrides.
- Probe SIS at `/health` and ReVal at `/info`.
- Accept only 2xx responses and the expected 401 response. Reject redirects, 404 responses, and other failures with endpoint-specific corrective guidance.
- Stop compute-plane registration dry runs before identity discovery when profile or reachability validation fails.

## Customer Release Notes

Self-managed profile and registration validation now detects missing gateway Host overrides and unreachable SIS or ReVal routes more reliably.

## Plan Summary

Not applicable.

## Usage

Not applicable.

## Testing

Passed on a clean Linux VM:

```bash
go test ./internal/selfhosted/controlplaneprofile ./internal/selfhosted/reachability ./cmd -count=1
go build ./...
```

Focused redirect tests also passed with the Go race detector. Repository-native Bazel tests could not start analysis locally because the macOS hermetic Zig toolchain returned `AccessDenied`; Bazel was not installed on the Linux VM.

## Notes

No k3d cluster was required because command-level integration tests cover missing and valid Host values, 404 and redirect rejection, expected 401 reachability, positive dry-run behavior, and pre-identity failure ordering.

## References

Closes #1438

## Related Pull Requests

None.

## Dependencies

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved self-hosted compute-plane registration checks when using a shared gateway.
  * Added validation for required service host overrides and shared gateway configuration.
  * Enhanced reachability checks for service-specific health and information endpoints.
  * Improved diagnostics for unavailable services, unexpected responses, and redirects.

* **Tests**
  * Expanded coverage for valid configurations, missing gateway settings, HTTP errors, redirects, and hostname routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->