### PR TITLE
fix(docs): align self-managed catalog with stack pins

### DIFF
--- a/docs/user/cluster-management/self-managed.md
+++ b/docs/user/cluster-management/self-managed.md
@@ -222,7 +222,7 @@ running Helmfile.
 
 | Chart | `helm-nvca-operator` |
 | --- | --- |
-| Version | `1.12.7` |
+| Version | `1.21.3` |
 | Namespace | `nvca-operator` |
 | Depends on | All control-plane services and gateway must be running |
 

--- a/docs/user/image-mirroring.md
+++ b/docs/user/image-mirroring.md
@@ -119,7 +119,7 @@ helm repo add nvcf https://helm.ngc.nvidia.com/nvidia/nvcf --force-update
 helm repo update
 
 # Pull the chart
-helm pull nvcf/helm-nvca-operator --version 1.12.7
+helm pull "${HELM_NVCA_OPERATOR_REFERENCE:?set HELM_NVCA_OPERATOR_REFERENCE to a published or mirrored helm-nvca-operator reference}" --version 1.21.3
 
 # Prerelease charts require --devel when searching
 helm search repo nvcf/helm-nvcf-vanity-gateway --versions --devel
@@ -195,12 +195,11 @@ First, ensure you have the [NGC CLI installed and configured](https://org.ngc.nv
 
 ```bash
 # Set stack versions
-export STACK_VERSION="0.6.0"
+export STACK_VERSION="0.9.1"
 export COMPUTE_STACK_VERSION="1.0.6"
 
 # Download a specific control-plane stack version
-ngc registry resource download-version \
-  "nvidia/nvcf/nvcf-self-managed-stack:${STACK_VERSION}"
+# Publication pending: nvcf-self-managed-stack 0.9.1 is not yet available for download.
 
 # Download a specific compute-plane stack version
 ngc registry resource download-version \
@@ -224,13 +223,7 @@ and its listed artifact versions are QA-qualified together.
 {/* docs-version-sync:BEGIN image-mirroring-stack-snippet */}
 
 ```bash
-# Set the version
-export VERSION="0.6.0"
-
-ngc registry resource download-version "nvidia/nvcf/nvcf-self-managed-stack:${VERSION}" && \
-   mkdir -p nvcf-self-managed-stack && \
-   tar -xzf nvcf-self-managed-stack_v${VERSION}/nvcf-self-managed-stack-${VERSION}.tar.gz -C nvcf-self-managed-stack && \
-   rm -rf nvcf-self-managed-stack_v${VERSION}
+# Publication pending: nvcf-self-managed-stack 0.9.1 is not yet available for download.
 ```
 
 {/* docs-version-sync:END image-mirroring-stack-snippet */}
@@ -287,27 +280,12 @@ Use the CLI version shown in the artifact manifest for this stack release.
 {/* docs-version-sync:BEGIN image-mirroring-cli-snippet */}
 
 ```bash
-# Set the version
-export VERSION="1.10.3"
-
-# Set your platform (linux-amd64, linux-arm64, darwin-amd64, darwin-arm64, windows-amd64)
-export PLATFORM="linux-amd64"
-
-ngc registry resource download-version "nvidia/nvcf/nvcf-cli:${VERSION}"
-
-tar -xzf nvcf-cli_v${VERSION}/${PLATFORM}/nvcf-cli-${PLATFORM}-${VERSION}.tar.gz
-mv nvcf-cli-${PLATFORM}-${VERSION} nvcf-cli
-chmod +x nvcf-cli/nvcf-cli
+# Publication pending: nvcf-cli 1.16.2 is not yet available for download.
 ```
 
+Package contents and extraction instructions will be available after publication or mirroring.
+
 {/* docs-version-sync:END image-mirroring-cli-snippet */}
-
-The extracted directory contains:
-
-- `nvcf-cli` - The CLI binary
-- `.nvcf-cli.yaml.template` - Configuration template
-- `examples/` - Sample configuration files for different environments
-- `USAGE-GUIDE.md` - Detailed usage documentation
 
 See [self-hosted-cli](./cli.md) for detailed configuration instructions
 
@@ -391,8 +369,8 @@ helm repo add nvcf https://helm.ngc.nvidia.com/nvidia/nvcf --force-update
 helm repo update
 
 # 2. Pull the Helm chart from NGC
-helm pull nvcf/helm-nvca-operator --version 1.12.7
-# This creates: helm-nvca-operator-1.12.7.tgz
+helm pull "${HELM_NVCA_OPERATOR_REFERENCE:?set HELM_NVCA_OPERATOR_REFERENCE to a published or mirrored helm-nvca-operator reference}" --version 1.21.3
+# This creates: helm-nvca-operator-1.21.3.tgz
 
 # 3. Login to AWS ECR with Helm
 aws ecr get-login-password --region us-east-1 | \
@@ -402,7 +380,7 @@ aws ecr get-login-password --region us-east-1 | \
 aws ecr create-repository --repository-name ${REPO_PREFIX}/helm-nvca-operator --region us-east-1
 
 # 5. Push to ECR as OCI artifact (include repository prefix)
-helm push helm-nvca-operator-1.12.7.tgz oci://<aws-account-id>.dkr.ecr.us-east-1.amazonaws.com/${REPO_PREFIX}
+helm push helm-nvca-operator-1.21.3.tgz oci://<aws-account-id>.dkr.ecr.us-east-1.amazonaws.com/${REPO_PREFIX}
 ```
 
 <Note>
@@ -480,8 +458,8 @@ helm repo add nvcf https://helm.ngc.nvidia.com/nvidia/nvcf --force-update
 helm repo update
 
 # 2. Pull the Helm chart from NGC
-helm pull nvcf/helm-nvca-operator --version 1.12.7
-# This creates: helm-nvca-operator-1.12.7.tgz
+helm pull "${HELM_NVCA_OPERATOR_REFERENCE:?set HELM_NVCA_OPERATOR_REFERENCE to a published or mirrored helm-nvca-operator reference}" --version 1.21.3
+# This creates: helm-nvca-operator-1.21.3.tgz
 
 # 3. Login to Volcano Engine CR with Helm
 helm registry login ${CR_ENDPOINT} \
@@ -489,7 +467,7 @@ helm registry login ${CR_ENDPOINT} \
   --password "${CR_PASSWORD}"
 
 # 4. Push to Volcano Engine CR as OCI artifact
-helm push helm-nvca-operator-1.12.7.tgz oci://${CR_ENDPOINT}/${NAMESPACE}
+helm push helm-nvca-operator-1.21.3.tgz oci://${CR_ENDPOINT}/${NAMESPACE}
 ```
 
 ## Troubleshooting

--- a/docs/user/manifest.md
+++ b/docs/user/manifest.md
@@ -154,7 +154,7 @@ The following tables list the complete artifact inventory.
 | `helm-nvcf-grpc-proxy` | `1.6.7` | Required | Deploys the gRPC proxy service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-grpc-proxy:1.6.7` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/grpc-proxy) |
 | `helm-nvcf-invocation-service` | `1.5.5` | Required | Deploys the HTTP invocation service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-invocation-service:1.5.5` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/http-invocation) |
 | `helm-nvcf-llm-api-gateway` | `1.2.0` | Optional | Deploys the OpenAI-compatible LLM API gateway. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-llm-api-gateway:1.2.0` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/llm-api-gateway) |
-| `helm-nvcf-llm-request-router` | `1.12.1` | Optional | Deploys the LLM request router. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-llm-request-router:1.12.1` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/llm-request-router) |
+| `helm-nvcf-llm-request-router` | `1.12.2` | Optional | Deploys the LLM request router. | `Publication pending` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/llm-request-router) |
 | `helm-nvcf-nats` | `0.7.1` | Required | Deploys NATS messaging for the control plane. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-nats:0.7.1` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/nats) / [Upstream](https://github.com/nats-io/k8s) |
 | `helm-nvcf-nats-auth-callout-service` | `1.1.3` | Required | Deploys the NATS authorization callout service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-nats-auth-callout-service:1.1.3` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/nats-auth-callout) |
 | `helm-nvcf-notary-service` | `1.4.2` | Required | Deploys the notary service for signing and validation. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-notary-service:1.4.2` |  |
@@ -168,14 +168,14 @@ The following tables list the complete artifact inventory.
 | `helm-nvcf-vanity-gateway` | `0.3.0` | Optional | Deploys the optional vanity hostname gateway. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvcf-vanity-gateway:0.3.0` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/vanity-gateway) |
 | `helm-reval` | `1.3.8` | Required | Deploys the function revalidation service. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-reval:1.3.8` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/helm-reval) |
 | `nvcf-example-dashboards` | `1.6.0` | Optional | Deploys example Grafana dashboards for NVCF telemetry. | `https://helm.ngc.nvidia.com/nvidia/nvcf/nvcf-example-dashboards:1.6.0` |  |
-| `nvcf-gateway-routes` | `1.17.0` | Optional | Deploys Gateway API routes for the reference architecture. | `https://helm.ngc.nvidia.com/nvidia/nvcf/nvcf-gateway-routes:1.17.0` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/gateway-routes) |
+| `nvcf-gateway-routes` | `1.17.0` | Optional | Deploys Gateway API routes for the reference architecture. | `Publication pending` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/gateway-routes) |
 | `nvcf-observability-reference-stack` | `1.10.0` | Optional | Deploys a reference observability backend for evaluation. | `https://helm.ngc.nvidia.com/nvidia/nvcf/nvcf-observability-reference-stack:1.10.0` |  |
 
 ### Control plane services and images
 
 | Artifact | Version | Required | Description | Distribution | Source code |
 | --- | --- | --- | --- | --- | --- |
-| `admin-token-issuer-proxy` | `1.0.2` | Optional | Proxies admin token requests for the reference architecture. | `nvcr.io/nvidia/nvcf/admin-token-issuer-proxy:1.0.2` |  |
+| `admin-token-issuer-proxy` | `1.0.2` | Optional | Proxies admin token requests for the reference architecture. | `nvcr.io/nvidia/nvcf/admin-token-issuer-proxy:1.0.2` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/control-plane-services/admin-token-issuer-proxy) |
 | `alpine-k8s` | `1.36.1` | Required | Provides Kubernetes command-line utilities for deployment jobs. | `docker.io/alpine/k8s:1.36.1` | [GitHub](https://github.com/alpine-docker/k8s) |
 | `cassandra` | `5.0.8-nv-2.0.1` | Required | Stores NVCF account, function, cluster, and service state. | `nvcr.io/nvidia/nvcf/cassandra:5.0.8-nv-2.0.1` | [Upstream](https://github.com/apache/cassandra) |
 | `cert-manager-cainjector` | `v1.20.2` | Required | Injects certificate authority data into Kubernetes resources. | `nvcr.io/nvidia/nvcf/cert-manager-cainjector:v1.20.2` | [Upstream](https://github.com/cert-manager/cert-manager) |
@@ -210,7 +210,7 @@ The following tables list the complete artifact inventory.
 | `csi-driver-smb` | `supported` | Optional | Provides SMB persistent volumes for supported deployments. | `https://raw.githubusercontent.com/kubernetes-csi/csi-driver-smb/master/charts` | [Upstream](https://github.com/kubernetes-csi/csi-driver-smb) |
 | `ebs-csi-driver` | `supported` | Optional | Provides Amazon EBS persistent volumes for EKS clusters. | `https://kubernetes-sigs.github.io/aws-ebs-csi-driver` | [Upstream](https://github.com/kubernetes-sigs/aws-ebs-csi-driver) |
 | `gpu-operator` | `supported` | Required | Manages NVIDIA GPU software on Kubernetes nodes. | `https://helm.ngc.nvidia.com/nvidia` | [Upstream](https://github.com/NVIDIA/gpu-operator) |
-| `helm-nvca-operator` | `1.12.7` | Required | Deploys the NVCA operator and compute-plane integration. | `https://helm.ngc.nvidia.com/nvidia/nvcf/helm-nvca-operator:1.12.7` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/nvca-operator) |
+| `helm-nvca-operator` | `1.21.3` | Required | Deploys the NVCA operator and compute-plane integration. | `Publication pending` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/nvca-operator) |
 | `modelexpress` | `supported` | Optional | Distributes model weights peer-to-peer between Dynamo workers to reduce scale-out cold starts. Installed separately from the compute-plane stack. | `https://helm.ngc.nvidia.com/nvidia/ai-dynamo` | [Upstream](https://github.com/ai-dynamo/modelexpress) |
 | `nvcf-container-cache` | `0.25.22` | Optional | Deploys container image caching on GPU cluster nodes. | `https://helm.ngc.nvidia.com/nvidia/nvcf/nvcf-container-cache:0.25.22` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/container-cache) |
 
@@ -222,15 +222,15 @@ The following tables list the complete artifact inventory.
 | `gpu-operator-validator` | `supported` | Required | Validates GPU Operator components on GPU nodes. | `https://catalog.ngc.nvidia.com/orgs/nvidia/teams/cloud-native/containers/gpu-operator-validator` | [Upstream](https://github.com/NVIDIA/gpu-operator) |
 | `k8s-device-plugin` | `supported` | Required | Advertises NVIDIA GPU resources to Kubernetes. | `https://catalog.ngc.nvidia.com/orgs/nvidia/teams/k8s/containers/device-plugin` | [Upstream](https://github.com/NVIDIA/k8s-device-plugin) |
 | `modelexpress-server` | `supported` | Optional | Serves model weights to Dynamo workers over NIXL RDMA transports. | `https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/modelexpress-server` | [Upstream](https://github.com/ai-dynamo/modelexpress) |
-| `nvca` | `3.0.3` | Required | Registers GPU clusters and orchestrates deployments in-cluster. | `nvcr.io/nvidia/nvcf/nvca:3.0.3` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/compute-plane-services/nvca) |
-| `nvca-operator` | `3.0.3` | Required | Reconciles NVCA resources and compute-plane configuration. | `nvcr.io/nvidia/nvcf/nvca-operator:3.0.3` |  |
+| `nvca` | `3.2.19` | Required | Registers GPU clusters and orchestrates deployments in-cluster. | `Publication pending` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/compute-plane-services/nvca) |
+| `nvca-operator` | `3.2.19` | Required | Reconciles NVCA resources and compute-plane configuration. | `Publication pending` |  |
 | `nvcf-container-cache` | `v1.1.36` | Optional | Caches container image layers on GPU cluster nodes. | `nvcr.io/nvidia/nvcf/nvcf-container-cache:v1.1.36` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/container-cache) |
 | `nvcf-image-credential-helper` | `0.10.2` | Required | Resolves container image credentials for function workloads. | `nvcr.io/nvidia/nvcf/nvcf-image-credential-helper:0.10.2` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/compute-plane-services/image-credential-helper) |
 | `nvcf-proxy-tls-certs` | `v1.2.10` | Optional | Configures TLS trust for the optional container cache proxy. | `nvcr.io/nvidia/nvcf/nvcf-proxy-tls-certs:v1.2.10` |  |
 | `nvcf_worker_init` | `1.0.1` | Required | Prepares function resources before the user container starts. | `nvcr.io/nvidia/nvcf/nvcf_worker_init:1.0.1` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/compute-plane-services/worker-init) |
 | `nvcf_worker_llm_credentials` | `1.0.1` | Optional | Maintains a current NVCF worker token for LLM function workloads. | `nvcr.io/nvidia/nvcf/nvcf_worker_llm_credentials:1.0.1` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/compute-plane-services/worker-llm-credentials) |
 | `nvcf_worker_utils` | `1.0.1` | Required | Proxies NATS traffic between function containers and the control plane. | `nvcr.io/nvidia/nvcf/nvcf_worker_utils:1.0.1` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/compute-plane-services/worker-utils) |
-| `pylon` | `0.14.1` | Optional | Connects LLM worker pods to the LLM request router. | `nvcr.io/nvidia/nvcf/pylon:0.14.1` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/libraries/rust/stargate) |
+| `pylon` | `0.14.3` | Optional | Connects LLM worker pods to the LLM request router. | `Publication pending` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/libraries/rust/stargate) |
 
 ### EA-only CVE-impacted artifacts
 
@@ -244,8 +244,8 @@ These Early Access artifacts have known CVE impact. Use only the QA-qualified ve
 
 | Artifact | Version | Description | Distribution | Source code |
 | --- | --- | --- | --- | --- |
-| `nvcf-cli` | `1.10.3` | Manages functions, deployments, and clusters from the command line. | `nvcr.io/nvidia/nvcf/nvcf-cli:1.10.3` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/clis/nvcf-cli) |
+| `nvcf-cli` | `1.16.2` | Manages functions, deployments, and clusters from the command line. | `Publication pending` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/clis/nvcf-cli) |
 | `nvcf-compute-plane-stack` | `1.0.6` | Provides the Helmfile bundle for compute-plane deployment. | `nvcr.io/nvidia/nvcf/nvcf-compute-plane-stack:1.0.6` |  |
-| `nvcf-self-managed-stack` | `0.6.0` | Provides the Helmfile bundle for control-plane deployment. | `nvcr.io/nvidia/nvcf/nvcf-self-managed-stack:0.6.0` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/stacks/self-managed) |
+| `nvcf-self-managed-stack` | `0.9.1` | Provides the Helmfile bundle for control-plane deployment. | `Publication pending` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/stacks/self-managed) |
 
 {/* docs-version-sync:END manifest-artifact-registry-paths */}

--- a/docs/version-catalog/main.yaml
+++ b/docs/version-catalog/main.yaml
@@ -233,7 +233,7 @@ publications:
     registry: public-helm
     chart_format: http
   - name: nvcf-gateway-routes
-    version: 1.17.0
+    version: 1.15.0
     registry: public-helm
     chart_format: http
   - name: nvcf-container-cache
@@ -256,6 +256,18 @@ version_overrides:
   - name: llm-api-gateway
     version: 0.8.3
     source: supplemental artifact missing from artifacts-0.6.0.txt
+  - name: nvcf-cli
+    version: 1.16.2
+    source: independent source release; not pinned by stack
+publication_pending:
+  - nvcf-self-managed-stack
+  - nvcf-cli
+  - helm-nvcf-llm-request-router
+  - nvcf-gateway-routes
+  - pylon
+  - helm-nvca-operator
+  - nvca-operator
+  - nvca
 manifest:
   entries:
     - artifact_id: helm-nvcf-api-keys
@@ -705,11 +717,18 @@ manifest:
       github_url: https://github.com/NVIDIA/nvcf/tree/main/src/clis/nvcf-cli
 stack:
   name: nvcf-self-managed-stack
-  version: 0.6.0
+  version: 0.9.1
   registry: public-resources
   gitlab_project_id: 182049
   package_name: ncp-deploy
-  artifacts_file: artifacts-0.6.0.txt
+  artifacts_file: artifacts-0.9.1.txt
+  source_commit: 9cf1103b0e9fe90bde6a8147c95d3d423e96c781
+  pin_sources:
+    - deploy/stacks/nvcf-compute-plane/environments/base.yaml
+    - deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
+    - deploy/stacks/self-managed/global.yaml.gotmpl
+    - deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+  pin_source_digest: sha256:952fba4fb3906887fe1661f6d8508b9470c2a5fe0746dba12a5a62d8384230dc
 denylist:
   - name: strap
     reason: Legacy name replaced by nvcf-service-oss
@@ -822,7 +841,7 @@ artifacts:
   - name: helm-nvcf-llm-request-router
     type: chart
     registry: staging
-    version: 1.12.1
+    version: 1.12.2
   - name: helm-nvcf-nats-auth-callout-service
     type: chart
     registry: staging
@@ -950,7 +969,7 @@ artifacts:
   - name: pylon
     type: image
     registry: staging
-    version: 0.14.1
+    version: 0.14.3
   - name: reval-server
     type: image
     registry: staging
@@ -963,19 +982,19 @@ supplemental_artifacts:
   - name: nvcf-cli
     type: resource
     registry: public-resources
-    version: 1.10.3
+    version: 1.16.2
   - name: helm-nvca-operator
     type: chart
     registry: staging
-    version: 1.12.7
+    version: 1.21.3
   - name: nvca-operator
     type: image
     registry: staging
-    version: 3.0.3
+    version: 3.2.19
   - name: nvca
     type: image
     registry: staging
-    version: 3.0.3
+    version: 3.2.19
   - name: nvcf-compute-plane-stack
     type: resource
     registry: public-resources

--- a/tools/docs-version-sync/catalog.go
+++ b/tools/docs-version-sync/catalog.go
@@ -38,6 +38,11 @@ const (
 	defaultCLIVersion        = "0.0.30"
 )
 
+var (
+	fullLowercaseCommitSHARe = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	lowercaseSHA256DigestRe  = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+)
+
 type ArtifactType string
 
 const (
@@ -87,6 +92,7 @@ type Catalog struct {
 	Registries            map[string]Registry `yaml:"registries"`
 	Publications          []Publication       `yaml:"publications,omitempty"`
 	VersionOverrides      []VersionOverride   `yaml:"version_overrides,omitempty"`
+	PublicationPending    []string            `yaml:"publication_pending,omitempty"`
 	Manifest              ManifestMetadata    `yaml:"manifest,omitempty"`
 	Stack                 StackMetadata       `yaml:"stack"`
 	Denylist              []DenylistEntry     `yaml:"denylist,omitempty"`
@@ -122,12 +128,15 @@ type VersionOverride struct {
 }
 
 type StackMetadata struct {
-	Name            string `yaml:"name"`
-	Version         string `yaml:"version"`
-	Registry        string `yaml:"registry"`
-	GitLabProjectID int    `yaml:"gitlab_project_id,omitempty"`
-	PackageName     string `yaml:"package_name,omitempty"`
-	ArtifactsFile   string `yaml:"artifacts_file,omitempty"`
+	Name            string   `yaml:"name"`
+	Version         string   `yaml:"version"`
+	Registry        string   `yaml:"registry"`
+	GitLabProjectID int      `yaml:"gitlab_project_id,omitempty"`
+	PackageName     string   `yaml:"package_name,omitempty"`
+	ArtifactsFile   string   `yaml:"artifacts_file,omitempty"`
+	SourceCommit    string   `yaml:"source_commit,omitempty"`
+	PinSources      []string `yaml:"pin_sources,omitempty"`
+	PinSourceDigest string   `yaml:"pin_source_digest,omitempty"`
 }
 
 type DenylistEntry struct {
@@ -283,6 +292,16 @@ func ValidateCatalog(catalog *Catalog) error {
 		}
 		seenVersionOverrides[override.Name] = struct{}{}
 	}
+	seenPending := map[string]struct{}{}
+	for _, name := range catalog.PublicationPending {
+		if strings.TrimSpace(name) == "" || strings.TrimSpace(name) != name {
+			return fmt.Errorf("publication_pending artifact names must be non-empty and trimmed")
+		}
+		if _, exists := seenPending[name]; exists {
+			return fmt.Errorf("duplicate publication_pending artifact %s", name)
+		}
+		seenPending[name] = struct{}{}
+	}
 	if strings.TrimSpace(catalog.Stack.Name) == "" {
 		return fmt.Errorf("stack name cannot be empty")
 	}
@@ -291,6 +310,31 @@ func ValidateCatalog(catalog *Catalog) error {
 	}
 	if _, ok := catalog.Registries[catalog.Stack.Registry]; !ok {
 		return fmt.Errorf("stack registry %q is not defined", catalog.Stack.Registry)
+	}
+	hasSourceCommit := strings.TrimSpace(catalog.Stack.SourceCommit) != ""
+	hasPinSources := len(catalog.Stack.PinSources) != 0
+	hasPinSourceDigest := strings.TrimSpace(catalog.Stack.PinSourceDigest) != ""
+	if (hasSourceCommit || hasPinSources || hasPinSourceDigest) && (!hasSourceCommit || !hasPinSources || !hasPinSourceDigest) {
+		return fmt.Errorf("stack source snapshot must set source_commit, pin_sources, and pin_source_digest together")
+	}
+	if hasSourceCommit {
+		if !fullLowercaseCommitSHARe.MatchString(catalog.Stack.SourceCommit) {
+			return fmt.Errorf("stack source_commit must be a full lowercase commit SHA")
+		}
+		if !lowercaseSHA256DigestRe.MatchString(catalog.Stack.PinSourceDigest) {
+			return fmt.Errorf("stack pin_source_digest must be a lowercase SHA-256 digest")
+		}
+		seenPinSources := map[string]struct{}{}
+		for _, sourcePath := range catalog.Stack.PinSources {
+			trimmed := strings.TrimSpace(sourcePath)
+			if trimmed == "" || trimmed != sourcePath {
+				return fmt.Errorf("stack pin source must be non-empty and trimmed")
+			}
+			if _, exists := seenPinSources[sourcePath]; exists {
+				return fmt.Errorf("duplicate stack pin source %s", sourcePath)
+			}
+			seenPinSources[sourcePath] = struct{}{}
+		}
 	}
 
 	denylist := catalog.DenylistMap()
@@ -310,6 +354,24 @@ func ValidateCatalog(catalog *Catalog) error {
 	}
 	if _, exists := seen[catalog.Stack.Name]; exists {
 		return fmt.Errorf("duplicate artifact id %s", catalog.Stack.Name)
+	}
+	for name := range seenPending {
+		artifact, exists := catalog.findArtifact(name)
+		if !exists {
+			for _, candidate := range append(append([]Artifact{}, catalog.Artifacts...), catalog.SupplementalArtifacts...) {
+				if candidate.catalogKey() == name {
+					artifact = candidate
+					exists = true
+					break
+				}
+			}
+		}
+		if !exists {
+			return fmt.Errorf("publication_pending references unknown artifact %s", name)
+		}
+		if _, published := catalog.publicationFor(artifact); published {
+			return fmt.Errorf("artifact %s:%s cannot be both published and publication_pending", artifact.Name, artifact.Version)
+		}
 	}
 	if err := validateManifestMetadata(catalog.Manifest); err != nil {
 		return err
@@ -488,6 +550,10 @@ func (catalog *Catalog) publicationFor(artifact Artifact) (Publication, bool) {
 }
 
 func (catalog *Catalog) chartPullReference(artifact Artifact) (string, error) {
+	if catalog.publicationIsPending(artifact) {
+		variable := strings.ToUpper(strings.ReplaceAll(artifact.Name, "-", "_")) + "_REFERENCE"
+		return fmt.Sprintf("\"${%s:?set %s to a published or mirrored %s reference}\"", variable, variable, artifact.Name), nil
+	}
 	publication, published := catalog.publicationFor(artifact)
 	if published && publication.ChartFormat == ChartFormatHTTP {
 		registry := catalog.Registries[publication.Registry]
@@ -505,6 +571,22 @@ func (catalog *Catalog) chartPullReference(artifact Artifact) (string, error) {
 		return "", err
 	}
 	return "oci://" + strings.TrimSuffix(path, ":"+artifact.Version), nil
+}
+
+func (catalog *Catalog) artifactDistribution(artifact Artifact) (string, error) {
+	if catalog.publicationIsPending(artifact) {
+		return "Publication pending", nil
+	}
+	return catalog.artifactPath(artifact)
+}
+
+func (catalog *Catalog) publicationIsPending(artifact Artifact) bool {
+	for _, name := range catalog.PublicationPending {
+		if name == artifact.catalogKey() || name == artifact.Name {
+			return true
+		}
+	}
+	return false
 }
 
 func (catalog *Catalog) resourceRef(artifact Artifact) (string, error) {
@@ -559,6 +641,7 @@ func BuildCatalogFromArtifacts(stackVersion string, artifacts []Artifact) *Catal
 		artifact.Source = ""
 		catalog.Artifacts = append(catalog.Artifacts, artifact)
 	}
+	catalog.reconcilePublicationPending()
 	return catalog
 }
 
@@ -575,8 +658,14 @@ func BuildCatalogFromArtifactsWithBase(stackVersion string, artifacts []Artifact
 	}
 	catalog.Publications = append(catalog.Publications, base.Publications...)
 	catalog.VersionOverrides = append(catalog.VersionOverrides, base.VersionOverrides...)
+	catalog.PublicationPending = append(catalog.PublicationPending, base.PublicationPending...)
 	catalog.Denylist = append(catalog.Denylist, base.Denylist...)
 	catalog.Manifest = base.Manifest
+	if base.Stack.Version == stackVersion {
+		catalog.Stack.SourceCommit = base.Stack.SourceCommit
+		catalog.Stack.PinSources = append(catalog.Stack.PinSources, base.Stack.PinSources...)
+		catalog.Stack.PinSourceDigest = base.Stack.PinSourceDigest
+	}
 
 	manifestNames := map[string]struct{}{}
 	for _, artifact := range catalog.Artifacts {
@@ -607,8 +696,52 @@ func BuildCatalogFromArtifactsWithBase(stackVersion string, artifacts []Artifact
 		seenSupplemental[key] = struct{}{}
 	}
 	catalog.applyVersionOverrides()
+	catalog.reconcilePublicationPending()
 	catalog.pruneUnusedRegistries()
 	return catalog
+}
+
+func (catalog *Catalog) reconcilePublicationPending() {
+	artifacts := append([]Artifact{catalog.stackArtifact()}, catalog.Artifacts...)
+	artifacts = append(artifacts, catalog.SupplementalArtifacts...)
+	pending := map[string]struct{}{}
+
+	for _, marker := range catalog.PublicationPending {
+		for _, artifact := range artifacts {
+			if marker != artifact.catalogKey() && marker != artifact.Name {
+				continue
+			}
+			if _, published := catalog.publicationFor(artifact); !published {
+				pending[artifact.catalogKey()] = struct{}{}
+			}
+		}
+	}
+	for _, artifact := range artifacts {
+		if !catalog.artifactUsesStagingRegistry(artifact) {
+			continue
+		}
+		if _, published := catalog.publicationFor(artifact); !published {
+			pending[artifact.catalogKey()] = struct{}{}
+		}
+	}
+
+	catalog.PublicationPending = catalog.PublicationPending[:0]
+	for name := range pending {
+		catalog.PublicationPending = append(catalog.PublicationPending, name)
+	}
+	sort.Strings(catalog.PublicationPending)
+}
+
+func (catalog *Catalog) artifactUsesStagingRegistry(artifact Artifact) bool {
+	registry, ok := catalog.Registries[artifact.Registry]
+	if !ok {
+		return false
+	}
+	staging, ok := catalog.Registries[defaultStackRegistry]
+	if !ok {
+		return false
+	}
+	return registry.Host == staging.Host && registry.Namespace == staging.Namespace
 }
 
 func (catalog *Catalog) applyVersionOverrides() {

--- a/tools/docs-version-sync/inline.go
+++ b/tools/docs-version-sync/inline.go
@@ -113,7 +113,7 @@ func replaceYAMLStringValue(content, key, value string) (string, int) {
 }
 
 func replaceNVCAOperatorChartPull(content, pullReference, version string) (string, int) {
-	re := regexp.MustCompile(`(?:oci://[^\s]+/|[a-z0-9-]+/)(?:helm-nvca-operator|nvca-operator) --version [^\s]+`)
+	re := regexp.MustCompile(`(?:(?:oci://[^\s]+/|[a-z0-9-]+/)(?:helm-nvca-operator|nvca-operator)|"\$\{HELM_NVCA_OPERATOR_REFERENCE:\?[^}]+\}") --version [^\s]+`)
 	count := len(re.FindAllStringIndex(content, -1))
 	replacement := pullReference + " --version " + version
 	return re.ReplaceAllString(content, replacement), count

--- a/tools/docs-version-sync/main.go
+++ b/tools/docs-version-sync/main.go
@@ -133,6 +133,7 @@ func updateCatalogFromGitLab(stackVersion string, base *Catalog) (*Catalog, erro
 	if err := syncComputeStackPackageVersion(client, catalog); err != nil {
 		return nil, err
 	}
+	catalog.reconcilePublicationPending()
 	if err := ValidateCatalog(catalog); err != nil {
 		return nil, err
 	}
@@ -140,7 +141,8 @@ func updateCatalogFromGitLab(stackVersion string, base *Catalog) (*Catalog, erro
 }
 
 func syncComputeStackPackageVersion(client *GitLabClient, catalog *Catalog) error {
-	if _, ok := catalog.findArtifact(computeStackResourceName); !ok {
+	compute, ok := catalog.findArtifact(computeStackResourceName)
+	if !ok {
 		return nil
 	}
 	projectID, err := computeStackProjectID()
@@ -153,6 +155,12 @@ func syncComputeStackPackageVersion(client *GitLabClient, catalog *Catalog) erro
 	}
 	if !setArtifactVersion(catalog, computeStackResourceName, version) {
 		return fmt.Errorf("artifact %s is required", computeStackResourceName)
+	}
+	if version != compute.Version {
+		updated, _ := catalog.findArtifact(computeStackResourceName)
+		if _, published := catalog.publicationFor(updated); !published {
+			catalog.PublicationPending = append(catalog.PublicationPending, updated.catalogKey())
+		}
 	}
 	return nil
 }

--- a/tools/docs-version-sync/main_test.go
+++ b/tools/docs-version-sync/main_test.go
@@ -229,6 +229,73 @@ func TestCatalogRefreshPreservesVersionQualifiedPublications(t *testing.T) {
 	}
 }
 
+func TestCatalogRefreshWithoutBaseRendersStagingArtifactsAsPending(t *testing.T) {
+	catalog := BuildCatalogFromArtifactsWithBase("0.9.1", []Artifact{
+		{Name: "helm-nvca-operator", Type: ArtifactTypeChart, Registry: "staging", Version: "1.21.3"},
+		{Name: "nvca", Type: ArtifactTypeImage, Registry: "staging", Version: "3.2.19"},
+	}, nil)
+	catalog.Manifest.Entries = []ManifestEntry{
+		{ArtifactID: defaultStackResourceName, Plane: ManifestPlaneShared, Kind: ManifestKindResource, Description: "Control-plane stack."},
+		{ArtifactID: "nvcf-cli", Plane: ManifestPlaneShared, Kind: ManifestKindResource, Description: "CLI."},
+		{ArtifactID: "helm-nvca-operator", Plane: ManifestPlaneCompute, Kind: ManifestKindChart, Requirement: ManifestRequired, Description: "NVCA chart."},
+		{ArtifactID: "nvca", Plane: ManifestPlaneCompute, Kind: ManifestKindServiceImage, Requirement: ManifestRequired, Description: "NVCA agent."},
+	}
+
+	got, err := Render("manifest-artifact-registry-paths", catalog)
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	for _, name := range []string{defaultStackResourceName, "nvcf-cli", "helm-nvca-operator", "nvca"} {
+		row := manifestRow(t, got, name)
+		if !strings.Contains(row, "`Publication pending`") {
+			t.Errorf("%s row does not mark the unverified staging artifact pending: %s", name, row)
+		}
+	}
+	if strings.Contains(got, catalog.Registries[defaultStackRegistry].Namespace) {
+		t.Fatalf("rendered manifest exposes staging namespace:\n%s", got)
+	}
+}
+
+func TestCatalogRefreshMarksChangedStagingVersionsPendingAndKeepsPublishedVersionsPublic(t *testing.T) {
+	base := testCatalog()
+	base.Registries["public-images"] = Registry{Host: "nvcr.io", Namespace: "nvidia/nvcf"}
+	base.Artifacts = append(base.Artifacts,
+		Artifact{Name: "nvca", Type: ArtifactTypeImage, Registry: "staging", Version: "3.2.18"},
+		Artifact{Name: "verified-service", Type: ArtifactTypeImage, Registry: "staging", Version: "2.0.0"},
+	)
+	base.Publications = []Publication{
+		{Name: "nvca", Version: "3.2.18", Registry: "public-images"},
+		{Name: "verified-service", Version: "2.0.0", Registry: "public-images"},
+	}
+	base.Manifest.Entries = append(base.Manifest.Entries,
+		ManifestEntry{ArtifactID: "nvca", Plane: ManifestPlaneCompute, Kind: ManifestKindServiceImage, Requirement: ManifestRequired, Description: "NVCA agent."},
+		ManifestEntry{ArtifactID: "verified-service", Plane: ManifestPlaneControl, Kind: ManifestKindServiceImage, Requirement: ManifestRequired, Description: "Published service."},
+	)
+
+	catalog := BuildCatalogFromArtifactsWithBase("0.6.0", []Artifact{
+		{Name: "nvca", Type: ArtifactTypeImage, Registry: "staging", Version: "3.2.19"},
+		{Name: "verified-service", Type: ArtifactTypeImage, Registry: "staging", Version: "2.0.0"},
+	}, base)
+	got, err := Render("manifest-artifact-registry-paths", catalog)
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	for _, name := range []string{defaultStackResourceName, computeStackResourceName, "nvcf-cli", "nvca"} {
+		row := manifestRow(t, got, name)
+		if !strings.Contains(row, "`Publication pending`") {
+			t.Errorf("%s row does not mark the unverified staging artifact pending: %s", name, row)
+		}
+	}
+	publicRow := manifestRow(t, got, "verified-service")
+	if !strings.Contains(publicRow, "`nvcr.io/nvidia/nvcf/verified-service:2.0.0`") {
+		t.Errorf("matching verified publication did not retain its public distribution: %s", publicRow)
+	}
+	if strings.Contains(got, catalog.Registries[defaultStackRegistry].Namespace) {
+		t.Fatalf("rendered manifest exposes staging namespace:\n%s", got)
+	}
+}
+
 func TestArtifactPathUsesPublishedVersionAlias(t *testing.T) {
 	catalog := testCatalog()
 	catalog.Registries["ea-images"] = Registry{Host: "nvcr.io", Namespace: "example/selfhosted-ga"}
@@ -381,6 +448,69 @@ func TestRenderImageMirroringSnippets(t *testing.T) {
 	}
 	if !strings.Contains(cli, `0833294136851237/nvcf-ncp-staging/nvcf-cli:${VERSION}`) {
 		t.Fatalf("cli snippet missing cli resource path:\n%s", cli)
+	}
+}
+
+func TestRenderImageMirroringCLIContentMatchesPublicationState(t *testing.T) {
+	pending := testCatalog()
+	pending.PublicationPending = []string{"nvcf-cli"}
+	pendingOutput, err := Render("image-mirroring-cli-snippet", pending)
+	if err != nil {
+		t.Fatalf("render pending CLI content: %v", err)
+	}
+	if strings.Contains(pendingOutput, "The extracted directory contains") {
+		t.Fatalf("pending CLI content implies extraction already occurred:\n%s", pendingOutput)
+	}
+	if !strings.Contains(pendingOutput, "Package contents and extraction instructions will be available after publication or mirroring") {
+		t.Fatalf("pending CLI content lacks actionable status guidance:\n%s", pendingOutput)
+	}
+
+	published := testCatalog()
+	publishedOutput, err := Render("image-mirroring-cli-snippet", published)
+	if err != nil {
+		t.Fatalf("render published CLI content: %v", err)
+	}
+	if !strings.Contains(publishedOutput, "The extracted directory contains") || !strings.Contains(publishedOutput, "`.nvcf-cli.yaml.template`") {
+		t.Fatalf("published CLI content omits extracted package details:\n%s", publishedOutput)
+	}
+}
+
+func TestRenderComputeStackDownloadsMatchPublicationState(t *testing.T) {
+	pending := testCatalog()
+	pending.PublicationPending = []string{computeStackResourceName}
+	for _, renderer := range []string{"image-mirroring-resource-examples", "image-mirroring-compute-stack-snippet"} {
+		t.Run(renderer+"-pending", func(t *testing.T) {
+			got, err := Render(renderer, pending)
+			if err != nil {
+				t.Fatalf("Render failed: %v", err)
+			}
+			if strings.Contains(got, "nvcf-compute-plane-stack:${") {
+				t.Fatalf("pending compute stack renders a download command:\n%s", got)
+			}
+			if !strings.Contains(got, "Publication pending: nvcf-compute-plane-stack 0.5.0 is not yet available for download") {
+				t.Fatalf("pending compute stack lacks publication status:\n%s", got)
+			}
+		})
+	}
+
+	published := testCatalog()
+	published.Registries["public-resources"] = Registry{Host: "nvcr.io", Namespace: "nvidia/nvcf"}
+	for i := range published.SupplementalArtifacts {
+		if published.SupplementalArtifacts[i].Name == computeStackResourceName {
+			published.SupplementalArtifacts[i].Registry = "public-resources"
+		}
+	}
+	published.Publications = []Publication{{Name: computeStackResourceName, Version: "0.5.0", Registry: "public-resources"}}
+	for _, renderer := range []string{"image-mirroring-resource-examples", "image-mirroring-compute-stack-snippet"} {
+		t.Run(renderer+"-published", func(t *testing.T) {
+			got, err := Render(renderer, published)
+			if err != nil {
+				t.Fatalf("Render failed: %v", err)
+			}
+			if !strings.Contains(got, "ngc registry resource download-version") || !strings.Contains(got, "nvidia/nvcf/nvcf-compute-plane-stack") {
+				t.Fatalf("published compute stack omits its public download command:\n%s", got)
+			}
+		})
 	}
 }
 
@@ -755,6 +885,91 @@ func TestUpdateCatalogSyncsComputePlaneStackPackage(t *testing.T) {
 	}
 }
 
+func TestUpdateCatalogMarksAdvancedComputeStackPendingWithoutExactPublication(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v4/projects/182049/packages/generic/ncp-deploy/0.9.0/artifacts-0.9.0.txt":
+			fmt.Fprint(w, ``)
+		case "/api/v4/projects/268903/packages":
+			fmt.Fprint(w, `[{"name":"nvcf-compute-plane-stack","version":"1.0.7"}]`)
+		default:
+			http.Error(w, fmt.Sprintf("unexpected path %s", r.URL.Path), http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("DOC_VERSION_SYNC_GITLAB_BASE_URL", server.URL)
+	t.Setenv("DOC_VERSION_SYNC_GITLAB_TOKEN", "env-token")
+
+	base := testCatalog()
+	base.Registries["public-resources"] = Registry{Host: "nvcr.io", Namespace: "nvidia/nvcf"}
+	for i := range base.SupplementalArtifacts {
+		if base.SupplementalArtifacts[i].Name == computeStackResourceName {
+			base.SupplementalArtifacts[i].Registry = "public-resources"
+			base.SupplementalArtifacts[i].Version = "1.0.6"
+		}
+	}
+	base.Publications = []Publication{{Name: computeStackResourceName, Version: "1.0.6", Registry: "public-resources"}}
+
+	catalog, err := updateCatalogFromGitLab("0.9.0", base)
+	if err != nil {
+		t.Fatalf("updateCatalogFromGitLab failed: %v", err)
+	}
+	compute, ok := catalog.findArtifact(computeStackResourceName)
+	if !ok || compute.Version != "1.0.7" {
+		t.Fatalf("compute stack = %#v, want version 1.0.7", compute)
+	}
+	got, err := Render("manifest-artifact-registry-paths", catalog)
+	if err != nil {
+		t.Fatalf("render manifest: %v", err)
+	}
+	if row := manifestRow(t, got, computeStackResourceName); !strings.Contains(row, "`Publication pending`") {
+		t.Fatalf("advanced compute stack is not marked pending: %s", row)
+	}
+}
+
+func TestUpdateCatalogKeepsAdvancedComputeStackPublicWithExactPublication(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v4/projects/182049/packages/generic/ncp-deploy/0.9.0/artifacts-0.9.0.txt":
+			fmt.Fprint(w, ``)
+		case "/api/v4/projects/268903/packages":
+			fmt.Fprint(w, `[{"name":"nvcf-compute-plane-stack","version":"1.0.7"}]`)
+		default:
+			http.Error(w, fmt.Sprintf("unexpected path %s", r.URL.Path), http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("DOC_VERSION_SYNC_GITLAB_BASE_URL", server.URL)
+	t.Setenv("DOC_VERSION_SYNC_GITLAB_TOKEN", "env-token")
+
+	base := testCatalog()
+	base.Registries["public-resources"] = Registry{Host: "nvcr.io", Namespace: "nvidia/nvcf"}
+	for i := range base.SupplementalArtifacts {
+		if base.SupplementalArtifacts[i].Name == computeStackResourceName {
+			base.SupplementalArtifacts[i].Registry = "public-resources"
+			base.SupplementalArtifacts[i].Version = "1.0.6"
+		}
+	}
+	base.Publications = []Publication{
+		{Name: computeStackResourceName, Version: "1.0.6", Registry: "public-resources"},
+		{Name: computeStackResourceName, Version: "1.0.7", Registry: "public-resources"},
+	}
+
+	catalog, err := updateCatalogFromGitLab("0.9.0", base)
+	if err != nil {
+		t.Fatalf("updateCatalogFromGitLab failed: %v", err)
+	}
+	got, err := Render("manifest-artifact-registry-paths", catalog)
+	if err != nil {
+		t.Fatalf("render manifest: %v", err)
+	}
+	if row := manifestRow(t, got, computeStackResourceName); !strings.Contains(row, "`nvcr.io/nvidia/nvcf/nvcf-compute-plane-stack:1.0.7`") {
+		t.Fatalf("exactly published compute stack does not use its public distribution: %s", row)
+	}
+}
+
 func TestUpdateCatalogDiscoversLatestStackPackage(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -913,6 +1128,18 @@ func writeFile(t *testing.T, path, content string) {
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
+}
+
+func manifestRow(t *testing.T, manifest, artifactName string) string {
+	t.Helper()
+	prefix := "| `" + artifactName + "` |"
+	for _, line := range strings.Split(manifest, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return line
+		}
+	}
+	t.Fatalf("manifest is missing row for %s:\n%s", artifactName, manifest)
+	return ""
 }
 
 func sectionBetween(t *testing.T, content, startMarker, endMarker string) string {

--- a/tools/docs-version-sync/manifest.go
+++ b/tools/docs-version-sync/manifest.go
@@ -87,7 +87,7 @@ func resolveManifestEntries(catalog *Catalog) ([]resolvedManifestEntry, error) {
 			if !ok {
 				return nil, fmt.Errorf("manifest metadata references unknown artifact %s", metadata.ArtifactID)
 			}
-			path, err := catalog.artifactPath(artifact)
+			path, err := catalog.artifactDistribution(artifact)
 			if err != nil {
 				return nil, err
 			}

--- a/tools/docs-version-sync/render.go
+++ b/tools/docs-version-sync/render.go
@@ -53,7 +53,7 @@ func renderManifestDeploymentResources(catalog *Catalog) (string, error) {
 	b.WriteString("| Type | Component Name | Full Path |\n")
 	b.WriteString("| --- | --- | --- |\n")
 	for _, artifact := range resources {
-		path, err := catalog.artifactPath(artifact)
+		path, err := catalog.artifactDistribution(artifact)
 		if err != nil {
 			return "", err
 		}
@@ -64,24 +64,30 @@ func renderManifestDeploymentResources(catalog *Catalog) (string, error) {
 
 func renderImageMirroringResourceExamples(catalog *Catalog) (string, error) {
 	stack := catalog.stackArtifact()
-	ref, err := catalog.resourceRef(stack)
-	if err != nil {
-		return "", err
-	}
-
-	compute, hasComputeStack := catalog.findArtifact(computeStackResourceName)
-	computeRef := ""
-	if hasComputeStack {
-		if compute.Type != ArtifactTypeResource {
-			return "", fmt.Errorf("%s must be a resource artifact", computeStackResourceName)
-		}
-		computeRef, err = catalog.resourceRef(compute)
+	stackPending := catalog.publicationIsPending(stack)
+	ref := ""
+	var err error
+	if !stackPending {
+		ref, err = catalog.resourceRef(stack)
 		if err != nil {
 			return "", err
 		}
 	}
 
-	refWithVersion := strings.Replace(ref, stack.Version, "${STACK_VERSION}", 1)
+	compute, hasComputeStack := catalog.findArtifact(computeStackResourceName)
+	computePending := hasComputeStack && catalog.publicationIsPending(compute)
+	computeRef := ""
+	if hasComputeStack {
+		if compute.Type != ArtifactTypeResource {
+			return "", fmt.Errorf("%s must be a resource artifact", computeStackResourceName)
+		}
+		if !computePending {
+			computeRef, err = catalog.resourceRef(compute)
+			if err != nil {
+				return "", err
+			}
+		}
+	}
 
 	var b strings.Builder
 	b.WriteString("```bash\n")
@@ -92,14 +98,23 @@ func renderImageMirroringResourceExamples(catalog *Catalog) (string, error) {
 	}
 	b.WriteString("\n")
 	b.WriteString("# Download a specific control-plane stack version\n")
-	b.WriteString("ngc registry resource download-version \\\n")
-	b.WriteString(fmt.Sprintf("  %q\n", refWithVersion))
+	if stackPending {
+		b.WriteString(fmt.Sprintf("# Publication pending: %s %s is not yet available for download.\n", stack.Name, stack.Version))
+	} else {
+		refWithVersion := strings.Replace(ref, stack.Version, "${STACK_VERSION}", 1)
+		b.WriteString("ngc registry resource download-version \\\n")
+		b.WriteString(fmt.Sprintf("  %q\n", refWithVersion))
+	}
 
 	if hasComputeStack {
-		computeRefWithVersion := strings.Replace(computeRef, compute.Version, "${COMPUTE_STACK_VERSION}", 1)
 		b.WriteString("\n# Download a specific compute-plane stack version\n")
-		b.WriteString("ngc registry resource download-version \\\n")
-		b.WriteString(fmt.Sprintf("  %q\n", computeRefWithVersion))
+		if computePending {
+			b.WriteString(fmt.Sprintf("# Publication pending: %s %s is not yet available for download.\n", compute.Name, compute.Version))
+		} else {
+			computeRefWithVersion := strings.Replace(computeRef, compute.Version, "${COMPUTE_STACK_VERSION}", 1)
+			b.WriteString("ngc registry resource download-version \\\n")
+			b.WriteString(fmt.Sprintf("  %q\n", computeRefWithVersion))
+		}
 	}
 
 	b.WriteString("```\n")
@@ -108,6 +123,9 @@ func renderImageMirroringResourceExamples(catalog *Catalog) (string, error) {
 
 func renderImageMirroringStackSnippet(catalog *Catalog) (string, error) {
 	stack := catalog.stackArtifact()
+	if catalog.publicationIsPending(stack) {
+		return fmt.Sprintf("```bash\n# Publication pending: %s %s is not yet available for download.\n```\n", stack.Name, stack.Version), nil
+	}
 	ref, err := catalog.resourceRef(stack)
 	if err != nil {
 		return "", err
@@ -131,6 +149,9 @@ func renderImageMirroringComputeStackSnippet(catalog *Catalog) (string, error) {
 	if compute.Type != ArtifactTypeResource {
 		return "", fmt.Errorf("%s must be a resource artifact", computeStackResourceName)
 	}
+	if catalog.publicationIsPending(compute) {
+		return fmt.Sprintf("```bash\n# Publication pending: %s %s is not yet available for download.\n```\n", compute.Name, compute.Version), nil
+	}
 	ref, err := catalog.resourceRef(compute)
 	if err != nil {
 		return "", err
@@ -151,11 +172,14 @@ func renderImageMirroringCLISnippet(catalog *Catalog) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("supplemental artifact nvcf-cli is required")
 	}
+	if catalog.publicationIsPending(cli) {
+		return fmt.Sprintf("```bash\n# Publication pending: %s %s is not yet available for download.\n```\n\nPackage contents and extraction instructions will be available after publication or mirroring.\n", cli.Name, cli.Version), nil
+	}
 	ref, err := catalog.resourceRef(cli)
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("```bash\n# Set the version\nexport VERSION=%q\n\n# Set your platform (linux-amd64, linux-arm64, darwin-amd64, darwin-arm64, windows-amd64)\nexport PLATFORM=\"linux-amd64\"\n\nngc registry resource download-version %q\n\ntar -xzf nvcf-cli_v${VERSION}/${PLATFORM}/nvcf-cli-${PLATFORM}-${VERSION}.tar.gz\nmv nvcf-cli-${PLATFORM}-${VERSION} nvcf-cli\nchmod +x nvcf-cli/nvcf-cli\n```\n",
+	return fmt.Sprintf("```bash\n# Set the version\nexport VERSION=%q\n\n# Set your platform (linux-amd64, linux-arm64, darwin-amd64, darwin-arm64, windows-amd64)\nexport PLATFORM=\"linux-amd64\"\n\nngc registry resource download-version %q\n\ntar -xzf nvcf-cli_v${VERSION}/${PLATFORM}/nvcf-cli-${PLATFORM}-${VERSION}.tar.gz\nmv nvcf-cli-${PLATFORM}-${VERSION} nvcf-cli\nchmod +x nvcf-cli/nvcf-cli\n```\n\nThe extracted directory contains:\n\n- `nvcf-cli` - The CLI binary\n- `.nvcf-cli.yaml.template` - Configuration template\n- `examples/` - Sample configuration files for different environments\n- `USAGE-GUIDE.md` - Detailed usage documentation\n",
 		cli.Version,
 		strings.Replace(ref, cli.Version, "${VERSION}", 1),
 	), nil

--- a/tools/docs-version-sync/stack_consistency_test.go
+++ b/tools/docs-version-sync/stack_consistency_test.go
@@ -1,0 +1,608 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+type effectiveStackPin struct {
+	artifact             string
+	path                 string
+	blockPattern         string
+	blockBoundaryPattern string
+	pattern              string
+}
+
+var effectiveStackPins = []effectiveStackPin{
+	{
+		artifact:             "helm-nvcf-llm-request-router",
+		path:                 "deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl",
+		blockPattern:         `(?m)^  - name: llm-request-router[ \t]*$`,
+		blockBoundaryPattern: `(?m)^  -[ \t]+`,
+		pattern:              `(?m)^    version:[ \t]*"?([^"\s]+)"?[ \t]*$`,
+	},
+	{
+		artifact:             "nvcf-gateway-routes",
+		path:                 "deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl",
+		blockPattern:         `(?m)^  - name: ingress[ \t]*$`,
+		blockBoundaryPattern: `(?m)^  -[ \t]+`,
+		pattern:              `(?m)^    version:[ \t]*"?([^"\s]+)"?[ \t]*$`,
+	},
+	{
+		artifact: "pylon",
+		path:     "deploy/stacks/self-managed/global.yaml.gotmpl",
+		pattern:  `pylon:([0-9][^"\s]*)`,
+	},
+	{
+		artifact:             "helm-nvca-operator",
+		path:                 "deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl",
+		blockPattern:         `(?m)^  - name: nvca-operator[ \t]*$`,
+		blockBoundaryPattern: `(?m)^  -[ \t]+`,
+		pattern:              `(?m)^    version:[ \t]*"?([^"\s]+)"?[ \t]*$`,
+	},
+	{
+		artifact:             "nvca-operator",
+		path:                 "deploy/stacks/nvcf-compute-plane/environments/base.yaml",
+		blockPattern:         `(?m)^  nvcaOperator:[ \t]*$`,
+		blockBoundaryPattern: `(?m)^  [A-Za-z0-9_-]+:[ \t]*`,
+		pattern:              `(?m)^    imageTag:[ \t]*"([^"]+)"[ \t]*$`,
+	},
+	{
+		artifact:             "nvca",
+		path:                 "deploy/stacks/nvcf-compute-plane/environments/base.yaml",
+		blockPattern:         `(?m)^  nvcaOperator:[ \t]*$`,
+		blockBoundaryPattern: `(?m)^  [A-Za-z0-9_-]+:[ \t]*`,
+		pattern:              `(?m)^      nvcaVersion:[ \t]*"([^"]+)"[ \t]*$`,
+	},
+}
+
+func extractEffectiveStackPins(sources map[string][]byte, pins []effectiveStackPin) (map[string]string, error) {
+	versions := make(map[string]string, len(pins))
+	matchedSources := make(map[string]struct{}, len(sources))
+	for _, pin := range pins {
+		body, ok := sources[pin.path]
+		if !ok {
+			return nil, fmt.Errorf("pin source %s for %s is not declared", pin.path, pin.artifact)
+		}
+		matchBody := body
+		if pin.blockPattern != "" {
+			blocks := regexp.MustCompile(pin.blockPattern).FindAllIndex(body, -1)
+			if len(blocks) != 1 {
+				return nil, fmt.Errorf("resolved %d target blocks for %s from %s; want exactly one", len(blocks), pin.artifact, pin.path)
+			}
+			blockStart, blockEnd := blocks[0][0], len(body)
+			if pin.blockBoundaryPattern != "" {
+				remainderStart := blocks[0][1]
+				if next := regexp.MustCompile(pin.blockBoundaryPattern).FindIndex(body[remainderStart:]); next != nil {
+					blockEnd = remainderStart + next[0]
+				}
+			}
+			matchBody = body[blockStart:blockEnd]
+		}
+		matches := regexp.MustCompile(pin.pattern).FindAllSubmatch(matchBody, -1)
+		if len(matches) != 1 {
+			if pin.blockPattern != "" {
+				return nil, fmt.Errorf("resolved %d versions for %s within target block from %s; want exactly one", len(matches), pin.artifact, pin.path)
+			}
+			return nil, fmt.Errorf("resolved %d definitions for %s from %s; want exactly one", len(matches), pin.artifact, pin.path)
+		}
+		if len(matches[0]) != 2 {
+			return nil, fmt.Errorf("pin matcher for %s from %s must capture exactly one version", pin.artifact, pin.path)
+		}
+		if _, exists := versions[pin.artifact]; exists {
+			return nil, fmt.Errorf("duplicate pin matcher for artifact %s", pin.artifact)
+		}
+		versions[pin.artifact] = string(matches[0][1])
+		matchedSources[pin.path] = struct{}{}
+	}
+
+	sourcePaths := make([]string, 0, len(sources))
+	for sourcePath := range sources {
+		sourcePaths = append(sourcePaths, sourcePath)
+	}
+	sort.Strings(sourcePaths)
+	for _, sourcePath := range sourcePaths {
+		if _, matched := matchedSources[sourcePath]; !matched {
+			return nil, fmt.Errorf("declared pin source %s has no matcher", sourcePath)
+		}
+	}
+	return versions, nil
+}
+
+func pinSourceDigest(sources map[string][]byte, pins []effectiveStackPin) (string, error) {
+	versions, err := extractEffectiveStackPins(sources, pins)
+	if err != nil {
+		return "", err
+	}
+	pins = append([]effectiveStackPin(nil), pins...)
+	sort.Slice(pins, func(i, j int) bool { return pins[i].artifact < pins[j].artifact })
+
+	digest := sha256.New()
+	for _, pin := range pins {
+		version, ok := versions[pin.artifact]
+		if !ok {
+			continue
+		}
+		digest.Write([]byte(pin.artifact))
+		digest.Write([]byte{0})
+		digest.Write([]byte(pin.path))
+		digest.Write([]byte{0})
+		digest.Write([]byte(version))
+		digest.Write([]byte{0})
+	}
+	return "sha256:" + hex.EncodeToString(digest.Sum(nil)), nil
+}
+
+func TestPinSourceDigestDetectsUnreleasedSourceMutation(t *testing.T) {
+	sources := map[string][]byte{
+		"b.yaml": []byte("image: example:4.5.6\n"),
+		"a.yaml": []byte("version: 1.2.3\n"),
+	}
+	pins := []effectiveStackPin{
+		{artifact: "chart", path: "a.yaml", pattern: `version: ([^\s]+)`},
+		{artifact: "image", path: "b.yaml", pattern: `image: example:([^\s]+)`},
+	}
+	const releasedDigest = "sha256:62f9f9f2d48a7798d50dc032ed7db77b8afcbb6eb8189c62cff9590572ff4f50"
+	got, err := pinSourceDigest(sources, pins)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != releasedDigest {
+		t.Fatalf("released source digest = %q, want independently calculated %q", got, releasedDigest)
+	}
+
+	sources["a.yaml"] = []byte("version: 9.9.9\n")
+	got, err = pinSourceDigest(sources, pins)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == releasedDigest {
+		t.Fatalf("unreleased source mutation retained released digest %q", got)
+	}
+
+	sources["a.yaml"] = []byte("# unrelated setting\nversion: 1.2.3\n")
+	got, err = pinSourceDigest(sources, pins)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != releasedDigest {
+		t.Fatalf("non-pin source mutation changed release digest to %q", got)
+	}
+}
+
+func TestExtractEffectiveStackPinsRejectsDuplicateArtifactDefinition(t *testing.T) {
+	sources := map[string][]byte{
+		"stack.yaml": []byte("version: 1.2.3\nversion: 4.5.6\n"),
+	}
+	pins := []effectiveStackPin{
+		{artifact: "chart", path: "stack.yaml", pattern: `(?m)^version: ([^\s]+)$`},
+	}
+
+	_, err := extractEffectiveStackPins(sources, pins)
+	if err == nil || !strings.Contains(err.Error(), "resolved 2 definitions for chart from stack.yaml") {
+		t.Fatalf("extractEffectiveStackPins error = %v, want duplicate-definition rejection", err)
+	}
+}
+
+func TestExtractEffectiveStackPinsRejectsMissingVersionInTargetBlock(t *testing.T) {
+	tests := []struct {
+		artifact string
+		body     string
+	}{
+		{
+			artifact: "helm-nvcf-llm-request-router",
+			body: `releases:
+  - name: llm-request-router
+    chart: nvcf/llm-request-router
+  - chart: nvcf/unrelated
+    version: 9.9.9
+	`,
+		},
+		{
+			artifact: "nvca",
+			body: `  nvcaOperator:
+    imageTag: "3.2.19"
+  unrelated:
+      nvcaVersion: "9.9.9"
+`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.artifact, func(t *testing.T) {
+			pin := effectiveStackPinForArtifact(t, test.artifact)
+			sources := map[string][]byte{pin.path: []byte(test.body)}
+
+			_, err := extractEffectiveStackPins(sources, []effectiveStackPin{pin})
+			want := "resolved 0 versions for " + test.artifact + " within target block"
+			if err == nil || !strings.Contains(err.Error(), want) {
+				t.Fatalf("extractEffectiveStackPins error = %v, want missing-target-version rejection", err)
+			}
+		})
+	}
+}
+
+func TestExtractEffectiveStackPinsRejectsDuplicateVersionsInTargetBlock(t *testing.T) {
+	tests := []struct {
+		artifact string
+		body     string
+	}{
+		{
+			artifact: "helm-nvcf-llm-request-router",
+			body: `releases:
+  - name: llm-request-router
+    version: 1.12.2
+    version: 1.12.3
+  - name: unrelated
+    version: 9.9.9
+	`,
+		},
+		{
+			artifact: "nvca",
+			body: `  nvcaOperator:
+    nvca:
+      nvcaVersion: "3.2.19"
+      nvcaVersion: "3.2.20"
+  unrelated:
+    enabled: true
+`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.artifact, func(t *testing.T) {
+			pin := effectiveStackPinForArtifact(t, test.artifact)
+			sources := map[string][]byte{pin.path: []byte(test.body)}
+
+			_, err := extractEffectiveStackPins(sources, []effectiveStackPin{pin})
+			want := "resolved 2 versions for " + test.artifact + " within target block"
+			if err == nil || !strings.Contains(err.Error(), want) {
+				t.Fatalf("extractEffectiveStackPins error = %v, want duplicate-target-version rejection", err)
+			}
+		})
+	}
+}
+
+func effectiveStackPinForArtifact(t *testing.T, artifact string) effectiveStackPin {
+	t.Helper()
+	for _, pin := range effectiveStackPins {
+		if pin.artifact == artifact {
+			return pin
+		}
+	}
+	t.Fatalf("effective stack pin for %s is not declared", artifact)
+	return effectiveStackPin{}
+}
+
+func TestExtractEffectiveStackPinsRejectsDeclaredSourceWithoutMatcher(t *testing.T) {
+	sources := map[string][]byte{
+		"stack.yaml":     []byte("version: 1.2.3\n"),
+		"unhandled.yaml": []byte("version: 9.9.9\n"),
+	}
+	pins := []effectiveStackPin{
+		{artifact: "chart", path: "stack.yaml", pattern: `(?m)^version: ([^\s]+)$`},
+	}
+
+	_, err := extractEffectiveStackPins(sources, pins)
+	if err == nil || !strings.Contains(err.Error(), "declared pin source unhandled.yaml has no matcher") {
+		t.Fatalf("extractEffectiveStackPins error = %v, want unhandled-source rejection", err)
+	}
+}
+
+func TestMainCatalogMatchesDeclaredReleaseStackPins(t *testing.T) {
+	root := docsVersionSyncRepoRoot(t)
+	catalog, err := LoadCatalog(filepath.Join(root, "docs", "version-catalog", "main.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "artifacts-" + catalog.Stack.Version + ".txt"; catalog.Stack.ArtifactsFile != want {
+		t.Errorf("stack artifacts_file = %q, want %q for catalog stack version %s", catalog.Stack.ArtifactsFile, want, catalog.Stack.Version)
+	}
+	if !regexp.MustCompile(`^[0-9a-f]{40}$`).MatchString(catalog.Stack.SourceCommit) {
+		t.Fatalf("stack source_commit = %q, want immutable 40-character commit SHA", catalog.Stack.SourceCommit)
+	}
+	if len(catalog.Stack.PinSources) == 0 {
+		t.Fatal("stack pin_sources must declare the release files used to resolve effective versions")
+	}
+
+	contents := make(map[string][]byte, len(catalog.Stack.PinSources))
+	for _, sourcePath := range catalog.Stack.PinSources {
+		body, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(sourcePath)))
+		if err != nil {
+			t.Fatalf("read declared pin source %s: %v", sourcePath, err)
+		}
+		contents[sourcePath] = body
+	}
+	pins := effectiveStackPins
+	versions, err := extractEffectiveStackPins(contents, pins)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := pinSourceDigest(contents, pins)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != catalog.Stack.PinSourceDigest {
+		t.Fatalf("effective stack pins have digest %s, want release snapshot %s for stack %s at %s; update the version, source commit, digest, and catalog together", got, catalog.Stack.PinSourceDigest, catalog.Stack.Version, catalog.Stack.SourceCommit)
+	}
+
+	for _, pin := range pins {
+		pin := pin
+		t.Run(pin.artifact, func(t *testing.T) {
+			_, ok := contents[pin.path]
+			if !ok {
+				t.Fatalf("pin source %s is not declared in catalog stack pin_sources", pin.path)
+			}
+			want, ok := versions[pin.artifact]
+			if !ok {
+				t.Fatalf("could not resolve %s from %s", pin.artifact, pin.path)
+			}
+			artifact, ok := catalog.findArtifact(pin.artifact)
+			if !ok {
+				t.Fatalf("catalog is missing stack-pinned artifact %s", pin.artifact)
+			}
+			if artifact.Version != want {
+				t.Errorf("catalog %s version = %s, want effective stack pin %s from %s", pin.artifact, artifact.Version, want, pin.path)
+			}
+		})
+	}
+
+	t.Run("nvcf-cli-independent-release", func(t *testing.T) {
+		artifact, ok := catalog.findArtifact("nvcf-cli")
+		if !ok {
+			t.Fatal("catalog is missing nvcf-cli")
+		}
+		var source *VersionOverride
+		for i := range catalog.VersionOverrides {
+			if catalog.VersionOverrides[i].Name == "nvcf-cli" {
+				source = &catalog.VersionOverrides[i]
+				break
+			}
+		}
+		if source == nil {
+			t.Fatal("nvcf-cli has no direct stack pin; declare its independent release in version_overrides")
+		}
+		if artifact.Version != source.Version {
+			t.Errorf("catalog nvcf-cli version = %s, want independent release %s", artifact.Version, source.Version)
+		}
+		if !strings.Contains(source.Source, "not pinned by stack") {
+			t.Errorf("nvcf-cli override source %q must explicitly say it is not pinned by stack", source.Source)
+		}
+	})
+}
+
+func TestPendingPublicationsNeverRenderPrivateRegistryPaths(t *testing.T) {
+	root := docsVersionSyncRepoRoot(t)
+	catalog, err := LoadCatalog(filepath.Join(root, "docs", "version-catalog", "main.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := SyncDocs(root, catalog, true); err != nil {
+		t.Fatalf("checked-in generated docs do not match the catalog: %v", err)
+	}
+
+	manifest, err := renderManifestArtifactRegistryPaths(catalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	imageMirroringPath := filepath.Join(root, "docs", "user", "image-mirroring.md")
+	imageMirroring, err := os.ReadFile(imageMirroringPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	imageMirroringOutput, _, err := syncImageMirroring(string(imageMirroring), catalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, renderer := range []string{
+		"image-mirroring-resource-examples",
+		"image-mirroring-stack-snippet",
+		"image-mirroring-cli-snippet",
+	} {
+		output, err := Render(renderer, catalog)
+		if err != nil {
+			t.Fatalf("render %s: %v", renderer, err)
+		}
+		imageMirroringOutput += output
+	}
+
+	allPublicOutput := manifest + imageMirroringOutput
+	staging := catalog.Registries[defaultStackRegistry]
+	privateRegistryPath := staging.Host + "/" + staging.Namespace
+	if strings.Contains(allPublicOutput, privateRegistryPath) {
+		t.Fatalf("generated public docs expose private registry path %q", privateRegistryPath)
+	}
+	if !strings.Contains(manifest, "Publication pending") {
+		t.Fatal("manifest does not identify versions awaiting publication")
+	}
+	if !strings.Contains(imageMirroringOutput, "HELM_NVCA_OPERATOR_REFERENCE") {
+		t.Fatal("mirroring instructions do not request an explicit chart reference while publication is pending")
+	}
+}
+
+func TestCatalogRefreshPreservesPublicationPending(t *testing.T) {
+	base := testCatalog()
+	base.PublicationPending = []string{"nvcf-self-managed-stack", "nvcf-cli"}
+
+	updated := BuildCatalogFromArtifactsWithBase("0.9.2", nil, base)
+
+	pending := make(map[string]struct{}, len(updated.PublicationPending))
+	for _, name := range updated.PublicationPending {
+		pending[name] = struct{}{}
+	}
+	for _, name := range []string{"nvcf-self-managed-stack", "nvcf-cli"} {
+		if _, ok := pending[name]; !ok {
+			t.Errorf("publication_pending = %v, want preserved entry %s", updated.PublicationPending, name)
+		}
+	}
+	if err := ValidateCatalog(updated); err != nil {
+		t.Fatalf("ValidateCatalog failed after refresh: %v", err)
+	}
+}
+
+func TestCatalogRefreshKeepsSnapshotOnlyForSameStackVersion(t *testing.T) {
+	base := testCatalog()
+	base.Stack.SourceCommit = "1111111111111111111111111111111111111111"
+	base.Stack.PinSources = []string{"stack.yaml"}
+	base.Stack.PinSourceDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+
+	sameRelease := BuildCatalogFromArtifactsWithBase(base.Stack.Version, nil, base)
+	if sameRelease.Stack.SourceCommit != base.Stack.SourceCommit ||
+		strings.Join(sameRelease.Stack.PinSources, ",") != "stack.yaml" ||
+		sameRelease.Stack.PinSourceDigest != base.Stack.PinSourceDigest {
+		t.Fatalf("same-release snapshot was not preserved: %#v", sameRelease.Stack)
+	}
+
+	newRelease := BuildCatalogFromArtifactsWithBase("0.9.2", nil, base)
+	if newRelease.Stack.SourceCommit != "" || len(newRelease.Stack.PinSources) != 0 || newRelease.Stack.PinSourceDigest != "" {
+		t.Fatalf("new release retained stale source snapshot: %#v", newRelease.Stack)
+	}
+}
+
+func TestValidateCatalogRejectsIncompleteStackSourceSnapshot(t *testing.T) {
+	catalog := testCatalog()
+	catalog.Stack.SourceCommit = "1111111111111111111111111111111111111111"
+
+	err := ValidateCatalog(catalog)
+	if err == nil || !strings.Contains(err.Error(), "source_commit, pin_sources, and pin_source_digest together") {
+		t.Fatalf("ValidateCatalog error = %v, want incomplete stack source snapshot", err)
+	}
+}
+
+func TestValidateCatalogRejectsInvalidStackSourceSnapshot(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*StackMetadata)
+		want   string
+	}{
+		{
+			name: "non-immutable commit",
+			mutate: func(stack *StackMetadata) {
+				stack.SourceCommit = "main"
+			},
+			want: "source_commit must be a full lowercase commit SHA",
+		},
+		{
+			name: "malformed digest",
+			mutate: func(stack *StackMetadata) {
+				stack.PinSourceDigest = "sha256:invalid"
+			},
+			want: "pin_source_digest must be a lowercase SHA-256 digest",
+		},
+		{
+			name: "duplicate source",
+			mutate: func(stack *StackMetadata) {
+				stack.PinSources = append(stack.PinSources, stack.PinSources[0])
+			},
+			want: "duplicate stack pin source stack.yaml",
+		},
+		{
+			name: "empty source",
+			mutate: func(stack *StackMetadata) {
+				stack.PinSources = []string{""}
+			},
+			want: "stack pin source must be non-empty and trimmed",
+		},
+		{
+			name: "whitespace-padded source",
+			mutate: func(stack *StackMetadata) {
+				stack.PinSources = []string{" stack.yaml "}
+			},
+			want: "stack pin source must be non-empty and trimmed",
+		},
+		{
+			name: "trim-equivalent duplicate source",
+			mutate: func(stack *StackMetadata) {
+				stack.PinSources = []string{"stack.yaml", " stack.yaml "}
+			},
+			want: "stack pin source must be non-empty and trimmed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			catalog := testCatalog()
+			catalog.Stack.SourceCommit = "1111111111111111111111111111111111111111"
+			catalog.Stack.PinSources = []string{"stack.yaml"}
+			catalog.Stack.PinSourceDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+			tt.mutate(&catalog.Stack)
+
+			err := ValidateCatalog(catalog)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("ValidateCatalog error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateCatalogAcceptsExactPinSourcePaths(t *testing.T) {
+	catalog := testCatalog()
+	catalog.Stack.SourceCommit = "1111111111111111111111111111111111111111"
+	catalog.Stack.PinSources = []string{"deploy/stack.yaml", "deploy/env.yaml"}
+	catalog.Stack.PinSourceDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+
+	if err := ValidateCatalog(catalog); err != nil {
+		t.Fatalf("ValidateCatalog rejected exact pin source paths: %v", err)
+	}
+}
+
+func TestValidateCatalogRejectsPublishedArtifactMarkedPending(t *testing.T) {
+	catalog := testCatalog()
+	cli, ok := catalog.findArtifact("nvcf-cli")
+	if !ok {
+		t.Fatal("test catalog is missing nvcf-cli")
+	}
+	catalog.Publications = []Publication{{
+		Name:     cli.Name,
+		Version:  cli.Version,
+		Registry: cli.Registry,
+	}}
+	catalog.PublicationPending = []string{cli.Name}
+
+	err := ValidateCatalog(catalog)
+	if err == nil || !strings.Contains(err.Error(), "cannot be both published and publication_pending") {
+		t.Fatalf("ValidateCatalog error = %v, want conflicting publication state", err)
+	}
+}
+
+func TestValidateCatalogAcceptsPendingArtifactID(t *testing.T) {
+	catalog := testCatalog()
+	catalog.SupplementalArtifacts = append(catalog.SupplementalArtifacts, Artifact{
+		ID:       "cache-image",
+		Name:     "cache",
+		Type:     ArtifactTypeImage,
+		Registry: "staging",
+		Version:  "1.2.3",
+	})
+	catalog.PublicationPending = []string{"cache-image"}
+
+	if err := ValidateCatalog(catalog); err != nil {
+		t.Fatalf("ValidateCatalog rejected pending artifact ID: %v", err)
+	}
+}
+
+func docsVersionSyncRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if info, err := os.Stat(filepath.Join(dir, "docs", "version-catalog", "main.yaml")); err == nil && !info.IsDir() {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find repository root above %s", dir)
+		}
+		dir = parent
+	}
+}


### PR DESCRIPTION
## Summary

- Align the self-managed catalog with effective v0.9.1 stack pins and regenerate supported documentation outputs.
- Add a self-contained release snapshot using an immutable source commit, exact pin-source file list, and deterministic digest so future catalog drift is detected without network or Git tag availability.
- Record nvcf-cli as an independent source release because it has no direct stack pin.
- Represent not-yet-public artifacts as publication pending so generated public docs never expose private registry locations or invent download URLs.
- Preserve existing verified-public artifact rendering and catalog refresh behavior.

## Validation

- Focused stack/catalog consistency, snapshot mutation, schema, refresh, renderer, and public-safety tests pass.
- Supported documentation generator and check mode pass.
- The exact commit passes focused validation on the Loki validation VM.
- Focused tests pass from extracted source archives with no .git directory, locally and on Loki.
- Generated public documentation contains no staging registry paths.

## Known baseline and follow-up

- The full docs-version-sync package retains three pre-existing Cassandra manifest failures on both main and this branch because bitnami-cassandra is absent from the current catalog metadata.
- Target chart, image, stack, and CLI artifacts still require public publication or confirmation. Until then, generated docs render explicit publication-pending guidance and require an explicit public or mirrored chart reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated release versions for the self-managed stack, operator, CLI, services, router, and related artifacts.
  - Refreshed image-mirroring, manifest, and version-catalog guidance with current chart names, versions, and publication details.
  - Clearly marked unavailable artifacts as “Publication pending.”

- **Improvements**
  - Removed unavailable download links and private registry paths.
  - Improved synchronization and validation of artifact versions, distribution references, and stack source information.
  - Added guidance for retrieving available CLI packages and stack artifacts.

- **Tests**
  - Expanded coverage for publication status, catalog validation, version refreshes, and documentation rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->