### PR TITLE
fix(pylon): log registration TLS validation failures

### DIFF
--- a/src/libraries/rust/stargate/crates/pylon-lib/src/quic_http_tunnel/tests.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/quic_http_tunnel/tests.rs
@@ -28,7 +28,6 @@ use super::reverse::{
     reverse_quic_dial_candidates, reverse_quic_sni,
 };
 use super::*;
-use std::collections::BTreeMap;
 use std::error::Error as _;
 use std::fs;
 use std::net::SocketAddr;
@@ -62,101 +61,11 @@ use crate::request_observer::{
 use crate::request_quality_monitor::RequestQualityMonitorConfig;
 use crate::runtime_state::ModelGeneration;
 use crate::stats::PylonMetrics;
+use crate::test_support::{
+    RecordingTracingSubscriber, assert_tracing_event_field, tracing_event_by_message,
+};
 use crate::upstream_health::UpstreamHealthPaths;
 use crate::{PylonRuntimeState, StatsCollectorConfig, start_stats_collector};
-
-#[derive(Clone, Default)]
-struct RecordingDebugSubscriber {
-    events: Arc<std::sync::Mutex<Vec<BTreeMap<String, String>>>>,
-}
-
-impl RecordingDebugSubscriber {
-    fn take_events(&self) -> Vec<BTreeMap<String, String>> {
-        std::mem::take(
-            &mut *self
-                .events
-                .lock()
-                .expect("recorded tracing events should not be poisoned"),
-        )
-    }
-}
-
-fn event_by_message<'a>(
-    events: &'a [BTreeMap<String, String>],
-    message: &str,
-) -> &'a BTreeMap<String, String> {
-    events
-        .iter()
-        .find(|event| event.get("message").map(String::as_str) == Some(message))
-        .unwrap_or_else(|| panic!("missing tracing event {message:?}"))
-}
-
-fn assert_event_field(event: &BTreeMap<String, String>, field: &str, expected: &str) {
-    assert_eq!(
-        event.get(field).map(String::as_str),
-        Some(expected),
-        "unexpected {field} field in {event:?}"
-    );
-}
-
-impl tracing::Subscriber for RecordingDebugSubscriber {
-    fn enabled(&self, metadata: &tracing::Metadata<'_>) -> bool {
-        metadata.level() <= &tracing::Level::DEBUG
-    }
-
-    fn new_span(&self, _attrs: &tracing::span::Attributes<'_>) -> tracing::span::Id {
-        tracing::span::Id::from_u64(1)
-    }
-
-    fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
-
-    fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
-
-    fn event(&self, event: &tracing::Event<'_>) {
-        let mut visitor = RecordingFieldVisitor::default();
-        event.record(&mut visitor);
-        self.events
-            .lock()
-            .expect("recorded tracing events should not be poisoned")
-            .push(visitor.fields);
-    }
-
-    fn enter(&self, _span: &tracing::span::Id) {}
-
-    fn exit(&self, _span: &tracing::span::Id) {}
-}
-
-#[derive(Default)]
-struct RecordingFieldVisitor {
-    fields: BTreeMap<String, String>,
-}
-
-impl tracing::field::Visit for RecordingFieldVisitor {
-    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
-        self.fields
-            .insert(field.name().to_string(), value.to_string());
-    }
-
-    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
-        self.fields
-            .insert(field.name().to_string(), value.to_string());
-    }
-
-    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
-        self.fields
-            .insert(field.name().to_string(), value.to_string());
-    }
-
-    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-        self.fields
-            .insert(field.name().to_string(), value.to_string());
-    }
-
-    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
-        self.fields
-            .insert(field.name().to_string(), format!("{value:?}"));
-    }
-}
 
 type TestWebTransportConnectStream = h3::client::RequestStream<
     <h3_quinn::OpenStreams as h3::quic::OpenStreams<Bytes>>::BidiStream,
@@ -3270,7 +3179,7 @@ async fn reverse_quic_endpoint_connect_logs_attempt_resolution_and_connection_me
     );
     config.quic_insecure = true;
     config.tunnel_protocol = TunnelTransportProtocol::Http3;
-    let subscriber = RecordingDebugSubscriber::default();
+    let subscriber = RecordingTracingSubscriber::default();
     let reverse_connection = {
         let dispatch = tracing::Dispatch::new(subscriber.clone());
         let _default_guard = tracing::dispatcher::set_default(&dispatch);
@@ -3281,28 +3190,30 @@ async fn reverse_quic_endpoint_connect_logs_attempt_resolution_and_connection_me
 
     let events = subscriber.take_events();
     let server_addr = server_addr.to_string();
-    let attempt_event = event_by_message(&events, "attempting Stargate reverse QUIC connection");
-    assert_event_field(attempt_event, "target_addr", &server_addr);
-    assert_event_field(attempt_event, "tunnel_protocol", "http3");
-    assert_event_field(attempt_event, "alpn_protocols", "[\"h3\"]");
-    assert_event_field(attempt_event, "quic_insecure", "true");
-    let resolved_event = event_by_message(&events, "resolved Stargate reverse QUIC target");
+    let attempt_event =
+        tracing_event_by_message(&events, "attempting Stargate reverse QUIC connection");
+    assert_tracing_event_field(attempt_event, "target_addr", &server_addr);
+    assert_tracing_event_field(attempt_event, "tunnel_protocol", "http3");
+    assert_tracing_event_field(attempt_event, "alpn_protocols", "[\"h3\"]");
+    assert_tracing_event_field(attempt_event, "quic_insecure", "true");
+    let resolved_event = tracing_event_by_message(&events, "resolved Stargate reverse QUIC target");
     let expected_candidates = format!("[{server_addr}]");
-    assert_event_field(resolved_event, "dial_candidates", &expected_candidates);
-    assert_event_field(resolved_event, "tunnel_protocol", "http3");
-    assert_event_field(resolved_event, "alpn_protocols", "[\"h3\"]");
-    assert_event_field(resolved_event, "quic_insecure", "true");
-    let connected_event = event_by_message(&events, "Stargate reverse QUIC connection established");
-    assert_event_field(connected_event, "transport", "quic");
+    assert_tracing_event_field(resolved_event, "dial_candidates", &expected_candidates);
+    assert_tracing_event_field(resolved_event, "tunnel_protocol", "http3");
+    assert_tracing_event_field(resolved_event, "alpn_protocols", "[\"h3\"]");
+    assert_tracing_event_field(resolved_event, "quic_insecure", "true");
+    let connected_event =
+        tracing_event_by_message(&events, "Stargate reverse QUIC connection established");
+    assert_tracing_event_field(connected_event, "transport", "quic");
     for field in ["target_addr", "dial_target", "remote_addr"] {
-        assert_event_field(connected_event, field, &server_addr);
+        assert_tracing_event_field(connected_event, field, &server_addr);
     }
     assert!(
-        connected_event.contains_key("stable_id"),
+        connected_event.fields.contains_key("stable_id"),
         "connected event should include the Quinn stable connection id"
     );
     assert!(
-        connected_event.contains_key("stats"),
+        connected_event.fields.contains_key("stats"),
         "connected event should include Quinn connection stats"
     );
 

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/registration/discovery.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/registration/discovery.rs
@@ -27,7 +27,9 @@ use stargate_protocol::parse_explicit_http_uri;
 use stargate_runtime::{OwnedTask, TASK_SHUTDOWN_TIMEOUT};
 use tracing::warn;
 
-use super::grpc_endpoint::{StargateGrpcEndpoint, log_stargate_grpc_connect_attempt};
+use super::grpc_endpoint::{
+    StargateGrpcEndpoint, log_stargate_grpc_certificate_failure, log_stargate_grpc_connect_attempt,
+};
 use super::topology::{RegistrationRouterTopology, publish_registration_router_topology};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -157,6 +159,7 @@ async fn watch_stargate_endpoint(
 ) {
     let target = StargateGrpcEndpoint::new(watch_url.clone(), "")
         .expect("normalized watch URL should be non-empty");
+    let mut last_certificate_failure = None;
     loop {
         if stop.is_cancelled() {
             return;
@@ -168,22 +171,55 @@ async fn watch_stargate_endpoint(
                 let mut client = StargateControlPlaneClient::new(endpoint.connect_lazy());
                 tokio::select! {
                     response = client.watch_stargates(WatchStargatesRequest {}) => {
-                        response.ok().map(|response| response.into_inner())
+                        match response {
+                            Ok(response) => {
+                                last_certificate_failure = None;
+                                Some(response.into_inner())
+                            }
+                            Err(error) => {
+                                last_certificate_failure = log_stargate_grpc_certificate_failure(
+                                    &target,
+                                    "watch_stargates",
+                                    &error,
+                                    last_certificate_failure,
+                                );
+                                None
+                            }
+                        }
                     }
                     _ = stop.cancelled() => return,
                 }
             }
-            Err(_) => None,
+            Err(error) => {
+                last_certificate_failure = log_stargate_grpc_certificate_failure(
+                    &target,
+                    "watch_stargates",
+                    error.as_ref(),
+                    last_certificate_failure,
+                );
+                None
+            }
         };
         if let Some(mut stream) = stream {
             loop {
                 let Some(message) = stop.run_until_cancelled(stream.message()).await else {
                     return;
                 };
-                let snapshot = message
-                    .ok()
-                    .flatten()
-                    .map(|response| watch_endpoint_snapshot_from_response(&watch_url, response));
+                let snapshot = match message {
+                    Ok(response) => response.map(|response| {
+                        last_certificate_failure = None;
+                        watch_endpoint_snapshot_from_response(&watch_url, response)
+                    }),
+                    Err(error) => {
+                        last_certificate_failure = log_stargate_grpc_certificate_failure(
+                            &target,
+                            "watch_stargates_stream",
+                            &error,
+                            last_certificate_failure,
+                        );
+                        None
+                    }
+                };
                 let disconnected = snapshot.is_none();
                 if !send_watch_endpoint_update(
                     &endpoint_updates_tx,

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/registration/grpc_endpoint.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/registration/grpc_endpoint.rs
@@ -13,9 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
+use std::{error::Error, fmt};
 
 use anyhow::Context;
+use rustls::{CertificateError as RustlsCertificateError, Error as RustlsError};
 use stargate_protocol::parse_explicit_http_uri;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint};
 
@@ -133,7 +134,6 @@ impl fmt::Display for StargateGrpcEndpoint {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct StargateGrpcDebugTarget {
-    pub(super) endpoint: String,
     pub(super) scheme: String,
     pub(super) host: String,
     pub(super) port: u16,
@@ -153,7 +153,6 @@ pub(super) fn stargate_grpc_debug_target(
     });
 
     Ok(StargateGrpcDebugTarget {
-        endpoint: endpoint.to_string(),
         scheme,
         host: authority.host().to_string(),
         port,
@@ -174,6 +173,118 @@ pub(super) async fn connect_stargate_grpc_channel(
     Ok(channel)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub(super) enum StargateGrpcCertificateFailure {
+    #[error("server certificate has an unknown issuer")]
+    UnknownIssuer,
+    #[error("server certificate SAN does not match the dial hostname")]
+    HostnameMismatch,
+    #[error("server certificate chain validation failed")]
+    ChainValidation,
+}
+
+impl StargateGrpcCertificateFailure {
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::UnknownIssuer => "tls_unknown_issuer",
+            Self::HostnameMismatch => "tls_hostname_mismatch",
+            Self::ChainValidation => "tls_chain_validation",
+        }
+    }
+
+    fn corrective_action(&self) -> &'static str {
+        match self {
+            Self::UnknownIssuer => {
+                "verify the configured gRPC CA signs the Stargate server certificate and the server presents the required certificate chain"
+            }
+            Self::HostnameMismatch => {
+                "configure a dial hostname present in the server certificate SAN or issue a certificate containing the configured hostname"
+            }
+            Self::ChainValidation => {
+                "verify the configured gRPC CA signs the Stargate server certificate, the server presents the required chain, and the certificate is valid"
+            }
+        }
+    }
+}
+
+fn rustls_certificate_error<'a>(
+    mut error: &'a (dyn Error + 'static),
+) -> Option<&'a RustlsCertificateError> {
+    loop {
+        if let Some(RustlsError::InvalidCertificate(certificate_error)) =
+            error.downcast_ref::<RustlsError>()
+        {
+            return Some(certificate_error);
+        }
+        // `io::Error::source` skips the custom inner error itself, so inspect it directly.
+        if let Some(RustlsError::InvalidCertificate(certificate_error)) = error
+            .downcast_ref::<std::io::Error>()
+            .and_then(std::io::Error::get_ref)
+            .and_then(|error| error.downcast_ref::<RustlsError>())
+        {
+            return Some(certificate_error);
+        }
+        error = error.source()?;
+    }
+}
+
+fn classify_stargate_grpc_certificate_failure(
+    error: &(dyn Error + 'static),
+) -> Option<StargateGrpcCertificateFailure> {
+    match rustls_certificate_error(error)? {
+        RustlsCertificateError::UnknownIssuer => {
+            Some(StargateGrpcCertificateFailure::UnknownIssuer)
+        }
+        RustlsCertificateError::NotValidForName
+        | RustlsCertificateError::NotValidForNameContext { .. } => {
+            Some(StargateGrpcCertificateFailure::HostnameMismatch)
+        }
+        _ => Some(StargateGrpcCertificateFailure::ChainValidation),
+    }
+}
+
+pub(super) fn log_stargate_grpc_certificate_failure(
+    target: &StargateGrpcEndpoint,
+    operation: &'static str,
+    error: &(dyn Error + 'static),
+    previous: Option<StargateGrpcCertificateFailure>,
+) -> Option<StargateGrpcCertificateFailure> {
+    let failure = classify_stargate_grpc_certificate_failure(error)?;
+    if previous == Some(failure) {
+        return previous;
+    }
+    let dial_endpoint = target.dial_endpoint();
+    let authority_endpoint = target.authority_endpoint();
+    match (
+        stargate_grpc_debug_target(&dial_endpoint),
+        stargate_grpc_debug_target(&authority_endpoint),
+    ) {
+        (Ok(dial), Ok(authority)) => tracing::error!(
+            transport = "grpc",
+            operation,
+            failure_kind = failure.kind(),
+            failure_reason = %failure,
+            corrective_action = failure.corrective_action(),
+            tls = dial.scheme == "https",
+            dial_host = %dial.host,
+            dial_port = dial.port,
+            authority_host = %authority.host,
+            authority_port = authority.port,
+            override_authority = dial_endpoint != authority_endpoint,
+            "Stargate gRPC connection failed"
+        ),
+        _ => tracing::error!(
+            transport = "grpc",
+            operation,
+            failure_kind = failure.kind(),
+            failure_reason = %failure,
+            corrective_action = failure.corrective_action(),
+            "Stargate gRPC connection failed"
+        ),
+    }
+    Some(failure)
+}
+
 macro_rules! log_stargate_grpc_target {
     ($target:expr, $operation:expr, [$($extra:tt)*], $message:literal, $error_message:literal) => {{
         if !tracing::enabled!(tracing::Level::DEBUG) {
@@ -190,26 +301,20 @@ macro_rules! log_stargate_grpc_target {
                 transport = "grpc",
                 operation = $operation,
                 http_version = "h2",
-                endpoint = %dial.endpoint,
-                dial_endpoint = %dial.endpoint,
                 dial_scheme = %dial.scheme,
                 tls = dial.scheme == "https",
                 dial_host = %dial.host,
                 dial_port = dial.port,
-                authority_endpoint = %authority.endpoint,
                 authority_host = %authority.host,
                 authority_port = authority.port,
                 override_authority,
                 $($extra)*
                 $message
             ),
-            (Err(error), _) | (_, Err(error)) => tracing::debug!(
+            (Err(_), _) | (_, Err(_)) => tracing::debug!(
                 transport = "grpc",
                 operation = $operation,
-                dial_endpoint = %dial_endpoint,
-                authority_endpoint = %authority_endpoint,
                 override_authority,
-                error = %error,
                 $($extra)*
                 $error_message
             ),

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/registration/grpc_endpoint.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/registration/grpc_endpoint.rs
@@ -249,7 +249,9 @@ pub(super) fn log_stargate_grpc_certificate_failure(
     error: &(dyn Error + 'static),
     previous: Option<StargateGrpcCertificateFailure>,
 ) -> Option<StargateGrpcCertificateFailure> {
-    let failure = classify_stargate_grpc_certificate_failure(error)?;
+    let Some(failure) = classify_stargate_grpc_certificate_failure(error) else {
+        return previous;
+    };
     if previous == Some(failure) {
         return previous;
     }

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/registration/router_stream.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/registration/router_stream.rs
@@ -28,7 +28,9 @@ use stargate_proto::pb::stargate_control_plane_client::StargateControlPlaneClien
 use stargate_proto::pb::{InferenceServerAck, InferenceServerRegistration, InferenceServerStatus};
 use stargate_runtime::{OwnedTask, TASK_SHUTDOWN_TIMEOUT};
 
-use super::grpc_endpoint::{StargateGrpcEndpoint, connect_stargate_grpc_channel};
+use super::grpc_endpoint::{
+    StargateGrpcEndpoint, connect_stargate_grpc_channel, log_stargate_grpc_certificate_failure,
+};
 use super::reverse_tunnel::{
     ReverseTunnelState, reverse_tunnel_endpoint_from_ack, run_reverse_tunnel_loop,
 };
@@ -43,6 +45,7 @@ pub(super) async fn run_router_registration_stream(
     stop: CancellationToken,
 ) {
     let router_addr = router_endpoint.authority_addr().to_string();
+    let mut last_certificate_failure = None;
 
     loop {
         let connection = tokio::select! {
@@ -54,15 +57,27 @@ pub(super) async fn run_router_registration_stream(
                 config.min_update_interval,
             ) => connection,
         };
-        let Ok((mut ack_stream, update_tx)) = connection else {
-            if stop
-                .run_until_cancelled(tokio::time::sleep(Duration::from_secs(1)))
-                .await
-                .is_none()
-            {
-                return;
+        let (mut ack_stream, update_tx) = match connection {
+            Ok(connection) => {
+                last_certificate_failure = None;
+                connection
             }
-            continue;
+            Err(error) => {
+                last_certificate_failure = log_stargate_grpc_certificate_failure(
+                    &router_endpoint,
+                    "register_inference_server",
+                    error.as_ref(),
+                    last_certificate_failure,
+                );
+                if stop
+                    .run_until_cancelled(tokio::time::sleep(Duration::from_secs(1)))
+                    .await
+                    .is_none()
+                {
+                    return;
+                }
+                continue;
+            }
         };
 
         let (reverse_state_tx, mut reverse_state_rx) =

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/registration/tests.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/registration/tests.rs
@@ -617,8 +617,7 @@ fn stargate_grpc_endpoint_rejects_custom_ca_for_plaintext_http() {
 
     let error = endpoint
         .channel_endpoint(Some(b"private CA contents must not be logged"))
-        .err()
-        .expect("custom CA with plaintext HTTP should be rejected");
+        .expect_err("custom CA with plaintext HTTP should be rejected");
 
     assert!(
         error
@@ -748,6 +747,37 @@ fn grpc_certificate_failure_log_emits_when_failure_kind_changes() {
     assert_eq!(
         failure_kinds,
         ["tls_unknown_issuer", "tls_hostname_mismatch"]
+    );
+}
+
+#[test]
+fn grpc_certificate_failure_log_stays_suppressed_across_unclassified_errors() {
+    let target = grpc_endpoint("router.example.test:50071");
+    let subscriber = RecordingTracingSubscriber::default();
+    let dispatch = tracing::Dispatch::new(subscriber.clone());
+    let _default_guard = tracing::dispatcher::set_default(&dispatch);
+    let certificate_error = typed_tls_io_error(rustls::CertificateError::UnknownIssuer);
+    let transport_error = std::io::Error::other("ordinary transport failure");
+
+    let mut last_failure =
+        log_stargate_grpc_certificate_failure(&target, "watch_stargates", &certificate_error, None);
+    last_failure = log_stargate_grpc_certificate_failure(
+        &target,
+        "watch_stargates",
+        &transport_error,
+        last_failure,
+    );
+    let _ = log_stargate_grpc_certificate_failure(
+        &target,
+        "watch_stargates",
+        &certificate_error,
+        last_failure,
+    );
+
+    assert_eq!(
+        subscriber.event_count("Stargate gRPC connection failed"),
+        1,
+        "an unclassified retry error must not start a new certificate-failure episode"
     );
 }
 

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/registration/tests.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/registration/tests.rs
@@ -42,6 +42,7 @@ use crate::quic_http_tunnel::{TunnelError, TunnelForwardingConfig};
 use crate::request_quality_monitor::RequestQualityMonitorConfig;
 use crate::runtime_state::{CurrentModelStats, PylonRuntimeState, gated_model_status};
 use crate::stats::PylonMetrics;
+use crate::test_support::{RecordedTracingEvent, RecordingTracingSubscriber};
 
 use super::discovery::*;
 use super::grpc_endpoint::*;
@@ -53,7 +54,7 @@ use super::types::RegistrationSessionConfig;
 use super::urls::infer_upstream_http_base_url;
 use super::*;
 
-const TEST_WAIT: Duration = Duration::from_secs(1);
+const TEST_WAIT: Duration = Duration::from_secs(5);
 const TEST_ROUTER_AUTHORITY: &str = "router-0.router-headless.example.invalid:50071";
 const DEFAULT_ROOT_TEST_DIAL_URL_ENV: &str = "PYLON_DEFAULT_ROOT_TEST_DIAL_URL";
 const CUSTOM_ROOT_TEST_CA_PATH_ENV: &str = "PYLON_CUSTOM_ROOT_TEST_CA_PATH";
@@ -240,6 +241,79 @@ async fn tls_connect_error(server: &TestTlsControlPlane, ca_cert_pem: Option<&[u
     format!("{error:?}").to_lowercase()
 }
 
+async fn wait_for_registration_failure_event(
+    subscriber: &RecordingTracingSubscriber,
+) -> RecordedTracingEvent {
+    wait_for_tracing_event_count(subscriber, "Stargate gRPC connection failed", 1).await;
+    subscriber
+        .events()
+        .into_iter()
+        .find(|event| {
+            event.fields.get("message").map(String::as_str)
+                == Some("Stargate gRPC connection failed")
+        })
+        .expect("Stargate gRPC failure event should remain recorded")
+}
+
+async fn wait_for_tracing_event_count(
+    subscriber: &RecordingTracingSubscriber,
+    message: &str,
+    expected: usize,
+) {
+    tokio::time::timeout(TEST_WAIT, async {
+        loop {
+            let count = subscriber.event_count(message);
+            if count >= expected {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("expected {expected} {message:?} tracing events"));
+}
+
+fn assert_registration_failure_event(
+    event: &RecordedTracingEvent,
+    expected_operation: &str,
+    expected_kind: &str,
+    expected_reason: &str,
+    expected_action: &str,
+) {
+    assert_eq!(event.level, tracing::Level::ERROR);
+    for (field, expected) in [
+        ("transport", "grpc"),
+        ("operation", expected_operation),
+        ("failure_kind", expected_kind),
+        ("failure_reason", expected_reason),
+        ("dial_host", "localhost"),
+        ("authority_host", "localhost"),
+        ("tls", "true"),
+    ] {
+        assert_eq!(
+            event.fields.get(field).map(String::as_str),
+            Some(expected),
+            "unexpected {field} in recorded event: {event:?}"
+        );
+    }
+    assert!(
+        event
+            .fields
+            .get("corrective_action")
+            .is_some_and(|action| action.contains(expected_action)),
+        "failure should tell the operator how to correct certificate validation: {event:?}"
+    );
+    for secret_fragment in ["BEGIN CERTIFICATE", "PRIVATE KEY"] {
+        assert!(
+            event
+                .fields
+                .values()
+                .all(|value| !value.contains(secret_fragment)),
+            "failure event exposed certificate material: {event:?}"
+        );
+    }
+}
+
 fn grpc_endpoint(authority_addr: &str) -> StargateGrpcEndpoint {
     StargateGrpcEndpoint::new(authority_addr.to_string(), "")
         .expect("test endpoint authority should be non-empty")
@@ -248,6 +322,13 @@ fn grpc_endpoint(authority_addr: &str) -> StargateGrpcEndpoint {
 fn grpc_endpoint_with_dial(authority_addr: &str, dial_addr: &str) -> StargateGrpcEndpoint {
     StargateGrpcEndpoint::new(authority_addr.to_string(), dial_addr.to_string())
         .expect("test endpoint authority should be non-empty")
+}
+
+fn typed_tls_io_error(certificate_error: rustls::CertificateError) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        rustls::Error::InvalidCertificate(certificate_error),
+    )
 }
 
 fn stargate_info(
@@ -548,6 +629,173 @@ fn stargate_grpc_endpoint_rejects_custom_ca_for_plaintext_http() {
 }
 
 #[test]
+fn grpc_failure_log_omits_unsafe_endpoint_userinfo_and_query() {
+    let unsafe_user = "unsafe-user";
+    let unsafe_password = "unsafe-password";
+    let unsafe_token = "unsafe-token";
+    let unsafe_endpoint = [
+        "https://",
+        unsafe_user,
+        ":",
+        unsafe_password,
+        "@",
+        "authority.example:443",
+        "/private?",
+        "token=",
+        unsafe_token,
+    ]
+    .concat();
+    let target = grpc_endpoint_with_dial(&unsafe_endpoint, "https://dial.example:443");
+    let subscriber = RecordingTracingSubscriber::default();
+    let dispatch = tracing::Dispatch::new(subscriber.clone());
+    let _default_guard = tracing::dispatcher::set_default(&dispatch);
+
+    let error = typed_tls_io_error(rustls::CertificateError::UnknownIssuer);
+    log_stargate_grpc_certificate_failure(&target, "watch_stargates", &error, None);
+
+    let event = subscriber
+        .events()
+        .into_iter()
+        .find(|event| {
+            event.fields.get("message").map(String::as_str)
+                == Some("Stargate gRPC connection failed")
+        })
+        .expect("failure should emit an event");
+    for unsafe_fragment in [unsafe_user, unsafe_password, unsafe_token, "/private"] {
+        assert!(
+            event
+                .fields
+                .values()
+                .all(|value| !value.contains(unsafe_fragment)),
+            "failure event exposed unsafe endpoint material: {event:?}"
+        );
+    }
+}
+
+#[test]
+fn grpc_debug_log_omits_unsafe_endpoint_userinfo_and_query() {
+    let unsafe_user = "unsafe-debug-user";
+    let unsafe_password = "unsafe-debug-password";
+    let unsafe_token = "unsafe-debug-token";
+    let unsafe_path = "/private-debug";
+    let unsafe_endpoint = format!(
+        "https://{unsafe_user}:{unsafe_password}@authority.example:443{unsafe_path}?token={unsafe_token}"
+    );
+    let target = grpc_endpoint_with_dial(&unsafe_endpoint, "https://dial.example:443");
+    let subscriber = RecordingTracingSubscriber::default();
+    let dispatch = tracing::Dispatch::new(subscriber.clone());
+    let _default_guard = tracing::dispatcher::set_default(&dispatch);
+
+    log_stargate_grpc_connect_attempt(&target, "watch_stargates", "lazy");
+
+    let event = subscriber
+        .events()
+        .into_iter()
+        .find(|event| {
+            event.fields.get("message").map(String::as_str)
+                == Some("attempting Stargate gRPC connection")
+        })
+        .expect("connection attempt should emit a debug event");
+    for unsafe_fragment in [unsafe_user, unsafe_password, unsafe_token, unsafe_path] {
+        assert!(
+            event
+                .fields
+                .values()
+                .all(|value| !value.contains(unsafe_fragment)),
+            "debug event exposed unsafe endpoint material: {event:?}"
+        );
+    }
+}
+
+#[test]
+fn grpc_certificate_failure_log_emits_when_failure_kind_changes() {
+    let target = grpc_endpoint("router.example.test:50071");
+    let subscriber = RecordingTracingSubscriber::default();
+    let dispatch = tracing::Dispatch::new(subscriber.clone());
+    let _default_guard = tracing::dispatcher::set_default(&dispatch);
+    let unknown_issuer = typed_tls_io_error(rustls::CertificateError::UnknownIssuer);
+    let hostname_mismatch = typed_tls_io_error(rustls::CertificateError::NotValidForName);
+
+    let mut last_failure = None;
+    last_failure = log_stargate_grpc_certificate_failure(
+        &target,
+        "watch_stargates",
+        &unknown_issuer,
+        last_failure,
+    );
+    last_failure = log_stargate_grpc_certificate_failure(
+        &target,
+        "watch_stargates",
+        &unknown_issuer,
+        last_failure,
+    );
+    let _ = log_stargate_grpc_certificate_failure(
+        &target,
+        "watch_stargates",
+        &hostname_mismatch,
+        last_failure,
+    );
+
+    let failure_kinds = subscriber
+        .events()
+        .into_iter()
+        .filter(|event| {
+            event.fields.get("message").map(String::as_str)
+                == Some("Stargate gRPC connection failed")
+        })
+        .filter_map(|event| event.fields.get("failure_kind").cloned())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        failure_kinds,
+        ["tls_unknown_issuer", "tls_hostname_mismatch"]
+    );
+}
+
+#[test]
+fn grpc_failure_log_ignores_certificate_words_without_a_typed_tls_error() {
+    let target = grpc_endpoint("unknownissuer-router.example.test:50071");
+    let subscriber = RecordingTracingSubscriber::default();
+    let dispatch = tracing::Dispatch::new(subscriber.clone());
+    let _default_guard = tracing::dispatcher::set_default(&dispatch);
+
+    let error = std::io::Error::other("ordinary transport failure");
+    log_stargate_grpc_certificate_failure(&target, "watch_stargates", &error, None);
+
+    assert!(
+        subscriber.events().iter().all(|event| {
+            event.fields.get("message").map(String::as_str)
+                != Some("Stargate gRPC connection failed")
+        }),
+        "certificate words in a type or endpoint name must not create a TLS validation log"
+    );
+}
+
+#[test]
+fn grpc_failure_log_classifies_other_typed_certificate_errors() {
+    let target = grpc_endpoint("router.example.test:50071");
+    let subscriber = RecordingTracingSubscriber::default();
+    let dispatch = tracing::Dispatch::new(subscriber.clone());
+    let _default_guard = tracing::dispatcher::set_default(&dispatch);
+    let error = typed_tls_io_error(rustls::CertificateError::BadSignature);
+
+    log_stargate_grpc_certificate_failure(&target, "watch_stargates", &error, None);
+
+    let event = subscriber
+        .events()
+        .into_iter()
+        .find(|event| {
+            event.fields.get("message").map(String::as_str)
+                == Some("Stargate gRPC connection failed")
+        })
+        .expect("certificate failure should emit an event");
+    assert_eq!(
+        event.fields.get("failure_kind").map(String::as_str),
+        Some("tls_chain_validation"),
+        "specific certificate failure was not classified: {event:?}"
+    );
+}
+
+#[test]
 fn stargate_grpc_origin_keeps_dial_scheme_when_authority_scheme_differs() {
     for (dial, authority, expected) in [
         (
@@ -751,6 +999,176 @@ async fn grpc_endpoint_rejects_leaf_without_external_dial_hostname() {
     assert!(
         error.contains("notvalidforname") || error.contains("not valid for name"),
         "unexpected TLS failure: {error}"
+    );
+    server.shutdown().await;
+}
+
+async fn watch_tls_failure_event(
+    server: &mut TestTlsControlPlane,
+    ca_cert_pem: Vec<u8>,
+) -> RecordedTracingEvent {
+    let (topology_tx, topology_rx) = watch::channel(RegistrationRouterTopology::default());
+    let stop = CancellationToken::new();
+    let subscriber = RecordingTracingSubscriber::default();
+    let dispatch = tracing::Dispatch::new(subscriber.clone());
+    let _default_guard = tracing::dispatcher::set_default(&dispatch);
+    let watch_task = tokio::spawn(run_watch_stargate_discovery(
+        vec![server.dial_url.clone()],
+        Some(ca_cert_pem),
+        topology_tx,
+        stop.clone(),
+    ));
+
+    let event = wait_for_registration_failure_event(&subscriber).await;
+    wait_for_tracing_event_count(&subscriber, "attempting Stargate gRPC connection", 3).await;
+    assert_eq!(
+        subscriber.event_count("Stargate gRPC connection failed"),
+        1,
+        "continuous certificate failures should be logged once until recovery"
+    );
+    assert!(
+        topology_rx.borrow().published_routers().is_none(),
+        "a certificate validation failure must not publish a registration router"
+    );
+    assert!(
+        server.watch_authorities.try_recv().is_err(),
+        "a certificate validation failure must not reach WatchStargates"
+    );
+
+    stop.cancel();
+    tokio::time::timeout(TEST_WAIT, watch_task)
+        .await
+        .expect("failed WatchStargates task should stop promptly")
+        .expect("failed WatchStargates task should not panic");
+    event
+}
+
+#[tokio::test]
+async fn watch_discovery_logs_unknown_issuer_and_remains_fail_closed() {
+    let server_ca = TestCertificateAuthority::new("server-ca");
+    let wrong_ca = TestCertificateAuthority::new("unrelated-ca");
+    let mut server = TestTlsControlPlane::spawn(&server_ca, "localhost").await;
+
+    let event = watch_tls_failure_event(&mut server, wrong_ca.pem()).await;
+
+    assert_registration_failure_event(
+        &event,
+        "watch_stargates",
+        "tls_unknown_issuer",
+        "server certificate has an unknown issuer",
+        "configured gRPC CA",
+    );
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn registration_stream_logs_unknown_issuer_and_remains_fail_closed() {
+    let server_ca = TestCertificateAuthority::new("server-ca");
+    let wrong_ca = TestCertificateAuthority::new("unrelated-ca");
+    let mut server = TestTlsControlPlane::spawn(&server_ca, "localhost").await;
+    let router_endpoint = StargateGrpcEndpoint::new(server.dial_url.clone(), "")
+        .expect("test registration endpoint should build");
+    let mut config = test_registration_config();
+    config.grpc_tls_ca_cert_pem = Some(wrong_ca.pem());
+    config.min_update_interval = Duration::from_millis(10);
+    let config = Arc::new(
+        RegistrationSessionConfig::try_from(config)
+            .expect("test registration session should build"),
+    );
+    let stop = CancellationToken::new();
+    let subscriber = RecordingTracingSubscriber::default();
+    let dispatch = tracing::Dispatch::new(subscriber.clone());
+    let _default_guard = tracing::dispatcher::set_default(&dispatch);
+    let registration_task = tokio::spawn(run_router_registration_stream(
+        router_endpoint,
+        config,
+        stop.clone(),
+    ));
+
+    let event = wait_for_registration_failure_event(&subscriber).await;
+    wait_for_tracing_event_count(&subscriber, "attempting Stargate gRPC connection", 3).await;
+
+    assert_registration_failure_event(
+        &event,
+        "register_inference_server",
+        "tls_unknown_issuer",
+        "server certificate has an unknown issuer",
+        "configured gRPC CA",
+    );
+    assert!(
+        server.registrations.try_recv().is_err(),
+        "a certificate validation failure must not reach registration"
+    );
+    assert_eq!(
+        subscriber.event_count("Stargate gRPC connection failed"),
+        1,
+        "continuous registration certificate failures should be logged once until recovery"
+    );
+    stop.cancel();
+    tokio::time::timeout(TEST_WAIT, registration_task)
+        .await
+        .expect("failed registration task should stop promptly")
+        .expect("failed registration task should not panic");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn watch_discovery_accepts_a_trusted_ca_and_matching_san_without_failure_log() {
+    let ca = TestCertificateAuthority::new("trusted-ca");
+    let mut server = TestTlsControlPlane::spawn(&ca, "localhost").await;
+    let (topology_tx, mut topology_rx) = watch::channel(RegistrationRouterTopology::default());
+    let stop = CancellationToken::new();
+    let subscriber = RecordingTracingSubscriber::default();
+    let dispatch = tracing::Dispatch::new(subscriber.clone());
+    let _default_guard = tracing::dispatcher::set_default(&dispatch);
+    let watch_task = tokio::spawn(run_watch_stargate_discovery(
+        vec![server.dial_url.clone()],
+        Some(ca.pem()),
+        topology_tx,
+        stop.clone(),
+    ));
+
+    tokio::time::timeout(TEST_WAIT, server.watch_authorities.recv())
+        .await
+        .expect("trusted WatchStargates request should not time out")
+        .expect("trusted WatchStargates request channel should remain open");
+    tokio::time::timeout(TEST_WAIT, topology_rx.changed())
+        .await
+        .expect("trusted WatchStargates topology should publish")
+        .expect("trusted WatchStargates topology channel should remain open");
+    assert!(
+        topology_rx.borrow().published_routers().is_some(),
+        "trusted WatchStargates response should publish registration routers"
+    );
+    assert!(
+        subscriber.events().iter().all(|event| {
+            event.fields.get("message").map(String::as_str)
+                != Some("Stargate gRPC connection failed")
+        }),
+        "trusted WatchStargates connection should not emit a failure event"
+    );
+
+    stop.cancel();
+    tokio::time::timeout(TEST_WAIT, watch_task)
+        .await
+        .expect("trusted WatchStargates task should stop promptly")
+        .expect("trusted WatchStargates task should not panic");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn watch_discovery_logs_certificate_san_mismatch_and_remains_fail_closed() {
+    let ca = TestCertificateAuthority::new("trusted-ca");
+    let mut server = TestTlsControlPlane::spawn(&ca, "not-localhost.invalid").await;
+
+    let event = watch_tls_failure_event(&mut server, ca.pem()).await;
+
+    assert_registration_failure_event(
+        &event,
+        "watch_stargates",
+        "tls_hostname_mismatch",
+        "server certificate SAN does not match the dial hostname",
+        "certificate SAN",
     );
     server.shutdown().await;
 }

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/test_support.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/test_support.rs
@@ -13,11 +13,156 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
 use std::ops::Deref;
+use std::sync::{Arc, Mutex};
 
 use axum::Router;
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
+
+#[derive(Clone, Debug)]
+pub(crate) struct RecordedTracingEvent {
+    pub(crate) level: tracing::Level,
+    pub(crate) fields: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct RecordingTracingSubscriber {
+    events: Arc<Mutex<Vec<RecordedTracingEvent>>>,
+}
+
+impl RecordingTracingSubscriber {
+    pub(crate) fn events(&self) -> Vec<RecordedTracingEvent> {
+        self.events
+            .lock()
+            .expect("recorded tracing events should not be poisoned")
+            .clone()
+    }
+
+    pub(crate) fn take_events(&self) -> Vec<RecordedTracingEvent> {
+        std::mem::take(
+            &mut *self
+                .events
+                .lock()
+                .expect("recorded tracing events should not be poisoned"),
+        )
+    }
+
+    pub(crate) fn event_count(&self, message: &str) -> usize {
+        self.events
+            .lock()
+            .expect("recorded tracing events should not be poisoned")
+            .iter()
+            .filter(|event| event.fields.get("message").map(String::as_str) == Some(message))
+            .count()
+    }
+}
+
+pub(crate) fn tracing_event_by_message<'a>(
+    events: &'a [RecordedTracingEvent],
+    message: &str,
+) -> &'a RecordedTracingEvent {
+    events
+        .iter()
+        .find(|event| event.fields.get("message").map(String::as_str) == Some(message))
+        .unwrap_or_else(|| panic!("missing tracing event {message:?}"))
+}
+
+pub(crate) fn assert_tracing_event_field(
+    event: &RecordedTracingEvent,
+    field: &str,
+    expected: &str,
+) {
+    assert_eq!(
+        event.fields.get(field).map(String::as_str),
+        Some(expected),
+        "unexpected {field} field in {event:?}"
+    );
+}
+
+impl tracing::Subscriber for RecordingTracingSubscriber {
+    fn enabled(&self, metadata: &tracing::Metadata<'_>) -> bool {
+        metadata.level() <= &tracing::Level::DEBUG
+    }
+
+    fn max_level_hint(&self) -> Option<tracing::metadata::LevelFilter> {
+        Some(tracing::metadata::LevelFilter::DEBUG)
+    }
+
+    fn new_span(&self, _attrs: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+
+    fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
+
+    fn event(&self, event: &tracing::Event<'_>) {
+        let mut visitor = RecordingTracingFieldVisitor::default();
+        event.record(&mut visitor);
+        self.events
+            .lock()
+            .expect("recorded tracing events should not be poisoned")
+            .push(RecordedTracingEvent {
+                level: *event.metadata().level(),
+                fields: visitor.fields,
+            });
+    }
+
+    fn enter(&self, _span: &tracing::span::Id) {}
+
+    fn exit(&self, _span: &tracing::span::Id) {}
+}
+
+#[derive(Default)]
+struct RecordingTracingFieldVisitor {
+    fields: BTreeMap<String, String>,
+}
+
+impl tracing::field::Visit for RecordingTracingFieldVisitor {
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.fields
+            .insert(field.name().to_string(), format!("{value:?}"));
+    }
+}
+
+#[test]
+fn recording_tracing_subscriber_records_debug_but_not_trace_events() {
+    let subscriber = RecordingTracingSubscriber::default();
+    let dispatch = tracing::Dispatch::new(subscriber.clone());
+    let _default_guard = tracing::dispatcher::set_default(&dispatch);
+
+    tracing::trace!("trace event");
+    tracing::debug!("debug event");
+
+    let messages = subscriber
+        .events()
+        .into_iter()
+        .filter_map(|event| event.fields.get("message").cloned())
+        .collect::<Vec<_>>();
+    assert_eq!(messages, ["debug event"]);
+}
 
 pub(crate) struct TestHttpServer {
     base_url: String,


### PR DESCRIPTION
## TL;DR

Emit an actionable, structured error when verified TLS blocks Pylon Stargate discovery or registration, while preserving fail-closed behavior.

## Additional Details

Pylon previously discarded `WatchStargates` and registration connection errors. Certificate verification correctly rejected untrusted peers, but operators received no explanation before reverse-tunnel setup.

This change walks the typed tonic/io/rustls error chain and classifies only certificate-validation errors: unknown issuer, hostname mismatch, or another chain-validation failure. It uses a small `thiserror` enum for fixed, operator-safe messages and as the retry de-duplication key; no debug-string or substring matching remains. The log includes the affected operation, parsed host/port metadata, a fixed reason, and corrective action once per continuous failure kind. Successful communication resets suppression, and a changed certificate failure kind is logged immediately.

Trust roots and TLS verification are unchanged. Raw errors, raw endpoints, endpoint userinfo and queries, PEM/DER data, private keys, and tokens are never logged. Ordinary transport, RPC, authentication, and configuration errors retain their existing behavior.

Regression coverage exercises unrelated-CA rejection, trusted CA with matching SAN, SAN-mismatch rejection, both discovery and registration paths, continued retries with de-duplicated logs, changed failure kinds, typed false-positive rejection, and error/debug log sanitization.

## For the Reviewer

Please focus on the typed rustls extraction in `grpc_endpoint.rs`, and the per-failure-kind suppression state in `discovery.rs` and `router_stream.rs`.

## Validation

- `cargo test -p pylon-lib`: 397 unit tests and 2 public API tests passed.
- Focused registration tests: 38/38 passed.
- `cargo clippy -p pylon-lib --all-targets -- -D warnings -A clippy::err-expect`: passed. The allowance covers one pre-existing unchanged test lint.
- `cargo fmt -p pylon-lib -- --check`: passed.
- `git diff --check origin/main...HEAD`: passed.
- Independent final YAGNI/KISS review of rebased commit `a53cc5a1`: no blocking or important findings.

No full k3d installation was run because the focused tests perform real TLS handshakes and establish both fail-closed and successful behavior directly.

## Issues

Relates to #1292

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics for Stargate certificate and TLS connection failures.
  * Identifies unknown certificate issuers, hostname mismatches, and certificate-chain validation failures.
  * Provides actionable, structured error details while protecting sensitive connection information.
  * Prevents repeated failure messages during retry cycles and resumes reporting after recovery.
  * Preserves existing retry, reconnection, and cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->