### PR TITLE
feat(stack): surface NATS server-side TLS in self-managed stack

### DIFF
--- a/deploy/stacks/self-managed/Makefile
+++ b/deploy/stacks/self-managed/Makefile
@@ -23,6 +23,7 @@ test:
 	@tests/api-env-wiring.sh
 	@tests/apikeys-env-wiring.sh
 	@tests/nats-placement-tags.sh
+	@tests/nats-tls-wiring.sh
 
 test-published-charts:
 	@: "$${NVCF_PUBLISHED_CHART_REGISTRY:?NVCF_PUBLISHED_CHART_REGISTRY is required}"

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -208,6 +208,14 @@ nats:
       server_tags:
         - "dc:ncp"
         - "aws-region:ncp"
+      # Split-plane server TLS: workers reach NATS over an L4-passthrough LB, so
+      # TLS terminates at the server; allow_non_tls keeps in-cluster plaintext
+      # clients on :4222. Both default off.
+      # allow_non_tls: true
+    # nats:
+    #   tls:
+    #     enabled: true
+    #     secretName: nats-server-tls   # cert-manager-issued
   # Image overrides for the NATS config reloader. The reloader is not
   # republished under the public nvidia/nvcf catalog, so it defaults to its
   # upstream source, docker.io/natsio/nats-server-config-reloader:0.23.0.

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -208,14 +208,29 @@ nats:
       server_tags:
         - "dc:ncp"
         - "aws-region:ncp"
-      # Split-plane server TLS: workers reach NATS over an L4-passthrough LB, so
-      # TLS terminates at the server; allow_non_tls keeps in-cluster plaintext
-      # clients on :4222. Both default off.
+      # --- Split-plane server TLS (optional; both settings default off) ---
+      # Use case: when GPU workers run outside the cluster they reach NATS over
+      # an L4 (TCP) passthrough load balancer, so TLS must terminate at the NATS
+      # server itself -- an LB can't terminate it because the NATS client is
+      # INFO-first (the server speaks first) and a terminated handshake deadlocks.
+      # Set the two knobs below to serve TLS from NATS to those workers.
+      #
+      # Gotchas:
+      #   1. allow_non_tls is mixed-mode: the server then accepts BOTH TLS and
+      #      plaintext on :4222. Enable it only intentionally -- it lets in-cluster
+      #      plaintext clients keep connecting while remote workers use TLS. Leave
+      #      it off if every client can speak TLS.
+      #   2. Changing allow_non_tls (or the tls block) requires a NATS
+      #      restart/rollout to take effect.
+      #   3. The cert in secretName must have a SAN covering the exact hostname the
+      #      external workers connect to (the LB / public NATS hostname), and those
+      #      workers must trust the issuing CA and use a TLS-capable NATS client
+      #      config.
       # allow_non_tls: true
     # nats:
     #   tls:
     #     enabled: true
-    #     secretName: nats-server-tls   # cert-manager-issued
+    #     secretName: nats-server-tls   # cert-manager-issued; SAN = external NATS hostname
   # Image overrides for the NATS config reloader. The reloader is not
   # republished under the public nvidia/nvcf catalog, so it defaults to its
   # upstream source, docker.io/natsio/nats-server-config-reloader:0.23.0.

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -247,15 +247,31 @@ nats:
         {{- end }}
   {{- end }}
 
+  # One merged config: block -- a second config: key under nats: would be
+  # silently collapsed. Surfaces server TLS for split-plane workers that reach
+  # NATS over an L4-passthrough LB: TLS must terminate at the server (an LB
+  # can't -- the INFO-first client deadlocks a terminated handshake), and
+  # allow_non_tls keeps in-cluster plaintext clients on :4222. Emitted only when
+  # set, so an env file that sets neither renders identical.
+  {{- $natsTls := dig "nats" "config" "nats" "tls" dict .Values }}
+  {{- $allowNonTls := dig "nats" "config" "merge" "allow_non_tls" nil .Values }}
   config:
     merge:
       server_tags:
         {{- toYaml $natsServerTags | nindent 8 }}
+      {{- if kindIs "bool" $allowNonTls }}
+      allow_non_tls: {{ $allowNonTls }}
+      {{- end }}
     {{- if .Values.global.storageClass }}
     jetstream:
       fileStore:
         pvc:
           storageClassName: {{ .Values.global.storageClass }}
+    {{- end }}
+    {{- with $natsTls }}
+    nats:
+      tls:
+        {{- toYaml . | nindent 8 }}
     {{- end }}
 
   {{- with dig "nats" "podDisruptionBudget" dict .Values }}

--- a/deploy/stacks/self-managed/tests/nats-tls-wiring.sh
+++ b/deploy/stacks/self-managed/tests/nats-tls-wiring.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Test that NATS server-side TLS threads from environments/<env>.yaml through
+# global.yaml.gotmpl into the nats release values. The nats release's chart
+# values are only global.yaml.gotmpl + secrets/<env>-secrets.yaml, so server
+# TLS has to be re-emitted from the nats: block. It lives in a single merged
+# config: block (a second config: key under nats: would collapse), so this
+# guards two things: (a) nats.config.nats.tls and nats.config.merge.allow_non_tls
+# thread through when set, and (b) adding allow_non_tls next to server_tags does
+# not clobber server_tags. Unset renders no tls / no allow_non_tls (default off).
+set -euo pipefail
+
+stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+stacks_dir="$(cd "$stack_dir/.." && pwd)"
+work_dir="$(mktemp -d)"
+test_stacks_dir="$work_dir/stacks"
+test_stack_dir="$test_stacks_dir/self-managed"
+environment_name="nats-tls-wiring-test"
+environment_file="$test_stack_dir/environments/$environment_name.yaml"
+secrets_file="$test_stack_dir/secrets/$environment_name-secrets.yaml"
+trap 'rm -rf "$work_dir"' EXIT
+
+fail() {
+  echo "nats-tls-wiring: $*" >&2
+  exit 1
+}
+
+# Copy the whole stacks directory: the self-managed helmfile.d reaches a sibling
+# stack through a relative path, so self-managed alone is not a working stack.
+mkdir -p "$test_stacks_dir"
+cp -R "$stacks_dir"/. "$test_stacks_dir"
+mkdir -p "$(dirname "$secrets_file")"
+printf '{}\n' >"$secrets_file"
+
+# Each stack the copy reaches resolves ../environments/$HELMFILE_ENV.yaml
+# against its own directory, so every one needs a file under this env name.
+for stack_environments in "$test_stacks_dir"/*/environments; do
+  test -d "$stack_environments" || continue
+  test -e "$stack_environments/$environment_name.yaml" ||
+    printf '{}\n' >"$stack_environments/$environment_name.yaml"
+done
+
+helmfile_common=(
+  --file "$test_stack_dir/helmfile.d"
+  --environment default
+  --state-values-set ingress.gatewayApi.controllerNamespace=envoy-gateway-system
+  --state-values-set ingress.gatewayApi.gateways.shared.name=shared-gw
+  --state-values-set ingress.gatewayApi.gateways.shared.namespace=envoy-gateway-system
+  --state-values-set ingress.gatewayApi.gateways.grpc.name=grpc-gw
+  --state-values-set ingress.gatewayApi.gateways.grpc.namespace=envoy-gateway-system
+)
+
+render_nats_values() {
+  local output_file="$1"
+  local render_log="$work_dir/nats-write-values.log"
+  if ! HELMFILE_ENV="$environment_name" HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" \
+    helmfile "${helmfile_common[@]}" \
+      --selector name=nats \
+      write-values \
+      --output-file-template "$output_file" 2>"$render_log"; then
+    cat "$render_log" >&2
+    fail "nats: helmfile could not render the stack"
+  fi
+  test -s "$output_file" || fail "nats: helmfile wrote no values to $output_file"
+}
+
+write_env() {
+  cat >"$environment_file"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Default: no TLS set. server_tags stays, no tls, no allow_non_tls.
+# ---------------------------------------------------------------------------
+write_env <<'EOF'
+global:
+  image:
+    registry: nvcr.io
+    repository: test/nvcf
+EOF
+
+default_values="$work_dir/nats-default-values.yaml"
+render_nats_values "$default_values"
+[[ "$(yq -r '.nats.config.nats.tls' "$default_values")" == null ]] ||
+  fail "default: nats.config.nats.tls must not be emitted when unset"
+[[ "$(yq -r '.nats.config.merge.allow_non_tls' "$default_values")" == null ]] ||
+  fail "default: nats.config.merge.allow_non_tls must not be emitted when unset"
+[[ "$(yq -r '.nats.config.merge.server_tags | length' "$default_values")" == 2 ]] ||
+  fail "default: nats.config.merge.server_tags must be preserved"
+
+# ---------------------------------------------------------------------------
+# 2. Override: server TLS + allow_non_tls thread through, and adding
+#    allow_non_tls next to server_tags does not drop server_tags.
+# ---------------------------------------------------------------------------
+write_env <<'EOF'
+global:
+  image:
+    registry: nvcr.io
+    repository: test/nvcf
+nats:
+  config:
+    nats:
+      tls:
+        enabled: true
+        secretName: nats-server-tls
+    merge:
+      allow_non_tls: true
+EOF
+
+override_values="$work_dir/nats-tls-values.yaml"
+render_nats_values "$override_values"
+yq -e '.nats.config.nats.tls.enabled == true' "$override_values" >/dev/null ||
+  fail "override: nats.config.nats.tls.enabled did not reach chart values"
+[[ "$(yq -r '.nats.config.nats.tls.secretName' "$override_values")" == nats-server-tls ]] ||
+  fail "override: nats.config.nats.tls.secretName did not reach chart values"
+yq -e '.nats.config.merge.allow_non_tls == true' "$override_values" >/dev/null ||
+  fail "override: nats.config.merge.allow_non_tls did not reach chart values"
+[[ "$(yq -r '.nats.config.merge.server_tags | length' "$override_values")" == 2 ]] ||
+  fail "override: server_tags must survive alongside allow_non_tls"
+
+# ---------------------------------------------------------------------------
+# 3. allow_non_tls: false is honored (explicit bool, not just truthy).
+# ---------------------------------------------------------------------------
+write_env <<'EOF'
+global:
+  image:
+    registry: nvcr.io
+    repository: test/nvcf
+nats:
+  config:
+    merge:
+      allow_non_tls: false
+EOF
+
+false_values="$work_dir/nats-allow-false-values.yaml"
+render_nats_values "$false_values"
+yq -e '.nats.config.merge.allow_non_tls == false' "$false_values" >/dev/null ||
+  fail "explicit false: nats.config.merge.allow_non_tls: false did not reach chart values"
+
+echo "nats-tls-wiring: all checks passed"


### PR DESCRIPTION
## Summary

Surface NATS **server-side TLS** in the self-managed stack so it can be enabled from `environments/<env>.yaml` (via `nats.config.nats.tls` + `nats.config.merge.allow_non_tls`), instead of only by misusing the secrets file or patching `global.yaml.gotmpl`. Both knobs default off, so existing installs render byte-identical.

## Additional Details

The `nats` release's chart values are only `../global.yaml.gotmpl` + `../secrets/<env>-secrets.yaml` — the environment file is **not** in the release's `values:` list, so it reaches the release only where `global.yaml.gotmpl` re-emits it via `dig … .Values`. The `nats:` block wired `reloader.image`, `podDisruptionBudget`, and a storageClass-gated `config:` block, but had **no** passthrough for `config.nats.tls` / `config.merge.allow_non_tls`. Net effect: a `nats.config.nats.tls` value in `environments/<env>.yaml` was silently dropped and NATS started with no cert — which the INFO-first worker client experiences as a silent hang, not an error.

This matters for split-plane deployments (workers outside the control-plane cluster reaching NATS over a public, L4-passthrough load balancer): TLS must terminate at the NATS **server**, because an LB cannot — the INFO-first client deadlocks an LB-terminated handshake. `allow_non_tls: true` keeps in-cluster plaintext clients working on the same `:4222`.

Fix — add the passthrough as per-field `dig` into the **single** existing `config:` block (a second `config:` key under `nats:` would be silently collapsed to the last one, dropping the block):

- `deploy/stacks/self-managed/global.yaml.gotmpl` — surface `config.nats.tls` (emitted only `with` a value) and `config.merge.allow_non_tls` (emitted only when an explicit bool), folded into the existing `config:` block next to `server_tags` and the storageClass `jetstream` override.
- `deploy/stacks/self-managed/environments/base.yaml` — document the two knobs as commented examples (so they don't materialize).
- `deploy/stacks/self-managed/tests/nats-tls-wiring.sh` — new wiring test, registered in the `Makefile`.

Operators then set it in `environments/<env>.yaml`:

```yaml
nats:
  config:
    nats:
      tls:
        enabled: true
        secretName: nats-server-tls   # cert-manager-issued, publicly trusted
    merge:
      allow_non_tls: true
```

## For the Reviewer

- **Default-off / backward-compatible:** `tls` uses `with` and `allow_non_tls` uses `kindIs "bool"`, so the stack never invents a default — an env file that sets neither renders byte-identical, and the chart's own default applies.
- **Convention:** this is the per-field `dig` pattern already used in this file (`reloader.image`, `podDisruptionBudget`, `startupProbe`, and the `apiKeys`/`sis`/`reval` route flags), rather than a whole-subtree merge — it keeps the override surface tight and stack-owned.
- **Single-block requirement:** everything stays in one `config:` block on purpose; a second `config:` (or `merge:`) key collapses silently, which is why `allow_non_tls` nests under the existing `merge` next to `server_tags`.
- **Auth-callout preserved:** the stack only emits `merge.server_tags` (+ optional `allow_non_tls`); Helm deep-merges the chart's `config.merge.accounts`/`authorization` underneath, unchanged.

## For QA

**Automated test (`make test`).** Added `deploy/stacks/self-managed/tests/nats-tls-wiring.sh`, wired into the offline `make test` target next to `nats-placement-tags.sh`. Following the existing value-wiring pattern (`pdb-value-wiring.sh`), it renders the `nats` release values with `helmfile write-values` and asserts via `yq`:
- **default (unset):** no `config.nats.tls`, no `config.merge.allow_non_tls`, and `server_tags` preserved;
- **override:** `config.nats.tls.{enabled,secretName}` and `config.merge.allow_non_tls: true` thread through, and `server_tags` survives alongside `allow_non_tls` (guards the single-block collapse);
- **explicit `false`:** `config.merge.allow_non_tls: false` is honored (explicit bool, not just truthy).

**Manual verification.**
- **Byte-identical default:** rendered the `nats` release values on this branch vs `origin/main` with a default env — a raw `diff` is empty for both the no-storageClass and `storageClass=gp3` cases, confirming no change when the knobs are unset.
- **Wrapper-chart render:** rendered the real `helm-nvcf-nats` chart (+ synadia `nats` subchart) `nats.conf` ConfigMap:
  - *override* → the client `:4222` listener carries `tls { cert_file, key_file }` and `allow_non_tls: true`, with `server_tags` and the `auth_callout` accounts preserved;
  - *default* → no `tls` and no `allow_non_tls`; `server_tags` and `auth_callout` intact.
- **Neighbors:** `nats-placement-tags.sh` and `pdb-value-wiring.sh` still pass.

## Issues

Fixes #1342

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for DCO compliance.
- [x] New or existing tests cover these changes. <!-- added tests/nats-tls-wiring.sh (offline `make test`); also verified via byte-identical origin/main diff + helm template of the nats.conf ConfigMap (default vs override) -->
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional NATS TLS configuration for self-managed deployments.
  * Added support for allowing or disabling non-TLS client connections.
  * Added guidance for split-plane TLS, certificates, CA trust, and TLS-capable clients.

* **Tests**
  * Added integration coverage for default, enabled, and disabled non-TLS behavior.
  * Verified TLS settings and existing server tags are preserved during configuration rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->