### PR TITLE
fix(stargate): aggregate shared-cluster request stats

### DIFF
--- a/src/libraries/rust/stargate/crates/proto/proto/stargate.proto
+++ b/src/libraries/rust/stargate/crates/proto/proto/stargate.proto
@@ -73,12 +73,10 @@ message ListModelsResponse {
 }
 
 message ModelStats {
-  // Aggregation note for multi-backend clusters: Stargate currently aggregates
-  // backend-scoped fields below across active backends that share a
-  // `cluster_id` according to each field's semantics, and takes the latest
-  // active backend snapshot for the cluster-scoped fields below. This is
-  // routing policy, not a permanent API contract; individual fields may move
-  // between sections if the reported semantics change.
+  // For active backends that share a cluster_id, Stargate sums request-local
+  // rates and gauges, takes the maximum max_output_tps, combines priority queue
+  // estimates using input-throughput weighting, and sources shared engine state
+  // from one backend.
 
   // Sticky last valid mean input TPS for this backend observation. Stargate
   // never receives live/raw input TPS. For shared clusters, active backend
@@ -94,24 +92,23 @@ message ModelStats {
   // value, add a new field rather than overloading `queued_input_size`.
   uint64 queued_input_size = 4;
 
-  // Cluster-scoped shared-hardware/scheduler state.
+  // Maximum observed output TPS used as fallback routing capacity.
   double max_output_tps = 5;
+  // Cluster-scoped shared engine state. These fields are not summed.
   uint64 kv_cache_capacity_tokens = 6;
   uint64 kv_cache_used_tokens = 7;
   uint64 kv_cache_free_tokens = 8;
-  // Current number of model requests consuming scheduling capacity in the
-  // underlying cluster. Stargate currently treats this as latest-wins across
-  // active backends that share a `cluster_id`.
+  // Current number of requests handled by this backend.
   uint64 num_running_queries = 9;
   // Cluster scheduler concurrency capacity. A value of 0 means the backend did
   // not report this metric; routers should not apply the full-backend admission
   // filter.
   uint64 max_engine_concurrency = 10;
-  // Sum of input tokens across active/queued requests for this model in the
-  // underlying cluster.
+  // Sum of input tokens across requests handled by this backend.
   uint64 total_query_input_size = 11;
-  // Cluster queue-time estimates keyed by request priority. When populated,
-  // priority-aware routers should prefer this over aggregate queue work.
+  // Backend queue-time estimates keyed by request priority. When populated,
+  // priority-aware routers should prefer the cluster aggregate of this map over
+  // aggregate queue work.
   map<uint32, uint64> queue_time_estimate_ms_by_priority = 12;
   // Number of live requests still in input/prefill processing.
   uint64 input_processing_queries = 13;

--- a/src/libraries/rust/stargate/crates/stargate/src/routing_state/cluster_snapshots.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/routing_state/cluster_snapshots.rs
@@ -68,8 +68,8 @@ fn has_queued_work(stats: &ModelStats) -> bool {
 
 fn checked_ceil_u64(value: f64) -> Option<u64> {
     let rounded = value.ceil();
-    // `u64::MAX as f64` rounds to 2^64, which is already outside u64.
-    (rounded.is_finite() && rounded >= 0.0 && rounded < u64::MAX as f64).then_some(rounded as u64)
+    // `u64::MAX as f64` rounds to 2^64, so the cast must saturate that boundary.
+    (rounded.is_finite() && rounded >= 0.0 && rounded <= u64::MAX as f64).then_some(rounded as u64)
 }
 
 fn proxy_local_priority_map(backends: &[Arc<RoutedInferenceServerSnapshot>]) -> HashMap<u32, u64> {
@@ -120,11 +120,11 @@ fn proxy_local_priority_map(backends: &[Arc<RoutedInferenceServerSnapshot>]) -> 
                     } else {
                         0
                     };
-                    input_tps * wait_ms as f64
+                    (input_tps / input_tps_sum) * wait_ms as f64
                 })
             })
             .sum::<f64>();
-        let Some(weighted_wait_ms) = checked_ceil_u64(weighted_wait_sum / input_tps_sum) else {
+        let Some(weighted_wait_ms) = checked_ceil_u64(weighted_wait_sum) else {
             return HashMap::new();
         };
         aggregate.insert(priority, weighted_wait_ms);

--- a/src/libraries/rust/stargate/crates/stargate/src/routing_state/cluster_snapshots.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/routing_state/cluster_snapshots.rs
@@ -31,31 +31,11 @@ use super::snapshots::{
     RoutedClusterSnapshot, RoutedClusterState, RoutedInferenceServerSnapshot,
 };
 
-const PROXY_LOCAL_REQUEST_LOAD_CAPABILITY: &str = "request.load.proxy_local";
-
-fn set_legacy_source_stats(stats: &mut ModelStats, src: &ModelStats) {
-    stats.max_output_tps = src.max_output_tps;
-    stats.kv_cache_capacity_tokens = src.kv_cache_capacity_tokens;
-    stats.kv_cache_used_tokens = src.kv_cache_used_tokens;
-    stats.kv_cache_free_tokens = src.kv_cache_free_tokens;
-    stats.num_running_queries = src.num_running_queries;
-    stats.max_engine_concurrency = src.max_engine_concurrency;
-    stats.total_query_input_size = src.total_query_input_size;
-    stats.queue_time_estimate_ms_by_priority = src.queue_time_estimate_ms_by_priority.clone();
-}
-
 fn set_shared_engine_stats(stats: &mut ModelStats, src: &ModelStats) {
     stats.kv_cache_capacity_tokens = src.kv_cache_capacity_tokens;
     stats.kv_cache_used_tokens = src.kv_cache_used_tokens;
     stats.kv_cache_free_tokens = src.kv_cache_free_tokens;
     stats.max_engine_concurrency = src.max_engine_concurrency;
-}
-
-fn has_proxy_local_request_load(stats: &ModelStats) -> bool {
-    stats
-        .stats_capabilities
-        .iter()
-        .any(|capability| capability == PROXY_LOCAL_REQUEST_LOAD_CAPABILITY)
 }
 
 fn valid_output_tps(output_tps: f64) -> bool {
@@ -66,7 +46,7 @@ fn has_queued_work(stats: &ModelStats) -> bool {
     stats.queue_size > 0 || stats.queued_input_size > 0
 }
 
-fn proxy_local_wait_ms(stats: &ModelStats, priority: u32) -> u64 {
+fn backend_wait_ms(stats: &ModelStats, priority: u32) -> u64 {
     if has_queued_work(stats) {
         crate::queue_estimate::priority_map_estimate_ms_for_priority(stats, priority)
             .unwrap_or_default()
@@ -75,7 +55,7 @@ fn proxy_local_wait_ms(stats: &ModelStats, priority: u32) -> u64 {
     }
 }
 
-fn proxy_local_priority_map(backends: &[Arc<RoutedInferenceServerSnapshot>]) -> HashMap<u32, u64> {
+fn aggregate_priority_map(backends: &[Arc<RoutedInferenceServerSnapshot>]) -> HashMap<u32, u64> {
     if backends.len() == 1 {
         return backends[0].stats.queue_time_estimate_ms_by_priority.clone();
     }
@@ -118,7 +98,7 @@ fn proxy_local_priority_map(backends: &[Arc<RoutedInferenceServerSnapshot>]) -> 
                 if !valid_last_mean_input_tps(input_tps) {
                     return None;
                 }
-                let wait_ms = proxy_local_wait_ms(&backend.stats, priority);
+                let wait_ms = backend_wait_ms(&backend.stats, priority);
                 min_wait_ms = min_wait_ms.min(wait_ms);
                 max_wait_ms = max_wait_ms.max(wait_ms);
                 Some(input_tps * wait_ms as f64)
@@ -188,61 +168,46 @@ impl ClusterRoutingGeneration {
             .is_ok_and(|index| Arc::ptr_eq(&self.backends[index].registration, registration))
     }
 
-    fn backend_aggregate(&self) -> Option<(ModelStats, Duration, usize, bool)> {
+    fn backend_aggregate(&self) -> Option<(ModelStats, Duration, usize)> {
         let active_backend_count = self.backends.len();
         if active_backend_count == 0 {
             return None;
         }
-        let proxy_local_request_load = self
-            .backends
-            .iter()
-            .all(|backend| has_proxy_local_request_load(&backend.stats));
         let backend_count = active_backend_count as u128;
         let mut backend_stats = ModelStats::default();
         let mut rtt_mean_nanos = 0_u128;
         let mut rtt_remainder_nanos = 0_u128;
 
         for backend in &self.backends {
-            if proxy_local_request_load {
-                if valid_last_mean_input_tps(backend.stats.last_mean_input_tps) {
-                    backend_stats.last_mean_input_tps += backend.stats.last_mean_input_tps;
-                }
-                if valid_output_tps(backend.stats.output_tps) {
-                    backend_stats.output_tps += backend.stats.output_tps;
-                }
-                if valid_output_tps(backend.stats.max_output_tps) {
-                    backend_stats.max_output_tps = backend_stats
-                        .max_output_tps
-                        .max(backend.stats.max_output_tps);
-                }
-                backend_stats.queue_size = backend_stats
-                    .queue_size
-                    .saturating_add(backend.stats.queue_size);
-                backend_stats.queued_input_size = backend_stats
-                    .queued_input_size
-                    .saturating_add(backend.stats.queued_input_size);
-                backend_stats.num_running_queries = backend_stats
-                    .num_running_queries
-                    .saturating_add(backend.stats.num_running_queries);
-                backend_stats.total_query_input_size = backend_stats
-                    .total_query_input_size
-                    .saturating_add(backend.stats.total_query_input_size);
-                backend_stats.input_processing_queries = backend_stats
-                    .input_processing_queries
-                    .saturating_add(backend.stats.input_processing_queries);
-                backend_stats.output_generation_queries = backend_stats
-                    .output_generation_queries
-                    .saturating_add(backend.stats.output_generation_queries);
-            } else {
-                backend_stats.output_tps += backend.stats.output_tps;
-                if valid_last_mean_input_tps(backend.stats.last_mean_input_tps) {
-                    backend_stats.last_mean_input_tps += backend.stats.last_mean_input_tps;
-                }
-                backend_stats.queue_size += backend.stats.queue_size;
-                backend_stats.queued_input_size += backend.stats.queued_input_size;
-                backend_stats.input_processing_queries += backend.stats.input_processing_queries;
-                backend_stats.output_generation_queries += backend.stats.output_generation_queries;
+            if valid_last_mean_input_tps(backend.stats.last_mean_input_tps) {
+                backend_stats.last_mean_input_tps += backend.stats.last_mean_input_tps;
             }
+            if valid_output_tps(backend.stats.output_tps) {
+                backend_stats.output_tps += backend.stats.output_tps;
+            }
+            if valid_output_tps(backend.stats.max_output_tps) {
+                backend_stats.max_output_tps = backend_stats
+                    .max_output_tps
+                    .max(backend.stats.max_output_tps);
+            }
+            backend_stats.queue_size = backend_stats
+                .queue_size
+                .saturating_add(backend.stats.queue_size);
+            backend_stats.queued_input_size = backend_stats
+                .queued_input_size
+                .saturating_add(backend.stats.queued_input_size);
+            backend_stats.num_running_queries = backend_stats
+                .num_running_queries
+                .saturating_add(backend.stats.num_running_queries);
+            backend_stats.total_query_input_size = backend_stats
+                .total_query_input_size
+                .saturating_add(backend.stats.total_query_input_size);
+            backend_stats.input_processing_queries = backend_stats
+                .input_processing_queries
+                .saturating_add(backend.stats.input_processing_queries);
+            backend_stats.output_generation_queries = backend_stats
+                .output_generation_queries
+                .saturating_add(backend.stats.output_generation_queries);
             backend_stats.stats_observed_at_unix_ms = backend_stats
                 .stats_observed_at_unix_ms
                 .max(backend.stats.stats_observed_at_unix_ms);
@@ -264,16 +229,13 @@ impl ClusterRoutingGeneration {
             rtt_remainder_nanos %= backend_count;
         }
 
-        if proxy_local_request_load {
-            if !backend_stats.last_mean_input_tps.is_finite() {
-                backend_stats.last_mean_input_tps = 0.0;
-            }
-            if !backend_stats.output_tps.is_finite() {
-                backend_stats.output_tps = 0.0;
-            }
-            backend_stats.queue_time_estimate_ms_by_priority =
-                proxy_local_priority_map(&self.backends);
+        if !backend_stats.last_mean_input_tps.is_finite() {
+            backend_stats.last_mean_input_tps = 0.0;
         }
+        if !backend_stats.output_tps.is_finite() {
+            backend_stats.output_tps = 0.0;
+        }
+        backend_stats.queue_time_estimate_ms_by_priority = aggregate_priority_map(&self.backends);
 
         // The loop maintains backend_count * mean + remainder = processed sum,
         // so the final mean is floor(total / backend_count). It cannot exceed
@@ -283,43 +245,28 @@ impl ClusterRoutingGeneration {
             (rtt_mean_nanos % 1_000_000_000) as u32,
         );
 
-        Some((
-            backend_stats,
-            rtt,
-            active_backend_count,
-            proxy_local_request_load,
-        ))
+        Some((backend_stats, rtt, active_backend_count))
     }
 
     fn refresh_snapshot(&mut self, updated_backend_id: Option<&str>) {
-        let Some((backend_stats, rtt, active_backend_count, proxy_local_request_load)) =
-            self.backend_aggregate()
-        else {
+        let Some((backend_stats, rtt, active_backend_count)) = self.backend_aggregate() else {
             self.snapshot_state = None;
             return;
         };
         if self.snapshot_state.is_none() && updated_backend_id.is_none() {
             return;
         }
-        let source_is_eligible = |index: usize| {
-            proxy_local_request_load || !has_proxy_local_request_load(&self.backends[index].stats)
-        };
         let source_backend_index = updated_backend_id
             .and_then(|backend_id| backend_index(&self.backends, backend_id).ok())
-            .filter(|index| source_is_eligible(*index))
             .or_else(|| {
-                self.snapshot_state
-                    .as_ref()
-                    .and_then(|state| {
-                        backend_index(&self.backends, &state.cluster_stats_source_backend_id).ok()
-                    })
-                    .filter(|index| source_is_eligible(*index))
+                self.snapshot_state.as_ref().and_then(|state| {
+                    backend_index(&self.backends, &state.cluster_stats_source_backend_id).ok()
+                })
             })
             .or_else(|| {
                 self.backends
                     .iter()
                     .enumerate()
-                    .filter(|(index, _)| source_is_eligible(*index))
                     .max_by_key(|(_, backend)| backend.snapshot_updated_at)
                     .map(|(index, _)| index)
             })
@@ -340,11 +287,7 @@ impl ClusterRoutingGeneration {
                 .retain(|pending| pending.inference_server_id != updated_backend_id);
         }
         let mut stats = backend_stats;
-        if proxy_local_request_load {
-            set_shared_engine_stats(&mut stats, &source_backend.stats);
-        } else {
-            set_legacy_source_stats(&mut stats, &source_backend.stats);
-        }
+        set_shared_engine_stats(&mut stats, &source_backend.stats);
         let base_snapshot = RoutedClusterSnapshot {
             cluster_id: source_backend.cluster_id.clone(),
             stats,
@@ -491,9 +434,6 @@ impl RoutedClusterState {
 
     #[cfg(test)]
     pub(super) fn backend_aggregate(&self) -> Option<(ModelStats, Duration, usize)> {
-        self.generation
-            .lock()
-            .backend_aggregate()
-            .map(|(stats, rtt, count, _)| (stats, rtt, count))
+        self.generation.lock().backend_aggregate()
     }
 }

--- a/src/libraries/rust/stargate/crates/stargate/src/routing_state/cluster_snapshots.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/routing_state/cluster_snapshots.rs
@@ -75,25 +75,25 @@ fn proxy_local_wait_ms(stats: &ModelStats, priority: u32) -> u64 {
     }
 }
 
-fn checked_ceil_u64(value: f64) -> Option<u64> {
-    let rounded = value.ceil();
-    // `u64::MAX as f64` rounds to 2^64, so the cast must saturate that boundary.
-    (rounded.is_finite() && rounded >= 0.0 && rounded <= u64::MAX as f64).then_some(rounded as u64)
+fn positive_f64_binary(value: f64) -> (u64, i16) {
+    debug_assert!(valid_last_mean_input_tps(value));
+    let bits = value.to_bits();
+    let exponent_bits = ((bits >> 52) & 0x7ff) as i16;
+    let fraction = bits & ((1_u64 << 52) - 1);
+    if exponent_bits == 0 {
+        (fraction, -1074)
+    } else {
+        ((1_u64 << 52) | fraction, exponent_bits - 1075)
+    }
 }
 
-fn compensated_sum(values: impl IntoIterator<Item = f64>) -> f64 {
-    let mut sum = 0.0_f64;
-    let mut correction = 0.0_f64;
-    for value in values {
-        let next = sum + value;
-        correction += if sum >= value {
-            (sum - next) + value
-        } else {
-            (value - next) + sum
-        };
-        sum = next;
+fn checked_ceil_ratio_u64(numerator: u128, denominator: u128) -> Option<u64> {
+    if denominator == 0 {
+        return None;
     }
-    sum + correction
+    let quotient = numerator / denominator;
+    let ceiled = quotient.checked_add(u128::from(!numerator.is_multiple_of(denominator)))?;
+    u64::try_from(ceiled).ok()
 }
 
 fn proxy_local_priority_map(backends: &[Arc<RoutedInferenceServerSnapshot>]) -> HashMap<u32, u64> {
@@ -127,23 +127,28 @@ fn proxy_local_priority_map(backends: &[Arc<RoutedInferenceServerSnapshot>]) -> 
     if priorities.is_empty() || !valid_last_mean_input_tps(input_tps_sum) {
         return HashMap::new();
     }
-    let max_input_tps = backends
+    let rate_components: Vec<(usize, u64, i16)> = backends
         .iter()
-        .map(|backend| backend.stats.last_mean_input_tps)
-        .filter(|input_tps| valid_last_mean_input_tps(*input_tps))
-        .fold(0.0_f64, f64::max);
-    let valid_input_tps_count = backends
+        .enumerate()
+        .filter_map(|(index, backend)| {
+            let input_tps = backend.stats.last_mean_input_tps;
+            valid_last_mean_input_tps(input_tps).then(|| {
+                let (significand, exponent) = positive_f64_binary(input_tps);
+                (index, significand, exponent)
+            })
+        })
+        .collect();
+    let min_rate_exponent = rate_components
         .iter()
-        .map(|backend| backend.stats.last_mean_input_tps)
-        .filter(|input_tps| valid_last_mean_input_tps(*input_tps))
-        .count();
+        .map(|(_, _, exponent)| *exponent)
+        .min()
+        .expect("a positive finite aggregate input rate has at least one component");
 
     let mut aggregate = HashMap::with_capacity(priorities.len());
     for priority in priorities {
-        let (min_wait_ms, max_wait_ms) = backends
+        let (min_wait_ms, max_wait_ms) = rate_components
             .iter()
-            .filter(|backend| valid_last_mean_input_tps(backend.stats.last_mean_input_tps))
-            .map(|backend| proxy_local_wait_ms(&backend.stats, priority))
+            .map(|(index, _, _)| proxy_local_wait_ms(&backends[*index].stats, priority))
             .fold((u64::MAX, 0), |(min_wait_ms, max_wait_ms), wait_ms| {
                 (min_wait_ms.min(wait_ms), max_wait_ms.max(wait_ms))
             });
@@ -152,76 +157,41 @@ fn proxy_local_priority_map(backends: &[Arc<RoutedInferenceServerSnapshot>]) -> 
             continue;
         }
 
-        let max_delta_ms = max_wait_ms - min_wait_ms;
-        let max_unscaled_term = max_input_tps * max_delta_ms as f64;
-        let unscaled_sum_is_finite = max_unscaled_term.is_finite()
-            && max_unscaled_term <= f64::MAX / valid_input_tps_count as f64;
-        // A common power-of-two divisor is exact for normal values. The
-        // conservative exponent also bounds a worst-case usize-length sum.
-        let rate_scale = if unscaled_sum_is_finite {
-            1.0
-        } else {
-            2.0_f64.powi((u64::BITS + usize::BITS + 1) as i32)
-        };
-        let scaled_input_tps_sum = compensated_sum(
-            backends
-                .iter()
-                .map(|backend| backend.stats.last_mean_input_tps)
-                .filter(|input_tps| valid_last_mean_input_tps(*input_tps))
-                .map(|input_tps| input_tps / rate_scale),
-        );
-        let weighted_delta_sum = compensated_sum(backends.iter().filter_map(|backend| {
-            let input_tps = backend.stats.last_mean_input_tps;
-            valid_last_mean_input_tps(input_tps).then(|| {
-                let wait_ms = proxy_local_wait_ms(&backend.stats, priority);
-                (input_tps / rate_scale) * wait_ms.saturating_sub(min_wait_ms) as f64
-            })
-        }));
-        if !valid_last_mean_input_tps(scaled_input_tps_sum)
-            || !weighted_delta_sum.is_finite()
-            || weighted_delta_sum < 0.0
-        {
-            return HashMap::new();
-        }
-        let weighted_delta_ms = weighted_delta_sum / scaled_input_tps_sum;
-        let Some(approximate_ceil_ms) =
-            checked_ceil_u64(weighted_delta_ms.clamp(0.0, max_delta_ms as f64))
-        else {
-            return HashMap::new();
-        };
+        // Positive finite f64 values are exact binary rationals. Align their
+        // significands in u128 so ceiling cannot cross an integer due to
+        // floating-point rounding. If the exact fast path does not fit, use
+        // the existing scalar fallback rather than publish an unsafe map.
+        let mut denominator = 0_u128;
+        let mut weighted_delta = 0_u128;
+        for (index, significand, exponent) in &rate_components {
+            let shift = u32::try_from(*exponent - min_rate_exponent)
+                .expect("the minimum rate exponent cannot exceed a component exponent");
+            let Some(scaled_significand) = u128::from(*significand).checked_shl(shift) else {
+                return HashMap::new();
+            };
+            let Some(next_denominator) = denominator.checked_add(scaled_significand) else {
+                return HashMap::new();
+            };
+            denominator = next_denominator;
 
-        // Division can round an exact integer quotient one ULP upward or a
-        // positive fraction downward. Resolve the adjacent integer boundary
-        // by comparing the weighted residual on each side of it.
-        let lower_delta_ms = approximate_ceil_ms.saturating_sub(1).min(max_delta_ms);
-        let positive_residual = compensated_sum(backends.iter().filter_map(|backend| {
-            let input_tps = backend.stats.last_mean_input_tps;
-            if !valid_last_mean_input_tps(input_tps) {
-                return None;
-            }
-            let delta_ms = proxy_local_wait_ms(&backend.stats, priority) - min_wait_ms;
-            (delta_ms > lower_delta_ms)
-                .then(|| (input_tps / rate_scale) * (delta_ms - lower_delta_ms) as f64)
-        }));
-        let negative_residual = compensated_sum(backends.iter().filter_map(|backend| {
-            let input_tps = backend.stats.last_mean_input_tps;
-            if !valid_last_mean_input_tps(input_tps) {
-                return None;
-            }
-            let delta_ms = proxy_local_wait_ms(&backend.stats, priority) - min_wait_ms;
-            (delta_ms < lower_delta_ms)
-                .then(|| (input_tps / rate_scale) * (lower_delta_ms - delta_ms) as f64)
-        }));
-        if !positive_residual.is_finite() || !negative_residual.is_finite() {
+            let wait_ms = proxy_local_wait_ms(&backends[*index].stats, priority);
+            let delta_ms = wait_ms - min_wait_ms;
+            let Some(weighted_component) = scaled_significand.checked_mul(u128::from(delta_ms))
+            else {
+                return HashMap::new();
+            };
+            let Some(next_weighted_delta) = weighted_delta.checked_add(weighted_component) else {
+                return HashMap::new();
+            };
+            weighted_delta = next_weighted_delta;
+        }
+        let Some(ceiled_delta_ms) = checked_ceil_ratio_u64(weighted_delta, denominator) else {
+            return HashMap::new();
+        };
+        if ceiled_delta_ms > max_wait_ms - min_wait_ms {
             return HashMap::new();
         }
-        let ceiled_delta_ms = if positive_residual > negative_residual {
-            lower_delta_ms.saturating_add(1)
-        } else {
-            lower_delta_ms
-        }
-        .min(max_delta_ms);
-        let weighted_wait_ms = min_wait_ms.saturating_add(ceiled_delta_ms).min(max_wait_ms);
+        let weighted_wait_ms = min_wait_ms + ceiled_delta_ms;
         aggregate.insert(priority, weighted_wait_ms);
     }
     aggregate

--- a/src/libraries/rust/stargate/crates/stargate/src/routing_state/cluster_snapshots.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/routing_state/cluster_snapshots.rs
@@ -166,9 +166,14 @@ fn proxy_local_priority_map(backends: &[Arc<RoutedInferenceServerSnapshot>]) -> 
         for (index, significand, exponent) in &rate_components {
             let shift = u32::try_from(*exponent - min_rate_exponent)
                 .expect("the minimum rate exponent cannot exceed a component exponent");
-            let Some(scaled_significand) = u128::from(*significand).checked_shl(shift) else {
+            let Some(max_significand) = u128::MAX.checked_shr(shift) else {
                 return HashMap::new();
             };
+            let significand = u128::from(*significand);
+            if significand > max_significand {
+                return HashMap::new();
+            }
+            let scaled_significand = significand << shift;
             let Some(next_denominator) = denominator.checked_add(scaled_significand) else {
                 return HashMap::new();
             };
@@ -364,17 +369,25 @@ impl ClusterRoutingGeneration {
         if self.snapshot_state.is_none() && updated_backend_id.is_none() {
             return;
         }
+        let source_is_eligible = |index: usize| {
+            proxy_local_request_load || !has_proxy_local_request_load(&self.backends[index].stats)
+        };
         let source_backend_index = updated_backend_id
             .and_then(|backend_id| backend_index(&self.backends, backend_id).ok())
+            .filter(|index| source_is_eligible(*index))
             .or_else(|| {
-                self.snapshot_state.as_ref().and_then(|state| {
-                    backend_index(&self.backends, &state.cluster_stats_source_backend_id).ok()
-                })
+                self.snapshot_state
+                    .as_ref()
+                    .and_then(|state| {
+                        backend_index(&self.backends, &state.cluster_stats_source_backend_id).ok()
+                    })
+                    .filter(|index| source_is_eligible(*index))
             })
             .or_else(|| {
                 self.backends
                     .iter()
                     .enumerate()
+                    .filter(|(index, _)| source_is_eligible(*index))
                     .max_by_key(|(_, backend)| backend.snapshot_updated_at)
                     .map(|(index, _)| index)
             })

--- a/src/libraries/rust/stargate/crates/stargate/src/routing_state/cluster_snapshots.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/routing_state/cluster_snapshots.rs
@@ -75,27 +75,6 @@ fn proxy_local_wait_ms(stats: &ModelStats, priority: u32) -> u64 {
     }
 }
 
-fn positive_f64_binary(value: f64) -> (u64, i16) {
-    debug_assert!(valid_last_mean_input_tps(value));
-    let bits = value.to_bits();
-    let exponent_bits = ((bits >> 52) & 0x7ff) as i16;
-    let fraction = bits & ((1_u64 << 52) - 1);
-    if exponent_bits == 0 {
-        (fraction, -1074)
-    } else {
-        ((1_u64 << 52) | fraction, exponent_bits - 1075)
-    }
-}
-
-fn checked_ceil_ratio_u64(numerator: u128, denominator: u128) -> Option<u64> {
-    if denominator == 0 {
-        return None;
-    }
-    let quotient = numerator / denominator;
-    let ceiled = quotient.checked_add(u128::from(!numerator.is_multiple_of(denominator)))?;
-    u64::try_from(ceiled).ok()
-}
-
 fn proxy_local_priority_map(backends: &[Arc<RoutedInferenceServerSnapshot>]) -> HashMap<u32, u64> {
     if backends.len() == 1 {
         return backends[0].stats.queue_time_estimate_ms_by_priority.clone();
@@ -127,76 +106,29 @@ fn proxy_local_priority_map(backends: &[Arc<RoutedInferenceServerSnapshot>]) -> 
     if priorities.is_empty() || !valid_last_mean_input_tps(input_tps_sum) {
         return HashMap::new();
     }
-    let rate_components: Vec<(usize, u64, i16)> = backends
-        .iter()
-        .enumerate()
-        .filter_map(|(index, backend)| {
-            let input_tps = backend.stats.last_mean_input_tps;
-            valid_last_mean_input_tps(input_tps).then(|| {
-                let (significand, exponent) = positive_f64_binary(input_tps);
-                (index, significand, exponent)
-            })
-        })
-        .collect();
-    let min_rate_exponent = rate_components
-        .iter()
-        .map(|(_, _, exponent)| *exponent)
-        .min()
-        .expect("a positive finite aggregate input rate has at least one component");
 
     let mut aggregate = HashMap::with_capacity(priorities.len());
     for priority in priorities {
-        let (min_wait_ms, max_wait_ms) = rate_components
+        let mut min_wait_ms = u64::MAX;
+        let mut max_wait_ms = 0;
+        let weighted_wait_sum: f64 = backends
             .iter()
-            .map(|(index, _, _)| proxy_local_wait_ms(&backends[*index].stats, priority))
-            .fold((u64::MAX, 0), |(min_wait_ms, max_wait_ms), wait_ms| {
-                (min_wait_ms.min(wait_ms), max_wait_ms.max(wait_ms))
-            });
-        if min_wait_ms == max_wait_ms {
-            aggregate.insert(priority, min_wait_ms);
-            continue;
-        }
-
-        // Positive finite f64 values are exact binary rationals. Align their
-        // significands in u128 so ceiling cannot cross an integer due to
-        // floating-point rounding. If the exact fast path does not fit, use
-        // the existing scalar fallback rather than publish an unsafe map.
-        let mut denominator = 0_u128;
-        let mut weighted_delta = 0_u128;
-        for (index, significand, exponent) in &rate_components {
-            let shift = u32::try_from(*exponent - min_rate_exponent)
-                .expect("the minimum rate exponent cannot exceed a component exponent");
-            let Some(max_significand) = u128::MAX.checked_shr(shift) else {
-                return HashMap::new();
-            };
-            let significand = u128::from(*significand);
-            if significand > max_significand {
-                return HashMap::new();
-            }
-            let scaled_significand = significand << shift;
-            let Some(next_denominator) = denominator.checked_add(scaled_significand) else {
-                return HashMap::new();
-            };
-            denominator = next_denominator;
-
-            let wait_ms = proxy_local_wait_ms(&backends[*index].stats, priority);
-            let delta_ms = wait_ms - min_wait_ms;
-            let Some(weighted_component) = scaled_significand.checked_mul(u128::from(delta_ms))
-            else {
-                return HashMap::new();
-            };
-            let Some(next_weighted_delta) = weighted_delta.checked_add(weighted_component) else {
-                return HashMap::new();
-            };
-            weighted_delta = next_weighted_delta;
-        }
-        let Some(ceiled_delta_ms) = checked_ceil_ratio_u64(weighted_delta, denominator) else {
-            return HashMap::new();
-        };
-        if ceiled_delta_ms > max_wait_ms - min_wait_ms {
+            .filter_map(|backend| {
+                let input_tps = backend.stats.last_mean_input_tps;
+                if !valid_last_mean_input_tps(input_tps) {
+                    return None;
+                }
+                let wait_ms = proxy_local_wait_ms(&backend.stats, priority);
+                min_wait_ms = min_wait_ms.min(wait_ms);
+                max_wait_ms = max_wait_ms.max(wait_ms);
+                Some(input_tps * wait_ms as f64)
+            })
+            .sum();
+        if !weighted_wait_sum.is_finite() {
             return HashMap::new();
         }
-        let weighted_wait_ms = min_wait_ms + ceiled_delta_ms;
+        let weighted_wait_ms =
+            ((weighted_wait_sum / input_tps_sum).ceil() as u64).clamp(min_wait_ms, max_wait_ms);
         aggregate.insert(priority, weighted_wait_ms);
     }
     aggregate

--- a/src/libraries/rust/stargate/crates/stargate/src/routing_state/cluster_snapshots.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/routing_state/cluster_snapshots.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
@@ -31,7 +31,9 @@ use super::snapshots::{
     RoutedClusterSnapshot, RoutedClusterState, RoutedInferenceServerSnapshot,
 };
 
-fn set_cluster_scoped_stats(stats: &mut ModelStats, src: &ModelStats) {
+const PROXY_LOCAL_REQUEST_LOAD_CAPABILITY: &str = "request.load.proxy_local";
+
+fn set_legacy_source_stats(stats: &mut ModelStats, src: &ModelStats) {
     stats.max_output_tps = src.max_output_tps;
     stats.kv_cache_capacity_tokens = src.kv_cache_capacity_tokens;
     stats.kv_cache_used_tokens = src.kv_cache_used_tokens;
@@ -40,6 +42,94 @@ fn set_cluster_scoped_stats(stats: &mut ModelStats, src: &ModelStats) {
     stats.max_engine_concurrency = src.max_engine_concurrency;
     stats.total_query_input_size = src.total_query_input_size;
     stats.queue_time_estimate_ms_by_priority = src.queue_time_estimate_ms_by_priority.clone();
+}
+
+fn set_shared_engine_stats(stats: &mut ModelStats, src: &ModelStats) {
+    stats.kv_cache_capacity_tokens = src.kv_cache_capacity_tokens;
+    stats.kv_cache_used_tokens = src.kv_cache_used_tokens;
+    stats.kv_cache_free_tokens = src.kv_cache_free_tokens;
+    stats.max_engine_concurrency = src.max_engine_concurrency;
+}
+
+fn has_proxy_local_request_load(stats: &ModelStats) -> bool {
+    stats
+        .stats_capabilities
+        .iter()
+        .any(|capability| capability == PROXY_LOCAL_REQUEST_LOAD_CAPABILITY)
+}
+
+fn valid_output_tps(output_tps: f64) -> bool {
+    output_tps >= 0.0 && output_tps.is_finite()
+}
+
+fn has_queued_work(stats: &ModelStats) -> bool {
+    stats.queue_size > 0 || stats.queued_input_size > 0
+}
+
+fn checked_ceil_u64(value: f64) -> Option<u64> {
+    let rounded = value.ceil();
+    // `u64::MAX as f64` rounds to 2^64, which is already outside u64.
+    (rounded.is_finite() && rounded >= 0.0 && rounded < u64::MAX as f64).then_some(rounded as u64)
+}
+
+fn proxy_local_priority_map(backends: &[Arc<RoutedInferenceServerSnapshot>]) -> HashMap<u32, u64> {
+    if backends.len() == 1 {
+        return backends[0].stats.queue_time_estimate_ms_by_priority.clone();
+    }
+
+    if backends.iter().any(|backend| {
+        has_queued_work(&backend.stats)
+            && (!valid_last_mean_input_tps(backend.stats.last_mean_input_tps)
+                || backend.stats.queue_time_estimate_ms_by_priority.is_empty())
+    }) {
+        return HashMap::new();
+    }
+
+    let priorities: BTreeSet<u32> = backends
+        .iter()
+        .flat_map(|backend| {
+            backend
+                .stats
+                .queue_time_estimate_ms_by_priority
+                .keys()
+                .copied()
+        })
+        .collect();
+    let input_tps_sum: f64 = backends
+        .iter()
+        .map(|backend| backend.stats.last_mean_input_tps)
+        .filter(|input_tps| valid_last_mean_input_tps(*input_tps))
+        .sum();
+    if priorities.is_empty() || !valid_last_mean_input_tps(input_tps_sum) {
+        return HashMap::new();
+    }
+
+    let mut aggregate = HashMap::with_capacity(priorities.len());
+    for priority in priorities {
+        let weighted_wait_sum = backends
+            .iter()
+            .filter_map(|backend| {
+                let input_tps = backend.stats.last_mean_input_tps;
+                valid_last_mean_input_tps(input_tps).then(|| {
+                    let wait_ms = if has_queued_work(&backend.stats) {
+                        crate::queue_estimate::priority_map_estimate_ms_for_priority(
+                            &backend.stats,
+                            priority,
+                        )
+                        .unwrap_or_default()
+                    } else {
+                        0
+                    };
+                    input_tps * wait_ms as f64
+                })
+            })
+            .sum::<f64>();
+        let Some(weighted_wait_ms) = checked_ceil_u64(weighted_wait_sum / input_tps_sum) else {
+            return HashMap::new();
+        };
+        aggregate.insert(priority, weighted_wait_ms);
+    }
+    aggregate
 }
 
 fn append_unique_strings(target: &mut Vec<String>, values: &[String]) {
@@ -96,25 +186,67 @@ impl ClusterRoutingGeneration {
             .is_ok_and(|index| Arc::ptr_eq(&self.backends[index].registration, registration))
     }
 
-    fn backend_aggregate(&self) -> Option<(ModelStats, Duration, usize)> {
+    fn backend_aggregate(&self) -> Option<(ModelStats, Duration, usize, bool)> {
         let active_backend_count = self.backends.len();
         if active_backend_count == 0 {
             return None;
         }
+        let proxy_local_request_load = self
+            .backends
+            .iter()
+            .all(|backend| has_proxy_local_request_load(&backend.stats));
         let backend_count = active_backend_count as u128;
         let mut backend_stats = ModelStats::default();
+        let mut valid_input_tps_components = 0_usize;
+        let mut valid_output_tps_components = 0_usize;
+        let mut valid_max_output_tps_components = 0_usize;
         let mut rtt_mean_nanos = 0_u128;
         let mut rtt_remainder_nanos = 0_u128;
 
         for backend in &self.backends {
-            backend_stats.output_tps += backend.stats.output_tps;
-            if valid_last_mean_input_tps(backend.stats.last_mean_input_tps) {
-                backend_stats.last_mean_input_tps += backend.stats.last_mean_input_tps;
+            if proxy_local_request_load {
+                if valid_last_mean_input_tps(backend.stats.last_mean_input_tps) {
+                    backend_stats.last_mean_input_tps += backend.stats.last_mean_input_tps;
+                    valid_input_tps_components += 1;
+                }
+                if valid_output_tps(backend.stats.output_tps) {
+                    backend_stats.output_tps += backend.stats.output_tps;
+                    valid_output_tps_components += 1;
+                }
+                if valid_output_tps(backend.stats.max_output_tps) {
+                    backend_stats.max_output_tps = backend_stats
+                        .max_output_tps
+                        .max(backend.stats.max_output_tps);
+                    valid_max_output_tps_components += 1;
+                }
+                backend_stats.queue_size = backend_stats
+                    .queue_size
+                    .saturating_add(backend.stats.queue_size);
+                backend_stats.queued_input_size = backend_stats
+                    .queued_input_size
+                    .saturating_add(backend.stats.queued_input_size);
+                backend_stats.num_running_queries = backend_stats
+                    .num_running_queries
+                    .saturating_add(backend.stats.num_running_queries);
+                backend_stats.total_query_input_size = backend_stats
+                    .total_query_input_size
+                    .saturating_add(backend.stats.total_query_input_size);
+                backend_stats.input_processing_queries = backend_stats
+                    .input_processing_queries
+                    .saturating_add(backend.stats.input_processing_queries);
+                backend_stats.output_generation_queries = backend_stats
+                    .output_generation_queries
+                    .saturating_add(backend.stats.output_generation_queries);
+            } else {
+                backend_stats.output_tps += backend.stats.output_tps;
+                if valid_last_mean_input_tps(backend.stats.last_mean_input_tps) {
+                    backend_stats.last_mean_input_tps += backend.stats.last_mean_input_tps;
+                }
+                backend_stats.queue_size += backend.stats.queue_size;
+                backend_stats.queued_input_size += backend.stats.queued_input_size;
+                backend_stats.input_processing_queries += backend.stats.input_processing_queries;
+                backend_stats.output_generation_queries += backend.stats.output_generation_queries;
             }
-            backend_stats.queue_size += backend.stats.queue_size;
-            backend_stats.queued_input_size += backend.stats.queued_input_size;
-            backend_stats.input_processing_queries += backend.stats.input_processing_queries;
-            backend_stats.output_generation_queries += backend.stats.output_generation_queries;
             backend_stats.stats_observed_at_unix_ms = backend_stats
                 .stats_observed_at_unix_ms
                 .max(backend.stats.stats_observed_at_unix_ms);
@@ -136,6 +268,20 @@ impl ClusterRoutingGeneration {
             rtt_remainder_nanos %= backend_count;
         }
 
+        if proxy_local_request_load {
+            if valid_input_tps_components == 0 || !backend_stats.last_mean_input_tps.is_finite() {
+                backend_stats.last_mean_input_tps = 0.0;
+            }
+            if valid_output_tps_components == 0 || !backend_stats.output_tps.is_finite() {
+                backend_stats.output_tps = 0.0;
+            }
+            if valid_max_output_tps_components == 0 {
+                backend_stats.max_output_tps = 0.0;
+            }
+            backend_stats.queue_time_estimate_ms_by_priority =
+                proxy_local_priority_map(&self.backends);
+        }
+
         // The loop maintains backend_count * mean + remainder = processed sum,
         // so the final mean is floor(total / backend_count). It cannot exceed
         // the largest input or Duration::MAX, and both casts are lossless.
@@ -144,11 +290,18 @@ impl ClusterRoutingGeneration {
             (rtt_mean_nanos % 1_000_000_000) as u32,
         );
 
-        Some((backend_stats, rtt, active_backend_count))
+        Some((
+            backend_stats,
+            rtt,
+            active_backend_count,
+            proxy_local_request_load,
+        ))
     }
 
     fn refresh_snapshot(&mut self, updated_backend_id: Option<&str>) {
-        let Some((backend_stats, rtt, active_backend_count)) = self.backend_aggregate() else {
+        let Some((backend_stats, rtt, active_backend_count, proxy_local_request_load)) =
+            self.backend_aggregate()
+        else {
             self.snapshot_state = None;
             return;
         };
@@ -186,7 +339,11 @@ impl ClusterRoutingGeneration {
                 .retain(|pending| pending.inference_server_id != updated_backend_id);
         }
         let mut stats = backend_stats;
-        set_cluster_scoped_stats(&mut stats, &source_backend.stats);
+        if proxy_local_request_load {
+            set_shared_engine_stats(&mut stats, &source_backend.stats);
+        } else {
+            set_legacy_source_stats(&mut stats, &source_backend.stats);
+        }
         let base_snapshot = RoutedClusterSnapshot {
             cluster_id: source_backend.cluster_id.clone(),
             stats,
@@ -333,6 +490,9 @@ impl RoutedClusterState {
 
     #[cfg(test)]
     pub(super) fn backend_aggregate(&self) -> Option<(ModelStats, Duration, usize)> {
-        self.generation.lock().backend_aggregate()
+        self.generation
+            .lock()
+            .backend_aggregate()
+            .map(|(stats, rtt, count, _)| (stats, rtt, count))
     }
 }

--- a/src/libraries/rust/stargate/crates/stargate/src/routing_state/cluster_snapshots.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/routing_state/cluster_snapshots.rs
@@ -66,6 +66,15 @@ fn has_queued_work(stats: &ModelStats) -> bool {
     stats.queue_size > 0 || stats.queued_input_size > 0
 }
 
+fn proxy_local_wait_ms(stats: &ModelStats, priority: u32) -> u64 {
+    if has_queued_work(stats) {
+        crate::queue_estimate::priority_map_estimate_ms_for_priority(stats, priority)
+            .unwrap_or_default()
+    } else {
+        0
+    }
+}
+
 fn checked_ceil_u64(value: f64) -> Option<u64> {
     let rounded = value.ceil();
     // `u64::MAX as f64` rounds to 2^64, so the cast must saturate that boundary.
@@ -103,28 +112,47 @@ fn proxy_local_priority_map(backends: &[Arc<RoutedInferenceServerSnapshot>]) -> 
     if priorities.is_empty() || !valid_last_mean_input_tps(input_tps_sum) {
         return HashMap::new();
     }
+    let input_tps_scale = backends
+        .iter()
+        .map(|backend| backend.stats.last_mean_input_tps)
+        .filter(|input_tps| valid_last_mean_input_tps(*input_tps))
+        .fold(0.0_f64, f64::max);
+    let scaled_input_tps_sum: f64 = backends
+        .iter()
+        .map(|backend| backend.stats.last_mean_input_tps)
+        .filter(|input_tps| valid_last_mean_input_tps(*input_tps))
+        .map(|input_tps| input_tps / input_tps_scale)
+        .sum();
 
     let mut aggregate = HashMap::with_capacity(priorities.len());
     for priority in priorities {
-        let weighted_wait_sum = backends
+        let (min_wait_ms, max_wait_ms) = backends
+            .iter()
+            .filter(|backend| valid_last_mean_input_tps(backend.stats.last_mean_input_tps))
+            .map(|backend| proxy_local_wait_ms(&backend.stats, priority))
+            .fold((u64::MAX, 0), |(min_wait_ms, max_wait_ms), wait_ms| {
+                (min_wait_ms.min(wait_ms), max_wait_ms.max(wait_ms))
+            });
+        if min_wait_ms == max_wait_ms {
+            aggregate.insert(priority, min_wait_ms);
+            continue;
+        }
+
+        // Scaling the rates before multiplication keeps every term bounded by
+        // u64::MAX while preserving the weighted mean.
+        let weighted_delta_sum: f64 = backends
             .iter()
             .filter_map(|backend| {
                 let input_tps = backend.stats.last_mean_input_tps;
                 valid_last_mean_input_tps(input_tps).then(|| {
-                    let wait_ms = if has_queued_work(&backend.stats) {
-                        crate::queue_estimate::priority_map_estimate_ms_for_priority(
-                            &backend.stats,
-                            priority,
-                        )
-                        .unwrap_or_default()
-                    } else {
-                        0
-                    };
-                    (input_tps / input_tps_sum) * wait_ms as f64
+                    let wait_ms = proxy_local_wait_ms(&backend.stats, priority);
+                    (input_tps / input_tps_scale) * wait_ms.saturating_sub(min_wait_ms) as f64
                 })
             })
-            .sum::<f64>();
-        let Some(weighted_wait_ms) = checked_ceil_u64(weighted_wait_sum) else {
+            .sum();
+        let bounded_wait_ms = (min_wait_ms as f64 + weighted_delta_sum / scaled_input_tps_sum)
+            .clamp(min_wait_ms as f64, max_wait_ms as f64);
+        let Some(weighted_wait_ms) = checked_ceil_u64(bounded_wait_ms) else {
             return HashMap::new();
         };
         aggregate.insert(priority, weighted_wait_ms);

--- a/src/libraries/rust/stargate/crates/stargate/src/routing_state/cluster_snapshots.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/routing_state/cluster_snapshots.rs
@@ -81,6 +81,21 @@ fn checked_ceil_u64(value: f64) -> Option<u64> {
     (rounded.is_finite() && rounded >= 0.0 && rounded <= u64::MAX as f64).then_some(rounded as u64)
 }
 
+fn compensated_sum(values: impl IntoIterator<Item = f64>) -> f64 {
+    let mut sum = 0.0_f64;
+    let mut correction = 0.0_f64;
+    for value in values {
+        let next = sum + value;
+        correction += if sum >= value {
+            (sum - next) + value
+        } else {
+            (value - next) + sum
+        };
+        sum = next;
+    }
+    sum + correction
+}
+
 fn proxy_local_priority_map(backends: &[Arc<RoutedInferenceServerSnapshot>]) -> HashMap<u32, u64> {
     if backends.len() == 1 {
         return backends[0].stats.queue_time_estimate_ms_by_priority.clone();
@@ -112,17 +127,16 @@ fn proxy_local_priority_map(backends: &[Arc<RoutedInferenceServerSnapshot>]) -> 
     if priorities.is_empty() || !valid_last_mean_input_tps(input_tps_sum) {
         return HashMap::new();
     }
-    let input_tps_scale = backends
+    let max_input_tps = backends
         .iter()
         .map(|backend| backend.stats.last_mean_input_tps)
         .filter(|input_tps| valid_last_mean_input_tps(*input_tps))
         .fold(0.0_f64, f64::max);
-    let scaled_input_tps_sum: f64 = backends
+    let valid_input_tps_count = backends
         .iter()
         .map(|backend| backend.stats.last_mean_input_tps)
         .filter(|input_tps| valid_last_mean_input_tps(*input_tps))
-        .map(|input_tps| input_tps / input_tps_scale)
-        .sum();
+        .count();
 
     let mut aggregate = HashMap::with_capacity(priorities.len());
     for priority in priorities {
@@ -138,23 +152,76 @@ fn proxy_local_priority_map(backends: &[Arc<RoutedInferenceServerSnapshot>]) -> 
             continue;
         }
 
-        // Scaling the rates before multiplication keeps every term bounded by
-        // u64::MAX while preserving the weighted mean.
-        let weighted_delta_sum: f64 = backends
-            .iter()
-            .filter_map(|backend| {
-                let input_tps = backend.stats.last_mean_input_tps;
-                valid_last_mean_input_tps(input_tps).then(|| {
-                    let wait_ms = proxy_local_wait_ms(&backend.stats, priority);
-                    (input_tps / input_tps_scale) * wait_ms.saturating_sub(min_wait_ms) as f64
-                })
+        let max_delta_ms = max_wait_ms - min_wait_ms;
+        let max_unscaled_term = max_input_tps * max_delta_ms as f64;
+        let unscaled_sum_is_finite = max_unscaled_term.is_finite()
+            && max_unscaled_term <= f64::MAX / valid_input_tps_count as f64;
+        // A common power-of-two divisor is exact for normal values. The
+        // conservative exponent also bounds a worst-case usize-length sum.
+        let rate_scale = if unscaled_sum_is_finite {
+            1.0
+        } else {
+            2.0_f64.powi((u64::BITS + usize::BITS + 1) as i32)
+        };
+        let scaled_input_tps_sum = compensated_sum(
+            backends
+                .iter()
+                .map(|backend| backend.stats.last_mean_input_tps)
+                .filter(|input_tps| valid_last_mean_input_tps(*input_tps))
+                .map(|input_tps| input_tps / rate_scale),
+        );
+        let weighted_delta_sum = compensated_sum(backends.iter().filter_map(|backend| {
+            let input_tps = backend.stats.last_mean_input_tps;
+            valid_last_mean_input_tps(input_tps).then(|| {
+                let wait_ms = proxy_local_wait_ms(&backend.stats, priority);
+                (input_tps / rate_scale) * wait_ms.saturating_sub(min_wait_ms) as f64
             })
-            .sum();
-        let bounded_wait_ms = (min_wait_ms as f64 + weighted_delta_sum / scaled_input_tps_sum)
-            .clamp(min_wait_ms as f64, max_wait_ms as f64);
-        let Some(weighted_wait_ms) = checked_ceil_u64(bounded_wait_ms) else {
+        }));
+        if !valid_last_mean_input_tps(scaled_input_tps_sum)
+            || !weighted_delta_sum.is_finite()
+            || weighted_delta_sum < 0.0
+        {
+            return HashMap::new();
+        }
+        let weighted_delta_ms = weighted_delta_sum / scaled_input_tps_sum;
+        let Some(approximate_ceil_ms) =
+            checked_ceil_u64(weighted_delta_ms.clamp(0.0, max_delta_ms as f64))
+        else {
             return HashMap::new();
         };
+
+        // Division can round an exact integer quotient one ULP upward or a
+        // positive fraction downward. Resolve the adjacent integer boundary
+        // by comparing the weighted residual on each side of it.
+        let lower_delta_ms = approximate_ceil_ms.saturating_sub(1).min(max_delta_ms);
+        let positive_residual = compensated_sum(backends.iter().filter_map(|backend| {
+            let input_tps = backend.stats.last_mean_input_tps;
+            if !valid_last_mean_input_tps(input_tps) {
+                return None;
+            }
+            let delta_ms = proxy_local_wait_ms(&backend.stats, priority) - min_wait_ms;
+            (delta_ms > lower_delta_ms)
+                .then(|| (input_tps / rate_scale) * (delta_ms - lower_delta_ms) as f64)
+        }));
+        let negative_residual = compensated_sum(backends.iter().filter_map(|backend| {
+            let input_tps = backend.stats.last_mean_input_tps;
+            if !valid_last_mean_input_tps(input_tps) {
+                return None;
+            }
+            let delta_ms = proxy_local_wait_ms(&backend.stats, priority) - min_wait_ms;
+            (delta_ms < lower_delta_ms)
+                .then(|| (input_tps / rate_scale) * (lower_delta_ms - delta_ms) as f64)
+        }));
+        if !positive_residual.is_finite() || !negative_residual.is_finite() {
+            return HashMap::new();
+        }
+        let ceiled_delta_ms = if positive_residual > negative_residual {
+            lower_delta_ms.saturating_add(1)
+        } else {
+            lower_delta_ms
+        }
+        .min(max_delta_ms);
+        let weighted_wait_ms = min_wait_ms.saturating_add(ceiled_delta_ms).min(max_wait_ms);
         aggregate.insert(priority, weighted_wait_ms);
     }
     aggregate

--- a/src/libraries/rust/stargate/crates/stargate/src/routing_state/cluster_snapshots.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/routing_state/cluster_snapshots.rs
@@ -262,9 +262,6 @@ impl ClusterRoutingGeneration {
             .all(|backend| has_proxy_local_request_load(&backend.stats));
         let backend_count = active_backend_count as u128;
         let mut backend_stats = ModelStats::default();
-        let mut valid_input_tps_components = 0_usize;
-        let mut valid_output_tps_components = 0_usize;
-        let mut valid_max_output_tps_components = 0_usize;
         let mut rtt_mean_nanos = 0_u128;
         let mut rtt_remainder_nanos = 0_u128;
 
@@ -272,17 +269,14 @@ impl ClusterRoutingGeneration {
             if proxy_local_request_load {
                 if valid_last_mean_input_tps(backend.stats.last_mean_input_tps) {
                     backend_stats.last_mean_input_tps += backend.stats.last_mean_input_tps;
-                    valid_input_tps_components += 1;
                 }
                 if valid_output_tps(backend.stats.output_tps) {
                     backend_stats.output_tps += backend.stats.output_tps;
-                    valid_output_tps_components += 1;
                 }
                 if valid_output_tps(backend.stats.max_output_tps) {
                     backend_stats.max_output_tps = backend_stats
                         .max_output_tps
                         .max(backend.stats.max_output_tps);
-                    valid_max_output_tps_components += 1;
                 }
                 backend_stats.queue_size = backend_stats
                     .queue_size
@@ -334,14 +328,11 @@ impl ClusterRoutingGeneration {
         }
 
         if proxy_local_request_load {
-            if valid_input_tps_components == 0 || !backend_stats.last_mean_input_tps.is_finite() {
+            if !backend_stats.last_mean_input_tps.is_finite() {
                 backend_stats.last_mean_input_tps = 0.0;
             }
-            if valid_output_tps_components == 0 || !backend_stats.output_tps.is_finite() {
+            if !backend_stats.output_tps.is_finite() {
                 backend_stats.output_tps = 0.0;
-            }
-            if valid_max_output_tps_components == 0 {
-                backend_stats.max_output_tps = 0.0;
             }
             backend_stats.queue_time_estimate_ms_by_priority =
                 proxy_local_priority_map(&self.backends);

--- a/src/libraries/rust/stargate/crates/stargate/src/routing_state/tests.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/routing_state/tests.rs
@@ -350,13 +350,6 @@ fn shared_backend_b_stats() -> ModelStats {
     }
 }
 
-fn proxy_local_stats(mut stats: ModelStats) -> ModelStats {
-    stats
-        .stats_capabilities
-        .push("request.load.proxy_local".to_string());
-    stats
-}
-
 async fn published_shared_cluster(
     stats_a: ModelStats,
     stats_b: ModelStats,
@@ -995,9 +988,7 @@ async fn shared_cluster_reservation_updates_cluster_snapshot_even_when_other_bac
     scenario.publish_connected(&running_b, &update_b).await;
 
     let cluster = scenario.only_cluster("model-reserved").await;
-    // Reservation delta uses summed backend input capacity:
-    // existing 5ms + ceil(37 tokens / 200 input TPS * 1000) = 190ms.
-    assert_queue_stats(&cluster.stats, 8, 1, 107, 37, 4, 190);
+    assert_queue_stats(&cluster.stats, 11, 1, 137, 37, 4, 185);
 }
 
 #[tokio::test]
@@ -1432,7 +1423,7 @@ fn cluster_snapshot_rtt_mean_handles_three_near_max_durations() {
 fn cluster_generation_derives_cluster_source_from_stored_backends() {
     let observed_at = Instant::now();
     let mut backend_a = backend!("cluster-derived-source", "backend-a", 1.0, 100.0, 10);
-    backend_a.stats.max_output_tps = 10.0;
+    backend_a.stats.max_engine_concurrency = 10;
     backend_a.snapshot_updated_at = observed_at;
     let cluster_state = Arc::new(RoutedClusterState::new(
         backend_a.registration.cluster_generation.clone(),
@@ -1442,13 +1433,13 @@ fn cluster_generation_derives_cluster_source_from_stored_backends() {
         backend_a.registration.cluster_generation.clone() =>
         "cluster-derived-source", "backend-c", 3.0, 100.0, 30
     );
-    backend_c.stats.max_output_tps = 30.0;
+    backend_c.stats.max_engine_concurrency = 30;
     backend_c.snapshot_updated_at = observed_at + Duration::from_millis(1);
     let mut backend_b = backend!(
         backend_a.registration.cluster_generation.clone() =>
         "cluster-derived-source", "backend-b", 2.0, 100.0, 20
     );
-    backend_b.stats.max_output_tps = 20.0;
+    backend_b.stats.max_engine_concurrency = 20;
     backend_b.snapshot_updated_at = observed_at + Duration::from_millis(2);
     let backend_b_registration = backend_b.registration.clone();
 
@@ -1462,15 +1453,15 @@ fn cluster_generation_derives_cluster_source_from_stored_backends() {
     let snapshot = cluster_state
         .routing_snapshot()
         .expect("latest backend should publish the cluster-scoped source");
-    assert_eq!(snapshot.stats.max_output_tps, 20.0);
+    assert_eq!(snapshot.stats.max_engine_concurrency, 20);
     assert_eq!(snapshot.stats.queue_size, 1);
 
-    backend_b.stats.max_output_tps = 25.0;
+    backend_b.stats.max_engine_concurrency = 25;
     cluster_state.upsert_backend(Arc::new(backend_b));
     let snapshot = cluster_state
         .routing_snapshot()
         .expect("source heartbeat should retain another backend's reservation");
-    assert_eq!(snapshot.stats.max_output_tps, 25.0);
+    assert_eq!(snapshot.stats.max_engine_concurrency, 25);
     assert_eq!(snapshot.stats.queue_size, 1);
 
     cluster_state.remove_backend(&backend_b_registration);
@@ -1478,7 +1469,7 @@ fn cluster_generation_derives_cluster_source_from_stored_backends() {
         .routing_snapshot()
         .expect("source removal should derive a surviving source");
     assert_eq!(snapshot.active_backend_count, 2);
-    assert_eq!(snapshot.stats.max_output_tps, 30.0);
+    assert_eq!(snapshot.stats.max_engine_concurrency, 30);
     assert_eq!(snapshot.stats.queue_size, 1);
 }
 
@@ -2175,49 +2166,21 @@ async fn shared_cluster_registration_exposes_one_aggregated_cluster_candidate() 
         kv_cache_capacity_tokens: 2000,
         kv_cache_used_tokens: 500,
         kv_cache_free_tokens: 1500,
-        num_running_queries: 7,
+        num_running_queries: 18,
         max_engine_concurrency: 77,
-        total_query_input_size: 777,
-        queue_time_estimate_ms_by_priority: HashMap::from([(1, 222), (2, 333)]),
+        total_query_input_size: 1888,
+        queue_time_estimate_ms_by_priority: HashMap::from([(1, 172), (2, 233)]),
     );
     assert_eq!(cluster.rtt, Duration::from_micros(7_500));
 }
 
 #[tokio::test]
-async fn proxy_local_shared_cluster_aggregates_request_load_and_weighted_priorities() {
-    let (scenario, _running_a, _running_b) = published_shared_cluster(
-        proxy_local_stats(shared_backend_a_stats()),
-        proxy_local_stats(shared_backend_b_stats()),
-        10,
-    )
-    .await;
-
-    let cluster = scenario.only_cluster("shared-model").await;
-    assert_stats!(cluster.stats,
-        last_mean_input_tps: 220.0,
-        output_tps: 7.0,
-        max_output_tps: 60.0,
-        queue_size: 3,
-        queued_input_size: 300,
-        num_running_queries: 18,
-        total_query_input_size: 1888,
-        input_processing_queries: 4,
-        output_generation_queries: 6,
-        kv_cache_capacity_tokens: 2000,
-        kv_cache_used_tokens: 500,
-        kv_cache_free_tokens: 1500,
-        max_engine_concurrency: 77,
-        queue_time_estimate_ms_by_priority: HashMap::from([(1, 172), (2, 233)]),
-    );
-}
-
-#[tokio::test]
-async fn proxy_local_aggregation_is_independent_of_heartbeat_order() {
+async fn shared_cluster_aggregation_is_independent_of_heartbeat_order() {
     let scenario = RegistrationScenario::new(Some("rk-order"));
     let running_a = scenario.start_in("inst-a", "cluster-order", 1111);
     let running_b = scenario.start_in("inst-b", "cluster-order", 2222);
-    let mut stats_a = proxy_local_stats(shared_backend_a_stats());
-    let stats_b = proxy_local_stats(shared_backend_b_stats());
+    let mut stats_a = shared_backend_a_stats();
+    let stats_b = shared_backend_b_stats();
     stats_a.kv_cache_capacity_tokens = stats_b.kv_cache_capacity_tokens;
     stats_a.kv_cache_used_tokens = stats_b.kv_cache_used_tokens;
     stats_a.kv_cache_free_tokens = stats_b.kv_cache_free_tokens;
@@ -2235,7 +2198,7 @@ async fn proxy_local_aggregation_is_independent_of_heartbeat_order() {
 }
 
 #[tokio::test]
-async fn three_proxy_local_backends_merge_sparse_priority_maps() {
+async fn three_shared_backends_merge_sparse_priority_maps() {
     let scenario = RegistrationScenario::new(Some("rk-three"));
     let running_a = scenario.start_in("inst-a", "cluster-three", 1111);
     let running_b = scenario.start_in("inst-b", "cluster-three", 2222);
@@ -2272,8 +2235,7 @@ async fn three_proxy_local_backends_merge_sparse_priority_maps() {
             queue_time_estimate_ms_by_priority: HashMap::from([(3, 900)]),
             ..ModelStats::default()
         },
-    ]
-    .map(proxy_local_stats);
+    ];
 
     for (running, stats) in [
         (&running_a, stats[0].clone()),
@@ -2303,7 +2265,7 @@ async fn three_proxy_local_backends_merge_sparse_priority_maps() {
             &competing,
             "model-three",
             Active,
-            proxy_local_stats(priority_stats(100.0, [(3, 180)])),
+            priority_stats(100.0, [(3, 180)]),
             Some(5),
         )
         .await;
@@ -2347,8 +2309,8 @@ async fn three_proxy_local_backends_merge_sparse_priority_maps() {
 }
 
 #[tokio::test]
-async fn proxy_local_aggregation_saturates_gauges_and_ignores_invalid_rates() {
-    let mut stats_a = ModelStats {
+async fn shared_cluster_aggregation_saturates_gauges_and_ignores_invalid_rates() {
+    let stats_a = ModelStats {
         last_mean_input_tps: 100.0,
         output_tps: 10.0,
         max_output_tps: 50.0,
@@ -2360,8 +2322,7 @@ async fn proxy_local_aggregation_saturates_gauges_and_ignores_invalid_rates() {
         output_generation_queries: u64::MAX,
         ..ModelStats::default()
     };
-    stats_a = proxy_local_stats(stats_a);
-    let stats_b = proxy_local_stats(ModelStats {
+    let stats_b = ModelStats {
         last_mean_input_tps: 200.0,
         output_tps: 20.0,
         max_output_tps: 60.0,
@@ -2372,7 +2333,7 @@ async fn proxy_local_aggregation_saturates_gauges_and_ignores_invalid_rates() {
         input_processing_queries: 1,
         output_generation_queries: 1,
         ..ModelStats::default()
-    });
+    };
     let (scenario, running_a, running_b) = published_shared_cluster(stats_a, stats_b, 5).await;
 
     let stats = scenario.only_cluster("shared-model").await.stats;
@@ -2393,12 +2354,12 @@ async fn proxy_local_aggregation_saturates_gauges_and_ignores_invalid_rates() {
             &running_a,
             "shared-model",
             Active,
-            proxy_local_stats(ModelStats {
+            ModelStats {
                 last_mean_input_tps: 125.0,
                 output_tps: 7.5,
                 max_output_tps: 50.0,
                 ..ModelStats::default()
-            }),
+            },
             Some(5),
         )
         .await;
@@ -2407,12 +2368,12 @@ async fn proxy_local_aggregation_saturates_gauges_and_ignores_invalid_rates() {
             &running_b,
             "shared-model",
             Active,
-            proxy_local_stats(ModelStats {
+            ModelStats {
                 last_mean_input_tps: f64::NAN,
                 output_tps: f64::INFINITY,
                 max_output_tps: -1.0,
                 ..ModelStats::default()
-            }),
+            },
             Some(5),
         )
         .await;
@@ -2425,7 +2386,7 @@ async fn proxy_local_aggregation_saturates_gauges_and_ignores_invalid_rates() {
 }
 
 #[tokio::test]
-async fn proxy_local_priority_weights_stay_within_source_bounds() {
+async fn shared_cluster_priority_weights_stay_within_source_bounds() {
     let scenario = RegistrationScenario::new(Some("rk-convex"));
     let backends = [
         (scenario.start_in("inst-a", "cluster-convex", 1111), 6.0, 5),
@@ -2442,13 +2403,13 @@ async fn proxy_local_priority_weights_stay_within_source_bounds() {
                 running,
                 "model-convex",
                 Active,
-                proxy_local_stats(ModelStats {
+                ModelStats {
                     last_mean_input_tps: *input_tps,
                     queue_size: 1,
                     queued_input_size: 1,
                     queue_time_estimate_ms_by_priority: HashMap::from([(0, *wait_ms)]),
                     ..ModelStats::default()
-                }),
+                },
                 Some(5),
             )
             .await;
@@ -2464,59 +2425,17 @@ async fn proxy_local_priority_weights_stay_within_source_bounds() {
 }
 
 #[tokio::test]
-async fn mixed_proxy_local_capability_uses_legacy_source_behavior() {
-    let (scenario, running_a, _running_b) = published_shared_cluster(
-        proxy_local_stats(shared_backend_a_stats()),
-        shared_backend_b_stats(),
-        10,
-    )
-    .await;
-
-    let stats = scenario.only_cluster("shared-model").await.stats;
-    assert_stats!(stats,
-        last_mean_input_tps: 220.0,
-        output_tps: 7.0,
-        queue_size: 3,
-        queued_input_size: 300,
-        input_processing_queries: 4,
-        output_generation_queries: 6,
-        max_output_tps: 60.0,
-        num_running_queries: 7,
-        total_query_input_size: 777,
-        queue_time_estimate_ms_by_priority: HashMap::from([(1, 222), (2, 333)]),
-    );
-
-    scenario
-        .publish(
-            &running_a,
-            "shared-model",
-            Active,
-            proxy_local_stats(shared_backend_a_stats()),
-            Some(10),
-        )
-        .await;
-    let stats = scenario.only_cluster("shared-model").await.stats;
-    assert_stats!(stats,
-        max_output_tps: 60.0,
-        num_running_queries: 7,
-        max_engine_concurrency: 77,
-        total_query_input_size: 777,
-        queue_time_estimate_ms_by_priority: HashMap::from([(1, 222), (2, 333)]),
-    );
-}
-
-#[tokio::test]
-async fn proxy_local_missing_priority_inputs_select_scalar_fallback() {
+async fn shared_cluster_missing_priority_inputs_select_scalar_fallback() {
     let scenario = RegistrationScenario::new(Some("rk-fallback"));
     let running_a = scenario.start_in("inst-a", "cluster-fallback", 1111);
     let running_b = scenario.start_in("inst-b", "cluster-fallback", 2222);
-    let missing_map = proxy_local_stats(ModelStats {
+    let missing_map = ModelStats {
         last_mean_input_tps: 100.0,
         queue_size: 1,
         queued_input_size: 100,
         ..ModelStats::default()
-    });
-    let valid = proxy_local_stats(priority_stats(200.0, [(0, 10)]));
+    };
+    let valid = priority_stats(200.0, [(0, 10)]);
 
     scenario
         .publish(&running_a, "model-fallback", Active, missing_map, Some(5))
@@ -2531,12 +2450,12 @@ async fn proxy_local_missing_priority_inputs_select_scalar_fallback() {
         Some(334)
     );
 
-    let invalid_rate = proxy_local_stats(ModelStats {
+    let invalid_rate = ModelStats {
         queue_size: 1,
         queued_input_size: 100,
         queue_time_estimate_ms_by_priority: HashMap::from([(0, 20)]),
         ..ModelStats::default()
-    });
+    };
     scenario
         .publish(&running_a, "model-fallback", Active, invalid_rate, Some(5))
         .await;
@@ -2549,13 +2468,9 @@ async fn proxy_local_missing_priority_inputs_select_scalar_fallback() {
 }
 
 #[tokio::test]
-async fn proxy_local_backend_removal_recomputes_local_aggregation() {
-    let (scenario, running_a, running_b) = published_shared_cluster(
-        proxy_local_stats(shared_backend_a_stats()),
-        proxy_local_stats(shared_backend_b_stats()),
-        10,
-    )
-    .await;
+async fn shared_cluster_backend_removal_recomputes_request_load() {
+    let (scenario, running_a, running_b) =
+        published_shared_cluster(shared_backend_a_stats(), shared_backend_b_stats(), 10).await;
     assert_eq!(
         scenario
             .only_cluster("shared-model")
@@ -2584,51 +2499,19 @@ async fn proxy_local_backend_removal_recomputes_local_aggregation() {
 }
 
 #[tokio::test]
-async fn proxy_local_reservation_is_applied_once_after_backend_aggregation() {
-    let scenario = RegistrationScenario::new(Some("rk-proxy-reserved"));
-    let running_a = scenario.start_in("inst-a", "cluster-proxy-reserved", 1111);
-    let running_b = scenario.start_in("inst-b", "cluster-proxy-reserved", 2222);
-    let stats_a = proxy_local_stats(ModelStats {
-        last_mean_input_tps: 100.0,
-        num_running_queries: 3,
-        total_query_input_size: 30,
-        queue_time_estimate_ms_by_priority: HashMap::from([(4, 10)]),
-        ..ModelStats::default()
-    });
-    let stats_b = proxy_local_stats(ModelStats {
-        last_mean_input_tps: 100.0,
-        num_running_queries: 7,
-        total_query_input_size: 70,
-        queue_time_estimate_ms_by_priority: HashMap::from([(4, 5)]),
-        ..ModelStats::default()
-    });
-    let update_a = scenario.update(&running_a, "model-proxy-reserved", Active, stats_a);
-    let update_b = scenario.update(&running_b, "model-proxy-reserved", Active, stats_b);
-    scenario.publish_connected(&running_a, &update_a).await;
-    scenario.publish_connected(&running_b, &update_b).await;
-
-    let selected = scenario.selected_cluster("model-proxy-reserved").await;
-    let _reservation = selected.reserve_backend(&running_a.generation(), 37, 4);
-    scenario.publish_connected(&running_b, &update_b).await;
-
-    let stats = scenario.only_cluster("model-proxy-reserved").await.stats;
-    assert_queue_stats(&stats, 11, 1, 137, 37, 4, 185);
-}
-
-#[tokio::test]
-async fn routing_uses_load_from_every_proxy_local_backend() {
+async fn routing_uses_load_from_every_shared_cluster_backend() {
     let scenario = RegistrationScenario::new(Some("rk-routing-load"));
     let shared_a = scenario.start_in("shared-a", "cluster-shared", 1111);
     let shared_b = scenario.start_in("shared-b", "cluster-shared", 2222);
     let light = scenario.start_in("light", "cluster-light", 3333);
     for (running, wait_ms) in [(&shared_a, 900), (&shared_b, 100), (&light, 300)] {
-        let stats = proxy_local_stats(ModelStats {
+        let stats = ModelStats {
             last_mean_input_tps: 100.0,
             queue_size: 1,
             queued_input_size: 100,
             queue_time_estimate_ms_by_priority: HashMap::from([(0, wait_ms)]),
             ..ModelStats::default()
-        });
+        };
         scenario
             .publish(running, "model-routing-load", Active, stats, Some(5))
             .await;

--- a/src/libraries/rust/stargate/crates/stargate/src/routing_state/tests.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/routing_state/tests.rs
@@ -2342,6 +2342,66 @@ async fn proxy_local_aggregation_saturates_gauges_and_rejects_invalid_rate_sums(
 }
 
 #[tokio::test]
+async fn proxy_local_priority_weights_preserve_numeric_boundaries() {
+    let scenario = RegistrationScenario::new(Some("rk-numeric"));
+    let running_a = scenario.start_in("inst-a", "cluster-numeric", 1111);
+    let running_b = scenario.start_in("inst-b", "cluster-numeric", 2222);
+    scenario
+        .publish(
+            &running_a,
+            "model-numeric",
+            Active,
+            proxy_local_stats(ModelStats {
+                last_mean_input_tps: f64::MAX,
+                queue_size: 1,
+                queued_input_size: 1,
+                queue_time_estimate_ms_by_priority: HashMap::from([(0, 2)]),
+                ..ModelStats::default()
+            }),
+            Some(5),
+        )
+        .await;
+    scenario
+        .publish(
+            &running_b,
+            "model-numeric",
+            Active,
+            proxy_local_stats(ModelStats::default()),
+            Some(5),
+        )
+        .await;
+    assert_eq!(
+        scenario
+            .only_cluster("model-numeric")
+            .await
+            .stats
+            .queue_time_estimate_ms_by_priority,
+        HashMap::from([(0, 2)])
+    );
+
+    let saturated = proxy_local_stats(ModelStats {
+        last_mean_input_tps: 1.0,
+        queue_size: 1,
+        queued_input_size: 1,
+        queue_time_estimate_ms_by_priority: HashMap::from([(0, u64::MAX)]),
+        ..ModelStats::default()
+    });
+    for running in [&running_a, &running_b] {
+        scenario
+            .publish(running, "model-numeric", Active, saturated.clone(), Some(5))
+            .await;
+    }
+    assert_eq!(
+        scenario
+            .only_cluster("model-numeric")
+            .await
+            .stats
+            .queue_time_estimate_ms_by_priority,
+        HashMap::from([(0, u64::MAX)])
+    );
+}
+
+#[tokio::test]
 async fn mixed_proxy_local_capability_uses_legacy_source_behavior() {
     let (scenario, _running_a, _running_b) = published_shared_cluster(
         proxy_local_stats(shared_backend_a_stats()),

--- a/src/libraries/rust/stargate/crates/stargate/src/routing_state/tests.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/routing_state/tests.rs
@@ -2240,6 +2240,7 @@ async fn three_proxy_local_backends_merge_sparse_priority_maps() {
     let running_a = scenario.start_in("inst-a", "cluster-three", 1111);
     let running_b = scenario.start_in("inst-b", "cluster-three", 2222);
     let running_c = scenario.start_in("inst-c", "cluster-three", 3333);
+    let competing = scenario.start_in("inst-competing", "cluster-competing", 4444);
     let stats = [
         ModelStats {
             last_mean_input_tps: 100.0,
@@ -2296,6 +2297,53 @@ async fn three_proxy_local_backends_merge_sparse_priority_maps() {
         output_generation_queries: 2,
         queue_time_estimate_ms_by_priority: HashMap::from([(1, 25), (2, 125), (3, 175)]),
     );
+
+    scenario
+        .publish(
+            &competing,
+            "model-three",
+            Active,
+            proxy_local_stats(priority_stats(100.0, [(3, 180)])),
+            Some(5),
+        )
+        .await;
+    let target = scenario.target("model-three");
+    let snapshot = scenario
+        .state
+        .routing_target_snapshot(&target)
+        .await
+        .expect("registered backends should publish a routable target");
+    let router = LoadBalancerRouter::from_config(&LoadBalancerConfig {
+        default: LoadBalancerAlgorithm::PowerOfN,
+        request_algorithms: HashMap::new(),
+        models: HashMap::from([(
+            "model-three".to_string(),
+            LoadBalancerModelConfig::Detailed(Box::new(LoadBalancerAlgorithmConfig {
+                settings: LoadBalancerAlgorithmSettings::PowerOfN(PowerOfNAlgorithmConfig {
+                    sample_count: 2,
+                    comparator: ClusterComparator::QueueTime,
+                }),
+                ..LoadBalancerAlgorithmConfig::default()
+            })),
+        )]),
+    })
+    .expect("power-of-n router should initialize");
+    let request = LoadBalancerRequest {
+        routing_target: &target,
+        cache_affinity_key: None,
+        input_tokens: None,
+        priority: 3,
+        received_at: Instant::now(),
+        request_slo: None,
+        excluded_cluster_ids: None,
+    };
+    let choice = router
+        .choose_candidate(snapshot.load_balancers(), &request, snapshot.clusters())
+        .expect("one cluster should be selected");
+    assert_eq!(
+        snapshot.clusters()[choice.candidate_index].cluster_id,
+        "cluster-three"
+    );
 }
 
 #[tokio::test]
@@ -2325,7 +2373,7 @@ async fn proxy_local_aggregation_saturates_gauges_and_rejects_invalid_rate_sums(
         output_generation_queries: 1,
         ..ModelStats::default()
     });
-    let (scenario, _running_a, _running_b) = published_shared_cluster(stats_a, stats_b, 5).await;
+    let (scenario, running_a, running_b) = published_shared_cluster(stats_a, stats_b, 5).await;
 
     let stats = scenario.only_cluster("shared-model").await.stats;
     assert_stats!(stats,
@@ -2338,6 +2386,41 @@ async fn proxy_local_aggregation_saturates_gauges_and_rejects_invalid_rate_sums(
         total_query_input_size: u64::MAX,
         input_processing_queries: u64::MAX,
         output_generation_queries: u64::MAX,
+    );
+
+    scenario
+        .publish(
+            &running_a,
+            "shared-model",
+            Active,
+            proxy_local_stats(ModelStats {
+                last_mean_input_tps: 125.0,
+                output_tps: 7.5,
+                max_output_tps: 50.0,
+                ..ModelStats::default()
+            }),
+            Some(5),
+        )
+        .await;
+    scenario
+        .publish(
+            &running_b,
+            "shared-model",
+            Active,
+            proxy_local_stats(ModelStats {
+                last_mean_input_tps: f64::NAN,
+                output_tps: f64::INFINITY,
+                max_output_tps: -1.0,
+                ..ModelStats::default()
+            }),
+            Some(5),
+        )
+        .await;
+    let stats = scenario.only_cluster("shared-model").await.stats;
+    assert_stats!(stats,
+        last_mean_input_tps: 125.0,
+        output_tps: 7.5,
+        max_output_tps: 50.0,
     );
 }
 

--- a/src/libraries/rust/stargate/crates/stargate/src/routing_state/tests.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/routing_state/tests.rs
@@ -2347,11 +2347,11 @@ async fn three_proxy_local_backends_merge_sparse_priority_maps() {
 }
 
 #[tokio::test]
-async fn proxy_local_aggregation_saturates_gauges_and_rejects_invalid_rate_sums() {
+async fn proxy_local_aggregation_saturates_gauges_and_ignores_invalid_rates() {
     let mut stats_a = ModelStats {
-        last_mean_input_tps: f64::MAX,
-        output_tps: f64::MAX,
-        max_output_tps: f64::NAN,
+        last_mean_input_tps: 100.0,
+        output_tps: 10.0,
+        max_output_tps: 50.0,
         queue_size: u64::MAX,
         queued_input_size: u64::MAX,
         num_running_queries: u64::MAX,
@@ -2362,9 +2362,9 @@ async fn proxy_local_aggregation_saturates_gauges_and_rejects_invalid_rate_sums(
     };
     stats_a = proxy_local_stats(stats_a);
     let stats_b = proxy_local_stats(ModelStats {
-        last_mean_input_tps: f64::MAX,
-        output_tps: f64::MAX,
-        max_output_tps: f64::INFINITY,
+        last_mean_input_tps: 200.0,
+        output_tps: 20.0,
+        max_output_tps: 60.0,
         queue_size: 1,
         queued_input_size: 1,
         num_running_queries: 1,
@@ -2377,9 +2377,9 @@ async fn proxy_local_aggregation_saturates_gauges_and_rejects_invalid_rate_sums(
 
     let stats = scenario.only_cluster("shared-model").await.stats;
     assert_stats!(stats,
-        last_mean_input_tps: 0.0,
-        output_tps: 0.0,
-        max_output_tps: 0.0,
+        last_mean_input_tps: 300.0,
+        output_tps: 30.0,
+        max_output_tps: 60.0,
         queue_size: u64::MAX,
         queued_input_size: u64::MAX,
         num_running_queries: u64::MAX,
@@ -2425,74 +2425,18 @@ async fn proxy_local_aggregation_saturates_gauges_and_rejects_invalid_rate_sums(
 }
 
 #[tokio::test]
-async fn proxy_local_priority_weights_preserve_numeric_boundaries() {
-    let scenario = RegistrationScenario::new(Some("rk-numeric"));
-    let running_a = scenario.start_in("inst-a", "cluster-numeric", 1111);
-    let running_b = scenario.start_in("inst-b", "cluster-numeric", 2222);
-    scenario
-        .publish(
-            &running_a,
-            "model-numeric",
-            Active,
-            proxy_local_stats(ModelStats {
-                last_mean_input_tps: f64::MAX,
-                queue_size: 1,
-                queued_input_size: 1,
-                queue_time_estimate_ms_by_priority: HashMap::from([(0, 2)]),
-                ..ModelStats::default()
-            }),
-            Some(5),
-        )
-        .await;
-    scenario
-        .publish(
-            &running_b,
-            "model-numeric",
-            Active,
-            proxy_local_stats(ModelStats::default()),
-            Some(5),
-        )
-        .await;
-    assert_eq!(
-        scenario
-            .only_cluster("model-numeric")
-            .await
-            .stats
-            .queue_time_estimate_ms_by_priority,
-        HashMap::from([(0, 2)])
-    );
-
-    let saturated = proxy_local_stats(ModelStats {
-        last_mean_input_tps: 1.0,
-        queue_size: 1,
-        queued_input_size: 1,
-        queue_time_estimate_ms_by_priority: HashMap::from([(0, u64::MAX)]),
-        ..ModelStats::default()
-    });
-    for running in [&running_a, &running_b] {
-        scenario
-            .publish(running, "model-numeric", Active, saturated.clone(), Some(5))
-            .await;
-    }
-    assert_eq!(
-        scenario
-            .only_cluster("model-numeric")
-            .await
-            .stats
-            .queue_time_estimate_ms_by_priority,
-        HashMap::from([(0, u64::MAX)])
-    );
-}
-
-#[tokio::test]
 async fn proxy_local_priority_weights_stay_within_source_bounds() {
     let scenario = RegistrationScenario::new(Some("rk-convex"));
     let backends = [
-        (scenario.start_in("inst-a", "cluster-convex", 1111), 6000.0),
-        (scenario.start_in("inst-b", "cluster-convex", 2222), 23000.0),
-        (scenario.start_in("inst-c", "cluster-convex", 3333), 1000.0),
+        (scenario.start_in("inst-a", "cluster-convex", 1111), 6.0, 5),
+        (
+            scenario.start_in("inst-b", "cluster-convex", 2222),
+            23.0,
+            20,
+        ),
+        (scenario.start_in("inst-c", "cluster-convex", 3333), 1.0, 50),
     ];
-    for (running, input_tps) in &backends {
+    for (running, input_tps, wait_ms) in &backends {
         scenario
             .publish(
                 running,
@@ -2502,7 +2446,7 @@ async fn proxy_local_priority_weights_stay_within_source_bounds() {
                     last_mean_input_tps: *input_tps,
                     queue_size: 1,
                     queued_input_size: 1,
-                    queue_time_estimate_ms_by_priority: HashMap::from([(0, 1)]),
+                    queue_time_estimate_ms_by_priority: HashMap::from([(0, *wait_ms)]),
                     ..ModelStats::default()
                 }),
                 Some(5),
@@ -2515,96 +2459,8 @@ async fn proxy_local_priority_weights_stay_within_source_bounds() {
             .await
             .stats
             .queue_time_estimate_ms_by_priority,
-        HashMap::from([(0, 1)])
+        HashMap::from([(0, 18)])
     );
-
-    for (running, input_tps) in &backends {
-        scenario
-            .publish(
-                running,
-                "model-convex",
-                Active,
-                proxy_local_stats(ModelStats {
-                    last_mean_input_tps: *input_tps,
-                    queue_size: 1,
-                    queued_input_size: 1,
-                    queue_time_estimate_ms_by_priority: HashMap::from([(0, u64::MAX)]),
-                    ..ModelStats::default()
-                }),
-                Some(5),
-            )
-            .await;
-    }
-    assert_eq!(
-        scenario
-            .only_cluster("model-convex")
-            .await
-            .stats
-            .queue_time_estimate_ms_by_priority,
-        HashMap::from([(0, u64::MAX)])
-    );
-}
-
-#[tokio::test]
-async fn proxy_local_priority_weights_resolve_integer_ceiling_boundaries() {
-    let scenario = RegistrationScenario::new(Some("rk-ceiling"));
-    let running_a = scenario.start_in("inst-a", "cluster-ceiling", 1111);
-    let running_b = scenario.start_in("inst-b", "cluster-ceiling", 2222);
-    let above_exact_integer = (1_u64 << 53) + 1;
-    let cases = [
-        ([(1.0, 6), (5.0, 0)], Some(1)),
-        ([((1_u64 << 53) as f64, 1), (1.0, 2)], Some(2)),
-        (
-            [(1.0, above_exact_integer), (1.0, above_exact_integer + 1)],
-            Some(above_exact_integer + 1),
-        ),
-        ([(1.0, 0), (1.0, u64::MAX)], Some(1_u64 << 63)),
-        (
-            [(1.0, 0), (1.0, (1_u64 << 63) + 1023)],
-            Some((1_u64 << 62) + 512),
-        ),
-        (
-            [(f64::from_bits(4.0_f64.to_bits() + 1), 27), (1.0, 22)],
-            Some(27),
-        ),
-        ([(0.1, 0), (1.1, 12)], Some(12)),
-        ([(1.0, 0), (2.0_f64.powi(76), 100)], None),
-        ([(1.0, 0), (f64::MAX / 2.0, u64::MAX - 1)], None),
-        ([(f64::MAX, 0), (f64::MIN_POSITIVE, 2)], None),
-    ];
-
-    for (local_stats, expected_wait_ms) in cases {
-        for (running, (input_tps, wait_ms)) in
-            [(&running_a, local_stats[0]), (&running_b, local_stats[1])]
-        {
-            scenario
-                .publish(
-                    running,
-                    "model-ceiling",
-                    Active,
-                    proxy_local_stats(ModelStats {
-                        last_mean_input_tps: input_tps,
-                        queue_size: 1,
-                        queued_input_size: 1,
-                        queue_time_estimate_ms_by_priority: HashMap::from([(0, wait_ms)]),
-                        ..ModelStats::default()
-                    }),
-                    Some(5),
-                )
-                .await;
-        }
-        let expected_map = expected_wait_ms
-            .map(|wait_ms| HashMap::from([(0, wait_ms)]))
-            .unwrap_or_default();
-        assert_eq!(
-            scenario
-                .only_cluster("model-ceiling")
-                .await
-                .stats
-                .queue_time_estimate_ms_by_priority,
-            expected_map
-        );
-    }
 }
 
 #[tokio::test]

--- a/src/libraries/rust/stargate/crates/stargate/src/routing_state/tests.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/routing_state/tests.rs
@@ -2469,13 +2469,24 @@ async fn proxy_local_priority_weights_resolve_integer_ceiling_boundaries() {
     let running_b = scenario.start_in("inst-b", "cluster-ceiling", 2222);
     let above_exact_integer = (1_u64 << 53) + 1;
     let cases = [
-        ([(1.0, 6), (5.0, 0)], 1),
-        ([((1_u64 << 53) as f64, 1), (1.0, 2)], 2),
+        ([(1.0, 6), (5.0, 0)], Some(1)),
+        ([((1_u64 << 53) as f64, 1), (1.0, 2)], Some(2)),
         (
             [(1.0, above_exact_integer), (1.0, above_exact_integer + 1)],
-            above_exact_integer + 1,
+            Some(above_exact_integer + 1),
         ),
-        ([(1.0, 0), (f64::MAX / 2.0, u64::MAX - 1)], u64::MAX - 1),
+        ([(1.0, 0), (1.0, u64::MAX)], Some(1_u64 << 63)),
+        (
+            [(1.0, 0), (1.0, (1_u64 << 63) + 1023)],
+            Some((1_u64 << 62) + 512),
+        ),
+        (
+            [(f64::from_bits(4.0_f64.to_bits() + 1), 27), (1.0, 22)],
+            Some(27),
+        ),
+        ([(0.1, 0), (1.1, 12)], Some(12)),
+        ([(1.0, 0), (f64::MAX / 2.0, u64::MAX - 1)], None),
+        ([(f64::MAX, 0), (f64::MIN_POSITIVE, 2)], None),
     ];
 
     for (local_stats, expected_wait_ms) in cases {
@@ -2498,13 +2509,16 @@ async fn proxy_local_priority_weights_resolve_integer_ceiling_boundaries() {
                 )
                 .await;
         }
+        let expected_map = expected_wait_ms
+            .map(|wait_ms| HashMap::from([(0, wait_ms)]))
+            .unwrap_or_default();
         assert_eq!(
             scenario
                 .only_cluster("model-ceiling")
                 .await
                 .stats
                 .queue_time_estimate_ms_by_priority,
-            HashMap::from([(0, expected_wait_ms)])
+            expected_map
         );
     }
 }

--- a/src/libraries/rust/stargate/crates/stargate/src/routing_state/tests.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/routing_state/tests.rs
@@ -21,9 +21,9 @@ use super::reservations::update_reserved_priority_queue_time;
 use super::snapshots::{ClusterBackendUpsert, RoutedClusterState, RoutingTargetGeneration};
 use super::*;
 use crate::load_balancer::{
-    LoadBalancerAlgorithm, LoadBalancerAlgorithmConfig, LoadBalancerAlgorithmSettings,
-    LoadBalancerConfig, LoadBalancerModelConfig, LoadBalancerRequest, LoadBalancerRouter,
-    WaitAndWidenAlgorithmConfig,
+    ClusterComparator, LoadBalancerAlgorithm, LoadBalancerAlgorithmConfig,
+    LoadBalancerAlgorithmSettings, LoadBalancerConfig, LoadBalancerModelConfig,
+    LoadBalancerRequest, LoadBalancerRouter, PowerOfNAlgorithmConfig, WaitAndWidenAlgorithmConfig,
 };
 use InferenceServerStatus::{Active, Inactive};
 use stargate_proto::pb::InferenceServerModelRegistration;
@@ -348,6 +348,13 @@ fn shared_backend_b_stats() -> ModelStats {
         total_query_input_size: 777,
         queue_time_estimate_ms_by_priority: HashMap::from([(1, 222), (2, 333)]),
     }
+}
+
+fn proxy_local_stats(mut stats: ModelStats) -> ModelStats {
+    stats
+        .stats_capabilities
+        .push("request.load.proxy_local".to_string());
+    stats
 }
 
 async fn published_shared_cluster(
@@ -2174,6 +2181,365 @@ async fn shared_cluster_registration_exposes_one_aggregated_cluster_candidate() 
         queue_time_estimate_ms_by_priority: HashMap::from([(1, 222), (2, 333)]),
     );
     assert_eq!(cluster.rtt, Duration::from_micros(7_500));
+}
+
+#[tokio::test]
+async fn proxy_local_shared_cluster_aggregates_request_load_and_weighted_priorities() {
+    let (scenario, _running_a, _running_b) = published_shared_cluster(
+        proxy_local_stats(shared_backend_a_stats()),
+        proxy_local_stats(shared_backend_b_stats()),
+        10,
+    )
+    .await;
+
+    let cluster = scenario.only_cluster("shared-model").await;
+    assert_stats!(cluster.stats,
+        last_mean_input_tps: 220.0,
+        output_tps: 7.0,
+        max_output_tps: 60.0,
+        queue_size: 3,
+        queued_input_size: 300,
+        num_running_queries: 18,
+        total_query_input_size: 1888,
+        input_processing_queries: 4,
+        output_generation_queries: 6,
+        kv_cache_capacity_tokens: 2000,
+        kv_cache_used_tokens: 500,
+        kv_cache_free_tokens: 1500,
+        max_engine_concurrency: 77,
+        queue_time_estimate_ms_by_priority: HashMap::from([(1, 172), (2, 233)]),
+    );
+}
+
+#[tokio::test]
+async fn proxy_local_aggregation_is_independent_of_heartbeat_order() {
+    let scenario = RegistrationScenario::new(Some("rk-order"));
+    let running_a = scenario.start_in("inst-a", "cluster-order", 1111);
+    let running_b = scenario.start_in("inst-b", "cluster-order", 2222);
+    let mut stats_a = proxy_local_stats(shared_backend_a_stats());
+    let stats_b = proxy_local_stats(shared_backend_b_stats());
+    stats_a.kv_cache_capacity_tokens = stats_b.kv_cache_capacity_tokens;
+    stats_a.kv_cache_used_tokens = stats_b.kv_cache_used_tokens;
+    stats_a.kv_cache_free_tokens = stats_b.kv_cache_free_tokens;
+    stats_a.max_engine_concurrency = stats_b.max_engine_concurrency;
+    let update_a = scenario.update(&running_a, "model-order", Active, stats_a);
+    let update_b = scenario.update(&running_b, "model-order", Active, stats_b);
+
+    scenario.publish_connected(&running_a, &update_a).await;
+    scenario.publish_connected(&running_b, &update_b).await;
+    let b_last = scenario.only_cluster("model-order").await.stats;
+    scenario.publish_connected(&running_a, &update_a).await;
+    let a_last = scenario.only_cluster("model-order").await.stats;
+
+    assert_eq!(a_last, b_last);
+}
+
+#[tokio::test]
+async fn three_proxy_local_backends_merge_sparse_priority_maps() {
+    let scenario = RegistrationScenario::new(Some("rk-three"));
+    let running_a = scenario.start_in("inst-a", "cluster-three", 1111);
+    let running_b = scenario.start_in("inst-b", "cluster-three", 2222);
+    let running_c = scenario.start_in("inst-c", "cluster-three", 3333);
+    let stats = [
+        ModelStats {
+            last_mean_input_tps: 100.0,
+            output_tps: 10.0,
+            queue_size: 1,
+            queued_input_size: 100,
+            num_running_queries: 1,
+            total_query_input_size: 100,
+            input_processing_queries: 1,
+            queue_time_estimate_ms_by_priority: HashMap::from([(1, 100), (3, 300)]),
+            ..ModelStats::default()
+        },
+        ModelStats {
+            last_mean_input_tps: 200.0,
+            output_tps: 20.0,
+            queue_size: 1,
+            queued_input_size: 200,
+            num_running_queries: 2,
+            total_query_input_size: 200,
+            output_generation_queries: 2,
+            queue_time_estimate_ms_by_priority: HashMap::from([(2, 200)]),
+            ..ModelStats::default()
+        },
+        ModelStats {
+            last_mean_input_tps: 100.0,
+            output_tps: 0.0,
+            num_running_queries: 3,
+            total_query_input_size: 300,
+            queue_time_estimate_ms_by_priority: HashMap::from([(3, 900)]),
+            ..ModelStats::default()
+        },
+    ]
+    .map(proxy_local_stats);
+
+    for (running, stats) in [
+        (&running_a, stats[0].clone()),
+        (&running_b, stats[1].clone()),
+        (&running_c, stats[2].clone()),
+    ] {
+        scenario
+            .publish(running, "model-three", Active, stats, Some(5))
+            .await;
+    }
+
+    let cluster = scenario.only_cluster("model-three").await;
+    assert_stats!(cluster.stats,
+        last_mean_input_tps: 400.0,
+        output_tps: 30.0,
+        queue_size: 2,
+        queued_input_size: 300,
+        num_running_queries: 6,
+        total_query_input_size: 600,
+        input_processing_queries: 1,
+        output_generation_queries: 2,
+        queue_time_estimate_ms_by_priority: HashMap::from([(1, 25), (2, 125), (3, 175)]),
+    );
+}
+
+#[tokio::test]
+async fn proxy_local_aggregation_saturates_gauges_and_rejects_invalid_rate_sums() {
+    let mut stats_a = ModelStats {
+        last_mean_input_tps: f64::MAX,
+        output_tps: f64::MAX,
+        max_output_tps: f64::NAN,
+        queue_size: u64::MAX,
+        queued_input_size: u64::MAX,
+        num_running_queries: u64::MAX,
+        total_query_input_size: u64::MAX,
+        input_processing_queries: u64::MAX,
+        output_generation_queries: u64::MAX,
+        ..ModelStats::default()
+    };
+    stats_a = proxy_local_stats(stats_a);
+    let stats_b = proxy_local_stats(ModelStats {
+        last_mean_input_tps: f64::MAX,
+        output_tps: f64::MAX,
+        max_output_tps: f64::INFINITY,
+        queue_size: 1,
+        queued_input_size: 1,
+        num_running_queries: 1,
+        total_query_input_size: 1,
+        input_processing_queries: 1,
+        output_generation_queries: 1,
+        ..ModelStats::default()
+    });
+    let (scenario, _running_a, _running_b) = published_shared_cluster(stats_a, stats_b, 5).await;
+
+    let stats = scenario.only_cluster("shared-model").await.stats;
+    assert_stats!(stats,
+        last_mean_input_tps: 0.0,
+        output_tps: 0.0,
+        max_output_tps: 0.0,
+        queue_size: u64::MAX,
+        queued_input_size: u64::MAX,
+        num_running_queries: u64::MAX,
+        total_query_input_size: u64::MAX,
+        input_processing_queries: u64::MAX,
+        output_generation_queries: u64::MAX,
+    );
+}
+
+#[tokio::test]
+async fn mixed_proxy_local_capability_uses_legacy_source_behavior() {
+    let (scenario, _running_a, _running_b) = published_shared_cluster(
+        proxy_local_stats(shared_backend_a_stats()),
+        shared_backend_b_stats(),
+        10,
+    )
+    .await;
+
+    let stats = scenario.only_cluster("shared-model").await.stats;
+    assert_stats!(stats,
+        last_mean_input_tps: 220.0,
+        output_tps: 7.0,
+        queue_size: 3,
+        queued_input_size: 300,
+        input_processing_queries: 4,
+        output_generation_queries: 6,
+        max_output_tps: 60.0,
+        num_running_queries: 7,
+        total_query_input_size: 777,
+        queue_time_estimate_ms_by_priority: HashMap::from([(1, 222), (2, 333)]),
+    );
+}
+
+#[tokio::test]
+async fn proxy_local_missing_priority_inputs_select_scalar_fallback() {
+    let scenario = RegistrationScenario::new(Some("rk-fallback"));
+    let running_a = scenario.start_in("inst-a", "cluster-fallback", 1111);
+    let running_b = scenario.start_in("inst-b", "cluster-fallback", 2222);
+    let missing_map = proxy_local_stats(ModelStats {
+        last_mean_input_tps: 100.0,
+        queue_size: 1,
+        queued_input_size: 100,
+        ..ModelStats::default()
+    });
+    let valid = proxy_local_stats(priority_stats(200.0, [(0, 10)]));
+
+    scenario
+        .publish(&running_a, "model-fallback", Active, missing_map, Some(5))
+        .await;
+    scenario
+        .publish(&running_b, "model-fallback", Active, valid.clone(), Some(5))
+        .await;
+    let stats = scenario.only_cluster("model-fallback").await.stats;
+    assert!(stats.queue_time_estimate_ms_by_priority.is_empty());
+    assert_eq!(
+        crate::queue_estimate::queue_time_estimate_ms_for_priority(&stats, 0),
+        Some(334)
+    );
+
+    let invalid_rate = proxy_local_stats(ModelStats {
+        queue_size: 1,
+        queued_input_size: 100,
+        queue_time_estimate_ms_by_priority: HashMap::from([(0, 20)]),
+        ..ModelStats::default()
+    });
+    scenario
+        .publish(&running_a, "model-fallback", Active, invalid_rate, Some(5))
+        .await;
+    let stats = scenario.only_cluster("model-fallback").await.stats;
+    assert!(stats.queue_time_estimate_ms_by_priority.is_empty());
+    assert_eq!(
+        crate::queue_estimate::queue_time_estimate_ms_for_priority(&stats, 0),
+        Some(500)
+    );
+}
+
+#[tokio::test]
+async fn proxy_local_backend_removal_recomputes_local_aggregation() {
+    let (scenario, running_a, running_b) = published_shared_cluster(
+        proxy_local_stats(shared_backend_a_stats()),
+        proxy_local_stats(shared_backend_b_stats()),
+        10,
+    )
+    .await;
+    assert_eq!(
+        scenario
+            .only_cluster("shared-model")
+            .await
+            .stats
+            .num_running_queries,
+        18
+    );
+
+    scenario.state.end_registration(running_b).await;
+    let stats = scenario.only_cluster("shared-model").await.stats;
+    assert_stats!(stats,
+        last_mean_input_tps: 100.0,
+        output_tps: 2.0,
+        max_output_tps: 50.0,
+        queue_size: 1,
+        queued_input_size: 100,
+        num_running_queries: 11,
+        total_query_input_size: 1111,
+        input_processing_queries: 1,
+        output_generation_queries: 2,
+        queue_time_estimate_ms_by_priority: HashMap::from([(1, 111)]),
+    );
+    scenario.state.end_registration(running_a).await;
+    assert!(scenario.clusters("shared-model").await.is_empty());
+}
+
+#[tokio::test]
+async fn proxy_local_reservation_is_applied_once_after_backend_aggregation() {
+    let scenario = RegistrationScenario::new(Some("rk-proxy-reserved"));
+    let running_a = scenario.start_in("inst-a", "cluster-proxy-reserved", 1111);
+    let running_b = scenario.start_in("inst-b", "cluster-proxy-reserved", 2222);
+    let stats_a = proxy_local_stats(ModelStats {
+        last_mean_input_tps: 100.0,
+        num_running_queries: 3,
+        total_query_input_size: 30,
+        queue_time_estimate_ms_by_priority: HashMap::from([(4, 10)]),
+        ..ModelStats::default()
+    });
+    let stats_b = proxy_local_stats(ModelStats {
+        last_mean_input_tps: 100.0,
+        num_running_queries: 7,
+        total_query_input_size: 70,
+        queue_time_estimate_ms_by_priority: HashMap::from([(4, 5)]),
+        ..ModelStats::default()
+    });
+    let update_a = scenario.update(&running_a, "model-proxy-reserved", Active, stats_a);
+    let update_b = scenario.update(&running_b, "model-proxy-reserved", Active, stats_b);
+    scenario.publish_connected(&running_a, &update_a).await;
+    scenario.publish_connected(&running_b, &update_b).await;
+
+    let selected = scenario.selected_cluster("model-proxy-reserved").await;
+    let _reservation = selected.reserve_backend(&running_a.generation(), 37, 4);
+    scenario.publish_connected(&running_b, &update_b).await;
+
+    let stats = scenario.only_cluster("model-proxy-reserved").await.stats;
+    assert_queue_stats(&stats, 11, 1, 137, 37, 4, 185);
+}
+
+#[tokio::test]
+async fn routing_uses_load_from_every_proxy_local_backend() {
+    let scenario = RegistrationScenario::new(Some("rk-routing-load"));
+    let shared_a = scenario.start_in("shared-a", "cluster-shared", 1111);
+    let shared_b = scenario.start_in("shared-b", "cluster-shared", 2222);
+    let light = scenario.start_in("light", "cluster-light", 3333);
+    for (running, wait_ms) in [(&shared_a, 900), (&shared_b, 100), (&light, 300)] {
+        let stats = proxy_local_stats(ModelStats {
+            last_mean_input_tps: 100.0,
+            queue_size: 1,
+            queued_input_size: 100,
+            queue_time_estimate_ms_by_priority: HashMap::from([(0, wait_ms)]),
+            ..ModelStats::default()
+        });
+        scenario
+            .publish(running, "model-routing-load", Active, stats, Some(5))
+            .await;
+    }
+    let target = scenario.target("model-routing-load");
+    let snapshot = scenario
+        .state
+        .routing_target_snapshot(&target)
+        .await
+        .expect("registered backends should publish a routable target");
+    let shared = snapshot
+        .clusters()
+        .iter()
+        .find(|cluster| cluster.cluster_id == "cluster-shared")
+        .expect("shared cluster should be present");
+    assert_eq!(
+        shared.stats.queue_time_estimate_ms_by_priority,
+        HashMap::from([(0, 500)])
+    );
+
+    let router = LoadBalancerRouter::from_config(&LoadBalancerConfig {
+        default: LoadBalancerAlgorithm::PowerOfN,
+        request_algorithms: HashMap::new(),
+        models: HashMap::from([(
+            "model-routing-load".to_string(),
+            LoadBalancerModelConfig::Detailed(Box::new(LoadBalancerAlgorithmConfig {
+                settings: LoadBalancerAlgorithmSettings::PowerOfN(PowerOfNAlgorithmConfig {
+                    sample_count: 2,
+                    comparator: ClusterComparator::QueueTime,
+                }),
+                ..LoadBalancerAlgorithmConfig::default()
+            })),
+        )]),
+    })
+    .expect("power-of-n router should initialize");
+    let request = LoadBalancerRequest {
+        routing_target: &target,
+        cache_affinity_key: None,
+        input_tokens: None,
+        priority: 0,
+        received_at: Instant::now(),
+        request_slo: None,
+        excluded_cluster_ids: None,
+    };
+    let choice = router
+        .choose_candidate(snapshot.load_balancers(), &request, snapshot.clusters())
+        .expect("one cluster should be selected");
+    assert_eq!(
+        snapshot.clusters()[choice.candidate_index].cluster_id,
+        "cluster-light"
+    );
 }
 
 #[tokio::test]

--- a/src/libraries/rust/stargate/crates/stargate/src/routing_state/tests.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/routing_state/tests.rs
@@ -2568,6 +2568,7 @@ async fn proxy_local_priority_weights_resolve_integer_ceiling_boundaries() {
             Some(27),
         ),
         ([(0.1, 0), (1.1, 12)], Some(12)),
+        ([(1.0, 0), (2.0_f64.powi(76), 100)], None),
         ([(1.0, 0), (f64::MAX / 2.0, u64::MAX - 1)], None),
         ([(f64::MAX, 0), (f64::MIN_POSITIVE, 2)], None),
     ];
@@ -2608,7 +2609,7 @@ async fn proxy_local_priority_weights_resolve_integer_ceiling_boundaries() {
 
 #[tokio::test]
 async fn mixed_proxy_local_capability_uses_legacy_source_behavior() {
-    let (scenario, _running_a, _running_b) = published_shared_cluster(
+    let (scenario, running_a, _running_b) = published_shared_cluster(
         proxy_local_stats(shared_backend_a_stats()),
         shared_backend_b_stats(),
         10,
@@ -2625,6 +2626,24 @@ async fn mixed_proxy_local_capability_uses_legacy_source_behavior() {
         output_generation_queries: 6,
         max_output_tps: 60.0,
         num_running_queries: 7,
+        total_query_input_size: 777,
+        queue_time_estimate_ms_by_priority: HashMap::from([(1, 222), (2, 333)]),
+    );
+
+    scenario
+        .publish(
+            &running_a,
+            "shared-model",
+            Active,
+            proxy_local_stats(shared_backend_a_stats()),
+            Some(10),
+        )
+        .await;
+    let stats = scenario.only_cluster("shared-model").await.stats;
+    assert_stats!(stats,
+        max_output_tps: 60.0,
+        num_running_queries: 7,
+        max_engine_concurrency: 77,
         total_query_input_size: 777,
         queue_time_estimate_ms_by_priority: HashMap::from([(1, 222), (2, 333)]),
     );

--- a/src/libraries/rust/stargate/crates/stargate/src/routing_state/tests.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/routing_state/tests.rs
@@ -2402,6 +2402,67 @@ async fn proxy_local_priority_weights_preserve_numeric_boundaries() {
 }
 
 #[tokio::test]
+async fn proxy_local_priority_weights_stay_within_source_bounds() {
+    let scenario = RegistrationScenario::new(Some("rk-convex"));
+    let backends = [
+        (scenario.start_in("inst-a", "cluster-convex", 1111), 6000.0),
+        (scenario.start_in("inst-b", "cluster-convex", 2222), 23000.0),
+        (scenario.start_in("inst-c", "cluster-convex", 3333), 1000.0),
+    ];
+    for (running, input_tps) in &backends {
+        scenario
+            .publish(
+                running,
+                "model-convex",
+                Active,
+                proxy_local_stats(ModelStats {
+                    last_mean_input_tps: *input_tps,
+                    queue_size: 1,
+                    queued_input_size: 1,
+                    queue_time_estimate_ms_by_priority: HashMap::from([(0, 1)]),
+                    ..ModelStats::default()
+                }),
+                Some(5),
+            )
+            .await;
+    }
+    assert_eq!(
+        scenario
+            .only_cluster("model-convex")
+            .await
+            .stats
+            .queue_time_estimate_ms_by_priority,
+        HashMap::from([(0, 1)])
+    );
+
+    for (running, input_tps) in &backends {
+        scenario
+            .publish(
+                running,
+                "model-convex",
+                Active,
+                proxy_local_stats(ModelStats {
+                    last_mean_input_tps: *input_tps,
+                    queue_size: 1,
+                    queued_input_size: 1,
+                    queue_time_estimate_ms_by_priority: HashMap::from([(0, u64::MAX)]),
+                    ..ModelStats::default()
+                }),
+                Some(5),
+            )
+            .await;
+    }
+    assert_eq!(
+        scenario
+            .only_cluster("model-convex")
+            .await
+            .stats
+            .queue_time_estimate_ms_by_priority,
+        HashMap::from([(0, u64::MAX)])
+    );
+}
+
+#[tokio::test]
 async fn mixed_proxy_local_capability_uses_legacy_source_behavior() {
     let (scenario, _running_a, _running_b) = published_shared_cluster(
         proxy_local_stats(shared_backend_a_stats()),

--- a/src/libraries/rust/stargate/crates/stargate/src/routing_state/tests.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/routing_state/tests.rs
@@ -2463,6 +2463,53 @@ async fn proxy_local_priority_weights_stay_within_source_bounds() {
 }
 
 #[tokio::test]
+async fn proxy_local_priority_weights_resolve_integer_ceiling_boundaries() {
+    let scenario = RegistrationScenario::new(Some("rk-ceiling"));
+    let running_a = scenario.start_in("inst-a", "cluster-ceiling", 1111);
+    let running_b = scenario.start_in("inst-b", "cluster-ceiling", 2222);
+    let above_exact_integer = (1_u64 << 53) + 1;
+    let cases = [
+        ([(1.0, 6), (5.0, 0)], 1),
+        ([((1_u64 << 53) as f64, 1), (1.0, 2)], 2),
+        (
+            [(1.0, above_exact_integer), (1.0, above_exact_integer + 1)],
+            above_exact_integer + 1,
+        ),
+        ([(1.0, 0), (f64::MAX / 2.0, u64::MAX - 1)], u64::MAX - 1),
+    ];
+
+    for (local_stats, expected_wait_ms) in cases {
+        for (running, (input_tps, wait_ms)) in
+            [(&running_a, local_stats[0]), (&running_b, local_stats[1])]
+        {
+            scenario
+                .publish(
+                    running,
+                    "model-ceiling",
+                    Active,
+                    proxy_local_stats(ModelStats {
+                        last_mean_input_tps: input_tps,
+                        queue_size: 1,
+                        queued_input_size: 1,
+                        queue_time_estimate_ms_by_priority: HashMap::from([(0, wait_ms)]),
+                        ..ModelStats::default()
+                    }),
+                    Some(5),
+                )
+                .await;
+        }
+        assert_eq!(
+            scenario
+                .only_cluster("model-ceiling")
+                .await
+                .stats
+                .queue_time_estimate_ms_by_priority,
+            HashMap::from([(0, expected_wait_ms)])
+        );
+    }
+}
+
+#[tokio::test]
 async fn mixed_proxy_local_capability_uses_legacy_source_behavior() {
     let (scenario, _running_a, _running_b) = published_shared_cluster(
         proxy_local_stats(shared_backend_a_stats()),


### PR DESCRIPTION
## Why

When multiple proxy-local Pylons advertise the same model and cluster, Stargate can retain request statistics from only the latest backend. This under-represents cluster request load and can produce queue estimates that ignore active work on other backends.

The matching Pylon and Stargate changes deploy together, so this change does not include a mixed-version capability gate or legacy fallback path.

## What changed

- Aggregate request-local gauges across every active backend in the cluster.
- Sum valid observed input and output throughput, and use the largest valid backend output capacity.
- Combine per-priority queue estimates with a direct input-throughput-weighted mean, rounded upward and kept within the observed range.
- Omit the aggregate priority map when a queued backend lacks the required inputs or the calculation is invalid, allowing the existing scalar estimate fallback to apply.
- Keep shared engine statistics, including KV cache state and maximum engine concurrency, sourced from one backend.
- Apply pending reservations once after backend aggregation and recompute the aggregate after backend removal.
- Remove the request-load capability check, mixed-version fallback, and capability-specific tests and helpers.

## Customer Release Notes

Stargate now accounts for request load from every Pylon in a shared cluster, improving routing and queue-time estimates.

## Plan Summary

No infrastructure, chart, or resource changes. Deploy this Stargate change together with the matching Pylon lifecycle and throughput changes in #1452 and #1457.

## Usage

Not applicable.

## Testing

- `rustfmt --edition 2024 --check` on the changed Rust files
- `cargo clippy -p stargate --all-targets -- -D warnings`
- `cargo test -p stargate --lib routing_state::tests`: 61 passed
- `cargo test -p stargate`: 351 library, 52 main binary, 18 probe, 3 CLI, and 142 integration tests passed
- Combined deploy-together branch: `cargo test --workspace` and `cargo clippy -p stargate -p pylon-lib -p pylon --all-targets -- -D warnings` passed.

`cargo fmt --all --check` also reports formatting drift in untouched Stargate files. Every file changed by this Pull Request passes the pinned formatter.

QA is not required beyond the automated Stargate suite.

## Notes

There is no compatibility marker or mixed-version behavior for this request-load contract. There are no logging, tracing, metrics, dashboard, alert, or diagram changes.

## Issues

Closes #1447

## References

- https://github.com/NVIDIA/nvcf/issues/1447

## Related Pull Requests

- Stack child: #1452
- Later stack PRs: #1457 and #1459

## Dependencies

None. No license or NOTICE changes are required.
