### PR TITLE
fix(pylon): derive request phases from generated output

### DIFF
--- a/src/libraries/rust/stargate/crates/pylon-lib/src/bringup.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/bringup.rs
@@ -140,6 +140,40 @@ mod tests {
         crate::runtime_state::ModelGeneration::new("test-model", 0)
     }
 
+    async fn send_observed_completion(
+        upstream_http_base_url: &str,
+    ) -> (
+        Result<ChatCompletionResponse, BringupError>,
+        Vec<crate::RequestObservationState>,
+    ) {
+        let (runtime_state, observations) = PylonRuntimeState::observed(
+            InferenceServerStatus::Active,
+            &["test-model".to_string()],
+            8,
+            None,
+        );
+        let result = send_completion_request(
+            &reqwest::Client::new(),
+            upstream_http_base_url,
+            Some(Duration::from_secs(1)),
+            &serde_json::json!({
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "max_tokens": 1,
+                "stream": false,
+            }),
+            crate::generated_request_id::GeneratedRequestKind::Calibration,
+            &test_generation(),
+            Some(&runtime_state),
+        )
+        .await;
+        let states = observations
+            .try_iter()
+            .map(|event| event.into_observation().state)
+            .collect();
+        (result, states)
+    }
+
     fn test_stats_collector() -> (PylonRuntimeState, StatsCollectorHandle) {
         let config = StatsCollectorConfig {
             duration_floor: Duration::ZERO,
@@ -185,6 +219,72 @@ mod tests {
         );
         assert_eq!(paths.resolved_path().as_deref(), Some("/v1/health/ready"));
 
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn calibration_execute_failure_is_recorded_as_failed_after_submission() {
+        let (result, states) = send_observed_completion("http://127.0.0.1:0").await;
+
+        assert!(matches!(result, Err(BringupError::Http(_))));
+        assert_eq!(
+            states,
+            [
+                crate::RequestObservationState::UpstreamConnecting,
+                crate::RequestObservationState::InputProcessing,
+                crate::RequestObservationState::Failed,
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn calibration_non_success_response_is_recorded_as_failed() {
+        let server = TestHttpServer::spawn(Router::new().route(
+            "/v1/chat/completions",
+            post(|| async {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": {"message": "backend failed"}})),
+                )
+            }),
+        ))
+        .await;
+
+        let (result, states) = send_observed_completion(server.as_str()).await;
+
+        assert!(matches!(result, Err(BringupError::Api { .. })));
+        assert_eq!(
+            states,
+            [
+                crate::RequestObservationState::UpstreamConnecting,
+                crate::RequestObservationState::InputProcessing,
+                crate::RequestObservationState::InputProcessing,
+                crate::RequestObservationState::Failed,
+            ]
+        );
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn calibration_invalid_response_is_recorded_as_failed() {
+        let server = TestHttpServer::spawn(Router::new().route(
+            "/v1/chat/completions",
+            post(|| async { (StatusCode::OK, "not-json") }),
+        ))
+        .await;
+
+        let (result, states) = send_observed_completion(server.as_str()).await;
+
+        assert!(matches!(result, Err(BringupError::InvalidResponse(_))));
+        assert_eq!(
+            states,
+            [
+                crate::RequestObservationState::UpstreamConnecting,
+                crate::RequestObservationState::InputProcessing,
+                crate::RequestObservationState::InputProcessing,
+                crate::RequestObservationState::Failed,
+            ]
+        );
         server.shutdown().await;
     }
 

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/bringup/upstream.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/bringup/upstream.rs
@@ -17,12 +17,12 @@ use std::time::{Duration, Instant};
 
 use crate::DEFAULT_MAX_SSE_BUFFER_BYTES;
 use crate::generated_request_id::{GeneratedRequestKind, next_generated_request_id};
-use crate::output_token_parser::{OutputTokenParser, OutputTokenProgress};
+use crate::output_token_parser::OutputTokenParser;
 use crate::request_observer::{
     RequestObservationEndpoint, RequiredTunnelHeaders, TunnelRequestObserver,
 };
 use crate::runtime_state::{ModelGeneration, PylonRuntimeState};
-use crate::sse_message_stream::{SseMessage, upstream_sse_message_stream};
+use crate::sse_message_stream::{RelayOutcome, upstream_sse_message_stream};
 use crate::upstream_health::UpstreamHealthPaths;
 use crate::upstream_url::upstream_endpoint;
 use futures::StreamExt;
@@ -156,30 +156,32 @@ pub(super) async fn send_canary_request(
     let mut observed_tokens = 0_u64;
     let mut completed = false;
     while let Some(message) = messages.next().await {
-        match message
-            .map_err(|error| BringupError::InvalidResponse(error.to_string()))?
-            .message
+        let message = message.map_err(|error| BringupError::InvalidResponse(error.to_string()))?;
+        if let Some(generated_output) = message.facts.generated_output
+            && let Some(delta) = output_tokens
+                .observe_estimated_output_tokens(generated_output.estimated_token_units)
         {
-            SseMessage::Done => {
+            observed_tokens = observed_tokens.saturating_add(delta);
+        }
+        if let Some(tokens) = message
+            .facts
+            .exact_usage
+            .and_then(|usage| usage.output_tokens)
+        {
+            observed_tokens = output_tokens.observe_exact_output_tokens(tokens);
+        }
+        if observed_tokens > u64::from(canary_max_generation_threshold) {
+            return Err(BringupError::RunawayGeneration {
+                tokens: u32::try_from(observed_tokens).unwrap_or(u32::MAX),
+            });
+        }
+        match message.facts.terminal {
+            Some(RelayOutcome::Complete) => {
                 completed = true;
                 break;
             }
-            SseMessage::ChatCompletionChunk { parsed } => {
-                if let Some(progress) = output_tokens.observe_json(parsed.as_ref()) {
-                    observed_tokens = match progress {
-                        OutputTokenProgress::ExplicitCumulative { tokens, .. } => tokens,
-                        OutputTokenProgress::EstimatedDelta { delta } => {
-                            observed_tokens.saturating_add(delta)
-                        }
-                    };
-                    if observed_tokens > u64::from(canary_max_generation_threshold) {
-                        return Err(BringupError::RunawayGeneration {
-                            tokens: u32::try_from(observed_tokens).unwrap_or(u32::MAX),
-                        });
-                    }
-                }
-            }
-            SseMessage::OtherData => {}
+            Some(RelayOutcome::Failed) => break,
+            None => {}
         }
     }
     if !completed || observed_tokens == 0 {
@@ -241,7 +243,7 @@ pub(super) async fn send_completion_request(
         let response = http_client.execute(request).await?;
 
         let status = response.status();
-        observe_response_headers(&mut observer, &response, status);
+        observe_response_headers(&mut observer, status);
         let response = ensure_success(response).await?;
         let body = response.bytes().await?;
         serde_json::from_slice::<ChatCompletionResponse>(&body)
@@ -262,13 +264,9 @@ pub(super) async fn send_completion_request(
     }
 }
 
-fn observe_response_headers(
-    observer: &mut Option<TunnelRequestObserver>,
-    response: &reqwest::Response,
-    status: StatusCode,
-) {
+fn observe_response_headers(observer: &mut Option<TunnelRequestObserver>, status: StatusCode) {
     if let Some(observer) = observer {
-        observer.on_upstream_response_headers(response.headers(), status.as_u16());
+        observer.on_upstream_response_headers(status.as_u16());
     }
 }
 

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/bringup/upstream.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/bringup/upstream.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::DEFAULT_MAX_SSE_BUFFER_BYTES;
 use crate::generated_request_id::{GeneratedRequestKind, next_generated_request_id};
@@ -220,29 +220,46 @@ pub(super) async fn send_completion_request(
             runtime_state.clone(),
         )
     });
-    let request = http_client
-        .post(upstream_endpoint(
-            upstream_http_base_url,
-            "/v1/chat/completions",
-        ))
-        .header(HEADER_REQUEST_ID, &request_id)
-        .header(HEADER_MODEL, model_id)
-        .header(HEADER_INPUT_TOKENS, input_tokens.to_string())
-        .json(request);
-    let response = match timeout {
-        Some(timeout) => request.timeout(timeout),
-        None => request,
+    let result = async {
+        let request = http_client
+            .post(upstream_endpoint(
+                upstream_http_base_url,
+                "/v1/chat/completions",
+            ))
+            .header(HEADER_REQUEST_ID, &request_id)
+            .header(HEADER_MODEL, model_id)
+            .header(HEADER_INPUT_TOKENS, input_tokens.to_string())
+            .json(request);
+        let request = match timeout {
+            Some(timeout) => request.timeout(timeout),
+            None => request,
+        }
+        .build()?;
+        if let Some(observer) = observer.as_mut() {
+            observer.on_backend_submission(Instant::now());
+        }
+        let response = http_client.execute(request).await?;
+
+        let status = response.status();
+        observe_response_headers(&mut observer, &response, status);
+        let response = ensure_success(response).await?;
+        let body = response.bytes().await?;
+        serde_json::from_slice::<ChatCompletionResponse>(&body)
+            .map_err(|error| BringupError::InvalidResponse(error.to_string()))
     }
-    .send()
-    .await?;
-    let status = response.status();
-    observe_response_headers(&mut observer, &response, status);
-    let response = ensure_success(response).await?;
-    let body = response.bytes().await?;
-    let completion = serde_json::from_slice::<ChatCompletionResponse>(&body)
-        .map_err(|error| BringupError::InvalidResponse(error.to_string()))?;
-    finish_observation(&mut observer, &completion);
-    Ok(completion)
+    .await;
+    match result {
+        Ok(completion) => {
+            finish_observation(&mut observer, &completion);
+            Ok(completion)
+        }
+        Err(error) => {
+            if let Some(observer) = observer.as_mut() {
+                observer.fail();
+            }
+            Err(error)
+        }
+    }
 }
 
 fn observe_response_headers(
@@ -263,9 +280,9 @@ fn finish_observation(
         let generation = observer
             .generation_mut()
             .expect("chat completion observer should expose generation progress");
-        generation.observe_output_message();
+        generation.observe_generated_output(Instant::now(), completion.usage.completion_tokens > 0);
         generation.observe_output_tokens_total(u64::from(completion.usage.completion_tokens));
-        observer.finish();
+        observer.complete();
     }
 }
 

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/output_token_parser.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/output_token_parser.rs
@@ -15,27 +15,31 @@
 
 #[derive(Debug, Default)]
 pub(crate) struct OutputTokenParser {
-    last_exact_tokens: Option<u64>,
+    reported_tokens: u64,
+    saw_exact_tokens: bool,
 }
 
 impl OutputTokenParser {
     pub(crate) fn new() -> Self {
-        Self {
-            last_exact_tokens: None,
-        }
+        Self::default()
     }
 
     pub(crate) fn observe_estimated_output_tokens(&mut self, delta: u64) -> Option<u64> {
-        (self.last_exact_tokens.is_none() && delta > 0).then_some(delta)
+        if self.saw_exact_tokens || delta == 0 {
+            return None;
+        }
+        self.reported_tokens = self.reported_tokens.saturating_add(delta);
+        Some(delta)
     }
 
-    pub(crate) fn observe_exact_output_tokens(&mut self, completion_tokens: u64) -> (u64, u64) {
-        let tokens = self
-            .last_exact_tokens
-            .map_or(completion_tokens, |prior| prior.max(completion_tokens));
-        let delta = tokens.saturating_sub(self.last_exact_tokens.unwrap_or_default());
-        self.last_exact_tokens = Some(tokens);
-        (tokens, delta)
+    pub(crate) fn observe_exact_output_tokens(&mut self, completion_tokens: u64) -> u64 {
+        self.reported_tokens = if self.saw_exact_tokens {
+            self.reported_tokens.max(completion_tokens)
+        } else {
+            completion_tokens
+        };
+        self.saw_exact_tokens = true;
+        self.reported_tokens
     }
 }
 
@@ -44,32 +48,20 @@ pub(crate) fn estimate_token_like_units(content: &str) -> u64 {
     if trimmed.is_empty() {
         return 0;
     }
-    let whitespace_units = trimmed.split_whitespace().count();
-    let units = if whitespace_units > 0 {
-        whitespace_units
-    } else {
-        trimmed.chars().count()
-    };
-    u64::try_from(units).unwrap_or(u64::MAX)
+    u64::try_from(trimmed.split_whitespace().count()).unwrap_or(u64::MAX)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    impl OutputTokenParser {
-        fn observe_exact_delta(&mut self, tokens: u64) -> u64 {
-            self.observe_exact_output_tokens(tokens).1
-        }
-    }
-
     #[test]
-    fn parser_tracks_continuous_exact_usage_deltas() {
+    fn parser_tracks_continuous_exact_usage() {
         let mut parser = OutputTokenParser::new();
 
-        assert_eq!(parser.observe_exact_output_tokens(1), (1, 1));
-        assert_eq!(parser.observe_exact_output_tokens(2), (2, 1));
-        assert_eq!(parser.observe_exact_output_tokens(2), (2, 0));
+        assert_eq!(parser.observe_exact_output_tokens(1), 1);
+        assert_eq!(parser.observe_exact_output_tokens(2), 2);
+        assert_eq!(parser.observe_exact_output_tokens(2), 2);
     }
 
     #[test]
@@ -77,14 +69,14 @@ mod tests {
         let mut parser = OutputTokenParser::new();
 
         assert_eq!(parser.observe_estimated_output_tokens(1), Some(1));
-        assert_eq!(parser.observe_exact_output_tokens(7), (7, 7));
+        assert_eq!(parser.observe_exact_output_tokens(7), 7);
     }
 
     #[test]
     fn explicit_counter_disables_later_text_estimates() {
         let mut parser = OutputTokenParser::new();
 
-        assert_eq!(parser.observe_exact_output_tokens(2), (2, 2));
+        assert_eq!(parser.observe_exact_output_tokens(2), 2);
         assert_eq!(parser.observe_estimated_output_tokens(2), None);
     }
 
@@ -96,20 +88,11 @@ mod tests {
     }
 
     #[test]
-    fn parser_never_subtracts_when_cumulative_usage_regresses() {
-        let mut parser = OutputTokenParser::new();
-
-        assert_eq!(parser.observe_exact_delta(5), 5);
-        assert_eq!(parser.observe_exact_delta(3), 0);
-        assert_eq!(parser.observe_exact_delta(7), 2);
-    }
-
-    #[test]
     fn parser_returns_monotonic_tokens_after_first_explicit_counter() {
         let mut parser = OutputTokenParser::new();
 
-        assert_eq!(parser.observe_exact_output_tokens(10), (10, 10));
-        assert_eq!(parser.observe_exact_output_tokens(5), (10, 0));
+        assert_eq!(parser.observe_exact_output_tokens(10), 10);
+        assert_eq!(parser.observe_exact_output_tokens(5), 10);
     }
 
     #[test]
@@ -117,8 +100,8 @@ mod tests {
         let mut parser = OutputTokenParser::new();
 
         assert_eq!(parser.observe_estimated_output_tokens(5), Some(5));
-        assert_eq!(parser.observe_exact_output_tokens(3), (3, 3));
-        assert_eq!(parser.observe_exact_output_tokens(4), (4, 1));
+        assert_eq!(parser.observe_exact_output_tokens(3), 3);
+        assert_eq!(parser.observe_exact_output_tokens(4), 4);
     }
 
     #[test]

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/output_token_parser.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/output_token_parser.rs
@@ -13,91 +13,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use sonic_rs::{JsonContainerTrait, JsonValueTrait, Value};
-
 #[derive(Debug, Default)]
 pub(crate) struct OutputTokenParser {
-    last_reported_tokens: u64,
-    saw_explicit_counter: bool,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum OutputTokenProgress {
-    ExplicitCumulative { tokens: u64, delta: u64 },
-    EstimatedDelta { delta: u64 },
-}
-
-impl OutputTokenProgress {
-    #[cfg(test)]
-    pub(crate) fn delta(self) -> u64 {
-        match self {
-            Self::ExplicitCumulative { delta, .. } | Self::EstimatedDelta { delta } => delta,
-        }
-    }
+    last_exact_tokens: Option<u64>,
 }
 
 impl OutputTokenParser {
     pub(crate) fn new() -> Self {
         Self {
-            last_reported_tokens: 0,
-            saw_explicit_counter: false,
+            last_exact_tokens: None,
         }
     }
 
-    pub(crate) fn observe_json(&mut self, value: Option<&Value>) -> Option<OutputTokenProgress> {
-        if let Some(completion_tokens) = explicit_completion_tokens(value) {
-            let tokens = if self.saw_explicit_counter {
-                self.last_reported_tokens.max(completion_tokens)
-            } else {
-                completion_tokens
-            };
-            let delta = tokens.saturating_sub(self.last_reported_tokens);
-            self.last_reported_tokens = tokens;
-            self.saw_explicit_counter = true;
-            return Some(OutputTokenProgress::ExplicitCumulative { tokens, delta });
-        }
+    pub(crate) fn observe_estimated_output_tokens(&mut self, delta: u64) -> Option<u64> {
+        (self.last_exact_tokens.is_none() && delta > 0).then_some(delta)
+    }
 
-        if self.saw_explicit_counter {
-            return None;
-        }
-
-        let delta = estimate_completion_delta_from_text(value?)?;
-        // Text-derived token estimates are telemetry counters; saturate instead of wrapping.
-        self.last_reported_tokens = self.last_reported_tokens.saturating_add(delta);
-        Some(OutputTokenProgress::EstimatedDelta { delta })
+    pub(crate) fn observe_exact_output_tokens(&mut self, completion_tokens: u64) -> (u64, u64) {
+        let tokens = self
+            .last_exact_tokens
+            .map_or(completion_tokens, |prior| prior.max(completion_tokens));
+        let delta = tokens.saturating_sub(self.last_exact_tokens.unwrap_or_default());
+        self.last_exact_tokens = Some(tokens);
+        (tokens, delta)
     }
 }
 
-fn explicit_completion_tokens(value: Option<&Value>) -> Option<u64> {
-    let value = value?;
-    value["usage"]["completion_tokens"]
-        .as_u64()
-        .or_else(|| value["output_tokens_so_far"].as_u64())
-        .or_else(|| value["response"]["usage"]["output_tokens"].as_u64())
-}
-
-fn estimate_completion_delta_from_text(value: &Value) -> Option<u64> {
-    let total = value["choices"]
-        .as_array()
-        .map(|choices| {
-            choices
-                .iter()
-                .filter_map(|choice| choice["delta"]["content"].as_str())
-                .map(estimate_token_like_units)
-                .sum()
-        })
-        .unwrap_or_default();
-    if total > 0 {
-        return Some(total);
-    }
-    let total = value["delta"]
-        .as_str()
-        .map(estimate_token_like_units)
-        .unwrap_or_default();
-    Some(total).filter(|units| *units > 0)
-}
-
-fn estimate_token_like_units(content: &str) -> u64 {
+pub(crate) fn estimate_token_like_units(content: &str) -> u64 {
     let trimmed = content.trim();
     if trimmed.is_empty() {
         return 0;
@@ -116,199 +58,72 @@ mod tests {
     use super::*;
 
     impl OutputTokenParser {
-        fn parse_output_token_progress(&mut self, raw_data: &str) -> Option<OutputTokenProgress> {
-            let value = sonic_rs::from_str(raw_data).ok();
-            self.observe_json(value.as_ref())
-        }
-
-        fn parse_incremental_output_tokens(&mut self, raw_data: &str) -> Option<u64> {
-            self.parse_output_token_progress(raw_data)
-                .map(OutputTokenProgress::delta)
+        fn observe_exact_delta(&mut self, tokens: u64) -> u64 {
+            self.observe_exact_output_tokens(tokens).1
         }
     }
 
     #[test]
-    fn vllm_parser_tracks_continuous_usage_deltas() {
+    fn parser_tracks_continuous_exact_usage_deltas() {
         let mut parser = OutputTokenParser::new();
-        let first = r#"{"object":"chat.completion.chunk","choices":[{"delta":{"content":"Hello"}}],"usage":{"prompt_tokens":8,"completion_tokens":1,"total_tokens":9}}"#;
-        let second = r#"{"object":"chat.completion.chunk","choices":[{"delta":{"content":" world"}}],"usage":{"prompt_tokens":8,"completion_tokens":2,"total_tokens":10}}"#;
-        let final_usage = r#"{"object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":8,"completion_tokens":2,"total_tokens":10}}"#;
 
-        assert_eq!(
-            parser.parse_output_token_progress(first),
-            Some(OutputTokenProgress::ExplicitCumulative {
-                tokens: 1,
-                delta: 1
-            })
-        );
-        assert_eq!(
-            parser.parse_output_token_progress(second),
-            Some(OutputTokenProgress::ExplicitCumulative {
-                tokens: 2,
-                delta: 1
-            })
-        );
-        assert_eq!(
-            parser.parse_output_token_progress(final_usage),
-            Some(OutputTokenProgress::ExplicitCumulative {
-                tokens: 2,
-                delta: 0
-            })
-        );
+        assert_eq!(parser.observe_exact_output_tokens(1), (1, 1));
+        assert_eq!(parser.observe_exact_output_tokens(2), (2, 1));
+        assert_eq!(parser.observe_exact_output_tokens(2), (2, 0));
     }
 
     #[test]
-    fn parser_reads_terminal_usage_chunk() {
+    fn exact_usage_replaces_text_estimation() {
         let mut parser = OutputTokenParser::new();
-        let content = r#"{"object":"chat.completion.chunk","choices":[{"delta":{"content":"。"}}],"usage":null}"#;
-        let terminal = r#"{"object":"chat.completion.chunk","choices":[{"delta":{"content":""},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":7,"total_tokens":7}}"#;
 
-        assert_eq!(
-            parser.parse_output_token_progress(content),
-            Some(OutputTokenProgress::EstimatedDelta { delta: 1 })
-        );
-        assert_eq!(
-            parser.parse_output_token_progress(terminal),
-            Some(OutputTokenProgress::ExplicitCumulative {
-                tokens: 7,
-                delta: 6
-            })
-        );
-    }
-
-    #[test]
-    fn parser_reads_output_tokens_so_far() {
-        let mut parser = OutputTokenParser::new();
-        let chunk = r#"{"object":"chat.completion.chunk","output_tokens_so_far":4,"choices":[{"delta":{"content":"hello"}}]}"#;
-
-        assert_eq!(
-            parser.parse_output_token_progress(chunk),
-            Some(OutputTokenProgress::ExplicitCumulative {
-                tokens: 4,
-                delta: 4
-            })
-        );
-    }
-
-    #[test]
-    fn parser_reads_responses_delta_and_terminal_usage() {
-        let mut parser = OutputTokenParser::new();
-        let delta = r#"{"type":"response.output_text.delta","delta":"hello world"}"#;
-        let terminal = r#"{"type":"response.completed","response":{"usage":{"input_tokens":4,"output_tokens":3,"total_tokens":7}}}"#;
-
-        assert_eq!(
-            parser.parse_output_token_progress(delta),
-            Some(OutputTokenProgress::EstimatedDelta { delta: 2 })
-        );
-        assert_eq!(
-            parser.parse_output_token_progress(terminal),
-            Some(OutputTokenProgress::ExplicitCumulative {
-                tokens: 3,
-                delta: 1
-            })
-        );
+        assert_eq!(parser.observe_estimated_output_tokens(1), Some(1));
+        assert_eq!(parser.observe_exact_output_tokens(7), (7, 7));
     }
 
     #[test]
     fn explicit_counter_disables_later_text_estimates() {
         let mut parser = OutputTokenParser::new();
-        let explicit = r#"{"object":"chat.completion.chunk","usage":{"completion_tokens":2},"choices":[{"delta":{"content":"alpha beta"}}]}"#;
-        let text_only =
-            r#"{"object":"chat.completion.chunk","choices":[{"delta":{"content":"gamma delta"}}]}"#;
 
-        assert!(matches!(
-            parser.parse_output_token_progress(explicit),
-            Some(OutputTokenProgress::ExplicitCumulative { tokens: 2, .. })
-        ));
-        assert_eq!(parser.parse_output_token_progress(text_only), None);
+        assert_eq!(parser.observe_exact_output_tokens(2), (2, 2));
+        assert_eq!(parser.observe_estimated_output_tokens(2), None);
     }
 
     #[test]
-    fn text_fallback_counts_all_choices_in_chunk() {
-        let mut parser = OutputTokenParser::new();
-        let chunk = r#"{"object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"alpha beta"}},{"index":1,"delta":{"content":"loop loop loop"}}]}"#;
-
-        assert_eq!(
-            parser.parse_output_token_progress(chunk),
-            Some(OutputTokenProgress::EstimatedDelta { delta: 5 })
-        );
+    fn token_like_estimator_counts_words_and_ignores_whitespace() {
+        assert_eq!(estimate_token_like_units("alpha beta"), 2);
+        assert_eq!(estimate_token_like_units("。"), 1);
+        assert_eq!(estimate_token_like_units("   "), 0);
     }
 
     #[test]
     fn parser_never_subtracts_when_cumulative_usage_regresses() {
         let mut parser = OutputTokenParser::new();
-        let five = r#"{"object":"chat.completion.chunk","usage":{"completion_tokens":5}}"#;
-        let three = r#"{"object":"chat.completion.chunk","usage":{"completion_tokens":3}}"#;
-        let seven = r#"{"object":"chat.completion.chunk","usage":{"completion_tokens":7}}"#;
 
-        assert_eq!(parser.parse_incremental_output_tokens(five), Some(5));
-        assert_eq!(parser.parse_incremental_output_tokens(three), Some(0));
-        assert_eq!(parser.parse_incremental_output_tokens(seven), Some(2));
+        assert_eq!(parser.observe_exact_delta(5), 5);
+        assert_eq!(parser.observe_exact_delta(3), 0);
+        assert_eq!(parser.observe_exact_delta(7), 2);
     }
 
     #[test]
     fn parser_returns_monotonic_tokens_after_first_explicit_counter() {
         let mut parser = OutputTokenParser::new();
-        let ten = r#"{"object":"chat.completion.chunk","usage":{"completion_tokens":10}}"#;
-        let five = r#"{"object":"chat.completion.chunk","usage":{"completion_tokens":5}}"#;
 
-        assert_eq!(
-            parser.parse_output_token_progress(ten),
-            Some(OutputTokenProgress::ExplicitCumulative {
-                tokens: 10,
-                delta: 10
-            })
-        );
-        assert_eq!(
-            parser.parse_output_token_progress(five),
-            Some(OutputTokenProgress::ExplicitCumulative {
-                tokens: 10,
-                delta: 0
-            })
-        );
+        assert_eq!(parser.observe_exact_output_tokens(10), (10, 10));
+        assert_eq!(parser.observe_exact_output_tokens(5), (10, 0));
     }
 
     #[test]
     fn first_explicit_counter_can_correct_text_estimate_downward() {
         let mut parser = OutputTokenParser::new();
-        let text = r#"{"object":"chat.completion.chunk","choices":[{"delta":{"content":"one two three four five"}}]}"#;
-        let three = r#"{"object":"chat.completion.chunk","usage":{"completion_tokens":3}}"#;
-        let four = r#"{"object":"chat.completion.chunk","usage":{"completion_tokens":4}}"#;
 
-        assert_eq!(
-            parser.parse_output_token_progress(text),
-            Some(OutputTokenProgress::EstimatedDelta { delta: 5 })
-        );
-        assert_eq!(
-            parser.parse_output_token_progress(three),
-            Some(OutputTokenProgress::ExplicitCumulative {
-                tokens: 3,
-                delta: 0
-            })
-        );
-        assert_eq!(
-            parser.parse_output_token_progress(four),
-            Some(OutputTokenProgress::ExplicitCumulative {
-                tokens: 4,
-                delta: 1
-            })
-        );
+        assert_eq!(parser.observe_estimated_output_tokens(5), Some(5));
+        assert_eq!(parser.observe_exact_output_tokens(3), (3, 3));
+        assert_eq!(parser.observe_exact_output_tokens(4), (4, 1));
     }
 
     #[test]
-    fn parser_ignores_missing_null_and_non_integer_usage() {
+    fn parser_ignores_zero_estimates() {
         let mut parser = OutputTokenParser::new();
-
-        for raw_data in [
-            r#"{"object":"chat.completion.chunk"}"#,
-            r#"{"object":"chat.completion.chunk","usage":null}"#,
-            r#"{"object":"chat.completion.chunk","usage":{"completion_tokens":null}}"#,
-            r#"{"object":"chat.completion.chunk","usage":{"completion_tokens":"4"}}"#,
-            r#"{"object":"chat.completion.chunk","usage":{"completion_tokens":4.5}}"#,
-            r#"{"object":"chat.completion.chunk","usage":{"completion_tokens":-1}}"#,
-            r#"not-json"#,
-        ] {
-            assert_eq!(parser.parse_incremental_output_tokens(raw_data), None);
-        }
+        assert_eq!(parser.observe_estimated_output_tokens(0), None);
     }
 }

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/queue_admission.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/queue_admission.rs
@@ -767,7 +767,7 @@ impl TrackedPromptPhase {
 }
 
 impl QueueTrackedRequestGuard {
-    pub(crate) fn on_upstream_response_headers(&mut self) {
+    pub(crate) fn on_backend_submission(&mut self) {
         let mut state = self.live_requests.inner.lock();
         state.advance_request_phase(&self.request_id, TrackedPromptPhase::InputProcessing);
     }
@@ -1025,10 +1025,10 @@ mod tests {
         let _priority_two = live_requests.track_request(&required("req-p2", 2, 20));
         let mut priority_four = live_requests.track_request(&required("req-p4", 4, 30));
         let mut zero_input = live_requests.track_request(&required("req-zero", 1, 0));
-        priority_four.on_upstream_response_headers();
+        priority_four.on_backend_submission();
 
         assert_eq!(live_requests.snapshot_model("model-a").queue_size, 3);
-        zero_input.on_upstream_response_headers();
+        zero_input.on_backend_submission();
         let snapshot = live_requests.snapshot_model("model-a");
 
         assert_eq!(snapshot.queue_size, 3);
@@ -1148,7 +1148,7 @@ mod tests {
         let live_requests = LiveRequestState::default();
         let mut request = live_requests.track_request(&required("req-output", 0, 100));
         request.observe_output();
-        request.on_upstream_response_headers();
+        request.on_backend_submission();
 
         let snapshot = live_requests.snapshot_model("model-a");
         assert_eq!(snapshot.queue_size, 0);
@@ -1197,11 +1197,11 @@ mod tests {
     }
 
     #[test]
-    fn upstream_response_headers_do_not_apply_retired_progress_contract() {
+    fn backend_submission_does_not_apply_retired_progress_contract() {
         let live_requests = LiveRequestState::default();
         let mut request = live_requests.track_request(&required("req-progress", 0, 100));
 
-        request.on_upstream_response_headers();
+        request.on_backend_submission();
 
         let snapshot = live_requests.snapshot_model("model-a");
         assert_eq!(snapshot.queued_input_size, 100);

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/quic_http_tunnel/core.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/quic_http_tunnel/core.rs
@@ -59,10 +59,9 @@ use crate::stats::PylonMetrics;
 use crate::upstream_health::UpstreamHealthPaths;
 
 pub(super) const DEFAULT_MAX_BODY_BYTES: usize = 64 * 1024 * 1024;
-// This bounds only one upstream SSE event waiting for its blank-line delimiter,
-// not the request body or completed response events. One MiB accommodates
-// unusually large structured chunks while a missing delimiter cannot make the
-// pylon retain unbounded upstream bytes.
+// This bounds each upstream SSE event, including its blank-line delimiter.
+// Complete events are delivered incrementally, so one input chunk cannot make
+// the pylon retain an unbounded batch of parsed events.
 pub const DEFAULT_MAX_SSE_BUFFER_BYTES: usize = 1024 * 1024;
 pub(super) const DEFAULT_FIRST_OUTPUT_TIMEOUT: Duration = Duration::from_secs(30);
 pub(super) const DEFAULT_OUTPUT_CHUNK_TIMEOUT: Duration = Duration::from_secs(30);
@@ -245,21 +244,29 @@ fn sse_timeout_phase_name(phase: SseReadTimeoutPhase) -> &'static str {
     }
 }
 
-fn relay_sse_error(error: UpstreamSseReadError) -> anyhow::Error {
+fn relay_sse_error(error: UpstreamSseReadError) -> ResponseRelayError {
     use UpstreamSseReadError::*;
     match error {
-        Timeout(phase) => anyhow!(
+        Timeout(phase) => ResponseRelayError::Upstream(anyhow!(
             "timed out waiting for {} output event from upstream",
             sse_timeout_phase_name(phase)
-        ),
+        )),
         BufferLimitExceeded {
             max_buffer_bytes,
             buffered_bytes,
-        } => anyhow!(
-            "upstream SSE buffer exceeded {max_buffer_bytes} bytes while waiting for an event boundary (buffered {buffered_bytes} bytes)"
+        } => ResponseRelayError::Upstream(anyhow!(
+            "upstream SSE event exceeded the {max_buffer_bytes}-byte buffer limit (buffered {buffered_bytes} bytes)"
+        )),
+        DeliveryBackpressure(phase) => ResponseRelayError::Downstream(anyhow!(
+            "downstream did not accept an SSE event before the {} output deadline",
+            sse_timeout_phase_name(phase)
+        )),
+        Upstream(error) => {
+            ResponseRelayError::Upstream(error.context("failed to read upstream response message"))
+        }
+        Producer(error) => ResponseRelayError::Upstream(
+            anyhow::Error::new(error).context("upstream SSE producer task failed"),
         ),
-        Upstream(error) => error.context("failed to read upstream response message"),
-        Producer(error) => anyhow::Error::new(error).context("upstream SSE producer task failed"),
     }
 }
 
@@ -398,7 +405,7 @@ impl TunnelRequestLifecycle {
             let parsed_message = upstream_messages
                 .try_next()
                 .await
-                .map_err(|error| ResponseRelayError::Upstream(relay_sse_error(error)))?;
+                .map_err(relay_sse_error)?;
             let Some(parsed_message) = parsed_message else {
                 if saw_output {
                     return Ok(RelayOutcome::Complete);
@@ -1262,6 +1269,22 @@ mod tests {
     use crate::test_support::TestHttpServer;
 
     use super::*;
+
+    #[test]
+    fn classifies_sse_delivery_backpressure_as_downstream_failure() {
+        assert!(matches!(
+            relay_sse_error(UpstreamSseReadError::DeliveryBackpressure(
+                SseReadTimeoutPhase::FirstOutput
+            )),
+            ResponseRelayError::Downstream(_)
+        ));
+        assert!(matches!(
+            relay_sse_error(UpstreamSseReadError::Timeout(
+                SseReadTimeoutPhase::FirstOutput
+            )),
+            ResponseRelayError::Upstream(_)
+        ));
+    }
 
     #[derive(Clone)]
     struct ResponseHeadGate {

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/quic_http_tunnel/core.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/quic_http_tunnel/core.rs
@@ -259,6 +259,7 @@ fn relay_sse_error(error: UpstreamSseReadError) -> anyhow::Error {
             "upstream SSE buffer exceeded {max_buffer_bytes} bytes while waiting for an event boundary (buffered {buffered_bytes} bytes)"
         ),
         Upstream(error) => error.context("failed to read upstream response message"),
+        Producer(error) => anyhow::Error::new(error).context("upstream SSE producer task failed"),
     }
 }
 

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/quic_http_tunnel/core.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/quic_http_tunnel/core.rs
@@ -52,7 +52,7 @@ use crate::request_quality_monitor::{
 };
 use crate::runtime_state::{ModelGeneration, PylonRuntimeState, RequestGenerationAdmission};
 use crate::sse_message_stream::{
-    ParsedSseMessage, SseReadTimeoutPhase, SseTerminalOutcome, UpstreamSseMessageStream,
+    ParsedSseMessage, RelayOutcome, SseReadTimeoutPhase, UpstreamSseMessageStream,
     UpstreamSseReadError, upstream_sse_message_stream,
 };
 use crate::stats::PylonMetrics;
@@ -263,12 +263,6 @@ fn relay_sse_error(error: UpstreamSseReadError) -> anyhow::Error {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RequestRelayOutcome {
-    Complete,
-    Failed,
-}
-
 #[derive(Debug, thiserror::Error)]
 enum ResponseRelayError {
     #[error("upstream response relay failed: {0}")]
@@ -397,7 +391,7 @@ impl TunnelRequestLifecycle {
         &mut self,
         mut upstream_messages: UpstreamSseMessageStream,
         transport: &mut impl TunnelRequestTransport,
-    ) -> Result<RequestRelayOutcome, ResponseRelayError> {
+    ) -> Result<RelayOutcome, ResponseRelayError> {
         let mut output_token_parser = OutputTokenParser::new();
         let mut saw_output = false;
         loop {
@@ -406,24 +400,24 @@ impl TunnelRequestLifecycle {
                 .await
                 .map_err(|error| ResponseRelayError::Upstream(relay_sse_error(error)))?;
             let Some(parsed_message) = parsed_message else {
+                if saw_output {
+                    return Ok(RelayOutcome::Complete);
+                }
                 return Err(ResponseRelayError::Upstream(anyhow!(
-                    "upstream SSE stream ended before a terminal event"
+                    "upstream SSE stream ended before generated output or a terminal event"
                 )));
             };
             let terminal = self.observe_sse_message(
                 &mut output_token_parser,
                 &parsed_message,
                 &mut saw_output,
-            )?;
+            );
             transport
                 .send_body_event(parsed_message.raw_event)
                 .await
                 .map_err(ResponseRelayError::Downstream)?;
             if let Some(terminal) = terminal {
-                return Ok(match terminal {
-                    SseTerminalOutcome::Complete => RequestRelayOutcome::Complete,
-                    SseTerminalOutcome::Failed => RequestRelayOutcome::Failed,
-                });
+                return Ok(terminal);
             }
         }
     }
@@ -433,16 +427,12 @@ impl TunnelRequestLifecycle {
         parser: &mut OutputTokenParser,
         message: &ParsedSseMessage,
         saw_output: &mut bool,
-    ) -> Result<Option<SseTerminalOutcome>, ResponseRelayError> {
+    ) -> Option<RelayOutcome> {
         let obs = self
             .observer
             .as_mut()
             .and_then(TunnelRequestObserver::generation_mut)
-            .ok_or_else(|| {
-                ResponseRelayError::Upstream(anyhow!(
-                    "observer missing for observed streaming request"
-                ))
-            })?;
+            .expect("streaming relay requires a generation observer");
         obs.observe_upstream_event(message.received_at);
         let mut quality_progress = None;
         if let Some(generated_output) = message.facts.generated_output.as_ref() {
@@ -463,9 +453,9 @@ impl TunnelRequestLifecycle {
                 obs.observe_input_tokens_total(input_tokens);
             }
             if let Some(output_tokens) = exact_usage.output_tokens {
-                let (tokens, delta) = parser.observe_exact_output_tokens(output_tokens);
+                let tokens = parser.observe_exact_output_tokens(output_tokens);
                 obs.observe_output_tokens_generated_so_far(tokens);
-                quality_progress = Some(RequestOutputTokenProgress::Cumulative { tokens, delta });
+                quality_progress = Some(RequestOutputTokenProgress::Cumulative { tokens });
             }
         }
         if (message.facts.generated_output.is_some() || message.facts.exact_usage.is_some())
@@ -475,20 +465,20 @@ impl TunnelRequestLifecycle {
                 .recorder
                 .observe_json_chunk(message.parsed.as_ref(), quality_progress);
         }
-        Ok(message.facts.terminal)
+        message.facts.terminal
     }
 
-    fn finish(&mut self, app: &TunnelServerApp, outcome: RequestRelayOutcome) {
+    fn finish(&mut self, app: &TunnelServerApp, outcome: RelayOutcome) {
         if let Some(observer) = self.observer.as_mut() {
             match outcome {
-                RequestRelayOutcome::Complete => observer.complete(),
-                RequestRelayOutcome::Failed => observer.fail(),
+                RelayOutcome::Complete => observer.complete(),
+                RelayOutcome::Failed => observer.fail(),
             }
         }
         if let Some(queue_request) = self.queue_request.as_mut() {
             queue_request.finish();
         }
-        if outcome != RequestRelayOutcome::Complete {
+        if outcome != RelayOutcome::Complete {
             return;
         }
         let Some((quality_check, metrics)) = self
@@ -568,7 +558,7 @@ async fn relay_upstream_response(
     mut lifecycle: Option<&mut TunnelRequestLifecycle>,
     response: Response,
     transport: &mut impl TunnelRequestTransport,
-) -> Result<RequestRelayOutcome, ResponseRelayError> {
+) -> Result<RelayOutcome, ResponseRelayError> {
     let status = response.status();
     let response_head = build_response_headers(
         status,
@@ -581,19 +571,15 @@ async fn relay_upstream_response(
     if let Some(lifecycle) = lifecycle.as_mut()
         && let Some(observer) = lifecycle.observer.as_mut()
     {
-        observer.on_upstream_response_headers(response.headers(), status.as_u16());
+        observer.on_upstream_response_headers(status.as_u16());
     }
-    let relay_as_sse = lifecycle.as_ref().is_some_and(|lifecycle| {
+    let observed_streaming = lifecycle.as_ref().is_some_and(|lifecycle| {
         lifecycle
             .observer
             .as_ref()
             .is_some_and(TunnelRequestObserver::is_streaming)
-            && response
-                .headers()
-                .get(CONTENT_TYPE)
-                .and_then(|value| value.to_str().ok())
-                .is_some_and(|value| value.starts_with("text/event-stream"))
     });
+    let relay_as_sse = observed_streaming && is_sse_content_type(response.headers());
     if relay_as_sse {
         let upstream_messages = upstream_sse_message_stream(
             response.bytes_stream(),
@@ -613,7 +599,7 @@ async fn relay_upstream_response(
         return Ok(if status.is_success() {
             outcome
         } else {
-            RequestRelayOutcome::Failed
+            RelayOutcome::Failed
         });
     }
 
@@ -622,6 +608,7 @@ async fn relay_upstream_response(
         .await
         .map_err(ResponseRelayError::Downstream)?;
     if status.is_success()
+        && !observed_streaming
         && let Some(lifecycle) = lifecycle.as_mut()
     {
         if let Some(queue_request) = lifecycle.queue_request.as_mut() {
@@ -647,11 +634,19 @@ async fn relay_upstream_response(
             .await
             .map_err(ResponseRelayError::Downstream)?;
     }
-    Ok(if status.is_success() {
-        RequestRelayOutcome::Complete
+    Ok(if status.is_success() && !observed_streaming {
+        RelayOutcome::Complete
     } else {
-        RequestRelayOutcome::Failed
+        RelayOutcome::Failed
     })
+}
+
+fn is_sse_content_type(headers: &HeaderMap) -> bool {
+    headers
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(';').next())
+        .is_some_and(|media_type| media_type.trim().eq_ignore_ascii_case("text/event-stream"))
 }
 
 pub(super) async fn forward_tunnel_request(
@@ -1375,17 +1370,38 @@ mod tests {
         TestTransport,
         Vec<crate::RequestObservationEvent>,
     ) {
+        run_observed_response(
+            path,
+            request_body,
+            status,
+            Some("text/event-stream"),
+            response_body,
+        )
+        .await
+    }
+
+    async fn run_observed_response(
+        path: &'static str,
+        request_body: &'static [u8],
+        status: StatusCode,
+        response_content_type: Option<&'static str>,
+        response_body: impl Into<String>,
+    ) -> (
+        anyhow::Result<()>,
+        TestTransport,
+        Vec<crate::RequestObservationEvent>,
+    ) {
         let response_body = response_body.into();
         let upstream = TestHttpServer::spawn(Router::new().route(
             path,
             post(move || {
                 let response_body = response_body.clone();
                 async move {
-                    AxumResponse::builder()
-                        .status(status)
-                        .header(CONTENT_TYPE, "text/event-stream")
-                        .body(Body::from(response_body))
-                        .unwrap()
+                    let mut response = AxumResponse::builder().status(status);
+                    if let Some(content_type) = response_content_type {
+                        response = response.header(CONTENT_TYPE, content_type);
+                    }
+                    response.body(Body::from(response_body)).unwrap()
                 }
             }),
         ))
@@ -1398,6 +1414,22 @@ mod tests {
         let result = forward_tunnel_request(&app, observed_request(path), &mut transport).await;
         let observations = observations.try_iter().collect();
         (result, transport, observations)
+    }
+
+    #[test]
+    fn sse_content_type_requires_an_exact_case_insensitive_media_type() {
+        for (value, expected) in [
+            ("text/event-stream", true),
+            ("Text/Event-Stream; charset=utf-8", true),
+            (" text/event-stream ; charset=utf-8", true),
+            ("text/event-streamfoo", false),
+            ("application/json", false),
+        ] {
+            let mut headers = HeaderMap::new();
+            headers.insert(CONTENT_TYPE, value.parse().unwrap());
+            assert_eq!(is_sse_content_type(&headers), expected, "{value}");
+        }
+        assert!(!is_sse_content_type(&HeaderMap::new()));
     }
 
     #[test]
@@ -1671,6 +1703,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn exact_usage_corrects_prior_stream_estimates() {
+        let raw = concat!(
+            "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"delta\":{\"content\":\"one two three four five\"}}]}\n\n",
+            "data: {\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"completion_tokens\":3}}\n\n",
+            "data: [DONE]\n\n",
+        );
+        let (result, _, observations) = run_observed_sse(
+            "/v1/chat/completions",
+            br#"{"messages":[],"stream":true}"#,
+            StatusCode::OK,
+            raw,
+        )
+        .await;
+        result.expect("exact usage should complete the SSE response");
+
+        let terminal = observations.last().unwrap().observation();
+        assert_eq!(terminal.state, crate::RequestObservationState::Complete);
+        assert_eq!(terminal.output_tokens, 3);
+        assert!(terminal.output_tokens_explicit);
+    }
+
+    #[tokio::test]
     async fn failed_responses_terminals_override_generated_output() {
         for (event_type, request_id_suffix) in [
             ("response.failed", "failed"),
@@ -1716,7 +1770,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn eof_before_terminal_is_an_upstream_error_even_after_generated_output() {
+    async fn clean_eof_completes_only_after_generated_output() {
         let (output_result, _, output_observations) = run_observed_sse(
             "/v1/chat/completions",
             br#"{"messages":[],"stream":true}"#,
@@ -1724,15 +1778,10 @@ mod tests {
             "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"delta\":{\"content\":\"x\"}}]}\n\n",
         )
         .await;
-        assert!(
-            output_result
-                .expect_err("truncated output stream should fail")
-                .to_string()
-                .contains("ended before a terminal event")
-        );
+        output_result.expect("clean EOF after generated output should complete");
         assert_eq!(
             output_observations.last().unwrap().observation().state,
-            crate::RequestObservationState::Failed
+            crate::RequestObservationState::Complete
         );
 
         let (metadata_result, _, metadata_observations) = run_observed_sse(
@@ -1746,11 +1795,57 @@ mod tests {
             metadata_result
                 .expect_err("truncated metadata stream should fail")
                 .to_string()
-                .contains("ended before a terminal event")
+                .contains("ended before generated output or a terminal event")
         );
         assert_eq!(
             metadata_observations.last().unwrap().observation().state,
             crate::RequestObservationState::Failed
+        );
+    }
+
+    #[tokio::test]
+    async fn observed_streaming_requires_an_sse_response_media_type() {
+        for content_type in [None, Some("application/json"), Some("text/event-streamfoo")] {
+            let (result, transport, observations) = run_observed_response(
+                "/v1/chat/completions",
+                br#"{"messages":[],"stream":true}"#,
+                StatusCode::OK,
+                content_type,
+                r#"{"message":"wrong response framing"}"#,
+            )
+            .await;
+            result.expect("the wire response should still be forwarded");
+
+            assert_eq!(
+                transport.response_events,
+                [bytes::Bytes::from_static(
+                    br#"{"message":"wrong response framing"}"#
+                )]
+            );
+            let terminal = observations.last().unwrap().observation();
+            assert_eq!(terminal.state, crate::RequestObservationState::Failed);
+            assert_eq!(terminal.output_messages, 0);
+            assert_eq!(terminal.time_to_first_output, None);
+            assert!(!observations.iter().any(|event| {
+                event.observation().state == crate::RequestObservationState::OutputGeneration
+            }));
+        }
+    }
+
+    #[tokio::test]
+    async fn observed_streaming_accepts_case_insensitive_sse_media_type() {
+        let (result, _, observations) = run_observed_response(
+            "/v1/chat/completions",
+            br#"{"messages":[],"stream":true}"#,
+            StatusCode::OK,
+            Some("Text/Event-Stream; charset=utf-8"),
+            "data: [DONE]\n\n",
+        )
+        .await;
+        result.expect("valid SSE media type should use the streaming relay");
+        assert_eq!(
+            observations.last().unwrap().observation().state,
+            crate::RequestObservationState::Complete
         );
     }
 }

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/quic_http_tunnel/core.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/quic_http_tunnel/core.rs
@@ -15,9 +15,9 @@
 
 use std::future::Future;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant, SystemTime};
 
-use anyhow::{Context, Result, anyhow, bail, ensure};
+use anyhow::{Context, Result, anyhow, ensure};
 use bytes::{Buf, BufMut};
 use futures::TryStreamExt;
 use reqwest::header::{
@@ -38,7 +38,7 @@ use tracing::{Instrument, Span, field};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use super::backend::{self, DEFAULT_PRIORITY_CEILING, UpstreamBackend};
-use crate::output_token_parser::{OutputTokenParser, OutputTokenProgress};
+use crate::output_token_parser::OutputTokenParser;
 use crate::queue_admission::{
     PylonQueueMismatchRetryConfig, QueueAdmissionDecision, QueueTrackedRequestGuard,
     RETRY_REASON_QUEUE_ESTIMATE_MISMATCH,
@@ -52,8 +52,8 @@ use crate::request_quality_monitor::{
 };
 use crate::runtime_state::{ModelGeneration, PylonRuntimeState, RequestGenerationAdmission};
 use crate::sse_message_stream::{
-    ParsedSseMessage, SseMessage, SseReadTimeoutPhase, UpstreamSseReadError,
-    upstream_sse_message_stream,
+    ParsedSseMessage, SseReadTimeoutPhase, SseTerminalOutcome, UpstreamSseMessageStream,
+    UpstreamSseReadError, upstream_sse_message_stream,
 };
 use crate::stats::PylonMetrics;
 use crate::upstream_health::UpstreamHealthPaths;
@@ -262,6 +262,20 @@ fn relay_sse_error(error: UpstreamSseReadError) -> anyhow::Error {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RequestRelayOutcome {
+    Complete,
+    Failed,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ResponseRelayError {
+    #[error("upstream response relay failed: {0}")]
+    Upstream(#[source] anyhow::Error),
+    #[error("downstream response relay failed: {0}")]
+    Downstream(#[source] anyhow::Error),
+}
+
 struct TunnelRequestLifecycle {
     required: RequiredTunnelHeaders,
     generation: Option<ModelGeneration>,
@@ -363,89 +377,117 @@ impl TunnelRequestLifecycle {
         }
     }
 
+    fn cancel(&mut self) {
+        if let Some(observer) = self.observer.as_mut() {
+            observer.cancel();
+        }
+    }
+
+    fn on_backend_submission(&mut self, submitted_at: Instant) {
+        if let Some(queue_request) = self.queue_request.as_mut() {
+            queue_request.on_backend_submission();
+        }
+        if let Some(observer) = self.observer.as_mut() {
+            observer.on_backend_submission(submitted_at);
+        }
+    }
+
     async fn relay_sse(
         &mut self,
-        app: &TunnelServerApp,
-        response: Response,
+        mut upstream_messages: UpstreamSseMessageStream,
         transport: &mut impl TunnelRequestTransport,
-    ) -> Result<()> {
-        let mut upstream_messages = upstream_sse_message_stream(
-            response.bytes_stream(),
-            app.first_output_timeout,
-            app.output_chunk_timeout,
-            app.max_sse_buffer_bytes,
-        );
+    ) -> Result<RequestRelayOutcome, ResponseRelayError> {
         let mut output_token_parser = OutputTokenParser::new();
         let mut saw_output = false;
         loop {
-            let parsed_message = upstream_messages.try_next().await.map_err(|error| {
-                self.fail();
-                relay_sse_error(error)
-            })?;
-            let Some(raw_event) = self.observe_sse_message(
-                &mut output_token_parser,
-                parsed_message,
-                &mut saw_output,
-            )?
-            else {
-                return Ok(());
+            let parsed_message = upstream_messages
+                .try_next()
+                .await
+                .map_err(|error| ResponseRelayError::Upstream(relay_sse_error(error)))?;
+            let Some(parsed_message) = parsed_message else {
+                return Err(ResponseRelayError::Upstream(anyhow!(
+                    "upstream SSE stream ended before a terminal event"
+                )));
             };
-            transport.send_body_event(raw_event).await?;
+            let terminal = self.observe_sse_message(
+                &mut output_token_parser,
+                &parsed_message,
+                &mut saw_output,
+            )?;
+            transport
+                .send_body_event(parsed_message.raw_event)
+                .await
+                .map_err(ResponseRelayError::Downstream)?;
+            if let Some(terminal) = terminal {
+                return Ok(match terminal {
+                    SseTerminalOutcome::Complete => RequestRelayOutcome::Complete,
+                    SseTerminalOutcome::Failed => RequestRelayOutcome::Failed,
+                });
+            }
         }
     }
 
     fn observe_sse_message(
         &mut self,
         parser: &mut OutputTokenParser,
-        message: Option<ParsedSseMessage>,
+        message: &ParsedSseMessage,
         saw_output: &mut bool,
-    ) -> Result<Option<bytes::Bytes>> {
+    ) -> Result<Option<SseTerminalOutcome>, ResponseRelayError> {
         let obs = self
             .observer
             .as_mut()
             .and_then(TunnelRequestObserver::generation_mut)
-            .ok_or_else(|| anyhow!("observer missing for observed streaming request"))?;
-        let Some(message) = message else {
-            if !*saw_output {
-                obs.fail();
-                bail!("upstream stream ended before first output event");
-            }
-            return Ok(None);
-        };
-        if let SseMessage::ChatCompletionChunk { parsed, .. } = &message.message {
+            .ok_or_else(|| {
+                ResponseRelayError::Upstream(anyhow!(
+                    "observer missing for observed streaming request"
+                ))
+            })?;
+        let mut quality_progress = None;
+        if let Some(generated_output) = message.facts.generated_output.as_ref() {
             if let (false, Some(queue)) = (*saw_output, self.queue_request.as_mut()) {
                 queue.observe_output();
             }
             *saw_output = true;
-            obs.observe_output_message();
-            let quality_progress =
-                parser
-                    .observe_json(parsed.as_ref())
-                    .map(|progress| match progress {
-                        OutputTokenProgress::ExplicitCumulative { tokens, delta } => {
-                            obs.observe_output_tokens_generated_so_far(tokens);
-                            RequestOutputTokenProgress::Cumulative { tokens, delta }
-                        }
-                        OutputTokenProgress::EstimatedDelta { delta } => {
-                            obs.observe_output_tokens(delta);
-                            RequestOutputTokenProgress::Delta(delta)
-                        }
-                    });
-            if let Some(quality_check) = self.quality_check.as_mut() {
-                quality_check
-                    .recorder
-                    .observe_json_chunk(parsed.as_ref(), quality_progress);
+            obs.observe_generated_output(message.received_at, generated_output.token_bearing);
+            quality_progress = parser
+                .observe_estimated_output_tokens(generated_output.estimated_token_units)
+                .map(|delta| {
+                    obs.observe_output_tokens(delta);
+                    RequestOutputTokenProgress::Delta(delta)
+                });
+        }
+        if let Some(exact_usage) = message.facts.exact_usage {
+            if let Some(input_tokens) = exact_usage.input_tokens {
+                obs.observe_input_tokens_total(input_tokens);
+            }
+            if let Some(output_tokens) = exact_usage.output_tokens {
+                let (tokens, delta) = parser.observe_exact_output_tokens(output_tokens);
+                obs.observe_output_tokens_generated_so_far(tokens);
+                quality_progress = Some(RequestOutputTokenProgress::Cumulative { tokens, delta });
             }
         }
-        Ok(Some(message.raw_event))
+        if (message.facts.generated_output.is_some() || message.facts.exact_usage.is_some())
+            && let Some(quality_check) = self.quality_check.as_mut()
+        {
+            quality_check
+                .recorder
+                .observe_json_chunk(message.parsed.as_ref(), quality_progress);
+        }
+        Ok(message.facts.terminal)
     }
 
-    fn finish(&mut self, app: &TunnelServerApp) {
+    fn finish(&mut self, app: &TunnelServerApp, outcome: RequestRelayOutcome) {
         if let Some(observer) = self.observer.as_mut() {
-            observer.finish();
+            match outcome {
+                RequestRelayOutcome::Complete => observer.complete(),
+                RequestRelayOutcome::Failed => observer.fail(),
+            }
         }
         if let Some(queue_request) = self.queue_request.as_mut() {
             queue_request.finish();
+        }
+        if outcome != RequestRelayOutcome::Complete {
+            return;
         }
         let Some((quality_check, metrics)) = self
             .quality_check
@@ -524,7 +566,7 @@ async fn relay_upstream_response(
     mut lifecycle: Option<&mut TunnelRequestLifecycle>,
     response: Response,
     transport: &mut impl TunnelRequestTransport,
-) -> Result<()> {
+) -> Result<RequestRelayOutcome, ResponseRelayError> {
     let status = response.status();
     let response_head = build_response_headers(
         status,
@@ -532,53 +574,82 @@ async fn relay_upstream_response(
         &app.retry,
         app.metrics.as_deref(),
         &app.inference_server_id,
-    )?;
-    transport.send_response_head(status, response_head).await?;
-    if let Some(lifecycle) = lifecycle.as_mut() {
-        if let Some(queue_request) = lifecycle.queue_request.as_mut() {
-            queue_request.on_upstream_response_headers();
-        }
-        if let Some(observer) = lifecycle.observer.as_mut() {
-            observer.on_upstream_response_headers(response.headers(), status.as_u16());
-        }
-    }
+    )
+    .map_err(ResponseRelayError::Upstream)?;
     if let Some(lifecycle) = lifecycle.as_mut()
-        && lifecycle
+        && let Some(observer) = lifecycle.observer.as_mut()
+    {
+        observer.on_upstream_response_headers(response.headers(), status.as_u16());
+    }
+    let relay_as_sse = lifecycle.as_ref().is_some_and(|lifecycle| {
+        lifecycle
             .observer
             .as_ref()
             .is_some_and(TunnelRequestObserver::is_streaming)
-        && response
-            .headers()
-            .get(CONTENT_TYPE)
-            .and_then(|value| value.to_str().ok())
-            .is_some_and(|value| value.starts_with("text/event-stream"))
-    {
-        lifecycle.relay_sse(app, response, transport).await
-    } else {
-        if status.is_success()
-            && let Some(lifecycle) = lifecycle.as_mut()
-        {
-            if let Some(queue_request) = lifecycle.queue_request.as_mut() {
-                queue_request.observe_output();
-            }
-            if let Some(observer) = lifecycle
-                .observer
-                .as_mut()
-                .and_then(TunnelRequestObserver::generation_mut)
-            {
-                observer.observe_output_message();
-            }
-        }
-        let mut body_stream = response.bytes_stream();
-        while let Some(chunk) = body_stream
-            .try_next()
+            && response
+                .headers()
+                .get(CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok())
+                .is_some_and(|value| value.starts_with("text/event-stream"))
+    });
+    if relay_as_sse {
+        let upstream_messages = upstream_sse_message_stream(
+            response.bytes_stream(),
+            app.first_output_timeout,
+            app.output_chunk_timeout,
+            app.max_sse_buffer_bytes,
+        );
+        transport
+            .send_response_head(status, response_head)
             .await
-            .context("failed to read upstream response body")?
-        {
-            transport.send_body_event(chunk).await?;
-        }
-        Ok(())
+            .map_err(ResponseRelayError::Downstream)?;
+        let outcome = lifecycle
+            .as_mut()
+            .expect("SSE relay should have an observed request lifecycle")
+            .relay_sse(upstream_messages, transport)
+            .await?;
+        return Ok(if status.is_success() {
+            outcome
+        } else {
+            RequestRelayOutcome::Failed
+        });
     }
+
+    transport
+        .send_response_head(status, response_head)
+        .await
+        .map_err(ResponseRelayError::Downstream)?;
+    if status.is_success()
+        && let Some(lifecycle) = lifecycle.as_mut()
+    {
+        if let Some(queue_request) = lifecycle.queue_request.as_mut() {
+            queue_request.observe_output();
+        }
+        if let Some(observer) = lifecycle
+            .observer
+            .as_mut()
+            .and_then(TunnelRequestObserver::generation_mut)
+        {
+            observer.observe_generated_output(Instant::now(), false);
+        }
+    }
+    let mut body_stream = response.bytes_stream();
+    while let Some(chunk) = body_stream
+        .try_next()
+        .await
+        .context("failed to read upstream response body")
+        .map_err(ResponseRelayError::Upstream)?
+    {
+        transport
+            .send_body_event(chunk)
+            .await
+            .map_err(ResponseRelayError::Downstream)?;
+    }
+    Ok(if status.is_success() {
+        RequestRelayOutcome::Complete
+    } else {
+        RequestRelayOutcome::Failed
+    })
 }
 
 pub(super) async fn forward_tunnel_request(
@@ -682,12 +753,15 @@ pub(super) async fn forward_tunnel_request(
         .and_then(|lifecycle| lifecycle.required.priority);
     let response = match send_upstream_request(
         app,
-        method,
-        &path_and_query,
-        &request_headers,
-        body_bytes,
-        health_request,
-        priority,
+        lifecycle.as_mut(),
+        UpstreamRequestParts {
+            method,
+            path_and_query: &path_and_query,
+            headers: &request_headers,
+            body: body_bytes,
+            health_request,
+            priority,
+        },
     )
     .await
     {
@@ -707,28 +781,66 @@ pub(super) async fn forward_tunnel_request(
             )
             .await;
         }
-        Err(error) => return Err(error.into()),
+        Err(error) => {
+            if let Some(lifecycle) = lifecycle.as_mut() {
+                lifecycle.fail();
+            }
+            return Err(error.into());
+        }
     };
 
-    relay_upstream_response(app, lifecycle.as_mut(), response, transport).await?;
+    let outcome = match relay_upstream_response(app, lifecycle.as_mut(), response, transport).await
+    {
+        Ok(outcome) => outcome,
+        Err(ResponseRelayError::Upstream(error)) => {
+            if let Some(lifecycle) = lifecycle.as_mut() {
+                lifecycle.fail();
+            }
+            return Err(error);
+        }
+        Err(ResponseRelayError::Downstream(error)) => {
+            if let Some(lifecycle) = lifecycle.as_mut() {
+                lifecycle.cancel();
+            }
+            return Err(error);
+        }
+    };
 
-    transport.finish_response().await?;
+    if let Err(error) = transport.finish_response().await {
+        if let Some(lifecycle) = lifecycle.as_mut() {
+            lifecycle.cancel();
+        }
+        return Err(error);
+    }
     if let Some(lifecycle) = lifecycle.as_mut() {
-        lifecycle.finish(app);
+        lifecycle.finish(app, outcome);
     }
 
     Ok(())
 }
 
-async fn send_upstream_request(
-    app: &TunnelServerApp,
+struct UpstreamRequestParts<'a> {
     method: Method,
-    path_and_query: &str,
-    request_headers: &HeaderMap,
-    body_bytes: Vec<u8>,
+    path_and_query: &'a str,
+    headers: &'a HeaderMap,
+    body: Vec<u8>,
     health_request: bool,
     priority: Option<u32>,
+}
+
+async fn send_upstream_request(
+    app: &TunnelServerApp,
+    lifecycle: Option<&mut TunnelRequestLifecycle>,
+    request: UpstreamRequestParts<'_>,
 ) -> Result<Response, UpstreamRequestError> {
+    let UpstreamRequestParts {
+        method,
+        path_and_query,
+        headers: request_headers,
+        body: body_bytes,
+        health_request,
+        priority,
+    } = request;
     let span = if !health_request {
         let span = tracing::info_span!(
             "pylon_upstream_http_request",
@@ -772,11 +884,18 @@ async fn send_upstream_request(
     let send = async {
         let request_url = join_base_path(&app.upstream_http_base_url, path_and_query)
             .map_err(UpstreamRequestError::Build)?;
-        app.http_client
+        let request = app
+            .http_client
             .request(method, request_url)
             .headers(upstream_headers)
             .body(body_bytes)
-            .send()
+            .build()
+            .map_err(|error| UpstreamRequestError::Build(anyhow::Error::new(error)))?;
+        if let Some(lifecycle) = lifecycle {
+            lifecycle.on_backend_submission(Instant::now());
+        }
+        app.http_client
+            .execute(request)
             .await
             .map_err(UpstreamRequestError::Send)
     };
@@ -1136,7 +1255,148 @@ fn is_tunnel_control_header(name: &HeaderName, retry: &PylonRetryConfig) -> bool
 
 #[cfg(test)]
 mod tests {
+    use axum::Router;
+    use axum::body::Body;
+    use axum::response::Response as AxumResponse;
+    use axum::routing::post;
+    use stargate_proto::pb::InferenceServerStatus;
+    use stargate_protocol::tunnel_contract::{HEADER_INPUT_TOKENS, HEADER_REQUEST_ID};
+
+    use crate::test_support::TestHttpServer;
+
     use super::*;
+
+    #[derive(Clone)]
+    struct ResponseHeadGate {
+        entered: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    #[derive(Default)]
+    struct TestTransport {
+        request_body: Vec<u8>,
+        response_heads: Vec<StatusCode>,
+        response_events: Vec<bytes::Bytes>,
+        response_head_gate: Option<ResponseHeadGate>,
+        fail_finish: bool,
+    }
+
+    impl ResponseBodyEventSink for TestTransport {
+        async fn send_body_event(&mut self, event: bytes::Bytes) -> Result<()> {
+            self.response_events.push(event);
+            Ok(())
+        }
+    }
+
+    impl TunnelRequestTransport for TestTransport {
+        async fn read_request_body(
+            &mut self,
+            _request_headers: &HeaderMap,
+            _max_request_body_bytes: usize,
+        ) -> Result<Vec<u8>> {
+            Ok(self.request_body.clone())
+        }
+
+        async fn send_response_head(
+            &mut self,
+            status: StatusCode,
+            _headers: HeaderMap,
+        ) -> Result<()> {
+            self.response_heads.push(status);
+            if let Some(gate) = &self.response_head_gate {
+                gate.entered.notify_one();
+                gate.release.notified().await;
+            }
+            Ok(())
+        }
+
+        async fn finish_response(&mut self) -> Result<()> {
+            if self.fail_finish {
+                return Err(anyhow!("client stopped before response completion"));
+            }
+            Ok(())
+        }
+    }
+
+    fn observed_app(
+        upstream_http_base_url: impl Into<String>,
+    ) -> (
+        TunnelServerApp,
+        flume::Receiver<crate::RequestObservationEvent>,
+    ) {
+        let (runtime_state, observations) = PylonRuntimeState::observed(
+            InferenceServerStatus::Unknown,
+            &["model-a".to_string()],
+            16,
+            None,
+        );
+        let app = TunnelServerApp::new(
+            "test-pylon".to_string(),
+            upstream_http_base_url.into(),
+            TunnelForwardingConfig {
+                runtime_state,
+                ..TunnelForwardingConfig::default()
+            },
+        );
+        (app, observations)
+    }
+
+    fn observed_request(path: &str) -> TunnelRequestParts {
+        let mut headers = HeaderMap::new();
+        headers.insert(HEADER_REQUEST_ID, "req-observed".parse().unwrap());
+        headers.insert(HEADER_MODEL, "model-a".parse().unwrap());
+        headers.insert(HEADER_INPUT_TOKENS, "12".parse().unwrap());
+        headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+        TunnelRequestParts {
+            method: Method::POST,
+            path_and_query: path.to_string(),
+            headers,
+        }
+    }
+
+    fn observed_states(
+        observations: &flume::Receiver<crate::RequestObservationEvent>,
+    ) -> Vec<crate::RequestObservationState> {
+        observations
+            .try_iter()
+            .map(|event| event.into_observation().state)
+            .collect()
+    }
+
+    async fn run_observed_sse(
+        path: &'static str,
+        request_body: &'static [u8],
+        status: StatusCode,
+        response_body: impl Into<String>,
+    ) -> (
+        anyhow::Result<()>,
+        TestTransport,
+        Vec<crate::RequestObservationEvent>,
+    ) {
+        let response_body = response_body.into();
+        let upstream = TestHttpServer::spawn(Router::new().route(
+            path,
+            post(move || {
+                let response_body = response_body.clone();
+                async move {
+                    AxumResponse::builder()
+                        .status(status)
+                        .header(CONTENT_TYPE, "text/event-stream")
+                        .body(Body::from(response_body))
+                        .unwrap()
+                }
+            }),
+        ))
+        .await;
+        let (app, observations) = observed_app(upstream.as_str());
+        let mut transport = TestTransport {
+            request_body: request_body.to_vec(),
+            ..TestTransport::default()
+        };
+        let result = forward_tunnel_request(&app, observed_request(path), &mut transport).await;
+        let observations = observations.try_iter().collect();
+        (result, transport, observations)
+    }
 
     #[test]
     fn operational_log_levels_reserve_info_for_rejections_and_failures() {
@@ -1170,5 +1430,325 @@ mod tests {
             StatusCode::INTERNAL_SERVER_ERROR,
             false
         ));
+    }
+
+    #[tokio::test]
+    async fn request_build_failure_is_not_backend_submitted() {
+        let (app, observations) = observed_app("not a valid upstream URL");
+        let mut transport = TestTransport {
+            request_body: br#"{"messages":[],"stream":true}"#.to_vec(),
+            ..TestTransport::default()
+        };
+
+        let error = forward_tunnel_request(
+            &app,
+            observed_request("/v1/chat/completions"),
+            &mut transport,
+        )
+        .await
+        .expect_err("invalid upstream URL should fail request construction");
+
+        assert!(
+            error
+                .to_string()
+                .contains("failed to build upstream request")
+        );
+        assert_eq!(
+            observed_states(&observations),
+            [
+                crate::RequestObservationState::UpstreamConnecting,
+                crate::RequestObservationState::Failed,
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_failure_terminates_an_already_submitted_request() {
+        let (app, observations) = observed_app("http://127.0.0.1:0");
+        let mut transport = TestTransport {
+            request_body: br#"{"messages":[],"stream":true}"#.to_vec(),
+            ..TestTransport::default()
+        };
+
+        forward_tunnel_request(
+            &app,
+            observed_request("/v1/chat/completions"),
+            &mut transport,
+        )
+        .await
+        .expect("local connect failure should return the problem response");
+
+        assert_eq!(transport.response_heads, [StatusCode::SERVICE_UNAVAILABLE]);
+        assert_eq!(
+            observed_states(&observations),
+            [
+                crate::RequestObservationState::UpstreamConnecting,
+                crate::RequestObservationState::InputProcessing,
+                crate::RequestObservationState::Failed,
+            ]
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn first_output_timeout_runs_while_downstream_response_head_is_stalled() {
+        let upstream = TestHttpServer::spawn(Router::new().route(
+            "/v1/chat/completions",
+            post(|| async {
+                let body = Body::from_stream(futures::stream::pending::<
+                    std::result::Result<bytes::Bytes, std::convert::Infallible>,
+                >());
+                AxumResponse::builder()
+                    .header(CONTENT_TYPE, "text/event-stream")
+                    .body(body)
+                    .unwrap()
+            }),
+        ))
+        .await;
+        let (mut app, observations) = observed_app(upstream.as_str());
+        app.first_output_timeout = Duration::from_secs(1);
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let gate = ResponseHeadGate {
+            entered: Arc::clone(&entered),
+            release: Arc::clone(&release),
+        };
+        let mut transport = TestTransport {
+            request_body: br#"{"messages":[],"stream":true}"#.to_vec(),
+            response_head_gate: Some(gate),
+            ..TestTransport::default()
+        };
+
+        let (completed_tx, completed_rx) = tokio::sync::oneshot::channel();
+        let forward = tokio::spawn(async move {
+            let result = forward_tunnel_request(
+                &app,
+                observed_request("/v1/chat/completions"),
+                &mut transport,
+            )
+            .await;
+            let _ = completed_tx.send(());
+            (result, transport)
+        });
+        entered.notified().await;
+        tokio::time::advance(Duration::from_millis(1001)).await;
+        release.notify_one();
+
+        tokio::time::timeout(Duration::from_millis(100), completed_rx)
+            .await
+            .expect("forwarding should complete promptly after releasing the response header")
+            .expect("forwarding task should report completion");
+        let (result, transport) = forward.await.expect("forwarding task should not panic");
+
+        assert!(
+            result
+                .expect_err("missing first output should fail the upstream relay")
+                .to_string()
+                .contains("timed out waiting for first output event")
+        );
+        assert_eq!(transport.response_heads, [StatusCode::OK]);
+        assert_eq!(
+            observations
+                .try_iter()
+                .last()
+                .expect("terminal observation should be emitted")
+                .observation()
+                .state,
+            crate::RequestObservationState::Failed
+        );
+    }
+
+    #[tokio::test]
+    async fn downstream_finish_failure_overrides_forwarded_success_terminal_once() {
+        let upstream = TestHttpServer::spawn(Router::new().route(
+            "/v1/chat/completions",
+            post(|| async {
+                AxumResponse::builder()
+                    .header(CONTENT_TYPE, "text/event-stream")
+                    .body(Body::from("data: [DONE]\n\n"))
+                    .unwrap()
+            }),
+        ))
+        .await;
+        let (app, observations) = observed_app(upstream.as_str());
+        let mut transport = TestTransport {
+            request_body: br#"{"messages":[],"stream":true}"#.to_vec(),
+            fail_finish: true,
+            ..TestTransport::default()
+        };
+
+        let error = forward_tunnel_request(
+            &app,
+            observed_request("/v1/chat/completions"),
+            &mut transport,
+        )
+        .await
+        .expect_err("downstream finish should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("client stopped before response completion")
+        );
+        assert_eq!(
+            transport.response_events,
+            [bytes::Bytes::from_static(b"data: [DONE]\n\n")]
+        );
+        let states = observed_states(&observations);
+        assert_eq!(
+            states,
+            [
+                crate::RequestObservationState::UpstreamConnecting,
+                crate::RequestObservationState::InputProcessing,
+                crate::RequestObservationState::InputProcessing,
+                crate::RequestObservationState::Cancelled,
+            ]
+        );
+        assert_eq!(
+            states
+                .iter()
+                .filter(|state| matches!(
+                    state,
+                    crate::RequestObservationState::Complete
+                        | crate::RequestObservationState::Failed
+                        | crate::RequestObservationState::Cancelled
+                ))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_success_terminal_completes_zero_output_after_applying_usage() {
+        let raw = "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":5,\"output_tokens\":2}}}\n\n";
+        let (result, transport, observations) = run_observed_sse(
+            "/v1/responses",
+            br#"{"input":"hello","stream":true}"#,
+            StatusCode::OK,
+            raw,
+        )
+        .await;
+        result.expect("explicit terminal should complete the SSE response");
+
+        assert_eq!(
+            transport.response_events,
+            [bytes::Bytes::from_static(raw.as_bytes())]
+        );
+        let terminal = observations
+            .last()
+            .expect("terminal observation should be emitted")
+            .observation();
+        assert_eq!(terminal.state, crate::RequestObservationState::Complete);
+        assert_eq!(terminal.output_messages, 0);
+        assert_eq!(terminal.input_tokens, 5);
+        assert_eq!(terminal.output_tokens, 2);
+        assert!(terminal.output_tokens_explicit);
+        assert_eq!(terminal.time_to_first_output, None);
+        assert_eq!(terminal.time_to_first_token, None);
+    }
+
+    #[tokio::test]
+    async fn whitespace_text_records_first_token_without_inventing_an_estimate() {
+        let raw = "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"delta\":{\"content\":\" \"}}]}\n\ndata: [DONE]\n\n";
+        let (result, _, observations) = run_observed_sse(
+            "/v1/chat/completions",
+            br#"{"messages":[],"stream":true}"#,
+            StatusCode::OK,
+            raw,
+        )
+        .await;
+        result.expect("explicit terminal should complete the whitespace SSE response");
+
+        let terminal = observations
+            .last()
+            .expect("terminal observation should be emitted")
+            .observation();
+        assert_eq!(terminal.state, crate::RequestObservationState::Complete);
+        assert!(terminal.time_to_first_output.is_some());
+        assert!(terminal.time_to_first_token.is_some());
+        assert_eq!(terminal.output_tokens, 0);
+    }
+
+    #[tokio::test]
+    async fn failed_responses_terminals_override_generated_output() {
+        for (event_type, request_id_suffix) in [
+            ("response.failed", "failed"),
+            ("response.incomplete", "incomplete"),
+            ("error", "error"),
+        ] {
+            let body = format!(
+                "data: {{\"type\":\"response.output_text.delta\",\"delta\":\"x\"}}\n\ndata: {{\"type\":\"{event_type}\"}}\n\n"
+            );
+            let (result, _, observations) = run_observed_sse(
+                "/v1/responses",
+                br#"{"input":"hello","stream":true}"#,
+                StatusCode::OK,
+                body,
+            )
+            .await;
+            result.expect("explicit failure terminal should complete the SSE response");
+            let terminal = observations.last().unwrap().observation();
+            assert_eq!(
+                terminal.state,
+                crate::RequestObservationState::Failed,
+                "unexpected outcome for {request_id_suffix}"
+            );
+            assert_eq!(terminal.output_messages, 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn non_success_http_status_overrides_done_terminal() {
+        let (result, _, observations) = run_observed_sse(
+            "/v1/chat/completions",
+            br#"{"messages":[],"stream":true}"#,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "data: [DONE]\n\n",
+        )
+        .await;
+        result.expect("explicit terminal should complete the non-success response");
+
+        assert_eq!(
+            observations.last().unwrap().observation().state,
+            crate::RequestObservationState::Failed
+        );
+    }
+
+    #[tokio::test]
+    async fn eof_before_terminal_is_an_upstream_error_even_after_generated_output() {
+        let (output_result, _, output_observations) = run_observed_sse(
+            "/v1/chat/completions",
+            br#"{"messages":[],"stream":true}"#,
+            StatusCode::OK,
+            "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"delta\":{\"content\":\"x\"}}]}\n\n",
+        )
+        .await;
+        assert!(
+            output_result
+                .expect_err("truncated output stream should fail")
+                .to_string()
+                .contains("ended before a terminal event")
+        );
+        assert_eq!(
+            output_observations.last().unwrap().observation().state,
+            crate::RequestObservationState::Failed
+        );
+
+        let (metadata_result, _, metadata_observations) = run_observed_sse(
+            "/v1/chat/completions",
+            br#"{"messages":[],"stream":true}"#,
+            StatusCode::OK,
+            "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}\n\n",
+        )
+        .await;
+        assert!(
+            metadata_result
+                .expect_err("truncated metadata stream should fail")
+                .to_string()
+                .contains("ended before a terminal event")
+        );
+        assert_eq!(
+            metadata_observations.last().unwrap().observation().state,
+            crate::RequestObservationState::Failed
+        );
     }
 }

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/quic_http_tunnel/core.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/quic_http_tunnel/core.rs
@@ -442,6 +442,7 @@ impl TunnelRequestLifecycle {
                     "observer missing for observed streaming request"
                 ))
             })?;
+        obs.observe_upstream_event(message.received_at);
         let mut quality_progress = None;
         if let Some(generated_output) = message.facts.generated_output.as_ref() {
             if let (false, Some(queue)) = (*saw_output, self.queue_request.as_mut()) {

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/quic_http_tunnel/tests.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/quic_http_tunnel/tests.rs
@@ -2104,7 +2104,7 @@ async fn quic_tunnel_emits_request_observation_for_streaming_responses() {
     assert_eq!(observation.request_id, "req-responses-observed");
     assert_eq!(observation.model_id, "model-responses");
     assert_eq!(observation.input_tokens, 11);
-    assert_eq!(observation.output_messages, 2);
+    assert_eq!(observation.output_messages, 1);
     assert_eq!(observation.output_tokens, 2);
     assert!(observation.output_tokens_explicit);
     assert!(observation.output_tokens_from_chunk_usage);
@@ -2257,7 +2257,7 @@ async fn quic_tunnel_counts_terminal_only_usage_tokens() {
     assert_eq!(observation.request_id, "req-terminal-usage");
     assert_eq!(observation.model_id, "model-terminal-usage");
     assert_eq!(observation.input_tokens, 13);
-    assert_eq!(observation.output_messages, 3);
+    assert_eq!(observation.output_messages, 2);
     assert_eq!(observation.output_tokens, 7);
     assert!(observation.output_tokens_explicit);
     assert!(observation.output_tokens_from_chunk_usage);

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/request_observer.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/request_observer.rs
@@ -133,6 +133,7 @@ struct BackendPhaseData {
     submitted_at: Instant,
     upstream_status: Option<u16>,
     response_headers_at: Option<Instant>,
+    last_upstream_event_at: Option<Instant>,
     first_generated_output_at: Option<Instant>,
     first_token_at: Option<Instant>,
     output_messages: u64,
@@ -206,6 +207,7 @@ impl RequestObserver {
             submitted_at,
             upstream_status: None,
             response_headers_at: None,
+            last_upstream_event_at: None,
             first_generated_output_at: None,
             first_token_at: None,
             output_messages: 0,
@@ -238,6 +240,19 @@ impl RequestObserver {
             backend.first_token_at.get_or_insert(observed_at);
         }
         self.emit();
+    }
+
+    pub(crate) fn observe_upstream_event(&mut self, observed_at: Instant) {
+        let backend = Self::backend_mut(
+            &mut self.state,
+            &self.request_id,
+            "upstream event observation",
+        );
+        backend.last_upstream_event_at = Some(
+            backend
+                .last_upstream_event_at
+                .map_or(observed_at, |previous| previous.max(observed_at)),
+        );
     }
 
     pub(crate) fn observe_input_tokens_total(&mut self, input_tokens: u64) {
@@ -394,6 +409,9 @@ impl RequestObserver {
             observation,
             self.generation.clone(),
             input_interval,
+            backend
+                .and_then(|backend| backend.last_upstream_event_at)
+                .map(|instant| instant.saturating_duration_since(self.started_at)),
         );
     }
 }
@@ -903,6 +921,46 @@ mod tests {
         );
     }
 
+    #[test]
+    fn terminal_observation_preserves_upstream_completion_time() {
+        let accepted_at = Instant::now()
+            .checked_sub(Duration::from_secs(10))
+            .expect("test acceptance time should be representable");
+        let required = RequiredTunnelHeaders {
+            request_id: "req-upstream-completion".to_string(),
+            routing_key: Some("rk-1".to_string()),
+            model_id: "model-a".to_string(),
+            priority: None,
+            input_tokens: 42,
+            accepted_at,
+        };
+        let (runtime_state, rx) = observed_runtime(8);
+        let mut observer = RequestObserver::from_required(
+            RequestObservationEndpoint::ChatCompletions,
+            required,
+            None,
+            runtime_state,
+        );
+        rx.try_recv().unwrap();
+        observer.on_backend_submission(accepted_at + Duration::from_millis(500));
+        rx.try_recv().unwrap();
+
+        let first_output_at = accepted_at + Duration::from_secs(1);
+        observer.observe_upstream_event(first_output_at);
+        observer.observe_generated_output(first_output_at, true);
+        let output = rx.try_recv().unwrap();
+        assert_eq!(output.output_duration(), Duration::from_secs(1));
+
+        observer.observe_output_tokens(100);
+        rx.try_recv().unwrap();
+        observer.observe_upstream_event(accepted_at + Duration::from_secs(2));
+        observer.complete();
+        let terminal = rx.try_recv().unwrap();
+
+        assert_eq!(terminal.output_duration(), Duration::from_secs(2));
+        assert!(terminal.observation().total_duration >= Duration::from_secs(9));
+    }
+
     #[tokio::test]
     async fn upstream_connecting_observation_is_emitted_when_request_starts() {
         let (runtime_state, rx) = observed_runtime(8);
@@ -1131,6 +1189,7 @@ mod tests {
             submitted_at: started_at,
             upstream_status: Some(200),
             response_headers_at: Some(started_at + Duration::from_millis(10)),
+            last_upstream_event_at: None,
             first_generated_output_at: None,
             first_token_at: None,
             output_messages: 0,
@@ -1162,6 +1221,7 @@ mod tests {
             submitted_at: started_at + Duration::from_millis(25),
             upstream_status: Some(200),
             response_headers_at: Some(started_at + Duration::from_millis(50)),
+            last_upstream_event_at: Some(first_output_at),
             first_generated_output_at: Some(first_output_at),
             first_token_at: Some(first_output_at),
             output_messages: 2,

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/request_observer.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/request_observer.rs
@@ -15,6 +15,7 @@
 
 use std::time::{Duration, Instant};
 
+#[cfg(test)]
 use reqwest::header::HeaderMap;
 
 use crate::generated_request_id::{GeneratedRequestKind, generated_request_kind};
@@ -218,11 +219,7 @@ impl RequestObserver {
         self.emit();
     }
 
-    pub(crate) fn on_upstream_response_headers(
-        &mut self,
-        _response_headers: &HeaderMap,
-        status: u16,
-    ) {
+    pub(crate) fn on_upstream_response_headers(&mut self, status: u16) {
         let backend = Self::backend_mut(&mut self.state, &self.request_id, "response-header");
         if backend.response_headers_at.is_some() {
             return;
@@ -596,7 +593,7 @@ mod tests {
         recv_observation(&rx, "initial observation should be emitted").await;
         observer.submit_now();
         recv_observation(&rx, "backend-submission observation should be emitted").await;
-        observer.on_upstream_response_headers(&HeaderMap::new(), 200);
+        observer.on_upstream_response_headers(200);
         let headers = recv_observation(&rx, "response-header observation should be emitted").await;
         (observer, rx, headers)
     }
@@ -748,7 +745,7 @@ mod tests {
                 runtime_state,
             );
             observer.on_backend_submission(Instant::now());
-            observer.on_upstream_response_headers(&HeaderMap::new(), 200);
+            observer.on_upstream_response_headers(200);
             if let Some(generation) = observer.generation_mut() {
                 generation.observe_output_message();
             }
@@ -797,7 +794,7 @@ mod tests {
         let mut observer = RequestObserver::accepted(embeddings_required_headers(), runtime_state);
         observer.update_embedding_items(Some(1));
         observer.submit_now();
-        observer.on_upstream_response_headers(&HeaderMap::new(), 200);
+        observer.on_upstream_response_headers(200);
         observer.finish();
         while rx.try_recv().is_ok() {}
 
@@ -825,7 +822,7 @@ mod tests {
     async fn counts_sse_events_across_chunk_boundaries() {
         let mut observer = test_observer("req-1", PylonRuntimeState::default());
         observer.submit_now();
-        observer.on_upstream_response_headers(&HeaderMap::new(), 200);
+        observer.on_upstream_response_headers(200);
         observer.observe_output_message();
         observer.observe_output_message();
         observer.finish();
@@ -854,7 +851,7 @@ mod tests {
         assert_eq!(submitted.state, RequestObservationState::InputProcessing);
         assert_eq!(submitted.upstream_status, None);
 
-        observer.on_upstream_response_headers(&HeaderMap::new(), 200);
+        observer.on_upstream_response_headers(200);
         let first = recv_observation(&rx, "response-header observation should be emitted").await;
         assert_eq!(first.state, RequestObservationState::InputProcessing);
         assert!(!first.is_terminal());
@@ -879,15 +876,15 @@ mod tests {
             submitted.observation().state,
             RequestObservationState::InputProcessing
         );
-        assert_eq!(submitted.input_processing_duration(), None);
+        assert_eq!(submitted.input_interval(), None);
 
-        observer.on_upstream_response_headers(&HeaderMap::new(), 200);
+        observer.on_upstream_response_headers(200);
         let headers = rx.try_recv().unwrap();
         assert_eq!(
             headers.observation().state,
             RequestObservationState::InputProcessing
         );
-        assert_eq!(headers.input_processing_duration(), None);
+        assert_eq!(headers.input_interval(), None);
 
         let first_generated_output_at = submitted_at + Duration::from_millis(10);
         observer.observe_generated_output(first_generated_output_at, true);
@@ -899,26 +896,13 @@ mod tests {
                 first_generated_output_at,
             })
         );
-        assert_eq!(
-            output.input_processing_duration(),
-            Some(Duration::from_millis(10))
-        );
-
         observer.observe_output_tokens(2);
         let tokens = rx.try_recv().unwrap();
         assert_eq!(tokens.input_interval(), output.input_interval());
-        assert_eq!(
-            tokens.input_processing_duration(),
-            Some(Duration::from_millis(10))
-        );
 
         observer.complete();
         let terminal = rx.try_recv().unwrap();
         assert_eq!(terminal.input_interval(), output.input_interval());
-        assert_eq!(
-            terminal.input_processing_duration(),
-            Some(Duration::from_millis(10))
-        );
     }
 
     #[test]
@@ -949,7 +933,7 @@ mod tests {
         observer.observe_upstream_event(first_output_at);
         observer.observe_generated_output(first_output_at, true);
         let output = rx.try_recv().unwrap();
-        assert_eq!(output.output_duration(), Duration::from_secs(1));
+        assert_eq!(output.upstream_duration, Some(Duration::from_secs(1)));
 
         observer.observe_output_tokens(100);
         rx.try_recv().unwrap();
@@ -957,7 +941,7 @@ mod tests {
         observer.complete();
         let terminal = rx.try_recv().unwrap();
 
-        assert_eq!(terminal.output_duration(), Duration::from_secs(2));
+        assert_eq!(terminal.upstream_duration, Some(Duration::from_secs(2)));
         assert!(terminal.observation().total_duration >= Duration::from_secs(9));
     }
 
@@ -994,7 +978,7 @@ mod tests {
     async fn accumulates_output_tokens() {
         let mut observer = test_observer("req-1", PylonRuntimeState::default());
         observer.submit_now();
-        observer.on_upstream_response_headers(&HeaderMap::new(), 200);
+        observer.on_upstream_response_headers(200);
         observer.observe_output_message();
         observer.observe_output_tokens(3);
         observer.observe_output_message();
@@ -1240,7 +1224,7 @@ mod tests {
     fn explicit_success_can_complete_without_output() {
         let mut observer = test_observer("req-2", PylonRuntimeState::default());
         observer.submit_now();
-        observer.on_upstream_response_headers(&HeaderMap::new(), 200);
+        observer.on_upstream_response_headers(200);
         observer.finish();
         assert_eq!(
             observer.state.observation_state(),
@@ -1254,7 +1238,7 @@ mod tests {
     fn terminalization_is_idempotent() {
         let mut observer = make_test_observer();
         observer.submit_now();
-        observer.on_upstream_response_headers(&HeaderMap::new(), 200);
+        observer.on_upstream_response_headers(200);
         observer.observe_output_message();
         observer.finish();
         observer.fail();
@@ -1284,7 +1268,7 @@ mod tests {
             terminalize(&mut observer);
 
             let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                observer.on_upstream_response_headers(&HeaderMap::new(), 200);
+                observer.on_upstream_response_headers(200);
             }))
             .expect_err("response headers after terminal state should panic");
 
@@ -1297,7 +1281,7 @@ mod tests {
         assert_terminal_response_header_panic(
             |observer| {
                 observer.submit_now();
-                observer.on_upstream_response_headers(&HeaderMap::new(), 200);
+                observer.on_upstream_response_headers(200);
                 observer.observe_output_message();
                 observer.finish();
             },
@@ -1311,7 +1295,7 @@ mod tests {
     async fn failed_response_stays_failed() {
         let mut observer = test_observer("req-3", PylonRuntimeState::default());
         observer.submit_now();
-        observer.on_upstream_response_headers(&HeaderMap::new(), 503);
+        observer.on_upstream_response_headers(503);
         observer.fail();
 
         let response = response(&observer);

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/request_observer.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/request_observer.rs
@@ -18,7 +18,7 @@ use std::time::{Duration, Instant};
 use reqwest::header::HeaderMap;
 
 use crate::generated_request_id::{GeneratedRequestKind, generated_request_kind};
-use crate::runtime_state::{ModelGeneration, PylonRuntimeState};
+use crate::runtime_state::{ModelGeneration, PylonRuntimeState, RequestInputInterval};
 
 mod embeddings;
 mod headers;
@@ -351,11 +351,12 @@ impl RequestObserver {
     }
     fn emit(&mut self) {
         let backend = self.state.backend();
-        let input_processing_duration = backend.and_then(|backend| {
+        let input_interval = backend.and_then(|backend| {
             backend
                 .first_generated_output_at
-                .map(|first_generated_output_at| {
-                    first_generated_output_at.saturating_duration_since(backend.submitted_at)
+                .map(|first_generated_output_at| RequestInputInterval {
+                    submitted_at: backend.submitted_at,
+                    first_generated_output_at,
                 })
         });
         let observation = RequestObservation {
@@ -392,7 +393,7 @@ impl RequestObserver {
         self.runtime_state.observe_request_for_generation(
             observation,
             self.generation.clone(),
-            input_processing_duration,
+            input_interval,
         );
     }
 }
@@ -848,7 +849,7 @@ mod tests {
     }
 
     #[test]
-    fn input_processing_duration_is_repeated_on_cumulative_output_and_terminal_events() {
+    fn input_interval_is_repeated_on_cumulative_output_and_terminal_events() {
         let (runtime_state, rx) = observed_runtime(8);
         let mut observer = test_observer("req-input-interval", runtime_state);
         rx.try_recv().unwrap();
@@ -874,12 +875,20 @@ mod tests {
         observer.observe_generated_output(first_generated_output_at, true);
         let output = rx.try_recv().unwrap();
         assert_eq!(
+            output.input_interval(),
+            Some(RequestInputInterval {
+                submitted_at,
+                first_generated_output_at,
+            })
+        );
+        assert_eq!(
             output.input_processing_duration(),
             Some(Duration::from_millis(10))
         );
 
         observer.observe_output_tokens(2);
         let tokens = rx.try_recv().unwrap();
+        assert_eq!(tokens.input_interval(), output.input_interval());
         assert_eq!(
             tokens.input_processing_duration(),
             Some(Duration::from_millis(10))
@@ -887,6 +896,7 @@ mod tests {
 
         observer.complete();
         let terminal = rx.try_recv().unwrap();
+        assert_eq!(terminal.input_interval(), output.input_interval());
         assert_eq!(
             terminal.input_processing_duration(),
             Some(Duration::from_millis(10))

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/request_observer.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/request_observer.rs
@@ -50,10 +50,10 @@ pub enum RequestObservationEndpoint {
 #[derive(Debug)]
 enum RequestLifecycleState {
     UpstreamConnecting,
-    Responding(ResponsePhaseData),
+    BackendSubmitted(BackendPhaseData),
     Terminal {
         outcome: RequestTerminalOutcome,
-        response: Option<ResponsePhaseData>,
+        backend: Option<BackendPhaseData>,
     },
 }
 
@@ -78,18 +78,18 @@ impl RequestLifecycleState {
     fn observation_state(&self) -> RequestObservationState {
         match self {
             Self::UpstreamConnecting => RequestObservationState::UpstreamConnecting,
-            Self::Responding(response) if response.first_output_at.is_none() => {
+            Self::BackendSubmitted(backend) if backend.first_generated_output_at.is_none() => {
                 RequestObservationState::InputProcessing
             }
-            Self::Responding(_) => RequestObservationState::OutputGeneration,
+            Self::BackendSubmitted(_) => RequestObservationState::OutputGeneration,
             Self::Terminal { outcome, .. } => outcome.observation_state(),
         }
     }
 
-    fn response(&self) -> Option<&ResponsePhaseData> {
+    fn backend(&self) -> Option<&BackendPhaseData> {
         match self {
-            Self::Responding(response) => Some(response),
-            Self::Terminal { response, .. } => response.as_ref(),
+            Self::BackendSubmitted(backend) => Some(backend),
+            Self::Terminal { backend, .. } => backend.as_ref(),
             Self::UpstreamConnecting => None,
         }
     }
@@ -129,10 +129,11 @@ impl RequestObservation {
 }
 
 #[derive(Clone, Copy, Debug)]
-struct ResponsePhaseData {
-    upstream_status: u16,
-    response_headers_at: Instant,
-    first_output_at: Option<Instant>,
+struct BackendPhaseData {
+    submitted_at: Instant,
+    upstream_status: Option<u16>,
+    response_headers_at: Option<Instant>,
+    first_generated_output_at: Option<Instant>,
     first_token_at: Option<Instant>,
     output_messages: u64,
     output_tokens: u64,
@@ -148,6 +149,7 @@ pub(crate) struct RequestObserver {
     model_id: String,
     priority: u32,
     input_tokens: u64,
+    input_tokens_explicit: bool,
     generation: Option<ModelGeneration>,
     embedding_items: Option<u64>,
     state: RequestLifecycleState,
@@ -178,6 +180,7 @@ impl RequestObserver {
             model_id,
             priority,
             input_tokens,
+            input_tokens_explicit: false,
             generation,
             embedding_items: None,
             state: RequestLifecycleState::UpstreamConnecting,
@@ -195,26 +198,15 @@ impl RequestObserver {
         }
     }
 
-    pub(crate) fn on_upstream_response_headers(
-        &mut self,
-        _response_headers: &HeaderMap,
-        status: u16,
-    ) {
-        match self.state {
-            RequestLifecycleState::UpstreamConnecting => {}
-            RequestLifecycleState::Responding(_) | RequestLifecycleState::Terminal { .. } => {
-                panic!(
-                    "invalid response-header transition for request_id={} from state={:?}",
-                    self.request_id,
-                    self.state.observation_state()
-                )
-            }
+    pub(crate) fn on_backend_submission(&mut self, submitted_at: Instant) {
+        if !matches!(self.state, RequestLifecycleState::UpstreamConnecting) {
+            return;
         }
-
-        self.state = RequestLifecycleState::Responding(ResponsePhaseData {
-            upstream_status: status,
-            response_headers_at: Instant::now(),
-            first_output_at: None,
+        self.state = RequestLifecycleState::BackendSubmitted(BackendPhaseData {
+            submitted_at,
+            upstream_status: None,
+            response_headers_at: None,
+            first_generated_output_at: None,
             first_token_at: None,
             output_messages: 0,
             output_tokens: 0,
@@ -224,11 +216,36 @@ impl RequestObserver {
         self.emit();
     }
 
-    pub(crate) fn observe_output_message(&mut self) {
-        let response =
-            Self::responding_mut(&mut self.state, &self.request_id, "output observation");
-        response.output_messages += 1;
-        response.first_output_at.get_or_insert_with(Instant::now);
+    pub(crate) fn on_upstream_response_headers(
+        &mut self,
+        _response_headers: &HeaderMap,
+        status: u16,
+    ) {
+        let backend = Self::backend_mut(&mut self.state, &self.request_id, "response-header");
+        if backend.response_headers_at.is_some() {
+            return;
+        }
+        backend.upstream_status = Some(status);
+        backend.response_headers_at = Some(Instant::now());
+        self.emit();
+    }
+
+    pub(crate) fn observe_generated_output(&mut self, observed_at: Instant, token_bearing: bool) {
+        let backend = Self::backend_mut(&mut self.state, &self.request_id, "output observation");
+        backend.output_messages = backend.output_messages.saturating_add(1);
+        backend.first_generated_output_at.get_or_insert(observed_at);
+        if token_bearing {
+            backend.first_token_at.get_or_insert(observed_at);
+        }
+        self.emit();
+    }
+
+    pub(crate) fn observe_input_tokens_total(&mut self, input_tokens: u64) {
+        if self.input_tokens_explicit && input_tokens == self.input_tokens {
+            return;
+        }
+        self.input_tokens = input_tokens;
+        self.input_tokens_explicit = true;
         self.emit();
     }
 
@@ -237,18 +254,15 @@ impl RequestObserver {
             return;
         }
 
-        let response = Self::responding_mut(
+        let backend = Self::backend_mut(
             &mut self.state,
             &self.request_id,
             "output token observation",
         );
-        if response.output_tokens_explicit {
+        if backend.output_tokens_explicit {
             return;
         }
-        response.output_tokens += output_tokens;
-        let now = Instant::now();
-        response.first_output_at.get_or_insert(now);
-        response.first_token_at.get_or_insert(now);
+        backend.output_tokens = backend.output_tokens.saturating_add(output_tokens);
         self.emit();
     }
 
@@ -266,92 +280,55 @@ impl RequestObserver {
         from_chunk_usage: bool,
         emit_live_update: bool,
     ) {
-        let response = Self::responding_mut(
+        let backend = Self::backend_mut(
             &mut self.state,
             &self.request_id,
             "output token observation",
         );
-        if response.output_tokens_explicit && output_tokens < response.output_tokens {
+        if backend.output_tokens_explicit && output_tokens < backend.output_tokens {
             tracing::warn!(
                 request_id = self.request_id,
-                prior_output_tokens = response.output_tokens,
+                prior_output_tokens = backend.output_tokens,
                 output_tokens_generated_so_far = output_tokens,
                 "ignoring regressing explicit output token counter"
             );
             return;
         }
-        let chunk_usage_observed = response.output_tokens_from_chunk_usage || from_chunk_usage;
-        if response.output_tokens_explicit
-            && output_tokens == response.output_tokens
-            && response.output_tokens_from_chunk_usage == chunk_usage_observed
+        let chunk_usage_observed = backend.output_tokens_from_chunk_usage || from_chunk_usage;
+        if backend.output_tokens_explicit
+            && output_tokens == backend.output_tokens
+            && backend.output_tokens_from_chunk_usage == chunk_usage_observed
         {
             return;
         }
-        let should_emit = output_tokens > 0 || output_tokens != response.output_tokens;
-        response.output_tokens = output_tokens;
-        response.output_tokens_explicit = true;
-        response.output_tokens_from_chunk_usage = chunk_usage_observed;
-        if output_tokens > 0 {
-            let now = Instant::now();
-            response.first_output_at.get_or_insert(now);
-            response.first_token_at.get_or_insert(now);
-        }
+        let should_emit = output_tokens > 0 || output_tokens != backend.output_tokens;
+        backend.output_tokens = output_tokens;
+        backend.output_tokens_explicit = true;
+        backend.output_tokens_from_chunk_usage = chunk_usage_observed;
         if emit_live_update && should_emit {
             self.emit();
         }
     }
 
-    pub(crate) fn finish(&mut self) {
-        let (outcome, response) = match &self.state {
-            RequestLifecycleState::Responding(response) => {
-                let success = (200..300).contains(&response.upstream_status);
-                let outcome = if response.first_output_at.is_some() {
-                    if success {
-                        RequestTerminalOutcome::Complete
-                    } else {
-                        RequestTerminalOutcome::Failed
-                    }
-                } else if self.endpoint == RequestObservationEndpoint::Embeddings && success {
-                    RequestTerminalOutcome::Complete
-                } else if success && response.output_messages == 0 {
-                    panic!(
-                        "invalid finish transition for request_id={} from state=InputProcessing without observed output",
-                        self.request_id
-                    )
-                } else {
-                    RequestTerminalOutcome::Failed
-                };
-                (outcome, Some(*response))
-            }
-            RequestLifecycleState::Terminal { outcome, .. } => panic!(
-                "invalid finish transition for request_id={} from state={outcome:?}",
-                self.request_id,
-            ),
-            RequestLifecycleState::UpstreamConnecting => (RequestTerminalOutcome::Failed, None),
-        };
-        self.state = RequestLifecycleState::Terminal { outcome, response };
-
-        self.emit();
+    pub(crate) fn complete(&mut self) {
+        self.terminate(RequestTerminalOutcome::Complete);
     }
 
     pub(crate) fn fail(&mut self) {
-        self.terminate(RequestTerminalOutcome::Failed, "fail");
+        self.terminate(RequestTerminalOutcome::Failed);
     }
 
-    fn cancel(&mut self) {
-        self.terminate(RequestTerminalOutcome::Cancelled, "cancel");
+    pub(crate) fn cancel(&mut self) {
+        self.terminate(RequestTerminalOutcome::Cancelled);
     }
 
-    fn terminate(&mut self, outcome: RequestTerminalOutcome, action: &'static str) {
-        let response = match &self.state {
-            RequestLifecycleState::Responding(response) => Some(*response),
+    fn terminate(&mut self, outcome: RequestTerminalOutcome) {
+        let backend = match &self.state {
+            RequestLifecycleState::BackendSubmitted(backend) => Some(*backend),
             RequestLifecycleState::UpstreamConnecting => None,
-            RequestLifecycleState::Terminal { outcome: prior, .. } => panic!(
-                "invalid {action} transition for request_id={} from state={prior:?}",
-                self.request_id,
-            ),
+            RequestLifecycleState::Terminal { .. } => return,
         };
-        self.state = RequestLifecycleState::Terminal { outcome, response };
+        self.state = RequestLifecycleState::Terminal { outcome, backend };
         self.emit();
     }
 
@@ -359,21 +336,28 @@ impl RequestObserver {
         matches!(self.state, RequestLifecycleState::Terminal { .. })
     }
 
-    fn responding_mut<'a>(
+    fn backend_mut<'a>(
         state: &'a mut RequestLifecycleState,
         request_id: &str,
         action: &'static str,
-    ) -> &'a mut ResponsePhaseData {
+    ) -> &'a mut BackendPhaseData {
         let observation_state = state.observation_state();
         match state {
-            RequestLifecycleState::Responding(response) => response,
+            RequestLifecycleState::BackendSubmitted(backend) => backend,
             _ => panic!(
                 "invalid {action} transition for request_id={request_id} from state={observation_state:?}"
             ),
         }
     }
     fn emit(&mut self) {
-        let response = self.state.response();
+        let backend = self.state.backend();
+        let input_processing_duration = backend.and_then(|backend| {
+            backend
+                .first_generated_output_at
+                .map(|first_generated_output_at| {
+                    first_generated_output_at.saturating_duration_since(backend.submitted_at)
+                })
+        });
         let observation = RequestObservation {
             endpoint: self.endpoint,
             request_id: self.request_id.clone(),
@@ -384,32 +368,32 @@ impl RequestObserver {
             embedding_items: self.embedding_items.unwrap_or_default(),
             embedding_items_observed: self.endpoint == RequestObservationEndpoint::Embeddings
                 && self.embedding_items.is_some(),
-            upstream_status: response.map(|response| response.upstream_status),
-            output_messages: response.map_or(0, |response| response.output_messages),
-            output_tokens: response.map_or(0, |response| response.output_tokens),
-            output_tokens_explicit: response
-                .is_some_and(|response| response.output_tokens_explicit),
-            output_tokens_from_chunk_usage: response
-                .is_some_and(|response| response.output_tokens_from_chunk_usage),
+            upstream_status: backend.and_then(|backend| backend.upstream_status),
+            output_messages: backend.map_or(0, |backend| backend.output_messages),
+            output_tokens: backend.map_or(0, |backend| backend.output_tokens),
+            output_tokens_explicit: backend.is_some_and(|backend| backend.output_tokens_explicit),
+            output_tokens_from_chunk_usage: backend
+                .is_some_and(|backend| backend.output_tokens_from_chunk_usage),
             state: self.state.observation_state(),
             // Observation timestamps can be coarser than event sequencing; never underflow
             // durations when two instants collapse to the same clock tick.
-            time_to_response_headers: response.map(|response| {
-                response
-                    .response_headers_at
-                    .saturating_duration_since(self.started_at)
-            }),
-            time_to_first_output: response
-                .and_then(|response| response.first_output_at)
+            time_to_response_headers: backend
+                .and_then(|backend| backend.response_headers_at)
                 .map(|instant| instant.saturating_duration_since(self.started_at)),
-            time_to_first_token: response
-                .and_then(|response| response.first_token_at)
+            time_to_first_output: backend
+                .and_then(|backend| backend.first_generated_output_at)
+                .map(|instant| instant.saturating_duration_since(self.started_at)),
+            time_to_first_token: backend
+                .and_then(|backend| backend.first_token_at)
                 .map(|instant| instant.saturating_duration_since(self.started_at)),
             total_duration: self.started_at.elapsed(),
         };
         log_observation(&observation);
-        self.runtime_state
-            .observe_request_for_generation(observation, self.generation.clone());
+        self.runtime_state.observe_request_for_generation(
+            observation,
+            self.generation.clone(),
+            input_processing_duration,
+        );
     }
 }
 
@@ -513,6 +497,18 @@ mod tests {
                 runtime_state,
             ))
         }
+
+        fn submit_now(&mut self) {
+            self.on_backend_submission(Instant::now());
+        }
+
+        fn observe_output_message(&mut self) {
+            self.observe_generated_output(Instant::now(), true);
+        }
+
+        fn finish(&mut self) {
+            self.complete();
+        }
     }
 
     fn observed_runtime(
@@ -579,16 +575,18 @@ mod tests {
         let (runtime_state, rx) = observed_runtime(8);
         let mut observer = test_observer(request_id, runtime_state);
         recv_observation(&rx, "initial observation should be emitted").await;
+        observer.submit_now();
+        recv_observation(&rx, "backend-submission observation should be emitted").await;
         observer.on_upstream_response_headers(&HeaderMap::new(), 200);
         let headers = recv_observation(&rx, "response-header observation should be emitted").await;
         (observer, rx, headers)
     }
 
-    fn response(observer: &RequestObserver) -> &ResponsePhaseData {
+    fn response(observer: &RequestObserver) -> &BackendPhaseData {
         match &observer.state {
-            RequestLifecycleState::Responding(response)
+            RequestLifecycleState::BackendSubmitted(response)
             | RequestLifecycleState::Terminal {
-                response: Some(response),
+                backend: Some(response),
                 ..
             } => response,
             state => panic!("state has no response: {state:?}"),
@@ -684,7 +682,7 @@ mod tests {
     }
 
     #[test]
-    fn tunnel_observer_drop_fails_each_observed_endpoint() {
+    fn tunnel_observer_drop_cancels_each_observed_endpoint() {
         for endpoint in [
             RequestObservationEndpoint::ChatCompletions,
             RequestObservationEndpoint::Responses,
@@ -712,7 +710,7 @@ mod tests {
                 RequestObservationState::UpstreamConnecting
             );
             assert_eq!(observations[1].endpoint, endpoint);
-            assert_eq!(observations[1].state, RequestObservationState::Failed);
+            assert_eq!(observations[1].state, RequestObservationState::Cancelled);
         }
     }
 
@@ -730,11 +728,12 @@ mod tests {
                 None,
                 runtime_state,
             );
+            observer.on_backend_submission(Instant::now());
             observer.on_upstream_response_headers(&HeaderMap::new(), 200);
             if let Some(generation) = observer.generation_mut() {
                 generation.observe_output_message();
             }
-            observer.finish();
+            observer.complete();
             let observations_before_drop = rx.len();
 
             // Dropping a terminal observer proves the wrapper does not emit again.
@@ -774,35 +773,39 @@ mod tests {
     }
 
     #[test]
-    fn embeddings_observer_rejects_terminal_fail_transition() {
+    fn embeddings_observer_ignores_repeated_terminal_transition() {
         let (runtime_state, rx) = observed_runtime(8);
         let mut observer = RequestObserver::accepted(embeddings_required_headers(), runtime_state);
         observer.update_embedding_items(Some(1));
+        observer.submit_now();
         observer.on_upstream_response_headers(&HeaderMap::new(), 200);
         observer.finish();
         while rx.try_recv().is_ok() {}
 
-        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| observer.fail()));
+        observer.fail();
 
-        assert!(panic.is_err());
         assert!(observer.is_terminal());
         drop(observer);
-        assert!(rx.is_empty(), "invalid transition must not emit on drop");
+        assert!(rx.is_empty(), "repeated terminalization must not emit");
     }
 
     #[test]
-    #[should_panic(expected = "invalid finish transition")]
-    fn embeddings_observer_rejects_terminal_finish_transition() {
+    fn embeddings_observer_ignores_repeated_completion() {
         let mut observer =
             RequestObserver::accepted(embeddings_required_headers(), PylonRuntimeState::default());
         observer.update_embedding_items(Some(1));
         observer.fail();
         observer.finish();
+        assert_eq!(
+            observer.state.observation_state(),
+            RequestObservationState::Failed
+        );
     }
 
     #[tokio::test]
     async fn counts_sse_events_across_chunk_boundaries() {
         let mut observer = test_observer("req-1", PylonRuntimeState::default());
+        observer.submit_now();
         observer.on_upstream_response_headers(&HeaderMap::new(), 200);
         observer.observe_output_message();
         observer.observe_output_message();
@@ -826,6 +829,12 @@ mod tests {
         assert_eq!(initial.state, RequestObservationState::UpstreamConnecting);
         assert!(!initial.is_terminal());
 
+        observer.submit_now();
+        let submitted =
+            recv_observation(&rx, "backend-submission observation should be emitted").await;
+        assert_eq!(submitted.state, RequestObservationState::InputProcessing);
+        assert_eq!(submitted.upstream_status, None);
+
         observer.on_upstream_response_headers(&HeaderMap::new(), 200);
         let first = recv_observation(&rx, "response-header observation should be emitted").await;
         assert_eq!(first.state, RequestObservationState::InputProcessing);
@@ -836,6 +845,52 @@ mod tests {
         assert_eq!(second.state, RequestObservationState::OutputGeneration);
         assert_eq!(second.output_messages, 1);
         assert!(!second.is_terminal());
+    }
+
+    #[test]
+    fn input_processing_duration_is_repeated_on_cumulative_output_and_terminal_events() {
+        let (runtime_state, rx) = observed_runtime(8);
+        let mut observer = test_observer("req-input-interval", runtime_state);
+        rx.try_recv().unwrap();
+
+        let submitted_at = Instant::now();
+        observer.on_backend_submission(submitted_at);
+        let submitted = rx.try_recv().unwrap();
+        assert_eq!(
+            submitted.observation().state,
+            RequestObservationState::InputProcessing
+        );
+        assert_eq!(submitted.input_processing_duration(), None);
+
+        observer.on_upstream_response_headers(&HeaderMap::new(), 200);
+        let headers = rx.try_recv().unwrap();
+        assert_eq!(
+            headers.observation().state,
+            RequestObservationState::InputProcessing
+        );
+        assert_eq!(headers.input_processing_duration(), None);
+
+        let first_generated_output_at = submitted_at + Duration::from_millis(10);
+        observer.observe_generated_output(first_generated_output_at, true);
+        let output = rx.try_recv().unwrap();
+        assert_eq!(
+            output.input_processing_duration(),
+            Some(Duration::from_millis(10))
+        );
+
+        observer.observe_output_tokens(2);
+        let tokens = rx.try_recv().unwrap();
+        assert_eq!(
+            tokens.input_processing_duration(),
+            Some(Duration::from_millis(10))
+        );
+
+        observer.complete();
+        let terminal = rx.try_recv().unwrap();
+        assert_eq!(
+            terminal.input_processing_duration(),
+            Some(Duration::from_millis(10))
+        );
     }
 
     #[tokio::test]
@@ -870,6 +925,7 @@ mod tests {
     #[tokio::test]
     async fn accumulates_output_tokens() {
         let mut observer = test_observer("req-1", PylonRuntimeState::default());
+        observer.submit_now();
         observer.on_upstream_response_headers(&HeaderMap::new(), 200);
         observer.observe_output_message();
         observer.observe_output_tokens(3);
@@ -883,18 +939,42 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn first_positive_output_tokens_start_real_ttft() {
+    async fn output_tokens_alone_do_not_start_real_ttft() {
         let (mut observer, rx, _) = responding_observer("req-token").await;
 
         observer.observe_output_tokens(3);
         let token_observation = recv_observation(&rx, "token observation should be emitted").await;
         assert_eq!(
             token_observation.state,
-            RequestObservationState::OutputGeneration
+            RequestObservationState::InputProcessing
         );
         assert_eq!(token_observation.output_tokens, 3);
-        assert!(token_observation.time_to_first_output.is_some());
-        assert!(token_observation.time_to_first_token.is_some());
+        assert_eq!(token_observation.time_to_first_output, None);
+        assert_eq!(token_observation.time_to_first_token, None);
+    }
+
+    #[tokio::test]
+    async fn modal_output_starts_first_output_without_claiming_a_first_token() {
+        let (mut observer, rx, _) = responding_observer("req-modal-output").await;
+
+        observer.observe_generated_output(Instant::now(), false);
+        let output = recv_observation(&rx, "modal output observation should be emitted").await;
+
+        assert_eq!(output.state, RequestObservationState::OutputGeneration);
+        assert!(output.time_to_first_output.is_some());
+        assert_eq!(output.time_to_first_token, None);
+    }
+
+    #[tokio::test]
+    async fn exact_input_usage_updates_tokens_without_starting_output() {
+        let (mut observer, rx, _) = responding_observer("req-input-usage").await;
+
+        observer.observe_input_tokens_total(7);
+        let usage = recv_observation(&rx, "input usage observation should be emitted").await;
+        assert_eq!(usage.state, RequestObservationState::InputProcessing);
+        assert_eq!(usage.input_tokens, 7);
+        assert_eq!(usage.time_to_first_output, None);
+        assert_eq!(usage.time_to_first_token, None);
     }
 
     #[tokio::test]
@@ -909,11 +989,11 @@ mod tests {
             recv_observation(&rx, "fallback token observation should be emitted").await;
         assert_eq!(
             estimated_observation.state,
-            RequestObservationState::OutputGeneration
+            RequestObservationState::InputProcessing
         );
         assert_eq!(estimated_observation.output_tokens, 3);
         assert!(!estimated_observation.output_tokens_explicit);
-        assert!(estimated_observation.time_to_first_token.is_some());
+        assert_eq!(estimated_observation.time_to_first_token, None);
     }
 
     #[tokio::test]
@@ -1012,12 +1092,12 @@ mod tests {
 
         observer.observe_output_tokens_generated_so_far(4);
         let explicit = recv_observation(&rx, "positive chunk usage should be emitted").await;
-        assert_eq!(explicit.state, RequestObservationState::OutputGeneration);
+        assert_eq!(explicit.state, RequestObservationState::InputProcessing);
         assert_eq!(explicit.output_tokens, 4);
         assert!(explicit.output_tokens_explicit);
         assert!(explicit.output_tokens_from_chunk_usage);
-        assert!(explicit.time_to_first_output.is_some());
-        assert!(explicit.time_to_first_token.is_some());
+        assert_eq!(explicit.time_to_first_output, None);
+        assert_eq!(explicit.time_to_first_token, None);
 
         observer.observe_output_tokens_generated_so_far(4);
         assert!(
@@ -1037,10 +1117,11 @@ mod tests {
         let mut observer = make_test_observer();
         let started_at = Instant::now() - Duration::from_secs(1);
         observer.started_at = started_at;
-        observer.state = RequestLifecycleState::Responding(ResponsePhaseData {
-            upstream_status: 200,
-            response_headers_at: started_at + Duration::from_millis(10),
-            first_output_at: None,
+        observer.state = RequestLifecycleState::BackendSubmitted(BackendPhaseData {
+            submitted_at: started_at,
+            upstream_status: Some(200),
+            response_headers_at: Some(started_at + Duration::from_millis(10)),
+            first_generated_output_at: None,
             first_token_at: None,
             output_messages: 0,
             output_tokens: 5,
@@ -1058,8 +1139,7 @@ mod tests {
             observer.state.observation_state(),
             RequestObservationState::InputProcessing
         );
-        assert_eq!(response.first_output_at, None);
-        assert_eq!(response.first_token_at, None);
+        assert_eq!(response.first_generated_output_at, None);
     }
 
     #[test]
@@ -1068,52 +1148,50 @@ mod tests {
         let started_at = Instant::now() - Duration::from_secs(10);
         let first_output_at = started_at + Duration::from_secs(2);
         observer.started_at = started_at;
-        observer.state = RequestLifecycleState::Responding(ResponsePhaseData {
-            upstream_status: 200,
-            response_headers_at: started_at + Duration::from_millis(50),
-            first_output_at: Some(first_output_at),
-            first_token_at: None,
+        observer.state = RequestLifecycleState::BackendSubmitted(BackendPhaseData {
+            submitted_at: started_at + Duration::from_millis(25),
+            upstream_status: Some(200),
+            response_headers_at: Some(started_at + Duration::from_millis(50)),
+            first_generated_output_at: Some(first_output_at),
+            first_token_at: Some(first_output_at),
             output_messages: 2,
             output_tokens: 0,
             output_tokens_explicit: false,
             output_tokens_from_chunk_usage: false,
         });
 
-        let before_token_observation = Instant::now();
         observer.observe_output_tokens(7);
 
         let response = response(&observer);
-        assert_eq!(response.first_output_at, Some(first_output_at));
-        let observed_first_token_at = response.first_token_at.unwrap();
-        assert!(observed_first_token_at >= before_token_observation);
-        assert!(observed_first_token_at > first_output_at);
+        assert_eq!(response.first_generated_output_at, Some(first_output_at));
     }
 
     #[test]
-    fn finish_without_output_panics() {
+    fn explicit_success_can_complete_without_output() {
         let mut observer = test_observer("req-2", PylonRuntimeState::default());
+        observer.submit_now();
         observer.on_upstream_response_headers(&HeaderMap::new(), 200);
-        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| observer.finish()));
-        assert!(panic.is_err());
+        observer.finish();
         assert_eq!(
             observer.state.observation_state(),
-            RequestObservationState::InputProcessing
+            RequestObservationState::Complete
         );
-
-        let headers_panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            observer.on_upstream_response_headers(&HeaderMap::new(), 200);
-        }));
-        assert!(headers_panic.is_err());
+        let response = response(&observer);
+        assert_eq!(response.first_generated_output_at, None);
     }
 
     #[test]
-    #[should_panic(expected = "invalid fail transition")]
-    fn fail_after_complete_panics() {
+    fn terminalization_is_idempotent() {
         let mut observer = make_test_observer();
+        observer.submit_now();
         observer.on_upstream_response_headers(&HeaderMap::new(), 200);
         observer.observe_output_message();
         observer.finish();
         observer.fail();
+        assert_eq!(
+            observer.state.observation_state(),
+            RequestObservationState::Complete
+        );
     }
 
     #[test]
@@ -1148,6 +1226,7 @@ mod tests {
 
         assert_terminal_response_header_panic(
             |observer| {
+                observer.submit_now();
                 observer.on_upstream_response_headers(&HeaderMap::new(), 200);
                 observer.observe_output_message();
                 observer.finish();
@@ -1161,8 +1240,9 @@ mod tests {
     #[tokio::test]
     async fn failed_response_stays_failed() {
         let mut observer = test_observer("req-3", PylonRuntimeState::default());
+        observer.submit_now();
         observer.on_upstream_response_headers(&HeaderMap::new(), 503);
-        observer.finish();
+        observer.fail();
 
         let response = response(&observer);
         assert_eq!(response.output_messages, 0);

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/request_observer.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/request_observer.rs
@@ -253,8 +253,19 @@ impl RequestObserver {
     }
 
     pub(crate) fn observe_input_tokens_total(&mut self, input_tokens: u64) {
-        if self.input_tokens_explicit && input_tokens == self.input_tokens {
-            return;
+        if self.input_tokens_explicit {
+            if input_tokens < self.input_tokens {
+                tracing::warn!(
+                    request_id = self.request_id,
+                    prior_input_tokens = self.input_tokens,
+                    input_tokens,
+                    "ignoring regressing explicit input token counter"
+                );
+                return;
+            }
+            if input_tokens == self.input_tokens {
+                return;
+            }
         }
         self.input_tokens = input_tokens;
         self.input_tokens_explicit = true;
@@ -1027,6 +1038,23 @@ mod tests {
         assert_eq!(usage.input_tokens, 7);
         assert_eq!(usage.time_to_first_output, None);
         assert_eq!(usage.time_to_first_token, None);
+    }
+
+    #[tokio::test]
+    async fn exact_input_usage_does_not_regress() {
+        let (mut observer, rx, _) = responding_observer("req-input-regression").await;
+
+        observer.observe_input_tokens_total(7);
+        let first = recv_observation(&rx, "first input usage should be emitted").await;
+        assert_eq!(first.input_tokens, 7);
+
+        observer.observe_input_tokens_total(9);
+        let increased = recv_observation(&rx, "increased input usage should be emitted").await;
+        assert_eq!(increased.input_tokens, 9);
+
+        observer.observe_input_tokens_total(8);
+        assert!(rx.is_empty(), "regressing input usage should not emit");
+        assert_eq!(observer.input_tokens, 9);
     }
 
     #[tokio::test]

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/request_observer/tunnel.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/request_observer/tunnel.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use reqwest::header::HeaderMap;
 use std::time::Instant;
 
 use crate::runtime_state::{ModelGeneration, PylonRuntimeState};
@@ -56,13 +55,8 @@ impl TunnelRequestObserver {
         self.observer.on_backend_submission(submitted_at);
     }
 
-    pub(crate) fn on_upstream_response_headers(
-        &mut self,
-        response_headers: &HeaderMap,
-        status: u16,
-    ) {
-        self.observer
-            .on_upstream_response_headers(response_headers, status);
+    pub(crate) fn on_upstream_response_headers(&mut self, status: u16) {
+        self.observer.on_upstream_response_headers(status);
     }
 
     pub(crate) fn complete(&mut self) {

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/request_observer/tunnel.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/request_observer/tunnel.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use reqwest::header::HeaderMap;
+use std::time::Instant;
 
 use crate::runtime_state::{ModelGeneration, PylonRuntimeState};
 
@@ -51,6 +52,10 @@ impl TunnelRequestObserver {
         }
     }
 
+    pub(crate) fn on_backend_submission(&mut self, submitted_at: Instant) {
+        self.observer.on_backend_submission(submitted_at);
+    }
+
     pub(crate) fn on_upstream_response_headers(
         &mut self,
         response_headers: &HeaderMap,
@@ -60,23 +65,15 @@ impl TunnelRequestObserver {
             .on_upstream_response_headers(response_headers, status);
     }
 
-    pub(crate) fn finish(&mut self) {
-        self.observer.finish();
+    pub(crate) fn complete(&mut self) {
+        self.observer.complete();
     }
 
     pub(crate) fn fail(&mut self) {
         self.observer.fail();
     }
 
-    fn is_terminal(&self) -> bool {
-        self.observer.is_terminal()
-    }
-}
-
-impl Drop for TunnelRequestObserver {
-    fn drop(&mut self) {
-        if !self.is_terminal() {
-            self.fail();
-        }
+    pub(crate) fn cancel(&mut self) {
+        self.observer.cancel();
     }
 }

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/request_quality_monitor/recorder.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/request_quality_monitor/recorder.rs
@@ -46,7 +46,7 @@ pub struct RequestQualityRecorder {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RequestOutputTokenProgress {
     Delta(u64),
-    Cumulative { tokens: u64, delta: u64 },
+    Cumulative { tokens: u64 },
 }
 
 impl RequestQualityRecorder {
@@ -118,7 +118,8 @@ impl RequestQualityRecorder {
                     *tokens = tokens.saturating_add(delta);
                 }
             }
-            RequestOutputTokenProgress::Cumulative { tokens, delta } => {
+            RequestOutputTokenProgress::Cumulative { tokens } => {
+                let delta = tokens.saturating_sub(self.output_tokens);
                 self.output_tokens = tokens;
                 if self.choices.len() == 1
                     && let Some(choice) = self.choices.values_mut().next()
@@ -411,7 +412,7 @@ mod tests {
         let (_metrics, result) = evaluate!(
             config!(output_tokens_threshold_min: Some(4));
             r#"{"choices":[{"index":0,"delta":{"content":"alpha beta gamma delta epsilon"}}]}"# => delta(5),
-            r#"{"choices":[{"index":0,"delta":{},"usage":{"completion_tokens":3}}]}"# => Some(RequestOutputTokenProgress::Cumulative { tokens: 3, delta: 0 })
+            r#"{"choices":[{"index":0,"delta":{},"usage":{"completion_tokens":3}}]}"# => Some(RequestOutputTokenProgress::Cumulative { tokens: 3 })
         );
 
         assert!(result.evaluated);
@@ -419,15 +420,15 @@ mod tests {
     }
 
     #[test]
-    fn recorder_cumulative_progress_uses_delta_for_multi_choice_attribution() {
+    fn recorder_cumulative_progress_derives_multi_choice_attribution_delta() {
         let (_metrics, result) = evaluate!(
             config!(
                 collect_quality_metrics: true,
                 collect_quality_metrics_min_tokens: 3,
                 output_repetition_1gram_threshold_min: Some(0.3),
             );
-            r#"{"choices":[{"index":0,"delta":{"content":"alpha beta gamma"}}]}"# => Some(RequestOutputTokenProgress::Cumulative { tokens: 3, delta: 3 }),
-            r#"{"choices":[{"index":1,"delta":{"content":"loop loop loop loop"}}]}"# => Some(RequestOutputTokenProgress::Cumulative { tokens: 4, delta: 1 })
+            r#"{"choices":[{"index":0,"delta":{"content":"alpha beta gamma"}}]}"# => Some(RequestOutputTokenProgress::Cumulative { tokens: 3 }),
+            r#"{"choices":[{"index":1,"delta":{"content":"loop loop loop loop"}}]}"# => Some(RequestOutputTokenProgress::Cumulative { tokens: 4 })
         );
 
         assert!(result.evaluated);
@@ -439,7 +440,7 @@ mod tests {
         let (_metrics, result) = evaluate!(
             config!(output_tokens_threshold_min: Some(2));
             r#"{"choices":[{"index":0,"delta":{"content":"alpha beta gamma"}}]}"# => delta(3),
-            r#"{"object":"chat.completion.chunk","choices":[],"usage":{"completion_tokens":3}}"# => Some(RequestOutputTokenProgress::Cumulative { tokens: 3, delta: 0 })
+            r#"{"object":"chat.completion.chunk","choices":[],"usage":{"completion_tokens":3}}"# => Some(RequestOutputTokenProgress::Cumulative { tokens: 3 })
         );
 
         assert!(result.evaluated);

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/runtime_state.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/runtime_state.rs
@@ -15,6 +15,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use parking_lot::Mutex;
 use stargate_proto::pb::{InferenceServerModelRegistration, InferenceServerStatus, ModelStats};
@@ -94,6 +95,7 @@ pub struct RequestObservationEvent {
     pub(crate) observation: RequestObservation,
     pub(crate) generation: Option<ModelGeneration>,
     pub(crate) changed_generations: Vec<ModelGeneration>,
+    pub(crate) input_processing_duration: Option<Duration>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -407,20 +409,34 @@ impl PylonRuntimeState {
 
     pub fn observe_request(&self, observation: RequestObservation) {
         let generation = self.current_generation(&observation.model_id);
-        self.observe_request_for_generation(observation, generation);
+        self.observe_request_for_generation(observation, generation, None);
     }
 
     pub(crate) fn observe_request_for_generation(
         &self,
         observation: RequestObservation,
         generation: Option<ModelGeneration>,
+        input_processing_duration: Option<Duration>,
     ) {
-        let event = self.transition_request_observation_for_generation(observation, generation);
-        if let Some(tx) = &self.observation_tx {
-            let request_id = event.observation.request_id.clone();
-            if let Err(error) = tx.try_send(event) {
-                tracing::warn!(request_id, error = %error, "dropping request observation");
-            }
+        let event = self.transition_request_observation_for_generation(
+            observation,
+            generation,
+            input_processing_duration,
+        );
+        if let Some(tx) = &self.observation_tx
+            && let Err(error) = tx.try_send(event)
+        {
+            let (drop_cause, event) = match error {
+                flume::TrySendError::Full(event) => ("full", event),
+                flume::TrySendError::Disconnected(event) => ("disconnected", event),
+            };
+            tracing::warn!(
+                request_id = %event.observation.request_id,
+                model_id = %event.observation.model_id,
+                state = ?event.observation.state,
+                drop_cause,
+                "dropping request observation"
+            );
         }
     }
 
@@ -445,13 +461,14 @@ impl PylonRuntimeState {
         let generation = self
             .current_generation(&observation.model_id)
             .expect("test model generation should already exist");
-        self.transition_request_observation_for_generation(observation, Some(generation))
+        self.transition_request_observation_for_generation(observation, Some(generation), None)
     }
 
-    pub(crate) fn transition_request_observation_for_generation(
+    fn transition_request_observation_for_generation(
         &self,
         observation: RequestObservation,
         generation: Option<ModelGeneration>,
+        input_processing_duration: Option<Duration>,
     ) -> RequestObservationEvent {
         // Held across the queue transition below: retire_generation() purges
         // live-request state under this lock, so releasing it after the
@@ -474,6 +491,7 @@ impl PylonRuntimeState {
                     observation,
                     generation,
                     changed_generations: Vec::new(),
+                    input_processing_duration,
                 };
             }
         }
@@ -490,6 +508,7 @@ impl PylonRuntimeState {
             observation,
             generation,
             changed_generations: transition.changed_generations,
+            input_processing_duration,
         }
     }
 
@@ -568,6 +587,10 @@ impl RequestObservationEvent {
     pub fn into_observation(self) -> RequestObservation {
         self.observation
     }
+
+    pub(crate) fn input_processing_duration(&self) -> Option<Duration> {
+        self.input_processing_duration
+    }
 }
 
 pub(crate) fn gated_model_status(
@@ -583,6 +606,8 @@ pub(crate) fn gated_model_status(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
     use stargate_proto::pb::InferenceServerStatus;
@@ -592,6 +617,79 @@ mod tests {
     use crate::request_observer::{
         RequestObservation, RequestObservationEndpoint, RequestObservationState,
     };
+
+    #[derive(Clone, Default)]
+    struct RecordingWarnSubscriber {
+        events: Arc<Mutex<Vec<BTreeMap<String, String>>>>,
+    }
+
+    impl tracing::Subscriber for RecordingWarnSubscriber {
+        fn enabled(&self, metadata: &tracing::Metadata<'_>) -> bool {
+            metadata.level() <= &tracing::Level::WARN
+        }
+
+        fn new_span(&self, _attrs: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+            tracing::span::Id::from_u64(1)
+        }
+
+        fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
+
+        fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
+
+        fn event(&self, event: &tracing::Event<'_>) {
+            let mut visitor = RecordingFieldVisitor::default();
+            event.record(&mut visitor);
+            self.events.lock().unwrap().push(visitor.fields);
+        }
+
+        fn enter(&self, _span: &tracing::span::Id) {}
+
+        fn exit(&self, _span: &tracing::span::Id) {}
+    }
+
+    #[derive(Default)]
+    struct RecordingFieldVisitor {
+        fields: BTreeMap<String, String>,
+    }
+
+    impl tracing::field::Visit for RecordingFieldVisitor {
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            self.fields
+                .insert(field.name().to_string(), format!("{value:?}"));
+        }
+    }
+
+    fn assert_drop_warning(
+        subscriber: &RecordingWarnSubscriber,
+        request_id: &str,
+        drop_cause: &str,
+    ) {
+        let events = subscriber.events.lock().unwrap();
+        let event = events
+            .iter()
+            .find(|event| {
+                event.get("message").map(String::as_str) == Some("dropping request observation")
+            })
+            .expect("drop warning should be recorded");
+        assert_eq!(
+            event.get("request_id").map(String::as_str),
+            Some(request_id)
+        );
+        assert_eq!(event.get("model_id").map(String::as_str), Some("model-a"));
+        assert_eq!(
+            event.get("state").map(String::as_str),
+            Some("UpstreamConnecting")
+        );
+        assert_eq!(
+            event.get("drop_cause").map(String::as_str),
+            Some(drop_cause)
+        );
+    }
 
     fn observation(
         request_id: &str,
@@ -708,6 +806,40 @@ mod tests {
     }
 
     #[test]
+    fn full_observation_channel_warns_with_request_context() {
+        let (runtime_state, _observation_rx) = PylonRuntimeState::observed(
+            InferenceServerStatus::Active,
+            &["model-a".to_string()],
+            1,
+            None,
+        );
+        runtime_state.observe_request(observation("req-retained", "model-a", None));
+        let subscriber = RecordingWarnSubscriber::default();
+        tracing::subscriber::with_default(subscriber.clone(), || {
+            runtime_state.observe_request(observation("req-dropped-full", "model-a", None));
+        });
+
+        assert_drop_warning(&subscriber, "req-dropped-full", "full");
+    }
+
+    #[test]
+    fn disconnected_observation_channel_warns_with_request_context() {
+        let (runtime_state, observation_rx) = PylonRuntimeState::observed(
+            InferenceServerStatus::Active,
+            &["model-a".to_string()],
+            1,
+            None,
+        );
+        drop(observation_rx);
+        let subscriber = RecordingWarnSubscriber::default();
+        tracing::subscriber::with_default(subscriber.clone(), || {
+            runtime_state.observe_request(observation("req-dropped-disconnected", "model-a", None));
+        });
+
+        assert_drop_warning(&subscriber, "req-dropped-disconnected", "disconnected");
+    }
+
+    #[test]
     fn pending_generation_is_omitted_until_exact_publication() {
         let runtime_state = PylonRuntimeState::new(InferenceServerStatus::Active, &[]);
         let generation = ModelGeneration::new("model-a", 1);
@@ -774,6 +906,7 @@ mod tests {
         runtime_state.transition_request_observation_for_generation(
             first_observation.clone(),
             Some(first.clone()),
+            None,
         );
         assert_eq!(runtime_state.snapshot_live_model("model-a").queue_size, 1);
 
@@ -781,7 +914,11 @@ mod tests {
         assert!(runtime_state.begin_generation(replacement.clone()));
         assert!(runtime_state.publish_generation(&replacement));
         first_observation.state = RequestObservationState::Complete;
-        runtime_state.transition_request_observation_for_generation(first_observation, Some(first));
+        runtime_state.transition_request_observation_for_generation(
+            first_observation,
+            Some(first),
+            None,
+        );
 
         assert_eq!(
             runtime_state.snapshot_live_model("model-a"),
@@ -806,7 +943,7 @@ mod tests {
 
         let mut stale = observation("req-first", "model-a", Some("rk-a"));
         stale.state = RequestObservationState::Failed;
-        runtime_state.transition_request_observation_for_generation(stale, Some(first));
+        runtime_state.transition_request_observation_for_generation(stale, Some(first), None);
 
         let body = metrics.gather_text().expect("metrics should encode");
         assert!(

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/runtime_state.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/runtime_state.rs
@@ -639,8 +639,6 @@ pub(crate) fn gated_model_status(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-    use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
     use stargate_proto::pb::InferenceServerStatus;
@@ -650,78 +648,22 @@ mod tests {
     use crate::request_observer::{
         RequestObservation, RequestObservationEndpoint, RequestObservationState,
     };
-
-    #[derive(Clone, Default)]
-    struct RecordingWarnSubscriber {
-        events: Arc<Mutex<Vec<BTreeMap<String, String>>>>,
-    }
-
-    impl tracing::Subscriber for RecordingWarnSubscriber {
-        fn enabled(&self, metadata: &tracing::Metadata<'_>) -> bool {
-            metadata.level() <= &tracing::Level::WARN
-        }
-
-        fn new_span(&self, _attrs: &tracing::span::Attributes<'_>) -> tracing::span::Id {
-            tracing::span::Id::from_u64(1)
-        }
-
-        fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
-
-        fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
-
-        fn event(&self, event: &tracing::Event<'_>) {
-            let mut visitor = RecordingFieldVisitor::default();
-            event.record(&mut visitor);
-            self.events.lock().unwrap().push(visitor.fields);
-        }
-
-        fn enter(&self, _span: &tracing::span::Id) {}
-
-        fn exit(&self, _span: &tracing::span::Id) {}
-    }
-
-    #[derive(Default)]
-    struct RecordingFieldVisitor {
-        fields: BTreeMap<String, String>,
-    }
-
-    impl tracing::field::Visit for RecordingFieldVisitor {
-        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-            self.fields
-                .insert(field.name().to_string(), value.to_string());
-        }
-
-        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
-            self.fields
-                .insert(field.name().to_string(), format!("{value:?}"));
-        }
-    }
+    use crate::test_support::{
+        RecordingTracingSubscriber, assert_tracing_event_field, tracing_event_by_message,
+    };
 
     fn assert_drop_warning(
-        subscriber: &RecordingWarnSubscriber,
+        subscriber: &RecordingTracingSubscriber,
         request_id: &str,
         drop_cause: &str,
     ) {
-        let events = subscriber.events.lock().unwrap();
-        let event = events
-            .iter()
-            .find(|event| {
-                event.get("message").map(String::as_str) == Some("dropping request observation")
-            })
-            .expect("drop warning should be recorded");
-        assert_eq!(
-            event.get("request_id").map(String::as_str),
-            Some(request_id)
-        );
-        assert_eq!(event.get("model_id").map(String::as_str), Some("model-a"));
-        assert_eq!(
-            event.get("state").map(String::as_str),
-            Some("UpstreamConnecting")
-        );
-        assert_eq!(
-            event.get("drop_cause").map(String::as_str),
-            Some(drop_cause)
-        );
+        let events = subscriber.events();
+        let event = tracing_event_by_message(&events, "dropping request observation");
+        assert_eq!(event.level, tracing::Level::WARN);
+        assert_tracing_event_field(event, "request_id", request_id);
+        assert_tracing_event_field(event, "model_id", "model-a");
+        assert_tracing_event_field(event, "state", "UpstreamConnecting");
+        assert_tracing_event_field(event, "drop_cause", drop_cause);
     }
 
     fn observation(
@@ -847,7 +789,7 @@ mod tests {
             None,
         );
         runtime_state.observe_request(observation("req-retained", "model-a", None));
-        let subscriber = RecordingWarnSubscriber::default();
+        let subscriber = RecordingTracingSubscriber::default();
         tracing::subscriber::with_default(subscriber.clone(), || {
             runtime_state.observe_request(observation("req-dropped-full", "model-a", None));
         });
@@ -864,7 +806,7 @@ mod tests {
             None,
         );
         drop(observation_rx);
-        let subscriber = RecordingWarnSubscriber::default();
+        let subscriber = RecordingTracingSubscriber::default();
         tracing::subscriber::with_default(subscriber.clone(), || {
             runtime_state.observe_request(observation("req-dropped-disconnected", "model-a", None));
         });

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/runtime_state.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/runtime_state.rs
@@ -96,6 +96,7 @@ pub struct RequestObservationEvent {
     pub(crate) generation: Option<ModelGeneration>,
     pub(crate) changed_generations: Vec<ModelGeneration>,
     pub(crate) input_interval: Option<RequestInputInterval>,
+    pub(crate) upstream_duration: Option<Duration>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -422,7 +423,7 @@ impl PylonRuntimeState {
 
     pub fn observe_request(&self, observation: RequestObservation) {
         let generation = self.current_generation(&observation.model_id);
-        self.observe_request_for_generation(observation, generation, None);
+        self.observe_request_for_generation(observation, generation, None, None);
     }
 
     pub(crate) fn observe_request_for_generation(
@@ -430,11 +431,13 @@ impl PylonRuntimeState {
         observation: RequestObservation,
         generation: Option<ModelGeneration>,
         input_interval: Option<RequestInputInterval>,
+        upstream_duration: Option<Duration>,
     ) {
         let event = self.transition_request_observation_for_generation(
             observation,
             generation,
             input_interval,
+            upstream_duration,
         );
         if let Some(tx) = &self.observation_tx
             && let Err(error) = tx.try_send(event)
@@ -474,7 +477,12 @@ impl PylonRuntimeState {
         let generation = self
             .current_generation(&observation.model_id)
             .expect("test model generation should already exist");
-        self.transition_request_observation_for_generation(observation, Some(generation), None)
+        self.transition_request_observation_for_generation(
+            observation,
+            Some(generation),
+            None,
+            None,
+        )
     }
 
     fn transition_request_observation_for_generation(
@@ -482,6 +490,7 @@ impl PylonRuntimeState {
         observation: RequestObservation,
         generation: Option<ModelGeneration>,
         input_interval: Option<RequestInputInterval>,
+        upstream_duration: Option<Duration>,
     ) -> RequestObservationEvent {
         // Held across the queue transition below: retire_generation() purges
         // live-request state under this lock, so releasing it after the
@@ -505,6 +514,7 @@ impl PylonRuntimeState {
                     generation,
                     changed_generations: Vec::new(),
                     input_interval,
+                    upstream_duration,
                 };
             }
         }
@@ -522,6 +532,7 @@ impl PylonRuntimeState {
             generation,
             changed_generations: transition.changed_generations,
             input_interval,
+            upstream_duration,
         }
     }
 
@@ -607,6 +618,11 @@ impl RequestObservationEvent {
 
     pub(crate) fn input_interval(&self) -> Option<RequestInputInterval> {
         self.input_interval
+    }
+
+    pub(crate) fn output_duration(&self) -> Duration {
+        self.upstream_duration
+            .unwrap_or(self.observation.total_duration)
     }
 }
 
@@ -924,6 +940,7 @@ mod tests {
             first_observation.clone(),
             Some(first.clone()),
             None,
+            None,
         );
         assert_eq!(runtime_state.snapshot_live_model("model-a").queue_size, 1);
 
@@ -934,6 +951,7 @@ mod tests {
         runtime_state.transition_request_observation_for_generation(
             first_observation,
             Some(first),
+            None,
             None,
         );
 
@@ -960,7 +978,7 @@ mod tests {
 
         let mut stale = observation("req-first", "model-a", Some("rk-a"));
         stale.state = RequestObservationState::Failed;
-        runtime_state.transition_request_observation_for_generation(stale, Some(first), None);
+        runtime_state.transition_request_observation_for_generation(stale, Some(first), None, None);
 
         let body = metrics.gather_text().expect("metrics should encode");
         assert!(

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/runtime_state.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/runtime_state.rs
@@ -15,7 +15,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use parking_lot::Mutex;
 use stargate_proto::pb::{InferenceServerModelRegistration, InferenceServerStatus, ModelStats};
@@ -95,7 +95,20 @@ pub struct RequestObservationEvent {
     pub(crate) observation: RequestObservation,
     pub(crate) generation: Option<ModelGeneration>,
     pub(crate) changed_generations: Vec<ModelGeneration>,
-    pub(crate) input_processing_duration: Option<Duration>,
+    pub(crate) input_interval: Option<RequestInputInterval>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct RequestInputInterval {
+    pub(crate) submitted_at: Instant,
+    pub(crate) first_generated_output_at: Instant,
+}
+
+impl RequestInputInterval {
+    pub(crate) fn duration(self) -> Duration {
+        self.first_generated_output_at
+            .saturating_duration_since(self.submitted_at)
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -416,12 +429,12 @@ impl PylonRuntimeState {
         &self,
         observation: RequestObservation,
         generation: Option<ModelGeneration>,
-        input_processing_duration: Option<Duration>,
+        input_interval: Option<RequestInputInterval>,
     ) {
         let event = self.transition_request_observation_for_generation(
             observation,
             generation,
-            input_processing_duration,
+            input_interval,
         );
         if let Some(tx) = &self.observation_tx
             && let Err(error) = tx.try_send(event)
@@ -468,7 +481,7 @@ impl PylonRuntimeState {
         &self,
         observation: RequestObservation,
         generation: Option<ModelGeneration>,
-        input_processing_duration: Option<Duration>,
+        input_interval: Option<RequestInputInterval>,
     ) -> RequestObservationEvent {
         // Held across the queue transition below: retire_generation() purges
         // live-request state under this lock, so releasing it after the
@@ -491,7 +504,7 @@ impl PylonRuntimeState {
                     observation,
                     generation,
                     changed_generations: Vec::new(),
-                    input_processing_duration,
+                    input_interval,
                 };
             }
         }
@@ -508,7 +521,7 @@ impl PylonRuntimeState {
             observation,
             generation,
             changed_generations: transition.changed_generations,
-            input_processing_duration,
+            input_interval,
         }
     }
 
@@ -589,7 +602,11 @@ impl RequestObservationEvent {
     }
 
     pub(crate) fn input_processing_duration(&self) -> Option<Duration> {
-        self.input_processing_duration
+        self.input_interval().map(RequestInputInterval::duration)
+    }
+
+    pub(crate) fn input_interval(&self) -> Option<RequestInputInterval> {
+        self.input_interval
     }
 }
 

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/runtime_state.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/runtime_state.rs
@@ -95,7 +95,15 @@ pub struct RequestObservationEvent {
     pub(crate) observation: RequestObservation,
     pub(crate) generation: Option<ModelGeneration>,
     pub(crate) changed_generations: Vec<ModelGeneration>,
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "consumed by the stacked throughput projection")
+    )]
     pub(crate) input_interval: Option<RequestInputInterval>,
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "consumed by the stacked throughput projection")
+    )]
     pub(crate) upstream_duration: Option<Duration>,
 }
 
@@ -103,13 +111,6 @@ pub struct RequestObservationEvent {
 pub(crate) struct RequestInputInterval {
     pub(crate) submitted_at: Instant,
     pub(crate) first_generated_output_at: Instant,
-}
-
-impl RequestInputInterval {
-    pub(crate) fn duration(self) -> Duration {
-        self.first_generated_output_at
-            .saturating_duration_since(self.submitted_at)
-    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -612,17 +613,12 @@ impl RequestObservationEvent {
         self.observation
     }
 
-    pub(crate) fn input_processing_duration(&self) -> Option<Duration> {
-        self.input_interval().map(RequestInputInterval::duration)
-    }
-
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "consumed by the stacked throughput projection")
+    )]
     pub(crate) fn input_interval(&self) -> Option<RequestInputInterval> {
         self.input_interval
-    }
-
-    pub(crate) fn output_duration(&self) -> Duration {
-        self.upstream_duration
-            .unwrap_or(self.observation.total_duration)
     }
 }
 

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/sse_message_stream.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/sse_message_stream.rs
@@ -14,31 +14,49 @@
 // limitations under the License.
 
 use std::pin::Pin;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use bytes::{Bytes, BytesMut};
 use futures::{Stream, StreamExt};
-use sonic_rs::{JsonValueTrait, Value};
+use sonic_rs::{JsonContainerTrait, JsonValueTrait, Value};
+use tokio_util::task::AbortOnDropHandle;
+
+use crate::output_token_parser::estimate_token_like_units;
 
 const SSE_DONE_SENTINEL: &str = "[DONE]";
+const SSE_DELIVERY_BUFFER_EVENTS: usize = 16;
 
-#[derive(Debug, PartialEq)]
-pub(crate) enum SseMessage {
-    Done,
-    ChatCompletionChunk { parsed: Option<Value> },
-    OtherData,
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct GeneratedOutput {
+    pub(crate) estimated_token_units: u64,
+    pub(crate) token_bearing: bool,
 }
 
-impl SseMessage {
-    pub(crate) fn counts_as_output(&self) -> bool {
-        matches!(self, Self::ChatCompletionChunk { .. })
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ExactUsage {
+    pub(crate) input_tokens: Option<u64>,
+    pub(crate) output_tokens: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SseTerminalOutcome {
+    Complete,
+    Failed,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct SseEventFacts {
+    pub(crate) generated_output: Option<GeneratedOutput>,
+    pub(crate) exact_usage: Option<ExactUsage>,
+    pub(crate) terminal: Option<SseTerminalOutcome>,
 }
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct ParsedSseMessage {
     pub(crate) raw_event: Bytes,
-    pub(crate) message: SseMessage,
+    pub(crate) parsed: Option<Value>,
+    pub(crate) facts: SseEventFacts,
+    pub(crate) received_at: Instant,
 }
 
 #[derive(Debug, Default)]
@@ -73,9 +91,12 @@ impl Iterator for SseMessageBuffer {
         let event_end = find_sse_event_end(&self.buffer)?;
         let raw_event = self.buffer.split_to(event_end).freeze();
         let fields = extract_sse_fields(raw_event.as_ref());
+        let (parsed, facts) = classify_sse_event(fields.event_name.as_deref(), &fields.data);
         Some(ParsedSseMessage {
-            message: classify_sse_message(fields.event_name.as_deref(), fields.data),
             raw_event,
+            parsed,
+            facts,
+            received_at: Instant::now(),
         })
     }
 }
@@ -105,7 +126,7 @@ pub(crate) type UpstreamSseMessageStream =
     Pin<Box<dyn Stream<Item = Result<ParsedSseMessage, UpstreamSseReadError>> + Send>>;
 
 pub(crate) fn upstream_sse_message_stream<S>(
-    mut byte_stream: S,
+    byte_stream: S,
     first_output_timeout: Duration,
     output_chunk_timeout: Duration,
     max_buffer_bytes: usize,
@@ -113,74 +134,372 @@ pub(crate) fn upstream_sse_message_stream<S>(
 where
     S: Stream<Item = reqwest::Result<bytes::Bytes>> + Send + Unpin + 'static,
 {
-    Box::pin(async_stream::try_stream! {
-        let mut sse_messages = SseMessageBuffer::default();
-        let mut has_seen_output = false;
-
-        loop {
-            if let Some(parsed_message) = sse_messages.next() {
-                if parsed_message.message.counts_as_output() {
-                    has_seen_output = true;
-                }
-                yield parsed_message;
-                continue;
-            }
-
-            let (timeout, timeout_phase) = if has_seen_output {
-                (output_chunk_timeout, SseReadTimeoutPhase::SubsequentOutput)
-            } else {
-                (first_output_timeout, SseReadTimeoutPhase::FirstOutput)
-            };
-
-            match tokio::time::timeout(timeout, byte_stream.next()).await {
-                Ok(Some(Ok(chunk))) => {
-                    if chunk.is_empty() {
-                        continue;
-                    }
-                    if let Some(buffered_bytes) =
-                        sse_messages.push_bytes_limited(chunk.as_ref(), max_buffer_bytes)
-                    {
-                        Err(UpstreamSseReadError::BufferLimitExceeded {
-                            max_buffer_bytes,
-                            buffered_bytes,
-                        })?;
-                    }
-                }
-                Ok(Some(Err(error))) => {
-                    Err(UpstreamSseReadError::Upstream(anyhow::Error::new(error)))?;
-                }
-                Ok(None) => {
-                    for parsed_message in sse_messages.by_ref() {
-                        yield parsed_message;
-                    }
-                    break;
-                }
-                Err(_) => {
-                    Err(UpstreamSseReadError::Timeout(timeout_phase))?;
-                }
-            }
+    let (delivery_tx, mut delivery_rx) = tokio::sync::mpsc::channel(SSE_DELIVERY_BUFFER_EVENTS);
+    let first_output_deadline = tokio::time::Instant::now() + first_output_timeout;
+    let producer = AbortOnDropHandle::new(tokio::spawn(produce_sse_messages(
+        byte_stream,
+        delivery_tx,
+        first_output_deadline,
+        output_chunk_timeout,
+        max_buffer_bytes,
+    )));
+    Box::pin(async_stream::stream! {
+        while let Some(message) = delivery_rx.recv().await {
+            yield message;
         }
+        drop(producer);
     })
 }
 
-fn classify_sse_message(event_name: Option<&str>, data: String) -> SseMessage {
+async fn produce_sse_messages<S>(
+    mut byte_stream: S,
+    delivery_tx: tokio::sync::mpsc::Sender<Result<ParsedSseMessage, UpstreamSseReadError>>,
+    first_output_deadline: tokio::time::Instant,
+    output_chunk_timeout: Duration,
+    max_buffer_bytes: usize,
+) where
+    S: Stream<Item = reqwest::Result<bytes::Bytes>> + Send + Unpin + 'static,
+{
+    let mut sse_messages = SseMessageBuffer::default();
+    let mut timeout_phase = SseReadTimeoutPhase::FirstOutput;
+    let mut deadline = first_output_deadline;
+    let mut buffered_received_at: Option<tokio::time::Instant> = None;
+    let mut delivery_pause = Duration::ZERO;
+
+    loop {
+        let processing_started_at = tokio::time::Instant::now();
+        if let Some(mut parsed_message) = sse_messages.next() {
+            let received_at = buffered_received_at
+                .expect("buffered SSE messages should retain their receipt timestamp");
+            let generated_output = parsed_message.facts.generated_output.is_some();
+            let terminal = parsed_message.facts.terminal.is_some();
+            if generated_output {
+                timeout_phase = SseReadTimeoutPhase::SubsequentOutput;
+                deadline = received_at + output_chunk_timeout + delivery_pause;
+            }
+            parsed_message.received_at = received_at.into_std();
+
+            let Ok(permit) = delivery_tx.reserve().await else {
+                return;
+            };
+            let processing_pause =
+                tokio::time::Instant::now().saturating_duration_since(processing_started_at);
+            delivery_pause += processing_pause;
+            deadline += processing_pause;
+            permit.send(Ok(parsed_message));
+            if terminal {
+                return;
+            }
+            continue;
+        }
+
+        buffered_received_at = None;
+        delivery_pause = Duration::ZERO;
+        let deadline_sleep = tokio::time::sleep_until(deadline);
+        tokio::pin!(deadline_sleep);
+        tokio::select! {
+            biased;
+            _ = &mut deadline_sleep => {
+                let _ = delivery_tx
+                    .send(Err(UpstreamSseReadError::Timeout(timeout_phase)))
+                    .await;
+                return;
+            }
+            _ = delivery_tx.closed() => return,
+            next = byte_stream.next() => {
+                let received_at = tokio::time::Instant::now();
+                if received_at >= deadline {
+                    let _ = delivery_tx
+                        .send(Err(UpstreamSseReadError::Timeout(timeout_phase)))
+                        .await;
+                    return;
+                }
+                match next {
+                    Some(Ok(chunk)) if chunk.is_empty() => {}
+                    Some(Ok(chunk)) => {
+                        if let Some(buffered_bytes) =
+                            sse_messages.push_bytes_limited(chunk.as_ref(), max_buffer_bytes)
+                        {
+                            let _ = delivery_tx
+                                .send(Err(UpstreamSseReadError::BufferLimitExceeded {
+                                    max_buffer_bytes,
+                                    buffered_bytes,
+                                }))
+                                .await;
+                            return;
+                        }
+                        buffered_received_at = Some(received_at);
+                    }
+                    Some(Err(error)) => {
+                        let _ = delivery_tx
+                            .send(Err(UpstreamSseReadError::Upstream(anyhow::Error::new(error))))
+                            .await;
+                        return;
+                    }
+                    None => return,
+                }
+            }
+        }
+    }
+}
+
+fn classify_sse_event(event_name: Option<&str>, data: &str) -> (Option<Value>, SseEventFacts) {
     let trimmed = data.trim();
     if trimmed == SSE_DONE_SENTINEL {
-        return SseMessage::Done;
+        let terminal = match terminal_outcome(event_name) {
+            Some(SseTerminalOutcome::Failed) => SseTerminalOutcome::Failed,
+            _ => SseTerminalOutcome::Complete,
+        };
+        return (
+            None,
+            SseEventFacts {
+                terminal: Some(terminal),
+                ..SseEventFacts::default()
+            },
+        );
     }
 
-    let parsed = (!trimmed.is_empty() && event_name != Some("response.created"))
+    let parsed = (!trimmed.is_empty())
         .then(|| sonic_rs::from_str::<Value>(trimmed).ok())
         .flatten();
-    if trimmed.is_empty()
-        || event_name == Some("response.created")
-        || parsed
-            .as_ref()
-            .is_some_and(|value| value["type"].as_str() == Some("response.created"))
+    let Some(value) = parsed.as_ref() else {
+        return (parsed, SseEventFacts::default());
+    };
+    let json_event_type = value["type"].as_str();
+    let event_type = json_event_type.or(event_name);
+    let facts = SseEventFacts {
+        generated_output: generated_output(value, event_type),
+        exact_usage: exact_usage(value),
+        terminal: merge_terminal_outcomes(
+            terminal_outcome(json_event_type),
+            terminal_outcome(event_name),
+        ),
+    };
+    (parsed, facts)
+}
+
+// Chat Completions | chat.completion.chunk | JSON path below | string
+const CHAT_DELTA_TEXT_FIELDS: &[(&str, &[&str])] = &[
+    ("choices[].delta.content", &["content"]),
+    ("choices[].delta.refusal", &["refusal"]),
+    ("choices[].delta.reasoning", &["reasoning"]),
+    ("choices[].delta.reasoning_content", &["reasoning_content"]),
+    (
+        "choices[].delta.function_call.name",
+        &["function_call", "name"],
+    ),
+    (
+        "choices[].delta.function_call.arguments",
+        &["function_call", "arguments"],
+    ),
+    ("choices[].delta.audio.transcript", &["audio", "transcript"]),
+];
+
+// Chat Completions | chat.completion.chunk | JSON path below | string
+const CHAT_TOOL_TEXT_FIELDS: &[(&str, &str)] = &[
+    ("choices[].delta.tool_calls[].function.name", "name"),
+    (
+        "choices[].delta.tool_calls[].function.arguments",
+        "arguments",
+    ),
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GeneratedValueKind {
+    Text,
+    Modal,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ResponsesOutputSpec {
+    event_type: &'static str,
+    field: &'static str,
+    kind: GeneratedValueKind,
+}
+
+// Responses | event_type | JSON path | accepted value type: string
+const RESPONSES_OUTPUT_ALLOWLIST: &[ResponsesOutputSpec] = &[
+    ResponsesOutputSpec {
+        event_type: "response.output_text.delta",
+        field: "delta",
+        kind: GeneratedValueKind::Text,
+    },
+    ResponsesOutputSpec {
+        event_type: "response.refusal.delta",
+        field: "delta",
+        kind: GeneratedValueKind::Text,
+    },
+    ResponsesOutputSpec {
+        event_type: "response.reasoning_text.delta",
+        field: "delta",
+        kind: GeneratedValueKind::Text,
+    },
+    ResponsesOutputSpec {
+        event_type: "response.reasoning_summary_text.delta",
+        field: "delta",
+        kind: GeneratedValueKind::Text,
+    },
+    ResponsesOutputSpec {
+        event_type: "response.function_call_arguments.delta",
+        field: "delta",
+        kind: GeneratedValueKind::Text,
+    },
+    ResponsesOutputSpec {
+        event_type: "response.mcp_call_arguments.delta",
+        field: "delta",
+        kind: GeneratedValueKind::Text,
+    },
+    ResponsesOutputSpec {
+        event_type: "response.custom_tool_call_input.delta",
+        field: "delta",
+        kind: GeneratedValueKind::Text,
+    },
+    ResponsesOutputSpec {
+        event_type: "response.code_interpreter_call_code.delta",
+        field: "delta",
+        kind: GeneratedValueKind::Text,
+    },
+    ResponsesOutputSpec {
+        event_type: "response.shell_call_command.added",
+        field: "command",
+        kind: GeneratedValueKind::Text,
+    },
+    ResponsesOutputSpec {
+        event_type: "response.shell_call_command.delta",
+        field: "delta",
+        kind: GeneratedValueKind::Text,
+    },
+    ResponsesOutputSpec {
+        event_type: "response.audio.transcript.delta",
+        field: "delta",
+        kind: GeneratedValueKind::Text,
+    },
+    ResponsesOutputSpec {
+        event_type: "response.audio.delta",
+        field: "delta",
+        kind: GeneratedValueKind::Modal,
+    },
+    ResponsesOutputSpec {
+        event_type: "response.image_generation_call.partial_image",
+        field: "partial_image_b64",
+        kind: GeneratedValueKind::Modal,
+    },
+];
+
+fn generated_output(value: &Value, event_type: Option<&str>) -> Option<GeneratedOutput> {
+    let mut output = GeneratedOutput::default();
+    let mut saw_generated_output = false;
+
+    if value["object"].as_str() == Some("chat.completion.chunk")
+        && let Some(choices) = value["choices"].as_array()
     {
-        return SseMessage::OtherData;
+        for choice in choices {
+            let delta = &choice["delta"];
+            for (_, path) in CHAT_DELTA_TEXT_FIELDS {
+                add_generated_text(
+                    &mut output,
+                    &mut saw_generated_output,
+                    string_at_path(delta, path),
+                );
+            }
+            if delta["audio"]["data"]
+                .as_str()
+                .is_some_and(|value| !value.is_empty())
+            {
+                saw_generated_output = true;
+            }
+            if let Some(tool_calls) = delta["tool_calls"].as_array() {
+                for tool_call in tool_calls {
+                    for (_, field) in CHAT_TOOL_TEXT_FIELDS {
+                        add_generated_text(
+                            &mut output,
+                            &mut saw_generated_output,
+                            tool_call["function"][field].as_str(),
+                        );
+                    }
+                }
+            }
+        }
     }
-    SseMessage::ChatCompletionChunk { parsed }
+
+    if let Some(spec) = RESPONSES_OUTPUT_ALLOWLIST
+        .iter()
+        .find(|spec| Some(spec.event_type) == event_type)
+        && let Some(fragment) = value[spec.field].as_str().filter(|value| !value.is_empty())
+    {
+        saw_generated_output = true;
+        match spec.kind {
+            GeneratedValueKind::Text => {
+                output.token_bearing = true;
+                output.estimated_token_units = output
+                    .estimated_token_units
+                    .saturating_add(estimate_token_like_units(fragment));
+            }
+            GeneratedValueKind::Modal => {}
+        }
+    }
+
+    saw_generated_output.then_some(output)
+}
+
+fn string_at_path<'a>(mut value: &'a Value, path: &[&str]) -> Option<&'a str> {
+    for field in path {
+        value = &value[field];
+    }
+    value.as_str()
+}
+
+fn add_generated_text(
+    output: &mut GeneratedOutput,
+    saw_generated_output: &mut bool,
+    value: Option<&str>,
+) {
+    if let Some(value) = value.filter(|value| !value.is_empty()) {
+        *saw_generated_output = true;
+        output.token_bearing = true;
+        output.estimated_token_units = output
+            .estimated_token_units
+            .saturating_add(estimate_token_like_units(value));
+    }
+}
+
+fn exact_usage(value: &Value) -> Option<ExactUsage> {
+    let input_tokens = value["usage"]["prompt_tokens"]
+        .as_u64()
+        .or_else(|| value["response"]["usage"]["input_tokens"].as_u64());
+    let output_tokens = value["usage"]["completion_tokens"]
+        .as_u64()
+        .or_else(|| value["response"]["usage"]["output_tokens"].as_u64())
+        .or_else(|| value["output_tokens_so_far"].as_u64());
+    (input_tokens.is_some() || output_tokens.is_some()).then_some(ExactUsage {
+        input_tokens,
+        output_tokens,
+    })
+}
+
+fn terminal_outcome(event_type: Option<&str>) -> Option<SseTerminalOutcome> {
+    match event_type {
+        Some("response.completed") => Some(SseTerminalOutcome::Complete),
+        Some("response.failed" | "response.incomplete" | "error") => {
+            Some(SseTerminalOutcome::Failed)
+        }
+        _ => None,
+    }
+}
+
+fn merge_terminal_outcomes(
+    first: Option<SseTerminalOutcome>,
+    second: Option<SseTerminalOutcome>,
+) -> Option<SseTerminalOutcome> {
+    match (first, second) {
+        (Some(SseTerminalOutcome::Failed), _) | (_, Some(SseTerminalOutcome::Failed)) => {
+            Some(SseTerminalOutcome::Failed)
+        }
+        (Some(SseTerminalOutcome::Complete), _) | (_, Some(SseTerminalOutcome::Complete)) => {
+            Some(SseTerminalOutcome::Complete)
+        }
+        (None, None) => None,
+    }
 }
 
 fn find_sse_event_end(buffer: &[u8]) -> Option<usize> {
@@ -229,58 +548,219 @@ fn extract_sse_fields(event_bytes: &[u8]) -> ExtractedSseFields {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::hint::black_box;
 
-    use crate::output_token_parser::OutputTokenParser;
-    use crate::request_quality_monitor::{RequestOutputTokenProgress, RequestQualityRecorder};
+    fn parse_event(raw_event: impl AsRef<[u8]>) -> ParsedSseMessage {
+        let mut messages = SseMessageBuffer::default();
+        messages.push_bytes(raw_event.as_ref());
+        let parsed = messages
+            .next()
+            .expect("fixture should contain one SSE event");
+        assert_eq!(messages.next(), None, "fixture should contain one event");
+        parsed
+    }
+
+    fn parse_data(data: &str) -> ParsedSseMessage {
+        parse_event(format!("data: {data}\n\n"))
+    }
 
     #[test]
-    fn yields_complete_messages() {
+    fn yields_only_complete_messages_and_preserves_raw_bytes() {
         let mut messages = SseMessageBuffer::default();
         messages.push_bytes(b"data: first\n\ndata: sec");
-        assert_eq!(
-            messages.next(),
-            Some(ParsedSseMessage {
-                message: SseMessage::ChatCompletionChunk { parsed: None },
-                raw_event: Bytes::from_static(b"data: first\n\n"),
-            })
-        );
+        let first = messages.next().expect("first event should be complete");
+        assert_eq!(first.raw_event, Bytes::from_static(b"data: first\n\n"));
+        assert_eq!(first.parsed, None);
+        assert_eq!(first.facts, SseEventFacts::default());
         assert_eq!(messages.next(), None);
 
         messages.push_bytes(b"ond\n\n");
-        assert_eq!(
-            messages.next(),
-            Some(ParsedSseMessage {
-                message: SseMessage::ChatCompletionChunk { parsed: None },
-                raw_event: Bytes::from_static(b"data: second\n\n"),
-            })
-        );
+        let second = messages
+            .next()
+            .expect("second event should now be complete");
+        assert_eq!(second.raw_event, Bytes::from_static(b"data: second\n\n"));
+        assert_eq!(second.facts, SseEventFacts::default());
         assert_eq!(messages.next(), None);
     }
 
     #[test]
-    fn classifies_done_and_output_messages() {
-        let mut messages = SseMessageBuffer::default();
-        messages.push_bytes(
-            b"data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n",
-        );
-        messages.push_bytes(b"data: [DONE]\n\n");
+    fn classifies_every_chat_generated_string_path() {
+        for (json_path, relative_path) in CHAT_DELTA_TEXT_FIELDS {
+            let delta = match *relative_path {
+                [field] => serde_json::json!({(*field): "x"}),
+                [container, field] => {
+                    serde_json::json!({(*container): {(*field): "x"}})
+                }
+                _ => panic!("unsupported test path {json_path}"),
+            };
+            let data = serde_json::json!({
+                "object": "chat.completion.chunk",
+                "choices": [{"delta": delta}],
+            });
+            let parsed = parse_data(&data.to_string());
+            let output = parsed
+                .facts
+                .generated_output
+                .unwrap_or_else(|| panic!("{json_path} should count as generated output"));
+            assert!(output.token_bearing, "{json_path} should be token-bearing");
+            assert_eq!(
+                output.estimated_token_units, 1,
+                "unexpected estimate for {json_path}"
+            );
+        }
 
-        assert!(matches!(
-            messages.next(),
-            Some(ParsedSseMessage {
-                message: SseMessage::ChatCompletionChunk { .. },
-                ..
-            })
-        ));
-        assert_eq!(
-            messages.next(),
-            Some(ParsedSseMessage {
-                message: SseMessage::Done,
-                raw_event: Bytes::from_static(b"data: [DONE]\n\n"),
-            })
+        for (json_path, field) in CHAT_TOOL_TEXT_FIELDS {
+            let data = serde_json::json!({
+                "object": "chat.completion.chunk",
+                "choices": [{"delta": {"tool_calls": [{"function": {(*field): "x"}}]}}],
+            });
+            let parsed = parse_data(&data.to_string());
+            let output = parsed
+                .facts
+                .generated_output
+                .unwrap_or_else(|| panic!("{json_path} should count as generated output"));
+            assert!(output.token_bearing, "{json_path} should be token-bearing");
+            assert_eq!(
+                output.estimated_token_units, 1,
+                "unexpected estimate for {json_path}"
+            );
+        }
+    }
+
+    #[test]
+    fn chat_mixed_channels_collect_all_generated_fragments() {
+        let parsed = parse_data(
+            r#"{"object":"chat.completion.chunk","choices":[{"delta":{"content":"answer","refusal":"refuse","reasoning":"think","reasoning_content":"think-more","function_call":{"name":"legacy","arguments":"{}"},"tool_calls":[{"function":{"name":"tool","arguments":"[]"}}],"audio":{"transcript":"spoken"}}}]}"#,
         );
-        assert_eq!(messages.next(), None);
+        assert_eq!(
+            parsed
+                .facts
+                .generated_output
+                .expect("mixed Chat event should count")
+                .estimated_token_units,
+            9
+        );
+    }
+
+    #[test]
+    fn chat_audio_data_is_modal_generated_output() {
+        let parsed = parse_data(
+            r#"{"object":"chat.completion.chunk","choices":[{"delta":{"audio":{"data":"YWJj"}}}]}"#,
+        );
+        let output = parsed
+            .facts
+            .generated_output
+            .expect("audio data should count as generated output");
+
+        assert!(!output.token_bearing);
+        assert_eq!(output.estimated_token_units, 0);
+    }
+
+    #[test]
+    fn chat_audio_data_with_transcript_is_token_bearing() {
+        let parsed = parse_data(
+            r#"{"object":"chat.completion.chunk","choices":[{"delta":{"audio":{"data":"YWJj","transcript":"spoken"}}}]}"#,
+        );
+        let output = parsed
+            .facts
+            .generated_output
+            .expect("mixed audio output should count as generated output");
+
+        assert!(output.token_bearing);
+        assert_eq!(output.estimated_token_units, 1);
+    }
+
+    #[test]
+    fn classifies_every_responses_generated_output_path() {
+        for spec in RESPONSES_OUTPUT_ALLOWLIST {
+            let mut data = serde_json::json!({"type": spec.event_type});
+            data[spec.field] = serde_json::json!("x");
+            let parsed = parse_data(&data.to_string());
+            let output = parsed.facts.generated_output.unwrap_or_else(|| {
+                panic!(
+                    "Responses {} {} should count as generated output",
+                    spec.event_type, spec.field
+                )
+            });
+            match spec.kind {
+                GeneratedValueKind::Text => {
+                    assert!(output.token_bearing);
+                    assert_eq!(output.estimated_token_units, 1);
+                }
+                GeneratedValueKind::Modal => {
+                    assert!(!output.token_bearing);
+                    assert_eq!(output.estimated_token_units, 0);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn non_empty_whitespace_text_is_token_bearing_even_when_its_estimate_is_zero() {
+        let parsed = parse_data(
+            r#"{"object":"chat.completion.chunk","choices":[{"delta":{"content":" "}}]}"#,
+        );
+        let output = parsed
+            .facts
+            .generated_output
+            .expect("non-empty text delta should count as generated output");
+
+        assert!(output.token_bearing);
+        assert_eq!(output.estimated_token_units, 0);
+    }
+
+    #[test]
+    fn empty_or_non_string_allowlisted_values_are_inert() {
+        for value in [
+            serde_json::Value::String(String::new()),
+            serde_json::json!(7),
+        ] {
+            let chat = serde_json::json!({
+                "object": "chat.completion.chunk",
+                "choices": [{"delta": {"content": value.clone()}}],
+            });
+            assert_eq!(parse_data(&chat.to_string()).facts.generated_output, None);
+
+            let response = serde_json::json!({
+                "type": "response.output_text.delta",
+                "delta": value,
+            });
+            assert_eq!(
+                parse_data(&response.to_string()).facts.generated_output,
+                None
+            );
+        }
+    }
+
+    #[test]
+    fn metadata_progress_unknown_and_malformed_events_are_inert() {
+        for data in [
+            r#"{"object":"chat.completion.chunk","choices":[{"delta":{"role":"assistant"}}]}"#,
+            r#"{"object":"chat.completion.chunk","choices":[{"delta":{},"finish_reason":"stop"}]}"#,
+            r#"{"object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":2,"completion_tokens":3}}"#,
+            r#"{"type":"response.created"}"#,
+            r#"{"type":"response.queued"}"#,
+            r#"{"type":"response.in_progress"}"#,
+            r#"{"type":"response.output_item.added"}"#,
+            r#"{"type":"response.content_part.added"}"#,
+            r#"{"type":"response.output_text.annotation.added"}"#,
+            r#"{"type":"response.web_search_call.searching"}"#,
+            r#"{"type":"response.mcp_call.in_progress"}"#,
+            r#"{"type":"response.code_interpreter_call.in_progress"}"#,
+            r#"{"type":"response.code_interpreter_call_code.interpreting"}"#,
+            r#"{"type":"response.shell_call_output.delta","delta":"stdout"}"#,
+            r#"{"type":"response.apply_patch_call_output.delta","delta":"stderr"}"#,
+            r#"{"type":"response.future.delta","delta":"unknown"}"#,
+            r#"{"choices":[{"delta":{"content":"missing-chat-event-type"}}]}"#,
+            "not-json",
+            "{",
+            "",
+        ] {
+            let parsed = parse_data(data);
+            assert_eq!(
+                parsed.facts.generated_output, None,
+                "unexpected generated output for {data}"
+            );
+        }
     }
 
     #[test]
@@ -291,13 +771,7 @@ mod tests {
         );
 
         let parsed = messages.next().expect("complete SSE event");
-        assert!(matches!(
-            parsed.message,
-            SseMessage::ChatCompletionChunk { .. }
-        ));
-        let SseMessage::ChatCompletionChunk { .. } = parsed.message else {
-            unreachable!("message kind asserted above");
-        };
+        assert!(parsed.facts.generated_output.is_some());
         let fields = extract_sse_fields(parsed.raw_event.as_ref());
         assert_eq!(
             fields.data,
@@ -307,30 +781,74 @@ mod tests {
     }
 
     #[test]
-    fn data_events_are_not_json_classified() {
-        let mut messages = SseMessageBuffer::default();
-        messages.push_bytes(b"data: {\"object\":\"chat.completion\"}\n\n");
-        messages.push_bytes(b"data: [DONE]\n\n");
-
-        let data = messages.next().expect("data event");
-        assert!(data.message.counts_as_output());
-        let done = messages.next().expect("done event");
-        assert_eq!(done.message, SseMessage::Done);
-        assert!(!done.message.counts_as_output());
+    fn parses_exact_usage_independently_from_generated_output() {
+        for (data, expected) in [
+            (
+                r#"{"object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":8,"completion_tokens":3}}"#,
+                ExactUsage {
+                    input_tokens: Some(8),
+                    output_tokens: Some(3),
+                },
+            ),
+            (
+                r#"{"type":"response.completed","response":{"usage":{"input_tokens":5,"output_tokens":2}}}"#,
+                ExactUsage {
+                    input_tokens: Some(5),
+                    output_tokens: Some(2),
+                },
+            ),
+            (
+                r#"{"object":"chat.completion.chunk","output_tokens_so_far":7,"choices":[]}"#,
+                ExactUsage {
+                    input_tokens: None,
+                    output_tokens: Some(7),
+                },
+            ),
+        ] {
+            let parsed = parse_data(data);
+            assert_eq!(parsed.facts.exact_usage, Some(expected));
+            assert_eq!(parsed.facts.generated_output, None);
+        }
     }
 
     #[test]
-    fn responses_created_does_not_count_as_output() {
-        let mut messages = SseMessageBuffer::default();
-        messages.push_bytes(b"event: response.created\ndata: {\"type\":\"response.created\"}\n\n");
-        messages.push_bytes(
-            b"event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n",
-        );
+    fn ignores_missing_null_and_non_integer_usage() {
+        for data in [
+            r#"{"object":"chat.completion.chunk"}"#,
+            r#"{"object":"chat.completion.chunk","usage":null}"#,
+            r#"{"object":"chat.completion.chunk","usage":{"completion_tokens":null}}"#,
+            r#"{"object":"chat.completion.chunk","usage":{"completion_tokens":"4"}}"#,
+            r#"{"object":"chat.completion.chunk","usage":{"completion_tokens":4.5}}"#,
+            r#"{"object":"chat.completion.chunk","usage":{"completion_tokens":-1}}"#,
+            "not-json",
+        ] {
+            assert_eq!(parse_data(data).facts.exact_usage, None);
+        }
+    }
 
-        let created = messages.next().expect("created event");
-        assert!(!created.message.counts_as_output());
-        let delta = messages.next().expect("delta event");
-        assert!(delta.message.counts_as_output());
+    #[test]
+    fn classifies_explicit_terminal_outcomes_without_output() {
+        assert_eq!(
+            parse_data("[DONE]").facts.terminal,
+            Some(SseTerminalOutcome::Complete)
+        );
+        let completed = parse_data(r#"{"type":"response.completed"}"#);
+        assert_eq!(completed.facts.terminal, Some(SseTerminalOutcome::Complete));
+        assert_eq!(completed.facts.generated_output, None);
+        for event_type in ["response.failed", "response.incomplete", "error"] {
+            let parsed = parse_data(&format!(r#"{{"type":"{event_type}"}}"#));
+            assert_eq!(parsed.facts.terminal, Some(SseTerminalOutcome::Failed));
+            assert_eq!(parsed.facts.generated_output, None);
+        }
+
+        let named_error = parse_event("event: error\ndata: {\"message\":\"bad\"}\n\n");
+        assert_eq!(named_error.facts.terminal, Some(SseTerminalOutcome::Failed));
+
+        let typed_named_error = parse_event("event: error\ndata: {\"type\":\"server_error\"}\n\n");
+        assert_eq!(
+            typed_named_error.facts.terminal,
+            Some(SseTerminalOutcome::Failed)
+        );
     }
 
     #[tokio::test]
@@ -372,163 +890,249 @@ mod tests {
             11,
         );
 
-        assert_eq!(
-            messages
-                .next()
-                .await
-                .expect("first complete SSE event should be emitted")
-                .expect("first complete SSE event should not fail"),
-            ParsedSseMessage {
-                message: SseMessage::ChatCompletionChunk { parsed: None },
-                raw_event: Bytes::from_static(b"data: one\n\n"),
-            }
-        );
-        assert_eq!(
-            messages
-                .next()
-                .await
-                .expect("second complete SSE event should be emitted")
-                .expect("second complete SSE event should not fail"),
-            ParsedSseMessage {
-                message: SseMessage::ChatCompletionChunk { parsed: None },
-                raw_event: Bytes::from_static(b"data: two\n\n"),
-            }
-        );
+        let first = messages
+            .next()
+            .await
+            .expect("first complete SSE event should be emitted")
+            .expect("first complete SSE event should not fail");
+        assert_eq!(first.raw_event, Bytes::from_static(b"data: one\n\n"));
+        assert_eq!(first.facts, SseEventFacts::default());
+        let second = messages
+            .next()
+            .await
+            .expect("second complete SSE event should be emitted")
+            .expect("second complete SSE event should not fail");
+        assert_eq!(second.raw_event, Bytes::from_static(b"data: two\n\n"));
+        assert_eq!(second.facts, SseEventFacts::default());
         assert!(
             messages.next().await.is_none(),
             "the byte stream should be exhausted after both events"
         );
     }
 
-    #[test]
-    fn sse_peeking_helpers_preserve_token_and_forwarding_accounting() {
-        let input = SseFixture::new(8, 37);
+    #[tokio::test(start_paused = true)]
+    async fn metadata_and_partial_bytes_do_not_extend_first_output_deadline() {
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+        let mut messages = upstream_sse_message_stream(
+            tokio_stream::wrappers::ReceiverStream::new(rx),
+            Duration::from_secs(1),
+            Duration::from_secs(5),
+            1024,
+        );
 
-        let raw_bytes = raw_forward_only(&input.chunks, 1);
-        let peeked = peek_sse_events(&input.chunks, 1);
-        let fallback = fallback_sse_events(&input.chunks, 1, false);
-        let quality_fallback = fallback_sse_events(&input.chunks, 1, true);
+        tx.send(Ok::<_, reqwest::Error>(Bytes::from_static(
+            b": keepalive\n\n",
+        )))
+        .await
+        .unwrap();
+        let keepalive = messages.next().await.unwrap().unwrap();
+        assert_eq!(keepalive.facts, SseEventFacts::default());
 
-        assert_eq!(raw_bytes, input.total_bytes);
-        assert_eq!(peeked.output_messages, input.output_events);
-        assert_eq!(fallback.output_messages, input.output_events);
-        assert_eq!(quality_fallback.output_messages, input.output_events);
-        assert_eq!(peeked.output_tokens, input.output_events as u64);
-        assert_eq!(fallback.output_tokens, input.output_events as u64);
-        assert_eq!(quality_fallback.output_tokens, input.output_events as u64);
-        assert_eq!(fallback.forwarded_bytes, input.total_bytes);
-        assert_eq!(quality_fallback.forwarded_bytes, input.total_bytes);
+        tokio::time::advance(Duration::from_millis(600)).await;
+        tx.send(Ok(Bytes::from_static(
+            b"data: {\"type\":\"response.in_progress\"}\n\n",
+        )))
+        .await
+        .unwrap();
+        let metadata = messages.next().await.unwrap().unwrap();
+        assert_eq!(metadata.facts.generated_output, None);
+
+        tokio::time::advance(Duration::from_millis(300)).await;
+        tx.send(Ok(Bytes::from_static(b"data: {\"type\":\"response.")))
+            .await
+            .unwrap();
+        let pending = messages.next();
+        tokio::pin!(pending);
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(101)).await;
+        assert!(matches!(
+            pending.await,
+            Some(Err(UpstreamSseReadError::Timeout(
+                SseReadTimeoutPhase::FirstOutput
+            )))
+        ));
     }
 
-    #[derive(Debug)]
-    struct SseFixture {
-        chunks: Vec<Bytes>,
-        output_events: usize,
-        total_bytes: usize,
+    #[tokio::test(start_paused = true)]
+    async fn first_output_deadline_starts_before_the_consumer_polls() {
+        let (_tx, rx) = tokio::sync::mpsc::channel(1);
+        let mut messages = upstream_sse_message_stream(
+            tokio_stream::wrappers::ReceiverStream::new(rx),
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            1024,
+        );
+
+        tokio::time::advance(Duration::from_millis(1001)).await;
+        let message = tokio::time::timeout(Duration::from_millis(100), messages.next())
+            .await
+            .expect("the constructor-time first-output deadline should already have elapsed");
+
+        assert!(matches!(
+            message,
+            Some(Err(UpstreamSseReadError::Timeout(
+                SseReadTimeoutPhase::FirstOutput
+            )))
+        ));
     }
 
-    impl SseFixture {
-        fn new(output_events: usize, fragment_size: usize) -> Self {
-            let mut body = Vec::new();
-            for index in 1..=output_events {
-                body.extend_from_slice(
-                    format!(
-                        "data: {{\"object\":\"chat.completion.chunk\",\"choices\":[{{\"delta\":{{\"content\":\"x\"}}}}],\"usage\":{{\"completion_tokens\":{index}}}}}\n\n"
-                    )
-                    .as_bytes(),
-                );
-                if index % 8 == 0 {
-                    body.extend_from_slice(b": keepalive\n\n");
-                }
-            }
-            body.extend_from_slice(b"data: [DONE]\n\n");
-            let total_bytes = body.len();
-            let chunks = body
-                .chunks(fragment_size)
-                .map(Bytes::copy_from_slice)
-                .collect();
+    #[tokio::test(start_paused = true)]
+    async fn only_generated_output_resets_subsequent_output_deadline() {
+        let (tx, rx) = tokio::sync::mpsc::channel(5);
+        let mut messages = upstream_sse_message_stream(
+            tokio_stream::wrappers::ReceiverStream::new(rx),
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            1024,
+        );
+        let output = Bytes::from_static(
+            b"data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"delta\":{\"content\":\"x\"}}]}\n\n",
+        );
 
-            Self {
-                chunks,
-                output_events,
-                total_bytes,
-            }
+        tx.send(Ok::<_, reqwest::Error>(output.clone()))
+            .await
+            .unwrap();
+        assert!(
+            messages
+                .next()
+                .await
+                .unwrap()
+                .unwrap()
+                .facts
+                .generated_output
+                .is_some()
+        );
+
+        tokio::time::advance(Duration::from_millis(700)).await;
+        tx.send(Ok(Bytes::from_static(b": keepalive\n\n")))
+            .await
+            .unwrap();
+        assert_eq!(
+            messages.next().await.unwrap().unwrap().facts,
+            SseEventFacts::default()
+        );
+
+        tokio::time::advance(Duration::from_millis(200)).await;
+        tx.send(Ok(output)).await.unwrap();
+        assert!(
+            messages
+                .next()
+                .await
+                .unwrap()
+                .unwrap()
+                .facts
+                .generated_output
+                .is_some()
+        );
+
+        tokio::time::advance(Duration::from_millis(800)).await;
+        tx.send(Ok(Bytes::from_static(b"data: partial")))
+            .await
+            .unwrap();
+        let pending = messages.next();
+        tokio::pin!(pending);
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(201)).await;
+        assert!(matches!(
+            pending.await,
+            Some(Err(UpstreamSseReadError::Timeout(
+                SseReadTimeoutPhase::SubsequentOutput
+            )))
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn buffered_output_does_not_hide_deadline_while_consumer_is_stalled() {
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        let mut messages = upstream_sse_message_stream(
+            tokio_stream::wrappers::ReceiverStream::new(rx),
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            1024,
+        );
+        tx.send(Ok::<_, reqwest::Error>(Bytes::from_static(
+            b": metadata\n\ndata: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"delta\":{\"content\":\"x\"}}]}\n\n",
+        )))
+        .await
+        .unwrap();
+
+        let metadata = messages.next().await.unwrap().unwrap();
+        assert_eq!(metadata.facts, SseEventFacts::default());
+        tokio::task::yield_now().await;
+
+        tokio::time::advance(Duration::from_millis(1001)).await;
+        tokio::task::yield_now().await;
+
+        let output = messages.next().await.unwrap().unwrap();
+        assert!(output.facts.generated_output.is_some());
+        assert!(matches!(
+            messages.next().await,
+            Some(Err(UpstreamSseReadError::Timeout(
+                SseReadTimeoutPhase::SubsequentOutput
+            )))
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn bounded_delivery_backpressure_pauses_the_unobservable_upstream_deadline() {
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        let mut messages = upstream_sse_message_stream(
+            tokio_stream::wrappers::ReceiverStream::new(rx),
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            1024,
+        );
+        let metadata = (0..20)
+            .map(|index| format!("data: {{\"index\":{index}}}\n\n"))
+            .collect::<String>();
+        tx.send(Ok::<_, reqwest::Error>(Bytes::from(metadata)))
+            .await
+            .unwrap();
+
+        let first = messages.next().await.unwrap().unwrap();
+        let received_at = first.received_at;
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(10)).await;
+        tokio::task::yield_now().await;
+
+        for _ in 1..20 {
+            let message = messages.next().await.unwrap().unwrap();
+            assert_eq!(message.facts, SseEventFacts::default());
+            assert_eq!(message.received_at, received_at);
         }
+
+        let output = Bytes::from_static(
+            b"data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"delta\":{\"content\":\"x\"}}]}\n\n",
+        );
+        tx.send(Ok(output)).await.unwrap();
+        assert!(
+            messages
+                .next()
+                .await
+                .unwrap()
+                .unwrap()
+                .facts
+                .generated_output
+                .is_some(),
+            "local delivery saturation must not become an upstream timeout"
+        );
     }
 
-    #[derive(Debug, Default)]
-    struct PeekedEvents {
-        output_messages: usize,
-        output_tokens: u64,
-        forwarded_bytes: usize,
-    }
+    #[tokio::test]
+    async fn terminal_event_is_yielded_before_stream_completion() {
+        let stream = futures::stream::iter([Ok::<_, reqwest::Error>(Bytes::from_static(
+            b"data: [DONE]\n\ndata: trailing\n\n",
+        ))]);
+        let mut messages = upstream_sse_message_stream(
+            stream,
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            1024,
+        );
 
-    fn raw_forward_only(chunks: &[Bytes], repetitions: usize) -> usize {
-        let mut bytes = 0usize;
-        for _ in 0..repetitions {
-            for chunk in chunks {
-                bytes += black_box(chunk.len());
-            }
-        }
-        black_box(bytes)
-    }
-
-    fn peek_sse_events(chunks: &[Bytes], repetitions: usize) -> PeekedEvents {
-        let mut peeked = PeekedEvents::default();
-        for _ in 0..repetitions {
-            let mut messages = SseMessageBuffer::default();
-            let mut token_parser = OutputTokenParser::new();
-            for chunk in chunks {
-                messages.push_bytes(black_box(chunk.as_ref()));
-                for parsed in messages.by_ref() {
-                    black_box(parsed.raw_event.len());
-                    if let SseMessage::ChatCompletionChunk { parsed, .. } = parsed.message {
-                        peeked.output_messages += 1;
-                        if let Some(progress) = token_parser.observe_json(parsed.as_ref()) {
-                            peeked.output_tokens += progress.delta();
-                        }
-                    }
-                }
-            }
-        }
-        black_box(peeked)
-    }
-
-    fn fallback_sse_events(
-        chunks: &[Bytes],
-        repetitions: usize,
-        quality_enabled: bool,
-    ) -> PeekedEvents {
-        let mut peeked = PeekedEvents::default();
-        for _ in 0..repetitions {
-            let mut messages = SseMessageBuffer::default();
-            let mut token_parser = OutputTokenParser::new();
-            let mut quality_recorder = quality_enabled.then(RequestQualityRecorder::new);
-            for chunk in chunks {
-                messages.push_bytes(black_box(chunk.as_ref()));
-                for parsed in messages.by_ref() {
-                    peeked.forwarded_bytes += parsed.raw_event.len();
-                    if let SseMessage::ChatCompletionChunk { parsed, .. } = parsed.message {
-                        peeked.output_messages += 1;
-                        let output_progress = token_parser.observe_json(parsed.as_ref());
-                        if let Some(progress) = output_progress {
-                            peeked.output_tokens += progress.delta();
-                        }
-                        if let Some(recorder) = quality_recorder.as_mut() {
-                            recorder.observe_json_chunk(
-                                parsed.as_ref(),
-                                output_progress.map(|progress| {
-                                    RequestOutputTokenProgress::Delta(progress.delta())
-                                }),
-                            );
-                        }
-                    }
-                }
-            }
-            if let Some(recorder) = quality_recorder.as_ref() {
-                black_box(recorder.has_observed_stream_output());
-            }
-        }
-        black_box(peeked)
+        let terminal = messages.next().await.unwrap().unwrap();
+        assert_eq!(terminal.raw_event, Bytes::from_static(b"data: [DONE]\n\n"));
+        assert_eq!(terminal.facts.terminal, Some(SseTerminalOutcome::Complete));
+        assert!(messages.next().await.is_none());
     }
 }

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/sse_message_stream.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/sse_message_stream.rs
@@ -120,6 +120,8 @@ pub(crate) enum UpstreamSseReadError {
     },
     #[error("failed to read upstream SSE bytes: {0}")]
     Upstream(#[source] anyhow::Error),
+    #[error("upstream SSE producer task failed: {0}")]
+    Producer(#[source] tokio::task::JoinError),
 }
 
 pub(crate) type UpstreamSseMessageStream =
@@ -147,7 +149,9 @@ where
         while let Some(message) = delivery_rx.recv().await {
             yield message;
         }
-        drop(producer);
+        if let Err(error) = producer.await {
+            yield Err(UpstreamSseReadError::Producer(error));
+        }
     })
 }
 
@@ -908,6 +912,24 @@ mod tests {
             messages.next().await.is_none(),
             "the byte stream should be exhausted after both events"
         );
+    }
+
+    #[tokio::test]
+    async fn producer_panics_are_reported_to_the_consumer() {
+        let mut messages = upstream_sse_message_stream(
+            futures::stream::poll_fn(|_| -> std::task::Poll<Option<reqwest::Result<Bytes>>> {
+                panic!("producer panic fixture");
+            }),
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            1024,
+        );
+
+        match messages.next().await {
+            Some(Err(UpstreamSseReadError::Producer(error))) => assert!(error.is_panic()),
+            unexpected => panic!("producer panic should surface as a stream error: {unexpected:?}"),
+        }
+        assert!(messages.next().await.is_none());
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/sse_message_stream.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/sse_message_stream.rs
@@ -69,18 +69,39 @@ impl SseMessageBuffer {
         self.buffer.extend_from_slice(chunk);
     }
 
-    fn push_bytes_limited(&mut self, chunk: &[u8], max_buffer_bytes: usize) -> Option<usize> {
-        self.push_bytes(chunk);
-        let buffered_bytes = self.unterminated_event_bytes();
-        (buffered_bytes > max_buffer_bytes).then_some(buffered_bytes)
+    fn push_bounded_prefix(&mut self, chunk: &[u8], max_buffer_bytes: usize) -> usize {
+        let buffer_limit = max_buffer_bytes.saturating_add(1);
+        let bytes_to_push = chunk
+            .len()
+            .min(buffer_limit.saturating_sub(self.buffer.len()));
+        self.push_bytes(&chunk[..bytes_to_push]);
+        bytes_to_push
     }
 
-    fn unterminated_event_bytes(&self) -> usize {
-        let mut remaining = self.buffer.as_ref();
-        while let Some(event_end) = find_sse_event_end(remaining) {
-            remaining = &remaining[event_end..];
+    fn next_limited(&mut self, max_buffer_bytes: usize) -> Result<Option<ParsedSseMessage>, usize> {
+        let Some(event_end) = find_sse_event_end(&self.buffer) else {
+            return if self.buffer.len() > max_buffer_bytes {
+                Err(self.buffer.len())
+            } else {
+                Ok(None)
+            };
+        };
+        if event_end > max_buffer_bytes {
+            return Err(event_end);
         }
-        remaining.len()
+        Ok(Some(self.pop_event(event_end)))
+    }
+
+    fn pop_event(&mut self, event_end: usize) -> ParsedSseMessage {
+        let raw_event = self.buffer.split_to(event_end).freeze();
+        let fields = extract_sse_fields(raw_event.as_ref());
+        let (parsed, facts) = classify_sse_event(fields.event_name.as_deref(), &fields.data);
+        ParsedSseMessage {
+            raw_event,
+            parsed,
+            facts,
+            received_at: Instant::now(),
+        }
     }
 }
 
@@ -89,15 +110,7 @@ impl Iterator for SseMessageBuffer {
 
     fn next(&mut self) -> Option<Self::Item> {
         let event_end = find_sse_event_end(&self.buffer)?;
-        let raw_event = self.buffer.split_to(event_end).freeze();
-        let fields = extract_sse_fields(raw_event.as_ref());
-        let (parsed, facts) = classify_sse_event(fields.event_name.as_deref(), &fields.data);
-        Some(ParsedSseMessage {
-            raw_event,
-            parsed,
-            facts,
-            received_at: Instant::now(),
-        })
+        Some(self.pop_event(event_end))
     }
 }
 
@@ -111,13 +124,13 @@ pub(crate) enum SseReadTimeoutPhase {
 pub(crate) enum UpstreamSseReadError {
     #[error("timed out waiting for {0:?} SSE message")]
     Timeout(SseReadTimeoutPhase),
-    #[error(
-        "upstream SSE buffer exceeded {max_buffer_bytes} bytes while waiting for an event boundary"
-    )]
+    #[error("upstream SSE event exceeded the {max_buffer_bytes}-byte buffer limit")]
     BufferLimitExceeded {
         max_buffer_bytes: usize,
         buffered_bytes: usize,
     },
+    #[error("downstream SSE delivery remained backpressured through the {0:?} output deadline")]
+    DeliveryBackpressure(SseReadTimeoutPhase),
     #[error("failed to read upstream SSE bytes: {0}")]
     Upstream(#[source] anyhow::Error),
     #[error("upstream SSE producer task failed: {0}")]
@@ -191,71 +204,47 @@ async fn produce_sse_messages<S>(
                 match next {
                     Some(Ok(chunk)) if chunk.is_empty() => {}
                     Some(Ok(chunk)) => {
-                        if let Some(buffered_bytes) =
-                            sse_messages.push_bytes_limited(chunk.as_ref(), max_buffer_bytes)
-                        {
-                            let _ = delivery_tx
-                                .send(Err(UpstreamSseReadError::BufferLimitExceeded {
-                                    max_buffer_bytes,
-                                    buffered_bytes,
-                                }))
-                                .await;
-                            return;
-                        }
-
-                        let mut messages = Vec::new();
-                        let mut terminal = false;
-                        for mut message in sse_messages.by_ref() {
-                            message.received_at = received_at.into_std();
-                            if message.facts.generated_output.is_some() {
-                                timeout_phase = SseReadTimeoutPhase::SubsequentOutput;
-                                deadline = received_at + output_chunk_timeout;
-                            }
-                            terminal = message.facts.terminal.is_some();
-                            messages.push(message);
-                            if terminal {
-                                break;
-                            }
-                        }
-
-                        let mut timed_out = false;
-                        for message in messages {
-                            if timed_out || terminal {
-                                if delivery_tx.send(Ok(message)).await.is_err() {
-                                    return;
+                        let mut remaining = chunk.as_ref();
+                        loop {
+                            match sse_messages.next_limited(max_buffer_bytes) {
+                                Ok(Some(mut message)) => {
+                                    message.received_at = received_at.into_std();
+                                    if message.facts.generated_output.is_some() {
+                                        timeout_phase = SseReadTimeoutPhase::SubsequentOutput;
+                                        deadline = received_at + output_chunk_timeout;
+                                    }
+                                    let terminal = message.facts.terminal.is_some();
+                                    if !deliver_sse_message(
+                                        &delivery_tx,
+                                        message,
+                                        deadline,
+                                        timeout_phase,
+                                    )
+                                    .await
+                                    {
+                                        return;
+                                    }
+                                    if terminal {
+                                        return;
+                                    }
                                 }
-                                continue;
-                            }
-
-                            let deadline_sleep = tokio::time::sleep_until(deadline);
-                            tokio::pin!(deadline_sleep);
-                            let permit = tokio::select! {
-                                biased;
-                                _ = &mut deadline_sleep => None,
-                                _ = delivery_tx.closed() => return,
-                                permit = delivery_tx.reserve() => match permit {
-                                    Ok(permit) => Some(permit),
-                                    Err(_) => return,
-                                },
-                            };
-                            if let Some(permit) = permit {
-                                permit.send(Ok(message));
-                            } else {
-                                timed_out = true;
-                                if delivery_tx.send(Ok(message)).await.is_err() {
+                                Ok(None) if remaining.is_empty() => break,
+                                Ok(None) => {
+                                    let pushed = sse_messages
+                                        .push_bounded_prefix(remaining, max_buffer_bytes);
+                                    debug_assert!(pushed > 0);
+                                    remaining = &remaining[pushed..];
+                                }
+                                Err(buffered_bytes) => {
+                                    let _ = delivery_tx
+                                        .send(Err(UpstreamSseReadError::BufferLimitExceeded {
+                                            max_buffer_bytes,
+                                            buffered_bytes,
+                                        }))
+                                        .await;
                                     return;
                                 }
                             }
-                        }
-
-                        if terminal {
-                            return;
-                        }
-                        if timed_out {
-                            let _ = delivery_tx
-                                .send(Err(UpstreamSseReadError::Timeout(timeout_phase)))
-                                .await;
-                            return;
                         }
                     }
                     Some(Err(error)) => {
@@ -269,6 +258,42 @@ async fn produce_sse_messages<S>(
             }
         }
     }
+}
+
+async fn deliver_sse_message(
+    delivery_tx: &tokio::sync::mpsc::Sender<Result<ParsedSseMessage, UpstreamSseReadError>>,
+    message: ParsedSseMessage,
+    deadline: tokio::time::Instant,
+    timeout_phase: SseReadTimeoutPhase,
+) -> bool {
+    if let Ok(permit) = delivery_tx.try_reserve() {
+        permit.send(Ok(message));
+        return true;
+    }
+    if delivery_tx.is_closed() {
+        return false;
+    }
+
+    let deadline_sleep = tokio::time::sleep_until(deadline);
+    tokio::pin!(deadline_sleep);
+    let permit = tokio::select! {
+        biased;
+        _ = &mut deadline_sleep => None,
+        permit = delivery_tx.reserve() => match permit {
+            Ok(permit) => Some(permit),
+            Err(_) => return false,
+        },
+    };
+    let Some(permit) = permit else {
+        let _ = delivery_tx
+            .send(Err(UpstreamSseReadError::DeliveryBackpressure(
+                timeout_phase,
+            )))
+            .await;
+        return false;
+    };
+    permit.send(Ok(message));
+    true
 }
 
 fn classify_sse_event(event_name: Option<&str>, data: &str) -> (Option<Value>, SseEventFacts) {
@@ -914,7 +939,7 @@ mod tests {
                 buffered_bytes,
             })) => {
                 assert_eq!(max_buffer_bytes, 11);
-                assert_eq!(buffered_bytes, 14);
+                assert_eq!(buffered_bytes, 12);
             }
             unexpected => panic!(
                 "an upstream peer must not keep an unterminated SSE event buffered indefinitely: {unexpected:?}"
@@ -923,10 +948,33 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn accepts_a_large_chunk_when_it_contains_complete_small_events() {
+    async fn rejects_a_complete_event_that_exceeds_the_buffer_limit() {
         let byte_stream = futures::stream::iter([Ok::<_, reqwest::Error>(Bytes::from_static(
-            b"data: one\n\ndata: two\n\n",
+            b"data: 123456\n\n",
         ))]);
+        let mut messages = upstream_sse_message_stream(
+            byte_stream,
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            13,
+        );
+
+        assert!(matches!(
+            messages.next().await,
+            Some(Err(UpstreamSseReadError::BufferLimitExceeded {
+                max_buffer_bytes: 13,
+                buffered_bytes: 14,
+            }))
+        ));
+    }
+
+    #[tokio::test]
+    async fn streams_many_small_events_from_a_chunk_larger_than_the_buffer_limit() {
+        let event_count = 128;
+        let chunk = (0..event_count)
+            .map(|index| format!("data: {index}\n\n"))
+            .collect::<String>();
+        let byte_stream = futures::stream::iter([Ok::<_, reqwest::Error>(Bytes::from(chunk))]);
         let mut messages = upstream_sse_message_stream(
             byte_stream,
             Duration::from_secs(1),
@@ -934,24 +982,14 @@ mod tests {
             11,
         );
 
-        let first = messages
-            .next()
-            .await
-            .expect("first complete SSE event should be emitted")
-            .expect("first complete SSE event should not fail");
-        assert_eq!(first.raw_event, Bytes::from_static(b"data: one\n\n"));
-        assert_eq!(first.facts, SseEventFacts::default());
-        let second = messages
-            .next()
-            .await
-            .expect("second complete SSE event should be emitted")
-            .expect("second complete SSE event should not fail");
-        assert_eq!(second.raw_event, Bytes::from_static(b"data: two\n\n"));
-        assert_eq!(second.facts, SseEventFacts::default());
-        assert!(
-            messages.next().await.is_none(),
-            "the byte stream should be exhausted after both events"
-        );
+        let mut received = 0;
+        while let Some(message) = messages.next().await {
+            let message = message.expect("complete small SSE events should not fail");
+            assert!(message.raw_event.len() <= 11);
+            assert_eq!(message.facts, SseEventFacts::default());
+            received += 1;
+        }
+        assert_eq!(received, event_count);
     }
 
     #[tokio::test]
@@ -1136,7 +1174,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn bounded_delivery_backpressure_does_not_pause_the_upstream_deadline() {
+    async fn delivery_backpressure_is_not_reported_as_an_upstream_timeout() {
         let (tx, rx) = tokio::sync::mpsc::channel(1);
         let mut messages = upstream_sse_message_stream(
             tokio_stream::wrappers::ReceiverStream::new(rx),
@@ -1157,15 +1195,12 @@ mod tests {
         tokio::time::advance(Duration::from_secs(10)).await;
         tokio::task::yield_now().await;
 
-        for _ in 1..20 {
-            let message = messages.next().await.unwrap().unwrap();
-            assert_eq!(message.facts, SseEventFacts::default());
-            assert_eq!(message.received_at, received_at);
-        }
-
+        let second = messages.next().await.unwrap().unwrap();
+        assert_eq!(second.facts, SseEventFacts::default());
+        assert_eq!(second.received_at, received_at);
         assert!(matches!(
             messages.next().await,
-            Some(Err(UpstreamSseReadError::Timeout(
+            Some(Err(UpstreamSseReadError::DeliveryBackpressure(
                 SseReadTimeoutPhase::FirstOutput
             )))
         ));

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/sse_message_stream.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/sse_message_stream.rs
@@ -24,7 +24,7 @@ use tokio_util::task::AbortOnDropHandle;
 use crate::output_token_parser::estimate_token_like_units;
 
 const SSE_DONE_SENTINEL: &str = "[DONE]";
-const SSE_DELIVERY_BUFFER_EVENTS: usize = 16;
+const SSE_DELIVERY_BUFFER_EVENTS: usize = 1;
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) struct GeneratedOutput {
@@ -39,7 +39,7 @@ pub(crate) struct ExactUsage {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum SseTerminalOutcome {
+pub(crate) enum RelayOutcome {
     Complete,
     Failed,
 }
@@ -48,7 +48,7 @@ pub(crate) enum SseTerminalOutcome {
 pub(crate) struct SseEventFacts {
     pub(crate) generated_output: Option<GeneratedOutput>,
     pub(crate) exact_usage: Option<ExactUsage>,
-    pub(crate) terminal: Option<SseTerminalOutcome>,
+    pub(crate) terminal: Option<RelayOutcome>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -167,38 +167,8 @@ async fn produce_sse_messages<S>(
     let mut sse_messages = SseMessageBuffer::default();
     let mut timeout_phase = SseReadTimeoutPhase::FirstOutput;
     let mut deadline = first_output_deadline;
-    let mut buffered_received_at: Option<tokio::time::Instant> = None;
-    let mut delivery_pause = Duration::ZERO;
 
     loop {
-        let processing_started_at = tokio::time::Instant::now();
-        if let Some(mut parsed_message) = sse_messages.next() {
-            let received_at = buffered_received_at
-                .expect("buffered SSE messages should retain their receipt timestamp");
-            let generated_output = parsed_message.facts.generated_output.is_some();
-            let terminal = parsed_message.facts.terminal.is_some();
-            if generated_output {
-                timeout_phase = SseReadTimeoutPhase::SubsequentOutput;
-                deadline = received_at + output_chunk_timeout + delivery_pause;
-            }
-            parsed_message.received_at = received_at.into_std();
-
-            let Ok(permit) = delivery_tx.reserve().await else {
-                return;
-            };
-            let processing_pause =
-                tokio::time::Instant::now().saturating_duration_since(processing_started_at);
-            delivery_pause += processing_pause;
-            deadline += processing_pause;
-            permit.send(Ok(parsed_message));
-            if terminal {
-                return;
-            }
-            continue;
-        }
-
-        buffered_received_at = None;
-        delivery_pause = Duration::ZERO;
         let deadline_sleep = tokio::time::sleep_until(deadline);
         tokio::pin!(deadline_sleep);
         tokio::select! {
@@ -232,7 +202,61 @@ async fn produce_sse_messages<S>(
                                 .await;
                             return;
                         }
-                        buffered_received_at = Some(received_at);
+
+                        let mut messages = Vec::new();
+                        let mut terminal = false;
+                        for mut message in sse_messages.by_ref() {
+                            message.received_at = received_at.into_std();
+                            if message.facts.generated_output.is_some() {
+                                timeout_phase = SseReadTimeoutPhase::SubsequentOutput;
+                                deadline = received_at + output_chunk_timeout;
+                            }
+                            terminal = message.facts.terminal.is_some();
+                            messages.push(message);
+                            if terminal {
+                                break;
+                            }
+                        }
+
+                        let mut timed_out = false;
+                        for message in messages {
+                            if timed_out || terminal {
+                                if delivery_tx.send(Ok(message)).await.is_err() {
+                                    return;
+                                }
+                                continue;
+                            }
+
+                            let deadline_sleep = tokio::time::sleep_until(deadline);
+                            tokio::pin!(deadline_sleep);
+                            let permit = tokio::select! {
+                                biased;
+                                _ = &mut deadline_sleep => None,
+                                _ = delivery_tx.closed() => return,
+                                permit = delivery_tx.reserve() => match permit {
+                                    Ok(permit) => Some(permit),
+                                    Err(_) => return,
+                                },
+                            };
+                            if let Some(permit) = permit {
+                                permit.send(Ok(message));
+                            } else {
+                                timed_out = true;
+                                if delivery_tx.send(Ok(message)).await.is_err() {
+                                    return;
+                                }
+                            }
+                        }
+
+                        if terminal {
+                            return;
+                        }
+                        if timed_out {
+                            let _ = delivery_tx
+                                .send(Err(UpstreamSseReadError::Timeout(timeout_phase)))
+                                .await;
+                            return;
+                        }
                     }
                     Some(Err(error)) => {
                         let _ = delivery_tx
@@ -251,8 +275,8 @@ fn classify_sse_event(event_name: Option<&str>, data: &str) -> (Option<Value>, S
     let trimmed = data.trim();
     if trimmed == SSE_DONE_SENTINEL {
         let terminal = match terminal_outcome(event_name) {
-            Some(SseTerminalOutcome::Failed) => SseTerminalOutcome::Failed,
-            _ => SseTerminalOutcome::Complete,
+            Some(RelayOutcome::Failed) => RelayOutcome::Failed,
+            _ => RelayOutcome::Complete,
         };
         return (
             None,
@@ -267,7 +291,18 @@ fn classify_sse_event(event_name: Option<&str>, data: &str) -> (Option<Value>, S
         .then(|| sonic_rs::from_str::<Value>(trimmed).ok())
         .flatten();
     let Some(value) = parsed.as_ref() else {
-        return (parsed, SseEventFacts::default());
+        let terminal = if trimmed.is_empty() {
+            None
+        } else {
+            terminal_outcome(event_name)
+        };
+        return (
+            parsed,
+            SseEventFacts {
+                terminal,
+                ..SseEventFacts::default()
+            },
+        );
     };
     let json_event_type = value["type"].as_str();
     let event_type = json_event_type.or(event_name);
@@ -481,26 +516,24 @@ fn exact_usage(value: &Value) -> Option<ExactUsage> {
     })
 }
 
-fn terminal_outcome(event_type: Option<&str>) -> Option<SseTerminalOutcome> {
+fn terminal_outcome(event_type: Option<&str>) -> Option<RelayOutcome> {
     match event_type {
-        Some("response.completed") => Some(SseTerminalOutcome::Complete),
-        Some("response.failed" | "response.incomplete" | "error") => {
-            Some(SseTerminalOutcome::Failed)
-        }
+        Some("response.completed") => Some(RelayOutcome::Complete),
+        Some("response.failed" | "response.incomplete" | "error") => Some(RelayOutcome::Failed),
         _ => None,
     }
 }
 
 fn merge_terminal_outcomes(
-    first: Option<SseTerminalOutcome>,
-    second: Option<SseTerminalOutcome>,
-) -> Option<SseTerminalOutcome> {
+    first: Option<RelayOutcome>,
+    second: Option<RelayOutcome>,
+) -> Option<RelayOutcome> {
     match (first, second) {
-        (Some(SseTerminalOutcome::Failed), _) | (_, Some(SseTerminalOutcome::Failed)) => {
-            Some(SseTerminalOutcome::Failed)
+        (Some(RelayOutcome::Failed), _) | (_, Some(RelayOutcome::Failed)) => {
+            Some(RelayOutcome::Failed)
         }
-        (Some(SseTerminalOutcome::Complete), _) | (_, Some(SseTerminalOutcome::Complete)) => {
-            Some(SseTerminalOutcome::Complete)
+        (Some(RelayOutcome::Complete), _) | (_, Some(RelayOutcome::Complete)) => {
+            Some(RelayOutcome::Complete)
         }
         (None, None) => None,
     }
@@ -834,25 +867,32 @@ mod tests {
     fn classifies_explicit_terminal_outcomes_without_output() {
         assert_eq!(
             parse_data("[DONE]").facts.terminal,
-            Some(SseTerminalOutcome::Complete)
+            Some(RelayOutcome::Complete)
         );
         let completed = parse_data(r#"{"type":"response.completed"}"#);
-        assert_eq!(completed.facts.terminal, Some(SseTerminalOutcome::Complete));
+        assert_eq!(completed.facts.terminal, Some(RelayOutcome::Complete));
         assert_eq!(completed.facts.generated_output, None);
         for event_type in ["response.failed", "response.incomplete", "error"] {
             let parsed = parse_data(&format!(r#"{{"type":"{event_type}"}}"#));
-            assert_eq!(parsed.facts.terminal, Some(SseTerminalOutcome::Failed));
+            assert_eq!(parsed.facts.terminal, Some(RelayOutcome::Failed));
             assert_eq!(parsed.facts.generated_output, None);
         }
 
         let named_error = parse_event("event: error\ndata: {\"message\":\"bad\"}\n\n");
-        assert_eq!(named_error.facts.terminal, Some(SseTerminalOutcome::Failed));
+        assert_eq!(named_error.facts.terminal, Some(RelayOutcome::Failed));
+
+        let plain_text_error = parse_event("event: error\ndata: overloaded\n\n");
+        assert_eq!(plain_text_error.facts.terminal, Some(RelayOutcome::Failed));
 
         let typed_named_error = parse_event("event: error\ndata: {\"type\":\"server_error\"}\n\n");
-        assert_eq!(
-            typed_named_error.facts.terminal,
-            Some(SseTerminalOutcome::Failed)
-        );
+        assert_eq!(typed_named_error.facts.terminal, Some(RelayOutcome::Failed));
+    }
+
+    #[test]
+    fn empty_named_events_are_not_terminal() {
+        let empty_error = parse_event("event: error\ndata:\n\n");
+
+        assert_eq!(empty_error.facts.terminal, None);
     }
 
     #[tokio::test]
@@ -1096,7 +1136,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn bounded_delivery_backpressure_pauses_the_unobservable_upstream_deadline() {
+    async fn bounded_delivery_backpressure_does_not_pause_the_upstream_deadline() {
         let (tx, rx) = tokio::sync::mpsc::channel(1);
         let mut messages = upstream_sse_message_stream(
             tokio_stream::wrappers::ReceiverStream::new(rx),
@@ -1123,21 +1163,12 @@ mod tests {
             assert_eq!(message.received_at, received_at);
         }
 
-        let output = Bytes::from_static(
-            b"data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"delta\":{\"content\":\"x\"}}]}\n\n",
-        );
-        tx.send(Ok(output)).await.unwrap();
-        assert!(
-            messages
-                .next()
-                .await
-                .unwrap()
-                .unwrap()
-                .facts
-                .generated_output
-                .is_some(),
-            "local delivery saturation must not become an upstream timeout"
-        );
+        assert!(matches!(
+            messages.next().await,
+            Some(Err(UpstreamSseReadError::Timeout(
+                SseReadTimeoutPhase::FirstOutput
+            )))
+        ));
     }
 
     #[tokio::test]
@@ -1154,7 +1185,7 @@ mod tests {
 
         let terminal = messages.next().await.unwrap().unwrap();
         assert_eq!(terminal.raw_event, Bytes::from_static(b"data: [DONE]\n\n"));
-        assert_eq!(terminal.facts.terminal, Some(SseTerminalOutcome::Complete));
+        assert_eq!(terminal.facts.terminal, Some(RelayOutcome::Complete));
         assert!(messages.next().await.is_none());
     }
 }

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/stats/collector.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/stats/collector.rs
@@ -746,22 +746,6 @@ mod tests {
         aggregator.apply_fallback_observation(&event)
     }
 
-    fn apply_fallback_observation_with_input_processing_duration(
-        aggregator: &mut StatsAggregator,
-        observation: &RequestObservation,
-        duration: Duration,
-    ) -> Vec<super::super::aggregator::ModelStatsUpdate> {
-        let mut event = aggregator
-            .runtime_state
-            .transition_request_observation(observation.clone());
-        let submitted_at = std::time::Instant::now();
-        event.input_interval = Some(crate::runtime_state::RequestInputInterval {
-            submitted_at,
-            first_generated_output_at: submitted_at + duration,
-        });
-        aggregator.apply_fallback_observation(&event)
-    }
-
     fn apply_stream_observation(
         aggregator: &mut StatsAggregator,
         observation: &RequestObservation,
@@ -1141,23 +1125,6 @@ mod tests {
                 assert_stats!(stats; $($field: $expected),+);
             }
         };
-    }
-
-    #[test]
-    fn fallback_input_tps_uses_backend_submission_interval() {
-        let mut aggregator = test_aggregator(StatsCollectorConfig::default());
-        for index in 0..5 {
-            apply_fallback_observation_with_input_processing_duration(
-                &mut aggregator,
-                &identified(
-                    completed_observation(100, 1, 10, seconds(10), seconds(12)),
-                    format!("req-input-interval-{index}"),
-                ),
-                seconds(2),
-            );
-        }
-
-        assert_eq!(aggregator.snapshot("model-a").last_mean_input_tps, 50.0);
     }
 
     #[test]
@@ -2153,20 +2120,6 @@ mod tests {
         completed_observation(120, 6, 30, seconds(3), seconds(9));
         last_mean_input_tps: 0.0, output_tps: 5.0, max_output_tps: 5.0
     );
-
-    #[test]
-    fn fallback_output_tps_excludes_downstream_delivery_delay() {
-        let mut aggregator = test_aggregator(StatsCollectorConfig::default());
-        let observation = completed_observation(120, 6, 100, seconds(1), seconds(11));
-        let mut event = aggregator
-            .runtime_state
-            .transition_request_observation(observation);
-        event.upstream_duration = Some(seconds(2));
-
-        let stats = published_stats(aggregator.apply_fallback_observation(&event));
-
-        assert_stats!(stats; output_tps: 100.0, max_output_tps: 100.0);
-    }
 
     fallback_snapshot_test!(
         ignores_observations_below_duration_floor,

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/stats/collector.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/stats/collector.rs
@@ -2154,6 +2154,20 @@ mod tests {
         last_mean_input_tps: 0.0, output_tps: 5.0, max_output_tps: 5.0
     );
 
+    #[test]
+    fn fallback_output_tps_excludes_downstream_delivery_delay() {
+        let mut aggregator = test_aggregator(StatsCollectorConfig::default());
+        let observation = completed_observation(120, 6, 100, seconds(1), seconds(11));
+        let mut event = aggregator
+            .runtime_state
+            .transition_request_observation(observation);
+        event.upstream_duration = Some(seconds(2));
+
+        let stats = published_stats(aggregator.apply_fallback_observation(&event));
+
+        assert_stats!(stats; output_tps: 100.0, max_output_tps: 100.0);
+    }
+
     fallback_snapshot_test!(
         ignores_observations_below_duration_floor,
         config!(duration_floor: milliseconds(50)),

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/stats/collector.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/stats/collector.rs
@@ -754,7 +754,11 @@ mod tests {
         let mut event = aggregator
             .runtime_state
             .transition_request_observation(observation.clone());
-        event.input_processing_duration = Some(duration);
+        let submitted_at = std::time::Instant::now();
+        event.input_interval = Some(crate::runtime_state::RequestInputInterval {
+            submitted_at,
+            first_generated_output_at: submitted_at + duration,
+        });
         aggregator.apply_fallback_observation(&event)
     }
 

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/stats/collector.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/stats/collector.rs
@@ -578,6 +578,14 @@ mod tests {
 
     const MODEL_STATS_TEST_TIMEOUT: Duration = milliseconds(500);
 
+    #[test]
+    fn default_observation_channel_capacity_remains_bounded() {
+        assert_eq!(
+            StatsCollectorConfig::default().observation_channel_capacity,
+            1024
+        );
+    }
+
     struct RunningCollector {
         runtime_state: PylonRuntimeState,
         stats_update_tx: Option<flume::Sender<StatsAggregatorUpdate>>,
@@ -735,6 +743,18 @@ mod tests {
         let event = aggregator
             .runtime_state
             .transition_request_observation(observation.clone());
+        aggregator.apply_fallback_observation(&event)
+    }
+
+    fn apply_fallback_observation_with_input_processing_duration(
+        aggregator: &mut StatsAggregator,
+        observation: &RequestObservation,
+        duration: Duration,
+    ) -> Vec<super::super::aggregator::ModelStatsUpdate> {
+        let mut event = aggregator
+            .runtime_state
+            .transition_request_observation(observation.clone());
+        event.input_processing_duration = Some(duration);
         aggregator.apply_fallback_observation(&event)
     }
 
@@ -1117,6 +1137,23 @@ mod tests {
                 assert_stats!(stats; $($field: $expected),+);
             }
         };
+    }
+
+    #[test]
+    fn fallback_input_tps_uses_backend_submission_interval() {
+        let mut aggregator = test_aggregator(StatsCollectorConfig::default());
+        for index in 0..5 {
+            apply_fallback_observation_with_input_processing_duration(
+                &mut aggregator,
+                &identified(
+                    completed_observation(100, 1, 10, seconds(10), seconds(12)),
+                    format!("req-input-interval-{index}"),
+                ),
+                seconds(2),
+            );
+        }
+
+        assert_eq!(aggregator.snapshot("model-a").last_mean_input_tps, 50.0);
     }
 
     #[test]

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/stats/projection.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/stats/projection.rs
@@ -136,9 +136,8 @@ impl StatsAggregator {
         let input_sample = (observation.state == RequestObservationState::Complete)
             .then(|| match observation.endpoint {
                 RequestObservationEndpoint::ChatCompletions
-                | RequestObservationEndpoint::Responses => event
-                    .input_processing_duration()
-                    .or(observation.time_to_first_output)
+                | RequestObservationEndpoint::Responses => observation
+                    .time_to_first_output
                     .map(|duration| (duration, false)),
                 RequestObservationEndpoint::Embeddings => Some((
                     observation
@@ -170,7 +169,7 @@ impl StatsAggregator {
                 RequestObservationEndpoint::ChatCompletions
                 | RequestObservationEndpoint::Responses => {
                     if !counter_already_observed
-                        && let Some(output_tps) = observed_output_tps(&self.config, event)
+                        && let Some(output_tps) = observed_output_tps(&self.config, observation)
                     {
                         record_sample(
                             &mut model_state.chat_output_tps_samples,
@@ -214,7 +213,7 @@ impl StatsAggregator {
         let active_chat_output_tps = self
             .config
             .openai_fallback_stats_enabled
-            .then(|| observed_output_tps(&self.config, event))
+            .then(|| observed_output_tps(&self.config, observation))
             .flatten();
         let mut changed_models = event
             .changed_generations
@@ -291,9 +290,8 @@ fn push_changed_model(models: &mut Vec<String>, model_id: String) {
 
 pub(super) fn observed_output_tps(
     config: &StatsCollectorConfig,
-    event: &RequestObservationEvent,
+    observation: &RequestObservation,
 ) -> Option<f64> {
-    let observation = &event.observation;
     if observation.endpoint == RequestObservationEndpoint::Embeddings
         || observation.output_tokens < config.min_output_tokens
     {
@@ -302,7 +300,7 @@ pub(super) fn observed_output_tps(
     tps_for_units(
         observation.output_tokens,
         output_decode_duration(
-            event.output_duration(),
+            observation.total_duration,
             observation.time_to_first_output,
             observation.time_to_first_token,
             config.duration_floor,

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/stats/projection.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/stats/projection.rs
@@ -136,8 +136,9 @@ impl StatsAggregator {
         let input_sample = (observation.state == RequestObservationState::Complete)
             .then(|| match observation.endpoint {
                 RequestObservationEndpoint::ChatCompletions
-                | RequestObservationEndpoint::Responses => observation
-                    .time_to_first_output
+                | RequestObservationEndpoint::Responses => event
+                    .input_processing_duration()
+                    .or(observation.time_to_first_output)
                     .map(|duration| (duration, false)),
                 RequestObservationEndpoint::Embeddings => Some((
                     observation

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/stats/projection.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/stats/projection.rs
@@ -170,7 +170,7 @@ impl StatsAggregator {
                 RequestObservationEndpoint::ChatCompletions
                 | RequestObservationEndpoint::Responses => {
                     if !counter_already_observed
-                        && let Some(output_tps) = observed_output_tps(&self.config, observation)
+                        && let Some(output_tps) = observed_output_tps(&self.config, event)
                     {
                         record_sample(
                             &mut model_state.chat_output_tps_samples,
@@ -214,7 +214,7 @@ impl StatsAggregator {
         let active_chat_output_tps = self
             .config
             .openai_fallback_stats_enabled
-            .then(|| observed_output_tps(&self.config, observation))
+            .then(|| observed_output_tps(&self.config, event))
             .flatten();
         let mut changed_models = event
             .changed_generations
@@ -291,8 +291,9 @@ fn push_changed_model(models: &mut Vec<String>, model_id: String) {
 
 pub(super) fn observed_output_tps(
     config: &StatsCollectorConfig,
-    observation: &RequestObservation,
+    event: &RequestObservationEvent,
 ) -> Option<f64> {
+    let observation = &event.observation;
     if observation.endpoint == RequestObservationEndpoint::Embeddings
         || observation.output_tokens < config.min_output_tokens
     {
@@ -301,7 +302,7 @@ pub(super) fn observed_output_tps(
     tps_for_units(
         observation.output_tokens,
         output_decode_duration(
-            observation.total_duration,
+            event.output_duration(),
             observation.time_to_first_output,
             observation.time_to_first_token,
             config.duration_floor,

--- a/src/libraries/rust/stargate/crates/stargate/tests/common/mod.rs
+++ b/src/libraries/rust/stargate/crates/stargate/tests/common/mod.rs
@@ -382,8 +382,16 @@ pub struct Delta {
 }
 
 pub async fn dummy_chat(State(state): State<DummyState>, Json(req): Json<ChatRequest>) -> Response {
+    dummy_chat_with_tokens(state.model, req, 3).await
+}
+
+async fn dummy_chat_with_tokens(
+    model: String,
+    req: ChatRequest,
+    completion_tokens: u32,
+) -> Response {
+    let prompt_tokens = req.messages.len().max(1);
     if req.stream == Some(true) {
-        let model = state.model.clone();
         let stream = async_stream::stream! {
             yield Ok::<_, std::convert::Infallible>(Event::default().data(
                 serde_json::to_string(&ChunkCompletion {
@@ -423,6 +431,17 @@ pub async fn dummy_chat(State(state): State<DummyState>, Json(req): Json<ChatReq
                     }],
                 }).unwrap(),
             ));
+            yield Ok(Event::default().data(serde_json::json!({
+                "id": "chunk-1",
+                "object": "chat.completion.chunk",
+                "model": model,
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
+                    "total_tokens": prompt_tokens + completion_tokens as usize,
+                },
+            }).to_string()));
             yield Ok(Event::default().data("[DONE]"));
         };
         return Sse::new(stream)
@@ -433,16 +452,16 @@ pub async fn dummy_chat(State(state): State<DummyState>, Json(req): Json<ChatReq
     Json(serde_json::json!({
         "id": "test-1",
         "object": "chat.completion",
-        "model": state.model,
+        "model": model,
         "choices": [{
             "index": 0,
             "message": { "role": "assistant", "content": "Hello world!" },
             "finish_reason": "stop",
         }],
         "usage": {
-            "prompt_tokens": req.messages.len().max(1),
-            "completion_tokens": 3,
-            "total_tokens": req.messages.len().max(1) + 3,
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens as usize,
         },
     }))
     .into_response()
@@ -485,11 +504,11 @@ pub async fn lifecycle_dummy_chat(
             .into_response();
     }
 
+    let completion_tokens = state.completion_tokens.load(Ordering::SeqCst);
     if req.stream == Some(true) {
-        return dummy_chat(State(DummyState { model: state.model }), Json(req)).await;
+        return dummy_chat_with_tokens(state.model, req, completion_tokens).await;
     }
 
-    let completion_tokens = state.completion_tokens.load(Ordering::SeqCst);
     Json(serde_json::json!({
         "id": "test-1",
         "object": "chat.completion",

--- a/src/libraries/rust/stargate/crates/stargate/tests/suite/lifecycle.rs
+++ b/src/libraries/rust/stargate/crates/stargate/tests/suite/lifecycle.rs
@@ -598,7 +598,7 @@ async fn exercise_active_canary_failure(case: TunnelTestCase, stargates: Stargat
 
     let successful_canaries = backend.canary_requests();
     let next_canary = successful_canaries + 1;
-    backend.set_completion_tokens(CANARY_FAILURE_TOKEN_THRESHOLD);
+    backend.set_completion_tokens(CANARY_FAILURE_TOKEN_THRESHOLD + 1);
     wait_requests!(backend.canary_requests(); reaches next_canary, "failing active canary requests");
     case.wait_for_unroutable(STATUS_TIMEOUT).await;
 


### PR DESCRIPTION
## TL;DR

Pylon now derives request phases, TTFT, stream deadlines, and terminal outcomes from positively recognized generated output instead of response headers or arbitrary SSE traffic. This makes request-observed statistics reliable when `--engine-stats-stream off` is used and establishes the lifecycle contract needed by the stacked throughput change.

## Additional Details

### Why

Pylon previously treated response headers and most JSON SSE events as evidence of prefill or output. Metadata, keepalives, partial frames, usage-only events, and failed terminal events could therefore distort queue state, TTFT, token estimates, timeout behavior, and the final request outcome.

### What changed

- Added an explicit `BackendSubmitted` lifecycle boundary immediately before upstream execution. Request-build failures remain local; execute failures terminate an already submitted request.
- Classified only exact Chat Completions and Responses generated-output shapes. Metadata, malformed input, unknown events, progress events, usage-only events, and terminal events remain statistically inert unless an independent parser recognizes another fact.
- Kept raw SSE bytes unchanged while parsing generated output, exact cumulative usage, and terminal outcome as independent facts.
- Replaced per-read timeouts with first-output and subsequent-output semantic deadlines. Only recognized generated output advances or resets those deadlines.
- Made the SSE producer eager, bounded, abort-on-drop, and independent of downstream response-head progress. Delivery backpressure is classified as a downstream failure instead of an upstream timeout.
- Bounded every complete and partial SSE event and delivered large multi-event chunks incrementally, so one upstream chunk cannot accumulate an unbounded parsed batch.
- Separated first generated output from first token so audio or image output starts TTFT without inventing token timing.
- Applied explicit outcome precedence and terminalized each request once. Downstream cancellation or transport failure wins over an upstream success terminal. Clean EOF after generated output completes; EOF before output, non-2xx responses, failure terminals, and execute or read failures fail the request.
- Carried the backend submission interval on cumulative output and terminal observations so the next PR can repair dropped first-output observations and compute retained input throughput.
- Kept explicit input-token totals monotonic after the first authoritative usage value; malformed regressions are ignored.
- Preserved the 1024-entry nonblocking observation channel and added warning context for every full or disconnected drop.
- Applied the same lifecycle boundaries to streaming relay and calibration/bringup traffic where request statistics participate.
- Updated the lifecycle backend fixture to emit configured streaming usage and exercise canary output above the accepted maximum.

### Customer Release Notes

Pylon now reports request phases and time to first output from generated model output, improving mode-off request statistics and timeout accuracy.

### Plan Summary

No infrastructure, chart, protobuf, or resource changes. Deploy this lifecycle change together with the Stargate aggregation already delivered on `main` by #1448 and the stacked fallback-throughput change in #1457. No mixed-version capability gate is required.

### Protocol evidence

Access date for living API documentation: 2026-09-01.

| Source | Revision | Events and accepted paths | Classification |
|---|---|---|---|
| [OpenAI Chat Completions API](https://developers.openai.com/api/reference/resources/chat/subresources/completions) | Accessed 2026-09-01 | Chat stream chunks: nonempty string content/refusal/function/tool/transcript fragments; audio data as modal output; numeric usage; `[DONE]` terminal | OpenAI standard |
| [OpenAI Responses streaming events](https://developers.openai.com/api/reference/resources/responses/streaming-events) | Accessed 2026-09-01 | Exact text, refusal, reasoning, function, MCP, custom-tool, code, shell, transcript, audio, and image events; completed/failed/incomplete/error terminals; response usage counters | OpenAI standard |
| [OpenAI Python Responses event types](https://github.com/openai/openai-python/tree/b19c2161b1eac80fbf1f6f67a64a50af99c53356/src/openai/types/responses) | `b19c2161b1eac80fbf1f6f67a64a50af99c53356` | Typed event names and string delta fields used by the exact Responses allowlist | Version-pinned OpenAI standard types |
| [OpenAI Node Chat audio accumulator](https://github.com/openai/openai-node/blob/a408e0b8d993fb4e04852cbaecbbcd92cee0dd1c/src/lib/ChatCompletionStream.ts#L1940-L1950) | `a408e0b8d993fb4e04852cbaecbbcd92cee0dd1c` | `choices[].delta.audio.data` and `.transcript` strings | Version-pinned OpenAI standard client behavior |
| [Dynamo Chat stream conversion](https://github.com/ai-dynamo/dynamo/blob/3c30b3ac9151fb50ecbe0da153c1f914a7aabcb4/lib/llm/src/protocols/openai/chat_completions.rs#L297-L326) and [Responses conversion](https://github.com/ai-dynamo/dynamo/blob/3c30b3ac9151fb50ecbe0da153c1f914a7aabcb4/lib/llm/src/protocols/openai/responses/stream_converter.rs#L7-L10) | `3c30b3ac9151fb50ecbe0da153c1f914a7aabcb4` | Canonical Chat delta fields and usage chunk; canonical Responses lifecycle, text delta, and terminal sequence | Standard-compatible implementation; no Dynamo-only wildcard dialect |
| [vLLM Chat protocol](https://github.com/vllm-project/vllm/blob/2f01039666b7d9bb6c93125c98318632c7de9272/vllm/entrypoints/openai/chat_completion/protocol.py#L63-L76) and [Responses events](https://github.com/vllm-project/vllm/blob/2f01039666b7d9bb6c93125c98318632c7de9272/vllm/entrypoints/openai/responses/streaming_events.py#L144-L287) | `2f01039666b7d9bb6c93125c98318632c7de9272` | String Chat content/reasoning, audio and tool-call shapes; exact output-text, reasoning, function, and MCP Responses deltas | Standard-compatible implementation; compatibility shapes have captured unit fixtures |

Unknown future `*.delta` events are intentionally inert. No Dynamo- or vLLM-specific event wildcard was added.

### Usage

No new operator flags in this slice. Use `--engine-stats-stream off` with the matching Stargate aggregation and fallback-throughput changes in #1448 and #1457.

### Testing

- `cargo test -p pylon-lib --lib --quiet` passed all 440 unit tests on this PR.
- The restacked tip passed 505 Pylon library unit tests and 2 public API tests.
- `cargo test -p stargate --quiet` passed 425 unit and CLI tests plus all 142 integration tests on the exact restacked tip.
- `cargo clippy -p pylon-lib -p pylon -p stargate -p stargate-bench --all-targets -- -D warnings` passed on the restacked tip.
- Exact-file `rustfmt --edition 2024 --check` and `git diff --check` passed.
- GitHub `bazel (stargate)` passed on this PR after the hardening changes.

QA is not required beyond the automated Rust suites.

### Notes

The observation channel remains bounded and nonblocking. A dropped terminal observation remains unrecoverable and is surfaced by a warning; later cumulative observations repair only retained in-flight state. No dependency, license, NOTICE, dashboard, alert, protobuf, or binary-diagram changes are required.

### Related Pull Requests

- Prerequisite delivered on `main`: #1448
- Child: #1457
- Stack tip: #1459

## For the Reviewer

Please focus on `sse_message_stream.rs` for the exact positive allowlist and semantic deadline ownership, `quic_http_tunnel/core.rs` for outcome precedence and eager relay behavior, and `request_observer.rs` for monotonic lifecycle transitions and cumulative interval metadata.

## For QA

No separate QA run is requested. The change is covered by unit, integration, transport, paused-time, and full workspace tests.

## Issues

Relates to #1447

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved streaming reliability with clearer handling of incomplete responses, connection failures, and downstream delivery errors.
  - Improved accuracy of token usage, output tracking, and throughput metrics across streaming and non-streaming requests.
  - Enhanced request timing data, including backend submission, first output, and generation durations.
  - Added stronger handling for structured output, tool calls, audio content, and multiple usage formats.
  - Improved lifecycle reporting for completed, failed, and cancelled requests.
  - Improved cluster routing statistics and load balancing across multiple backends, including priority-aware queue estimates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

