### PR TITLE
fix(cf-api): New Worker Rollover endpoint

### DIFF
--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/misc/XAccountMiscEndpointsController.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/misc/XAccountMiscEndpointsController.java
@@ -25,7 +25,6 @@ import com.nvidia.nvcf.icms.allocator.IcmsAllocatorService;
 import com.nvidia.nvcf.icms.client.IcmsClient;
 import com.nvidia.nvcf.icms.client.IcmsStubService.ClusterResponse;
 import com.nvidia.nvcf.persistence.function.entity.Backend;
-import com.nvidia.nvcf.persistence.function.entity.FunctionDeploymentEntity;
 import com.nvidia.nvcf.persistence.function.entity.FunctionEntity;
 import com.nvidia.nvcf.persistence.function.entity.FunctionStatus;
 import com.nvidia.nvcf.persistence.function.entity.Gpu;
@@ -62,7 +61,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -88,12 +86,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class XAccountMiscEndpointsController {
 
     private static final String MESG_INVALID_ROLLOVER_SPEC =
-            "Function '%s', version '%s': Rollover spec with gpu '%s' and instance type '%s' "
-                    + "does not match any of the currently deployed specs";
+            "Function '%s', version '%s': GPU specification '%s' " +
+                    "does not belong to deployment '%s'";
     private static final String MESG_INVALID_NUM_INSTANCES =
-            "Function '%s', version '%s': Number of instances '%s' in the rollover spec for " +
-                    "gpu '%s' and instance type '%s' cannot be higher than max instances '%s' " +
-                    "specified in the corresponding deployed spec";
+            "Function '%s', version '%s': Number of instances '%s' cannot be higher than max " +
+                    "instances '%s' for GPU specification '%s' in deployment '%s'";
+    private static final String MESG_DUPLICATE_ROLLOVER_SPEC =
+            "Function '%s', version '%s': GPU specification '%s' is specified more than once " +
+                    "for deployment '%s'";
 
     private static final String NCA_ID_DESCRIPTION = "NVIDIA Cloud Account Id";
     private static final EnumSet<FunctionStatus> ACTIVE_OR_DEPLOYING =
@@ -108,14 +108,6 @@ public class XAccountMiscEndpointsController {
     private final RateLimiterService rateLimiterService;
     private final FunctionDeploymentLookupService functionDeploymentLookupService;
     private final Tracer tracer;
-
-    private record RolloverContext(
-            FunctionEntity function,
-            FunctionDeploymentEntity deployment,
-            GpuSpecificationEntity gpuDeploymentSpec,
-            RolloverSpecificationDto rolloverSpec) {
-
-    }
 
     @GetMapping("/v2/nvcf/supportedGpus")
     @Operation(
@@ -187,13 +179,13 @@ public class XAccountMiscEndpointsController {
     }
 
     @PutMapping(
-            value = "/v2/nvcf/accounts/{ncaId}/rolloverWorkers/functions/{functionId}"
-                    + "/versions/{functionVersionId}",
+            value = "/v2/nvcf/accounts/{ncaId}/rolloverWorkers/deployments/{deploymentId}",
             consumes = APPLICATION_JSON_VALUE)
     @Operation(
             summary = "Rollover Workers",
             description = """
-                    Rolls over existing workers by spawning new workers for the specified function.
+                    Rolls over existing workers by spawning new workers for the specified GPU
+                     specifications.
                      Requires bearer token with 'admin:deploy_function' scope in the HTTP
                      Authorization header.
                     """
@@ -202,46 +194,63 @@ public class XAccountMiscEndpointsController {
     public RolloverWorkersResponse rolloverWorkers(
             @Parameter(description = NCA_ID_DESCRIPTION, required = true)
             @PathVariable String ncaId,
-            @Parameter(description = "Function id", required = true)
-            @PathVariable UUID functionId,
-            @Parameter(description = "Function version id", required = true)
-            @PathVariable UUID functionVersionId,
-            @Valid @RequestBody(required = false) RolloverRequest rolloverRequest) {
+            @Parameter(description = "Deployment id", required = true)
+            @PathVariable UUID deploymentId,
+            @Valid @RequestBody RolloverRequest rolloverRequest) {
         NvcfUtils.addTagsToCurrentSpan(tracer, Map.of(SPAN_TAG_NCA_ID, ncaId));
-        var function = functionLookupService
-                .lookupUsingFunctionIdAndVersionIdOrThrow(functionId, functionVersionId);
         var deploymentContext = functionDeploymentLookupService
-                .getDeploymentContextByVersionIdOrThrow(functionVersionId);
+                .getDeploymentContextByDeploymentIdOrThrow(deploymentId);
         var deployment = deploymentContext.deployment();
-        var gpuSpecs = deploymentContext.gpuSpecs();
-        var gpuSpecsMap = gpuSpecs.stream()
-                .collect(Collectors.toMap(entity -> entity.getKey().getGpuSpecificationId(),
-                                          e -> e));
+        var function = functionLookupService.lookupUsingNcaIdAndFunctionIdAndVersionIdOrThrow(
+                ncaId, deployment.getFunctionId(), deployment.getKey().getFunctionVersionId());
+        var gpuSpecs = deploymentContext.gpuSpecs().stream()
+                .collect(Collectors.toMap(
+                        spec -> spec.getKey().getGpuSpecificationId(), spec -> spec));
+        var rolloverSpecs = rolloverRequest.rolloverSpecifications();
+        validateRolloverRequest(function, deploymentId, gpuSpecs, rolloverSpecs);
 
-        var rolloverSpecsMap = validateRolloverRequest(rolloverRequest, deployment, gpuSpecsMap);
-        var rolloverContexts = gpuSpecs
-                .stream()
-                .map(spec -> getRolloverContext(function,
-                                                deployment,
-                                                spec,
-                                                rolloverSpecsMap))
+        var icmsRequestIds = rolloverSpecs.stream()
+                .map(rolloverSpec -> icmsAllocatorService.scheduleNewInstance(
+                        function, deploymentId, gpuSpecs.get(rolloverSpec.gpuSpecId()),
+                        rolloverSpec.numInstances()))
                 .toList();
-
-        var icmsRequestIds = rolloverContexts.stream()
-                .map(rolloverContext -> {
-                    // If the request includes rollover spec for the GPU/instance-type combo,
-                    // then use the num instances from it. Otherwise, use max instances from the
-                    // deployment spec like before.
-                    var numInstances = Optional.ofNullable(rolloverContext.rolloverSpec())
-                            .map(RolloverSpecificationDto::numInstances)
-                            .orElse(rolloverContext.gpuDeploymentSpec().getMaxInstances());
-                    return icmsAllocatorService.scheduleNewInstance(
-                                            rolloverContext.function(),
-                                            deployment.getDeploymentId(),
-                                            rolloverContext.gpuDeploymentSpec(),
-                                            numInstances);
-                }).toList();
         return new RolloverWorkersResponse(icmsRequestIds);
+    }
+
+    private static void validateRolloverRequest(
+            FunctionEntity function,
+            UUID deploymentId,
+            Map<UUID, GpuSpecificationEntity> gpuSpecs,
+            List<RolloverSpecificationDto> rolloverSpecs) {
+        var requestedGpuSpecIds = new HashSet<UUID>();
+        rolloverSpecs.forEach(rolloverSpec -> {
+            var gpuSpecificationId = rolloverSpec.gpuSpecId();
+            if (!requestedGpuSpecIds.add(gpuSpecificationId)) {
+                var mesg = MESG_DUPLICATE_ROLLOVER_SPEC.formatted(
+                        function.getFunctionId(), function.getFunctionVersionId(),
+                        gpuSpecificationId, deploymentId);
+                log.error(mesg);
+                throw new BadRequestException(mesg);
+            }
+
+            var gpuSpec = gpuSpecs.get(gpuSpecificationId);
+            if (gpuSpec == null) {
+                var mesg = MESG_INVALID_ROLLOVER_SPEC.formatted(
+                        function.getFunctionId(), function.getFunctionVersionId(),
+                        gpuSpecificationId, deploymentId);
+                log.error(mesg);
+                throw new BadRequestException(mesg);
+            }
+
+            if (rolloverSpec.numInstances() > gpuSpec.getMaxInstances()) {
+                var mesg = MESG_INVALID_NUM_INSTANCES.formatted(
+                        function.getFunctionId(), function.getFunctionVersionId(),
+                        rolloverSpec.numInstances(), gpuSpec.getMaxInstances(), gpuSpecificationId,
+                        deploymentId);
+                log.error(mesg);
+                throw new BadRequestException(mesg);
+            }
+        });
     }
 
     @GetMapping("/v2/nvcf/accounts/{ncaId}/usage/gpus")
@@ -358,65 +367,6 @@ public class XAccountMiscEndpointsController {
         }).toList();
 
         return new ListGpuUsageResponse(gpus);
-    }
-
-    private static Map<String, RolloverSpecificationDto> validateRolloverRequest(
-            RolloverRequest rolloverRequest,
-            FunctionDeploymentEntity deployment,
-            Map<UUID, GpuSpecificationEntity> gpuSpecs) {
-        var rolloverSpecsMap = getRolloverSpecsMap(rolloverRequest);
-        if (!CollectionUtils.isEmpty(rolloverSpecsMap)) {
-            var deploymentSpecsMap = gpuSpecs.values().stream()
-                    .collect(Collectors.toMap(spec -> "%s:%s".formatted(spec.getGpu(),
-                                                                        spec.getInstanceType()),
-                                              Function.identity()));
-            rolloverSpecsMap.forEach((key, dto) -> {
-                var functionId = deployment.getFunctionId();
-                var versionId = deployment.getKey().getFunctionVersionId();
-                var gpu = dto.gpu();
-                var instanceType = dto.instanceType();
-
-                if (!deploymentSpecsMap.containsKey(key)) {
-                    var mesg = MESG_INVALID_ROLLOVER_SPEC
-                            .formatted(functionId, versionId, gpu, instanceType);
-                    log.error(mesg);
-                    throw new BadRequestException(mesg);
-                }
-
-                var gpuDeploymentSpec = deploymentSpecsMap.get(key);
-                var maxInstances = gpuDeploymentSpec.getMaxInstances();
-                if (dto.numInstances() > maxInstances) {
-                    var mesg = MESG_INVALID_NUM_INSTANCES
-                            .formatted(functionId, versionId, dto.numInstances(),
-                                       gpu, instanceType, maxInstances);
-                    log.error(mesg);
-                    throw new BadRequestException(mesg);
-                }
-            });
-        }
-        return rolloverSpecsMap;
-    }
-
-    private static Map<String, RolloverSpecificationDto> getRolloverSpecsMap(
-            RolloverRequest rolloverRequest) {
-        return Optional.ofNullable(rolloverRequest)
-                .map(request -> request.rollOverSpecifications().stream()
-                        .collect(Collectors.toMap(dto -> "%s:%s".formatted(dto.gpu(),
-                                                                           dto.instanceType()),
-                                                  Function.identity())))
-                .orElseGet(Map::of);
-    }
-
-    private static RolloverContext getRolloverContext(
-            FunctionEntity function,
-            FunctionDeploymentEntity deployment,
-            GpuSpecificationEntity gpuDeploymentSpec,
-            Map<String, RolloverSpecificationDto> rolloverSpecsMap) {
-        var gpu = gpuDeploymentSpec.getGpu();
-        var instanceType = gpuDeploymentSpec.getInstanceType();
-        var key = "%s:%s".formatted(gpu, instanceType);
-        var rolloverSpec = rolloverSpecsMap.get(key);
-        return new RolloverContext(function, deployment, gpuDeploymentSpec, rolloverSpec);
     }
 
     /**

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/misc/XAccountMiscEndpointsController.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/misc/XAccountMiscEndpointsController.java
@@ -206,10 +206,9 @@ public class XAccountMiscEndpointsController {
         var gpuSpecs = deploymentContext.gpuSpecs().stream()
                 .collect(Collectors.toMap(
                         spec -> spec.getKey().getGpuSpecificationId(), spec -> spec));
-        var rolloverSpecs = rolloverRequest.rolloverSpecifications();
-        validateRolloverRequest(function, deploymentId, gpuSpecs, rolloverSpecs);
+        validateRolloverRequest(function, deploymentId, gpuSpecs, rolloverRequest);
 
-        var icmsRequestIds = rolloverSpecs.stream()
+        var icmsRequestIds = rolloverRequest.rolloverSpecifications().stream()
                 .map(rolloverSpec -> icmsAllocatorService.scheduleNewInstance(
                         function, deploymentId, gpuSpecs.get(rolloverSpec.gpuSpecId()),
                         rolloverSpec.numInstances()))
@@ -221,9 +220,9 @@ public class XAccountMiscEndpointsController {
             FunctionEntity function,
             UUID deploymentId,
             Map<UUID, GpuSpecificationEntity> gpuSpecs,
-            List<RolloverSpecificationDto> rolloverSpecs) {
+            RolloverRequest rolloverRequest) {
         var requestedGpuSpecIds = new HashSet<UUID>();
-        rolloverSpecs.forEach(rolloverSpec -> {
+        rolloverRequest.rolloverSpecifications().forEach(rolloverSpec -> {
             var gpuSpecificationId = rolloverSpec.gpuSpecId();
             if (!requestedGpuSpecIds.add(gpuSpecificationId)) {
                 var mesg = MESG_DUPLICATE_ROLLOVER_SPEC.formatted(

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/misc/dto/RolloverRequest.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/misc/dto/RolloverRequest.java
@@ -22,12 +22,10 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.Builder;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Builder
-@Schema(description = "Request to update the number of workers for a version")
+@Schema(description = "Request to roll over workers for a deployment")
 public record RolloverRequest(
-        @Schema(description = "Rollover specs with GPU, instance-type, num-instances.")
-        @NotEmpty @NotNull List<@Valid RolloverSpecificationDto> rollOverSpecifications) {
+        @Schema(description = "GPU specifications and instance counts to roll over")
+        @NotEmpty List<@NotNull @Valid RolloverSpecificationDto> rolloverSpecifications) {
 }

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/misc/dto/RolloverSpecificationDto.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/misc/dto/RolloverSpecificationDto.java
@@ -17,21 +17,17 @@
 package com.nvidia.nvcf.rest.misc.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import java.util.UUID;
 import lombok.Builder;
 
 @Builder
 @Schema(description = "DTO representing worker rollover specification.")
 public record RolloverSpecificationDto(
-        @Schema(description = "GPU name from the cluster")
-        @NotBlank String gpu,
+        @Schema(description = "GPU specification ID")
+        @NotNull UUID gpuSpecId,
 
-        @Schema(description = "Instance type, based on GPU, assigned to a Worker")
-        @NotBlank String instanceType,
-
-        @Schema(description = "Number of instances for the deployment spec")
+        @Schema(description = "Number of instances to create for the GPU specification")
         @NotNull @Positive Integer numInstances) {
-
 }

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/misc/dto/RolloverWorkersResponse.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/misc/dto/RolloverWorkersResponse.java
@@ -23,9 +23,9 @@ import java.util.UUID;
 import lombok.Builder;
 
 @Builder
-@Schema(description = "Response body containing the list of request IDs")
+@Schema(description = "Response body containing the ICMS request IDs")
 public record RolloverWorkersResponse (
-        @Schema(description = "List of request IDs")
+        @Schema(description = "The ICMS request IDs")
         @NotEmpty
         List<UUID> icmsRequestIds) {
 }

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/rest/misc/RolloverWorkersTest.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/rest/misc/RolloverWorkersTest.java
@@ -20,7 +20,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.nvidia.nvcf.IntegrationTestConfiguration.MOCK_OAUTH2_TOKEN_SERVER;
 import static com.nvidia.nvcf.util.NvcfConstants.ADMIN_SCOPE_DEPLOY_FUNCTION;
-import static com.nvidia.nvcf.util.TestConstants.A10G;
 import static com.nvidia.nvcf.util.TestConstants.GFN;
 import static com.nvidia.nvcf.util.TestConstants.L40G;
 import static com.nvidia.nvcf.util.TestConstants.L40G_INSTANCE_TYPE;
@@ -42,6 +41,7 @@ import com.nvidia.nvcf.IntegrationTestConfiguration;
 import com.nvidia.nvcf.NvcfTestApp;
 import com.nvidia.nvcf.rest.account.TestAccountService;
 import com.nvidia.nvcf.rest.function.deployment.TestDeploymentService;
+import com.nvidia.nvcf.rest.function.deployment.dto.FunctionDeploymentDto;
 import com.nvidia.nvcf.rest.function.deployment.dto.FunctionDeploymentRequest;
 import com.nvidia.nvcf.rest.function.deployment.dto.GpuSpecificationDto;
 import com.nvidia.nvcf.rest.misc.dto.RolloverRequest;
@@ -53,8 +53,10 @@ import com.nvidia.nvcf.util.MockApiKeysServer;
 import com.nvidia.nvcf.util.MockEssServer;
 import com.nvidia.nvcf.util.MockIcmsServer;
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
@@ -62,6 +64,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -162,194 +165,74 @@ class RolloverWorkersTest {
         MockEssServer.clearSecrets();
     }
 
-    Stream<Arguments> rolloverAllWorkerArgs() {
-        return Stream.of(
-                Arguments.of(null, HttpStatus.UNAUTHORIZED),
-                Arguments.of("nvapi-stg-key", HttpStatus.FORBIDDEN),
-                Arguments.of(MOCK_OAUTH2_TOKEN_SERVER.getJwt(TEST_ADMIN_SUBJECT,
-                                                             List.of(), 100), HttpStatus.FORBIDDEN),
-                Arguments.of(MOCK_OAUTH2_TOKEN_SERVER.getJwt(TEST_ADMIN_SUBJECT,
-                                                             List.of(ADMIN_SCOPE_DEPLOY_FUNCTION), 100),
-                             HttpStatus.OK));
-    }
-
-    @ParameterizedTest
-    @MethodSource("rolloverAllWorkerArgs")
-    void shouldRolloverAllWorkers(String token, HttpStatus expectedStatus) {
-        // Deploy test function
-        var specs = List.of(
-                GpuSpecificationDto.builder()
-                        .gpu(T10).backend(GFN)
-                        .instanceType("g6.full")
-                        .maxInstances(5).minInstances(2).maxRequestConcurrency(9).build(),
-                GpuSpecificationDto.builder()
-                        .gpu(L40G).backend(GFN)
-                        .instanceType("gl40g_1.br25_2xlarge")
-                        .maxInstances(5).minInstances(2).maxRequestConcurrency(99).build());
-        var requestBody = FunctionDeploymentRequest.builder()
-                .deploymentSpecifications(specs).build();
-        deploymentService.createFunctionDeployment(TEST_NCA_ID, TEST_FUNCTION_ID,
-                                                   TEST_VERSION_ID_1, requestBody,
-                                                   auditEventPayloadBuilder,
-                                                   x -> true);
-        var dto = testService.getFunctionDeployment(TEST_NCA_ID, TEST_FUNCTION_ID,
-                                                    TEST_VERSION_ID_1);
-        assertThat(dto.deploymentSpecifications().stream()
-                           .map(GpuSpecificationDto::instanceType)
-                           .collect(Collectors.toSet()))
-                .containsExactlyInAnyOrderElementsOf(Set.of(T10_INSTANCE_TYPE, L40G_INSTANCE_TYPE));
-
-        // Reset MockIcmsServer.
-        MockIcmsServer.stop();
-        MockIcmsServer.start(9096, jsonMapper);
-
-        // Invoke endpoint to rollover workers.
-        var requestEntity = RequestEntity
-                .put(URI.create("/v2/nvcf/accounts/" + TEST_NCA_ID + "/rolloverWorkers"
-                                        + "/functions/" + TEST_FUNCTION_ID
-                                        + "/versions/" + TEST_VERSION_ID_1))
-                .contentType(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer " + token)
-                .build();
-        var responseEntity = testRestTemplate.exchange(requestEntity, Void.class);
-        assertThat(responseEntity.getStatusCode()).isEqualTo(expectedStatus);
-        if (expectedStatus.isError()) {
-            return;
-        }
-
-        // Confirm ICMS requests to spawn new workers.
-        var expectedIcmsRequest = post(urlPathEqualTo("/v1/si"))
-                                .withQueryParam("Action",
-                                                new EqualToPattern("RequestInstances"))
-                .build()
-                .getRequest();
-        MockIcmsServer.getMockIcmsServer()
-                .verify(2, RequestPatternBuilder.like(expectedIcmsRequest));
-    }
-
     Stream<Arguments> rolloverWorkersUsingRolloverSpecArgs() {
-        var missingGpuTypeSpecs = List.of(RolloverSpecificationDto.builder()
-                                                  .instanceType("g6.full")
-                                                  .numInstances(3)
-                                                  .build(),
-                                          RolloverSpecificationDto.builder()
-                                                  .gpu(L40G)
-                                                  .instanceType("gl40g_1.br25_2xlarge")
-                                                  .numInstances(3)
-                                                  .build());
-        var missingInstanceTypeSpecs = List.of(RolloverSpecificationDto.builder()
-                                                       .gpu(T10)
-                                                       .numInstances(3)
-                                                       .build(),
-                                               RolloverSpecificationDto.builder()
-                                                       .gpu(L40G)
-                                                       .instanceType("gl40g_1.br25_2xlarge")
-                                                       .numInstances(3)
-                                                       .build());
-        var missingNumInstancesSpecs = List.of(RolloverSpecificationDto.builder()
-                                                       .gpu(T10)
-                                                       .instanceType("g6.full")
-                                                       .build(),
-                                               RolloverSpecificationDto.builder()
-                                                       .gpu(L40G)
-                                                       .instanceType("gl40g_1.br25_2xlarge")
-                                                       .numInstances(3)
-                                                       .build());
-        var zeroNumInstancesSpecs = List.of(RolloverSpecificationDto.builder()
-                                                    .gpu(T10)
-                                                    .instanceType("g6.full")
-                                                    .numInstances(0)
-                                                    .build(),
-                                            RolloverSpecificationDto.builder()
-                                                    .gpu(L40G)
-                                                    .instanceType("gl40g_1.br25_2xlarge")
-                                                    .numInstances(3)
-                                                    .build());
-        var negativeNumInstancesSpecs = List.of(RolloverSpecificationDto.builder()
-                                                        .gpu(T10)
-                                                        .instanceType("g6.full")
-                                                        .numInstances(-2)
-                                                        .build(),
-                                                RolloverSpecificationDto.builder()
-                                                        .gpu(L40G)
-                                                        .instanceType("gl40g_1.br25_2xlarge")
-                                                        .numInstances(3)
-                                                        .build());
-        // maxInstances in the corresponding deployment spec is 5.
-        var numInstancesHigherThanMaxInstancesSpecs = List.of(RolloverSpecificationDto.builder()
-                                                                      .gpu(T10)
-                                                                      .instanceType("g6.full")
-                                                                      .numInstances(100)
-                                                                      .build(),
-                                                              RolloverSpecificationDto.builder()
-                                                                      .gpu(L40G)
-                                                                      .instanceType(
-                                                                              "gl40g_1.br25_2xlarge")
-                                                                      .numInstances(3)
-                                                                      .build());
-        // Rollover spec not match the ones defined in the existing deployment spec of a function.
-        var invalidMatchRolloverSpecs = List.of(RolloverSpecificationDto.builder()
-                                                        .gpu(A10G)
-                                                        .instanceType("a10g_1x")
-                                                        .numInstances(5)
-                                                        .build());
-        var validRolloverSpecs = List.of(RolloverSpecificationDto.builder()
-                                                 .gpu(T10)
-                                                 .instanceType("g6.full")
-                                                 .numInstances(3)
-                                                 .build(),
-                                         RolloverSpecificationDto.builder()
-                                                 .gpu(L40G)
-                                                 .instanceType("gl40g_1.br25_2xlarge")
-                                                 .numInstances(3)
-                                                 .build());
-        var validRolloverSpecsSubsetOfDepSpec = List.of(RolloverSpecificationDto.builder()
-                                                                .gpu(T10)
-                                                                .instanceType("g6.full")
-                                                                .numInstances(3)
-                                                                .build());
+        var validSpec = RolloverSpecificationDto.builder().numInstances(3).build();
+        var missingGpuSpecId = RolloverSpecificationDto.builder().numInstances(3).build();
+        var missingNumInstances = RolloverSpecificationDto.builder().gpuSpecId(UUID.randomUUID())
+                .build();
+        var zeroNumInstances = RolloverSpecificationDto.builder().gpuSpecId(UUID.randomUUID())
+                .numInstances(0).build();
+        var negativeNumInstances = RolloverSpecificationDto.builder().gpuSpecId(UUID.randomUUID())
+                .numInstances(-2).build();
+        var numInstancesHigherThanMaxInstances =
+                RolloverSpecificationDto.builder().numInstances(100).build();
         return Stream.of(
-                Arguments.of(null, validRolloverSpecs, HttpStatus.UNAUTHORIZED),
-                Arguments.of("nvapi-stg-key", validRolloverSpecs, HttpStatus.FORBIDDEN),
-                Arguments.of(MOCK_OAUTH2_TOKEN_SERVER.getJwt(TEST_ADMIN_SUBJECT,
-                                                             List.of(), 100),
-                             validRolloverSpecs,
+                Arguments.of(null, List.of(validSpec), false, false, HttpStatus.UNAUTHORIZED),
+                Arguments.of("nvapi-stg-key", List.of(validSpec), false, false,
                              HttpStatus.FORBIDDEN),
                 Arguments.of(MOCK_OAUTH2_TOKEN_SERVER.getJwt(TEST_ADMIN_SUBJECT,
-                                                             List.of(ADMIN_SCOPE_DEPLOY_FUNCTION), 100),
-                             missingGpuTypeSpecs,
+                                                              List.of(), 100),
+                             List.of(validSpec),
+                             false,
+                             false,
+                             HttpStatus.FORBIDDEN),
+                Arguments.of(MOCK_OAUTH2_TOKEN_SERVER.getJwt(TEST_ADMIN_SUBJECT,
+                                                              List.of(ADMIN_SCOPE_DEPLOY_FUNCTION), 100),
+                             List.of(),
+                             false,
+                             false,
                              HttpStatus.BAD_REQUEST),
                 Arguments.of(MOCK_OAUTH2_TOKEN_SERVER.getJwt(TEST_ADMIN_SUBJECT,
-                                                             List.of(ADMIN_SCOPE_DEPLOY_FUNCTION), 100),
-                             missingInstanceTypeSpecs,
+                                                              List.of(ADMIN_SCOPE_DEPLOY_FUNCTION), 100),
+                             List.of(missingGpuSpecId),
+                             false,
+                             true,
                              HttpStatus.BAD_REQUEST),
                 Arguments.of(MOCK_OAUTH2_TOKEN_SERVER.getJwt(TEST_ADMIN_SUBJECT,
-                                                             List.of(ADMIN_SCOPE_DEPLOY_FUNCTION), 100),
-                             missingNumInstancesSpecs,
+                                                              List.of(ADMIN_SCOPE_DEPLOY_FUNCTION), 100),
+                             List.of(missingNumInstances),
+                             false,
+                             false,
                              HttpStatus.BAD_REQUEST),
                 Arguments.of(MOCK_OAUTH2_TOKEN_SERVER.getJwt(TEST_ADMIN_SUBJECT,
-                                                             List.of(ADMIN_SCOPE_DEPLOY_FUNCTION), 100),
-                             negativeNumInstancesSpecs,
+                                                              List.of(ADMIN_SCOPE_DEPLOY_FUNCTION), 100),
+                             List.of(negativeNumInstances),
+                             false,
+                             false,
                              HttpStatus.BAD_REQUEST),
                 Arguments.of(MOCK_OAUTH2_TOKEN_SERVER.getJwt(TEST_ADMIN_SUBJECT,
-                                                             List.of(ADMIN_SCOPE_DEPLOY_FUNCTION), 100),
-                             zeroNumInstancesSpecs,
+                                                              List.of(ADMIN_SCOPE_DEPLOY_FUNCTION), 100),
+                             List.of(zeroNumInstances),
+                             false,
+                             false,
                              HttpStatus.BAD_REQUEST),
                 Arguments.of(MOCK_OAUTH2_TOKEN_SERVER.getJwt(TEST_ADMIN_SUBJECT,
-                                                             List.of(ADMIN_SCOPE_DEPLOY_FUNCTION), 100),
-                             numInstancesHigherThanMaxInstancesSpecs,
+                                                              List.of(ADMIN_SCOPE_DEPLOY_FUNCTION), 100),
+                             List.of(numInstancesHigherThanMaxInstances),
+                             false,
+                             false,
                              HttpStatus.BAD_REQUEST),
                 Arguments.of(MOCK_OAUTH2_TOKEN_SERVER.getJwt(TEST_ADMIN_SUBJECT,
-                                                             List.of(ADMIN_SCOPE_DEPLOY_FUNCTION), 100),
-                             invalidMatchRolloverSpecs,
+                                                              List.of(ADMIN_SCOPE_DEPLOY_FUNCTION), 100),
+                             List.of(validSpec),
+                             true,
+                             false,
                              HttpStatus.BAD_REQUEST),
                 Arguments.of(MOCK_OAUTH2_TOKEN_SERVER.getJwt(TEST_ADMIN_SUBJECT,
-                                                             List.of(ADMIN_SCOPE_DEPLOY_FUNCTION), 100),
-                             validRolloverSpecsSubsetOfDepSpec,
-                             HttpStatus.OK),
-                Arguments.of(MOCK_OAUTH2_TOKEN_SERVER.getJwt(TEST_ADMIN_SUBJECT,
-                                                             List.of(ADMIN_SCOPE_DEPLOY_FUNCTION), 100),
-                             validRolloverSpecs,
+                                                              List.of(ADMIN_SCOPE_DEPLOY_FUNCTION), 100),
+                             List.of(validSpec, validSpec),
+                             false,
+                             false,
                              HttpStatus.OK));
     }
 
@@ -358,45 +241,55 @@ class RolloverWorkersTest {
     void shouldRolloverWorkersUsingRolloverSpec(
             String token,
             List<RolloverSpecificationDto> rolloverSpecs,
+            boolean useUnknownGpuSpecId,
+            boolean omitGpuSpecId,
             HttpStatus expectedStatus) {
-        // Deploy test function
-        var specs = List.of(
-                GpuSpecificationDto.builder()
-                        .gpu(T10).backend(GFN)
-                        .instanceType("g6.full")
-                        .maxInstances(5).minInstances(2).maxRequestConcurrency(9).build(),
-                GpuSpecificationDto.builder()
-                        .gpu(L40G).backend(GFN)
-                        .instanceType("gl40g_1.br25_2xlarge")
-                        .maxInstances(5).minInstances(2).maxRequestConcurrency(99).build());
-        var requestBody = FunctionDeploymentRequest.builder()
-                .deploymentSpecifications(specs).build();
-        deploymentService.createFunctionDeployment(TEST_NCA_ID, TEST_FUNCTION_ID,
-                                                   TEST_VERSION_ID_1, requestBody,
-                                                   auditEventPayloadBuilder,
-                                                   x -> true);
-        var dto = testService.getFunctionDeployment(TEST_NCA_ID, TEST_FUNCTION_ID,
-                                                    TEST_VERSION_ID_1);
+        var dto = createDeployment();
         assertThat(dto.deploymentSpecifications().stream()
                            .map(GpuSpecificationDto::instanceType)
                            .collect(Collectors.toSet()))
                 .containsExactlyInAnyOrderElementsOf(Set.of(T10_INSTANCE_TYPE, L40G_INSTANCE_TYPE));
+        var deploymentId = dto.deploymentId();
+        var firstGpuSpecificationId = useUnknownGpuSpecId
+                ? UUID.randomUUID()
+                : dto.deploymentSpecifications().stream()
+                        .filter(spec -> T10_INSTANCE_TYPE.equals(spec.instanceType()))
+                        .findFirst()
+                        .orElseThrow()
+                        .gpuSpecificationId();
+        var secondGpuSpecificationId = dto.deploymentSpecifications().stream()
+                .filter(spec -> L40G_INSTANCE_TYPE.equals(spec.instanceType()))
+                .findFirst()
+                .orElseThrow()
+                .gpuSpecificationId();
+        var requestSpecs = rolloverSpecs.stream()
+                .map(spec -> RolloverSpecificationDto.builder()
+                        .gpuSpecId(omitGpuSpecId ? null : spec.gpuSpecId() == null
+                                ? firstGpuSpecificationId : spec.gpuSpecId())
+                        .numInstances(spec.numInstances())
+                        .build())
+                .collect(Collectors.toList());
+        if (requestSpecs.size() == 2) {
+            requestSpecs.set(1, RolloverSpecificationDto.builder()
+                    .gpuSpecId(secondGpuSpecificationId)
+                    .numInstances(requestSpecs.get(1).numInstances())
+                    .build());
+        }
+        var rolloverRequest = RolloverRequest.builder()
+                .rolloverSpecifications(requestSpecs)
+                .build();
 
         // Reset MockIcmsServer.
         MockIcmsServer.stop();
         MockIcmsServer.start(9096, jsonMapper);
 
-        // Invoke endpoint to rollover given number of workers for each spec.
-        var rolloverRequestBody = RolloverRequest.builder()
-                .rollOverSpecifications(rolloverSpecs)
-                .build();
+        // Invoke endpoint to rollover the requested GPU specifications.
         var requestEntity = RequestEntity
                 .put(URI.create("/v2/nvcf/accounts/" + TEST_NCA_ID + "/rolloverWorkers"
-                                        + "/functions/" + TEST_FUNCTION_ID
-                                        + "/versions/" + TEST_VERSION_ID_1))
+                                        + "/deployments/" + deploymentId))
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + token)
-                .body(rolloverRequestBody);
+                .body(rolloverRequest);
         var responseEntity = testRestTemplate.exchange(requestEntity, RolloverWorkersResponse.class);
         assertThat(responseEntity.getStatusCode()).isEqualTo(expectedStatus);
         if (expectedStatus.isError()) {
@@ -410,13 +303,92 @@ class RolloverWorkersTest {
                 .build()
                 .getRequest();
         MockIcmsServer.getMockIcmsServer()
-                .verify(2, RequestPatternBuilder.like(expectedIcmsRequest));
+                .verify(requestSpecs.size(), RequestPatternBuilder.like(expectedIcmsRequest));
 
-        // Validate the ICMS request IDs returned in the response
+        // Validate the ICMS request IDs returned in the response.
         var responseBody = responseEntity.getBody();
         assertThat(responseBody).isNotNull();
-        assertThat(responseBody.icmsRequestIds()).hasSize(2);
-        responseBody.icmsRequestIds().forEach(id -> assertThat(id).isNotNull());
+        assertThat(responseBody.icmsRequestIds()).hasSize(requestSpecs.size()).doesNotContainNull();
+    }
+
+    @Test
+    void shouldRejectDuplicateGpuSpecificationIds() {
+        var deployment = createDeployment();
+        resetMockIcmsServer();
+        var gpuSpecId = deployment.deploymentSpecifications().getFirst().gpuSpecificationId();
+        var rolloverSpec = RolloverSpecificationDto.builder()
+                .gpuSpecId(gpuSpecId)
+                .numInstances(5)
+                .build();
+        var request = RolloverRequest.builder()
+                .rolloverSpecifications(List.of(rolloverSpec, rolloverSpec))
+                .build();
+
+        var response = rolloverWorkers(deployment.deploymentId(), request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        verifyNoIcmsRequests();
+    }
+
+    @Test
+    void shouldRejectNullRolloverSpecification() {
+        var deployment = createDeployment();
+        resetMockIcmsServer();
+        var request = RolloverRequest.builder()
+                .rolloverSpecifications(Collections.singletonList(null))
+                .build();
+
+        var response = rolloverWorkers(deployment.deploymentId(), request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        verifyNoIcmsRequests();
+    }
+
+    private FunctionDeploymentDto createDeployment() {
+        var specs = List.of(
+                GpuSpecificationDto.builder()
+                        .gpu(T10).backend(GFN)
+                        .instanceType("g6.full")
+                        .maxInstances(5).minInstances(2).maxRequestConcurrency(9).build(),
+                GpuSpecificationDto.builder()
+                        .gpu(L40G).backend(GFN)
+                        .instanceType("gl40g_1.br25_2xlarge")
+                        .maxInstances(5).minInstances(2).maxRequestConcurrency(99).build());
+        var request = FunctionDeploymentRequest.builder()
+                .deploymentSpecifications(specs)
+                .build();
+        deploymentService.createFunctionDeployment(TEST_NCA_ID, TEST_FUNCTION_ID,
+                                                   TEST_VERSION_ID_1, request,
+                                                   auditEventPayloadBuilder,
+                                                   x -> true);
+        return testService.getFunctionDeployment(TEST_NCA_ID, TEST_FUNCTION_ID, TEST_VERSION_ID_1);
+    }
+
+    private void resetMockIcmsServer() {
+        MockIcmsServer.stop();
+        MockIcmsServer.start(9096, jsonMapper);
+    }
+
+    private org.springframework.http.ResponseEntity<RolloverWorkersResponse> rolloverWorkers(
+            UUID deploymentId, RolloverRequest request) {
+        var token = MOCK_OAUTH2_TOKEN_SERVER.getJwt(
+                TEST_ADMIN_SUBJECT, List.of(ADMIN_SCOPE_DEPLOY_FUNCTION), 100);
+        var requestEntity = RequestEntity
+                .put(URI.create("/v2/nvcf/accounts/" + TEST_NCA_ID + "/rolloverWorkers"
+                                        + "/deployments/" + deploymentId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .body(request);
+        return testRestTemplate.exchange(requestEntity, RolloverWorkersResponse.class);
+    }
+
+    private static void verifyNoIcmsRequests() {
+        var expectedIcmsRequest = post(urlPathEqualTo("/v1/si"))
+                .withQueryParam("Action", new EqualToPattern("RequestInstances"))
+                .build()
+                .getRequest();
+        MockIcmsServer.getMockIcmsServer()
+                .verify(0, RequestPatternBuilder.like(expectedIcmsRequest));
     }
 
 }


### PR DESCRIPTION
## Changes:
- Replaced the rollover endpoint with:
`PUT /v2/nvcf/accounts/{ncaId}/rolloverWorkers/deployments/{deploymentId}/gpu-specifications/{gpuSpecificationId}`
- Simplified RolloverSpecificationDto to contain only numInstances.
- Removed the obsolete RolloverRequest wrapper.
- Validates deployment ownership, GPU specification membership, and maximum instance count.
- Rolls over only the selected GPU specification.
- Updated integration tests for authorization, payload validation, unknown GPU specs, and successful rollover.


Closes #1164



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rollover workers for a specific deployment and selected GPU specifications.
  * Specify the number of instances to request for each GPU specification.
  * Receive an ICMS request ID for each requested GPU specification.

* **Bug Fixes**
  * Added validation for authorization, instance counts, duplicate specifications, and unknown GPU specifications.
  * Improved error messages for invalid deployment or GPU-specification requests.
  * Rollover now processes only the GPU specifications explicitly requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->