### PR TITLE
feat(compute-plane): read Dynamo v1.4.0 records and add a debug backend

### DIFF
--- a/src/compute-plane-services/request-trace-uploader/backend/debug/BUILD.bazel
+++ b/src/compute-plane-services/request-trace-uploader/backend/debug/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "debug",
+    srcs = ["debug.go"],
+    importpath = "github.com/NVIDIA/nvcf/src/compute-plane-services/request-trace-uploader/backend/debug",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/compute-plane-services/request-trace-uploader/backend",
+        "//src/compute-plane-services/request-trace-uploader/config",
+        "//src/compute-plane-services/request-trace-uploader/record",
+    ],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":debug",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "debug_test",
+    srcs = ["debug_test.go"],
+    embed = [":debug"],
+    deps = [
+        "//src/compute-plane-services/request-trace-uploader/backend",
+        "//src/compute-plane-services/request-trace-uploader/config",
+        "//src/compute-plane-services/request-trace-uploader/segment",
+    ],
+)

--- a/src/compute-plane-services/request-trace-uploader/backend/debug/debug.go
+++ b/src/compute-plane-services/request-trace-uploader/backend/debug/debug.go
@@ -50,6 +50,11 @@ func (c *Client) Submit(ctx context.Context, request backend.SubmitRequest) (str
 	incomplete := 0
 
 	for reader.Next() {
+		// A segment can hold many records, so a scan must not outlive a
+		// shutdown. Checking per record bounds the delay to one record.
+		if err := ctx.Err(); err != nil {
+			return "", fmt.Errorf("debug backend: stop reading segment: %w", err)
+		}
 		rec := reader.Record()
 		if _, ok := rec.RequestID(); ok {
 			withRequestID++

--- a/src/compute-plane-services/request-trace-uploader/backend/debug/debug.go
+++ b/src/compute-plane-services/request-trace-uploader/backend/debug/debug.go
@@ -49,11 +49,16 @@ func (c *Client) Submit(ctx context.Context, request backend.SubmitRequest) (str
 	withHeaders := 0
 	incomplete := 0
 
-	for reader.Next() {
-		// A segment can hold many records, so a scan must not outlive a
-		// shutdown. Checking per record bounds the delay to one record.
+	// A segment can hold many records, so a scan must not outlive a shutdown.
+	// The check runs before each advance and once more after the loop, so a
+	// cancellation that lands while the final read reaches the end of the
+	// segment is still reported rather than returning success.
+	for {
 		if err := ctx.Err(); err != nil {
 			return "", fmt.Errorf("debug backend: stop reading segment: %w", err)
+		}
+		if !reader.Next() {
+			break
 		}
 		rec := reader.Record()
 		if _, ok := rec.RequestID(); ok {
@@ -71,6 +76,9 @@ func (c *Client) Submit(ctx context.Context, request backend.SubmitRequest) (str
 	}
 	if err := reader.Err(); err != nil {
 		return "", fmt.Errorf("debug backend: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return "", fmt.Errorf("debug backend: stop reading segment: %w", err)
 	}
 
 	stats := reader.Stats()

--- a/src/compute-plane-services/request-trace-uploader/backend/debug/debug.go
+++ b/src/compute-plane-services/request-trace-uploader/backend/debug/debug.go
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package debug implements a backend that reports what it received and
+// exports nothing.
+//
+// It exists so the read path can be exercised against a real Dynamo without
+// credentials, a bucket, or a namespace. Selecting it reads each closed
+// segment, reports what was in it, and reports success without transmitting
+// anything or deleting the source.
+package debug
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/request-trace-uploader/backend"
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/request-trace-uploader/config"
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/request-trace-uploader/record"
+)
+
+func init() {
+	backend.Register(config.BackendDebug, New)
+}
+
+// Client reports segments instead of exporting them.
+type Client struct{}
+
+// New builds the debug backend.
+func New(config.Config) (backend.Client, error) { return &Client{}, nil }
+
+// Submit reads the segment and reports what it contains.
+//
+// It reports counts and shapes only. Request identifiers, session
+// identifiers, header values, and record bodies are deliberately absent: this
+// is a diagnostic aid, and its output is subject to the same containment rules
+// as any other uploader log.
+func (c *Client) Submit(ctx context.Context, request backend.SubmitRequest) (string, error) {
+	reader, err := record.Open(request.Path)
+	if err != nil {
+		return "", fmt.Errorf("debug backend: %w", err)
+	}
+	defer reader.Close()
+
+	withRequestID := 0
+	withSession := 0
+	withHeaders := 0
+	incomplete := 0
+
+	for reader.Next() {
+		rec := reader.Record()
+		if _, ok := rec.RequestID(); ok {
+			withRequestID++
+		}
+		if _, ok := rec.SessionID(); ok {
+			withSession++
+		}
+		if len(rec.Headers()) > 0 {
+			withHeaders++
+		}
+		if rec.Payload != nil && !rec.Payload.Complete {
+			incomplete++
+		}
+	}
+	if err := reader.Err(); err != nil {
+		return "", fmt.Errorf("debug backend: %w", err)
+	}
+
+	stats := reader.Stats()
+	slog.Info("debug backend read a segment",
+		"segment", request.Segment.Index,
+		"records", stats.Records,
+		"record_bytes", stats.Bytes,
+		"unparseable", stats.Unparseable,
+		"unknown_event_types", stats.Unknown,
+		"with_request_id", withRequestID,
+		"with_session_id", withSession,
+		"with_headers", withHeaders,
+		"incomplete_payloads", incomplete,
+		"by_event_type", formatCounts(stats.ByEventType))
+
+	return fmt.Sprintf("debug-%d", request.Segment.Index), nil
+}
+
+// Status reports success. Nothing was transmitted, so nothing can be pending.
+func (c *Client) Status(context.Context, string) (backend.Status, error) {
+	return backend.StatusSuccess, nil
+}
+
+// formatCounts renders the per-event-type counts in a stable order so log
+// lines from different runs compare directly.
+func formatCounts(counts map[record.EventType]int) string {
+	if len(counts) == 0 {
+		return "none"
+	}
+	types := make([]string, 0, len(counts))
+	for eventType := range counts {
+		types = append(types, string(eventType))
+	}
+	sort.Strings(types)
+
+	out := ""
+	for i, eventType := range types {
+		if i > 0 {
+			out += " "
+		}
+		out += fmt.Sprintf("%s=%d", eventType, counts[record.EventType(eventType)])
+	}
+	return out
+}

--- a/src/compute-plane-services/request-trace-uploader/backend/debug/debug_test.go
+++ b/src/compute-plane-services/request-trace-uploader/backend/debug/debug_test.go
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package debug
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/request-trace-uploader/backend"
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/request-trace-uploader/config"
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/request-trace-uploader/segment"
+)
+
+func writeSegment(t *testing.T, lines ...string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	for _, line := range lines {
+		if _, err := gz.Write([]byte(line + "\n")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "request-trace.000000.jsonl.gz")
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestRegisteredUnderDebugBackend(t *testing.T) {
+	client, err := backend.New(config.Config{Backend: config.BackendDebug})
+	if err != nil {
+		t.Fatalf("New() error = %v, want the debug backend to be registered", err)
+	}
+	if client == nil {
+		t.Fatal("New() returned a nil client")
+	}
+}
+
+func TestSubmitReadsSegmentAndReportsSuccess(t *testing.T) {
+	path := writeSegment(t,
+		`{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":1,"request":{"request_id":"req-1"}}`,
+		`{"schema":"dynamo.request.trace.v1","event_type":"request_payload","event_time_unix_ms":2,"payload":{"request_id":"req-1","payload_complete":true,"http_request_headers":{"nvcf-ncaid":"acme"}}}`,
+		`{not valid json`,
+	)
+
+	client := &Client{}
+	id, err := client.Submit(context.Background(), backend.SubmitRequest{
+		Segment: segment.Segment{Index: 7, Path: path},
+		Path:    path,
+	})
+	if err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+	if id == "" {
+		t.Fatal("Submit() returned an empty id")
+	}
+
+	status, err := client.Status(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if status != backend.StatusSuccess {
+		t.Errorf("Status() = %v, want success", status)
+	}
+}
+
+func TestSubmitDoesNotDeleteTheSource(t *testing.T) {
+	path := writeSegment(t,
+		`{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":1,"request":{"request_id":"req-1"}}`,
+	)
+
+	client := &Client{}
+	if _, err := client.Submit(context.Background(), backend.SubmitRequest{
+		Segment: segment.Segment{Index: 0, Path: path},
+		Path:    path,
+	}); err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("source segment was removed: %v", err)
+	}
+}
+
+func TestSubmitFailsOnAMissingSegment(t *testing.T) {
+	client := &Client{}
+	_, err := client.Submit(context.Background(), backend.SubmitRequest{
+		Segment: segment.Segment{Index: 0, Path: "/nonexistent/request-trace.000000.jsonl.gz"},
+		Path:    "/nonexistent/request-trace.000000.jsonl.gz",
+	})
+	if err == nil {
+		t.Fatal("Submit() error = nil, want an open failure")
+	}
+}

--- a/src/compute-plane-services/request-trace-uploader/backend/debug/debug_test.go
+++ b/src/compute-plane-services/request-trace-uploader/backend/debug/debug_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -98,5 +99,40 @@ func TestSubmitFailsOnAMissingSegment(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("Submit() error = nil, want an open failure")
+	}
+}
+
+func TestSubmitStopsOnCancellation(t *testing.T) {
+	path := writeSegment(t,
+		`{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":1,"request":{"request_id":"a"}}`,
+		`{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":2,"request":{"request_id":"b"}}`,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	client := &Client{}
+	_, err := client.Submit(ctx, backend.SubmitRequest{
+		Segment: segment.Segment{Index: 0, Path: path},
+		Path:    path,
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Submit() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestSubmitOnAnEmptySegmentSucceeds(t *testing.T) {
+	path := writeSegment(t)
+
+	client := &Client{}
+	id, err := client.Submit(context.Background(), backend.SubmitRequest{
+		Segment: segment.Segment{Index: 3, Path: path},
+		Path:    path,
+	})
+	if err != nil {
+		t.Fatalf("Submit() error = %v, want an empty segment to be accepted", err)
+	}
+	if id == "" {
+		t.Fatal("Submit() returned an empty id")
 	}
 }

--- a/src/compute-plane-services/request-trace-uploader/cmd/BUILD.bazel
+++ b/src/compute-plane-services/request-trace-uploader/cmd/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//src/compute-plane-services/request-trace-uploader/backend",
+        "//src/compute-plane-services/request-trace-uploader/backend/debug",
         "//src/compute-plane-services/request-trace-uploader/config",
         "//src/compute-plane-services/request-trace-uploader/service",
     ],

--- a/src/compute-plane-services/request-trace-uploader/cmd/main.go
+++ b/src/compute-plane-services/request-trace-uploader/cmd/main.go
@@ -4,9 +4,12 @@
 // request-trace-uploader validates and discovers Dynamo request-trace segments.
 //
 // Backends register themselves from an init function, so a build links only
-// the backends it imports. This binary links none, which is what the -oss
-// image ships. A distribution that needs a backend imports it in its own main
-// and reuses the packages here.
+// the backends it imports. This binary links the debug backend, which reports
+// what it read and exports nothing. That makes the binary runnable against a
+// real Dynamo with no credentials and no destination.
+//
+// It links no exporting backend. A distribution that needs one imports it in
+// its own main and reuses the packages here.
 package main
 
 import (
@@ -20,6 +23,8 @@ import (
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/request-trace-uploader/backend"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/request-trace-uploader/config"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/request-trace-uploader/service"
+
+	_ "github.com/NVIDIA/nvcf/src/compute-plane-services/request-trace-uploader/backend/debug"
 )
 
 func main() {

--- a/src/compute-plane-services/request-trace-uploader/config/config.go
+++ b/src/compute-plane-services/request-trace-uploader/config/config.go
@@ -52,6 +52,10 @@ type Backend string
 const (
 	BackendObjectStore Backend = "objectstore"
 	BackendKratos      Backend = "kratos"
+	// BackendDebug reads and reports segments without exporting them. It
+	// exists so the read path can be exercised against a real Dynamo without
+	// credentials or a destination.
+	BackendDebug Backend = "debug"
 )
 
 // LookupFunc obtains one environment setting.
@@ -223,10 +227,10 @@ func backendValue(lookup LookupFunc, name string) (Backend, error) {
 		return "", fmt.Errorf("%s is required", name)
 	}
 	switch Backend(value) {
-	case BackendObjectStore, BackendKratos:
+	case BackendObjectStore, BackendKratos, BackendDebug:
 		return Backend(value), nil
 	default:
-		return "", fmt.Errorf("%s must be %q or %q", name, BackendObjectStore, BackendKratos)
+		return "", fmt.Errorf("%s must be one of %q, %q, or %q", name, BackendObjectStore, BackendKratos, BackendDebug)
 	}
 }
 

--- a/src/compute-plane-services/request-trace-uploader/record/BUILD.bazel
+++ b/src/compute-plane-services/request-trace-uploader/record/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "record",
+    srcs = [
+        "reader.go",
+        "record.go",
+    ],
+    importpath = "github.com/NVIDIA/nvcf/src/compute-plane-services/request-trace-uploader/record",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":record",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "record_test",
+    srcs = ["reader_test.go"],
+    embed = [":record"],
+)

--- a/src/compute-plane-services/request-trace-uploader/record/reader.go
+++ b/src/compute-plane-services/request-trace-uploader/record/reader.go
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package record
+
+import (
+	"bufio"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// ErrLegacyAuditRecord reports a Dynamo v1.3.x AuditRecord. That type was
+// removed in v1.4.0, and its shape differs enough that parsing it as a request
+// trace record would silently produce empty fields rather than fail.
+var ErrLegacyAuditRecord = errors.New("record: Dynamo v1.3.x AuditRecord found, minimum supported version is v1.4.0")
+
+// Stats summarizes one pass over a segment.
+type Stats struct {
+	Records     int
+	Unparseable int
+	ByEventType map[EventType]int
+	Unknown     int
+	Bytes       int64
+}
+
+// Reader streams records out of a gzipped JSON-lines segment.
+//
+// It never holds more than one record in memory, so segment size does not
+// bound memory. A record that fails to parse is reported through Err and
+// skipped; it does not end the scan, because one malformed line must not
+// discard the other records in a segment.
+type Reader struct {
+	file    *os.File
+	gz      *gzip.Reader
+	scan    *bufio.Scanner
+	current *Record
+	err     error
+	line    int
+	stats   Stats
+}
+
+// maxLineBytes bounds a single record. Payload records carry entire request
+// and response bodies, so the default scanner limit is far too small.
+const maxLineBytes = 64 << 20
+
+// Open starts reading the segment at path.
+func Open(path string) (*Reader, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open segment: %w", err)
+	}
+	gz, err := gzip.NewReader(file)
+	if err != nil {
+		file.Close()
+		return nil, fmt.Errorf("read segment gzip header: %w", err)
+	}
+	// Dynamo appends gzip members as it rolls, so a segment is a concatenated
+	// stream rather than a single member.
+	gz.Multistream(true)
+
+	scan := bufio.NewScanner(gz)
+	scan.Buffer(make([]byte, 0, 64<<10), maxLineBytes)
+	return &Reader{
+		file:  file,
+		gz:    gz,
+		scan:  scan,
+		stats: Stats{ByEventType: map[EventType]int{}},
+	}, nil
+}
+
+// Next advances to the next record, reporting whether one was read.
+func (r *Reader) Next() bool {
+	for r.scan.Scan() {
+		r.line++
+		line := r.scan.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		rec, err := parseLine(line)
+		if err != nil {
+			if errors.Is(err, ErrLegacyAuditRecord) {
+				r.err = fmt.Errorf("line %d: %w", r.line, err)
+				return false
+			}
+			r.stats.Unparseable++
+			continue
+		}
+
+		r.stats.Records++
+		r.stats.Bytes += int64(len(line))
+		r.stats.ByEventType[rec.EventType]++
+		if !rec.EventType.Known() {
+			r.stats.Unknown++
+		}
+		r.current = rec
+		return true
+	}
+	if err := r.scan.Err(); err != nil && !errors.Is(err, io.EOF) {
+		r.err = fmt.Errorf("scan segment: %w", err)
+	}
+	return false
+}
+
+// Record returns the record read by the last successful Next.
+func (r *Reader) Record() *Record { return r.current }
+
+// Stats returns the running totals for this pass.
+func (r *Reader) Stats() Stats { return r.stats }
+
+// Err returns the error that ended the scan, if any. A scan that ended at the
+// end of the segment returns nil. Unparseable records are counted in Stats
+// rather than reported here.
+func (r *Reader) Err() error { return r.err }
+
+// Close releases the segment.
+func (r *Reader) Close() error {
+	gzErr := r.gz.Close()
+	fileErr := r.file.Close()
+	if gzErr != nil {
+		return fmt.Errorf("close segment gzip: %w", gzErr)
+	}
+	if fileErr != nil {
+		return fmt.Errorf("close segment: %w", fileErr)
+	}
+	return nil
+}
+
+// envelope is the timestamp-wrapped form some Dynamo sinks emit. The file sink
+// writes bare records, so both shapes have to parse.
+type envelope struct {
+	Timestamp *uint64         `json:"timestamp"`
+	Event     json.RawMessage `json:"event"`
+}
+
+// legacyAudit is the Dynamo v1.3.x AuditRecord. It is detected, never parsed.
+// It has schema_version rather than schema, and no event_type at all.
+type legacyAudit struct {
+	SchemaVersion *uint32 `json:"schema_version"`
+	EventType     *string `json:"event_type"`
+}
+
+func parseLine(line []byte) (*Record, error) {
+	body := line
+
+	var env envelope
+	if err := json.Unmarshal(line, &env); err == nil && len(env.Event) > 0 {
+		body = env.Event
+	}
+
+	var legacy legacyAudit
+	if err := json.Unmarshal(body, &legacy); err == nil {
+		if legacy.SchemaVersion != nil && legacy.EventType == nil {
+			return nil, ErrLegacyAuditRecord
+		}
+	}
+
+	var rec Record
+	if err := json.Unmarshal(body, &rec); err != nil {
+		return nil, fmt.Errorf("parse record: %w", err)
+	}
+	if rec.EventType == "" {
+		return nil, errors.New("parse record: no event_type")
+	}
+
+	rec.Raw = append([]byte(nil), body...)
+	return &rec, nil
+}

--- a/src/compute-plane-services/request-trace-uploader/record/reader.go
+++ b/src/compute-plane-services/request-trace-uploader/record/reader.go
@@ -5,6 +5,7 @@ package record
 
 import (
 	"bufio"
+	"bytes"
 	"compress/gzip"
 	"encoding/json"
 	"errors"
@@ -22,6 +23,7 @@ var ErrLegacyAuditRecord = errors.New("record: Dynamo v1.3.x AuditRecord found, 
 type Stats struct {
 	Records     int
 	Unparseable int
+	Oversized   int
 	ByEventType map[EventType]int
 	Unknown     int
 	Bytes       int64
@@ -30,13 +32,13 @@ type Stats struct {
 // Reader streams records out of a gzipped JSON-lines segment.
 //
 // It never holds more than one record in memory, so segment size does not
-// bound memory. A record that fails to parse is reported through Err and
-// skipped; it does not end the scan, because one malformed line must not
-// discard the other records in a segment.
+// bound memory. A record that fails to parse, including one that exceeds the
+// size bound, is counted and skipped; it does not end the scan, because one
+// bad line must not discard the other records in a segment.
 type Reader struct {
 	file    *os.File
 	gz      *gzip.Reader
-	scan    *bufio.Scanner
+	buf     *bufio.Reader
 	current *Record
 	err     error
 	line    int
@@ -62,21 +64,76 @@ func Open(path string) (*Reader, error) {
 	// stream rather than a single member.
 	gz.Multistream(true)
 
-	scan := bufio.NewScanner(gz)
-	scan.Buffer(make([]byte, 0, 64<<10), maxLineBytes)
 	return &Reader{
 		file:  file,
 		gz:    gz,
-		scan:  scan,
+		buf:   bufio.NewReaderSize(gz, 64<<10),
 		stats: Stats{ByEventType: map[EventType]int{}},
 	}, nil
 }
 
+// readLine returns the next line with its terminator stripped.
+//
+// A line longer than maxLineBytes is drained to its newline and reported as
+// oversized, so the reader resumes at the following record instead of stopping
+// at the first one it cannot hold. bufio.Scanner cannot do this: it fails
+// permanently once a token exceeds its buffer.
+func (r *Reader) readLine() (line []byte, oversized bool, err error) {
+	var acc []byte
+	for {
+		chunk, chunkErr := r.buf.ReadSlice('\n')
+		if errors.Is(chunkErr, bufio.ErrBufferFull) {
+			if len(acc)+len(chunk) > maxLineBytes {
+				oversized = true
+				acc = nil
+				// Keep draining until the newline so the next read starts on a
+				// record boundary.
+				continue
+			}
+			acc = append(acc, chunk...)
+			continue
+		}
+		if chunkErr != nil {
+			if len(acc) == 0 && len(chunk) == 0 {
+				return nil, oversized, chunkErr
+			}
+			if !oversized {
+				acc = append(acc, chunk...)
+			}
+			return trimEOL(acc), oversized, nil
+		}
+		if oversized {
+			return nil, true, nil
+		}
+		if len(acc)+len(chunk) > maxLineBytes {
+			return nil, true, nil
+		}
+		acc = append(acc, chunk...)
+		return trimEOL(acc), false, nil
+	}
+}
+
+func trimEOL(line []byte) []byte {
+	line = bytes.TrimSuffix(line, []byte("\n"))
+	return bytes.TrimSuffix(line, []byte("\r"))
+}
+
 // Next advances to the next record, reporting whether one was read.
 func (r *Reader) Next() bool {
-	for r.scan.Scan() {
+	for {
+		line, oversized, err := r.readLine()
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				r.err = fmt.Errorf("read segment: %w", err)
+			}
+			return false
+		}
 		r.line++
-		line := r.scan.Bytes()
+		if oversized {
+			r.stats.Unparseable++
+			r.stats.Oversized++
+			continue
+		}
 		if len(line) == 0 {
 			continue
 		}
@@ -100,10 +157,6 @@ func (r *Reader) Next() bool {
 		r.current = rec
 		return true
 	}
-	if err := r.scan.Err(); err != nil && !errors.Is(err, io.EOF) {
-		r.err = fmt.Errorf("scan segment: %w", err)
-	}
-	return false
 }
 
 // Record returns the record read by the last successful Next.

--- a/src/compute-plane-services/request-trace-uploader/record/reader_test.go
+++ b/src/compute-plane-services/request-trace-uploader/record/reader_test.go
@@ -173,8 +173,12 @@ func TestConcatenatedGzipMembersAreRead(t *testing.T) {
 		`{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":2,"request":{"request_id":"b"}}`,
 	} {
 		gz := gzip.NewWriter(&buf)
-		gz.Write([]byte(line + "\n"))
-		gz.Close()
+		if _, err := gz.Write([]byte(line + "\n")); err != nil {
+			t.Fatalf("write gzip member: %v", err)
+		}
+		if err := gz.Close(); err != nil {
+			t.Fatalf("close gzip member: %v", err)
+		}
 	}
 	path := filepath.Join(t.TempDir(), "request-trace.000000.jsonl.gz")
 	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
@@ -220,8 +224,12 @@ func TestOversizedLineDoesNotStopTheScan(t *testing.T) {
 func TestSegmentWithNoTrailingNewlineIsRead(t *testing.T) {
 	var buf bytes.Buffer
 	gz := gzip.NewWriter(&buf)
-	gz.Write([]byte(`{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":1,"request":{"request_id":"last"}}`))
-	gz.Close()
+	if _, err := gz.Write([]byte(`{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":1,"request":{"request_id":"last"}}`)); err != nil {
+		t.Fatalf("write gzip member: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip member: %v", err)
+	}
 	path := filepath.Join(t.TempDir(), "request-trace.000000.jsonl.gz")
 	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
 		t.Fatal(err)

--- a/src/compute-plane-services/request-trace-uploader/record/reader_test.go
+++ b/src/compute-plane-services/request-trace-uploader/record/reader_test.go
@@ -1,0 +1,191 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package record
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeSegment(t *testing.T, lines ...string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	for _, line := range lines {
+		if _, err := gz.Write([]byte(line + "\n")); err != nil {
+			t.Fatalf("write line: %v", err)
+		}
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "request-trace.000000.jsonl.gz")
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatalf("write segment: %v", err)
+	}
+	return path
+}
+
+func readAll(t *testing.T, path string) ([]*Record, Stats, error) {
+	t.Helper()
+	reader, err := Open(path)
+	if err != nil {
+		return nil, Stats{}, err
+	}
+	defer reader.Close()
+
+	var records []*Record
+	for reader.Next() {
+		records = append(records, reader.Record())
+	}
+	return records, reader.Stats(), reader.Err()
+}
+
+func TestReadsEveryEventType(t *testing.T) {
+	path := writeSegment(t,
+		`{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":1,"request":{"request_id":"req-1","model":"m"}}`,
+		`{"schema":"dynamo.request.trace.v1","event_type":"request_payload","event_time_unix_ms":2,"payload":{"request_id":"req-1","endpoint":"openai.chat_completion","payload_complete":true,"http_request_headers":{"nvcf-ncaid":"acme"}}}`,
+		`{"schema":"dynamo.request.trace.v1","event_type":"tool_start","event_time_unix_ms":3,"agent_context":{"session_id":"sess-1"},"tool":{"tool_call_id":"t-1","tool_class":"search"}}`,
+		`{"schema":"dynamo.request.trace.v1","event_type":"tool_end","event_time_unix_ms":4,"agent_context":{"session_id":"sess-1"},"tool":{"tool_call_id":"t-1","tool_class":"search"}}`,
+		`{"schema":"dynamo.request.trace.v1","event_type":"tool_error","event_time_unix_ms":5,"agent_context":{"session_id":"sess-1"},"tool":{"tool_call_id":"t-2","tool_class":"search","error_type":"timeout"}}`,
+	)
+
+	records, stats, err := readAll(t, path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(records) != 5 || stats.Records != 5 {
+		t.Fatalf("records = %d, stats = %+v, want 5", len(records), stats)
+	}
+	for _, want := range []EventType{EventRequestEnd, EventRequestPayload, EventToolStart, EventToolEnd, EventToolError} {
+		if stats.ByEventType[want] != 1 {
+			t.Errorf("event type %q count = %d, want 1", want, stats.ByEventType[want])
+		}
+	}
+	if stats.Unknown != 0 || stats.Unparseable != 0 {
+		t.Errorf("unknown = %d, unparseable = %d, want 0", stats.Unknown, stats.Unparseable)
+	}
+}
+
+func TestRequestIDResolvesPerRecordType(t *testing.T) {
+	path := writeSegment(t,
+		`{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":1,"request":{"request_id":"from-request"}}`,
+		`{"schema":"dynamo.request.trace.v1","event_type":"request_payload","event_time_unix_ms":2,"payload":{"request_id":"from-payload","payload_complete":true}}`,
+		`{"schema":"dynamo.request.trace.v1","event_type":"tool_end","event_time_unix_ms":3,"agent_context":{"session_id":"sess-9"},"tool":{"tool_call_id":"t","tool_class":"c"}}`,
+	)
+
+	records, _, err := readAll(t, path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	if id, ok := records[0].RequestID(); !ok || id != "from-request" {
+		t.Errorf("request_end id = %q ok = %v, want from-request true", id, ok)
+	}
+	if id, ok := records[1].RequestID(); !ok || id != "from-payload" {
+		t.Errorf("request_payload id = %q ok = %v, want from-payload true", id, ok)
+	}
+	if _, ok := records[2].RequestID(); ok {
+		t.Error("tool_end reported a request id, want none")
+	}
+	if id, ok := records[2].SessionID(); !ok || id != "sess-9" {
+		t.Errorf("tool_end session = %q ok = %v, want sess-9 true", id, ok)
+	}
+}
+
+func TestOneBadLineDoesNotDiscardTheSegment(t *testing.T) {
+	path := writeSegment(t,
+		`{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":1,"request":{"request_id":"a"}}`,
+		`{"this is not valid json`,
+		`{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":2,"request":{"request_id":"b"}}`,
+	)
+
+	records, stats, err := readAll(t, path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("records = %d, want 2 good records around the bad line", len(records))
+	}
+	if stats.Unparseable != 1 {
+		t.Errorf("unparseable = %d, want 1", stats.Unparseable)
+	}
+}
+
+func TestUnknownEventTypeIsKeptAndCounted(t *testing.T) {
+	path := writeSegment(t,
+		`{"schema":"dynamo.request.trace.v1","event_type":"request_squirrel","event_time_unix_ms":1,"squirrel":{"nuts":3}}`,
+	)
+
+	records, stats, err := readAll(t, path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(records) != 1 || stats.Unknown != 1 {
+		t.Fatalf("records = %d unknown = %d, want 1 and 1", len(records), stats.Unknown)
+	}
+	if !bytes.Contains(records[0].Raw, []byte("squirrel")) {
+		t.Error("unknown record lost its original bytes")
+	}
+}
+
+func TestLegacyAuditRecordIsRejected(t *testing.T) {
+	path := writeSegment(t,
+		`{"schema_version":1,"request_id":"req-1","requested_streaming":false,"model":"m"}`,
+	)
+
+	_, _, err := readAll(t, path)
+	if !errors.Is(err, ErrLegacyAuditRecord) {
+		t.Fatalf("err = %v, want ErrLegacyAuditRecord", err)
+	}
+	if !strings.Contains(err.Error(), "v1.4.0") {
+		t.Errorf("err = %v, want it to name the minimum version", err)
+	}
+}
+
+func TestTimestampWrappedFormParses(t *testing.T) {
+	path := writeSegment(t,
+		`{"timestamp":1777312801000,"event":{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":1,"request":{"request_id":"wrapped"}}}`,
+	)
+
+	records, _, err := readAll(t, path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records = %d, want 1", len(records))
+	}
+	if id, ok := records[0].RequestID(); !ok || id != "wrapped" {
+		t.Errorf("id = %q ok = %v, want wrapped true", id, ok)
+	}
+}
+
+func TestConcatenatedGzipMembersAreRead(t *testing.T) {
+	var buf bytes.Buffer
+	for _, line := range []string{
+		`{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":1,"request":{"request_id":"a"}}`,
+		`{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":2,"request":{"request_id":"b"}}`,
+	} {
+		gz := gzip.NewWriter(&buf)
+		gz.Write([]byte(line + "\n"))
+		gz.Close()
+	}
+	path := filepath.Join(t.TempDir(), "request-trace.000000.jsonl.gz")
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	records, _, err := readAll(t, path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("records = %d, want 2 across concatenated members", len(records))
+	}
+}

--- a/src/compute-plane-services/request-trace-uploader/record/reader_test.go
+++ b/src/compute-plane-services/request-trace-uploader/record/reader_test.go
@@ -189,3 +189,49 @@ func TestConcatenatedGzipMembersAreRead(t *testing.T) {
 		t.Fatalf("records = %d, want 2 across concatenated members", len(records))
 	}
 }
+
+func TestOversizedLineDoesNotStopTheScan(t *testing.T) {
+	huge := `{"schema":"dynamo.request.trace.v1","event_type":"request_payload","event_time_unix_ms":1,"payload":{"request_id":"huge","payload_complete":true,"pad":"` +
+		strings.Repeat("x", maxLineBytes+1024) + `"}}`
+
+	path := writeSegment(t,
+		`{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":1,"request":{"request_id":"before"}}`,
+		huge,
+		`{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":2,"request":{"request_id":"after"}}`,
+	)
+
+	records, stats, err := readAll(t, path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("records = %d, want the records either side of the oversized line", len(records))
+	}
+	first, _ := records[0].RequestID()
+	second, _ := records[1].RequestID()
+	if first != "before" || second != "after" {
+		t.Errorf("ids = %q %q, want before after", first, second)
+	}
+	if stats.Oversized != 1 || stats.Unparseable != 1 {
+		t.Errorf("oversized = %d unparseable = %d, want 1 and 1", stats.Oversized, stats.Unparseable)
+	}
+}
+
+func TestSegmentWithNoTrailingNewlineIsRead(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	gz.Write([]byte(`{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":1,"request":{"request_id":"last"}}`))
+	gz.Close()
+	path := filepath.Join(t.TempDir(), "request-trace.000000.jsonl.gz")
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	records, _, err := readAll(t, path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records = %d, want the final unterminated record", len(records))
+	}
+}

--- a/src/compute-plane-services/request-trace-uploader/record/record.go
+++ b/src/compute-plane-services/request-trace-uploader/record/record.go
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package record models the Dynamo v1.4.0 request trace format.
+//
+// Dynamo v1.4.0 writes every record type to one segment family as gzipped
+// JSON lines. A record is classified by its event_type, never by the file it
+// came from. Dynamo v1.3.x additionally emitted a separate AuditRecord type to
+// its own family; that format is detected and rejected rather than parsed.
+package record
+
+import "encoding/json"
+
+// Schema is the only schema string Dynamo emits for request traces. It is
+// unchanged between v1.3.x and v1.4.0, so it cannot be used to tell the
+// versions apart.
+const Schema = "dynamo.request.trace.v1"
+
+// EventType classifies a record. Only these five exist in v1.4.0.
+type EventType string
+
+const (
+	EventRequestEnd     EventType = "request_end"
+	EventRequestPayload EventType = "request_payload"
+	EventToolStart      EventType = "tool_start"
+	EventToolEnd        EventType = "tool_end"
+	EventToolError      EventType = "tool_error"
+)
+
+// Known reports whether the event type is one this build understands.
+// Unrecognized types are still exported, so this only drives counting.
+func (e EventType) Known() bool {
+	switch e {
+	case EventRequestEnd, EventRequestPayload, EventToolStart, EventToolEnd, EventToolError:
+		return true
+	}
+	return false
+}
+
+// Record is one Dynamo request trace record.
+//
+// Raw holds the original bytes. Everything the uploader exports is derived
+// from Raw rather than re-serialized, so a record survives a round trip even
+// if it carries fields this build does not model.
+type Record struct {
+	Schema    string          `json:"schema"`
+	EventType EventType       `json:"event_type"`
+	TimeMS    uint64          `json:"event_time_unix_ms"`
+	Source    string          `json:"event_source,omitempty"`
+	Agent     *AgentContext   `json:"agent_context,omitempty"`
+	Request   *RequestMetrics `json:"request,omitempty"`
+	Tool      *ToolEvent      `json:"tool,omitempty"`
+	Payload   *Payload        `json:"payload,omitempty"`
+
+	Raw []byte `json:"-"`
+}
+
+// AgentContext carries session identity for harness-sourced records.
+type AgentContext struct {
+	SessionID       string `json:"session_id"`
+	ParentSessionID string `json:"parent_session_id,omitempty"`
+}
+
+// RequestMetrics is the metadata on a request_end record. It carries no
+// request or response body.
+type RequestMetrics struct {
+	RequestID    string   `json:"request_id"`
+	XRequestID   string   `json:"x_request_id,omitempty"`
+	Model        string   `json:"model,omitempty"`
+	InputTokens  *uint64  `json:"input_tokens,omitempty"`
+	OutputTokens *uint64  `json:"output_tokens,omitempty"`
+	CachedTokens *uint64  `json:"cached_tokens,omitempty"`
+	TTFTMS       *float64 `json:"ttft_ms,omitempty"`
+	TotalTimeMS  *float64 `json:"total_time_ms,omitempty"`
+	QueueDepth   *uint64  `json:"queue_depth,omitempty"`
+}
+
+// ToolEvent is the metadata on a tool_start, tool_end, or tool_error record.
+// It carries no request identifier, so tool records correlate by session.
+type ToolEvent struct {
+	ToolCallID string   `json:"tool_call_id"`
+	ToolClass  string   `json:"tool_class"`
+	Status     string   `json:"status,omitempty"`
+	DurationMS *float64 `json:"duration_ms,omitempty"`
+	ErrorType  string   `json:"error_type,omitempty"`
+}
+
+// Payload is the request and response content on a request_payload record.
+// This is the only record type that carries bodies or headers.
+type Payload struct {
+	RequestID          string            `json:"request_id"`
+	Endpoint           string            `json:"endpoint,omitempty"`
+	Model              string            `json:"model,omitempty"`
+	Request            json.RawMessage   `json:"request,omitempty"`
+	Response           json.RawMessage   `json:"response,omitempty"`
+	HTTPRequestHeaders map[string]string `json:"http_request_headers,omitempty"`
+	Complete           bool              `json:"payload_complete"`
+	DropReason         string            `json:"payload_drop_reason,omitempty"`
+}
+
+// RequestID returns the record's request identifier and whether it has one.
+//
+// The location differs by record type: request_end nests it under request,
+// request_payload nests it under payload, and tool records carry none.
+func (r *Record) RequestID() (string, bool) {
+	if r.Payload != nil && r.Payload.RequestID != "" {
+		return r.Payload.RequestID, true
+	}
+	if r.Request != nil && r.Request.RequestID != "" {
+		return r.Request.RequestID, true
+	}
+	return "", false
+}
+
+// SessionID returns the record's session identifier and whether it has one.
+func (r *Record) SessionID() (string, bool) {
+	if r.Agent != nil && r.Agent.SessionID != "" {
+		return r.Agent.SessionID, true
+	}
+	return "", false
+}
+
+// Headers returns the record's captured HTTP headers. Only request_payload
+// records carry them, and only those named in Dynamo's capture allowlist.
+func (r *Record) Headers() map[string]string {
+	if r.Payload == nil {
+		return nil
+	}
+	return r.Payload.HTTPRequestHeaders
+}

--- a/src/compute-plane-services/request-trace-uploader/service/BUILD.bazel
+++ b/src/compute-plane-services/request-trace-uploader/service/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/NVIDIA/nvcf/src/compute-plane-services/request-trace-uploader/service",
     visibility = ["//visibility:public"],
     deps = [
+        "//src/compute-plane-services/request-trace-uploader/backend",
         "//src/compute-plane-services/request-trace-uploader/config",
         "//src/compute-plane-services/request-trace-uploader/internal/health",
         "//src/compute-plane-services/request-trace-uploader/segment",
@@ -16,7 +17,10 @@ go_test(
     name = "service_test",
     srcs = ["service_test.go"],
     embed = [":service"],
-    deps = ["//src/compute-plane-services/request-trace-uploader/config"],
+    deps = [
+        "//src/compute-plane-services/request-trace-uploader/backend",
+        "//src/compute-plane-services/request-trace-uploader/config",
+    ],
 )
 
 alias(

--- a/src/compute-plane-services/request-trace-uploader/service/service.go
+++ b/src/compute-plane-services/request-trace-uploader/service/service.go
@@ -12,6 +12,9 @@ import (
 	"os"
 	"time"
 
+	"log/slog"
+
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/request-trace-uploader/backend"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/request-trace-uploader/config"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/request-trace-uploader/internal/health"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/request-trace-uploader/segment"
@@ -20,16 +23,30 @@ import (
 // Service owns local readiness checks and the sidecar HTTP server. It
 // intentionally does not submit or delete request-trace segments.
 type Service struct {
-	config config.Config
-	health *health.Handler
+	config  config.Config
+	health  *health.Handler
+	backend backend.Client
 }
 
-// New creates a request-trace uploader service.
+// New creates a request-trace uploader service using the configured backend.
+// That backend must be linked into the build; see backend.Register.
 func New(cfg config.Config) (*Service, error) {
+	client, err := backend.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return NewWithBackend(cfg, client), nil
+}
+
+// NewWithBackend creates a service around an already-built backend. It exists
+// so a caller that constructs its own backend, including a test, does not have
+// to go through the registry.
+func NewWithBackend(cfg config.Config, client backend.Client) *Service {
 	return &Service{
-		config: cfg,
-		health: health.New(),
-	}, nil
+		config:  cfg,
+		health:  health.New(),
+		backend: client,
+	}
 }
 
 // Handler returns the service HTTP handler.
@@ -62,12 +79,43 @@ func (s *Service) Initialize() error {
 	return nil
 }
 
-// Refresh verifies that local request-trace segment discovery succeeds without
-// changing source files.
+// Refresh submits every closed segment to the backend.
+//
+// Sources are never deleted here. Deletion waits on durable lifecycle state and
+// confirmed terminal success, which is a later increment. A segment that fails
+// is logged and left in place, so the next scan retries it.
 func (s *Service) Refresh() error {
-	if _, err := segment.Discover(s.config.SourceDir, s.config.SegmentPrefix); err != nil {
+	segments, err := segment.Discover(s.config.SourceDir, s.config.SegmentPrefix)
+	if err != nil {
 		return fmt.Errorf("discover request trace segments: %w", err)
 	}
+	for _, item := range segments {
+		if err := s.submit(item); err != nil {
+			slog.Error("submit request trace segment",
+				"segment", item.Index,
+				"bytes", item.Size,
+				"error", err)
+		}
+	}
+	return nil
+}
+
+func (s *Service) submit(item segment.Segment) error {
+	id, err := s.backend.Submit(context.Background(), backend.SubmitRequest{
+		Segment: item,
+		Path:    item.Path,
+	})
+	if err != nil {
+		return err
+	}
+	status, err := s.backend.Status(context.Background(), id)
+	if err != nil {
+		return fmt.Errorf("read status: %w", err)
+	}
+	slog.Info("submitted request trace segment",
+		"segment", item.Index,
+		"bytes", item.Size,
+		"status", status)
 	return nil
 }
 

--- a/src/compute-plane-services/request-trace-uploader/service/service.go
+++ b/src/compute-plane-services/request-trace-uploader/service/service.go
@@ -59,7 +59,10 @@ func (s *Service) Handler() http.Handler {
 
 // Initialize performs local, non-destructive startup checks. Remote
 // reachability and backlog state do not affect readiness.
-func (s *Service) Initialize() error {
+//
+// It takes a context so a shutdown during startup stops the first scan rather
+// than waiting for it.
+func (s *Service) Initialize(ctx context.Context) error {
 	for _, directory := range []string{s.config.StateDir, s.config.QuarantineDir} {
 		if err := os.MkdirAll(directory, 0o750); err != nil {
 			return fmt.Errorf("create uploader directory: %w", err)
@@ -72,7 +75,7 @@ func (s *Service) Initialize() error {
 	if err := secret.Close(); err != nil {
 		return fmt.Errorf("close uploader secret file: %w", err)
 	}
-	if err := s.Refresh(context.Background()); err != nil {
+	if err := s.Refresh(ctx); err != nil {
 		return fmt.Errorf("refresh local segment state: %w", err)
 	}
 	s.health.SetReady(true)
@@ -124,7 +127,7 @@ func (s *Service) submit(ctx context.Context, item segment.Segment) error {
 
 // Run starts the HTTP server and periodically refreshes local discovery.
 func (s *Service) Run(ctx context.Context) error {
-	if err := s.Initialize(); err != nil {
+	if err := s.Initialize(ctx); err != nil {
 		return fmt.Errorf("initialize request-trace uploader: %w", err)
 	}
 	server := s.httpServer()

--- a/src/compute-plane-services/request-trace-uploader/service/service.go
+++ b/src/compute-plane-services/request-trace-uploader/service/service.go
@@ -33,7 +33,7 @@ type Service struct {
 func New(cfg config.Config) (*Service, error) {
 	client, err := backend.New(cfg)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("build backend for request trace uploader: %w", err)
 	}
 	return NewWithBackend(cfg, client), nil
 }
@@ -72,7 +72,7 @@ func (s *Service) Initialize() error {
 	if err := secret.Close(); err != nil {
 		return fmt.Errorf("close uploader secret file: %w", err)
 	}
-	if err := s.Refresh(); err != nil {
+	if err := s.Refresh(context.Background()); err != nil {
 		return fmt.Errorf("refresh local segment state: %w", err)
 	}
 	s.health.SetReady(true)
@@ -84,13 +84,16 @@ func (s *Service) Initialize() error {
 // Sources are never deleted here. Deletion waits on durable lifecycle state and
 // confirmed terminal success, which is a later increment. A segment that fails
 // is logged and left in place, so the next scan retries it.
-func (s *Service) Refresh() error {
+func (s *Service) Refresh(ctx context.Context) error {
 	segments, err := segment.Discover(s.config.SourceDir, s.config.SegmentPrefix)
 	if err != nil {
 		return fmt.Errorf("discover request trace segments: %w", err)
 	}
 	for _, item := range segments {
-		if err := s.submit(item); err != nil {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("stop scanning request trace segments: %w", err)
+		}
+		if err := s.submit(ctx, item); err != nil {
 			slog.Error("submit request trace segment",
 				"segment", item.Index,
 				"bytes", item.Size,
@@ -100,17 +103,17 @@ func (s *Service) Refresh() error {
 	return nil
 }
 
-func (s *Service) submit(item segment.Segment) error {
-	id, err := s.backend.Submit(context.Background(), backend.SubmitRequest{
+func (s *Service) submit(ctx context.Context, item segment.Segment) error {
+	id, err := s.backend.Submit(ctx, backend.SubmitRequest{
 		Segment: item,
 		Path:    item.Path,
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("submit segment to backend: %w", err)
 	}
-	status, err := s.backend.Status(context.Background(), id)
+	status, err := s.backend.Status(ctx, id)
 	if err != nil {
-		return fmt.Errorf("read status: %w", err)
+		return fmt.Errorf("read backend status: %w", err)
 	}
 	slog.Info("submitted request trace segment",
 		"segment", item.Index,
@@ -146,7 +149,7 @@ func (s *Service) Run(ctx context.Context) error {
 		case err := <-errs:
 			return fmt.Errorf("serve uploader HTTP endpoints: %w", err)
 		case <-ticker.C:
-			if err := s.Refresh(); err != nil {
+			if err := s.Refresh(ctx); err != nil {
 				return fmt.Errorf("refresh request trace segments: %w", err)
 			}
 		}

--- a/src/compute-plane-services/request-trace-uploader/service/service_test.go
+++ b/src/compute-plane-services/request-trace-uploader/service/service_test.go
@@ -41,7 +41,7 @@ func TestInitializeReadinessAndDiscovery(t *testing.T) {
 		ScanInterval:  config.DefaultScanInterval,
 	}
 	svc := NewWithBackend(cfg, &stubBackend{})
-	if err := svc.Initialize(); err != nil {
+	if err := svc.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
 	for path, want := range map[string]int{
@@ -89,7 +89,7 @@ func TestInitializeRejectsUnreadableSecret(t *testing.T) {
 		StateDir:      filepath.Join(root, "state"),
 		QuarantineDir: filepath.Join(root, "quarantine"),
 	}, &stubBackend{})
-	if err := svc.Initialize(); err == nil {
+	if err := svc.Initialize(context.Background()); err == nil {
 		t.Fatal("Initialize() error = nil, want error")
 	}
 }
@@ -177,6 +177,41 @@ func TestRefreshStopsOnCancellation(t *testing.T) {
 	err := svc.Refresh(ctx)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Refresh() error = %v, want context.Canceled", err)
+	}
+	if len(stub.submitted) != 0 {
+		t.Errorf("submitted = %v, want nothing after cancellation", stub.submitted)
+	}
+}
+
+func TestInitializeStopsOnCancellation(t *testing.T) {
+	root := t.TempDir()
+	secretsFile := filepath.Join(root, "secrets.json")
+	if err := os.WriteFile(secretsFile, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{
+		"request-trace.000000.jsonl.gz",
+		"request-trace.000001.jsonl.gz",
+	} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte("fixture"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stub := &stubBackend{}
+	svc := NewWithBackend(config.Config{
+		SourceDir:     root,
+		SegmentPrefix: "request-trace",
+		SecretsFile:   secretsFile,
+		StateDir:      filepath.Join(root, "state"),
+		QuarantineDir: filepath.Join(root, "quarantine"),
+	}, stub)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := svc.Initialize(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Initialize() error = %v, want context.Canceled", err)
 	}
 	if len(stub.submitted) != 0 {
 		t.Errorf("submitted = %v, want nothing after cancellation", stub.submitted)

--- a/src/compute-plane-services/request-trace-uploader/service/service_test.go
+++ b/src/compute-plane-services/request-trace-uploader/service/service_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/request-trace-uploader/backend"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/request-trace-uploader/config"
 )
 
@@ -36,10 +37,7 @@ func TestInitializeReadinessAndDiscovery(t *testing.T) {
 		HealthAddr:    ":8011",
 		ScanInterval:  config.DefaultScanInterval,
 	}
-	svc, err := New(cfg)
-	if err != nil {
-		t.Fatalf("New() error = %v", err)
-	}
+	svc := NewWithBackend(cfg, stubBackend{})
 	if err := svc.Initialize(); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
@@ -63,10 +61,7 @@ func TestInitializeReadinessAndDiscovery(t *testing.T) {
 }
 
 func TestHTTPServerTimeouts(t *testing.T) {
-	svc, err := New(config.Config{HealthAddr: ":8011"})
-	if err != nil {
-		t.Fatalf("New() error = %v", err)
-	}
+	svc := NewWithBackend(config.Config{HealthAddr: ":8011"}, stubBackend{})
 	server := svc.httpServer()
 	if server.ReadHeaderTimeout != 5*time.Second {
 		t.Errorf("ReadHeaderTimeout = %v, want %v", server.ReadHeaderTimeout, 5*time.Second)
@@ -84,17 +79,26 @@ func TestHTTPServerTimeouts(t *testing.T) {
 
 func TestInitializeRejectsUnreadableSecret(t *testing.T) {
 	root := t.TempDir()
-	svc, err := New(config.Config{
+	svc := NewWithBackend(config.Config{
 		SourceDir:     root,
 		SegmentPrefix: "request-trace",
 		SecretsFile:   filepath.Join(root, "missing.json"),
 		StateDir:      filepath.Join(root, "state"),
 		QuarantineDir: filepath.Join(root, "quarantine"),
-	})
-	if err != nil {
-		t.Fatalf("New() error = %v", err)
-	}
+	}, stubBackend{})
 	if err := svc.Initialize(); err == nil {
 		t.Fatal("Initialize() error = nil, want error")
 	}
+}
+
+// stubBackend stands in for a real destination. The service tests cover
+// startup, readiness, and discovery, none of which submit anything.
+type stubBackend struct{}
+
+func (stubBackend) Submit(context.Context, backend.SubmitRequest) (string, error) {
+	return "stub", nil
+}
+
+func (stubBackend) Status(context.Context, string) (backend.Status, error) {
+	return backend.StatusSuccess, nil
 }

--- a/src/compute-plane-services/request-trace-uploader/service/service_test.go
+++ b/src/compute-plane-services/request-trace-uploader/service/service_test.go
@@ -5,10 +5,13 @@ package service
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -37,7 +40,7 @@ func TestInitializeReadinessAndDiscovery(t *testing.T) {
 		HealthAddr:    ":8011",
 		ScanInterval:  config.DefaultScanInterval,
 	}
-	svc := NewWithBackend(cfg, stubBackend{})
+	svc := NewWithBackend(cfg, &stubBackend{})
 	if err := svc.Initialize(); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
@@ -61,7 +64,7 @@ func TestInitializeReadinessAndDiscovery(t *testing.T) {
 }
 
 func TestHTTPServerTimeouts(t *testing.T) {
-	svc := NewWithBackend(config.Config{HealthAddr: ":8011"}, stubBackend{})
+	svc := NewWithBackend(config.Config{HealthAddr: ":8011"}, &stubBackend{})
 	server := svc.httpServer()
 	if server.ReadHeaderTimeout != 5*time.Second {
 		t.Errorf("ReadHeaderTimeout = %v, want %v", server.ReadHeaderTimeout, 5*time.Second)
@@ -85,20 +88,97 @@ func TestInitializeRejectsUnreadableSecret(t *testing.T) {
 		SecretsFile:   filepath.Join(root, "missing.json"),
 		StateDir:      filepath.Join(root, "state"),
 		QuarantineDir: filepath.Join(root, "quarantine"),
-	}, stubBackend{})
+	}, &stubBackend{})
 	if err := svc.Initialize(); err == nil {
 		t.Fatal("Initialize() error = nil, want error")
 	}
 }
 
-// stubBackend stands in for a real destination. The service tests cover
-// startup, readiness, and discovery, none of which submit anything.
-type stubBackend struct{}
-
-func (stubBackend) Submit(context.Context, backend.SubmitRequest) (string, error) {
-	return "stub", nil
+// stubBackend stands in for a real destination and records what it was asked
+// to do, so a test can tell "the segment was submitted" apart from "nothing
+// happened".
+type stubBackend struct {
+	submitted []string
+	statuses  []string
 }
 
-func (stubBackend) Status(context.Context, string) (backend.Status, error) {
+func (b *stubBackend) Submit(_ context.Context, request backend.SubmitRequest) (string, error) {
+	b.submitted = append(b.submitted, request.Path)
+	return fmt.Sprintf("stub-%d", request.Segment.Index), nil
+}
+
+func (b *stubBackend) Status(_ context.Context, id string) (backend.Status, error) {
+	b.statuses = append(b.statuses, id)
 	return backend.StatusSuccess, nil
+}
+
+func TestRefreshSubmitsEveryClosedSegment(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{
+		"request-trace.000000.jsonl.gz",
+		"request-trace.000001.jsonl.gz",
+		"request-trace.000002.jsonl.gz",
+	} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte("fixture"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stub := &stubBackend{}
+	svc := NewWithBackend(config.Config{
+		SourceDir:     root,
+		SegmentPrefix: "request-trace",
+		StateDir:      filepath.Join(root, "state"),
+		QuarantineDir: filepath.Join(root, "quarantine"),
+	}, stub)
+
+	if err := svc.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	// Index 2 is the active segment and must not be submitted.
+	want := []string{
+		filepath.Join(root, "request-trace.000000.jsonl.gz"),
+		filepath.Join(root, "request-trace.000001.jsonl.gz"),
+	}
+	if !reflect.DeepEqual(stub.submitted, want) {
+		t.Errorf("submitted = %v, want %v", stub.submitted, want)
+	}
+	if !reflect.DeepEqual(stub.statuses, []string{"stub-0", "stub-1"}) {
+		t.Errorf("statuses = %v, want the id from each submit", stub.statuses)
+	}
+	for _, path := range want {
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("source %s was removed: %v", filepath.Base(path), err)
+		}
+	}
+}
+
+func TestRefreshStopsOnCancellation(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{
+		"request-trace.000000.jsonl.gz",
+		"request-trace.000001.jsonl.gz",
+	} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte("fixture"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stub := &stubBackend{}
+	svc := NewWithBackend(config.Config{
+		SourceDir:     root,
+		SegmentPrefix: "request-trace",
+	}, stub)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := svc.Refresh(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Refresh() error = %v, want context.Canceled", err)
+	}
+	if len(stub.submitted) != 0 {
+		t.Errorf("submitted = %v, want nothing after cancellation", stub.submitted)
+	}
 }


### PR DESCRIPTION
## Why

The uploader discovered closed segments but never opened one. Nothing validated that it can parse what Dynamo actually writes, and there was no way to run it end to end without a destination and credentials.

## What changed

Adds a `record` package modelling the Dynamo v1.4.0 format with a streaming reader, and a `debug` backend that reports what a segment contained and exports nothing. The service now hands every closed segment to the configured backend.

Sources are never deleted. That waits on durable lifecycle state in #1050.

### Reading

The reader holds one record at a time, so segment size does not bound memory. It handles the shapes Dynamo actually produces:

- concatenated gzip members, because Dynamo appends members as it rolls
- both the bare record form the file sink writes and the timestamp-wrapped form
- all three places a request identifier appears: `request.request_id` on `request_end`, `payload.request_id` on `request_payload`, and absent on tool records, which correlate by `agent_context.session_id`

Two behaviors are deliberate rather than incidental:

**A record that fails to parse is counted and skipped.** One malformed line must not discard the other records in a segment. That is a named root cause in the internal bug behind this work.

**A record with an unrecognized event type is kept with its original bytes.** A Dynamo upgrade adding an event type should not silently drop data.

**A Dynamo v1.3.x `AuditRecord` is detected and rejected by name.** Parsing it as a request trace record would produce empty fields rather than fail, so the error states the minimum supported version.

### The debug backend

It reads a segment, reports counts and shapes, and exports nothing. It carries no dependencies, so it is linked into this binary. That makes the uploader runnable against a real Dynamo with no credentials, no bucket, and no namespace.

Its output is counts only. Request identifiers, session identifiers, header values, and bodies are deliberately absent: it is a diagnostic aid, and its logs are subject to the same containment rules as any other uploader log.

This changes what this binary is. It previously linked no backend at all. It now links `debug` and still links no exporting backend.

## Customer Release Notes

Not customer visible.

## Plan Summary

Not applicable.

## Usage

```
REQUEST_TRACE_UPLOADER_BACKEND=debug
REQUEST_TRACE_UPLOADER_SOURCE_DIR=/var/spool/dynamo/request-traces
```

Each scan reports per segment: record count, bytes, unparseable count, unknown event types, how many records carry a request id, a session id, or headers, incomplete payloads, and a per-event-type breakdown.

## Testing

`go build`, `go vet`, `go test ./...`, and `bazel test //src/compute-plane-services/request-trace-uploader/...` all pass. Seven Bazel test targets.

Twelve new tests. The ones worth reading are the behavioral guarantees rather than the happy path: one bad line surrounded by good records yields both good records and an unparseable count of one; an unknown event type is retained with its original bytes; a v1.3.x AuditRecord produces an error naming v1.4.0; concatenated gzip members are read across; and the debug backend never removes its source.

## Notes

Service tests now use a `NewWithBackend(cfg, client)` seam so they inject a stub rather than depending on the registry. That is also useful for any caller building its own backend.

The nvcf-internal distribution builds its own mains and will need a matching blank import of `backend/debug` before its oss image can use the debug backend.

Follow-on under #1004: object-store upload completes #1047, durable lifecycle in #1050, policy in #1051, Kratos in #1443, suppression in #1048, sampling in #1444, telemetry in #1046.

## References

Relates to #1004

## Related Pull Requests

Follows #1454.

## Dependencies

None. Standard library only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a debug mode that analyzes request-trace segments without exporting sensitive content.
  * Added support for gzip-compressed JSONL records, event classification, metadata extraction, and oversized-record tracking.
  * The uploader now submits discovered segments through the configured backend and verifies processing status.
* **Bug Fixes**
  * Improved recovery from malformed and oversized records, including continued processing after invalid lines.
  * Added cancellation handling throughout processing.
  * Empty segments are accepted, and source trace files remain preserved after processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->