### PR TITLE
feat(translate): add ClusterID to TranslateConfig and inject NVCF_CLUSTER_ID

### DIFF
--- a/src/libraries/go/lib/pkg/icms-translate/translate/common/translator.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/common/translator.go
@@ -76,6 +76,7 @@ type TranslateConfig struct {
 
 	ClusterRegion string `json:"clusterRegion"`
 	ClusterName   string `json:"clusterName"`
+	ClusterID     string `json:"clusterID,omitempty"`
 }
 
 func (c *TranslateConfig) Default() {

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
@@ -129,6 +129,12 @@ func newLLMRouterClientContainer(
 			Value: llmWorkerTokenPath,
 		},
 	)
+	if tcfg.ClusterID != "" {
+		envs = append(envs, corev1.EnvVar{
+			Name:  "NVCF_CLUSTER_ID",
+			Value: tcfg.ClusterID,
+		})
+	}
 
 	var upstreamHttpBaseUrl string
 	svcPort := allEnvSet["INFERENCE_PORT"]

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_helm.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_helm.go
@@ -260,10 +260,17 @@ func translateHelmChart(t CreationQueueMessage, tcfg TranslateConfig) (objs []me
 		Name:  "INSTANCE_ID",
 		Value: instanceID,
 	}
+	infraEnvs := []corev1.EnvVar{instanceIDEnv}
+	if tcfg.ClusterID != "" {
+		infraEnvs = append(infraEnvs, corev1.EnvVar{
+			Name:  "NVCF_CLUSTER_ID",
+			Value: tcfg.ClusterID,
+		})
+	}
 	initEnvs := common.MapToEnv(allEnvSet)
-	initEnvs = append(initEnvs, instanceIDEnv)
+	initEnvs = append(initEnvs, infraEnvs...)
 	utilsEnvs := common.MapToEnv(allEnvSet)
-	utilsEnvs = append(utilsEnvs, instanceIDEnv)
+	utilsEnvs = append(utilsEnvs, infraEnvs...)
 
 	if hasSecretsAssertionToken {
 		essEnvs := []corev1.EnvVar{{


### PR DESCRIPTION
## TL;DR
Add `ClusterID` to `common.TranslateConfig` and inject it as `NVCF_CLUSTER_ID` into the utils container environment on Helm and LLM function paths.

## Additional Details
The metering library (companion PR #1460 in `libraries/go/worker`) reads `NVCF_CLUSTER_ID` from the utils container environment. This PR is the translate-library-side change that makes that env var available: `ClusterID` is added to `TranslateConfig` and injected conditionally (when non-empty) so existing callers that do not supply a cluster ID are unaffected.

The nvca service wires `ClusterID` from `BackendK8sCache` (populated via `WithClusterID` from the agent's existing `ClusterID` field) through `TranslateConfig` into the pod spec — that change is in a follow-up PR after this library lands.

## For the Reviewer
- `translator.go`: adds `ClusterID string` to `TranslateConfig`
- `translate_helm.go`: injects `NVCF_CLUSTER_ID` alongside `INSTANCE_ID` for Helm functions
- `llm.go`: same for the LLM worker path

## For QA
No behavior change when `ClusterID` is empty. When set, `NVCF_CLUSTER_ID` appears in the utils container env. Verify in a self-managed deployment after the nvca follow-up PR lands.

## Issues
Relates to #1437

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional cluster identification for translation configurations.
  * Configured translation services and Helm-based workloads to use the specified cluster when provided.
  * Existing configurations without a cluster identifier continue to operate without changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->