### PR TITLE
build(openbao): rebuild bundled helper tools

### DIFF
--- a/migrations/openbao/Dockerfile
+++ b/migrations/openbao/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add --no-cache curl tar && \
         -ldflags="-s -w -buildid= -X main.version=${JWKER_BUILD_VERSION} -X main.commit=${JWKER_COMMIT} -X main.date=${JWKER_BUILD_DATE}" \
         -o /out/jwker ./cmd/jwker
 
-FROM alpine:${ALPINE_VERSION} AS kubectl-downloader
+FROM --platform=$BUILDPLATFORM alpine:${ALPINE_VERSION} AS kubectl-downloader
 
 ARG TARGETARCH
 ARG KUBECTL_VERSION=v1.36.4

--- a/migrations/openbao/Dockerfile
+++ b/migrations/openbao/Dockerfile
@@ -1,37 +1,48 @@
 ARG ALPINE_VERSION=3.23
+ARG GO_IMAGE=golang:1.27.0-alpine3.23@sha256:3747dcba41c8b0db3211fda4db61638b980e17ac5bb3c94460a975a9cfe19395
 
-FROM alpine:${ALPINE_VERSION} AS jwker-downloader
+FROM --platform=$BUILDPLATFORM ${GO_IMAGE} AS jwker-builder
 
 ARG TARGETARCH
-ARG JWKER_VERSION=v0.2.1
-ARG JWKER_LINUX_AMD64_SHA256=f37866a81509a5021378035df31a767c60a49a71e91379aef1fed621bc3e024d
-ARG JWKER_LINUX_ARM64_SHA256=7482cf4c5f3be63c8cca5ec00a720cf0f5bdd0a34f607c558e68ebbebed82e95
+ARG JWKER_VERSION=v0.2.2
+ARG JWKER_COMMIT=d708da84676fb39f7c957d7e4d589206d56c3089
+ARG JWKER_BUILD_DATE=2025-11-13T20:16:40Z
+ARG JWKER_SOURCE_SHA256=258c3618e7dfa293b9db529ff013a09a2ce5bffd468715e26943b9185d773910
 
-# jwker v0.2.1 has no release attestation, so pin the reviewed asset digests here.
+# Build jwker from reviewed source with a fixed toolchain and source digest.
 RUN apk add --no-cache curl tar && \
-    case "${TARGETARCH}" in \
-        amd64) JWKER_ARCH="x86_64"; JWKER_SHA256="${JWKER_LINUX_AMD64_SHA256}" ;; \
-        arm64) JWKER_ARCH="arm64"; JWKER_SHA256="${JWKER_LINUX_ARM64_SHA256}" ;; \
-        *) echo "Unsupported architecture for jwker: ${TARGETARCH}" >&2; exit 1 ;; \
-    esac && \
-    JWKER_ASSET="jwker_Linux_${JWKER_ARCH}.tar.gz" && \
-    curl -fsSLo /tmp/jwker_checksums.txt "https://github.com/jphastings/jwker/releases/download/${JWKER_VERSION}/checksums.txt" && \
-    curl -fsSLo "/tmp/${JWKER_ASSET}" "https://github.com/jphastings/jwker/releases/download/${JWKER_VERSION}/${JWKER_ASSET}" && \
-    awk -v asset="${JWKER_ASSET}" '$2 == asset { print; found=1 } END { exit found ? 0 : 1 }' /tmp/jwker_checksums.txt > /tmp/jwker_checksum.txt && \
-    (cd /tmp && sha256sum -c jwker_checksum.txt) && \
-    printf '%s  %s\n' "${JWKER_SHA256}" "/tmp/${JWKER_ASSET}" | sha256sum -c - && \
-    mkdir -p /out && \
-    tar xzf "/tmp/${JWKER_ASSET}" -C /out jwker && \
-    chmod +x /out/jwker
+    curl -fsSLo /tmp/jwker.tar.gz "https://github.com/jphastings/jwker/archive/refs/tags/${JWKER_VERSION}.tar.gz" && \
+    printf '%s  %s\n' "${JWKER_SOURCE_SHA256}" /tmp/jwker.tar.gz | sha256sum -c - && \
+    mkdir -p /out /src && \
+    tar xzf /tmp/jwker.tar.gz -C /src --strip-components=1 && \
+    cd /src && \
+    GOTOOLCHAIN=local go mod download && \
+    JWKER_BUILD_VERSION="${JWKER_VERSION#v}" && \
+    CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" GOTOOLCHAIN=local \
+        go build -mod=readonly -trimpath -buildvcs=false \
+        -ldflags="-s -w -buildid= -X main.version=${JWKER_BUILD_VERSION} -X main.commit=${JWKER_COMMIT} -X main.date=${JWKER_BUILD_DATE}" \
+        -o /out/jwker ./cmd/jwker
 
 FROM alpine:${ALPINE_VERSION} AS kubectl-downloader
 
-ARG KUBECTL_APK_VERSION=1.34.2-r6
+ARG TARGETARCH
+ARG KUBECTL_VERSION=v1.36.4
+ARG KUBECTL_LINUX_AMD64_SHA256=8b8f088da2dab964f853b38464033b1be15ede2839eca751482357c45abdd05a
+ARG KUBECTL_LINUX_ARM64_SHA256=0ecf44450ee6063bf19dd166a103ee6df4a9034455c2abce626e6eea657d73fb
 
-# apk verifies the signed repository index and package checksums.
-RUN apk add --no-cache "kubectl=${KUBECTL_APK_VERSION}" && \
+# Verify the official checksum and the reviewed per-architecture checksum.
+RUN apk add --no-cache curl && \
+    case "${TARGETARCH}" in \
+        amd64) KUBECTL_SHA256="${KUBECTL_LINUX_AMD64_SHA256}" ;; \
+        arm64) KUBECTL_SHA256="${KUBECTL_LINUX_ARM64_SHA256}" ;; \
+        *) echo "Unsupported architecture for kubectl: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    KUBECTL_BASE_URL="https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}" && \
     mkdir -p /out && \
-    cp /usr/bin/kubectl /out/kubectl && \
+    curl -fsSLo /out/kubectl "${KUBECTL_BASE_URL}/kubectl" && \
+    curl -fsSLo /tmp/kubectl.sha256 "${KUBECTL_BASE_URL}/kubectl.sha256" && \
+    test "$(cat /tmp/kubectl.sha256)" = "${KUBECTL_SHA256}" && \
+    printf '%s  %s\n' "${KUBECTL_SHA256}" /out/kubectl | sha256sum -c - && \
     chmod +x /out/kubectl
 
 FROM openbao/openbao:2.5.5
@@ -39,7 +50,7 @@ FROM openbao/openbao:2.5.5
 # Install runtime dependencies and copy verified tools from downloader stages.
 RUN apk add --no-cache openssl uuidgen helm curl bash jq
 
-COPY --from=jwker-downloader /out/jwker /usr/local/bin/jwker
+COPY --from=jwker-builder /out/jwker /usr/local/bin/jwker
 COPY --from=kubectl-downloader /out/kubectl /usr/local/bin/kubectl
 
 WORKDIR /app

--- a/migrations/openbao/README.md
+++ b/migrations/openbao/README.md
@@ -11,7 +11,7 @@ This repository ships:
 - Numbered shell migrations under `migrations/` that run in order against an OpenBao leader
 - Helper utilities under `migrations/utils/`
 - The `jwker` CLI used by the install pipeline to convert Kubernetes JWKS material to PEM
-- Verified `jwker` binary and signed-package `kubectl` copied from downloader stages
+- Reproducible `jwker` source build and checksum-verified official `kubectl` binary copied from build stages
 - Optional addons under `addons/` (e.g., LLS / TURN secret rotation)
 - An example Kubernetes Job manifest (`job.yaml`)
 - A Docker-based integration test for the helper functions (`tests/`)
@@ -42,12 +42,10 @@ The shipped `job.yaml` sets a default placeholder value for this variable so the
 ## Building the container
 
 The `Dockerfile` uses the public upstream OpenBao image (`openbao/openbao:2.5.5`) as the base. To use a different base, edit the `FROM` line directly.
-`kubectl` is installed from Alpine's signed package repository and pinned with `KUBECTL_APK_VERSION`.
+It builds `jwker` v0.2.2 from checksum-pinned source with Go 1.27.0 and downloads the official Kubernetes v1.36.4 `kubectl` binary for the target architecture. The build verifies both the published Kubernetes checksum and the pinned per-architecture checksum.
 
 ```bash
-docker build \
-  --build-arg KUBECTL_APK_VERSION=1.34.2-r6 \
-  -t <your-registry>/<your-org>/openbao-migrations:<version> .
+docker build -t <your-registry>/<your-org>/openbao-migrations:<version> .
 ```
 
 ## Running the migrations


### PR DESCRIPTION
## TL;DR

- Installs checksum-verified kubectl v1.36.4 binaries for amd64 and arm64.
- Builds jwker v0.2.2 from pinned source with Go 1.27 instead of copying a release binary.

## Additional Details

- OpenBao remains at 2.5.5 because its newer release does not resolve the targeted Go library versions.
- Pinned source, toolchain image, and release checksums make the helper tools reproducible.

## For the Reviewer

- Review the architecture-specific checksum selection and the isolated jwker builder stage.

## For QA

- Built the migration image for amd64 and arm64.
- Verified the runtime kubectl and jwker versions.

## Issues

Closes #1466

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for DCO compliance.
- [x] Existing build checks cover the update.
- [x] Documentation is current.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the OpenBao container to include jwker version 0.2.2 and kubectl version 1.36.4.
  * Container tooling is now built or downloaded from checksum-verified sources, with support for target architectures.

* **Documentation**
  * Updated build instructions to describe the revised jwker build and kubectl acquisition process.
  * Removed the requirement to provide the previous kubectl package version argument.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->