### PR TITLE
build(cassandra): refresh base image and yq

### DIFF
--- a/infra/cassandra/AGENTS.md
+++ b/infra/cassandra/AGENTS.md
@@ -7,7 +7,7 @@ Container image that runs Apache Cassandra for NVCF, built on the official
 
 ## Image facts
 
-- Base: `cassandra:5.0.8` (official Apache Cassandra, Docker Hub). Bump the
+- Base: `cassandra:5.0.9` (official Apache Cassandra, Docker Hub). Bump the
   Cassandra version by editing the `FROM cassandra:<version>` line; that tag is
   the single source of truth, there is no version build-arg.
 - yq: fetched in a pinned `alpine:3.21` build stage and checksum-verified. The

--- a/infra/cassandra/Dockerfile
+++ b/infra/cassandra/Dockerfile
@@ -6,9 +6,9 @@
 # emulation) and verify it against a pinned checksum.
 FROM --platform=$BUILDPLATFORM alpine:3.21 AS yq-downloader
 ARG TARGETARCH
-ARG YQ_VERSION=v4.44.3
-ARG YQ_LINUX_AMD64_SHA256=a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7
-ARG YQ_LINUX_ARM64_SHA256=0e7e1524f68d91b3ff9b089872d185940ab0fa020a5a9052046ef10547023156
+ARG YQ_VERSION=v4.53.6
+ARG YQ_LINUX_AMD64_SHA256=c5f056448f973ae7d39b5401949648a78f2dc1947d6a8eb65be60d5c504b9385
+ARG YQ_LINUX_ARM64_SHA256=88a1016bc1d657375a35864e4f44b6f333df8ff97b559f51bba0adcb2169df09
 RUN apk add --no-cache curl && \
     case "${TARGETARCH}" in \
       amd64) YQ_SHA256="${YQ_LINUX_AMD64_SHA256}" ;; \
@@ -19,7 +19,7 @@ RUN apk add --no-cache curl && \
     printf '%s  /tmp/yq\n' "${YQ_SHA256}" | sha256sum -c - && \
     chmod +x /tmp/yq
 
-FROM cassandra:5.0.8
+FROM cassandra:5.0.9
 
 # Metrics exporter agent. The OSS snapshot does not redistribute the jar;
 # only files/.gitkeep ships, so the default here points at that placeholder


### PR DESCRIPTION
## TL;DR

- Updates the Cassandra base image from 5.0.8 to 5.0.9.
- Updates yq from v4.44.3 to v4.53.6 with verified checksums for both architectures.

## Additional Details

- The documented base-image version remains synchronized with the Dockerfile.
- Cassandra-bundled Java libraries, gosu, and the externally supplied exporter are outside this focused update.

## For QA

- Completed a cache-only multi-platform build for linux/amd64 and linux/arm64.
- Both yq checksum validations passed.
- Loaded the arm64 image and verified Cassandra 5.0.9 and yq v4.53.6.

## Issues

Closes #1467

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for DCO compliance.
- [x] Existing build checks cover the update.
- [x] Documentation is current.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Cassandra base image to version 5.0.9.
  * Updated the bundled yq utility to version 4.53.6.
  * Refreshed verification checksums for supported AMD64 and ARM64 builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->