### PR TITLE
build(images): adopt distroless v4.1.2 bases

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -444,7 +444,7 @@ oci.pull(
 # rather than an internal-only path.
 oci.pull(
     name = "distroless_go",
-    digest = "sha256:938bd28ce4ddb800118a951774203e7563c2067a72b20ae6b85d2c7da165a178",
+    digest = "sha256:731531712c92ee24001a4a6e0a0897c4fa542432d7186c5d73b0110ba6d0da16",
     image = "nvcr.io/nvidia/distroless/go",
     platforms = [
         "linux/amd64",
@@ -458,7 +458,7 @@ oci.pull(
 # platform string literally when it names the generated child repository.
 oci.pull(
     name = "distroless_cc",
-    digest = "sha256:92a46f84206c3e4610043eaef50946451019e3c479b71d280015919ba311babb",
+    digest = "sha256:d2b9ccba4833f76861a3edae3d5df18a6c29050970a8a4500a0fa6b31f880da8",
     image = "nvcr.io/nvidia/distroless/cc",
     platforms = [
         "linux/amd64",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -573,7 +573,7 @@
     "@@rules_oci+//oci:extensions.bzl%oci": {
       "general": {
         "bzlTransitiveDigest": "Vjs2aLDiztq2JcqxCwBcmhWsa/nb80kDJ1sMT56l+0k=",
-        "usagesDigest": "EDzShmIAPaiLhkdqPiXbibm5GmGgklN1Yz6iboWtAQ4=",
+        "usagesDigest": "GfEGPHDJLIkQqO2Q9ELhIPEm7IlMCLIEUB08Qv2k4ko=",
         "recordedInputs": [
           "REPO_MAPPING:aspect_bazel_lib+,bazel_tools bazel_tools",
           "REPO_MAPPING:bazel_features+,bazel_tools bazel_tools",
@@ -819,7 +819,7 @@
               "scheme": "https",
               "registry": "nvcr.io",
               "repository": "nvidia/distroless/go",
-              "identifier": "sha256:938bd28ce4ddb800118a951774203e7563c2067a72b20ae6b85d2c7da165a178",
+              "identifier": "sha256:731531712c92ee24001a4a6e0a0897c4fa542432d7186c5d73b0110ba6d0da16",
               "platform": "linux/amd64",
               "target_name": "distroless_go_linux_amd64",
               "bazel_tags": []
@@ -832,7 +832,7 @@
               "scheme": "https",
               "registry": "nvcr.io",
               "repository": "nvidia/distroless/go",
-              "identifier": "sha256:938bd28ce4ddb800118a951774203e7563c2067a72b20ae6b85d2c7da165a178",
+              "identifier": "sha256:731531712c92ee24001a4a6e0a0897c4fa542432d7186c5d73b0110ba6d0da16",
               "platform": "linux/arm64/v8",
               "target_name": "distroless_go_linux_arm64_v8",
               "bazel_tags": []
@@ -846,7 +846,7 @@
               "scheme": "https",
               "registry": "nvcr.io",
               "repository": "nvidia/distroless/go",
-              "identifier": "sha256:938bd28ce4ddb800118a951774203e7563c2067a72b20ae6b85d2c7da165a178",
+              "identifier": "sha256:731531712c92ee24001a4a6e0a0897c4fa542432d7186c5d73b0110ba6d0da16",
               "platforms": {
                 "@@platforms//cpu:x86_64": "@distroless_go_linux_amd64",
                 "@@platforms//cpu:arm64": "@distroless_go_linux_arm64_v8"
@@ -862,7 +862,7 @@
               "scheme": "https",
               "registry": "nvcr.io",
               "repository": "nvidia/distroless/cc",
-              "identifier": "sha256:92a46f84206c3e4610043eaef50946451019e3c479b71d280015919ba311babb",
+              "identifier": "sha256:d2b9ccba4833f76861a3edae3d5df18a6c29050970a8a4500a0fa6b31f880da8",
               "platform": "linux/amd64",
               "target_name": "distroless_cc_linux_amd64",
               "bazel_tags": []
@@ -875,7 +875,7 @@
               "scheme": "https",
               "registry": "nvcr.io",
               "repository": "nvidia/distroless/cc",
-              "identifier": "sha256:92a46f84206c3e4610043eaef50946451019e3c479b71d280015919ba311babb",
+              "identifier": "sha256:d2b9ccba4833f76861a3edae3d5df18a6c29050970a8a4500a0fa6b31f880da8",
               "platform": "linux/arm64/v8",
               "target_name": "distroless_cc_linux_arm64_v8",
               "bazel_tags": []
@@ -889,7 +889,7 @@
               "scheme": "https",
               "registry": "nvcr.io",
               "repository": "nvidia/distroless/cc",
-              "identifier": "sha256:92a46f84206c3e4610043eaef50946451019e3c479b71d280015919ba311babb",
+              "identifier": "sha256:d2b9ccba4833f76861a3edae3d5df18a6c29050970a8a4500a0fa6b31f880da8",
               "platforms": {
                 "@@platforms//cpu:x86_64": "@distroless_cc_linux_amd64",
                 "@@platforms//cpu:arm64": "@distroless_cc_linux_arm64_v8"

--- a/src/compute-plane-services/byoo-otel-collector/Dockerfile
+++ b/src/compute-plane-services/byoo-otel-collector/Dockerfile
@@ -54,7 +54,7 @@ RUN cd otelcol && \
 ####
 ### Stage 3: Create the final Distroless image for byoo-otel-collector
 ####
-FROM nvcr.io/nvidia/distroless/go:v4.0.4 AS byoo-otel-collector
+FROM nvcr.io/nvidia/distroless/go:v4.1.2 AS byoo-otel-collector
 
 WORKDIR /app
 

--- a/src/compute-plane-services/byoo-otel-collector/Dockerfile.nvcf-otel-collector
+++ b/src/compute-plane-services/byoo-otel-collector/Dockerfile.nvcf-otel-collector
@@ -37,7 +37,7 @@ RUN cd otelcol && \
 ####
 ### Stage 2: Create distroless image for nvcf-otel-collector
 ####
-FROM nvcr.io/nvidia/distroless/go:v4.0.4 AS nvcf-otel-collector
+FROM nvcr.io/nvidia/distroless/go:v4.1.2 AS nvcf-otel-collector
 
 LABEL description="NVCF OpenTelemetry Collector - Custom build with curated components for NVCF services"
 LABEL version="0.157.0"

--- a/src/compute-plane-services/ess-agent/nv_releases/docker/Dockerfile.distroless
+++ b/src/compute-plane-services/ess-agent/nv_releases/docker/Dockerfile.distroless
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG TAG=v4.0.1
-ARG IMG=urm.nvidia.com/sw-gpu-ucs-hardened-docker/distroless/go
+ARG TAG=v4.1.2
+ARG IMG=nvcr.io/nvidia/distroless/go
 FROM --platform=$TARGETPLATFORM dockerhub.nvidia.com/golang:1.25.6-bookworm AS builder
 ARG TARGETOS
 ARG TARGETARCH

--- a/src/compute-plane-services/image-credential-helper/docker/Dockerfile
+++ b/src/compute-plane-services/image-credential-helper/docker/Dockerfile
@@ -45,7 +45,7 @@ RUN set -eux; \
 
 # This distroless image already provides a non-root runtime user, so do not add a USER override here unless
 # the runtime requirements change.
-FROM nvcr.io/nvidia/distroless/go:v4.0.4
+FROM nvcr.io/nvidia/distroless/go:v4.1.2
 LABEL io.k8s.display-name="NVCF Image Credential Helper"
 
 # The following build args are automatically populated by BuildKit.

--- a/src/invocation-plane-services/grpc-proxy/Dockerfile
+++ b/src/invocation-plane-services/grpc-proxy/Dockerfile
@@ -43,7 +43,7 @@ RUN GOOS=$TARGETOS GOARCH=$TARGETARCH \
 # Final runtime image – one per requested TARGETPLATFORM
 # BuildKit will create a final image per platform and copy the pre-built
 # binary that matches the platform's architecture.
-FROM nvcr.io/nvidia/distroless/go:v4.0.6
+FROM nvcr.io/nvidia/distroless/go:v4.1.2
 
 # The following build arg is automatically populated by BuildKit.
 ARG TARGETARCH

--- a/src/invocation-plane-services/llm-api-gateway/Dockerfile
+++ b/src/invocation-plane-services/llm-api-gateway/Dockerfile
@@ -36,7 +36,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOFLAGS=-mod=mod \
     go build -o /out/$TARGETARCH/llm-api-gateway-rate-limit-sync-worker ./cmd/llm-api-gateway-rate-limit-sync-worker
 
-FROM nvcr.io/nvidia/distroless/go:v4.0.8
+FROM nvcr.io/nvidia/distroless/go:v4.1.2
 
 ARG TARGETARCH
 

--- a/src/libraries/go/lib/validator/otelconfig/Dockerfile
+++ b/src/libraries/go/lib/validator/otelconfig/Dockerfile
@@ -7,7 +7,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -o /out/validate ./cmd/validate
 
-FROM nvcr.io/nvidia/distroless/go:v4.0.3
+FROM nvcr.io/nvidia/distroless/go:v4.1.2
 WORKDIR /app
 ENV GOLDEN_DIR=/golden
 COPY --from=builder /out/validate /usr/local/bin/validate

--- a/src/libraries/rust/stargate/Dockerfile
+++ b/src/libraries/rust/stargate/Dockerfile
@@ -107,7 +107,7 @@ RUN curl -sSfL -o /usr/local/bin/grpc_health_probe \
 #########################
 ### BASE RUNTIME STAGE ##
 #########################
-FROM nvcr.io/nvidia/distroless/cc:v4.0.8 AS runtime-base
+FROM nvcr.io/nvidia/distroless/cc:v4.1.2 AS runtime-base
 
 ################################
 ### TILT INTEGRATION RUNTIME ###


### PR DESCRIPTION
## TL;DR

- Refreshes shared Go and C/C++ runtime images to signed distroless v4.1.2 releases.
- Aligns direct Dockerfile defaults with the digest-pinned Bazel bases.

## Additional Details

- The v4.1.2 Go and C/C++ images contain OpenSSL 3.5.7 packages for amd64 and arm64.
- The ESS legacy Dockerfile now uses the same public base as the Bazel image path.
- Five Rust/C++ indexes require the Linux cross-toolchain and remain CI validation gates.

## For the Reviewer

- Review the two root image digests and the direct Dockerfile defaults together.

## For QA

- `bazel mod deps --lockfile_mode=error`
- Built 19 affected Go image indexes locally.
- Verified both architectures in each signed v4.1.2 base.
- Two BYOO collector builds reached collector generation but exceeded the local 11-minute check.

## Issues

Closes #1463

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for DCO compliance.
- [x] Existing build checks cover the update.
- [x] Documentation is current.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime containers to use the newer Distroless base image release, v4.1.2.
  * Refreshed pinned multi-architecture base image references for improved consistency across services.
  * Applied the update across OpenTelemetry Collector, ESS Agent, image credential helper, gRPC proxy, LLM API gateway, OTEL configuration validation, and Stargate components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->