### PR TITLE
build(cassandra): rebuild migration tooling

### DIFF
--- a/migrations/cassandra/Dockerfile
+++ b/migrations/cassandra/Dockerfile
@@ -1,7 +1,50 @@
-FROM cassandra:5.0.8
+ARG GO_IMAGE=golang:1.27.0-alpine3.23@sha256:3747dcba41c8b0db3211fda4db61638b980e17ac5bb3c94460a975a9cfe19395
+
+FROM --platform=$BUILDPLATFORM ${GO_IMAGE} AS migrate-builder
 
 ARG TARGETARCH
-ARG KUBECTL_VERSION="1.36.1"
+ARG MIGRATE_VERSION=v4.19.1
+ARG MIGRATE_SOURCE_SHA256=a81780cf0fd577735fc58ce6c2f9829b3b8c9a2f41d326c9edbe3f00ff271c68
+
+# Build only the Cassandra database driver. The upstream release binary also
+# bundles unrelated database and cloud drivers and their runtime dependencies.
+RUN apk add --no-cache curl unzip && \
+    curl -fsSLo /tmp/migrate.zip \
+      "https://github.com/golang-migrate/migrate/releases/download/${MIGRATE_VERSION}/migrate-${MIGRATE_VERSION#v}.zip" && \
+    printf '%s  %s\n' "${MIGRATE_SOURCE_SHA256}" /tmp/migrate.zip | sha256sum -c - && \
+    mkdir -p /src /out && \
+    unzip -q /tmp/migrate.zip -d /src && \
+    cd /src && \
+    MIGRATE_BUILD_VERSION="${MIGRATE_VERSION#v}" && \
+    CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" GOTOOLCHAIN=local \
+      go build -mod=readonly -trimpath -buildvcs=false -tags cassandra \
+      -ldflags="-s -w -buildid= -X main.Version=${MIGRATE_BUILD_VERSION}" \
+      -o /out/migrate ./cmd/migrate
+
+FROM --platform=$BUILDPLATFORM alpine:3.23 AS kubectl-downloader
+
+ARG TARGETARCH
+ARG KUBECTL_VERSION=v1.36.4
+ARG KUBECTL_LINUX_AMD64_SHA256=8b8f088da2dab964f853b38464033b1be15ede2839eca751482357c45abdd05a
+ARG KUBECTL_LINUX_ARM64_SHA256=0ecf44450ee6063bf19dd166a103ee6df4a9034455c2abce626e6eea657d73fb
+
+# Verify both the official checksum and the reviewed per-architecture digest.
+RUN apk add --no-cache curl && \
+    case "${TARGETARCH}" in \
+      amd64) KUBECTL_SHA256="${KUBECTL_LINUX_AMD64_SHA256}" ;; \
+      arm64) KUBECTL_SHA256="${KUBECTL_LINUX_ARM64_SHA256}" ;; \
+      *) echo "Unsupported architecture for kubectl: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    KUBECTL_BASE_URL="https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}" && \
+    mkdir -p /out && \
+    curl -fsSLo /out/kubectl "${KUBECTL_BASE_URL}/kubectl" && \
+    curl -fsSLo /tmp/kubectl.sha256 "${KUBECTL_BASE_URL}/kubectl.sha256" && \
+    test "$(cat /tmp/kubectl.sha256)" = "${KUBECTL_SHA256}" && \
+    printf '%s  %s\n' "${KUBECTL_SHA256}" /out/kubectl | sha256sum -c - && \
+    chmod 0555 /out/kubectl
+
+FROM cassandra:5.0.9
+
 ARG GIT_SHA
 
 USER root
@@ -10,21 +53,10 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl gettext-base && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    if [ -n "$KUBECTL_VERSION" ]; then \
-        curl -Lo /usr/local/bin/kubectl "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl"; \
-    else \
-        echo "no kubectl version provided, using latest" && \
-        curl -Lo /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl"; \
-    fi && \
-    chmod +x /usr/local/bin/kubectl
+    rm -rf /var/lib/apt/lists/*
 
-# Expects an upstream `golang-migrate` CLI binary for the target
-# architecture at files/migrate-${TARGETARCH}. See README "Driver binaries"
-# section for the download + rename steps. The migrate database URL in
-# execute_sqls.sh uses only upstream-supported parameters, so the stock
-# binary works.
-ADD --chmod=775 files/migrate-${TARGETARCH} /usr/bin/migrate
+COPY --from=migrate-builder --chmod=0555 /out/migrate /usr/bin/migrate
+COPY --from=kubectl-downloader --chmod=0555 /out/kubectl /usr/local/bin/kubectl
 
 COPY keyspaces /app/keyspaces
 COPY --chmod=775 execute_sqls.sh /app

--- a/migrations/cassandra/README.md
+++ b/migrations/cassandra/README.md
@@ -10,45 +10,25 @@ This repository ships:
 - The migration entrypoint (`execute_sqls.sh`)
 - Cassandra DDL migrations under `keyspaces/<service>/*.up.sql`, one keyspace per service
 
-## Driver binaries
+## Migration driver
 
-The container ENTRYPOINT runs the [`golang-migrate`](https://github.com/golang-migrate/migrate) CLI. A pre-built binary for each target architecture is required at build time, placed at:
+The container builds [`golang-migrate`](https://github.com/golang-migrate/migrate) v4.19.1 from its checksum-verified release source. The build enables only the Cassandra database driver. This keeps unrelated database and cloud-provider clients out of the runtime binary.
 
-- `files/migrate-amd64` (for `--platform linux/amd64`)
-- `files/migrate-arm64` (for `--platform linux/arm64`)
-
-Download the release matching your platform (v4.18.2 or compatible) from https://github.com/golang-migrate/migrate/releases, extract the `migrate` binary, rename it to `migrate-amd64` or `migrate-arm64`, place it in `files/`, and ensure it is executable. For example:
-
-```bash
-# amd64
-curl -L https://github.com/golang-migrate/migrate/releases/download/v4.18.2/migrate.linux-amd64.tar.gz \
-  | tar xz -C files/
-mv files/migrate files/migrate-amd64
-chmod +x files/migrate-amd64
-
-# arm64 (run on / for an arm64 build)
-curl -L https://github.com/golang-migrate/migrate/releases/download/v4.18.2/migrate.linux-arm64.tar.gz \
-  | tar xz -C files/
-mv files/migrate files/migrate-arm64
-chmod +x files/migrate-arm64
-```
-
-`execute_sqls.sh` uses the standard `golang-migrate` cassandra driver query parameters: `x-multi-statement`, `x-migrations-table`, `username`, and `password`.
+`execute_sqls.sh` uses the standard `golang-migrate` Cassandra driver query parameters: `x-multi-statement`, `x-migrations-table`, `username`, and `password`.
 
 ## Prerequisites
 
 - A reachable Cassandra cluster (the container connects via `cqlsh` and the migrate driver)
 - Docker or another OCI-compatible builder
-- The driver binaries listed above, placed in `files/`
+- Network access to download the pinned build inputs
 
 ## Building the container
 
-The `Dockerfile` defaults to the official `cassandra:5.0.8` base image. Override the FROM via your own build pipeline if you need a different base.
+The `Dockerfile` uses the official `cassandra:5.0.9` base image and builds both supported architectures from the same pinned sources.
 
 ```bash
 docker build \
   --build-arg TARGETARCH=amd64 \
-  --build-arg KUBECTL_VERSION=1.31.0 \
   -t <your-registry>/<your-org>/nvcf-cassandra-migrations:<version> .
 ```
 
@@ -157,7 +137,3 @@ For a brand-new keyspace, the conventional sequence is:
 Subsequent files (`04_*` and later) are incremental migrations applied as the schema evolves. Most are DDL; `ess_api/04_*` is a data seed.
 
 The `03_init_tables.up.sql` follows a clean-slate model: it is updated in place when the canonical schema changes rather than accumulating `ALTER TABLE` history. Existing clusters apply only the deltas that postdate their last applied migration.
-
-## Notes
-
-- The `golang-migrate` driver binary at `files/migrate-${TARGETARCH}` must be supplied locally before building. See "Driver binaries" above for the download steps.

--- a/migrations/cassandra/README.md
+++ b/migrations/cassandra/README.md
@@ -28,9 +28,20 @@ The `Dockerfile` uses the official `cassandra:5.0.9` base image and builds both 
 
 ```bash
 docker build \
-  --build-arg TARGETARCH=amd64 \
+  --platform linux/amd64 \
   -t <your-registry>/<your-org>/nvcf-cassandra-migrations:<version> .
 ```
+
+To build and publish both supported architectures:
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  --push \
+  -t <your-registry>/<your-org>/nvcf-cassandra-migrations:<version> .
+```
+
+BuildKit sets `TARGETARCH` from each selected target platform so the downloaded and compiled binaries match the final image architecture.
 
 ## Running the migrations
 


### PR DESCRIPTION
## TL;DR

- Updates the Cassandra migrations image to Cassandra 5.0.9 and kubectl v1.36.4.
- Builds golang-migrate v4.19.1 from pinned source with only the Cassandra driver enabled.

## Additional Details

- Verifies source and per-architecture kubectl checksums during the build.
- Pins the Go builder by digest and removes unrelated database and cloud drivers from the runtime binary.
- Updates the image README for the self-contained build.

## For the Reviewer

- Review the multi-stage build, pinned checksums, and Cassandra-only build tag together.

## For QA

- Built the full image for linux/amd64 and linux/arm64.
- Inspected Cassandra, kubectl, migrate, Go, and registered driver versions in the loaded arm64 image.
- Ran `sh migrations/cassandra/tests/test-execute-sqls.sh`.

## Issues

Closes #1473

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for DCO compliance.
- [x] Existing build checks cover the update.
- [x] Documentation is current.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Cassandra migration images now build with architecture-specific, integrity-verified versions of the migration tool and kubectl.
  - Updated the Cassandra base image to version 5.0.9 for supported architectures.
  - Added support for single- and multi-architecture image builds.

- **Documentation**
  - Updated build instructions to reflect automatic migration-tool compilation and pinned build inputs.
  - Removed obsolete instructions for supplying prebuilt binaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->