### PR TITLE
feat(stack): gate the bundled sis release with a helmfile condition

### DIFF
--- a/deploy/stacks/self-managed/Makefile
+++ b/deploy/stacks/self-managed/Makefile
@@ -23,6 +23,7 @@ test:
 	@tests/api-env-wiring.sh
 	@tests/apikeys-env-wiring.sh
 	@tests/ess-base-url-wiring.sh
+	@tests/sis-condition-wiring.sh
 	@tests/nats-placement-tags.sh
 
 test-published-charts:

--- a/deploy/stacks/self-managed/Makefile
+++ b/deploy/stacks/self-managed/Makefile
@@ -23,7 +23,7 @@ test:
 	@tests/api-env-wiring.sh
 	@tests/apikeys-env-wiring.sh
 	@tests/ess-base-url-wiring.sh
-	@tests/sis-condition-wiring.sh
+	@tests/icms-condition-wiring.sh
 	@tests/nats-placement-tags.sh
 
 test-published-charts:

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -514,10 +514,10 @@ rateLimiter:
     enabled: false
     maxUnavailable: 1
 
-# Bundled in-cluster SIS (spot-instance-service). Gated by a helmfile
-# condition; defaults to true so existing installs are unchanged. Set to false
-# to skip it when scheduling workers through an external/production SIS.
-sis:
+# Bundled in-cluster ICMS -- the sis release (spot-instance-service). Gated by a
+# helmfile condition; defaults to true so existing installs are unchanged. Set to
+# false to skip it when scheduling workers through an external/production ICMS.
+icms:
   enabled: true
 
 # PDB knobs for control-plane services. Disabled by default.

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -514,6 +514,12 @@ rateLimiter:
     enabled: false
     maxUnavailable: 1
 
+# Bundled in-cluster SIS (spot-instance-service). Gated by a helmfile
+# condition; defaults to true so existing installs are unchanged. Set to false
+# to skip it when scheduling workers through an external/production SIS.
+sis:
+  enabled: true
+
 # PDB knobs for control-plane services. Disabled by default.
 # Set enabled: true for any service running more than one replica.
 

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -54,7 +54,7 @@ releases:
     namespace: sis
     inherit:
       - template: service
-    condition: sis.enabled
+    condition: icms.enabled
 
   - name: api
     version: 1.25.1

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -54,6 +54,7 @@ releases:
     namespace: sis
     inherit:
       - template: service
+    condition: sis.enabled
 
   - name: api
     version: 1.25.1

--- a/deploy/stacks/self-managed/tests/icms-condition-wiring.sh
+++ b/deploy/stacks/self-managed/tests/icms-condition-wiring.sh
@@ -13,13 +13,13 @@ stacks_dir="$(cd "$stack_dir/.." && pwd)"
 work_dir="$(mktemp -d)"
 test_stacks_dir="$work_dir/stacks"
 test_stack_dir="$test_stacks_dir/self-managed"
-environment_name="sis-condition-wiring-test"
+environment_name="icms-condition-wiring-test"
 environment_file="$test_stack_dir/environments/$environment_name.yaml"
 secrets_file="$test_stack_dir/secrets/$environment_name-secrets.yaml"
 trap 'rm -rf "$work_dir"' EXIT
 
 fail() {
-  echo "sis-condition-wiring: $*" >&2
+  echo "icms-condition-wiring: $*" >&2
   exit 1
 }
 
@@ -107,4 +107,4 @@ render_list "$off_list"
 assert_enabled "$off_list" sis false
 assert_enabled "$off_list" api true
 
-echo "sis-condition-wiring: all checks passed"
+echo "icms-condition-wiring: all checks passed"

--- a/deploy/stacks/self-managed/tests/sis-condition-wiring.sh
+++ b/deploy/stacks/self-managed/tests/sis-condition-wiring.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # Test that the bundled sis release honors a helmfile condition driven from
 # environments/<env>.yaml. The sis release (spot-instance-service) had no
-# condition, so it installed on every deploy and sis.enabled had no effect.
-# It is now gated by `condition: sis.enabled`, defaulted to true in base.yaml so
+# condition, so it installed on every deploy and icms.enabled had no effect.
+# It is now gated by `condition: icms.enabled`, defaulted to true in base.yaml so
 # existing installs are unchanged. This guards two things: (a) with the default
-# the release stays enabled (backward-compatible), and (b) sis.enabled: false in
+# the release stays enabled (backward-compatible), and (b) icms.enabled: false in
 # an environment file disables it, while leaving the other releases enabled.
 set -euo pipefail
 
@@ -75,7 +75,7 @@ write_env() {
 }
 
 # ---------------------------------------------------------------------------
-# 1. Default: sis.enabled unset in the env file, so the base.yaml default (true)
+# 1. Default: icms.enabled unset in the env file, so the base.yaml default (true)
 #    stands and the release stays enabled -- existing installs are unchanged.
 # ---------------------------------------------------------------------------
 write_env <<'EOF'
@@ -90,7 +90,7 @@ render_list "$default_list"
 assert_enabled "$default_list" sis true
 
 # ---------------------------------------------------------------------------
-# 2. Override: sis.enabled: false disables the release, while the other releases
+# 2. Override: icms.enabled: false disables the release, while the other releases
 #    (e.g. api) stay enabled -- the condition gates only sis.
 # ---------------------------------------------------------------------------
 write_env <<'EOF'
@@ -98,7 +98,7 @@ global:
   image:
     registry: nvcr.io
     repository: test/nvcf
-sis:
+icms:
   enabled: false
 EOF
 

--- a/deploy/stacks/self-managed/tests/sis-condition-wiring.sh
+++ b/deploy/stacks/self-managed/tests/sis-condition-wiring.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Test that the bundled sis release honors a helmfile condition driven from
+# environments/<env>.yaml. The sis release (spot-instance-service) had no
+# condition, so it installed on every deploy and sis.enabled had no effect.
+# It is now gated by `condition: sis.enabled`, defaulted to true in base.yaml so
+# existing installs are unchanged. This guards two things: (a) with the default
+# the release stays enabled (backward-compatible), and (b) sis.enabled: false in
+# an environment file disables it, while leaving the other releases enabled.
+set -euo pipefail
+
+stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+stacks_dir="$(cd "$stack_dir/.." && pwd)"
+work_dir="$(mktemp -d)"
+test_stacks_dir="$work_dir/stacks"
+test_stack_dir="$test_stacks_dir/self-managed"
+environment_name="sis-condition-wiring-test"
+environment_file="$test_stack_dir/environments/$environment_name.yaml"
+secrets_file="$test_stack_dir/secrets/$environment_name-secrets.yaml"
+trap 'rm -rf "$work_dir"' EXIT
+
+fail() {
+  echo "sis-condition-wiring: $*" >&2
+  exit 1
+}
+
+# The self-managed helmfile.d reaches a sibling stack through a relative path,
+# so copy the whole stacks directory, not just self-managed.
+mkdir -p "$test_stacks_dir"
+cp -R "$stacks_dir"/. "$test_stacks_dir"
+mkdir -p "$(dirname "$secrets_file")"
+printf '{}\n' >"$secrets_file"
+
+# Every stack the copy reaches resolves ../environments/$HELMFILE_ENV.yaml
+# against its own directory, so each one needs a file under this test's
+# environment name.
+for stack_environments in "$test_stacks_dir"/*/environments; do
+  test -d "$stack_environments" || continue
+  test -e "$stack_environments/$environment_name.yaml" ||
+    printf '{}\n' >"$stack_environments/$environment_name.yaml"
+done
+
+# global.yaml.gotmpl marks the shared and grpc gateway values as required, so
+# every invocation has to supply them even though this test only lists releases.
+helmfile_common=(
+  --file "$test_stack_dir/helmfile.d"
+  --environment default
+  --state-values-set ingress.gatewayApi.controllerNamespace=envoy-gateway-system
+  --state-values-set ingress.gatewayApi.gateways.shared.name=shared-gw
+  --state-values-set ingress.gatewayApi.gateways.shared.namespace=envoy-gateway-system
+  --state-values-set ingress.gatewayApi.gateways.grpc.name=grpc-gw
+  --state-values-set ingress.gatewayApi.gateways.grpc.namespace=envoy-gateway-system
+)
+
+# helmfile list evaluates each release's condition and reports enabled per
+# release, so it exercises the condition without pulling any chart.
+render_list() {
+  local output_file="$1"
+  local render_log="$work_dir/list.log"
+  if ! HELMFILE_ENV="$environment_name" HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" \
+    helmfile "${helmfile_common[@]}" list --output json >"$output_file" 2>"$render_log"; then
+    cat "$render_log" >&2
+    fail "helmfile could not list the stack"
+  fi
+  test -s "$output_file" || fail "helmfile wrote no release list to $output_file"
+}
+
+assert_enabled() {
+  local file="$1" name="$2" want="$3"
+  yq -e -p=json ".[] | select(.name == \"$name\") | .enabled == $want" "$file" >/dev/null 2>&1 ||
+    fail "$name: expected enabled == $want in $(basename "$file")"
+}
+
+write_env() {
+  cat >"$environment_file"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Default: sis.enabled unset in the env file, so the base.yaml default (true)
+#    stands and the release stays enabled -- existing installs are unchanged.
+# ---------------------------------------------------------------------------
+write_env <<'EOF'
+global:
+  image:
+    registry: nvcr.io
+    repository: test/nvcf
+EOF
+
+default_list="$work_dir/list-default.json"
+render_list "$default_list"
+assert_enabled "$default_list" sis true
+
+# ---------------------------------------------------------------------------
+# 2. Override: sis.enabled: false disables the release, while the other releases
+#    (e.g. api) stay enabled -- the condition gates only sis.
+# ---------------------------------------------------------------------------
+write_env <<'EOF'
+global:
+  image:
+    registry: nvcr.io
+    repository: test/nvcf
+sis:
+  enabled: false
+EOF
+
+off_list="$work_dir/list-off.json"
+render_list "$off_list"
+assert_enabled "$off_list" sis false
+assert_enabled "$off_list" api true
+
+echo "sis-condition-wiring: all checks passed"


### PR DESCRIPTION
## Summary

Gate the bundled `sis` release (`spot-instance-service`, image `icms-service-oss`) behind a helmfile `condition: icms.enabled`, defaulted to `true`, so operators backed by an external/production SIS can drop the in-cluster SIS from `environments/<env>.yaml` instead of carrying a patch. Defaults keep existing installs byte-identical.

> **Naming:** the operator-facing knob is `icms.enabled` (per review — the component is migrating to ICMS; the release image is already `icms-service-oss`). The release name/namespace stay `sis` and the existing `sis.image.tag` override is untouched, so a full `sis`→`icms` rename (namespace, chart, keyspace, route wiring, and `sis.image.tag`) is tracked separately.

## Additional Details

The `sis` release had no helmfile `condition:`, so a value in an environment file had no effect — the release (and its namespace) installed on every deploy. Contrast `ratelimiter`, which is gated by `condition: rateLimiter.enabled` with a `rateLimiter.enabled: true` default in `base.yaml`.

This is a **pair** of changes, because the condition alone is not enough: helmfile hard-errors when a `condition:` references a values path whose parent map is undefined. With no `icms:` block in `base.yaml`, adding `condition: icms.enabled` on its own makes every render fail with `environment values field '.icms' not found`. So:

- `deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl` — add `condition: icms.enabled` to the `sis` release.
- `deploy/stacks/self-managed/environments/base.yaml` — add `icms.enabled: true` next to `rateLimiter.enabled`, so existing installs are unchanged and the condition always resolves.
- `deploy/stacks/self-managed/tests/icms-condition-wiring.sh` — new wiring test, registered in the `Makefile`.

Operators that don't want the bundled SIS then set it in `environments/<env>.yaml`:

```yaml
icms:
  enabled: false
```

## For the Reviewer

- **Default-off risk: none.** `icms.enabled` defaults to `true` in `base.yaml`, so the release stays enabled unless an operator opts out — existing installs are unchanged.
- **Convention:** this is the exact `condition:` + `base.yaml` default pattern the stack already uses for `ratelimiter` (`condition: rateLimiter.enabled`) and the `nats` dependency (`condition: nats.enabled`).
- **No chart-values leak:** the new `icms.enabled` env key is consumed only by the helmfile condition. The `sis:` values block in `global.yaml.gotmpl` reads `sis.image.tag` / `global.*`, never `icms.enabled`, so the chart values the release renders are unchanged (verified byte-identical below).

## For QA

**Automated test (`make test`).** Added `deploy/stacks/self-managed/tests/icms-condition-wiring.sh`, wired into the offline `make test` target. It runs `helmfile list --output json` and asserts via `yq`:
- **default (unset):** `sis` is `enabled: true` (backward-compatible);
- **override (`icms.enabled: false`):** `sis` is `enabled: false` while `api` stays `enabled: true` (the condition gates only `sis`).

**Manual verification.**
- **Byte-identical default:** rendered the `sis` release values on this branch vs `origin/main` with a default env (`helmfile write-values --selector name=sis`) — a raw `diff` is empty, confirming no change when `icms.enabled` is unset.
- **Default enabled:** `helmfile list` → `sis … ENABLED=true`.
- **Disabled:** `icms.enabled: false` → `helmfile list` shows `sis … ENABLED=false`, and `helmfile template --selector name=sis` returns `no releases found that matches specified selector` — i.e. the release is excluded from what would be deployed.
- **Default is required:** removing the `icms:` default from `base.yaml` while keeping the condition reproduces `environment values field '.icms' not found`, confirming why the default ships with the condition.
- **Full suite:** `make test` passes (including `icms-condition-wiring` and neighbors).

## Issues

Fixes #1343

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for DCO compliance.
- [x] New or existing tests cover these changes. <!-- added tests/icms-condition-wiring.sh (offline `make test`); also verified byte-identical origin/main diff + helmfile list/template enable/disable + the no-default error case -->
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable in-cluster ESS base URLs for API and NVCT API requests.
  * Bundled ICMS configuration is now enabled by default, with guidance for external or production ICMS deployments.
  * The self-managed SIS release can now be controlled through the ICMS enablement setting.

* **Tests**
  * Added coverage verifying SIS and API release behavior when ICMS is enabled or disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->