### PR TITLE
feat(stack): make the in-cluster ESS base URL configurable in the self-managed stack

### DIFF
--- a/deploy/stacks/self-managed/Makefile
+++ b/deploy/stacks/self-managed/Makefile
@@ -22,6 +22,7 @@ test:
 	@tests/sidecar-registry-wiring.sh
 	@tests/api-env-wiring.sh
 	@tests/apikeys-env-wiring.sh
+	@tests/ess-base-url-wiring.sh
 	@tests/nats-placement-tags.sh
 
 test-published-charts:

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -177,8 +177,20 @@ functionAutoscaler:
 # global.sidecars (or global.image) at version 0.14.1.
 api:
   env: {}
+  # In-cluster ESS base URL for the API's own ESS calls. Empty defaults to
+  # global.workerEndpoints.essServiceURL. In split-plane deployments that value
+  # is the public ESS URL for remote workers, so set this to the in-cluster
+  # ess-api Service to keep control-plane ESS calls off the public edge, e.g.
+  # http://ess-api.ess.svc.cluster.local:8080. The worker alias
+  # (NVCF_ESS_WORKER_BASE_URL) stays on essServiceURL.
+  essBaseURL: ""
   remoteConfig:
     configData: {}
+
+# NVCT API in-cluster ESS base URL, mirroring api.essBaseURL. Empty defaults to
+# global.workerEndpoints.essServiceURL; NVCT_ESS_WORKER_BASE_URL stays on it.
+nvctApi:
+  essBaseURL: ""
 
 # Image overrides for the API account-bootstrap job. alpine-k8s is not
 # republished under the public nvidia/nvcf catalog, so it defaults to its

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -312,6 +312,12 @@ natsAuthCalloutService:
 {{- $nvcfNatsWorkerServiceURL := dig "nvcfNatsServiceURL" "" $workerEndpoints }}
 {{- $grpcProxyNatsServiceURL := dig "grpcproxy" "natsServiceURL" "" .Values | default "nats://nats.nats-system.svc.cluster.local:4222" }}
 {{- $essWorkerBaseURL := dig "essServiceURL" "" $workerEndpoints }}
+{{- /* In-cluster ESS base URL for the API's/NVCT's own ESS calls. Defaults to
+       the worker-advertised ESS URL so existing installs are unchanged; set it
+       to the in-cluster ess-api Service in split-plane deployments so control-
+       plane ESS calls do not hairpin out to the public edge. */}}
+{{- $essApiBaseURL := dig "api" "essBaseURL" "" .Values | default $essWorkerBaseURL }}
+{{- $essNvctApiBaseURL := dig "nvctApi" "essBaseURL" "" .Values | default $essWorkerBaseURL }}
 {{- $nvctWorkerServiceURL := dig "nvctServiceURL" "" $workerEndpoints }}
 {{- $nvctWorkerGrpcServiceURL := dig "nvctGrpcServiceURL" "" $workerEndpoints }}
 {{- $invocationWorkerBaseURL := dig "invocationServiceURL" "" $workerEndpoints }}
@@ -544,6 +550,8 @@ api:
   {{- with $essWorkerBaseURL }}
   {{- /* Keep the legacy worker alias until all API builds consume nvcf.ess.base-url directly. */}}
   {{- $_ := set $apiEnv "NVCF_ESS_WORKER_BASE_URL" . }}
+  {{- end }}
+  {{- with $essApiBaseURL }}
   {{- $_ := set $apiEnv "NVCF_ESS_BASE_URL" . }}
   {{- end }}
   {{- with dig "api" "icmsBaseUrl" nil .Values }}
@@ -634,8 +642,11 @@ nvctApi:
     {{- with $nvctWorkerGrpcServiceURL }}
     NVCT_GLOBAL_FQDN_GRPC: {{ . | quote }}
     {{- end }}
-    {{- with $essWorkerBaseURL }}
+    {{- with $essNvctApiBaseURL }}
     NVCT_ESS_BASE_URL: {{ . | quote }}
+    {{- end }}
+    {{- with $essWorkerBaseURL }}
+    {{- /* Keep the legacy worker alias until all NVCT builds consume the base URL directly. */}}
     NVCT_ESS_WORKER_BASE_URL: {{ . | quote }}
     {{- end }}
     {{- with dig "nvctApi" "icmsBaseUrl" nil .Values }}

--- a/deploy/stacks/self-managed/tests/ess-base-url-wiring.sh
+++ b/deploy/stacks/self-managed/tests/ess-base-url-wiring.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Test that the in-cluster ESS base URL for the NVCF/NVCT API is configurable
+# separately from the worker-advertised ESS endpoint. The stack used to derive
+# both the API's own NVCF_ESS_BASE_URL / NVCT_ESS_BASE_URL and the worker alias
+# (NVCF_ESS_WORKER_BASE_URL / NVCT_ESS_WORKER_BASE_URL) from the single
+# global.workerEndpoints.essServiceURL value, so a split-plane operator could
+# not keep workers on the public ESS URL while pointing the in-cluster API at
+# the in-cluster ess-api Service. api.essBaseURL / nvctApi.essBaseURL now
+# override only the self base URL and default to essServiceURL, so existing
+# installs are unchanged.
+#
+# global.yaml.gotmpl is the shared values source for every release, so it emits
+# both the api: and nvctApi: top-level blocks into any release it renders;
+# rendering the api release therefore exposes both for assertion.
+set -euo pipefail
+
+stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+work_dir="$(mktemp -d)"
+test_stack_dir="$work_dir/self-managed"
+environment_name="ess-base-url-wiring-test"
+environment_file="$test_stack_dir/environments/$environment_name.yaml"
+secrets_file="$test_stack_dir/secrets/$environment_name-secrets.yaml"
+trap 'rm -rf "$work_dir"' EXIT
+
+fail() {
+  echo "ess-base-url-wiring: $*" >&2
+  exit 1
+}
+
+mkdir -p "$test_stack_dir"
+cp -R "$stack_dir"/. "$test_stack_dir"
+printf '{}\n' >"$secrets_file"
+
+write_environment() {
+  cat >"$environment_file"
+}
+
+render_values() {
+  local output_file="$1"
+  local render_log="$work_dir/write-values.log"
+  if ! HELMFILE_ENV="$environment_name" HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" \
+    helmfile \
+      --file "$test_stack_dir/helmfile.d/02-core.yaml.gotmpl" \
+      --environment default \
+      --state-values-set ingress.gatewayApi.controllerNamespace=envoy-gateway-system \
+      --state-values-set ingress.gatewayApi.gateways.shared.name=shared-gw \
+      --state-values-set ingress.gatewayApi.gateways.shared.namespace=envoy-gateway-system \
+      --state-values-set ingress.gatewayApi.gateways.grpc.name=grpc-gw \
+      --state-values-set ingress.gatewayApi.gateways.grpc.namespace=envoy-gateway-system \
+      --selector name=api \
+      write-values \
+      --output-file-template "$output_file" 2>"$render_log"; then
+    cat "$render_log" >&2
+    fail "helmfile could not render the stack"
+  fi
+  test -s "$output_file" || fail "helmfile wrote no values to $output_file"
+}
+
+assert_value() {
+  local file="$1" expression="$2" want="$3" label="$4" got
+  got="$(yq -r "$expression" "$file")"
+  [[ "$got" == "$want" ]] ||
+    fail "$label: expected $want, got ${got:-<none>}"
+}
+
+public_url="https://ess.example.test"
+incluster_url="http://ess-api.ess.svc.cluster.local:8080"
+
+# ---------------------------------------------------------------------------
+# 1. Default: essServiceURL set, no essBaseURL override. Both the self base URL
+#    and the worker alias track essServiceURL -- unchanged behavior.
+# ---------------------------------------------------------------------------
+write_environment <<EOF
+global:
+  image:
+    registry: nvcr.io
+    repository: test/nvcf
+  workerEndpoints:
+    essServiceURL: $public_url
+EOF
+
+default_values="$work_dir/default-values.yaml"
+render_values "$default_values"
+assert_value "$default_values" '.api.env.NVCF_ESS_BASE_URL' "$public_url" \
+  "default: NVCF_ESS_BASE_URL tracks essServiceURL"
+assert_value "$default_values" '.api.env.NVCF_ESS_WORKER_BASE_URL' "$public_url" \
+  "default: NVCF_ESS_WORKER_BASE_URL tracks essServiceURL"
+assert_value "$default_values" '.nvctApi.env.NVCT_ESS_BASE_URL' "$public_url" \
+  "default: NVCT_ESS_BASE_URL tracks essServiceURL"
+assert_value "$default_values" '.nvctApi.env.NVCT_ESS_WORKER_BASE_URL' "$public_url" \
+  "default: NVCT_ESS_WORKER_BASE_URL tracks essServiceURL"
+
+# ---------------------------------------------------------------------------
+# 2. Override: essServiceURL is the public URL for workers; essBaseURL points
+#    the in-cluster API at the in-cluster Service. Only the self base URL
+#    changes; the worker alias stays on essServiceURL.
+# ---------------------------------------------------------------------------
+write_environment <<EOF
+global:
+  image:
+    registry: nvcr.io
+    repository: test/nvcf
+  workerEndpoints:
+    essServiceURL: $public_url
+api:
+  essBaseURL: $incluster_url
+nvctApi:
+  essBaseURL: $incluster_url
+EOF
+
+override_values="$work_dir/override-values.yaml"
+render_values "$override_values"
+assert_value "$override_values" '.api.env.NVCF_ESS_BASE_URL' "$incluster_url" \
+  "override: NVCF_ESS_BASE_URL uses api.essBaseURL"
+assert_value "$override_values" '.api.env.NVCF_ESS_WORKER_BASE_URL' "$public_url" \
+  "override: NVCF_ESS_WORKER_BASE_URL stays on essServiceURL"
+assert_value "$override_values" '.nvctApi.env.NVCT_ESS_BASE_URL' "$incluster_url" \
+  "override: NVCT_ESS_BASE_URL uses nvctApi.essBaseURL"
+assert_value "$override_values" '.nvctApi.env.NVCT_ESS_WORKER_BASE_URL' "$public_url" \
+  "override: NVCT_ESS_WORKER_BASE_URL stays on essServiceURL"
+
+# ---------------------------------------------------------------------------
+# 3. Neither set: no ESS endpoint at all -> no base URL and no worker alias are
+#    emitted, matching the pre-change empty case.
+# ---------------------------------------------------------------------------
+write_environment <<'EOF'
+global:
+  image:
+    registry: nvcr.io
+    repository: test/nvcf
+EOF
+
+empty_values="$work_dir/empty-values.yaml"
+render_values "$empty_values"
+assert_value "$empty_values" '.api.env.NVCF_ESS_BASE_URL' null \
+  "empty: NVCF_ESS_BASE_URL not emitted"
+assert_value "$empty_values" '.api.env.NVCF_ESS_WORKER_BASE_URL' null \
+  "empty: NVCF_ESS_WORKER_BASE_URL not emitted"
+assert_value "$empty_values" '.nvctApi.env.NVCT_ESS_BASE_URL' null \
+  "empty: NVCT_ESS_BASE_URL not emitted"
+assert_value "$empty_values" '.nvctApi.env.NVCT_ESS_WORKER_BASE_URL' null \
+  "empty: NVCT_ESS_WORKER_BASE_URL not emitted"
+
+# ---------------------------------------------------------------------------
+# 4. Override without a worker endpoint: essBaseURL set, essServiceURL empty ->
+#    the in-cluster API base URL is emitted with no worker alias.
+# ---------------------------------------------------------------------------
+write_environment <<EOF
+global:
+  image:
+    registry: nvcr.io
+    repository: test/nvcf
+api:
+  essBaseURL: $incluster_url
+nvctApi:
+  essBaseURL: $incluster_url
+EOF
+
+incluster_only_values="$work_dir/incluster-only-values.yaml"
+render_values "$incluster_only_values"
+assert_value "$incluster_only_values" '.api.env.NVCF_ESS_BASE_URL' "$incluster_url" \
+  "incluster-only: NVCF_ESS_BASE_URL uses api.essBaseURL"
+assert_value "$incluster_only_values" '.api.env.NVCF_ESS_WORKER_BASE_URL' null \
+  "incluster-only: NVCF_ESS_WORKER_BASE_URL not emitted"
+assert_value "$incluster_only_values" '.nvctApi.env.NVCT_ESS_BASE_URL' "$incluster_url" \
+  "incluster-only: NVCT_ESS_BASE_URL uses nvctApi.essBaseURL"
+assert_value "$incluster_only_values" '.nvctApi.env.NVCT_ESS_WORKER_BASE_URL' null \
+  "incluster-only: NVCT_ESS_WORKER_BASE_URL not emitted"
+
+echo "ess-base-url-wiring: OK"


### PR DESCRIPTION
## Summary

Add a first-class in-cluster override for the NVCF/NVCT API's **own** ESS base URL (`api.essBaseURL` / `nvctApi.essBaseURL`), separate from the worker-advertised ESS endpoint. Both default to `global.workerEndpoints.essServiceURL`, so existing installs render byte-identical.

## Additional Details

The stack derived the in-cluster API's own `NVCF_ESS_BASE_URL` / `NVCT_ESS_BASE_URL` from the **same** single value it uses to advertise ESS to remote workers (`global.workerEndpoints.essServiceURL`), and there was no `api.essBaseURL` / `nvctApi.essBaseURL` override anywhere.

In a split-plane deployment (workers outside the control-plane cluster), `essServiceURL` must be the **public** ESS URL so remote workers can reach it. But because that same value also set the in-cluster API's own base URL, the control plane's ESS calls hairpinned out to the public edge (LB/WAF) instead of the in-cluster `ess-api` Service — added latency plus a hard dependency on the public edge for an internal call. There was no supported way to keep workers on the public URL while pointing the in-cluster API at the Service.

Fix — add an in-cluster override that defaults to the worker endpoint, following the same `dig … "" .Values | default $workerURL` pattern the stack already uses for grpc-proxy's in-cluster targets (`grpcproxy.nvcfGrpcServiceURL`, `grpcproxy.natsServiceURL`, `grpcproxy.workerConnectBaseURL`):

- `deploy/stacks/self-managed/global.yaml.gotmpl` — resolve `$essApiBaseURL` / `$essNvctApiBaseURL` (default to `$essWorkerBaseURL`), and emit them for `NVCF_ESS_BASE_URL` / `NVCT_ESS_BASE_URL`. The worker aliases (`NVCF_ESS_WORKER_BASE_URL` / `NVCT_ESS_WORKER_BASE_URL`) stay tied to `essServiceURL`.
- `deploy/stacks/self-managed/environments/base.yaml` — document `api.essBaseURL` and `nvctApi.essBaseURL`.
- `deploy/stacks/self-managed/tests/ess-base-url-wiring.sh` — new wiring test, registered in the `Makefile`.

Operators then set it in `environments/<env>.yaml`:

```yaml
api:
  essBaseURL: "http://ess-api.ess.svc.cluster.local:8080"   # defaults to workerEndpoints.essServiceURL
nvctApi:
  essBaseURL: "http://ess-api.ess.svc.cluster.local:8080"
```

## For the Reviewer

- **Default-off / backward-compatible:** both knobs default to `$essWorkerBaseURL`, and the self base URL is still emitted only `with` a non-empty value, so an install that sets neither renders byte-identical (verified below for both the `essServiceURL`-empty and `essServiceURL`-set cases).
- **Convention:** uses the codebase's `dig … "" .Values | default $workerURL` form (as grpc-proxy does), not a new pattern.
- **Worker alias untouched:** `NVCF_ESS_WORKER_BASE_URL` / `NVCT_ESS_WORKER_BASE_URL` remain bound to `essServiceURL`; only the API's self base URL follows the override. NVCT key order (`BASE` then `WORKER`) is preserved so the default render is unchanged.
- **`nvctApi:` block added to `base.yaml`:** none existed; it carries only `essBaseURL: ""` and changes no render.

## For QA

**Automated test (`make test`).** Added `deploy/stacks/self-managed/tests/ess-base-url-wiring.sh`, wired into the offline `make test` target. It renders the release values with `helmfile write-values` and asserts via `yq` across four cases:
- **default (`essServiceURL` set, no override):** self base URL and worker alias both track `essServiceURL` (NVCF and NVCT);
- **override:** `NVCF_ESS_BASE_URL` / `NVCT_ESS_BASE_URL` use `essBaseURL` while the worker aliases stay on `essServiceURL`;
- **neither set:** no base URL and no worker alias emitted;
- **override without worker endpoint:** self base URL emitted, no worker alias.

**Manual verification.**
- **Byte-identical default:** rendered the API release values on this branch vs `origin/main` with `helmfile write-values` — a raw `diff` is empty for both `essServiceURL` empty and `essServiceURL` set to a public URL.
- **Override → rendered env ConfigMap:** with `essServiceURL=https://ess.public.example.test` and `essBaseURL=http://ess-api.ess.svc.cluster.local:8080`, `helm template` of both charts shows the split landing in the env ConfigMap:
  - `nvcf-api`: `NVCF_ESS_BASE_URL="http://ess-api.ess.svc.cluster.local:8080"`, `NVCF_ESS_WORKER_BASE_URL="https://ess.public.example.test"`;
  - `nvct-api`: `NVCT_ESS_BASE_URL="http://ess-api.ess.svc.cluster.local:8080"`, `NVCT_ESS_WORKER_BASE_URL="https://ess.public.example.test"`.
- **Neighbors:** `api-env-wiring.sh` and `invocation-env-wiring.sh` still pass.

## Issues

Fixes #1341

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for DCO compliance.
- [x] New or existing tests cover these changes. <!-- added tests/ess-base-url-wiring.sh (offline `make test`); also verified byte-identical origin/main diff (empty + set cases) and helm template of the nvcf-api/nvct-api env ConfigMap -->
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable in-cluster ESS base URLs for API and NVCT API traffic.
  * Defaults preserve existing worker ESS endpoint behavior while allowing separate internal routing.

* **Tests**
  * Added coverage for default, separate, omitted, and in-cluster-only ESS URL configurations.
  * Included the ESS URL wiring checks in the self-managed deployment test target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->