### PR TITLE
fix(stack): bump Pylon for registration TLS logging

### DIFF
--- a/deploy/helm/cloud-functions/nvcf-api/values.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/values.yaml
@@ -245,7 +245,7 @@ api:
           ess-agent-container: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/ess-agent:1.4.0
           otel-collector-container: dummy
           llm-credential-manager-image: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/nvcf-worker-llm-credentials-oss:1.1.1
-          llm-router-client-image: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/pylon:0.14.3
+          llm-router-client-image: ${nvcf.sidecars.hostname}/${nvcf.sidecars.repository}/pylon:0.15.1
         notary:
           turn:
             enabled: true

--- a/deploy/helm/cloud-functions/tests/sidecar_release_artifacts_test.sh
+++ b/deploy/helm/cloud-functions/tests/sidecar_release_artifacts_test.sh
@@ -53,7 +53,7 @@ expected_annotations=(
   "release-artifact-niclls-container-image: \"${hostname}/${repository}/nvcf_worker_niclls:2.109.4\""
   "release-artifact-ess-agent-container-image: \"${hostname}/${repository}/ess-agent:1.4.0\""
   "release-artifact-llm-credential-manager-image: \"${hostname}/${repository}/nvcf-worker-llm-credentials-oss:1.1.1\""
-  "release-artifact-llm-router-client-image: \"${hostname}/${repository}/pylon:0.14.3\""
+  "release-artifact-llm-router-client-image: \"${hostname}/${repository}/pylon:0.15.1\""
 )
 
 for annotation in "${expected_annotations[@]}"; do

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -445,7 +445,7 @@ natsAuthCalloutService:
 {{- else if $legacyPylonImageConfigured }}
 {{- $effectivePylonImage = $legacyPylonImage }}
 {{- else if $llmEnabled }}
-{{- $effectivePylonImage = printf "%s/%s/pylon:0.14.3" $sidecarsHost $sidecarsRepo }}
+{{- $effectivePylonImage = printf "%s/%s/pylon:0.15.1" $sidecarsHost $sidecarsRepo }}
 {{- end }}
 {{- $stackApiRemoteConfigData := dict }}
 {{- $stackNvcfRemoteConfig := dict }}

--- a/deploy/stacks/self-managed/tests/api-env-wiring.sh
+++ b/deploy/stacks/self-managed/tests/api-env-wiring.sh
@@ -139,7 +139,7 @@ assert_yaml_value "$explicit_manifest" \
   'select(.kind == "ConfigMap" and .data."nvcf-api.yaml" != null) | .data."nvcf-api.yaml" | from_yaml | .nvcf.sidecars.retained-setting' \
   keep-inside-sidecars "rendered nested sidecar remote config"
 
-# With no explicit value, the enabled LLM addon derives Pylon 0.14.3 from the
+# With no explicit value, the enabled LLM addon derives Pylon 0.15.1 from the
 # effective worker-sidecar registry rather than the control-plane image path.
 write_environment <<'EOF'
 global:
@@ -157,7 +157,7 @@ EOF
 default_values="$work_dir/default-values.yaml"
 render_api_values "$default_values" >/dev/null
 assert_yaml_value "$default_values" "$remote_pylon_expression" \
-  registry.example.test/team/sidecars/pylon:0.14.3 "computed Pylon default"
+  registry.example.test/team/sidecars/pylon:0.15.1 "computed Pylon default"
 
 # Local BDD fixtures rely on the same computed default after their registry
 # paths are configured. They must not carry unresolved fixture placeholders
@@ -174,8 +174,8 @@ for fixture_name in self-managed-local-bdd.yaml self-managed-local-bdd-multi.yam
   fixture_pylon_image="$(yq -r "$remote_pylon_expression" "$fixture_values")"
   [[ "$fixture_pylon_image" != *REPLACE_WITH_* ]] ||
     fail "$fixture_name Pylon property retained an unresolved fixture placeholder"
-  [[ "$fixture_pylon_image" == nvcr.io/sample-org/sample-team/pylon:0.14.3 ]] ||
-    fail "$fixture_name Pylon property: expected computed 0.14.3 image, got $fixture_pylon_image"
+  [[ "$fixture_pylon_image" == nvcr.io/sample-org/sample-team/pylon:0.15.1 ]] ||
+    fail "$fixture_name Pylon property: expected computed 0.15.1 image, got $fixture_pylon_image"
 done
 
 # The deprecated env key remains accepted for one compatibility window, but

--- a/docs/user/manifest.md
+++ b/docs/user/manifest.md
@@ -230,7 +230,7 @@ The following tables list the complete artifact inventory.
 | `nvcf_worker_init` | `1.0.1` | Required | Prepares function resources before the user container starts. | `nvcr.io/nvidia/nvcf/nvcf_worker_init:1.0.1` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/compute-plane-services/worker-init) |
 | `nvcf_worker_llm_credentials` | `1.0.1` | Optional | Maintains a current NVCF worker token for LLM function workloads. | `nvcr.io/nvidia/nvcf/nvcf_worker_llm_credentials:1.0.1` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/compute-plane-services/worker-llm-credentials) |
 | `nvcf_worker_utils` | `1.0.1` | Required | Proxies NATS traffic between function containers and the control plane. | `nvcr.io/nvidia/nvcf/nvcf_worker_utils:1.0.1` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/compute-plane-services/worker-utils) |
-| `pylon` | `0.14.3` | Optional | Connects LLM worker pods to the LLM request router. | `Publication pending` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/libraries/rust/stargate) |
+| `pylon` | `0.15.1` | Optional | Connects LLM worker pods to the LLM request router. | `Publication pending` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/libraries/rust/stargate) |
 
 ### EA-only CVE-impacted artifacts
 

--- a/docs/version-catalog/main.yaml
+++ b/docs/version-catalog/main.yaml
@@ -728,7 +728,7 @@ stack:
     - deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
     - deploy/stacks/self-managed/global.yaml.gotmpl
     - deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
-  pin_source_digest: sha256:952fba4fb3906887fe1661f6d8508b9470c2a5fe0746dba12a5a62d8384230dc
+  pin_source_digest: sha256:ce09f463f36314045441c14320dce63693d924e6ba240afdcb4a276c670bda66
 denylist:
   - name: strap
     reason: Legacy name replaced by nvcf-service-oss
@@ -969,7 +969,7 @@ artifacts:
   - name: pylon
     type: image
     registry: staging
-    version: 0.14.3
+    version: 0.15.1
   - name: reval-server
     type: image
     registry: staging


### PR DESCRIPTION
## Summary

Bump the worker Pylon sidecar from `0.14.3` to released `0.15.1` so self-managed NVCF deployments receive the actionable registration TLS validation logging for [NVBug 6696946](https://nvbugspro.nvidia.com/bug/6696946).

The runtime default, Cloud Functions sidecar default, staging version catalog, generated artifact manifest, and version assertions are updated together.

## Pylon release delta

The `src/libraries/rust/stargate/v0.14.3` to `v0.15.1` delta includes these merged PRs affecting the Stargate/Pylon release:

- [#1327](https://github.com/NVIDIA/nvcf/pull/1327) — support explicit Raw QUIC upstream trust in `stargate-k8s-router`.
- [#1417](https://github.com/NVIDIA/nvcf/pull/1417) — add warmup stabilization detection for early readiness promotion.
- [#1441](https://github.com/NVIDIA/nvcf/pull/1441) — log registration TLS validation failures, including actionable unknown-issuer diagnostics.

The `src/libraries/rust/stargate/v0.15.1` tag resolves to the merge commit for #1441.

## Validation

- `bash deploy/helm/cloud-functions/tests/sidecar_release_artifacts_test.sh`
- `bash deploy/stacks/self-managed/tests/api-env-wiring.sh`
- `make -C deploy/helm/cloud-functions lint`
- Focused `tools/docs-version-sync` catalog/render tests
- `git diff --check`

Full k3d installation testing is not included because this is a version/catalog pin update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Pylon LLM router client to version 0.15.1 across cloud-function and self-managed deployment configurations.
  - Updated optional compute-plane service documentation and staging artifact references to version 0.15.1.
  - Aligned deployment validation expectations with the updated Pylon version to ensure consistent environment setup and release checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->