### PR TITLE
fix(cli): validate shared gateway API and NATS hosts

### DIFF
--- a/src/clis/nvcf-cli/cmd/self_hosted_compute_plane.go
+++ b/src/clis/nvcf-cli/cmd/self_hosted_compute_plane.go
@@ -263,6 +263,7 @@ func runSelfHostedComputePlaneRegister(c *cobra.Command, _ []string) error {
 		NATSURL:           selected.Endpoints.NATSURL,
 		SISHost:           validation.Profile.ControlPlane.Hosts.SIS,
 		ReValHost:         validation.Profile.ControlPlane.Hosts.ReVal,
+		NATSHost:          validation.Profile.ControlPlane.Hosts.NATS,
 		ProbeHTTP:         shouldProbeComputeRegisterHTTP(selected.Name),
 	}); err != nil {
 		return err

--- a/src/clis/nvcf-cli/cmd/self_hosted_compute_plane_test.go
+++ b/src/clis/nvcf-cli/cmd/self_hosted_compute_plane_test.go
@@ -338,6 +338,9 @@ func TestComputePlaneRegisterDryRunRunsReachabilityCheck(t *testing.T) {
 	resetComputePlaneFlags(t)
 
 	profileFile := writeTestControlPlaneProfile(t, "cp-cluster")
+	updateTestControlPlaneProfile(t, profileFile, func(profile *controlplaneprofile.ControlPlaneProfile) {
+		profile.ControlPlane.Endpoints.ComputeReachable.NATSURL = "tls://api.example.test:4222"
+	})
 
 	prevFetcher := fetchClusterIdentity
 	t.Cleanup(func() { fetchClusterIdentity = prevFetcher })
@@ -366,9 +369,10 @@ func TestComputePlaneRegisterDryRunRunsReachabilityCheck(t *testing.T) {
 	assert.Equal(t, "https://api.example.test", got.GatewayHTTPURL)
 	assert.Equal(t, "https://sis.example.test", got.ICMSURL)
 	assert.Equal(t, "https://reval.example.test", got.ReValURL)
-	assert.Equal(t, "tls://nats.example.test:4222", got.NATSURL)
+	assert.Equal(t, "tls://api.example.test:4222", got.NATSURL)
 	assert.Equal(t, "sis.example.test", got.SISHost)
 	assert.Equal(t, "reval.example.test", got.ReValHost)
+	assert.Equal(t, "nats.example.test", got.NATSHost)
 	assert.False(t, got.ProbeHTTP)
 }
 
@@ -442,8 +446,11 @@ func TestComputePlaneRegisterDryRunRejectsMissingSharedGatewayHostsBeforeIdentit
 	updateTestControlPlaneProfile(t, profileFile, func(profile *controlplaneprofile.ControlPlaneProfile) {
 		profile.ControlPlane.Endpoints.ComputeReachable.ICMSURL = profile.ControlPlane.Gateway.HTTPURL
 		profile.ControlPlane.Endpoints.ComputeReachable.ReValURL = profile.ControlPlane.Gateway.HTTPURL
+		profile.ControlPlane.Endpoints.ComputeReachable.NATSURL = "tls://api.example.test:4222"
+		profile.ControlPlane.Hosts.API = ""
 		profile.ControlPlane.Hosts.SIS = ""
 		profile.ControlPlane.Hosts.ReVal = ""
+		profile.ControlPlane.Hosts.NATS = ""
 	})
 
 	fetchCalls := 0
@@ -465,10 +472,14 @@ func TestComputePlaneRegisterDryRunRejectsMissingSharedGatewayHostsBeforeIdentit
 
 	err := rootCmd.Execute()
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "controlPlane.gateway.httpURL")
+	assert.Contains(t, err.Error(), "controlPlane.hosts.api")
 	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.icmsURL")
 	assert.Contains(t, err.Error(), "controlPlane.hosts.sis")
 	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.revalURL")
 	assert.Contains(t, err.Error(), "controlPlane.hosts.reval")
+	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.natsURL")
+	assert.Contains(t, err.Error(), "controlPlane.hosts.nats")
 	assert.Equal(t, 0, fetchCalls, "identity discovery must not run after profile validation failure")
 }
 

--- a/src/clis/nvcf-cli/cmd/self_hosted_control_plane_test.go
+++ b/src/clis/nvcf-cli/cmd/self_hosted_control_plane_test.go
@@ -83,8 +83,11 @@ func TestControlPlaneProfileValidateCommandRejectsMissingSharedGatewayHosts(t *t
 	doc := strings.ReplaceAll(validControlPlaneProfileYAML(), "https://sis.nvcf-cp.internal", "https://gateway.nvcf-cp.internal")
 	doc = strings.ReplaceAll(doc, "https://reval.nvcf-cp.internal", "https://gateway.nvcf-cp.internal")
 	doc = strings.Replace(doc, "    httpURL: https://api.nvcf-cp.internal", "    httpURL: https://gateway.nvcf-cp.internal", 1)
+	doc = strings.Replace(doc, "      natsURL: tls://nats.nvcf-cp.internal:4222", "      natsURL: tls://gateway.nvcf-cp.internal:4222", 1)
+	doc = removeLine(doc, "    api: api.nvcf-cp.internal")
 	doc = removeLine(doc, "    sis: sis.nvcf-cp.internal")
 	doc = removeLine(doc, "    reval: reval.nvcf-cp.internal")
+	doc = removeLine(doc, "    nats: nats.nvcf-cp.internal")
 	path := writeControlPlaneProfileFixture(t, doc)
 	resetControlPlaneProfileValidateCommand(t)
 
@@ -98,10 +101,34 @@ func TestControlPlaneProfileValidateCommandRejectsMissingSharedGatewayHosts(t *t
 
 	err := rootCmd.Execute()
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "controlPlane.gateway.httpURL")
+	assert.Contains(t, err.Error(), "controlPlane.hosts.api")
 	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.icmsURL")
 	assert.Contains(t, err.Error(), "controlPlane.hosts.sis")
 	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.revalURL")
 	assert.Contains(t, err.Error(), "controlPlane.hosts.reval")
+	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.natsURL")
+	assert.Contains(t, err.Error(), "controlPlane.hosts.nats")
+}
+
+func TestControlPlaneProfileValidateCommandAcceptsSharedGatewayAPIAndNATSHosts(t *testing.T) {
+	doc := strings.Replace(validControlPlaneProfileYAML(), "    httpURL: https://api.nvcf-cp.internal", "    httpURL: https://gateway.nvcf-cp.internal", 1)
+	doc = strings.Replace(doc, "      natsURL: tls://nats.nvcf-cp.internal:4222", "      natsURL: tls://gateway.nvcf-cp.internal:4222", 1)
+	path := writeControlPlaneProfileFixture(t, doc)
+	resetControlPlaneProfileValidateCommand(t)
+
+	var stdout bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"self-hosted", "control-plane", "profile", "validate",
+		"--file", path,
+		"--require", "compute-reachable",
+	})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "control-plane profile is valid")
 }
 
 func TestControlPlaneProfileValidateCommandHelpShowsAnyRequireMode(t *testing.T) {

--- a/src/clis/nvcf-cli/internal/selfhosted/controlplaneprofile/profile.go
+++ b/src/clis/nvcf-cli/internal/selfhosted/controlplaneprofile/profile.go
@@ -289,9 +289,10 @@ func (v *validator) validateHosts() {
 
 func (v *validator) validateNoDNSHostHeaders() {
 	cp := v.doc.ControlPlane
-	requireHostForGatewayURL(v.add, "controlPlane.gateway.httpURL", cp.Gateway.HTTPURL, "", "controlPlane.hosts.api", cp.Hosts.API)
+	requireHostForGatewayURL(v.add, "controlPlane.gateway.httpURL", cp.Gateway.HTTPURL, cp.Gateway.HTTPURL, "controlPlane.hosts.api", cp.Hosts.API)
 	requireHostForGatewayURL(v.add, "controlPlane.endpoints.computeReachable.icmsURL", cp.Endpoints.ComputeReachable.ICMSURL, cp.Gateway.HTTPURL, "controlPlane.hosts.sis", cp.Hosts.SIS)
 	requireHostForGatewayURL(v.add, "controlPlane.endpoints.computeReachable.revalURL", cp.Endpoints.ComputeReachable.ReValURL, cp.Gateway.HTTPURL, "controlPlane.hosts.reval", cp.Hosts.ReVal)
+	requireHostForGatewayURL(v.add, "controlPlane.endpoints.computeReachable.natsURL", cp.Endpoints.ComputeReachable.NATSURL, cp.Gateway.HTTPURL, "controlPlane.hosts.nats", cp.Hosts.NATS)
 }
 
 // validateManagementTLS validates managementTls only when it is provided. An

--- a/src/clis/nvcf-cli/internal/selfhosted/controlplaneprofile/profile_test.go
+++ b/src/clis/nvcf-cli/internal/selfhosted/controlplaneprofile/profile_test.go
@@ -92,9 +92,33 @@ func TestValidateSharedGatewayHostnameRequiresServiceHostHeaders(t *testing.T) {
 	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.revalURL")
 }
 
+func TestValidateSharedGatewayHostnameRequiresAPIAndNATSHostHeaders(t *testing.T) {
+	doc := strings.Replace(validControlPlaneProfileYAML(), "    httpURL: https://api.nvcf-cp.internal", "    httpURL: https://gateway.nvcf-cp.internal", 1)
+	doc = strings.Replace(doc, "      natsURL: tls://nats.nvcf-cp.internal:4222", "      natsURL: tls://gateway.nvcf-cp.internal:4222", 1)
+	doc = strings.Replace(doc, "    api: api.nvcf-cp.internal\n", "", 1)
+	doc = strings.Replace(doc, "    nats: nats.nvcf-cp.internal\n", "", 1)
+
+	_, err := ParseAndValidate([]byte(doc), ValidateOptions{Require: RequireComputeReachable})
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "controlPlane.gateway.httpURL")
+	assert.Contains(t, err.Error(), "controlPlane.hosts.api")
+	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.natsURL")
+	assert.Contains(t, err.Error(), "controlPlane.hosts.nats")
+}
+
+func TestValidateSharedGatewayHostnameAcceptsAPIAndNATSHostHeaders(t *testing.T) {
+	doc := strings.Replace(validControlPlaneProfileYAML(), "    httpURL: https://api.nvcf-cp.internal", "    httpURL: https://gateway.nvcf-cp.internal", 1)
+	doc = strings.Replace(doc, "      natsURL: tls://nats.nvcf-cp.internal:4222", "      natsURL: tls://gateway.nvcf-cp.internal:4222", 1)
+
+	_, err := ParseAndValidate([]byte(doc), ValidateOptions{Require: RequireComputeReachable})
+	require.NoError(t, err)
+}
+
 func TestValidateDirectServiceHostnamesDoNotRequireHostOverrides(t *testing.T) {
 	doc := strings.Replace(validControlPlaneProfileYAML(), "    sis: sis.nvcf-cp.internal\n", "", 1)
 	doc = strings.Replace(doc, "    reval: reval.nvcf-cp.internal\n", "", 1)
+	doc = strings.Replace(doc, "    nats: nats.nvcf-cp.internal\n", "", 1)
 
 	_, err := ParseAndValidate([]byte(doc), ValidateOptions{Require: RequireComputeReachable})
 	require.NoError(t, err)

--- a/src/clis/nvcf-cli/internal/selfhosted/reachability/reachability.go
+++ b/src/clis/nvcf-cli/internal/selfhosted/reachability/reachability.go
@@ -36,6 +36,7 @@ type CheckRequest struct {
 	NATSURL           string
 	SISHost           string
 	ReValHost         string
+	NATSHost          string
 	HTTPClient        *http.Client
 	ProbeHTTP         bool
 }
@@ -67,7 +68,7 @@ func Check(ctx context.Context, req CheckRequest) error {
 	var problems []string
 	problems = append(problems, validateHTTPService("controlPlane.endpoints.computeReachable.icmsURL", req.ICMSURL, req.GatewayHTTPURL, "controlPlane.hosts.sis", req.SISHost)...)
 	problems = append(problems, validateHTTPService("controlPlane.endpoints.computeReachable.revalURL", req.ReValURL, req.GatewayHTTPURL, "controlPlane.hosts.reval", req.ReValHost)...)
-	problems = append(problems, validateNATSServiceShape(req.NATSURL)...)
+	problems = append(problems, validateNATSServiceShape(req.NATSURL, req.GatewayHTTPURL, req.NATSHost)...)
 	if len(problems) == 0 && req.ProbeHTTP {
 		client := req.HTTPClient
 		if client == nil {
@@ -108,7 +109,7 @@ func validateHTTPService(urlField, rawURL, gatewayHTTPURL, hostField, hostHeader
 	return problems
 }
 
-func validateNATSServiceShape(rawURL string) []string {
+func validateNATSServiceShape(rawURL, gatewayHTTPURL, hostHeader string) []string {
 	if strings.TrimSpace(rawURL) == "" {
 		return []string{"controlPlane.endpoints.computeReachable.natsURL: required"}
 	}
@@ -118,6 +119,9 @@ func validateNATSServiceShape(rawURL string) []string {
 	}
 	if u.Scheme != "nats" && u.Scheme != "tls" {
 		return []string{"controlPlane.endpoints.computeReachable.natsURL: scheme must be nats or tls; TCP reachability is not probed"}
+	}
+	if isGatewayAddress(u.Hostname(), gatewayHTTPURL) && strings.TrimSpace(hostHeader) == "" {
+		return []string{"controlPlane.hosts.nats: required when controlPlane.endpoints.computeReachable.natsURL uses a shared gateway address; set controlPlane.hosts.nats to the service Host header"}
 	}
 	return nil
 }

--- a/src/clis/nvcf-cli/internal/selfhosted/reachability/reachability_test.go
+++ b/src/clis/nvcf-cli/internal/selfhosted/reachability/reachability_test.go
@@ -50,7 +50,7 @@ func TestCheckRequiresHostHeadersForSharedGatewayHostname(t *testing.T) {
 		GatewayHTTPURL:    "https://gateway.example.test",
 		ICMSURL:           "https://gateway.example.test",
 		ReValURL:          "https://gateway.example.test",
-		NATSURL:           "tls://nats.example.test:4222",
+		NATSURL:           "tls://gateway.example.test:4222",
 		ProbeHTTP:         false,
 	})
 
@@ -59,6 +59,8 @@ func TestCheckRequiresHostHeadersForSharedGatewayHostname(t *testing.T) {
 	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.icmsURL")
 	assert.Contains(t, err.Error(), "controlPlane.hosts.reval")
 	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.revalURL")
+	assert.Contains(t, err.Error(), "controlPlane.hosts.nats")
+	assert.Contains(t, err.Error(), "controlPlane.endpoints.computeReachable.natsURL")
 }
 
 func TestCheckAllowsDirectServiceHostnamesWithoutHostOverrides(t *testing.T) {
@@ -68,6 +70,20 @@ func TestCheckAllowsDirectServiceHostnamesWithoutHostOverrides(t *testing.T) {
 		ICMSURL:           "https://sis.example.test",
 		ReValURL:          "https://reval.example.test",
 		NATSURL:           "tls://nats.example.test:4222",
+		ProbeHTTP:         false,
+	})
+
+	require.NoError(t, err)
+}
+
+func TestCheckAllowsSharedGatewayNATSWithHostOverride(t *testing.T) {
+	err := Check(context.Background(), CheckRequest{
+		TargetClusterName: "gpu-a",
+		GatewayHTTPURL:    "https://gateway.example.test",
+		ICMSURL:           "https://sis.example.test",
+		ReValURL:          "https://reval.example.test",
+		NATSURL:           "tls://gateway.example.test:4222",
+		NATSHost:          "nats.example.test",
 		ProbeHTTP:         false,
 	})
 


### PR DESCRIPTION
## TL;DR

Require API and NATS Host overrides when a self-managed control-plane profile routes those services through one shared gateway hostname.

## Additional Details

The CLI already validates SIS and ReVal Host overrides for shared gateways. The API gateway URL and compute-reachable NATS URL could still omit their consumed Host overrides, allowing profile validation and registration dry runs to accept routes that the gateway cannot select.

This change validates those two remaining paths, passes the NATS Host through registration reachability checks, and preserves direct service-DNS endpoints that do not need Host overrides.

SIS/ReVal Host forwarding and HTTP probe response handling are provided by [#1439](https://github.com/NVIDIA/nvcf/pull/1439). This PR does not duplicate those changes.

## Before and After

```mermaid
flowchart LR
  subgraph OLD["Before this PR"]
    direction TB
    B1["API and NATS use a shared gateway hostname"] --> B2["API or NATS Host override is missing"]
    B2 --> B3["Profile validation can pass"]
    B3 --> B4["Registration proceeds to identity discovery and reachability"]
  end

  subgraph NEW["After this PR"]
    direction TB
    A1["Validate control-plane profile"] --> A2{"hosts.api is set"}
    A2 -->|No| A7["Reject before identity discovery or reachability"]
    A2 -->|Yes| A3{"NATS endpoint shares the gateway hostname"}
    A3 -->|Yes| A4{"hosts.nats is set"}
    A4 -->|No| A7
    A3 -->|No, direct service DNS| A5["Profile is valid"]
    A4 -->|Yes| A5
    A5 --> A6["Registration passes NATSHost to reachability validation"]
  end
```

## For the Reviewer

Please focus on the shared-hostname comparison in the profile and reachability validators and the direct service-DNS compatibility tests.

## Public Verification

Run from `src/clis/nvcf-cli`:

```bash
go test ./cmd -run 'Test(ControlPlaneProfileValidateCommandRejectsMissingSharedGatewayHosts|ControlPlaneProfileValidateCommandAcceptsSharedGatewayAPIAndNATSHosts|ComputePlaneRegisterDryRunRejectsMissingSharedGatewayHostsBeforeIdentity|ComputePlaneRegisterDryRunRunsReachabilityCheck)$' -count=1
go test ./internal/selfhosted/controlplaneprofile -run 'TestValidate(SharedGatewayHostnameRequiresAPIAndNATSHostHeaders|SharedGatewayHostnameAcceptsAPIAndNATSHostHeaders|DirectServiceHostnamesDoNotRequireHostOverrides)$' -count=1
go test ./internal/selfhosted/reachability -run 'TestCheck(RequiresHostHeadersForSharedGatewayHostname|AllowsSharedGatewayNATSWithHostOverride|AllowsDirectServiceHostnamesWithoutHostOverrides)$' -count=1
go test ./cmd ./internal/selfhosted/controlplaneprofile ./internal/selfhosted/reachability -count=1
go build ./...
```

These cases verify that:

- Profiles missing required API or NATS Host overrides for a shared gateway are rejected before identity discovery or reachability.
- Shared-gateway profiles with both overrides are accepted.
- Direct service-DNS endpoints remain accepted without Host overrides.
- Registration passes `controlPlane.hosts.nats` to reachability validation as `NATSHost`.

## For QA

Additional validation completed:

- Compute-plane Helmfile render and handoff tests
- Live shared-gateway validation with missing and present Host overrides
- `git diff --check`

## Issues

Closes #1484

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Require API and NATS Host overrides when those endpoints use a shared gateway address.
  * Pass the configured NATS Host into compute-plane reachability validation.
  * Preserve direct service-DNS endpoints that do not require Host overrides.

* **Tests**
  * Expanded coverage for NATS reachability, endpoint validation, and shared gateway configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
