### PR TITLE
fix(gateway): require timeout-capable Envoy Gateway

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -134,6 +134,7 @@ jobs:
         run: |
           make -C tools/ncp-local-cluster test-cluster-lifecycle-make
           make -C tools/ncp-local-cluster test-multicluster-make
+          make -C tools/ncp-local-cluster test-gateway-timeout-compatibility
 
       # The repo tooling modules carry tests that no workflow ran, so a pull
       # request could break them and still go green. tools/docs-version-sync

--- a/docs/user/gateway-routing.md
+++ b/docs/user/gateway-routing.md
@@ -53,11 +53,15 @@ done
 
 ### Install Envoy Gateway
 
-Install Envoy Gateway as the Gateway API controller:
+Install Envoy Gateway as the Gateway API controller. The secure LLM worker
+route requires an Envoy Gateway CRD that exposes
+`BackendTrafficPolicy.spec.timeout.http.requestTimeout`. The pinned v1.5.4
+chart provides this field so the route can disable the default 15-second
+request timeout.
 
 ```bash
 helm upgrade --install eg oci://docker.io/envoyproxy/gateway-helm \
-  --version v1.1.3 \
+  --version v1.5.4 \
   -n envoy-gateway-system
 ```
 

--- a/tools/ncp-local-cluster/AGENTS.md
+++ b/tools/ncp-local-cluster/AGENTS.md
@@ -19,6 +19,7 @@ make print-compute-clusters
 make test-cluster-lifecycle-make
 make test-multicluster-make
 make test-validate-gateway-route
+make test-gateway-timeout-compatibility
 ```
 
 Cluster lifecycle targets require local tools such as `k3d`, `kubectl`, `helm`, and Docker.

--- a/tools/ncp-local-cluster/Makefile
+++ b/tools/ncp-local-cluster/Makefile
@@ -15,6 +15,8 @@
 
 .PHONY: help clean build test test-coverage-html test-manual start stop destroy destroy-all-ncp-local status ensure-cluster ensure-context ensure-docker-config validate-compute-clusters print-compute-clusters start-control-plane deploy-control-plane-addons deploy-control-plane-endpoints build-and-deploy-control-plane-cluster destroy-control-plane start-compute-plane deploy-compute-plane-addons configure-compute-control-plane-dns deploy-compute-control-plane-endpoints build-and-deploy-compute-plane-cluster destroy-compute-plane build-and-deploy-multicluster destroy-multicluster test-cluster-lifecycle-make test-destroy-all-ncp-local test-multicluster-make test-validate-gateway-route setup-gateway-api setup-metallb check-gateway-api deploy-sample deploy-nginx wait-for-nginx wait-for-gateway validate-gateway cleanup-nginx wait-for-deployment validate-deployment cleanup-sample build-and-deploy-cluster build-csi-smb deploy-csi-smb wait-for-csi-smb build-fake-gpu-operator deploy-fake-gpu-operator wait-for-fake-gpu-operator deploy-prometheus-crds uninstall-prometheus-crds deploy-kube-state-metrics wait-for-kube-state-metrics uninstall-kube-state-metrics build-credential-provider-multiarch
 
+.PHONY: test-gateway-timeout-compatibility
+
 # === Cluster Configuration ===
 CLUSTER_NAME := ncp-local
 K3D_CONFIG_FILE := k3d-config.yaml
@@ -314,6 +316,9 @@ test-destroy-all-ncp-local: ## Run dry Makefile tests for host-wide local-cluste
 
 test-validate-gateway-route: ## Run Gateway route retry tests
 	@tests/test-validate-gateway-route.sh
+
+test-gateway-timeout-compatibility: ## Run Envoy Gateway timeout capability tests
+	@tests/test-gateway-timeout-compatibility.sh
 
 # --- Load Balancer & Gateway API Setup ---
 setup-gateway-api:

--- a/tools/ncp-local-cluster/scripts/setup-gateway-api.sh
+++ b/tools/ncp-local-cluster/scripts/setup-gateway-api.sh
@@ -63,6 +63,20 @@ helm upgrade --install ${ENVOY_GATEWAY_RELEASE_NAME} ${ENVOY_GATEWAY_CHART} \
     --wait
 log_info "OK Envoy Gateway Helm chart applied successfully."
 
+# Secure LLM worker streams require this field to disable Envoy's default
+# 15-second request timeout. Older CRDs silently prune the field on a regular
+# apply, so check the installed schema before creating Gateway resources.
+request_timeout_type="$(
+    kubectl get crd backendtrafficpolicies.gateway.envoyproxy.io \
+        -o jsonpath='{range .spec.versions[?(@.served==true)]}{.schema.openAPIV3Schema.properties.spec.properties.timeout.properties.http.properties.requestTimeout.type}{"\n"}{end}'
+)"
+if ! grep -qx string <<<"${request_timeout_type}"; then
+    log_error "The installed Envoy Gateway CRD does not support BackendTrafficPolicy spec.timeout.http.requestTimeout."
+    log_error "Install or upgrade the CRDs to a timeout-capable Envoy Gateway release before enabling secure LLM worker routes."
+    exit 1
+fi
+log_info "OK Envoy Gateway supports disabling the LLM worker request timeout."
+
 # Step 2: Apply GatewayClass and Gateway resources
 log_info "Applying Envoy Gateway configuration..."
 kubectl apply -k "${PROJECT_ROOT}/apps/envoy-gateway"

--- a/tools/ncp-local-cluster/scripts/setup-gateway-api.sh
+++ b/tools/ncp-local-cluster/scripts/setup-gateway-api.sh
@@ -66,11 +66,11 @@ log_info "OK Envoy Gateway Helm chart applied successfully."
 # Secure LLM worker streams require this field to disable Envoy's default
 # 15-second request timeout. Older CRDs silently prune the field on a regular
 # apply, so check the installed schema before creating Gateway resources.
-request_timeout_type="$(
+request_timeout_schema="$(
     kubectl get crd backendtrafficpolicies.gateway.envoyproxy.io \
-        -o jsonpath='{range .spec.versions[?(@.served==true)]}{.schema.openAPIV3Schema.properties.spec.properties.timeout.properties.http.properties.requestTimeout.type}{"\n"}{end}'
+        -o jsonpath='{range .spec.versions[?(@.name=="v1alpha1")]}{.name}{"\t"}{.served}{"\t"}{.schema.openAPIV3Schema.properties.spec.properties.timeout.properties.http.properties.requestTimeout.type}{"\n"}{end}'
 )"
-if ! grep -qx string <<<"${request_timeout_type}"; then
+if ! grep -Eq '^v1alpha1[[:space:]]+true[[:space:]]+string$' <<<"${request_timeout_schema}"; then
     log_error "The installed Envoy Gateway CRD does not support BackendTrafficPolicy spec.timeout.http.requestTimeout."
     log_error "Install or upgrade the CRDs to a timeout-capable Envoy Gateway release before enabling secure LLM worker routes."
     exit 1

--- a/tools/ncp-local-cluster/tests/test-gateway-timeout-compatibility.sh
+++ b/tools/ncp-local-cluster/tests/test-gateway-timeout-compatibility.sh
@@ -34,7 +34,17 @@ case "${1:-}:${2:-}" in
     ;;
   get:crd)
     [[ "${3:-}" == "backendtrafficpolicies.gateway.envoyproxy.io" ]]
-    printf '%s\n' "${MOCK_REQUEST_TIMEOUT_TYPE-}"
+    if [[ "$*" == *'.name=="v1alpha1"'* ]]; then
+      printf 'v1alpha1\t%s\t%s\n' \
+        "${MOCK_V1ALPHA1_SERVED-}" "${MOCK_V1ALPHA1_REQUEST_TIMEOUT_TYPE-}"
+    else
+      if [[ "${MOCK_V1ALPHA1_SERVED-}" == true ]]; then
+        printf '%s\n' "${MOCK_V1ALPHA1_REQUEST_TIMEOUT_TYPE-}"
+      fi
+      if [[ "${MOCK_V1BETA1_SERVED-}" == true ]]; then
+        printf '%s\n' "${MOCK_V1BETA1_REQUEST_TIMEOUT_TYPE-}"
+      fi
+    fi
     ;;
   apply:-k)
     ;;
@@ -73,7 +83,10 @@ lowest_version="$(printf '%s\n%s\n' "$minimum_version" "$setup_version" | sort -
 [[ "$lowest_version" == "$minimum_version" ]] ||
   fail "Envoy Gateway $setup_version predates requestTimeout support"
 
-export MOCK_REQUEST_TIMEOUT_TYPE=string
+export MOCK_V1ALPHA1_SERVED=true
+export MOCK_V1ALPHA1_REQUEST_TIMEOUT_TYPE=string
+export MOCK_V1BETA1_SERVED=true
+export MOCK_V1BETA1_REQUEST_TIMEOUT_TYPE=
 "$setup_script" >"$test_dir/success.out"
 grep -Fq "helm upgrade --install eg" "$call_log" ||
   fail "setup did not install Envoy Gateway"
@@ -81,18 +94,21 @@ grep -Fq -- "--version $setup_version" "$call_log" ||
   fail "setup did not use the pinned Envoy Gateway version"
 grep -Fq "kubectl get crd backendtrafficpolicies.gateway.envoyproxy.io" "$call_log" ||
   fail "setup did not inspect the BackendTrafficPolicy CRD"
+grep -Fq '.spec.versions[?(@.name=="v1alpha1")]' "$call_log" ||
+  fail "setup did not inspect the v1alpha1 BackendTrafficPolicy schema"
 grep -Fq "kubectl apply -k" "$call_log" ||
   fail "timeout-capable CRD did not proceed to Gateway creation"
 grep -Fq "supports disabling the LLM worker request timeout" "$test_dir/success.out" ||
   fail "successful capability check was not reported"
 
 : >"$call_log"
-export MOCK_REQUEST_TIMEOUT_TYPE=
+export MOCK_V1ALPHA1_REQUEST_TIMEOUT_TYPE=
+export MOCK_V1BETA1_REQUEST_TIMEOUT_TYPE=string
 if "$setup_script" >"$test_dir/failure.out" 2>&1; then
-  fail "setup accepted a CRD without requestTimeout"
+  fail "setup accepted v1alpha1 without requestTimeout because another served version provided it"
 fi
 grep -Fq "installed Envoy Gateway CRD does not support BackendTrafficPolicy spec.timeout.http.requestTimeout" "$test_dir/failure.out" ||
-  fail "missing requestTimeout did not return the expected error"
+  fail "missing v1alpha1 requestTimeout did not return the expected error"
 if grep -Fq "kubectl apply -k" "$call_log"; then
   fail "setup created Gateway resources after the capability check failed"
 fi

--- a/tools/ncp-local-cluster/tests/test-gateway-timeout-compatibility.sh
+++ b/tools/ncp-local-cluster/tests/test-gateway-timeout-compatibility.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+local_cluster_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_dir="$(cd "${local_cluster_dir}/../.." && pwd)"
+test_dir="$(mktemp -d)"
+trap 'rm -rf "$test_dir"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+mkdir -p "$test_dir/bin"
+call_log="$test_dir/calls.log"
+: >"$call_log"
+
+cat >"$test_dir/bin/helm" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'helm %s\n' "$*" >>"$TEST_CALL_LOG"
+EOF
+
+cat >"$test_dir/bin/kubectl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'kubectl %s\n' "$*" >>"$TEST_CALL_LOG"
+
+case "${1:-}:${2:-}" in
+  cluster-info:)
+    ;;
+  get:crd)
+    [[ "${3:-}" == "backendtrafficpolicies.gateway.envoyproxy.io" ]]
+    printf '%s\n' "${MOCK_REQUEST_TIMEOUT_TYPE-}"
+    ;;
+  apply:-k)
+    ;;
+  get:gatewayclass)
+    if [[ "$*" == *jsonpath* ]]; then
+      printf 'True\n'
+    fi
+    ;;
+  *)
+    echo "unexpected kubectl command: $*" >&2
+    exit 64
+    ;;
+esac
+EOF
+
+chmod +x "$test_dir/bin/helm" "$test_dir/bin/kubectl"
+export PATH="$test_dir/bin:$PATH"
+export TEST_CALL_LOG="$call_log"
+
+setup_script="$local_cluster_dir/scripts/setup-gateway-api.sh"
+docs_file="$repo_dir/docs/user/gateway-routing.md"
+setup_version="$(sed -n 's/^ENVOY_GATEWAY_VERSION="\([^"]*\)"$/\1/p' "$setup_script")"
+docs_version="$(
+  awk '
+    /helm upgrade --install eg oci:\/\/docker.io\/envoyproxy\/gateway-helm/ { in_install = 1 }
+    in_install && /--version/ { print $2; exit }
+  ' "$docs_file"
+)"
+
+[[ -n "$setup_version" ]] || fail "setup script does not pin an Envoy Gateway version"
+[[ "$docs_version" == "$setup_version" ]] ||
+  fail "gateway guide pins $docs_version, but local setup pins $setup_version"
+
+minimum_version="v1.5.0"
+lowest_version="$(printf '%s\n%s\n' "$minimum_version" "$setup_version" | sort -V | head -1)"
+[[ "$lowest_version" == "$minimum_version" ]] ||
+  fail "Envoy Gateway $setup_version predates requestTimeout support"
+
+export MOCK_REQUEST_TIMEOUT_TYPE=string
+"$setup_script" >"$test_dir/success.out"
+grep -Fq "helm upgrade --install eg" "$call_log" ||
+  fail "setup did not install Envoy Gateway"
+grep -Fq -- "--version $setup_version" "$call_log" ||
+  fail "setup did not use the pinned Envoy Gateway version"
+grep -Fq "kubectl get crd backendtrafficpolicies.gateway.envoyproxy.io" "$call_log" ||
+  fail "setup did not inspect the BackendTrafficPolicy CRD"
+grep -Fq "kubectl apply -k" "$call_log" ||
+  fail "timeout-capable CRD did not proceed to Gateway creation"
+grep -Fq "supports disabling the LLM worker request timeout" "$test_dir/success.out" ||
+  fail "successful capability check was not reported"
+
+: >"$call_log"
+export MOCK_REQUEST_TIMEOUT_TYPE=
+if "$setup_script" >"$test_dir/failure.out" 2>&1; then
+  fail "setup accepted a CRD without requestTimeout"
+fi
+grep -Fq "installed Envoy Gateway CRD does not support BackendTrafficPolicy spec.timeout.http.requestTimeout" "$test_dir/failure.out" ||
+  fail "missing requestTimeout did not return the expected error"
+if grep -Fq "kubectl apply -k" "$call_log"; then
+  fail "setup created Gateway resources after the capability check failed"
+fi
+
+echo "Envoy Gateway timeout compatibility tests passed."


### PR DESCRIPTION
## TL;DR

Pin the gateway quickstart to Envoy Gateway v1.5.4 and fail local setup when the installed `BackendTrafficPolicy` CRD cannot disable the secure LLM worker request timeout.

## Additional Details

Secure LLM worker routing uses a `GRPCRoute` and renders `requestTimeout: 0s` for long-lived streams. The previously documented Envoy Gateway v1.1.3 CRD does not declare that field. Kubernetes can prune it during a normal apply while the resulting empty policy still reports accepted, leaving Envoy's default 15-second timeout active.

This change aligns the public guide with the v1.5.4 version already used by monorepo local-cluster tooling, checks the live CRD capability after installation, and adds a focused regression for the guard and version alignment. Existing route and policy templates are unchanged.

## For the Reviewer

Please focus on the post-install CRD capability check and the mocked compatibility test. The guard intentionally runs before local Gateway resources are created.

## For QA

Validated with:

- Live v1.1.3 and v1.5.4 CRD, Envoy config, and 20-second gRPC stream comparison
- `make -C deploy/helm/gateway-routes test`
- `make -C tools/ncp-local-cluster test-gateway-timeout-compatibility`
- Local-cluster lifecycle, multicluster, and Gateway route tests
- A unique Helmfile environment render with stored `requestTimeout: 0s`
- A live rerun of the modified setup script against v1.5.4
- Bash syntax and ShellCheck
- `tools/ci/check-docs` with zero errors
- `git diff --check`

## Follow-up Timeout Validation

Validated at PR head `1ec2a9411b822e503febaa397b2e7e2cfbbdb4b1` using Envoy Gateway v1.5.4 and the chart-rendered TLS `GRPCRoute` / `BackendTrafficPolicy` path.

### Envoy request-timeout matrix

The backend delayed its response headers for 20 seconds so the request timer could be attributed unambiguously.

| Policy | Effective Envoy route | Client result | Envoy attribution |
| --- | --- | --- | --- |
| Policy omitted | No explicit timeout | Failed after 15.388s with `Unavailable: upstream request timeout` | 15,000 ms, `UT`, `response_timeout`; backend observed cancellation at 14.999s |
| `requestTimeout: 0s` | `timeout: 0s`, `idle_timeout: 0s` | Succeeded after 20.371s | Normal upstream response with no timeout flag; backend completed at 20.021s |
| `requestTimeout: 5s` | `timeout: 5s`, `idle_timeout: 3600s` | Failed after 5.456s with `Unavailable: upstream request timeout` | 5,000 ms, `UT`, `response_timeout`; backend observed cancellation at 5.001s |

A separate bidirectional-stream control with response headers already received survived a 20-second inter-message gap. This confirms that the policy controls Envoy's request/pending-response cutoff; it should not be interpreted as disabling every downstream application timeout.

### Downstream application control

The Stargate binary from the same checkout built successfully. These focused tests passed:

```text
registration_stream_idle_timeout_closes_admitted_session
registration_idle_timeout_policy
```

They verify that Stargate retains a distinct, heartbeat-aware registration idle policy:

- A silent admitted registration is closed when its application timer expires, and its identity is released.
- The negotiated timeout uses three times the advertised heartbeat interval, constrained by the configured floor and maximum.
- Missing or malformed heartbeat metadata falls back to the configured maximum.
- Setting the application idle values to zero disables that application-level enforcement.

The default Stargate registration floor and maximum are 60 seconds and 300 seconds. Its separate 30-second QUIC request timeout and 10-second reverse-tunnel connection timeout are not the worker registration-stream timer.

### Scope and conclusion

The Envoy matrix and Stargate tests are separate controls, not one coupled end-to-end Stargate request. Within that boundary, the evidence confirms the intended behavior: `requestTimeout: 0s` removes Envoy's unwanted 15-second cutoff, while Stargate intentionally retains its own stale-registration protection. No additional code change is indicated by this validation.

## Issues

Closes #1486

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Local cluster setup now validates Gateway timeout support before creating resources.
  * Clear upgrade guidance is provided when the installed Envoy Gateway version lacks the required capability.

* **Documentation**
  * Updated installation guidance to use Envoy Gateway `v1.5.4`.
  * Documented the timeout configuration required for secure LLM worker routing.

* **Tests**
  * Added compatibility checks for supported and unsupported Gateway timeout configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
