### PR TITLE
fix(ratelimiter): bound grpc drain so the olric leave is broadcast

### DIFF
--- a/src/invocation-plane-services/ratelimiter/cmd/main.go
+++ b/src/invocation-plane-services/ratelimiter/cmd/main.go
@@ -28,6 +28,7 @@ import (
 	"os/signal"
 	"reflect"
 	"syscall"
+	"time"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	olricConfig "github.com/olric-data/olric/config"
@@ -35,6 +36,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
+	"google.golang.org/grpc"
 
 	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/nvkit/config"
 	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/nvkit/logs"
@@ -43,6 +45,27 @@ import (
 
 	"ratelimiter"
 )
+
+// Bounded so the deferred Olric leave in RateLimiter.Close still runs before the
+// termination grace period expires.
+const grpcDrainTimeout = 10 * time.Second
+
+func stopGrpcServer(server *grpc.Server, drainTimeout time.Duration) {
+	drained := make(chan struct{})
+	go func() {
+		server.GracefulStop()
+		close(drained)
+	}()
+
+	select {
+	case <-drained:
+	case <-time.After(drainTimeout):
+		zap.L().Warn("grpc drain timed out, forcing shutdown to preserve the olric leave",
+			zap.Duration("timeout", drainTimeout))
+		server.Stop()
+		<-drained
+	}
+}
 
 func main() {
 	setupLogger()
@@ -244,7 +267,7 @@ func NewRootCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			defer baseServer.GracefulStop()
+			defer stopGrpcServer(baseServer, grpcDrainTimeout)
 			grpcErrChan := make(chan error, 1)
 			go func() {
 				if err := baseServer.Serve(grpcListener); err != nil {

--- a/src/invocation-plane-services/ratelimiter/cmd/main.go
+++ b/src/invocation-plane-services/ratelimiter/cmd/main.go
@@ -59,11 +59,13 @@ func stopGrpcServer(server *grpc.Server, drainTimeout time.Duration) {
 
 	select {
 	case <-drained:
+		zap.L().Info("grpc server drained", zap.String("operation", "grpc_drain"))
 	case <-time.After(drainTimeout):
-		zap.L().Warn("grpc drain timed out, forcing shutdown to preserve the olric leave",
-			zap.Duration("timeout", drainTimeout))
+		// Not waiting on drained: a handler that ignores context cancellation
+		// keeps GracefulStop blocked even after Stop.
 		server.Stop()
-		<-drained
+		zap.L().Warn("grpc drain timed out, forced shutdown to preserve the olric leave",
+			zap.String("operation", "grpc_drain"), zap.Duration("timeout", drainTimeout))
 	}
 }
 

--- a/src/invocation-plane-services/ratelimiter/cmd/shutdown_test.go
+++ b/src/invocation-plane-services/ratelimiter/cmd/shutdown_test.go
@@ -35,15 +35,12 @@ type blockingRateLimitServer struct {
 	release chan struct{}
 }
 
-func (s *blockingRateLimitServer) RateLimit(ctx context.Context, _ *pb.RateLimitRequest) (*pb.RateLimitResponse, error) {
+func (s *blockingRateLimitServer) RateLimit(_ context.Context, _ *pb.RateLimitRequest) (*pb.RateLimitResponse, error) {
 	select {
 	case s.entered <- struct{}{}:
 	default:
 	}
-	select {
-	case <-s.release:
-	case <-ctx.Done():
-	}
+	<-s.release // ignores ctx cancellation, so only a forced stop unblocks shutdown
 	return &pb.RateLimitResponse{}, nil
 }
 

--- a/src/invocation-plane-services/ratelimiter/cmd/shutdown_test.go
+++ b/src/invocation-plane-services/ratelimiter/cmd/shutdown_test.go
@@ -1,0 +1,135 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"ratelimiter/pb"
+)
+
+type blockingRateLimitServer struct {
+	pb.UnimplementedRateLimitServiceServer
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s *blockingRateLimitServer) RateLimit(ctx context.Context, _ *pb.RateLimitRequest) (*pb.RateLimitResponse, error) {
+	select {
+	case s.entered <- struct{}{}:
+	default:
+	}
+	select {
+	case <-s.release:
+	case <-ctx.Done():
+	}
+	return &pb.RateLimitResponse{}, nil
+}
+
+// Returns a running server with one RateLimit call in flight.
+func startBlockedServer(t *testing.T) (*grpc.Server, func()) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	stub := &blockingRateLimitServer{
+		entered: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	server := grpc.NewServer()
+	pb.RegisterRateLimitServiceServer(server, stub)
+	go func() { _ = server.Serve(listener) }()
+
+	conn, err := grpc.NewClient(listener.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	callDone := make(chan struct{})
+	go func() {
+		defer close(callDone)
+		_, _ = pb.NewRateLimitServiceClient(conn).RateLimit(context.Background(), &pb.RateLimitRequest{})
+	}()
+
+	select {
+	case <-stub.entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("handler never received the call")
+	}
+
+	return server, func() {
+		close(stub.release)
+		_ = conn.Close()
+		<-callDone
+	}
+}
+
+// An unbounded drain delays the Olric leave until the pod is SIGKILLed.
+func TestStopGrpcServerBoundedByDrainTimeout(t *testing.T) {
+	server, cleanup := startBlockedServer(t)
+	defer cleanup()
+
+	drainTimeout := 200 * time.Millisecond
+	returned := make(chan time.Duration, 1)
+	go func() {
+		start := time.Now()
+		stopGrpcServer(server, drainTimeout)
+		returned <- time.Since(start)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("stopGrpcServer still blocked on an in-flight call, want it bounded near %v", drainTimeout)
+	}
+}
+
+func TestStopGrpcServerReturnsEarlyWhenIdle(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	server := grpc.NewServer()
+	pb.RegisterRateLimitServiceServer(server, &blockingRateLimitServer{
+		entered: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	})
+	go func() { _ = server.Serve(listener) }()
+
+	returned := make(chan struct{})
+	go func() {
+		stopGrpcServer(server, 10*time.Second)
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("idle shutdown did not return promptly")
+	}
+}


### PR DESCRIPTION
## Why

On SIGTERM the ratelimiter's deferred cleanup runs LIFO:

```
defer rateLimiter.Close()       // broadcasts the Olric leave
defer baseServer.GracefulStop() // runs first, waits for in-flight calls
```

`GracefulStop` is unbounded. Under load an in-flight RateLimit call can hold
the drain open past the pod termination grace period, so the process is
SIGKILLed before `RateLimiter.Close` runs and the Olric leave is never sent.

The departing address then stays in the cluster routing table. Peers keep
dialing it until each dial times out, the coordinator wedges, and a newly
started pod never receives a routing table. It fails `NewDMap` with
`operation timeout` at the bootstrap timeout, exits, and crashloops. The state
is self-sustaining: redeploying the previous image does not clear it, because
the stale member lives in cluster runtime state rather than in the image.
Recovery requires restarting every pod so the ring reforms.

Confirmed against a three-pod deployment under sustained RateLimit traffic.
Deleting a pod normally (leave broadcast sent) let the replacement bootstrap in
under a second. Deleting one with `--grace-period=0` (no leave broadcast) made
the replacement fail with `operation timeout` at exactly the bootstrap timeout
and crashloop, while peers logged tens of thousands of dial timeouts to the
dead address. An overrunning graceful stop produces the same condition.

## What changed

`stopGrpcServer` caps the drain at `grpcDrainTimeout` (10s) and calls
`server.Stop()` once it expires, so the deferred Olric leave always has budget
to run inside the termination grace period. Shutdown stays graceful whenever
in-flight calls finish in time.

## Customer Release Notes

Fixed a rate limiter shutdown path that could leave a departing pod registered
in the distributed cache cluster, causing newly started pods to crashloop
during a rolling update.

## Plan Summary

Not applicable

## Usage

Not applicable

## Testing

`go test ./cmd/ -run TestStopGrpcServer`. Both cases pass with the change. With
the bound removed, `TestStopGrpcServerBoundedByDrainTimeout` fails after
blocking the full 5s guard, so the test covers the regression rather than the
implementation.

Not yet exercised end to end against a deployed build; that needs an image and
a rolling update to confirm the leave is broadcast in the SIGTERM path.

## Notes

`grpcDrainTimeout` is 10s against a 30s default termination grace period,
leaving room for the leave broadcast plus the remaining deferred cleanup. It is
a constant rather than configuration; worth revisiting if a deployment lowers
its grace period below roughly 20s.

Two related hardening items are deliberately out of scope here: making a
joiner's bootstrap tolerate a transient routing table delay instead of exiting
on the first timeout, and the upstream behavior where one unreachable member
can stall routing updates for the cluster.

## References

Closes #1493

## Related Pull Requests

None

## Dependencies

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate-limiter service shutdown handling with a bounded 10-second graceful-drain period.
  * The service now completes shutdown promptly when idle and forces shutdown when active requests exceed the timeout.
  * Shutdown outcomes are logged clearly, including successful draining and timed-out requests.

* **Tests**
  * Added coverage for shutdown behavior with both active and idle requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->