### PR TITLE
fix(grpc-proxy): touch README to trigger a release

### DIFF
--- a/src/invocation-plane-services/grpc-proxy/README.md
+++ b/src/invocation-plane-services/grpc-proxy/README.md
@@ -14,6 +14,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
+<!-- Release-pipeline touchpoint for #315: validates version-registration on release. -->
 # NVCF GRPC Proxy
 
 A proxy service that facilitates communication between clients and NVIDIA Cloud Functions (NVCF) workers. This service handles HTTP/3 CONNECT endpoints, HTTP/1 CONNECT endpoints, and HTTP/1-2 forwarding for GRPC requests.


### PR DESCRIPTION
## Why
Testing release-pipeline version-registration wiring for #315 requires a
real release. This is a deliberate no-op commit to cut one.

## What changed
Added a comment to README.md.

## Testing
No-op change made to trigger a release for pipeline validation.

## Issues
Relates to #315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a note about release-pipeline validation for version registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->