### PR TITLE
fix(worker-utils): bump the worker library pin so the transport rotation ships

### DIFF
--- a/src/compute-plane-services/worker-init/go.mod
+++ b/src/compute-plane-services/worker-init/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/NVIDIA/nvcf/src/libraries/go/lib v0.0.0-20260807010315-d791d3c11262
-	github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260710034659-973443ac16c3
+	github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.10
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.10

--- a/src/compute-plane-services/worker-init/go.mod
+++ b/src/compute-plane-services/worker-init/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/NVIDIA/nvcf/src/libraries/go/lib v0.0.0-20260807010315-d791d3c11262
-	github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7
+	github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260903135415-10c9eba7e15d
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.10
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.10

--- a/src/compute-plane-services/worker-init/go.sum
+++ b/src/compute-plane-services/worker-init/go.sum
@@ -16,6 +16,8 @@ github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260710034659-973443ac16c
 github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260710034659-973443ac16c3/go.mod h1:LYrJLNwPMTruA5cu+9GuMhNvji24ErB1UwcaaB/yooE=
 github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7 h1:53FW/pykhuSZSIiwN2iL15bpO/IXxo/Zi0IzPE7neok=
 github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7/go.mod h1:LYrJLNwPMTruA5cu+9GuMhNvji24ErB1UwcaaB/yooE=
+github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260903135415-10c9eba7e15d h1:UGAIo0ovVo8DaH46H+fEqrfhB/uPU+uKFuYPaMg/MBg=
+github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260903135415-10c9eba7e15d/go.mod h1:yPG1uaGhjD+83ku7ylHeZPlKsDUFujZTaTjgtp3zk4U=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/antithesishq/antithesis-sdk-go v0.4.3-default-no-op h1:+OSa/t11TFhqfrX0EOSqQBDJ0YlpmK0rDSiB19dg9M0=

--- a/src/compute-plane-services/worker-init/go.sum
+++ b/src/compute-plane-services/worker-init/go.sum
@@ -14,6 +14,8 @@ github.com/NVIDIA/nvcf/src/libraries/go/lib v0.0.0-20260807010315-d791d3c11262 h
 github.com/NVIDIA/nvcf/src/libraries/go/lib v0.0.0-20260807010315-d791d3c11262/go.mod h1:WUFjMVtVWK1PAw7WBXM0nWhYbtlE/4zyfjkj+lHUEtY=
 github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260710034659-973443ac16c3 h1:3a00OqSlHTn3BQnzNEQXqY8x0j25tgLDztNepZsDkgg=
 github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260710034659-973443ac16c3/go.mod h1:LYrJLNwPMTruA5cu+9GuMhNvji24ErB1UwcaaB/yooE=
+github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7 h1:53FW/pykhuSZSIiwN2iL15bpO/IXxo/Zi0IzPE7neok=
+github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7/go.mod h1:LYrJLNwPMTruA5cu+9GuMhNvji24ErB1UwcaaB/yooE=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/antithesishq/antithesis-sdk-go v0.4.3-default-no-op h1:+OSa/t11TFhqfrX0EOSqQBDJ0YlpmK0rDSiB19dg9M0=

--- a/src/compute-plane-services/worker-llm-credentials/go.mod
+++ b/src/compute-plane-services/worker-llm-credentials/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/NVIDIA/nvcf/src/libraries/go/lib v0.0.0-20260710034659-973443ac16c3
-	github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260710034659-973443ac16c3
+	github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7
 	github.com/samber/lo v1.51.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/src/compute-plane-services/worker-llm-credentials/go.mod
+++ b/src/compute-plane-services/worker-llm-credentials/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/NVIDIA/nvcf/src/libraries/go/lib v0.0.0-20260710034659-973443ac16c3
-	github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7
+	github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260903135415-10c9eba7e15d
 	github.com/samber/lo v1.51.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/src/compute-plane-services/worker-llm-credentials/go.sum
+++ b/src/compute-plane-services/worker-llm-credentials/go.sum
@@ -6,6 +6,8 @@ github.com/NVIDIA/nvcf/src/libraries/go/lib v0.0.0-20260710034659-973443ac16c3 h
 github.com/NVIDIA/nvcf/src/libraries/go/lib v0.0.0-20260710034659-973443ac16c3/go.mod h1:nj3yBW2weO0qzi1ML45tBqviLa2Y/KG9qCalxQuJVB8=
 github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260710034659-973443ac16c3 h1:3a00OqSlHTn3BQnzNEQXqY8x0j25tgLDztNepZsDkgg=
 github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260710034659-973443ac16c3/go.mod h1:LYrJLNwPMTruA5cu+9GuMhNvji24ErB1UwcaaB/yooE=
+github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7 h1:53FW/pykhuSZSIiwN2iL15bpO/IXxo/Zi0IzPE7neok=
+github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7/go.mod h1:LYrJLNwPMTruA5cu+9GuMhNvji24ErB1UwcaaB/yooE=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/src/compute-plane-services/worker-llm-credentials/go.sum
+++ b/src/compute-plane-services/worker-llm-credentials/go.sum
@@ -8,6 +8,8 @@ github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260710034659-973443ac16c
 github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260710034659-973443ac16c3/go.mod h1:LYrJLNwPMTruA5cu+9GuMhNvji24ErB1UwcaaB/yooE=
 github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7 h1:53FW/pykhuSZSIiwN2iL15bpO/IXxo/Zi0IzPE7neok=
 github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7/go.mod h1:LYrJLNwPMTruA5cu+9GuMhNvji24ErB1UwcaaB/yooE=
+github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260903135415-10c9eba7e15d h1:UGAIo0ovVo8DaH46H+fEqrfhB/uPU+uKFuYPaMg/MBg=
+github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260903135415-10c9eba7e15d/go.mod h1:yPG1uaGhjD+83ku7ylHeZPlKsDUFujZTaTjgtp3zk4U=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/src/compute-plane-services/worker-task/go.mod
+++ b/src/compute-plane-services/worker-task/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/NVIDIA/nvcf/src/libraries/go/lib v0.0.0-20260710034659-973443ac16c3
-	github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260710034659-973443ac16c3
+	github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-viper/mapstructure/v2 v2.5.0

--- a/src/compute-plane-services/worker-task/go.mod
+++ b/src/compute-plane-services/worker-task/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/NVIDIA/nvcf/src/libraries/go/lib v0.0.0-20260710034659-973443ac16c3
-	github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7
+	github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260903135415-10c9eba7e15d
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-viper/mapstructure/v2 v2.5.0

--- a/src/compute-plane-services/worker-task/go.sum
+++ b/src/compute-plane-services/worker-task/go.sum
@@ -8,6 +8,8 @@ github.com/NVIDIA/nvcf/src/libraries/go/lib v0.0.0-20260710034659-973443ac16c3 h
 github.com/NVIDIA/nvcf/src/libraries/go/lib v0.0.0-20260710034659-973443ac16c3/go.mod h1:nj3yBW2weO0qzi1ML45tBqviLa2Y/KG9qCalxQuJVB8=
 github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260710034659-973443ac16c3 h1:3a00OqSlHTn3BQnzNEQXqY8x0j25tgLDztNepZsDkgg=
 github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260710034659-973443ac16c3/go.mod h1:LYrJLNwPMTruA5cu+9GuMhNvji24ErB1UwcaaB/yooE=
+github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7 h1:53FW/pykhuSZSIiwN2iL15bpO/IXxo/Zi0IzPE7neok=
+github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7/go.mod h1:LYrJLNwPMTruA5cu+9GuMhNvji24ErB1UwcaaB/yooE=
 github.com/antithesishq/antithesis-sdk-go v0.4.3-default-no-op h1:+OSa/t11TFhqfrX0EOSqQBDJ0YlpmK0rDSiB19dg9M0=
 github.com/antithesishq/antithesis-sdk-go v0.4.3-default-no-op/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl3v2yvUZjmKncl7U91fup7E=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/src/compute-plane-services/worker-task/go.sum
+++ b/src/compute-plane-services/worker-task/go.sum
@@ -10,6 +10,8 @@ github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260710034659-973443ac16c
 github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260710034659-973443ac16c3/go.mod h1:LYrJLNwPMTruA5cu+9GuMhNvji24ErB1UwcaaB/yooE=
 github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7 h1:53FW/pykhuSZSIiwN2iL15bpO/IXxo/Zi0IzPE7neok=
 github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7/go.mod h1:LYrJLNwPMTruA5cu+9GuMhNvji24ErB1UwcaaB/yooE=
+github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260903135415-10c9eba7e15d h1:UGAIo0ovVo8DaH46H+fEqrfhB/uPU+uKFuYPaMg/MBg=
+github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260903135415-10c9eba7e15d/go.mod h1:yPG1uaGhjD+83ku7ylHeZPlKsDUFujZTaTjgtp3zk4U=
 github.com/antithesishq/antithesis-sdk-go v0.4.3-default-no-op h1:+OSa/t11TFhqfrX0EOSqQBDJ0YlpmK0rDSiB19dg9M0=
 github.com/antithesishq/antithesis-sdk-go v0.4.3-default-no-op/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl3v2yvUZjmKncl7U91fup7E=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/src/compute-plane-services/worker-utils/go.mod
+++ b/src/compute-plane-services/worker-utils/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/NVIDIA/nvcf/src/libraries/go/lib v0.0.0-20260710034659-973443ac16c3
-	github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7
+	github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260903135415-10c9eba7e15d
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/src/compute-plane-services/worker-utils/go.mod
+++ b/src/compute-plane-services/worker-utils/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/NVIDIA/nvcf/src/libraries/go/lib v0.0.0-20260710034659-973443ac16c3
-	github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260710034659-973443ac16c3
+	github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/src/compute-plane-services/worker-utils/go.sum
+++ b/src/compute-plane-services/worker-utils/go.sum
@@ -20,6 +20,8 @@ github.com/NVIDIA/nvcf/src/libraries/go/lib v0.0.0-20260710034659-973443ac16c3 h
 github.com/NVIDIA/nvcf/src/libraries/go/lib v0.0.0-20260710034659-973443ac16c3/go.mod h1:nj3yBW2weO0qzi1ML45tBqviLa2Y/KG9qCalxQuJVB8=
 github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260710034659-973443ac16c3 h1:3a00OqSlHTn3BQnzNEQXqY8x0j25tgLDztNepZsDkgg=
 github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260710034659-973443ac16c3/go.mod h1:LYrJLNwPMTruA5cu+9GuMhNvji24ErB1UwcaaB/yooE=
+github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7 h1:53FW/pykhuSZSIiwN2iL15bpO/IXxo/Zi0IzPE7neok=
+github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7/go.mod h1:LYrJLNwPMTruA5cu+9GuMhNvji24ErB1UwcaaB/yooE=
 github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2 h1:ZBbLwSJqkHBuFDA6DUhhse0IGJ7T5bemHyNILUjvOq4=
 github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2/go.mod h1:VSw57q4QFiWDbRnjdX8Cb3Ow0SFncRw+bA/ofY6Q83w=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=

--- a/src/compute-plane-services/worker-utils/go.sum
+++ b/src/compute-plane-services/worker-utils/go.sum
@@ -22,6 +22,8 @@ github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260710034659-973443ac16c
 github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260710034659-973443ac16c3/go.mod h1:LYrJLNwPMTruA5cu+9GuMhNvji24ErB1UwcaaB/yooE=
 github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7 h1:53FW/pykhuSZSIiwN2iL15bpO/IXxo/Zi0IzPE7neok=
 github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260902221359-b62eeeca37a7/go.mod h1:LYrJLNwPMTruA5cu+9GuMhNvji24ErB1UwcaaB/yooE=
+github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260903135415-10c9eba7e15d h1:UGAIo0ovVo8DaH46H+fEqrfhB/uPU+uKFuYPaMg/MBg=
+github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260903135415-10c9eba7e15d/go.mod h1:yPG1uaGhjD+83ku7ylHeZPlKsDUFujZTaTjgtp3zk4U=
 github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2 h1:ZBbLwSJqkHBuFDA6DUhhse0IGJ7T5bemHyNILUjvOq4=
 github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2/go.mod h1:VSw57q4QFiWDbRnjdX8Cb3Ow0SFncRw+bA/ofY6Q83w=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=


### PR DESCRIPTION
## Issues

Relates to #1382

## Why

The four worker services consume `src/libraries/go/worker` as a pinned pseudo-version, not as local source:

```
src/compute-plane-services/{worker-utils,worker-init,worker-task,worker-llm-credentials}/go.mod
  github.com/NVIDIA/nvcf/src/libraries/go/worker v0.0.0-20260710034659-973443ac16c3
```

That pin is from 10 July, so every worker image built since then excludes anything merged into the library — including the QUIC transport rotation from #1383.

This was verified, not assumed. Two dev images built from different commits, one containing #1383, came out with identical digests:

```
gh.1136-748ba8d1   sha256:5a0a158a...
gh.1182-ce91506b   sha256:5a0a158a...
```

Extracting the layers and grepping the binary:

```
'failed to dial host'            1   <- control, the proxy package IS linked
'rotating quic transport'        0   <- #1383 absent
'consecutive dial failures'      0   <- #1383 absent
```

Deploying either image would have shown the failure unchanged and read as the fix not working, when it was never compiled in.

## What changed

The pin moves to a commit containing #1383, in all four consumers plus their `go.sum`:

```
v0.0.0-20260710034659-973443ac16c3  ->  v0.0.0-20260902221359-b62eeeca37a7
```

All four are bumped together on purpose. Leaving any behind produces images that disagree about the library version.

## Customer Release Notes

Not customer visible on its own. It is what allows the worker-side fix in #1383 to reach a built image.

## Plan Summary

Not applicable.

## Usage

Verify any worker image before drawing conclusions from a deploy:

```sh
skopeo copy docker://<image> dir:/tmp/x
for f in /tmp/x/*; do gzip -t "$f" 2>/dev/null && zcat "$f" || cat "$f"; done > all.bin
grep -ac 'rotating quic transport' all.bin      # must be >= 1
```

## Testing

Built `//src/compute-plane-services/worker-utils/worker:worker` against the new pin and grepped the compiled archive:

```
proxy.a  'rotating quic transport'   2
         'consecutive dial failures' 2
         'failed to dial host'       2   (control)
```

Before the bump the first two were zero in the shipped image.

The module proxy serves the new pseudo-version (`200` for the `.info` endpoint), so CI needs no special resolution. Local `go get` required `GOPRIVATE` because the proxy will not resolve the nested module path by SHA without it, but that is a workstation concern and not a build dependency.

## Notes

The pin is a recurring trap: it is silent, and the failure mode is a build that succeeds and produces an image identical to the previous one. Worth considering whether these services should consume the library through the workspace instead, so library changes cannot be silently excluded. Not attempted here.

## References

None

## Related Pull Requests

#1383 is the rotation this makes shippable. #1492 adds diagnostics for it and is not included in this pin.

## Dependencies

No new third-party dependencies. Only the in-repo library pin and the corresponding `go.sum` entries change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated supporting worker service components to use a newer internal worker library version.
  * Improved consistency across worker-based services through aligned internal maintenance updates.
  * No user-visible functionality, workflows, or capabilities changed in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->