### PR TITLE
feat(icms-api): New ICMS endpoints that accept an instance count and perform the selection and termination within ICMS.

### DIFF
--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/errors/GlobalErrorHandler.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/errors/GlobalErrorHandler.java
@@ -39,6 +39,7 @@ import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSourceResolvable;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.dao.DataAccessException;
@@ -49,12 +50,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.annotation.RequestScope;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 
 import static com.nvidia.icms.service.telemetry.model.Events.INTERNAL_SERVER_ERROR_EVENT;
 
@@ -137,6 +140,44 @@ public class GlobalErrorHandler {
         error.setError(errMsg);
 
         return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(HandlerMethodValidationException.class)
+    public ResponseEntity<Object> handleHandlerMethodValidationException(
+            HandlerMethodValidationException exception) {
+
+        sendTelemetryEvent(exception, Events.ERROR_EVENT.toString());
+        CustomErrorResponse error = new CustomErrorResponse();
+        error.setError(toCleanMessage(exception));
+
+        return new ResponseEntity<>(error, exception.getStatusCode());
+    }
+
+    private static String toCleanMessage(HandlerMethodValidationException exception) {
+        StringBuilder message = new StringBuilder("Validation failed with ");
+        appendErrors(message, exception.getAllErrors());
+        return message.toString();
+    }
+
+    private static void appendErrors(
+            StringBuilder message, List<? extends MessageSourceResolvable> errors) {
+        for (MessageSourceResolvable error : errors) {
+            message.append('[');
+            if (error instanceof FieldError fieldError) {
+                message.append("Field error in object '")
+                        .append(fieldError.getObjectName())
+                        .append("' on field '")
+                        .append(fieldError.getField())
+                        .append("': rejected value [")
+                        .append(fieldError.getRejectedValue())
+                        .append("]; ")
+                        .append(fieldError.getDefaultMessage());
+            } else {
+                message.append(error);
+            }
+            message.append("] ");
+        }
+        message.deleteCharAt(message.length() - 1);
     }
 
     @ExceptionHandler(IcmsBadRequestException.class)

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/inbound/rest/controllers/InstanceController.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/inbound/rest/controllers/InstanceController.java
@@ -547,7 +547,10 @@ public class InstanceController {
             @Schema(description = "Number of instances to terminate")
             @RequestParam(name = "InstanceCount") int instanceCount) {
 
-        validateBoundedTermination(ncaId, instanceCount);
+        if (StringUtils.isBlank(ncaId)) {
+            throw new IcmsBadRequestException("ncaId should be provided");
+        }
+
         Map<String, Object> auditProps = AuditUtils.getAuditPropertiesFromRequest(request);
         return instanceService.terminateInstances(
                 ncaId, workloadId, null, instanceCount, auditProps);
@@ -627,20 +630,13 @@ public class InstanceController {
             @Schema(description = "Number of instances to terminate")
             @RequestParam(name = "InstanceCount") int instanceCount) {
 
-        validateBoundedTermination(ncaId, instanceCount);
+        if (StringUtils.isBlank(ncaId)) {
+            throw new IcmsBadRequestException("ncaId should be provided");
+        }
 
         Map<String, Object> auditProps = AuditUtils.getAuditPropertiesFromRequest(request);
         return instanceService.terminateInstances(
                 ncaId, workloadId, gpuSpecId, instanceCount, auditProps);
-    }
-
-    private void validateBoundedTermination(String ncaId, int instanceCount) {
-        if (StringUtils.isBlank(ncaId)) {
-            throw new IcmsBadRequestException("ncaId should be provided");
-        }
-        if (instanceCount <= 0) {
-            throw new IcmsBadRequestException("InstanceCount should be greater than zero");
-        }
     }
 
     @PutMapping

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/inbound/rest/controllers/InstanceController.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/inbound/rest/controllers/InstanceController.java
@@ -518,6 +518,41 @@ public class InstanceController {
         return instanceService.instanceDeploymentTermination(ncaId, workloadId,null, auditProps);
     }
 
+    @DeleteMapping(value = "/accounts/{ncaId}/workloads/{workloadId}/instances",
+            params = "InstanceCount")
+    @PreAuthorize("hasAuthority('spot-request') or hasAuthority('instance-request')")
+    @Operation(summary = "Terminate a number of workload instances",
+            description = "Select and terminate a number of instances for a workload",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(content = @Content(schema = @Schema(hidden = true)),
+                            responseCode = "400", description = "Bad request"),
+                    @ApiResponse(content = @Content(schema = @Schema(hidden = true)),
+                            responseCode = "401", description = "Unauthorized"),
+                    @ApiResponse(content = @Content(schema = @Schema(hidden = true)),
+                            responseCode = "403", description = "Forbidden - invalid token provided"),
+                    @ApiResponse(content = @Content(schema = @Schema(hidden = true)),
+                            responseCode = "404", description = "Not Found"),
+                    @ApiResponse(content = @Content(schema = @Schema(hidden = true)),
+                            responseCode = "429", description = "Too many requests"),
+                    @ApiResponse(content = @Content(schema = @Schema(hidden = true)),
+                            responseCode = "500", description = "Internal server error")
+            })
+    public TerminateInstancesResponse deleteInstancesByWorkload(
+            HttpServletRequest request,
+            @Schema(description = "nca id of function owner")
+            @PathVariable("ncaId") @NotNull String ncaId,
+            @Schema(description = "NVCF deployment id or NVCT task id")
+            @PathVariable("workloadId") @NotNull UUID workloadId,
+            @Schema(description = "Number of instances to terminate")
+            @RequestParam(name = "InstanceCount") int instanceCount) {
+
+        validateBoundedTermination(ncaId, instanceCount);
+        Map<String, Object> auditProps = AuditUtils.getAuditPropertiesFromRequest(request);
+        return instanceService.terminateInstances(
+                ncaId, workloadId, null, instanceCount, auditProps);
+    }
+
 
     @DeleteMapping({"/accounts/{ncaId}/deployments/{workloadId}/gpuSpecs/{gpuSpecId}",
             "/accounts/{ncaId}/tasks/{workloadId}/gpuSpecs/{gpuSpecId}",
@@ -559,6 +594,53 @@ public class InstanceController {
         Map<String, Object> auditProps = AuditUtils.getAuditPropertiesFromRequest(request);
 
         return instanceService.instanceDeploymentTermination(ncaId, workloadId,gpuSpecId, auditProps);
+    }
+
+    @DeleteMapping("/accounts/{ncaId}/workloads/{workloadId}/gpuSpecs/{gpuSpecId}/instances")
+    @PreAuthorize("hasAuthority('spot-request') or hasAuthority('instance-request')")
+    @Operation(summary = "Terminate a number of workload instances",
+            description = "Select and terminate a number of instances for a workload and GPU "
+                    + "specification",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(content = @Content(schema = @Schema(hidden = true)),
+                            responseCode = "400", description = "Bad request"),
+                    @ApiResponse(content = @Content(schema = @Schema(hidden = true)),
+                            responseCode = "401", description = "Unauthorized"),
+                    @ApiResponse(content = @Content(schema = @Schema(hidden = true)),
+                            responseCode = "403", description = "Forbidden - invalid token provided"),
+                    @ApiResponse(content = @Content(schema = @Schema(hidden = true)),
+                            responseCode = "404", description = "Not Found"),
+                    @ApiResponse(content = @Content(schema = @Schema(hidden = true)),
+                            responseCode = "429", description = "Too many requests"),
+                    @ApiResponse(content = @Content(schema = @Schema(hidden = true)),
+                            responseCode = "500", description = "Internal server error")
+            })
+    public TerminateInstancesResponse deleteInstancesByGpuSpec(
+            HttpServletRequest request,
+            @Schema(description = "nca id of function owner")
+            @PathVariable("ncaId") @NotNull String ncaId,
+            @Schema(description = "NVCF deployment id or NVCT task id")
+            @PathVariable("workloadId") @NotNull UUID workloadId,
+            @Schema(description = "NVCF GPU Specification id")
+            @PathVariable("gpuSpecId") @NotNull UUID gpuSpecId,
+            @Schema(description = "Number of instances to terminate")
+            @RequestParam(name = "InstanceCount") int instanceCount) {
+
+        validateBoundedTermination(ncaId, instanceCount);
+
+        Map<String, Object> auditProps = AuditUtils.getAuditPropertiesFromRequest(request);
+        return instanceService.terminateInstances(
+                ncaId, workloadId, gpuSpecId, instanceCount, auditProps);
+    }
+
+    private void validateBoundedTermination(String ncaId, int instanceCount) {
+        if (StringUtils.isBlank(ncaId)) {
+            throw new IcmsBadRequestException("ncaId should be provided");
+        }
+        if (instanceCount <= 0) {
+            throw new IcmsBadRequestException("InstanceCount should be greater than zero");
+        }
     }
 
     @PutMapping

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/inbound/rest/controllers/InstanceController.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/inbound/rest/controllers/InstanceController.java
@@ -18,11 +18,9 @@ package com.nvidia.icms.inbound.rest.controllers;
 
 import static com.nvidia.icms.inbound.rest.converters.ErrorDataConverter.toUnifiedErrorData;
 import static com.nvidia.icms.uec.IcmsUnifiedError.NVCF_INCORRECT_PARAMETER;
-import static com.nvidia.icms.uec.UnifiedErrorData.stringFromUuid;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import com.nvidia.icms.errors.IcmsBadRequestException;
-import com.nvidia.icms.errors.IcmsConflictException;
 import com.nvidia.icms.inbound.rest.converters.CreateInstanceApiModelConverter;
 import com.nvidia.icms.inbound.rest.converters.InstanceModelConverter;
 import com.nvidia.icms.inbound.rest.model.CreateSpotInstanceRequestApiModel;
@@ -38,8 +36,8 @@ import com.nvidia.icms.inbound.rest.model.instance.TerminateInstanceRequestsResp
 import com.nvidia.icms.inbound.rest.model.swagger.schema.SpotInstanceRequestSchema;
 import com.nvidia.icms.service.InstanceService;
 import com.nvidia.icms.uec.IcmsHttpUnifiedErrorException;
-import com.nvidia.icms.uec.UnifiedErrorException;
 import com.nvidia.icms.uec.UnifiedErrorData;
+import com.nvidia.icms.uec.UnifiedErrorException;
 import com.nvidia.icms.uec.UnifiedErrorReporter;
 import com.nvidia.icms.util.AuthUtils;
 import com.nvidia.icms.util.audit.AuditUtils;
@@ -52,8 +50,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.time.Instant;
+import jakarta.validation.constraints.Positive;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -521,8 +520,8 @@ public class InstanceController {
     @DeleteMapping(value = "/accounts/{ncaId}/workloads/{workloadId}/instances",
             params = "InstanceCount")
     @PreAuthorize("hasAuthority('spot-request') or hasAuthority('instance-request')")
-    @Operation(summary = "Terminate a number of workload instances",
-            description = "Select and terminate a number of instances for a workload",
+    @Operation(summary = "Terminate specified number of instances",
+            description = "Terminates specified number of instances for the specified workload",
             responses = {
                     @ApiResponse(responseCode = "200", description = "OK"),
                     @ApiResponse(content = @Content(schema = @Schema(hidden = true)),
@@ -541,15 +540,11 @@ public class InstanceController {
     public TerminateInstancesResponse deleteInstancesByWorkload(
             HttpServletRequest request,
             @Schema(description = "nca id of function owner")
-            @PathVariable("ncaId") @NotNull String ncaId,
-            @Schema(description = "NVCF deployment id or NVCT task id")
+            @PathVariable("ncaId") @NotBlank String ncaId,
+            @Schema(description = "NVCF workload id")
             @PathVariable("workloadId") @NotNull UUID workloadId,
             @Schema(description = "Number of instances to terminate")
-            @RequestParam(name = "InstanceCount") int instanceCount) {
-
-        if (StringUtils.isBlank(ncaId)) {
-            throw new IcmsBadRequestException("ncaId should be provided");
-        }
+            @RequestParam(name = "InstanceCount") @Positive int instanceCount) {
 
         Map<String, Object> auditProps = AuditUtils.getAuditPropertiesFromRequest(request);
         return instanceService.terminateInstances(
@@ -601,9 +596,8 @@ public class InstanceController {
 
     @DeleteMapping("/accounts/{ncaId}/workloads/{workloadId}/gpuSpecs/{gpuSpecId}/instances")
     @PreAuthorize("hasAuthority('spot-request') or hasAuthority('instance-request')")
-    @Operation(summary = "Terminate a number of workload instances",
-            description = "Select and terminate a number of instances for a workload and GPU "
-                    + "specification",
+    @Operation(summary = "Terminate specified number of instances",
+            description = "Terminates specified number of instances for the specified gpu-spec",
             responses = {
                     @ApiResponse(responseCode = "200", description = "OK"),
                     @ApiResponse(content = @Content(schema = @Schema(hidden = true)),
@@ -622,17 +616,13 @@ public class InstanceController {
     public TerminateInstancesResponse deleteInstancesByGpuSpec(
             HttpServletRequest request,
             @Schema(description = "nca id of function owner")
-            @PathVariable("ncaId") @NotNull String ncaId,
-            @Schema(description = "NVCF deployment id or NVCT task id")
+            @PathVariable("ncaId") @NotBlank String ncaId,
+            @Schema(description = "NVCF workload id")
             @PathVariable("workloadId") @NotNull UUID workloadId,
             @Schema(description = "NVCF GPU Specification id")
             @PathVariable("gpuSpecId") @NotNull UUID gpuSpecId,
             @Schema(description = "Number of instances to terminate")
-            @RequestParam(name = "InstanceCount") int instanceCount) {
-
-        if (StringUtils.isBlank(ncaId)) {
-            throw new IcmsBadRequestException("ncaId should be provided");
-        }
+            @RequestParam(name = "InstanceCount") @Positive int instanceCount) {
 
         Map<String, Object> auditProps = AuditUtils.getAuditPropertiesFromRequest(request);
         return instanceService.terminateInstances(

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/InstanceService.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/InstanceService.java
@@ -112,6 +112,16 @@ public class InstanceService {
         return terminateInstanceService.terminateInstances(ncaId, deploymentId, gpuSpecificationId, instanceId, auditProps);
     }
 
+    public TerminateInstancesResponse terminateInstances(
+            @NotNull String ncaId,
+            @NotNull UUID deploymentId,
+            @Nullable UUID gpuSpecificationId,
+            int instanceCount,
+            @NotNull Map<String, Object> auditProps) {
+        return terminateInstanceService.terminateInstances(
+                ncaId, deploymentId, gpuSpecificationId, instanceCount, auditProps);
+    }
+
     public TerminateInstancesResponse terminateInstanceRequests(
             String customer,
             Set<String> requestIds,

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/InstanceService.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/InstanceService.java
@@ -113,11 +113,11 @@ public class InstanceService {
     }
 
     public TerminateInstancesResponse terminateInstances(
-            @NotNull String ncaId,
-            @NotNull UUID deploymentId,
-            @Nullable UUID gpuSpecificationId,
+            String ncaId,
+            UUID deploymentId,
+            UUID gpuSpecificationId,
             int instanceCount,
-            @NotNull Map<String, Object> auditProps) {
+            Map<String, Object> auditProps) {
         return terminateInstanceService.terminateInstances(
                 ncaId, deploymentId, gpuSpecificationId, instanceCount, auditProps);
     }

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/TerminateInstanceService.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/TerminateInstanceService.java
@@ -17,6 +17,7 @@
 package com.nvidia.icms.service;
 
 import com.nvidia.icms.configuration.bean.IcmsConfigurationProperties;
+import com.nvidia.icms.errors.IcmsBadRequestException;
 import com.nvidia.icms.errors.IcmsInternalServerException;
 import com.nvidia.icms.errors.IcmsNotFoundException;
 import com.nvidia.icms.inbound.rest.model.ClientRequestDataModel;
@@ -35,6 +36,7 @@ import com.nvidia.icms.service.platform.ComputePlatformService;
 import com.nvidia.icms.service.telemetry.TelemetryEventClient;
 import com.nvidia.icms.service.telemetry.model.Events;
 import com.nvidia.icms.service.telemetry.model.GenericMetric;
+import com.nvidia.icms.util.TimeUtils;
 import com.nvidia.icms.util.audit.AuditUtils;
 import io.micrometer.observation.annotation.Observed;
 import jakarta.annotation.Nullable;
@@ -45,6 +47,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -55,6 +58,7 @@ import java.util.stream.Collectors;
 
 import static com.nvidia.icms.inbound.rest.model.SpotRequestStatusCode.PENDING_FULFILLMENT;
 import static com.nvidia.icms.util.audit.AuditUtils.populateAuditValuesForTerminateInstanceRequest;
+import static java.util.stream.Collectors.toSet;
 
 @Service
 @Slf4j
@@ -98,6 +102,57 @@ public class TerminateInstanceService {
 
         validatedInstances = validateInstancesOwnership(validatedInstances, ncaId, deploymentId, gpuSpecificationId);
         return terminateInstancesForAllProviders(validatedInstances, auditProps);
+    }
+
+    @Observed
+    public TerminateInstancesResponse terminateInstances(
+            @NotNull String ncaId,
+            @NotNull UUID deploymentId,
+            @Nullable UUID gpuSpecificationId,
+            int instanceCount,
+            @NotNull Map<String, Object> auditProps) {
+        if (instanceCount <= 0) {
+            throw new IcmsBadRequestException("InstanceCount should be greater than zero");
+        }
+
+        List<InstanceV2Entity> deploymentInstances = gpuSpecificationId == null
+                ? instanceV2Repository.findInstancesByDeploymentId(deploymentId)
+                : instanceV2Repository.findInstancesByGpuSpecificationId(
+                        deploymentId, gpuSpecificationId);
+        Set<InstanceV2Entity> instances = selectInstancesToTerminate(
+                deploymentInstances
+                .stream()
+                .filter(instance -> ncaId.equals(instance.getNcaId()))
+                .filter(this::isInstanceRunning)
+                .collect(toSet()),
+                instanceCount);
+
+        if (instances.isEmpty()) {
+            return emptyResponse();
+        }
+
+        Set<String> instanceIds = instances.stream()
+                .map(InstanceV2Entity::getInstanceId)
+                .collect(toSet());
+        Set<InstanceV2Entity> validatedInstances = validateInstanceTermination(null, instanceIds);
+        validatedInstances = validateInstancesOwnership(
+                validatedInstances, ncaId, deploymentId, gpuSpecificationId);
+        return terminateInstancesForAllProviders(validatedInstances, auditProps);
+    }
+
+    // Keep this selection order in sync with NVCF's IcmsAllocatorService.
+    private static Set<InstanceV2Entity> selectInstancesToTerminate(
+            Set<InstanceV2Entity> instances,
+            int count) {
+        return instances.stream()
+                .filter(instance -> instance.getInstanceId() != null)
+                .sorted(Comparator
+                        .comparing((InstanceV2Entity instance) ->
+                                instance.getInstanceStateName() == SpotInstanceInternalState.RUNNING)
+                        .thenComparing(instance ->
+                                TimeUtils.getInstantFromUuid(instance.getCreateTimeuuid())))
+                .limit(count)
+                .collect(toSet());
     }
 
 

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/TerminateInstanceService.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/TerminateInstanceService.java
@@ -106,15 +106,11 @@ public class TerminateInstanceService {
 
     @Observed
     public TerminateInstancesResponse terminateInstances(
-            @NotNull String ncaId,
-            @NotNull UUID deploymentId,
-            @Nullable UUID gpuSpecificationId,
+            String ncaId,
+            UUID deploymentId,
+            UUID gpuSpecificationId,
             int instanceCount,
-            @NotNull Map<String, Object> auditProps) {
-        if (instanceCount <= 0) {
-            throw new IcmsBadRequestException("InstanceCount should be greater than zero");
-        }
-
+            Map<String, Object> auditProps) {
         List<InstanceV2Entity> deploymentInstances = gpuSpecificationId == null
                 ? instanceV2Repository.findInstancesByDeploymentId(deploymentId)
                 : instanceV2Repository.findInstancesByGpuSpecificationId(

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/inbound/rest/controllers/InstanceControllerTest.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/inbound/rest/controllers/InstanceControllerTest.java
@@ -739,6 +739,61 @@ class InstanceControllerTest extends IntegrationTest {
     }
 
     @Test
+    void terminateInstanceCountPerGpuSpec_routesToBoundedTermination()
+            throws Exception {
+        String ncaId = RandomFactory.getRandomStringWithPrefix("ncaid", 5);
+        UUID workloadId = UUID.randomUUID();
+        UUID gpuSpecId = UUID.randomUUID();
+        var response = new TerminateInstancesResponse();
+
+        doReturn(response).when(instanceService).terminateInstances(
+                eq(ncaId), eq(workloadId), eq(gpuSpecId), eq(2), Mockito.any());
+
+        String url = "/v1/si/accounts/" + ncaId + "/workloads/" + workloadId
+                + "/gpuSpecs/" + gpuSpecId + "/instances";
+        mockMvc.perform(MockMvcRequestBuilders.delete(url)
+                        .headers(generateAuthorizationHeader())
+                        .param("InstanceCount", "2"))
+                .andExpect(status().isOk());
+
+        verify(instanceService).terminateInstances(
+                eq(ncaId), eq(workloadId), eq(gpuSpecId), eq(2), Mockito.any());
+    }
+
+    @Test
+    void terminateInstanceCountPerWorkload_routesToBoundedTermination()
+            throws Exception {
+        String ncaId = RandomFactory.getRandomStringWithPrefix("ncaid", 5);
+        UUID workloadId = UUID.randomUUID();
+        var response = new TerminateInstancesResponse();
+
+        doReturn(response).when(instanceService).terminateInstances(
+                eq(ncaId), eq(workloadId), eq(null), eq(2), Mockito.any());
+
+        String url = "/v1/si/accounts/" + ncaId + "/workloads/" + workloadId
+                + "/instances";
+        mockMvc.perform(MockMvcRequestBuilders.delete(url)
+                        .headers(generateAuthorizationHeader())
+                        .param("InstanceCount", "2"))
+                .andExpect(status().isOk());
+
+        verify(instanceService).terminateInstances(
+                eq(ncaId), eq(workloadId), eq(null), eq(2), Mockito.any());
+    }
+
+    @Test
+    void terminateInstanceCountPerGpuSpec_withNonPositiveCount_returnsBadRequest()
+            throws Exception {
+        String url = "/v1/si/accounts/nca/workloads/" + UUID.randomUUID()
+                + "/gpuSpecs/" + UUID.randomUUID() + "/instances";
+
+        mockMvc.perform(MockMvcRequestBuilders.delete(url)
+                        .headers(generateAuthorizationHeader())
+                        .param("InstanceCount", "0"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     void terminateInstances_withInstanceIdsNotProvided_returnsError()
             throws Exception {
         HttpHeaders httpHeaders = generateAuthorizationHeader();

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/inbound/rest/controllers/InstanceControllerTest.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/inbound/rest/controllers/InstanceControllerTest.java
@@ -782,18 +782,6 @@ class InstanceControllerTest extends IntegrationTest {
     }
 
     @Test
-    void terminateInstanceCountPerGpuSpec_withNonPositiveCount_returnsBadRequest()
-            throws Exception {
-        String url = "/v1/si/accounts/nca/workloads/" + UUID.randomUUID()
-                + "/gpuSpecs/" + UUID.randomUUID() + "/instances";
-
-        mockMvc.perform(MockMvcRequestBuilders.delete(url)
-                        .headers(generateAuthorizationHeader())
-                        .param("InstanceCount", "0"))
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
     void terminateInstances_withInstanceIdsNotProvided_returnsError()
             throws Exception {
         HttpHeaders httpHeaders = generateAuthorizationHeader();

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/inbound/rest/controllers/InstanceControllerTest.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/inbound/rest/controllers/InstanceControllerTest.java
@@ -51,6 +51,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -779,6 +780,41 @@ class InstanceControllerTest extends IntegrationTest {
 
         verify(instanceService).terminateInstances(
                 eq(ncaId), eq(workloadId), eq(null), eq(2), Mockito.any());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1})
+    void terminateInstanceCountPerWorkload_withNonPositiveCount_returnsBadRequest(
+            int instanceCount) throws Exception {
+        String ncaId = RandomFactory.getRandomStringWithPrefix("ncaid", 5);
+        UUID workloadId = UUID.randomUUID();
+        String url = "/v1/si/accounts/" + ncaId + "/workloads/" + workloadId
+                + "/instances";
+
+        mockMvc.perform(MockMvcRequestBuilders.delete(url)
+                        .headers(generateAuthorizationHeader())
+                        .param("InstanceCount", String.valueOf(instanceCount)))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(instanceService);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1})
+    void terminateInstanceCountPerGpuSpec_withNonPositiveCount_returnsBadRequest(
+            int instanceCount) throws Exception {
+        String ncaId = RandomFactory.getRandomStringWithPrefix("ncaid", 5);
+        UUID workloadId = UUID.randomUUID();
+        UUID gpuSpecId = UUID.randomUUID();
+        String url = "/v1/si/accounts/" + ncaId + "/workloads/" + workloadId
+                + "/gpuSpecs/" + gpuSpecId + "/instances";
+
+        mockMvc.perform(MockMvcRequestBuilders.delete(url)
+                        .headers(generateAuthorizationHeader())
+                        .param("InstanceCount", String.valueOf(instanceCount)))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(instanceService);
     }
 
     @Test

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/service/InstanceServiceTest.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/service/InstanceServiceTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 import com.nvidia.icms.configuration.bean.IcmsConfigurationProperties;
 import com.nvidia.icms.inbound.rest.model.CreateSpotInstancesResponse;
 import com.nvidia.icms.inbound.rest.model.GetSpotInstanceRequests;
+import com.nvidia.icms.inbound.rest.model.TerminateInstancesResponse;
 import com.nvidia.icms.inbound.rest.model.swagger.schema.SpotInstanceRequestSchema;
 import com.nvidia.icms.service.createInstances.CreateInstanceService;
 import java.util.Map;
@@ -107,6 +108,22 @@ public class InstanceServiceTest {
         Assertions.assertEquals(uuid, createInstancesResponse.getRequestId());
         verify(createInstanceService).processInstanceRequest(DUMMY_CUSTOMER_1,
                                                              instanceRequestSchema, Map.of());
+    }
+
+    @Test
+    void terminateInstancesByGpuSpec_delegatesToTerminateService() {
+        UUID deploymentId = UUID.randomUUID();
+        UUID gpuSpecId = UUID.randomUUID();
+        var response = new TerminateInstancesResponse();
+        when(terminateInstanceService.terminateInstances(
+                "nca", deploymentId, gpuSpecId, 2, Map.of())).thenReturn(response);
+
+        var result = instanceService.terminateInstances(
+                "nca", deploymentId, gpuSpecId, 2, Map.of());
+
+        Assertions.assertSame(response, result);
+        verify(terminateInstanceService).terminateInstances(
+                "nca", deploymentId, gpuSpecId, 2, Map.of());
     }
 
     @Test

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/service/TerminateInstanceServiceTest.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/service/TerminateInstanceServiceTest.java
@@ -28,6 +28,7 @@ import com.nvidia.icms.inbound.rest.model.SpotInstanceState;
 import com.nvidia.icms.inbound.rest.model.SpotRequestStatusCode;
 import com.nvidia.icms.inbound.rest.model.TerminateInstancesResponse;
 import com.nvidia.icms.outbound.cassandra.instance.InstanceV2Repository;
+import com.nvidia.icms.outbound.cassandra.instance.entity.InstanceV2Entity;
 import com.nvidia.icms.outbound.cassandra.request.InstanceRequestV2Repository;
 import com.nvidia.icms.service.extensions.api.InstanceLifecycleService;
 import com.nvidia.icms.service.platform.ComputePlatformTestFixtures;
@@ -47,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 import static com.nvidia.icms.util.TestUtil.DUMMY_BYOC_INSTANCE_TYPE;
 import static com.nvidia.icms.util.TestUtil.DUMMY_BYOC_NCA_ID;
@@ -65,6 +67,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -194,6 +197,171 @@ class TerminateInstanceServiceTest {
         verify(instanceLifecycleService).terminateInstances(DUMMY_CUSTOMER_ID,
                                                        Set.of(nonByocInstanceEntity),
                                                        Map.of());
+    }
+
+    @Test
+    void terminateInstancesByGpuSpec_selectsNonRunningThenRunningOldestFirst() {
+        UUID deploymentId = UUID.randomUUID();
+        UUID gpuSpecId = UUID.randomUUID();
+        Instant now = Instant.now();
+        var oldestRunning = instance("running-old", SpotInstanceInternalState.RUNNING,
+                                     now.minusSeconds(30), deploymentId, gpuSpecId);
+        var newestStarting = instance("starting-new", SpotInstanceInternalState.STARTING,
+                                      now.minusSeconds(10), deploymentId, gpuSpecId);
+        var oldestStarting = instance("starting-old", SpotInstanceInternalState.STARTING,
+                                      now.minusSeconds(20), deploymentId, gpuSpecId);
+        var newestRunning = instance("running-new", SpotInstanceInternalState.RUNNING,
+                                     now, deploymentId, gpuSpecId);
+        var otherOwner = instance("other-owner", SpotInstanceInternalState.STARTING,
+                                  now.minusSeconds(40), deploymentId, gpuSpecId);
+        otherOwner.setNcaId("other-nca");
+
+        when(instanceV2Repository.findInstancesByGpuSpecificationId(deploymentId, gpuSpecId))
+                .thenReturn(List.of(oldestRunning, newestStarting, oldestStarting,
+                                    newestRunning, otherOwner));
+        when(instanceV2Repository.findInstancesByCustomerAndIds(
+                null, Set.of("starting-old", "starting-new", "running-old")))
+                .thenReturn(List.of(oldestStarting, newestStarting, oldestRunning));
+        var request = getDummyInstanceRequestEntity(
+                SpotInstanceRequestState.ACTIVE, SpotRequestStatusCode.FULFILLED,
+                DUMMY_OPEN_REQUEST_HAVING_INSTANCE_ID, now, ResourceProvider.OCI);
+        request.setNcaId(DUMMY_NON_BYOC_NCA_ID);
+        request.setDeploymentId(deploymentId);
+        request.setGpuSpecificationId(gpuSpecId);
+        when(instanceRequestV2Repository.findRequestById(
+                DUMMY_OPEN_REQUEST_HAVING_INSTANCE_ID)).thenReturn(Optional.of(request));
+        when(instanceLifecycleService.terminateInstances(
+                eq(DUMMY_CUSTOMER_ID), any(), eq(Map.of())))
+                .thenReturn(new TerminateInstancesResponse(List.of()));
+
+        terminateInstanceService.terminateInstances(
+                DUMMY_NON_BYOC_NCA_ID, deploymentId, gpuSpecId, 3, Map.of());
+
+        verify(instanceLifecycleService).terminateInstances(
+                eq(DUMMY_CUSTOMER_ID),
+                eq(Set.of(oldestStarting, newestStarting, oldestRunning)),
+                eq(Map.of()));
+    }
+
+    @Test
+    void terminateInstancesByGpuSpec_countExceedsInstances_terminatesAllAvailable() {
+        UUID deploymentId = UUID.randomUUID();
+        UUID gpuSpecId = UUID.randomUUID();
+        var instance = instance("instance", SpotInstanceInternalState.RUNNING,
+                                Instant.now(), deploymentId, gpuSpecId);
+
+        when(instanceV2Repository.findInstancesByGpuSpecificationId(deploymentId, gpuSpecId))
+                .thenReturn(List.of(instance));
+        when(instanceV2Repository.findInstancesByCustomerAndIds(null, Set.of("instance")))
+                .thenReturn(List.of(instance));
+        var request = getDummyInstanceRequestEntity(
+                SpotInstanceRequestState.ACTIVE, SpotRequestStatusCode.FULFILLED,
+                DUMMY_OPEN_REQUEST_HAVING_INSTANCE_ID, dummyInstant, ResourceProvider.OCI);
+        request.setNcaId(DUMMY_NON_BYOC_NCA_ID);
+        request.setDeploymentId(deploymentId);
+        request.setGpuSpecificationId(gpuSpecId);
+        when(instanceRequestV2Repository.findRequestById(
+                DUMMY_OPEN_REQUEST_HAVING_INSTANCE_ID)).thenReturn(Optional.of(request));
+        when(instanceLifecycleService.terminateInstances(
+                DUMMY_CUSTOMER_ID, Set.of(instance), Map.of()))
+                .thenReturn(new TerminateInstancesResponse(List.of()));
+
+        terminateInstanceService.terminateInstances(
+                DUMMY_NON_BYOC_NCA_ID, deploymentId, gpuSpecId, 2, Map.of());
+
+        verify(instanceLifecycleService).terminateInstances(
+                DUMMY_CUSTOMER_ID, Set.of(instance), Map.of());
+    }
+
+    @Test
+    void terminateInstancesByWorkload_selectsAcrossGpuSpecifications() {
+        UUID deploymentId = UUID.randomUUID();
+        UUID firstGpuSpecId = UUID.randomUUID();
+        UUID secondGpuSpecId = UUID.randomUUID();
+        Instant now = Instant.now();
+        var starting = instance("starting", SpotInstanceInternalState.STARTING,
+                                now, deploymentId, firstGpuSpecId);
+        var running = instance("running", SpotInstanceInternalState.RUNNING,
+                               now.minusSeconds(10), deploymentId, secondGpuSpecId);
+
+        when(instanceV2Repository.findInstancesByDeploymentId(deploymentId))
+                .thenReturn(List.of(running, starting));
+        when(instanceV2Repository.findInstancesByCustomerAndIds(null, Set.of("starting")))
+                .thenReturn(List.of(starting));
+        var request = getDummyInstanceRequestEntity(
+                SpotInstanceRequestState.ACTIVE, SpotRequestStatusCode.FULFILLED,
+                DUMMY_OPEN_REQUEST_HAVING_INSTANCE_ID, now, ResourceProvider.OCI);
+        request.setNcaId(DUMMY_NON_BYOC_NCA_ID);
+        request.setDeploymentId(deploymentId);
+        request.setGpuSpecificationId(firstGpuSpecId);
+        when(instanceRequestV2Repository.findRequestById(
+                DUMMY_OPEN_REQUEST_HAVING_INSTANCE_ID)).thenReturn(Optional.of(request));
+        when(instanceLifecycleService.terminateInstances(
+                DUMMY_CUSTOMER_ID, Set.of(starting), Map.of()))
+                .thenReturn(new TerminateInstancesResponse(List.of()));
+
+        terminateInstanceService.terminateInstances(
+                DUMMY_NON_BYOC_NCA_ID, deploymentId, null, 1, Map.of());
+
+        verify(instanceV2Repository).findInstancesByDeploymentId(deploymentId);
+        verify(instanceV2Repository, never())
+                .findInstancesByGpuSpecificationId(any(), any());
+        verify(instanceLifecycleService).terminateInstances(
+                DUMMY_CUSTOMER_ID, Set.of(starting), Map.of());
+    }
+
+    @Test
+    void terminateInstancesByGpuSpec_withNoOwnedInstances_returnsEmptyResponse() {
+        UUID deploymentId = UUID.randomUUID();
+        UUID gpuSpecId = UUID.randomUUID();
+        var instance = instance("instance", SpotInstanceInternalState.RUNNING,
+                                Instant.now(), deploymentId, gpuSpecId);
+        instance.setNcaId("other-nca");
+        when(instanceV2Repository.findInstancesByGpuSpecificationId(deploymentId, gpuSpecId))
+                .thenReturn(List.of(instance));
+
+        var response = terminateInstanceService.terminateInstances(
+                DUMMY_NON_BYOC_NCA_ID, deploymentId, gpuSpecId, 1, Map.of());
+
+        assertTrue(response.getTerminatingInstances().isEmpty());
+        verify(instanceV2Repository, never()).findInstancesByCustomerAndIds(any(), any());
+        verify(instanceLifecycleService, never()).terminateInstances(any(), any(), any());
+    }
+
+    @Test
+    void terminateInstancesByGpuSpec_excludesIneligibleInstances() {
+        UUID deploymentId = UUID.randomUUID();
+        UUID gpuSpecId = UUID.randomUUID();
+        var shuttingDown = instance("shutting-down", SpotInstanceInternalState.SHUTTING_DOWN,
+                                    Instant.now(), deploymentId, gpuSpecId);
+        var closed = instance("closed", SpotInstanceInternalState.STARTING,
+                              Instant.now(), deploymentId, gpuSpecId);
+        closed.setRequestState(SpotInstanceRequestState.CLOSED);
+        when(instanceV2Repository.findInstancesByGpuSpecificationId(deploymentId, gpuSpecId))
+                .thenReturn(List.of(shuttingDown, closed));
+
+        var response = terminateInstanceService.terminateInstances(
+                DUMMY_NON_BYOC_NCA_ID, deploymentId, gpuSpecId, 2, Map.of());
+
+        assertTrue(response.getTerminatingInstances().isEmpty());
+        verify(instanceV2Repository, never()).findInstancesByCustomerAndIds(any(), any());
+        verify(instanceLifecycleService, never()).terminateInstances(any(), any(), any());
+    }
+
+    private InstanceV2Entity instance(
+            String instanceId,
+            SpotInstanceInternalState state,
+            Instant createTime,
+            UUID deploymentId,
+            UUID gpuSpecId) {
+        var instance = getDummyInstanceEntity(
+                state, SpotInstanceRequestState.ACTIVE, createTime, ResourceProvider.OCI);
+        instance.setInstanceId(instanceId);
+        instance.setRequestId(DUMMY_OPEN_REQUEST_HAVING_INSTANCE_ID);
+        instance.setNcaId(DUMMY_NON_BYOC_NCA_ID);
+        instance.setDeploymentId(deploymentId);
+        instance.setGpuSpecificationId(gpuSpecId);
+        return instance;
     }
 
     @Test


### PR DESCRIPTION
## Why
NVCF currently scales down a deployment by fetching its instances from ICMS, selecting eligible instances locally, and sending one termination request per instance.
This adds ICMS endpoints that accept an instance count and perform the selection and termination within ICMS. This will allow skip fetching instances step on termination operation.

## What changed
- Added bounded termination for a workload:
`DELETE /v1/si/accounts/{ncaId}/workloads/{workloadId}/instances?InstanceCount={count}`
- Added bounded termination for a workload and GPU specification:
`DELETE /v1/si/accounts/{ncaId}/workloads/{workloadId}/gpuSpecs/{gpuSpecId}/instances?InstanceCount={count}`
- Limited the new endpoints to the canonical workloads routes. They do not expose deployments or tasks aliases.
- Added validation that InstanceCount is greater than zero.
- Moved instance selection into ICMS:
- select active instances in STARTING or RUNNING state
- select STARTING instances before RUNNING instances
- select the oldest instances first within each state group
- terminate at most the requested count
- Added optional GPU specification filtering. When no GPU specification is provided, selection considers all eligible instances in the workload.
- Reused existing instance ownership, resource provider, audit, and termination handling.
- Documented the API response status codes in the OpenAPI annotations.
- Added controller, service delegation, ownership, eligibility, ordering, count, and cross-GPU-specification tests.

## Note
This should be hard-stop version in self-hosted as it introduces new enapoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated APIs to terminate a specified number of running workload instances.
  * Added optional GPU specification filtering for instance termination.
  * Instance selection respects account ownership, running status, deterministic ordering, and requested limits.
  * Requests require a valid account identifier and positive instance count.

* **Bug Fixes**
  * Improved validation error responses with consolidated, field-specific details and appropriate HTTP status codes.

* **Tests**
  * Added coverage for workload- and GPU-specific termination, validation, limits, ordering, and ownership filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->