### PR TITLE
fix(nvca): report terminated instances to ICMS immediately on ICMSRequest deletion

### DIFF
--- a/src/compute-plane-services/nvca/pkg/nvca/agent.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/agent.go
@@ -1174,6 +1174,9 @@ func (a *Agent) Start(ctx context.Context) error {
 		WithInfraOverheadGetter(infraOverheadGetter).
 		WithSecretMirrorConfig(a.SecretMirrorSourceNamespace, a.SecretMirrorLabelSelector).
 		WithEnvOverrides(a.FunctionEnvOverrides, a.TaskEnvOverrides).
+		WithNotFoundInstanceStatusReporter(func(ctx context.Context, reqID, instanceID string) error {
+			return a.handleNotFoundInstanceStatusSyncAction(ctx, reqID, instanceID, ICMSInstanceReconcileTerminateAndUpdate)
+		}).
 		Start(ctx)
 	if err != nil {
 		log.WithError(err).Error("Failed to configure the Backend K8s Cache")

--- a/src/compute-plane-services/nvca/pkg/nvca/backendk8scache.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/backendk8scache.go
@@ -187,8 +187,14 @@ type BackendK8sCache struct {
 	// Use Function Deployment Stages to log state transition events.
 	fndsClient fnds.Client
 
-	icmsRequestWQ workqueue.RateLimitingInterface
-	nodeUpdateWQ  workqueue.RateLimitingInterface
+	icmsRequestWQ      workqueue.RateLimitingInterface
+	nodeUpdateWQ       workqueue.RateLimitingInterface
+	notFoundInstanceWQ workqueue.RateLimitingInterface
+	// notFoundInstanceReporter posts a terminated status to ICMS for an
+	// instance whose ICMSRequest CR was deleted locally before ICMS itself
+	// was ever told the instance is gone. Wired by Agent, which owns the
+	// ICMS HTTP client; nil in builds/tests that don't need it.
+	notFoundInstanceReporter func(ctx context.Context, reqID, instanceID string) error
 
 	podLister                            listersv1.PodLister
 	podSpecLister                        listersv1.PodNamespaceLister
@@ -454,6 +460,17 @@ func (b *BackendK8sCacheBuilder) WithFNDSClient(client fnds.Client) *BackendK8sC
 	return &next
 }
 
+// WithNotFoundInstanceStatusReporter wires the callback used to tell ICMS an
+// instance is terminated immediately when its ICMSRequest CR is deleted
+// locally, instead of waiting for the next periodic instance status sync.
+func (b *BackendK8sCacheBuilder) WithNotFoundInstanceStatusReporter(
+	reporter func(ctx context.Context, reqID, instanceID string) error,
+) *BackendK8sCacheBuilder {
+	next := *b
+	next.notFoundInstanceReporter = reporter
+	return &next
+}
+
 func (b *BackendK8sCacheBuilder) WithPVCRebind(on bool) *BackendK8sCacheBuilder {
 	next := *b
 	next.pvcRebindEnabled = on
@@ -534,6 +551,8 @@ func (b *BackendK8sCacheBuilder) Start(ctx context.Context) (*BackendK8sCache, <
 		autoPurgeDegradedWorkers:             b.autoPurgeDegradedWorkers,
 		icmsRequestWQ:                        workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		nodeUpdateWQ:                         workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		notFoundInstanceWQ:                   workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		notFoundInstanceReporter:             b.notFoundInstanceReporter,
 		featureFlagFetcher:                   b.featureFlagFetcher,
 		nsightProfilingAllowlist:             profiling.New(),
 		lowLatencyStreamingEnabled:           b.lowLatencyStreamingEnabled,
@@ -556,6 +575,10 @@ func (b *BackendK8sCacheBuilder) Start(ctx context.Context) (*BackendK8sCache, <
 	go func() {
 		<-ctx.Done()
 		c.nodeUpdateWQ.ShutDown()
+	}()
+	go func() {
+		<-ctx.Done()
+		c.notFoundInstanceWQ.ShutDown()
 	}()
 
 	if c.systemNamespace == "" {
@@ -828,6 +851,9 @@ func (b *BackendK8sCacheBuilder) Start(ctx context.Context) (*BackendK8sCache, <
 				}
 				c.icmsRequestWQ.Add(makeNamespacedName(req))
 			},
+			DeleteFunc: func(obj interface{}) {
+				c.enqueueNotFoundInstancesOnDelete(ctx, obj)
+			},
 		})
 		if err != nil {
 			log.WithError(err).Error("failed to add event handler for ICMS requests")
@@ -905,7 +931,52 @@ func (b *BackendK8sCacheBuilder) Start(ctx context.Context) (*BackendK8sCache, <
 		}()
 	}
 
+	if c.notFoundInstanceReporter != nil {
+		log.Info("Starting not-found instance status worker")
+		go func() {
+			for c.processNotFoundInstanceWork(ctx) {
+			}
+		}()
+	}
+
 	return c, out, nil
+}
+
+// notFoundInstanceKey identifies one instance to report to ICMS as
+// terminated because its ICMSRequest CR was deleted locally without ICMS
+// ever being told the instance is gone.
+type notFoundInstanceKey struct {
+	RequestID  string
+	InstanceID string
+}
+
+// enqueueNotFoundInstancesOnDelete handles an ICMSRequest informer delete
+// event. Once the CR is gone, nothing will ever enumerate its instances
+// again to tell ICMS they're terminated (see PostICMSInstanceRequestStatusUpdates,
+// which only walks currently-existing CRs), so this reports them now instead
+// of waiting for the periodic instance status sync to notice the CR is
+// missing.
+func (c *BackendK8sCache) enqueueNotFoundInstancesOnDelete(ctx context.Context, obj interface{}) {
+	log := core.GetLogger(ctx)
+
+	req, ok := obj.(*nvcav2beta1new.ICMSRequest)
+	if !ok {
+		if _, isTombstone := obj.(cache.DeletedFinalStateUnknown); isTombstone {
+			// The informer lost the object before delivering its delete
+			// event, so its last known status.instances isn't available
+			// here. The periodic instance status sync remains the fallback
+			// for this case.
+			log.Warn("ICMS request delete tombstone: last known instance status unavailable, " +
+				"deferring to periodic instance status sync")
+			return
+		}
+		log.Errorf("Wrong object type in ICMS request delete event handler: %T", obj)
+		return
+	}
+
+	for instanceID := range req.Status.Instances {
+		c.notFoundInstanceWQ.Add(notFoundInstanceKey{RequestID: req.Spec.RequestID, InstanceID: instanceID})
+	}
 }
 
 type eventWatcher func(ctx context.Context, event *corev1.Event)
@@ -1170,6 +1241,44 @@ func (c *BackendK8sCache) processICMSRequestWork(ctx context.Context) bool {
 		log.Debug("Successfully synced ICMS request")
 	}()
 
+	return true
+}
+
+// processNotFoundInstanceWork drains notFoundInstanceWQ, reporting each
+// queued instance to ICMS as terminated via notFoundInstanceReporter. This
+// is the same corrective action the periodic instance status sync takes for
+// an instance ICMS still thinks is live but that has no local ICMSRequest CR
+// (see ReconcileInstanceStatus), just triggered immediately by the CR's
+// deletion instead of waiting for the next periodic pass.
+func (c *BackendK8sCache) processNotFoundInstanceWork(ctx context.Context) bool {
+	log := core.GetLogger(ctx)
+
+	obj, shutdown := c.notFoundInstanceWQ.Get()
+	if shutdown {
+		log.Info("Not-found instance worker shutting down")
+		return false
+	}
+	defer c.notFoundInstanceWQ.Done(obj)
+
+	key, ok := obj.(notFoundInstanceKey)
+	if !ok {
+		c.notFoundInstanceWQ.Forget(obj)
+		log.Errorf("Unexpected dequeued object type: %T", obj)
+		return true
+	}
+
+	log = log.WithFields(logrus.Fields{
+		"requestID":  key.RequestID,
+		"instanceID": key.InstanceID,
+	})
+	if err := c.notFoundInstanceReporter(ctx, key.RequestID, key.InstanceID); err != nil {
+		log.WithError(err).Error("Failed to report not-found instance as terminated, requeuing")
+		c.notFoundInstanceWQ.AddRateLimited(obj)
+		return true
+	}
+
+	c.notFoundInstanceWQ.Forget(obj)
+	log.Debug("Reported not-found instance as terminated")
 	return true
 }
 

--- a/src/compute-plane-services/nvca/pkg/nvca/backendk8scache.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/backendk8scache.go
@@ -959,19 +959,31 @@ type notFoundInstanceKey struct {
 func (c *BackendK8sCache) enqueueNotFoundInstancesOnDelete(ctx context.Context, obj interface{}) {
 	log := core.GetLogger(ctx)
 
+	// No worker drains notFoundInstanceWQ without a reporter (see the guard
+	// on the worker startup in Start()), so enqueueing here would just leak
+	// entries for the process lifetime. The periodic instance status sync
+	// remains the fallback in builds that don't wire a reporter.
+	if c.notFoundInstanceReporter == nil {
+		return
+	}
+
 	req, ok := obj.(*nvcav2beta1new.ICMSRequest)
 	if !ok {
-		if _, isTombstone := obj.(cache.DeletedFinalStateUnknown); isTombstone {
+		tombstone, isTombstone := obj.(cache.DeletedFinalStateUnknown)
+		if !isTombstone {
+			log.Errorf("Wrong object type in ICMS request delete event handler: %T", obj)
+			return
+		}
+		req, ok = tombstone.Obj.(*nvcav2beta1new.ICMSRequest)
+		if !ok {
 			// The informer lost the object before delivering its delete
-			// event, so its last known status.instances isn't available
-			// here. The periodic instance status sync remains the fallback
-			// for this case.
+			// event, and the tombstone's last-known object isn't an
+			// ICMSRequest either, so status.instances isn't available here.
+			// The periodic instance status sync remains the fallback.
 			log.Warn("ICMS request delete tombstone: last known instance status unavailable, " +
 				"deferring to periodic instance status sync")
 			return
 		}
-		log.Errorf("Wrong object type in ICMS request delete event handler: %T", obj)
-		return
 	}
 
 	for instanceID := range req.Status.Instances {
@@ -1271,7 +1283,15 @@ func (c *BackendK8sCache) processNotFoundInstanceWork(ctx context.Context) bool 
 		"requestID":  key.RequestID,
 		"instanceID": key.InstanceID,
 	})
-	if err := c.notFoundInstanceReporter(ctx, key.RequestID, key.InstanceID); err != nil {
+	err := nvcaotel.InvokeWithSpan(ctx, c.tracer, "nvca.BackendK8sCache.ReportNotFoundInstance",
+		func(ctx context.Context) error {
+			return c.notFoundInstanceReporter(ctx, key.RequestID, key.InstanceID)
+		},
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			otelattr.String(nvcaotel.ICMSRequestIDAttributeKey, key.RequestID),
+			otelattr.String("nvcf.instance.id", key.InstanceID)))
+	if err != nil {
 		log.WithError(err).Error("Failed to report not-found instance as terminated, requeuing")
 		c.notFoundInstanceWQ.AddRateLimited(obj)
 		return true

--- a/src/compute-plane-services/nvca/pkg/nvca/backendk8scache_test.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/backendk8scache_test.go
@@ -5183,22 +5183,64 @@ func TestEnqueueNotFoundInstancesOnDeleteEnqueuesEachInstance(t *testing.T) {
 	}
 
 	bc := &BackendK8sCache{
-		notFoundInstanceWQ: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		notFoundInstanceWQ:       workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		notFoundInstanceReporter: func(context.Context, string, string) error { return nil },
 	}
 	bc.enqueueNotFoundInstancesOnDelete(ctx, req)
 
 	assert.Equal(t, 2, bc.notFoundInstanceWQ.Len())
 }
 
+func TestEnqueueNotFoundInstancesOnDeleteNoopsWithoutReporter(t *testing.T) {
+	ctx := newTestContext()
+	req := &nvcav2beta1.ICMSRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "sr-deleted", Namespace: RequestsNamespace},
+		Spec:       nvcav2beta1.ICMSRequestSpec{RequestID: "req-1"},
+		Status: nvcav2beta1.ICMSRequestStatus{
+			Instances: map[string]nvcav2beta1.InstanceStatus{"instance-a": {ID: "instance-a"}},
+		},
+	}
+
+	bc := &BackendK8sCache{
+		notFoundInstanceWQ: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+	}
+	bc.enqueueNotFoundInstancesOnDelete(ctx, req)
+
+	assert.Zero(t, bc.notFoundInstanceWQ.Len())
+}
+
 func TestEnqueueNotFoundInstancesOnDeleteSkipsTombstoneWithoutPanicking(t *testing.T) {
 	ctx := newTestContext()
 	bc := &BackendK8sCache{
-		notFoundInstanceWQ: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		notFoundInstanceWQ:       workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		notFoundInstanceReporter: func(context.Context, string, string) error { return nil },
 	}
 
 	bc.enqueueNotFoundInstancesOnDelete(ctx, cache.DeletedFinalStateUnknown{Key: "nvcf-backend/sr-deleted"})
 
 	assert.Zero(t, bc.notFoundInstanceWQ.Len())
+}
+
+func TestEnqueueNotFoundInstancesOnDeleteReadsTombstoneObj(t *testing.T) {
+	ctx := newTestContext()
+	req := &nvcav2beta1.ICMSRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "sr-deleted", Namespace: RequestsNamespace},
+		Spec:       nvcav2beta1.ICMSRequestSpec{RequestID: "req-1"},
+		Status: nvcav2beta1.ICMSRequestStatus{
+			Instances: map[string]nvcav2beta1.InstanceStatus{"instance-a": {ID: "instance-a"}},
+		},
+	}
+	bc := &BackendK8sCache{
+		notFoundInstanceWQ:       workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		notFoundInstanceReporter: func(context.Context, string, string) error { return nil },
+	}
+
+	bc.enqueueNotFoundInstancesOnDelete(ctx, cache.DeletedFinalStateUnknown{
+		Key: "nvcf-backend/sr-deleted",
+		Obj: req,
+	})
+
+	assert.Equal(t, 1, bc.notFoundInstanceWQ.Len())
 }
 
 func TestProcessNotFoundInstanceWorkReportsAndForgets(t *testing.T) {
@@ -5212,6 +5254,7 @@ func TestProcessNotFoundInstanceWorkReportsAndForgets(t *testing.T) {
 			gotReqID, gotInstanceID = reqID, instanceID
 			return nil
 		},
+		tracer: noop.NewTracerProvider().Tracer("test"),
 	}
 	bc.notFoundInstanceWQ.Add(key)
 
@@ -5230,6 +5273,7 @@ func TestProcessNotFoundInstanceWorkRequeuesOnReporterError(t *testing.T) {
 		notFoundInstanceReporter: func(_ context.Context, _, _ string) error {
 			return errors.New("icms unavailable")
 		},
+		tracer: noop.NewTracerProvider().Tracer("test"),
 	}
 	bc.notFoundInstanceWQ.Add(key)
 

--- a/src/compute-plane-services/nvca/pkg/nvca/backendk8scache_test.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/backendk8scache_test.go
@@ -5169,6 +5169,74 @@ func TestProcessICMSRequestWorkDoesNotRateLimitDeletingRequestRetainingFinalizer
 	assert.Zero(t, bc.icmsRequestWQ.NumRequeues(key))
 }
 
+func TestEnqueueNotFoundInstancesOnDeleteEnqueuesEachInstance(t *testing.T) {
+	ctx := newTestContext()
+	req := &nvcav2beta1.ICMSRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "sr-deleted", Namespace: RequestsNamespace},
+		Spec:       nvcav2beta1.ICMSRequestSpec{RequestID: "req-1"},
+		Status: nvcav2beta1.ICMSRequestStatus{
+			Instances: map[string]nvcav2beta1.InstanceStatus{
+				"instance-a": {ID: "instance-a"},
+				"instance-b": {ID: "instance-b"},
+			},
+		},
+	}
+
+	bc := &BackendK8sCache{
+		notFoundInstanceWQ: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+	}
+	bc.enqueueNotFoundInstancesOnDelete(ctx, req)
+
+	assert.Equal(t, 2, bc.notFoundInstanceWQ.Len())
+}
+
+func TestEnqueueNotFoundInstancesOnDeleteSkipsTombstoneWithoutPanicking(t *testing.T) {
+	ctx := newTestContext()
+	bc := &BackendK8sCache{
+		notFoundInstanceWQ: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+	}
+
+	bc.enqueueNotFoundInstancesOnDelete(ctx, cache.DeletedFinalStateUnknown{Key: "nvcf-backend/sr-deleted"})
+
+	assert.Zero(t, bc.notFoundInstanceWQ.Len())
+}
+
+func TestProcessNotFoundInstanceWorkReportsAndForgets(t *testing.T) {
+	ctx := newTestContext()
+	key := notFoundInstanceKey{RequestID: "req-1", InstanceID: "instance-a"}
+
+	var gotReqID, gotInstanceID string
+	bc := &BackendK8sCache{
+		notFoundInstanceWQ: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		notFoundInstanceReporter: func(_ context.Context, reqID, instanceID string) error {
+			gotReqID, gotInstanceID = reqID, instanceID
+			return nil
+		},
+	}
+	bc.notFoundInstanceWQ.Add(key)
+
+	require.True(t, bc.processNotFoundInstanceWork(ctx))
+	assert.Equal(t, "req-1", gotReqID)
+	assert.Equal(t, "instance-a", gotInstanceID)
+	assert.Zero(t, bc.notFoundInstanceWQ.NumRequeues(key))
+}
+
+func TestProcessNotFoundInstanceWorkRequeuesOnReporterError(t *testing.T) {
+	ctx := newTestContext()
+	key := notFoundInstanceKey{RequestID: "req-1", InstanceID: "instance-a"}
+
+	bc := &BackendK8sCache{
+		notFoundInstanceWQ: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		notFoundInstanceReporter: func(_ context.Context, _, _ string) error {
+			return errors.New("icms unavailable")
+		},
+	}
+	bc.notFoundInstanceWQ.Add(key)
+
+	require.True(t, bc.processNotFoundInstanceWork(ctx))
+	assert.Positive(t, bc.notFoundInstanceWQ.NumRequeues(key))
+}
+
 func TestUpdateSchedulerWorkloadMetrics(t *testing.T) {
 	makeReq := func(requestID string, action common.MessageAction) *nvcav2beta1.ICMSRequest {
 		return &nvcav2beta1.ICMSRequest{


### PR DESCRIPTION
## TL;DR
`kill-all`/`kill-function` deletes the `ICMSRequest` CR and workload on the compute-plane cluster, but NVCA only pushes instance-terminated status to ICMS by enumerating currently-existing CRs. Once the CR is gone, nothing tells ICMS the instance terminated until a slow periodic reconciliation sweep happens to notice the mismatch — leaving the function reported `ACTIVE` and invocations timing out with `504` for an extended period. This adds a `DeleteFunc` handler on the `ICMSRequest` informer that reports the instance to ICMS as terminated immediately when its CR is deleted, instead of waiting on the periodic sync.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
`ReconcileInstanceStatus` already computes `ICMSInstanceReconcileTerminateAndUpdate` unconditionally whenever an instance ICMS still tracks has no corresponding local `ICMSRequest` CR — that's exactly the state a deleted CR leaves behind. The periodic sync (`SyncPeriodicInstanceStatuses`) discovers this by polling ICMS's full instance list on a ticker and diffing it against local CRs, which is why the correction only happens whenever that ticker next fires.

This change adds a `notFoundInstanceWQ` workqueue and a `notFoundInstanceReporter` callback (wired from `Agent`, which owns the ICMS HTTP client) to `BackendK8sCache`. The ICMSRequest informer's new `DeleteFunc` enqueues each instance still in the deleted CR's `status.instances`, and a worker drains the queue and posts a terminated status to ICMS for each one — the same corrective action the periodic sync already takes, just triggered by the deletion event instead of the next tick. Tombstone deletes (`DeletedFinalStateUnknown`) are logged and skipped, since the last-known instance list isn't available; the periodic sync remains the fallback for that case.

## For the Reviewer
Core change is in `src/compute-plane-services/nvca/pkg/nvca/backendk8scache.go` (`enqueueNotFoundInstancesOnDelete`, `processNotFoundInstanceWork`, and the new `DeleteFunc` wiring) and `agent.go` (wiring the reporter callback to `handleNotFoundInstanceStatusSyncAction`). Please look closely at:
- The queue/worker lifecycle (`notFoundInstanceWQ` init, shutdown goroutine, worker startup guarded on `notFoundInstanceReporter != nil`) mirrors the existing `icmsRequestWQ`/`processICMSRequestWork` pattern.
- Tombstone handling in `enqueueNotFoundInstancesOnDelete` — deliberately a no-op beyond logging, since a `DeletedFinalStateUnknown` only carries a key, not the CR's last-known `status.instances`.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
New regression tests in `backendk8scache_test.go`: `TestEnqueueNotFoundInstancesOnDeleteEnqueuesEachInstance`, `TestEnqueueNotFoundInstancesOnDeleteSkipsTombstoneWithoutPanicking`, `TestProcessNotFoundInstanceWorkReportsAndForgets`, `TestProcessNotFoundInstanceWorkRequeuesOnReporterError`.
`go build ./...`, `go vet ./...`, `gofmt -l`: clean. `go test ./pkg/nvca/...`: all pass, no regressions.
Live-verified against a local self-hosted stack (k3d, real NVCA/ICMS/control-plane services): before this change, ICMS only learned of a kill-all termination via the periodic sync; after, the terminated status reaches ICMS within 1-2 seconds of the workload actually disappearing (confirmed via ICMS's own audit log, terminationCause: instance-terminated-sync-action). Invocation still returns 504 until the control plane's own separate, unrelated ~1-minute reconcile sweep (cloud-functions) next picks up the now-correct ICMS state, after which it fails fast and clean with 400 "DEGRADED function cannot be invoked" instead of hanging. Closing that remaining window is outside this change's scope (different service/subtree).

## Issues
NO-REF

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved instance-status synchronization when an instance is no longer found.
  * Deleted instance requests are now promptly reported as terminated.
  * Failed status reports are retried automatically to improve reliability.
  * Improved handling of deletion events to safely process available instance information.

* **Tests**
  * Added coverage for deletion handling, successful reporting, retry behavior, and safe processing of tombstone events.
  * Verified that deletion events are skipped safely when reporting is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->