### PR TITLE
feat(worker): add quic dial and transport rotation metrics

### DIFF
--- a/src/libraries/go/worker/go.mod
+++ b/src/libraries/go/worker/go.mod
@@ -69,6 +69,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/minio/highwayhash v1.0.3 // indirect

--- a/src/libraries/go/worker/metrics/nvcf/nvcf_metrics.go
+++ b/src/libraries/go/worker/metrics/nvcf/nvcf_metrics.go
@@ -40,10 +40,14 @@ const (
 	DialFailureOther   = "other"
 )
 
-// Reasons a dial failure was declined for rotation. Each of these is a silent
+// Reasons a dial result was declined for rotation. Each of these is a silent
 // return in the dial path, and a silent return that reads as "nothing wrong"
 // is what made the original defect hard to find. Counting them separates
 // "rotation never fired" from "rotation fired and did not help".
+//
+// stale_transport covers successful dials as well as failed ones: the
+// staleness guard runs before the error is examined, so a dial that succeeded
+// on a superseded socket lands here too.
 const (
 	DialSkipStaleTransport = "stale_transport"
 	DialSkipCtxCancelled   = "ctx_cancelled"
@@ -118,7 +122,7 @@ var (
 		prometheus.CounterOpts{
 			Namespace: QuicNamespace,
 			Name:      "dial_skip_total",
-			Help:      "dial failures that did not count toward rotation, by reason",
+			Help:      "dial results that did not count toward rotation, by reason",
 		}, []string{"reason"})
 
 	QuicTunnelGauge = promauto.NewGauge(

--- a/src/libraries/go/worker/metrics/nvcf/nvcf_metrics.go
+++ b/src/libraries/go/worker/metrics/nvcf/nvcf_metrics.go
@@ -40,6 +40,16 @@ const (
 	DialFailureOther   = "other"
 )
 
+// Reasons a dial failure was declined for rotation. Each of these is a silent
+// return in the dial path, and a silent return that reads as "nothing wrong"
+// is what made the original defect hard to find. Counting them separates
+// "rotation never fired" from "rotation fired and did not help".
+const (
+	DialSkipStaleTransport = "stale_transport"
+	DialSkipCtxCancelled   = "ctx_cancelled"
+	DialSkipNotTimeout     = "not_timeout"
+)
+
 // NVCF metrics shared between utils and niclls containers
 var (
 	RequestCounter = promauto.NewCounter(
@@ -103,6 +113,13 @@ var (
 			Name:      "transport_rotation_total",
 			Help:      "total quic transport rotations after consecutive dial failures",
 		})
+
+	QuicDialSkipCounter = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: QuicNamespace,
+			Name:      "dial_skip_total",
+			Help:      "dial failures that did not count toward rotation, by reason",
+		}, []string{"reason"})
 
 	QuicTunnelGauge = promauto.NewGauge(
 		prometheus.GaugeOpts{
@@ -181,5 +198,8 @@ var (
 func init() {
 	for _, reason := range []string{DialFailureTimeout, DialFailureAuth, DialFailureOther} {
 		QuicDialFailureCounter.WithLabelValues(reason)
+	}
+	for _, reason := range []string{DialSkipStaleTransport, DialSkipCtxCancelled, DialSkipNotTimeout} {
+		QuicDialSkipCounter.WithLabelValues(reason)
 	}
 }

--- a/src/libraries/go/worker/metrics/nvcf/nvcf_metrics.go
+++ b/src/libraries/go/worker/metrics/nvcf/nvcf_metrics.go
@@ -27,6 +27,17 @@ import (
 const (
 	ResponseNamespace     = metrics.NvcfRootNamespace + "_response"
 	WorkerThreadNamespace = metrics.NvcfRootNamespace + "_worker_thread"
+	QuicNamespace         = metrics.NvcfRootNamespace + "_quic"
+)
+
+// Reasons a QUIC dial failed. The label separates the two tunnel failures that
+// share the log message "quic connection attempt failed" and can only be told
+// apart by the error: a network timeout is flow poisoning, a 403 is the
+// saturated backlog wedge. Keep this list short; it is a metric label.
+const (
+	DialFailureTimeout = "timeout"
+	DialFailureAuth    = "auth"
+	DialFailureOther   = "other"
 )
 
 // NVCF metrics shared between utils and niclls containers
@@ -64,6 +75,40 @@ var (
 			Namespace: WorkerThreadNamespace,
 			Name:      "busy_seconds_total",
 			Help:      "total seconds spent being busy by thread",
+		})
+
+	// QuicDialCounter and QuicDialFailureCounter are the denominator and
+	// numerator of the dial failure rate. Failures alone are not actionable:
+	// a routine proxy scale-down produces a large, harmless burst.
+	QuicDialCounter = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: QuicNamespace,
+			Name:      "dial_total",
+			Help:      "total quic dial attempts made by the worker",
+		})
+
+	QuicDialFailureCounter = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: QuicNamespace,
+			Name:      "dial_failure_total",
+			Help:      "total quic dial attempts that failed, by reason",
+		}, []string{"reason"})
+
+	// QuicTransportRotationCounter rising alongside dial failures means the
+	// worker is recovering on its own. Dial failures rising while this stays
+	// flat means it is not, which is the condition that needs an operator.
+	QuicTransportRotationCounter = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: QuicNamespace,
+			Name:      "transport_rotation_total",
+			Help:      "total quic transport rotations after consecutive dial failures",
+		})
+
+	QuicTunnelGauge = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: QuicNamespace,
+			Name:      "tunnel_active",
+			Help:      "quic tunnels currently held open by the worker",
 		})
 
 	NatsErrorCounter = promauto.NewCounter(
@@ -129,3 +174,12 @@ var (
 			Help:      "total stateful proxy successes",
 		})
 )
+
+// Pre-initialize the dial failure reasons so every series exists at zero on
+// the first scrape. Without this, absent() alerts misfire and rate() has gaps
+// until the first failure of each kind actually occurs.
+func init() {
+	for _, reason := range []string{DialFailureTimeout, DialFailureAuth, DialFailureOther} {
+		QuicDialFailureCounter.WithLabelValues(reason)
+	}
+}

--- a/src/libraries/go/worker/proxy/BUILD.bazel
+++ b/src/libraries/go/worker/proxy/BUILD.bazel
@@ -84,6 +84,7 @@ go_test(
         "@com_github_nats_io_nats_go//:nats_go",
         "@com_github_nats_io_nats_go//jetstream",
         "@com_github_prometheus_client_golang//prometheus/testutil",
+        "@com_github_quic_go_quic_go//:quic-go",
         "@com_github_quic_go_quic_go//http3",
         "@com_github_quic_go_quic_go//integrationtests/tools",
         "@com_github_stretchr_testify//require",

--- a/src/libraries/go/worker/proxy/BUILD.bazel
+++ b/src/libraries/go/worker/proxy/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
     name = "proxy_test",
     srcs = [
         "h3_addrlist_test.go",
+        "h3_metrics_test.go",
         "h3_rotate_test.go",
         "proxy_e2e_test.go",
         "proxy_extra_test.go",
@@ -70,6 +71,7 @@ go_test(
     deps = [
         "//src/libraries/go/lib/pkg/nvkit/logs",
         "//src/libraries/go/lib/pkg/nvkit/tracing",
+        "//src/libraries/go/worker/metrics/nvcf",
         "//src/libraries/go/worker/proto/nvcf:pb",
         "//src/libraries/go/worker/proxy/handlerisolationconn",
         "//src/libraries/go/worker/proxy/quicconn",
@@ -81,6 +83,7 @@ go_test(
         "@com_github_google_uuid//:uuid",
         "@com_github_nats_io_nats_go//:nats_go",
         "@com_github_nats_io_nats_go//jetstream",
+        "@com_github_prometheus_client_golang//prometheus/testutil",
         "@com_github_quic_go_quic_go//http3",
         "@com_github_quic_go_quic_go//integrationtests/tools",
         "@com_github_stretchr_testify//require",

--- a/src/libraries/go/worker/proxy/h3.go
+++ b/src/libraries/go/worker/proxy/h3.go
@@ -148,6 +148,7 @@ func (t *h3ConnectionCache) noteDialResult(ctx context.Context, dialed *quic.Tra
 	// This check therefore has to come before both the reset and the
 	// increment, not after them.
 	if t.quicTransport == nil || t.quicTransport != dialed {
+		logSkip(&skippedStaleDial, nvcf.DialSkipStaleTransport, "dial predates the current transport", destination, dialErr)
 		return
 	}
 	if dialErr == nil {
@@ -155,6 +156,16 @@ func (t *h3ConnectionCache) noteDialResult(ctx context.Context, dialed *quic.Tra
 		return
 	}
 	if !isTransportDialFailure(ctx, dialErr) {
+		// Two very different reasons land here and they need telling apart: a
+		// cancelled context means the dial never got a verdict, while a
+		// non-timeout error means the socket reached something. Reporting them
+		// as one silent return makes "rotation never fired" indistinguishable
+		// from "rotation fired and did not help".
+		if cause := context.Cause(ctx); cause != nil {
+			logSkip(&skippedCtxCancelled, nvcf.DialSkipCtxCancelled, "dial context cancelled", destination, cause)
+		} else {
+			logSkip(&skippedNotTimeout, nvcf.DialSkipNotTimeout, "error is not a network timeout", destination, dialErr)
+		}
 		return
 	}
 	if t.dialFailures == nil {
@@ -181,6 +192,31 @@ func dialFailureReason(ctx context.Context, dialErr error) string {
 	default:
 		return nvcf.DialFailureOther
 	}
+}
+
+// Occurrence counts for the skip paths. These back the log rate limiter only;
+// the exported series is nvcf.QuicDialSkipCounter, which is what alerts read.
+var (
+	skippedStaleDial    atomic.Int64
+	skippedCtxCancelled atomic.Int64
+	skippedNotTimeout   atomic.Int64
+)
+
+// logSkip records the skip and reports the first occurrence, then every
+// 1000th. Under a real blackhole these paths are hit thousands of times a
+// second, so logging each one would drown the signal it exists to provide.
+// The metric is incremented every time regardless; only the log is sampled.
+func logSkip(counter *atomic.Int64, reason, detail, destination string, err error) {
+	nvcf.QuicDialSkipCounter.WithLabelValues(reason).Inc()
+	n := counter.Add(1)
+	if n != 1 && n%1000 != 0 {
+		return
+	}
+	zap.L().Warn("dial failure did not count toward rotation",
+		zap.String("reason", detail),
+		zap.String("destination", destination),
+		zap.Int64("occurrences", n),
+		zap.Error(err))
 }
 
 func isTransportDialFailure(ctx context.Context, dialErr error) bool {

--- a/src/libraries/go/worker/proxy/h3.go
+++ b/src/libraries/go/worker/proxy/h3.go
@@ -130,14 +130,6 @@ func (t *h3ConnectionCache) transportLocked() (*quic.Transport, error) {
 // A success resets only that destination, so unrelated flows cannot suppress
 // or trigger rotation.
 func (t *h3ConnectionCache) noteDialResult(ctx context.Context, dialed *quic.Transport, destination string, dialErr error) {
-	// Counted before the staleness guard below. That guard governs rotation
-	// bookkeeping only; a dial that happened still happened, and hiding it
-	// here would understate the failure rate the alert depends on.
-	nvcf.QuicDialCounter.Inc()
-	if dialErr != nil {
-		nvcf.QuicDialFailureCounter.WithLabelValues(dialFailureReason(ctx, dialErr)).Inc()
-	}
-
 	t.transportMu.Lock()
 	defer t.transportMu.Unlock()
 
@@ -177,6 +169,17 @@ func (t *h3ConnectionCache) noteDialResult(ctx context.Context, dialed *quic.Tra
 		return
 	}
 	t.rotateLocked(destination, failures)
+}
+
+// recordDialAttempt counts every dial and classifies its failure. It is
+// deliberately separate from noteDialResult: that function governs rotation
+// bookkeeping and is reached only from the default dial path, whereas every
+// dial regardless of path must be measured.
+func recordDialAttempt(ctx context.Context, dialErr error) {
+	nvcf.QuicDialCounter.Inc()
+	if dialErr != nil {
+		nvcf.QuicDialFailureCounter.WithLabelValues(dialFailureReason(ctx, dialErr)).Inc()
+	}
 }
 
 // dialFailureReason labels a failure for the metric. It mirrors
@@ -387,6 +390,11 @@ func (t *h3ConnectionCache) dial(ctx context.Context, hostname string) (*quic.Co
 		}
 	}
 	conn, err := dial(ctx, hostname, tlsConf, t.wrappedTransport.QUICConfig)
+	// Counted here rather than in noteDialResult so that a configured
+	// wrappedTransport.Dial is measured too. noteDialResult is reached only
+	// from the default dial path, so leaving the counters there would make
+	// the metrics silently go quiet if that field were ever set.
+	recordDialAttempt(ctx, err)
 	if err != nil {
 		zap.L().Warn("failed to dial quic connection", zap.Error(err), zap.String("hostname", hostname))
 		return nil, nil, err
@@ -439,7 +447,13 @@ func (t *h3ConnectionCache) deleteClientLocked(hostname string) {
 func (t *h3ConnectionCache) Close() error {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
-	for _, cl := range t.clients {
+	for hostname, cl := range t.clients {
+		// Decrement here rather than relying on the cache-removal callback.
+		// cl.Close triggers that callback on another goroutine, which blocks
+		// on t.mutex until this function returns and then finds the map
+		// already nil, so it would never decrement and the gauge would leak.
+		delete(t.clients, hostname)
+		nvcf.QuicTunnelGauge.Dec()
 		if err := cl.Close(); err != nil {
 			return err
 		}

--- a/src/libraries/go/worker/proxy/h3.go
+++ b/src/libraries/go/worker/proxy/h3.go
@@ -36,6 +36,8 @@ import (
 
 	"github.com/NVIDIA/nvcf/src/libraries/go/worker/ca"
 	"github.com/NVIDIA/nvcf/src/libraries/go/worker/utils"
+
+	"github.com/NVIDIA/nvcf/src/libraries/go/worker/metrics/nvcf"
 )
 
 var quicInsecure = os.Getenv("QUIC_INSECURE") == "true"
@@ -128,6 +130,14 @@ func (t *h3ConnectionCache) transportLocked() (*quic.Transport, error) {
 // A success resets only that destination, so unrelated flows cannot suppress
 // or trigger rotation.
 func (t *h3ConnectionCache) noteDialResult(ctx context.Context, dialed *quic.Transport, destination string, dialErr error) {
+	// Counted before the staleness guard below. That guard governs rotation
+	// bookkeeping only; a dial that happened still happened, and hiding it
+	// here would understate the failure rate the alert depends on.
+	nvcf.QuicDialCounter.Inc()
+	if dialErr != nil {
+		nvcf.QuicDialFailureCounter.WithLabelValues(dialFailureReason(ctx, dialErr)).Inc()
+	}
+
 	t.transportMu.Lock()
 	defer t.transportMu.Unlock()
 
@@ -156,6 +166,21 @@ func (t *h3ConnectionCache) noteDialResult(ctx context.Context, dialed *quic.Tra
 		return
 	}
 	t.rotateLocked(destination, failures)
+}
+
+// dialFailureReason labels a failure for the metric. It mirrors
+// isTransportDialFailure so that the "timeout" series counts exactly the
+// failures that drive rotation, which is what makes the two comparable in an
+// alert expression.
+func dialFailureReason(ctx context.Context, dialErr error) string {
+	switch {
+	case isTransportDialFailure(ctx, dialErr):
+		return nvcf.DialFailureTimeout
+	case errors.Is(dialErr, ErrAuth):
+		return nvcf.DialFailureAuth
+	default:
+		return nvcf.DialFailureOther
+	}
 }
 
 func isTransportDialFailure(ctx context.Context, dialErr error) bool {
@@ -192,6 +217,7 @@ func (t *h3ConnectionCache) rotateLocked(destination string, failures int) {
 	t.quicTransport = &quic.Transport{Conn: udpConn}
 	clear(t.dialFailures)
 	closeTransport(old)
+	nvcf.QuicTransportRotationCounter.Inc()
 }
 
 // closeTransport releases a transport and its socket. Errors are logged rather
@@ -269,11 +295,12 @@ func (t *h3ConnectionCache) getClient(ctx context.Context, hostname string) (rtc
 			})
 		}()
 		t.clients[hostname] = cl
+		nvcf.QuicTunnelGauge.Inc()
 	}
 	select {
 	case <-cl.dialing:
 		if cl.dialErr != nil {
-			delete(t.clients, hostname)
+			t.deleteClientLocked(hostname)
 			return nil, false, cl.dialErr
 		}
 		select {
@@ -357,7 +384,19 @@ func (t *h3ConnectionCache) removeClient(hostname string) {
 	if t.clients == nil {
 		return
 	}
+	t.deleteClientLocked(hostname)
+}
+
+// deleteClientLocked drops a cached client and keeps the tunnel gauge balanced
+// with it. The presence check is what keeps them balanced: removal is reached
+// from more than one path for the same hostname, and decrementing on a key
+// that is already gone would drive the gauge negative.
+func (t *h3ConnectionCache) deleteClientLocked(hostname string) {
+	if _, ok := t.clients[hostname]; !ok {
+		return
+	}
 	delete(t.clients, hostname)
+	nvcf.QuicTunnelGauge.Dec()
 }
 
 // Close closes the QUIC connections that this Transport has used.

--- a/src/libraries/go/worker/proxy/h3.go
+++ b/src/libraries/go/worker/proxy/h3.go
@@ -114,9 +114,14 @@ func (t *h3ConnectionCache) transport() (*quic.Transport, error) {
 	return t.transportLocked()
 }
 
+// listenUDP is a seam so tests can exercise the socket-bind failure path,
+// which is otherwise unreachable: binding an ephemeral UDP port essentially
+// never fails outside fd exhaustion.
+var listenUDP = net.ListenUDP
+
 func (t *h3ConnectionCache) transportLocked() (*quic.Transport, error) {
 	if t.quicTransport == nil {
-		udpConn, err := net.ListenUDP("udp", nil)
+		udpConn, err := listenUDP("udp", nil)
 		if err != nil {
 			return nil, err
 		}
@@ -238,7 +243,7 @@ func isTransportDialFailure(ctx context.Context, dialErr error) bool {
 // rotation without any outward sign that it had failed.
 func (t *h3ConnectionCache) rotateLocked(destination string, failures int) {
 	old := t.quicTransport
-	udpConn, err := net.ListenUDP("udp", nil)
+	udpConn, err := listenUDP("udp", nil)
 	if err != nil {
 		// Keep the existing socket rather than leaving the worker with none.
 		// The next failure retries the rotation.
@@ -376,6 +381,10 @@ func (t *h3ConnectionCache) dial(ctx context.Context, hostname string) (*quic.Co
 	if dial == nil {
 		quicTransport, err := t.transport()
 		if err != nil {
+			// A dial that cannot get a socket is still a dial attempt. Without
+			// this, a worker unable to bind would report no dial activity at
+			// all rather than failures, which reads as idle instead of broken.
+			recordDialAttempt(ctx, err)
 			return nil, nil, err
 		}
 		dial = func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (*quic.Conn, error) {

--- a/src/libraries/go/worker/proxy/h3_metrics_test.go
+++ b/src/libraries/go/worker/proxy/h3_metrics_test.go
@@ -20,9 +20,11 @@ package proxy
 import (
 	"context"
 	"errors"
+	"net"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/quic-go/quic-go"
 
 	"github.com/NVIDIA/nvcf/src/libraries/go/worker/metrics/nvcf"
 )
@@ -144,5 +146,54 @@ func TestTunnelGaugeStaysBalancedAcrossRepeatedRemoval(t *testing.T) {
 
 	if got := testutil.ToFloat64(nvcf.QuicTunnelGauge) - before; got != 0 {
 		t.Errorf("after repeated removal: gauge moved by %v, want 0", got)
+	}
+}
+
+func skips(reason string) float64 {
+	return testutil.ToFloat64(nvcf.QuicDialSkipCounter.WithLabelValues(reason))
+}
+
+// Each skip path is otherwise a silent return, and a silent return that reads
+// as "nothing wrong" is the defect class this area keeps producing. Counting
+// them separates "rotation never fired" from "rotation fired and did not help".
+func TestSkipPathsAreCountedByReason(t *testing.T) {
+	c := newTestCache()
+	defer c.Close()
+
+	tr, err := c.transport()
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+
+	// A non-timeout error must not count toward rotation, and must be recorded.
+	before := skips(nvcf.DialSkipNotTimeout)
+	c.noteDialResult(context.Background(), tr, "dest-a", errors.New("connection refused"))
+	if got := skips(nvcf.DialSkipNotTimeout) - before; got != 1 {
+		t.Errorf("not_timeout skips moved by %v, want 1", got)
+	}
+	if c.dialFailures["dest-a"] != 0 {
+		t.Error("a non-timeout error incremented the rotation counter")
+	}
+
+	// A cancelled context is attributed separately, not lumped in with it.
+	beforeCtx := skips(nvcf.DialSkipCtxCancelled)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	c.noteDialResult(ctx, tr, "dest-b", &net.DNSError{IsTimeout: true})
+	if got := skips(nvcf.DialSkipCtxCancelled) - beforeCtx; got != 1 {
+		t.Errorf("ctx_cancelled skips moved by %v, want 1", got)
+	}
+
+	// A dial from a superseded transport is attributed to staleness.
+	beforeStale := skips(nvcf.DialSkipStaleTransport)
+	c.noteDialResult(context.Background(), &quic.Transport{}, "dest-c", &net.DNSError{IsTimeout: true})
+	if got := skips(nvcf.DialSkipStaleTransport) - beforeStale; got != 1 {
+		t.Errorf("stale_transport skips moved by %v, want 1", got)
+	}
+
+	// A genuine network timeout on the current transport still counts.
+	c.noteDialResult(context.Background(), tr, "dest-d", &net.DNSError{IsTimeout: true})
+	if c.dialFailures["dest-d"] != 1 {
+		t.Errorf("dialFailures[dest-d] = %d, want 1", c.dialFailures["dest-d"])
 	}
 }

--- a/src/libraries/go/worker/proxy/h3_metrics_test.go
+++ b/src/libraries/go/worker/proxy/h3_metrics_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
 
 	"github.com/NVIDIA/nvcf/src/libraries/go/worker/metrics/nvcf"
 )
@@ -210,5 +211,35 @@ func TestTunnelGaugeReturnsToZeroAfterClose(t *testing.T) {
 
 	if got := testutil.ToFloat64(nvcf.QuicTunnelGauge) - before; got != 0 {
 		t.Errorf("after Close: gauge moved by %v, want 0 (tunnels leaked)", got)
+	}
+}
+
+// A dial that cannot obtain a socket is still a dial attempt. If it were not
+// counted, a worker unable to bind would report no dial activity rather than
+// failures, which reads as idle rather than broken. That is the same
+// silent-zero shape as the defect this package exists to make visible.
+func TestTransportInitFailureIsCountedAsADialAttempt(t *testing.T) {
+	c := newTestCache()
+	defer c.Close()
+	c.wrappedTransport = &http3.Transport{}
+
+	orig := listenUDP
+	listenUDP = func(string, *net.UDPAddr) (*net.UDPConn, error) {
+		return nil, errors.New("bind: cannot allocate memory")
+	}
+	defer func() { listenUDP = orig }()
+
+	dialsBefore := testutil.ToFloat64(nvcf.QuicDialCounter)
+	failBefore := failures(nvcf.DialFailureOther)
+
+	if _, _, err := c.dial(context.Background(), "proxy.example:443"); err == nil {
+		t.Fatal("expected dial to fail when the socket cannot be bound")
+	}
+
+	if got := testutil.ToFloat64(nvcf.QuicDialCounter) - dialsBefore; got != 1 {
+		t.Errorf("dial attempts moved by %v, want 1", got)
+	}
+	if got := failures(nvcf.DialFailureOther) - failBefore; got != 1 {
+		t.Errorf("other failures moved by %v, want 1", got)
 	}
 }

--- a/src/libraries/go/worker/proxy/h3_metrics_test.go
+++ b/src/libraries/go/worker/proxy/h3_metrics_test.go
@@ -39,23 +39,15 @@ func failures(reason string) float64 {
 // flow poisoning; a 403 is the backlog wedge. Conflating them is what made the
 // original incident untriageable.
 func TestDialFailureReasonSeparatesTimeoutFromAuth(t *testing.T) {
-	c := newTestCache()
-	defer c.Close()
-
-	tr, err := c.transport()
-	if err != nil {
-		t.Fatalf("transport: %v", err)
-	}
-
 	before := map[string]float64{
 		nvcf.DialFailureTimeout: failures(nvcf.DialFailureTimeout),
 		nvcf.DialFailureAuth:    failures(nvcf.DialFailureAuth),
 		nvcf.DialFailureOther:   failures(nvcf.DialFailureOther),
 	}
 
-	c.noteDialResult(context.Background(), tr, testDestination, dialTimeoutError{})
-	c.noteDialResult(context.Background(), c.quicTransport, testDestination, ErrAuth)
-	c.noteDialResult(context.Background(), c.quicTransport, testDestination, errors.New("tls: bad certificate"))
+	recordDialAttempt(context.Background(), dialTimeoutError{})
+	recordDialAttempt(context.Background(), ErrAuth)
+	recordDialAttempt(context.Background(), errors.New("tls: bad certificate"))
 
 	for reason, want := range map[string]float64{
 		nvcf.DialFailureTimeout: 1,
@@ -71,18 +63,10 @@ func TestDialFailureReasonSeparatesTimeoutFromAuth(t *testing.T) {
 // A successful dial must not register as a failure, otherwise the alert
 // expression pages on healthy traffic.
 func TestSuccessfulDialRecordsNoFailure(t *testing.T) {
-	c := newTestCache()
-	defer c.Close()
-
-	tr, err := c.transport()
-	if err != nil {
-		t.Fatalf("transport: %v", err)
-	}
-
 	dialsBefore := testutil.ToFloat64(nvcf.QuicDialCounter)
 	before := failures(nvcf.DialFailureTimeout)
 
-	c.noteDialResult(context.Background(), tr, testDestination, nil)
+	recordDialAttempt(context.Background(), nil)
 
 	if got := failures(nvcf.DialFailureTimeout) - before; got != 0 {
 		t.Errorf("successful dial recorded %v failures, want 0", got)
@@ -195,5 +179,36 @@ func TestSkipPathsAreCountedByReason(t *testing.T) {
 	c.noteDialResult(context.Background(), tr, "dest-d", &net.DNSError{IsTimeout: true})
 	if c.dialFailures["dest-d"] != 1 {
 		t.Errorf("dialFailures[dest-d] = %d, want 1", c.dialFailures["dest-d"])
+	}
+}
+
+// Close clears the client map directly. The cache-removal callback cannot cover
+// it: cl.Close fires that callback on another goroutine, which blocks on the
+// cache mutex until Close returns and then finds the map already nil. Without
+// an explicit decrement the gauge leaks every tunnel the cache ever held.
+func TestTunnelGaugeReturnsToZeroAfterClose(t *testing.T) {
+	c := newTestCache()
+
+	before := testutil.ToFloat64(nvcf.QuicTunnelGauge)
+
+	c.mutex.Lock()
+	for _, h := range []string{"a.example:443", "b.example:443", "c.example:443"} {
+		dialed := make(chan struct{})
+		close(dialed) // Close waits on this; a live dial would block the test
+		c.clients[h] = &roundTripperWithCount{cancel: func() {}, dialing: dialed}
+		nvcf.QuicTunnelGauge.Inc()
+	}
+	c.mutex.Unlock()
+
+	if got := testutil.ToFloat64(nvcf.QuicTunnelGauge) - before; got != 3 {
+		t.Fatalf("after three adds: gauge moved by %v, want 3", got)
+	}
+
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if got := testutil.ToFloat64(nvcf.QuicTunnelGauge) - before; got != 0 {
+		t.Errorf("after Close: gauge moved by %v, want 0 (tunnels leaked)", got)
 	}
 }

--- a/src/libraries/go/worker/proxy/h3_metrics_test.go
+++ b/src/libraries/go/worker/proxy/h3_metrics_test.go
@@ -1,0 +1,148 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/NVIDIA/nvcf/src/libraries/go/worker/metrics/nvcf"
+)
+
+// The counters are process-global, so every assertion is a delta.
+func failures(reason string) float64 {
+	return testutil.ToFloat64(nvcf.QuicDialFailureCounter.WithLabelValues(reason))
+}
+
+// The whole point of the reason label is to separate the two failures that
+// share the log message "quic connection attempt failed". A network timeout is
+// flow poisoning; a 403 is the backlog wedge. Conflating them is what made the
+// original incident untriageable.
+func TestDialFailureReasonSeparatesTimeoutFromAuth(t *testing.T) {
+	c := newTestCache()
+	defer c.Close()
+
+	tr, err := c.transport()
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+
+	before := map[string]float64{
+		nvcf.DialFailureTimeout: failures(nvcf.DialFailureTimeout),
+		nvcf.DialFailureAuth:    failures(nvcf.DialFailureAuth),
+		nvcf.DialFailureOther:   failures(nvcf.DialFailureOther),
+	}
+
+	c.noteDialResult(context.Background(), tr, testDestination, dialTimeoutError{})
+	c.noteDialResult(context.Background(), c.quicTransport, testDestination, ErrAuth)
+	c.noteDialResult(context.Background(), c.quicTransport, testDestination, errors.New("tls: bad certificate"))
+
+	for reason, want := range map[string]float64{
+		nvcf.DialFailureTimeout: 1,
+		nvcf.DialFailureAuth:    1,
+		nvcf.DialFailureOther:   1,
+	} {
+		if got := failures(reason) - before[reason]; got != want {
+			t.Errorf("reason %q: got %v new failures, want %v", reason, got, want)
+		}
+	}
+}
+
+// A successful dial must not register as a failure, otherwise the alert
+// expression pages on healthy traffic.
+func TestSuccessfulDialRecordsNoFailure(t *testing.T) {
+	c := newTestCache()
+	defer c.Close()
+
+	tr, err := c.transport()
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+
+	dialsBefore := testutil.ToFloat64(nvcf.QuicDialCounter)
+	before := failures(nvcf.DialFailureTimeout)
+
+	c.noteDialResult(context.Background(), tr, testDestination, nil)
+
+	if got := failures(nvcf.DialFailureTimeout) - before; got != 0 {
+		t.Errorf("successful dial recorded %v failures, want 0", got)
+	}
+	if got := testutil.ToFloat64(nvcf.QuicDialCounter) - dialsBefore; got != 1 {
+		t.Errorf("successful dial recorded %v attempts, want 1", got)
+	}
+}
+
+// The alert distinguishes "failing and recovering" from "failing and stuck" by
+// comparing these two counters. If rotation did not increment its counter, a
+// wedged worker would be indistinguishable from a recovering one.
+func TestRotationIncrementsCounterOnlyWhenRotating(t *testing.T) {
+	c := newTestCache()
+	defer c.Close()
+
+	tr, err := c.transport()
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+
+	before := testutil.ToFloat64(nvcf.QuicTransportRotationCounter)
+
+	// Below the threshold: no rotation, so no increment.
+	for i := 1; i < dialFailuresBeforeRotate; i++ {
+		c.noteDialResult(context.Background(), tr, testDestination, dialTimeoutError{})
+	}
+	if got := testutil.ToFloat64(nvcf.QuicTransportRotationCounter) - before; got != 0 {
+		t.Fatalf("counted %v rotations below the threshold, want 0", got)
+	}
+
+	// Crossing it rotates exactly once.
+	c.noteDialResult(context.Background(), tr, testDestination, dialTimeoutError{})
+	if got := testutil.ToFloat64(nvcf.QuicTransportRotationCounter) - before; got != 1 {
+		t.Fatalf("counted %v rotations at the threshold, want 1", got)
+	}
+}
+
+// Removal is reached from more than one path for the same hostname: the
+// AfterFunc on connection close, and the dial-error path in getClient. If the
+// decrement were unguarded, the second removal would drive the gauge negative
+// and a negative tunnel count would read as an outage that is not happening.
+func TestTunnelGaugeStaysBalancedAcrossRepeatedRemoval(t *testing.T) {
+	c := newTestCache()
+	defer c.Close()
+
+	before := testutil.ToFloat64(nvcf.QuicTunnelGauge)
+
+	c.mutex.Lock()
+	c.clients["proxy.example:443"] = &roundTripperWithCount{}
+	nvcf.QuicTunnelGauge.Inc()
+	c.mutex.Unlock()
+
+	if got := testutil.ToFloat64(nvcf.QuicTunnelGauge) - before; got != 1 {
+		t.Fatalf("after one add: gauge moved by %v, want 1", got)
+	}
+
+	for i := 0; i < 3; i++ {
+		c.removeClient("proxy.example:443")
+	}
+
+	if got := testutil.ToFloat64(nvcf.QuicTunnelGauge) - before; got != 0 {
+		t.Errorf("after repeated removal: gauge moved by %v, want 0", got)
+	}
+}


### PR DESCRIPTION
## Why

The worker proxy package exports no metrics. Both QUIC tunnel failures, and the
rotation added in #1383 that recovers from one of them, are visible only in log
lines. A tunnel outage cannot be detected without reading worker logs across
every function instance, which is why the last one was reported by a customer
rather than by monitoring.

The two failures also share the log message `quic connection attempt failed`
and differ only in the error: a network timeout is QUIC flow poisoning, a 403
is the saturated backlog wedge. Anything keyed on the message measures both at
once.

## What changed

Six series under `nvcf_worker_service_quic`:

    dial_total                  all dial attempts
    dial_failure_total{reason}  timeout | auth | other
    dial_skip_total{reason}     stale_transport | ctx_cancelled | not_timeout
    transport_rotation_total    rotations performed by #1383
    tunnel_active               tunnels currently held

Two design points carry the value:

- `reason` separates failure A from failure B at the metrics layer.
- `dial_skip_total` covers the three paths that decline to rotate and would
  otherwise return silently, so "rotation never fired" is distinguishable from
  "rotation fired and did not help".

Absorbs #1492 (closed) so this lands as one worker change and one image
rollout. #1492 counted the skip paths with `atomic.Int64` in sampled logs only;
they are now exported. The atomics remain solely to rate limit the log line.

## Customer Release Notes

Not customer visible.

## Plan Summary

Not applicable.

## Usage

Alerting pairs the counters rather than thresholding failures. A routine proxy
scale-down was measured producing 331 dial failures that cleared in 8 seconds,
so a threshold on failure count pages on every scale-down. The actionable
condition is failures sustained while rotation is not engaging:

    rate(dial_failure_total{reason="timeout"}[5m]) > 0
      AND rate(transport_rotation_total[5m]) == 0

## Testing

`go test ./proxy/... ./metrics/...`, `-race`, and
`bazel test //src/libraries/go/worker/proxy:all --flaky_test_attempts=3` pass.

Seven tests cover what the alerting depends on: reason labels separate timeout
from auth, a successful dial records no failure, the rotation counter moves
only on a real rotation, skip paths are attributed by reason, and the tunnel
gauge stays balanced across both repeated removal and close.

`proxy_test` flakes without `--flaky_test_attempts=3` because `mockGrpcProxy`
binds a hardcoded `127.0.0.1:10084`. Pre-existing on main, unrelated.

No QA needed; this adds instrumentation and changes no request-handling
behaviour.

## Notes

Review found two gauge defects, both fixed in ae165b9:

- `Close` cleared the client map without decrementing `tunnel_active`, leaking
  every tunnel the cache held. The removal callback could not cover it:
  `cl.Close` fires it on another goroutine, which blocks on the cache mutex
  until `Close` returns and then finds the map already nil.
- Dial counting sat in `noteDialResult`, which is reached only from the default
  dial path. `wrappedTransport.Dial` is assigned only in tests, so nothing was
  under-counted in production, but setting it later would have taken the
  metrics offline silently. Counting moved to the dial call site.

Alert rules and dashboards are follow-up work, not in this PR.

## References

Closes #1499

## Related Pull Requests

#1383 adds the rotation this instruments. #1492 absorbed here and closed.
#1496 is the pin bump; re-point it at a commit containing this so rotation and
metrics ship in one worker image.

## Dependencies

No new direct dependencies. `go.mod` gains `github.com/kylelemons/godebug
v1.1.0` as an indirect dependency of
`prometheus/client_golang/prometheus/testutil`, used in tests only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Monitoring**
  * Improved QUIC connection metrics, including clearer tracking of dial failures, skipped attempts, timeouts, cancellations, stale transports, and transport initialization failures.
  * Improved rotation and tunnel activity metrics for more accurate operational visibility.

* **Bug Fixes**
  * QUIC dial attempts that fail during transport initialization are now recorded consistently.

* **Tests**
  * Added coverage for connection outcomes, transport rotation, failure categorization, and balanced tunnel metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->