### PR TITLE
feat(stargate): add mock inference profiles

### DIFF
--- a/src/libraries/rust/stargate/crates/mock-dynamo/src/main.rs
+++ b/src/libraries/rust/stargate/crates/mock-dynamo/src/main.rs
@@ -36,21 +36,99 @@ use tracing_subscriber::EnvFilter;
 #[derive(clap::Parser, Debug)]
 #[command(name = "mock-dynamo")]
 struct Args {
+    /// Use a named inference behavior profile
+    #[arg(
+        long,
+        value_enum,
+        value_name = "PROFILE",
+        conflicts_with_all = [
+            "num_tokens",
+            "context_length_tokens",
+            "token_delay_ms",
+            "decode_jitter_ms",
+            "output_tps_min",
+            "output_tps_max",
+            "ttft_ms",
+            "ttft_jitter_ms",
+            "prefill_tokens_per_s",
+            "max_concurrent_requests",
+            "kv_cache_capacity_tokens"
+        ]
+    )]
+    profile: Option<Profile>,
+    /// Print a profile's behavior and expected rates, then exit
+    #[arg(long, value_enum, value_name = "PROFILE", exclusive = true)]
+    explain_profile: Option<Profile>,
     /// HTTP listen address for the mock inference server
     #[arg(long, default_value = "127.0.0.1:8090", value_name = "ADDR")]
     http_listen_addr: String,
     /// Model name served by this server
     #[arg(long, default_value = "dummy-model", value_name = "MODEL")]
     model_name: String,
-    /// Number of dummy tokens to generate
-    #[arg(long, default_value_t = 10, value_name = "N")]
-    num_tokens: usize,
+    /// Fixed output token count when no output-token distribution is configured
+    #[arg(
+        long,
+        value_name = "N",
+        conflicts_with_all = [
+            "profile",
+            "output_tokens_min",
+            "output_tokens_max",
+            "output_token_distribution"
+        ]
+    )]
+    num_tokens: Option<usize>,
+    /// Minimum selected output token count
+    #[arg(
+        long,
+        value_name = "TOKENS",
+        requires_all = ["output_tokens_max", "output_token_distribution"],
+        conflicts_with = "num_tokens"
+    )]
+    output_tokens_min: Option<usize>,
+    /// Maximum selected output token count
+    #[arg(
+        long,
+        value_name = "TOKENS",
+        requires_all = ["output_tokens_min", "output_token_distribution"],
+        conflicts_with = "num_tokens"
+    )]
+    output_tokens_max: Option<usize>,
+    /// Distribution used to select each request's output token count
+    #[arg(
+        long,
+        value_enum,
+        value_name = "SCHEME",
+        requires_all = ["output_tokens_min", "output_tokens_max"],
+        conflicts_with = "num_tokens"
+    )]
+    output_token_distribution: Option<OutputTokenDistribution>,
+    /// Maximum combined input and output tokens. 0 disables the context limit
+    #[arg(long, default_value_t = 0, value_name = "TOKENS")]
+    context_length_tokens: usize,
     /// Delay between tokens in milliseconds
     #[arg(long, default_value_t = 100, value_name = "MS")]
     token_delay_ms: u64,
     /// Deterministic bounded jitter added to each decode token delay based on request id
     #[arg(long, default_value_t = 0, value_name = "MS")]
     decode_jitter_ms: u64,
+    /// Minimum per-request decode rate for deterministic uniform rate variation
+    #[arg(
+        long,
+        value_name = "TPS",
+        value_parser = parse_positive_rate,
+        requires = "output_tps_max",
+        conflicts_with_all = ["token_delay_ms", "decode_jitter_ms"]
+    )]
+    output_tps_min: Option<f64>,
+    /// Maximum per-request decode rate for deterministic uniform rate variation
+    #[arg(
+        long,
+        value_name = "TPS",
+        value_parser = parse_positive_rate,
+        requires = "output_tps_min",
+        conflicts_with_all = ["token_delay_ms", "decode_jitter_ms"]
+    )]
+    output_tps_max: Option<f64>,
     /// Delay before the first output token in milliseconds
     #[arg(long, default_value_t = 0, value_name = "MS")]
     ttft_ms: u64,
@@ -71,12 +149,252 @@ struct Args {
     kv_cache_capacity_tokens: u64,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, clap::ValueEnum)]
+enum Profile {
+    /// One H100 80GB serving Llama 3.1 8B with FP8 weights near concurrency 25
+    #[value(name = "h100-llama-3.1-8b")]
+    H100Llama31EightB,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct Behavior {
+    context_length_tokens: usize,
+    decode_rate: DecodeRate,
+    ttft_ms: u64,
+    ttft_jitter_ms: u64,
+    prefill_tokens_per_s: f64,
+    max_concurrent_requests: usize,
+    kv_cache_capacity_tokens: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum DecodeRate {
+    TokenDelay {
+        base_ms: u64,
+        jitter_ms: u64,
+    },
+    Uniform {
+        min_tokens_per_s: f64,
+        max_tokens_per_s: f64,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, clap::ValueEnum)]
+enum OutputTokenDistribution {
+    Uniform,
+    Gaussian,
+}
+
+impl OutputTokenDistribution {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Uniform => "uniform",
+            Self::Gaussian => "gaussian",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct OutputTokenConfig {
+    min: usize,
+    max: usize,
+    distribution: OutputTokenDistribution,
+}
+
+impl OutputTokenConfig {
+    const fn fixed(tokens: usize) -> Self {
+        let tokens = if tokens == 0 { 1 } else { tokens };
+        Self {
+            min: tokens,
+            max: tokens,
+            distribution: OutputTokenDistribution::Uniform,
+        }
+    }
+}
+
+impl Args {
+    fn behavior(&self) -> Result<Behavior> {
+        if let Some(profile) = self.profile {
+            return Ok(profile.behavior());
+        }
+
+        let decode_rate = match (self.output_tps_min, self.output_tps_max) {
+            (Some(min_tokens_per_s), Some(max_tokens_per_s)) => {
+                anyhow::ensure!(
+                    min_tokens_per_s <= max_tokens_per_s,
+                    "--output-tps-min must be less than or equal to --output-tps-max"
+                );
+                DecodeRate::Uniform {
+                    min_tokens_per_s,
+                    max_tokens_per_s,
+                }
+            }
+            (None, None) => DecodeRate::TokenDelay {
+                base_ms: self.token_delay_ms,
+                jitter_ms: self.decode_jitter_ms,
+            },
+            _ => unreachable!("clap requires both output rate bounds"),
+        };
+
+        Ok(Behavior {
+            context_length_tokens: self.context_length_tokens,
+            decode_rate,
+            ttft_ms: self.ttft_ms,
+            ttft_jitter_ms: self.ttft_jitter_ms,
+            prefill_tokens_per_s: self.prefill_tokens_per_s,
+            max_concurrent_requests: self.max_concurrent_requests,
+            kv_cache_capacity_tokens: self.kv_cache_capacity_tokens,
+        })
+    }
+
+    fn output_tokens(&self) -> Result<OutputTokenConfig> {
+        let defaults = self.profile.map_or_else(
+            || OutputTokenConfig::fixed(self.num_tokens.unwrap_or(10)),
+            Profile::default_output_tokens,
+        );
+        match (
+            self.output_tokens_min,
+            self.output_tokens_max,
+            self.output_token_distribution,
+        ) {
+            (None, None, None) => Ok(defaults),
+            (Some(min), Some(max), Some(distribution)) => {
+                anyhow::ensure!(min > 0, "--output-tokens-min must be greater than zero");
+                anyhow::ensure!(
+                    min <= max,
+                    "--output-tokens-min must be less than or equal to --output-tokens-max"
+                );
+                Ok(OutputTokenConfig {
+                    min,
+                    max,
+                    distribution,
+                })
+            }
+            _ => unreachable!("clap requires complete output token distribution settings"),
+        }
+    }
+}
+
+fn parse_positive_rate(value: &str) -> Result<f64, String> {
+    let rate = value
+        .parse::<f64>()
+        .map_err(|error| format!("invalid output rate: {error}"))?;
+    if rate.is_finite() && rate > 0.0 {
+        Ok(rate)
+    } else {
+        Err("output rate must be finite and greater than zero".to_string())
+    }
+}
+
+impl Profile {
+    const fn behavior(self) -> Behavior {
+        match self {
+            Self::H100Llama31EightB => {
+                let context_length_tokens = 131_072;
+                Behavior {
+                    context_length_tokens,
+                    decode_rate: DecodeRate::Uniform {
+                        min_tokens_per_s: 128.0,
+                        max_tokens_per_s: 200.0,
+                    },
+                    ttft_ms: 10,
+                    ttft_jitter_ms: 20,
+                    prefill_tokens_per_s: 7000.0,
+                    max_concurrent_requests: 25,
+                    kv_cache_capacity_tokens: 400_000,
+                }
+            }
+        }
+    }
+
+    const fn default_output_tokens(self) -> OutputTokenConfig {
+        match self {
+            Self::H100Llama31EightB => OutputTokenConfig {
+                min: 128,
+                max: 8192,
+                distribution: OutputTokenDistribution::Gaussian,
+            },
+        }
+    }
+
+    fn explanation(self) -> String {
+        let behavior = self.behavior();
+        let output_tokens = self.default_output_tokens();
+        let DecodeRate::Uniform {
+            min_tokens_per_s,
+            max_tokens_per_s,
+        } = behavior.decode_rate
+        else {
+            unreachable!("named profile must use an output rate distribution");
+        };
+        let average_output_tps = (min_tokens_per_s + max_tokens_per_s) / 2.0;
+        let aggregate_output_tps = average_output_tps * behavior.max_concurrent_requests as f64;
+        let average_ttft_ms = |input_tokens: usize| {
+            behavior.ttft_ms as f64
+                + behavior.ttft_jitter_ms as f64 / 2.0
+                + input_tokens as f64 * 1000.0 / behavior.prefill_tokens_per_s
+        };
+
+        format!(
+            r#"Profile: h100-llama-3.1-8b
+Calibration: NVIDIA NIM 1.8.0, Llama 3.1 8B Instruct, one H100 80GB, FP8 TP1, near 25 concurrent requests.
+Model: fixed-delay approximation; dynamic batching and load-dependent slowdown are not modeled.
+
+Model and hardware behavior:
+  context length: {} input + output tokens
+  prefill rate: {:.0} uncached input tokens/s
+  TTFT: {} ms + deterministic 0..={} ms jitter + uncached prefill time
+  decode rate: deterministic uniform {:.1}..={:.1} tokens/s per request
+  active request limit: {}; additional requests wait
+  KV cache capacity: {} input tokens, keyed by x-cache-affinity-key
+
+Default request workload (overridable with --output-tokens-min, --output-tokens-max, and --output-token-distribution):
+  sampled output tokens: deterministic {} distribution over {}..={}
+  gaussian mean: {:.1} tokens; standard deviation: {:.1} tokens; samples are clamped to the range
+  selected output tokens: min(sampled output tokens, request max_tokens when present)
+  actual output tokens: min(selected output tokens, context length - input tokens)
+  Pylon canary requests: one output token, "2"
+
+Expected steady-state output rate:
+  per active request: {:.1} tokens/s average ({:.1}..={:.1})
+  at {} active requests: about {:.1} tokens/s before runtime overhead
+
+Expected cold-cache TTFT:
+  1,000 input tokens: about {:.1} ms average
+  5,000 input tokens: about {:.1} ms average
+
+Benchmark reference: https://docs.nvidia.com/nim/benchmarking/llm/1.0.0/performance.html#llama-3-1-8b-instruct-results
+"#,
+            behavior.context_length_tokens,
+            behavior.prefill_tokens_per_s,
+            behavior.ttft_ms,
+            behavior.ttft_jitter_ms,
+            min_tokens_per_s,
+            max_tokens_per_s,
+            behavior.max_concurrent_requests,
+            behavior.kv_cache_capacity_tokens,
+            output_tokens.distribution.name(),
+            output_tokens.min,
+            output_tokens.max,
+            (output_tokens.min as f64 + output_tokens.max as f64) / 2.0,
+            (output_tokens.max - output_tokens.min) as f64 / 6.0,
+            average_output_tps,
+            min_tokens_per_s,
+            max_tokens_per_s,
+            behavior.max_concurrent_requests,
+            aggregate_output_tps,
+            average_ttft_ms(1000),
+            average_ttft_ms(5000),
+        )
+    }
+}
+
 #[derive(Clone)]
 struct AppState {
     model_name: String,
-    num_tokens: usize,
-    token_delay: Duration,
-    decode_jitter_ms: u64,
+    output_tokens: OutputTokenConfig,
+    context_length_tokens: usize,
+    decode_rate: DecodeRate,
     ttft: Duration,
     ttft_jitter_ms: u64,
     prefill_tokens_per_s: f64,
@@ -98,22 +416,28 @@ async fn main() -> Result<()> {
         .init();
 
     let args = Args::parse();
+    if let Some(profile) = args.explain_profile {
+        print!("{}", profile.explanation());
+        return Ok(());
+    }
+    let behavior = args.behavior()?;
+    let output_tokens = args.output_tokens()?;
     let http_addr: std::net::SocketAddr = args.http_listen_addr.parse()?;
 
     let (stats_events, _) = broadcast::channel(1024);
     let state = AppState {
         model_name: args.model_name.clone(),
-        num_tokens: args.num_tokens,
-        token_delay: Duration::from_millis(args.token_delay_ms),
-        decode_jitter_ms: args.decode_jitter_ms,
-        ttft: Duration::from_millis(args.ttft_ms),
-        ttft_jitter_ms: args.ttft_jitter_ms,
-        prefill_tokens_per_s: args.prefill_tokens_per_s,
-        request_slots: (args.max_concurrent_requests > 0)
-            .then(|| Arc::new(Semaphore::new(args.max_concurrent_requests))),
+        output_tokens,
+        context_length_tokens: behavior.context_length_tokens,
+        decode_rate: behavior.decode_rate,
+        ttft: Duration::from_millis(behavior.ttft_ms),
+        ttft_jitter_ms: behavior.ttft_jitter_ms,
+        prefill_tokens_per_s: behavior.prefill_tokens_per_s,
+        request_slots: (behavior.max_concurrent_requests > 0)
+            .then(|| Arc::new(Semaphore::new(behavior.max_concurrent_requests))),
         health_delay: Duration::from_millis(args.health_delay_ms),
         kv_cache: Arc::new(Mutex::new(kv_cache::KvCacheState::new(
-            args.kv_cache_capacity_tokens,
+            behavior.kv_cache_capacity_tokens,
         ))),
         stats_events,
         test_control: test_control::TestControlState::with_discovered_models([args.model_name]),

--- a/src/libraries/rust/stargate/crates/mock-dynamo/src/openai.rs
+++ b/src/libraries/rust/stargate/crates/mock-dynamo/src/openai.rs
@@ -170,12 +170,11 @@ struct StreamResponseConfig {
     kv_cache_access: KvCacheAccess,
     request_slot: Option<OwnedSemaphorePermit>,
     kind: StreamKind,
-    canary: bool,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum StreamKind {
-    Chat,
+    Chat { canary: bool },
     Responses { created_at: u64 },
 }
 
@@ -252,8 +251,7 @@ pub(crate) async fn chat_completions(
             output_tokens,
             kv_cache_access,
             request_slot,
-            kind: StreamKind::Chat,
-            canary,
+            kind: StreamKind::Chat { canary },
         });
     }
 
@@ -293,7 +291,7 @@ pub(crate) async fn chat_completions(
         usage: ChatUsage {
             prompt_tokens: input_tokens,
             completion_tokens: output_tokens,
-            total_tokens: input_tokens + output_tokens,
+            total_tokens: input_tokens.saturating_add(output_tokens),
         },
     })
     .into_response();
@@ -362,7 +360,6 @@ pub(crate) async fn responses(
         kind: StreamKind::Responses {
             created_at: current_unix_timestamp(),
         },
-        canary: false,
     })
 }
 
@@ -535,7 +532,6 @@ fn stream_response(config: StreamResponseConfig) -> Response {
         kv_cache_access,
         request_slot,
         kind,
-        canary,
     } = config;
     let stream = async_stream::stream! {
         let _request_slot = request_slot;
@@ -561,7 +557,7 @@ fn stream_response(config: StreamResponseConfig) -> Response {
 
         state.emit_counters(&request_id, &model, input_tokens, 0, false);
 
-        if kind == StreamKind::Chat {
+        if matches!(kind, StreamKind::Chat { .. }) {
             yield Ok(chat_sse_event(&id, &model, ChatStreamChunk::Role));
         }
 
@@ -569,13 +565,15 @@ fn stream_response(config: StreamResponseConfig) -> Response {
             if i > 0 {
                 tokio::time::sleep(token_delay(&state, &request_id, i)).await;
             }
-            let token = if canary {
+            let token = if matches!(kind, StreamKind::Chat { canary: true }) {
                 CANARY_ANSWER
             } else {
                 DUMMY_TOKENS[i % DUMMY_TOKENS.len()]
             };
             let event = match kind {
-                StreamKind::Chat => chat_sse_event(&id, &model, ChatStreamChunk::Content(token)),
+                StreamKind::Chat { .. } => {
+                    chat_sse_event(&id, &model, ChatStreamChunk::Content(token))
+                }
                 StreamKind::Responses { .. } => {
                     output_text.push_str(token);
                     responses_sse_event(
@@ -595,7 +593,7 @@ fn stream_response(config: StreamResponseConfig) -> Response {
         }
 
         let completed = match kind {
-            StreamKind::Chat => chat_sse_event(&id, &model, ChatStreamChunk::Stop),
+            StreamKind::Chat { .. } => chat_sse_event(&id, &model, ChatStreamChunk::Stop),
             StreamKind::Responses { created_at } => responses_sse_event(
                 "response.completed",
                 &serde_json::json!({
@@ -620,7 +618,7 @@ fn stream_response(config: StreamResponseConfig) -> Response {
                         "usage": {
                             "input_tokens": input_tokens,
                             "output_tokens": output_tokens,
-                            "total_tokens": input_tokens + output_tokens,
+                            "total_tokens": input_tokens.saturating_add(output_tokens),
                         },
                     },
                 }),
@@ -630,7 +628,7 @@ fn stream_response(config: StreamResponseConfig) -> Response {
 
         state.emit_counters(&request_id, &model, input_tokens, output_tokens, true);
 
-        if kind == StreamKind::Chat {
+        if matches!(kind, StreamKind::Chat { .. }) {
             yield Ok(Event::default().data("[DONE]"));
         }
     };

--- a/src/libraries/rust/stargate/crates/mock-dynamo/src/openai.rs
+++ b/src/libraries/rust/stargate/crates/mock-dynamo/src/openai.rs
@@ -26,11 +26,11 @@ use tracing::info;
 use crate::AppState;
 use crate::kv_cache::{KvCacheAccess, KvCacheStats, insert_kv_cache_headers};
 use crate::stats_stream::StatsStreamEvent;
-use crate::test_control::{TestEndpoint, TestRequestClass, request_class};
+use crate::test_control::{TestEndpoint, TestRequestClass, is_canary_request, request_class};
 use crate::timing::{
-    embedding_item_count, jitter_ms, non_streaming_delay, optional_header, prefill_delay,
-    request_embedding_tokens, request_input_tokens, request_output_tokens, response_input_tokens,
-    response_output_tokens, token_delay,
+    bounded_output_tokens, embedding_item_count, jitter_ms, non_streaming_delay, optional_header,
+    prefill_delay, request_embedding_tokens, request_input_tokens, response_input_tokens,
+    select_output_tokens, token_delay,
 };
 
 #[derive(Serialize)]
@@ -67,6 +67,7 @@ const DUMMY_TOKENS: &[&str] = &[
     " helpful", " AI", " assistant", ".", " Let", " me", " know", " what", " you", " need", ".",
     " I", "'m", " here", " to", " assist", " you", "!",
 ];
+const CANARY_ANSWER: &str = "2";
 
 #[derive(Deserialize)]
 pub(crate) struct ChatRequest {
@@ -169,6 +170,7 @@ struct StreamResponseConfig {
     kv_cache_access: KvCacheAccess,
     request_slot: Option<OwnedSemaphorePermit>,
     kind: StreamKind,
+    canary: bool,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -194,13 +196,31 @@ pub(crate) async fn chat_completions(
             }),
         );
     }
-    let request_slot = state.acquire_request_slot().await;
     let input_tokens = request_input_tokens(&headers, &req);
-    let output_tokens = request_output_tokens(&headers, &req, state.num_tokens);
-    let stream = req.stream == Some(true);
+    let canary = is_canary_request(&headers);
     let id = format!("chatcmpl-mock-{}", rand_id());
-    info!(id = %id, model = %model, stream = stream, "received chat/completions request");
     let request_id = optional_header(&headers, "x-request-id").unwrap_or_else(|| id.clone());
+    let selected_output_tokens = if canary {
+        1
+    } else {
+        select_output_tokens(&headers, &request_id, state.output_tokens, req.max_tokens)
+    };
+    let Some(output_tokens) = bounded_output_tokens(
+        input_tokens,
+        selected_output_tokens,
+        state.context_length_tokens,
+    ) else {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            format!(
+                "input token count {input_tokens} leaves no output capacity within the context length of {} tokens",
+                state.context_length_tokens
+            ),
+        );
+    };
+    let request_slot = state.acquire_request_slot().await;
+    let stream = req.stream == Some(true);
+    info!(id = %id, model = %model, stream = stream, "received chat/completions request");
     let cache_affinity_key = optional_header(&headers, "x-cache-affinity-key");
     if stream {
         state.emit_counters(&request_id, &model, 0, 0, false);
@@ -233,6 +253,7 @@ pub(crate) async fn chat_completions(
             kv_cache_access,
             request_slot,
             kind: StreamKind::Chat,
+            canary,
         });
     }
 
@@ -244,12 +265,16 @@ pub(crate) async fn chat_completions(
     ))
     .await;
 
-    let content: String = DUMMY_TOKENS
-        .iter()
-        .cycle()
-        .take(output_tokens)
-        .copied()
-        .collect();
+    let content = if canary {
+        CANARY_ANSWER.to_string()
+    } else {
+        DUMMY_TOKENS
+            .iter()
+            .cycle()
+            .take(output_tokens)
+            .copied()
+            .collect()
+    };
 
     info!(id = %id, status = 200, "responding with JSON");
     state.emit_counters(&request_id, &model, input_tokens, output_tokens, true);
@@ -292,12 +317,30 @@ pub(crate) async fn responses(
     state
         .record_request(&headers, TestEndpoint::Responses, &model)
         .await;
-    let request_slot = state.acquire_request_slot().await;
     let input_tokens = response_input_tokens(&headers, &req);
-    let output_tokens = response_output_tokens(&headers, &req, state.num_tokens);
     let id = format!("resp-mock-{}", rand_id());
+    let request_id = optional_header(&headers, "x-request-id").unwrap_or_else(|| id.clone());
+    let selected_output_tokens = select_output_tokens(
+        &headers,
+        &request_id,
+        state.output_tokens,
+        req.max_output_tokens,
+    );
+    let Some(output_tokens) = bounded_output_tokens(
+        input_tokens,
+        selected_output_tokens,
+        state.context_length_tokens,
+    ) else {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            format!(
+                "input token count {input_tokens} leaves no output capacity within the context length of {} tokens",
+                state.context_length_tokens
+            ),
+        );
+    };
+    let request_slot = state.acquire_request_slot().await;
     info!(id = %id, model = %model, "received responses request");
-    let request_id = optional_header(&headers, "x-request-id").unwrap_or_default();
     let cache_affinity_key = optional_header(&headers, "x-cache-affinity-key");
     state.emit_counters(&request_id, &model, 0, 0, false);
     let kv_cache_access = state
@@ -319,6 +362,7 @@ pub(crate) async fn responses(
         kind: StreamKind::Responses {
             created_at: current_unix_timestamp(),
         },
+        canary: false,
     })
 }
 
@@ -491,6 +535,7 @@ fn stream_response(config: StreamResponseConfig) -> Response {
         kv_cache_access,
         request_slot,
         kind,
+        canary,
     } = config;
     let stream = async_stream::stream! {
         let _request_slot = request_slot;
@@ -524,7 +569,11 @@ fn stream_response(config: StreamResponseConfig) -> Response {
             if i > 0 {
                 tokio::time::sleep(token_delay(&state, &request_id, i)).await;
             }
-            let token = DUMMY_TOKENS[i % DUMMY_TOKENS.len()];
+            let token = if canary {
+                CANARY_ANSWER
+            } else {
+                DUMMY_TOKENS[i % DUMMY_TOKENS.len()]
+            };
             let event = match kind {
                 StreamKind::Chat => chat_sse_event(&id, &model, ChatStreamChunk::Content(token)),
                 StreamKind::Responses { .. } => {

--- a/src/libraries/rust/stargate/crates/mock-dynamo/src/test_control.rs
+++ b/src/libraries/rust/stargate/crates/mock-dynamo/src/test_control.rs
@@ -266,3 +266,10 @@ pub(crate) fn request_class(headers: &HeaderMap) -> TestRequestClass {
         _ => TestRequestClass::ApiGateway,
     }
 }
+
+pub(crate) fn is_canary_request(headers: &HeaderMap) -> bool {
+    headers
+        .get("x-request-id")
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|request_id| request_id.starts_with(CANARY_REQUEST_ID_PREFIX))
+}

--- a/src/libraries/rust/stargate/crates/mock-dynamo/src/tests.rs
+++ b/src/libraries/rust/stargate/crates/mock-dynamo/src/tests.rs
@@ -663,6 +663,30 @@ fn selected_output_tokens_are_bounded_by_remaining_context() {
     assert_eq!(bounded_output_tokens(usize::MAX, 64, 0), Some(64));
 }
 
+#[tokio::test]
+async fn chat_completion_saturates_total_tokens_at_usize_max() {
+    let app = Router::new()
+        .route("/v1/chat/completions", post(chat_completions))
+        .with_state(test_state());
+    let (addr, server) = spawn_test_app(app).await;
+
+    let response = json_response(
+        addr,
+        "POST",
+        "/v1/chat/completions",
+        &format!(
+            "connection: close\r\nx-input-tokens: {}\r\nx-output-tokens: 1",
+            usize::MAX
+        ),
+        r#"{"model":"dummy-model","messages":[],"stream":false}"#,
+    )
+    .await;
+
+    assert!(response.starts_with("HTTP/1.1 200 OK"));
+    assert!(response.contains(&format!(r#""total_tokens":{}"#, usize::MAX)));
+    server.abort();
+}
+
 #[test]
 fn prefill_delay_scales_with_input_tokens() {
     assert_eq!(prefill_delay(4_000, 2_000.0), Duration::from_secs(2));

--- a/src/libraries/rust/stargate/crates/mock-dynamo/src/tests.rs
+++ b/src/libraries/rust/stargate/crates/mock-dynamo/src/tests.rs
@@ -26,11 +26,11 @@ use axum::http::HeaderValue;
 use axum::routing::{get, post, put};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-fn request(max_tokens: Option<usize>) -> ChatRequest {
+fn request() -> ChatRequest {
     ChatRequest {
         stream: Some(true),
         model: Some("dummy-model".to_string()),
-        max_tokens,
+        max_tokens: Some(1),
         messages: Vec::new(),
     }
 }
@@ -43,9 +43,12 @@ fn test_stats_events() -> broadcast::Sender<StatsStreamEvent> {
 fn test_state() -> AppState {
     AppState {
         model_name: "dummy-model".to_string(),
-        num_tokens: 1,
-        token_delay: Duration::ZERO,
-        decode_jitter_ms: 0,
+        output_tokens: OutputTokenConfig::fixed(1),
+        context_length_tokens: 0,
+        decode_rate: DecodeRate::TokenDelay {
+            base_ms: 0,
+            jitter_ms: 0,
+        },
         ttft: Duration::ZERO,
         ttft_jitter_ms: 0,
         prefill_tokens_per_s: 0.0,
@@ -55,6 +58,146 @@ fn test_state() -> AppState {
         stats_events: test_stats_events(),
         test_control: TestControlState::with_discovered_models(["dummy-model".to_string()]),
     }
+}
+
+#[test]
+fn h100_llama_profile_selects_complete_behavior() {
+    let args = Args::try_parse_from(["mock-dynamo", "--profile", "h100-llama-3.1-8b"])
+        .expect("profile should parse");
+
+    assert_eq!(
+        args.behavior().expect("profile behavior should be valid"),
+        Behavior {
+            context_length_tokens: 131_072,
+            decode_rate: DecodeRate::Uniform {
+                min_tokens_per_s: 128.0,
+                max_tokens_per_s: 200.0,
+            },
+            ttft_ms: 10,
+            ttft_jitter_ms: 20,
+            prefill_tokens_per_s: 7000.0,
+            max_concurrent_requests: 25,
+            kv_cache_capacity_tokens: 400_000,
+        }
+    );
+    assert_eq!(
+        args.output_tokens()
+            .expect("profile output token defaults should be valid"),
+        OutputTokenConfig {
+            min: 128,
+            max: 8192,
+            distribution: OutputTokenDistribution::Gaussian,
+        }
+    );
+}
+
+#[test]
+fn h100_llama_profile_rejects_manual_overrides() {
+    let error = Args::try_parse_from([
+        "mock-dynamo",
+        "--profile",
+        "h100-llama-3.1-8b",
+        "--token-delay-ms",
+        "1",
+    ])
+    .expect_err("manual behavior overrides should conflict with a profile");
+    assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+}
+
+#[test]
+fn profile_output_token_defaults_can_be_overridden() {
+    let args = Args::try_parse_from([
+        "mock-dynamo",
+        "--profile",
+        "h100-llama-3.1-8b",
+        "--output-tokens-min",
+        "64",
+        "--output-tokens-max",
+        "512",
+        "--output-token-distribution",
+        "uniform",
+    ])
+    .expect("profile output token defaults should be overridable");
+
+    assert_eq!(
+        args.output_tokens()
+            .expect("output token override should be valid"),
+        OutputTokenConfig {
+            min: 64,
+            max: 512,
+            distribution: OutputTokenDistribution::Uniform,
+        }
+    );
+}
+
+#[test]
+fn output_rate_range_is_complete_ordered_and_deterministic() {
+    let args = Args::try_parse_from([
+        "mock-dynamo",
+        "--output-tps-min",
+        "120",
+        "--output-tps-max",
+        "200",
+    ])
+    .expect("complete output rate bounds should parse");
+    assert_eq!(
+        args.behavior()
+            .expect("ordered bounds should be valid")
+            .decode_rate,
+        DecodeRate::Uniform {
+            min_tokens_per_s: 120.0,
+            max_tokens_per_s: 200.0,
+        }
+    );
+    assert!(
+        Args::try_parse_from(["mock-dynamo", "--output-tps-min", "120"]).is_err(),
+        "one output rate bound must not silently select a partial range"
+    );
+
+    let reversed = Args::try_parse_from([
+        "mock-dynamo",
+        "--output-tps-min",
+        "200",
+        "--output-tps-max",
+        "120",
+    ])
+    .expect("individual output rate bounds should parse");
+    assert!(reversed.behavior().is_err());
+
+    let first = distributed_output_rate("request-a", 120.0, 200.0);
+    assert_eq!(first, distributed_output_rate("request-a", 120.0, 200.0));
+    assert!((120.0..=200.0).contains(&first));
+}
+
+#[tokio::test]
+async fn pylon_canary_streams_one_correct_token() {
+    let state = AppState {
+        output_tokens: OutputTokenConfig {
+            min: 100,
+            max: 200,
+            distribution: OutputTokenDistribution::Gaussian,
+        },
+        ..test_state()
+    };
+    let app = Router::new()
+        .route("/v1/chat/completions", post(chat_completions))
+        .with_state(state);
+    let (addr, server) = spawn_test_app(app).await;
+    let response = json_response(
+        addr,
+        "POST",
+        "/v1/chat/completions",
+        "connection: close\r\nx-request-id: canary-00000000-0000-4000-8000-000000000000-g0-1",
+        r#"{"model":"dummy-model","messages":[{"role":"user","content":"1+1="}],"max_tokens":237,"stream":true}"#,
+    )
+    .await;
+
+    assert!(response.starts_with("HTTP/1.1 200 OK"));
+    assert!(response.contains("content-type: text/event-stream"));
+    assert!(response.contains(r#""content":"2""#));
+    assert_eq!(response.matches(r#""content":""#).count(), 1);
+    assert!(response.contains("data: [DONE]"));
+    server.abort();
 }
 
 async fn spawn_test_app(app: Router) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
@@ -479,19 +622,45 @@ async fn embeddings_endpoint_returns_json_without_stream() {
 }
 
 #[test]
-fn output_tokens_prefer_benchmark_header() {
+fn output_token_selection_supports_overrides_and_bounded_distributions() {
     let mut headers = HeaderMap::new();
     headers.insert("x-output-tokens", HeaderValue::from_static("64"));
+    let uniform = OutputTokenConfig {
+        min: 120,
+        max: 200,
+        distribution: OutputTokenDistribution::Uniform,
+    };
+    let gaussian = OutputTokenConfig {
+        distribution: OutputTokenDistribution::Gaussian,
+        ..uniform
+    };
 
-    assert_eq!(request_output_tokens(&headers, &request(Some(16)), 8), 64);
+    assert_eq!(
+        select_output_tokens(&headers, "request-a", uniform, Some(32)),
+        64
+    );
+    for config in [uniform, gaussian] {
+        let selected = select_output_tokens(&HeaderMap::new(), "request-a", config, None);
+        assert_eq!(
+            selected,
+            select_output_tokens(&HeaderMap::new(), "request-a", config, None)
+        );
+        assert!((120..=200).contains(&selected));
+        assert_eq!(
+            select_output_tokens(&HeaderMap::new(), "request-a", config, Some(16)),
+            16
+        );
+    }
 }
 
 #[test]
-fn max_tokens_is_capped_by_default_when_header_absent() {
+fn selected_output_tokens_are_bounded_by_remaining_context() {
     assert_eq!(
-        request_output_tokens(&HeaderMap::new(), &request(Some(128)), 8),
-        8
+        bounded_output_tokens(120_000, 20_000, 131_072),
+        Some(11_072)
     );
+    assert_eq!(bounded_output_tokens(131_072, 1, 131_072), None);
+    assert_eq!(bounded_output_tokens(usize::MAX, 64, 0), Some(64));
 }
 
 #[test]
@@ -600,7 +769,7 @@ async fn chat_completion_retains_prefix_only_after_modeled_prefill_completes() {
     headers.insert("x-input-tokens", HeaderValue::from_static("100"));
     headers.insert("x-cache-affinity-key", HeaderValue::from_static("cache-a"));
 
-    let mut chat_request = request(Some(1));
+    let mut chat_request = request();
     chat_request.messages = vec![serde_json::json!({ "content": "x".repeat(100) })];
     let request = tokio::spawn(chat_completions(State(state), headers, Json(chat_request)));
     tokio::time::timeout(Duration::from_millis(100), stats_events.recv())
@@ -687,7 +856,7 @@ async fn streaming_response_delays_first_data_frame_until_ttft() {
 #[tokio::test]
 async fn streaming_response_exposes_stats_stream_endpoint() {
     let state = AppState {
-        num_tokens: 2,
+        output_tokens: OutputTokenConfig::fixed(2),
         ..test_state()
     };
     let app = Router::new()
@@ -758,7 +927,7 @@ fn stats_stream_events_are_ndjson() {
 #[tokio::test]
 async fn responses_endpoint_streams_response_events_without_private_stats_headers() {
     let state = AppState {
-        num_tokens: 2,
+        output_tokens: OutputTokenConfig::fixed(2),
         kv_cache: Arc::new(Mutex::new(KvCacheState::new(10_000))),
         ..test_state()
     };
@@ -822,7 +991,7 @@ async fn responses_endpoint_streams_response_events_without_private_stats_header
 #[tokio::test]
 async fn responses_endpoint_rejects_non_streaming_requests() {
     let state = AppState {
-        num_tokens: 2,
+        output_tokens: OutputTokenConfig::fixed(2),
         kv_cache: Arc::new(Mutex::new(KvCacheState::new(10_000))),
         ..test_state()
     };

--- a/src/libraries/rust/stargate/crates/mock-dynamo/src/timing.rs
+++ b/src/libraries/rust/stargate/crates/mock-dynamo/src/timing.rs
@@ -16,41 +16,42 @@
 use axum::http::HeaderMap;
 use std::time::Duration;
 
-use crate::AppState;
 use crate::openai::{ChatRequest, ResponsesRequest};
+use crate::{AppState, DecodeRate, OutputTokenConfig, OutputTokenDistribution};
 
 pub(crate) fn request_input_tokens(headers: &HeaderMap, request: &ChatRequest) -> usize {
     input_tokens(headers, || estimate_prompt_tokens(&request.messages))
 }
 
-pub(crate) fn request_output_tokens(
+pub(crate) fn select_output_tokens(
     headers: &HeaderMap,
-    request: &ChatRequest,
-    default_tokens: usize,
+    request_id: &str,
+    config: OutputTokenConfig,
+    request_limit: Option<usize>,
 ) -> usize {
-    output_tokens(headers, request.max_tokens, default_tokens)
+    if let Some(tokens) = header_usize(headers, "x-output-tokens") {
+        return at_least_one_token(tokens);
+    }
+    let sampled = sample_output_tokens(request_id, config);
+    request_limit.map_or(sampled, |limit| sampled.min(at_least_one_token(limit)))
+}
+
+pub(crate) fn bounded_output_tokens(
+    input_tokens: usize,
+    selected_output_tokens: usize,
+    context_length_tokens: usize,
+) -> Option<usize> {
+    if context_length_tokens == 0 {
+        return Some(selected_output_tokens);
+    }
+    let available_output_tokens = context_length_tokens.checked_sub(input_tokens)?;
+    (available_output_tokens > 0).then(|| selected_output_tokens.min(available_output_tokens))
 }
 
 pub(crate) fn response_input_tokens(headers: &HeaderMap, request: &ResponsesRequest) -> usize {
     input_tokens(headers, || {
         estimate_response_input_tokens(request.input.as_ref())
     })
-}
-
-pub(crate) fn response_output_tokens(
-    headers: &HeaderMap,
-    request: &ResponsesRequest,
-    default_tokens: usize,
-) -> usize {
-    output_tokens(headers, request.max_output_tokens, default_tokens)
-}
-
-fn output_tokens(headers: &HeaderMap, requested: Option<usize>, default_tokens: usize) -> usize {
-    if let Some(tokens) = header_usize(headers, "x-output-tokens") {
-        return at_least_one_token(tokens);
-    }
-    let default_tokens = at_least_one_token(default_tokens);
-    at_least_one_token(requested.unwrap_or(default_tokens).min(default_tokens))
 }
 
 pub(crate) fn request_embedding_tokens(headers: &HeaderMap, input: &serde_json::Value) -> usize {
@@ -150,12 +151,18 @@ pub(crate) fn non_streaming_delay(
 }
 
 pub(crate) fn token_delay(state: &AppState, request_id: &str, token_index: usize) -> Duration {
-    state.token_delay
-        + Duration::from_millis(jitter_ms(
-            request_id,
-            &format!("decode-{token_index}"),
-            state.decode_jitter_ms,
-        ))
+    match state.decode_rate {
+        DecodeRate::TokenDelay { base_ms, jitter_ms } => {
+            Duration::from_millis(base_ms)
+                + Duration::from_millis(jitter_ms_for_token(request_id, token_index, jitter_ms))
+        }
+        DecodeRate::Uniform {
+            min_tokens_per_s,
+            max_tokens_per_s,
+        } => Duration::from_secs_f64(
+            1.0 / distributed_output_rate(request_id, min_tokens_per_s, max_tokens_per_s),
+        ),
+    }
 }
 
 pub(crate) fn jitter_ms(request_id: &str, salt: &str, max_jitter_ms: u64) -> u64 {
@@ -163,13 +170,59 @@ pub(crate) fn jitter_ms(request_id: &str, salt: &str, max_jitter_ms: u64) -> u64
         return 0;
     }
 
-    let hash = request_id
+    let hash = deterministic_hash(request_id, salt);
+    max_jitter_ms
+        .checked_add(1)
+        .map_or(hash, |range| hash % range)
+}
+
+fn jitter_ms_for_token(request_id: &str, token_index: usize, max_jitter_ms: u64) -> u64 {
+    jitter_ms(request_id, &format!("decode-{token_index}"), max_jitter_ms)
+}
+
+pub(crate) fn distributed_output_rate(
+    request_id: &str,
+    min_tokens_per_s: f64,
+    max_tokens_per_s: f64,
+) -> f64 {
+    let position = deterministic_hash(request_id, "output-rate") as f64 / u64::MAX as f64;
+    min_tokens_per_s + position * (max_tokens_per_s - min_tokens_per_s)
+}
+
+pub(crate) fn sample_output_tokens(request_id: &str, config: OutputTokenConfig) -> usize {
+    if config.min == config.max {
+        return config.min;
+    }
+    match config.distribution {
+        OutputTokenDistribution::Uniform => {
+            let width = (config.max - config.min) as u128 + 1;
+            let offset = u128::from(deterministic_hash(request_id, "output-tokens-uniform"))
+                * width
+                / (u128::from(u64::MAX) + 1);
+            config.min + offset as usize
+        }
+        OutputTokenDistribution::Gaussian => {
+            let unit = |salt| {
+                let value = deterministic_hash(request_id, salt) >> 11;
+                (value as f64 + 1.0) / ((1_u64 << 53) as f64 + 1.0)
+            };
+            let standard_normal = (-2.0 * unit("output-tokens-gaussian-radius").ln()).sqrt()
+                * (std::f64::consts::TAU * unit("output-tokens-gaussian-angle")).cos();
+            let min = config.min as f64;
+            let max = config.max as f64;
+            let sample = ((min + max) / 2.0 + standard_normal * (max - min) / 6.0)
+                .round()
+                .clamp(min, max);
+            sample as usize
+        }
+    }
+}
+
+fn deterministic_hash(request_id: &str, salt: &str) -> u64 {
+    request_id
         .bytes()
         .chain(salt.bytes())
         .fold(1469598103934665603, |hash, byte| {
             (hash ^ u64::from(byte)).wrapping_mul(1099511628211)
-        });
-    max_jitter_ms
-        .checked_add(1)
-        .map_or(hash, |range| hash % range)
+        })
 }

--- a/src/libraries/rust/stargate/crates/mock-dynamo/src/timing.rs
+++ b/src/libraries/rust/stargate/crates/mock-dynamo/src/timing.rs
@@ -185,7 +185,7 @@ pub(crate) fn distributed_output_rate(
     min_tokens_per_s: f64,
     max_tokens_per_s: f64,
 ) -> f64 {
-    let position = deterministic_hash(request_id, "output-rate") as f64 / u64::MAX as f64;
+    let position = deterministic_hash_domain(request_id, HashDomain::Rate) as f64 / u64::MAX as f64;
     min_tokens_per_s + position * (max_tokens_per_s - min_tokens_per_s)
 }
 
@@ -196,18 +196,20 @@ pub(crate) fn sample_output_tokens(request_id: &str, config: OutputTokenConfig) 
     match config.distribution {
         OutputTokenDistribution::Uniform => {
             let width = (config.max - config.min) as u128 + 1;
-            let offset = u128::from(deterministic_hash(request_id, "output-tokens-uniform"))
-                * width
+            let offset = u128::from(deterministic_hash_domain(
+                request_id,
+                HashDomain::TokensUniform,
+            )) * width
                 / (u128::from(u64::MAX) + 1);
             config.min + offset as usize
         }
         OutputTokenDistribution::Gaussian => {
-            let unit = |salt| {
-                let value = deterministic_hash(request_id, salt) >> 11;
+            let unit = |domain| {
+                let value = deterministic_hash_domain(request_id, domain) >> 11;
                 (value as f64 + 1.0) / ((1_u64 << 53) as f64 + 1.0)
             };
-            let standard_normal = (-2.0 * unit("output-tokens-gaussian-radius").ln()).sqrt()
-                * (std::f64::consts::TAU * unit("output-tokens-gaussian-angle")).cos();
+            let standard_normal = (-2.0 * unit(HashDomain::TokensGaussianRadius).ln()).sqrt()
+                * (std::f64::consts::TAU * unit(HashDomain::TokensGaussianAngle)).cos();
             let min = config.min as f64;
             let max = config.max as f64;
             let sample = ((min + max) / 2.0 + standard_normal * (max - min) / 6.0)
@@ -218,10 +220,26 @@ pub(crate) fn sample_output_tokens(request_id: &str, config: OutputTokenConfig) 
     }
 }
 
+#[derive(Clone, Copy)]
+enum HashDomain {
+    Rate,
+    TokensUniform,
+    TokensGaussianRadius,
+    TokensGaussianAngle,
+}
+
 fn deterministic_hash(request_id: &str, salt: &str) -> u64 {
+    deterministic_hash_bytes(request_id, salt.bytes())
+}
+
+fn deterministic_hash_domain(request_id: &str, domain: HashDomain) -> u64 {
+    deterministic_hash_bytes(request_id, [domain as u8])
+}
+
+fn deterministic_hash_bytes(request_id: &str, salt: impl IntoIterator<Item = u8>) -> u64 {
     request_id
         .bytes()
-        .chain(salt.bytes())
+        .chain(salt)
         .fold(1469598103934665603, |hash, byte| {
             (hash ^ u64::from(byte)).wrapping_mul(1099511628211)
         })

--- a/src/libraries/rust/stargate/crates/mock-dynamo/tests/cli.rs
+++ b/src/libraries/rust/stargate/crates/mock-dynamo/tests/cli.rs
@@ -16,6 +16,21 @@
 use std::process::Command;
 
 #[test]
+fn explains_profile_without_starting_server() {
+    let output = Command::new(env!("CARGO_BIN_EXE_mock-dynamo"))
+        .args(["--explain-profile", "h100-llama-3.1-8b"])
+        .output()
+        .expect("mock-dynamo process should start");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("profile explanation should be UTF-8");
+    assert!(stdout.contains("context length: 131072 input + output tokens"));
+    assert!(stdout.contains("deterministic gaussian distribution over 128..=8192"));
+    assert!(stdout.contains("per active request: 164.0 tokens/s average"));
+    assert!(stdout.contains("1,000 input tokens: about 162.9 ms average"));
+}
+
+#[test]
 fn invalid_http_listen_addr_exits_nonzero() {
     let status = Command::new(env!("CARGO_BIN_EXE_mock-dynamo"))
         .args(["--http-listen-addr", "not-a-socket-addr"])

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/bringup.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/bringup.rs
@@ -325,7 +325,7 @@ mod tests {
     #[tokio::test]
     async fn canary_request_detects_runaway_generation() {
         let base_url = spawn_test_server(TestServerState {
-            completion_tokens: 7,
+            completion_tokens: 8,
             ..TestServerState::default()
         })
         .await;
@@ -341,8 +341,76 @@ mod tests {
         .expect_err("expected runaway generation");
         assert!(matches!(
             error,
-            BringupError::RunawayGeneration { tokens: 7 }
+            BringupError::RunawayGeneration { tokens: 8 }
         ));
+    }
+
+    #[tokio::test]
+    async fn canary_request_accepts_generation_at_threshold() {
+        let base_url = spawn_test_server(TestServerState {
+            completion_tokens: 7,
+            ..TestServerState::default()
+        })
+        .await;
+
+        send_canary_request(
+            &reqwest::Client::new(),
+            &base_url,
+            &test_generation(),
+            Duration::from_secs(1),
+            7,
+        )
+        .await
+        .expect("generation at the configured threshold should be accepted");
+    }
+
+    #[tokio::test]
+    async fn canary_error_without_json_message_does_not_echo_body() {
+        let base_url = spawn_test_server(TestServerState {
+            error_body: Some("sensitive upstream response".to_string()),
+            ..TestServerState::default()
+        })
+        .await;
+
+        let error = send_canary_request(
+            &reqwest::Client::new(),
+            &base_url,
+            &test_generation(),
+            Duration::from_secs(1),
+            7,
+        )
+        .await
+        .expect_err("unsuccessful canary response should fail");
+        let BringupError::Api { message, .. } = error else {
+            panic!("expected an API error");
+        };
+        assert!(!message.contains("sensitive upstream response"));
+        assert!(message.contains("without a JSON error message"));
+    }
+
+    #[tokio::test]
+    async fn canary_error_body_is_bounded() {
+        let error_body = "sensitive upstream response ".repeat(8_000);
+        let base_url = spawn_test_server(TestServerState {
+            error_body: Some(error_body),
+            ..TestServerState::default()
+        })
+        .await;
+
+        let error = send_canary_request(
+            &reqwest::Client::new(),
+            &base_url,
+            &test_generation(),
+            Duration::from_secs(1),
+            7,
+        )
+        .await
+        .expect_err("oversized canary error response should fail");
+        let BringupError::Api { message, .. } = error else {
+            panic!("expected an API error");
+        };
+        assert!(!message.contains("sensitive upstream response"));
+        assert!(message.contains("exceeding 65536 bytes"));
     }
 
     #[tokio::test]
@@ -827,6 +895,7 @@ mod tests {
     #[derive(Clone)]
     struct TestServerState {
         completion_tokens: u32,
+        error_body: Option<String>,
         prompt_too_long_above: Option<usize>,
         calibration_barrier: Option<Arc<Barrier>>,
         completions_before_block: Option<Arc<AtomicUsize>>,
@@ -845,6 +914,7 @@ mod tests {
         fn default() -> Self {
             Self {
                 completion_tokens: 1,
+                error_body: None,
                 prompt_too_long_above: None,
                 calibration_barrier: None,
                 completions_before_block: None,
@@ -1005,6 +1075,10 @@ mod tests {
                 .into_response();
         }
 
+        if let Some(error_body) = state.error_body {
+            return (StatusCode::SERVICE_UNAVAILABLE, error_body).into_response();
+        }
+
         let mut completion_tokens = state.completion_tokens;
         if prompt == "1+1=" {
             if let Some(canaries) = &state.canaries {
@@ -1015,7 +1089,7 @@ mod tests {
                     started.notify_one();
                     release.notified().await;
                 }
-                completion_tokens = if request == 0 { 7 } else { 1 };
+                completion_tokens = if request == 0 { 8 } else { 1 };
             } else if state
                 .canary_failures_remaining
                 .as_ref()

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/bringup.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/bringup.rs
@@ -365,6 +365,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn canary_request_accepts_case_insensitive_event_stream_content_type() {
+        let base_url = spawn_test_server(TestServerState {
+            event_stream_content_type: Some("Text/Event-Stream; charset=utf-8".to_string()),
+            ..TestServerState::default()
+        })
+        .await;
+
+        send_canary_request(
+            &reqwest::Client::new(),
+            &base_url,
+            &test_generation(),
+            Duration::from_secs(1),
+            7,
+        )
+        .await
+        .expect("a parameterized SSE content type should be accepted");
+    }
+
+    #[tokio::test]
     async fn canary_error_without_json_message_does_not_echo_body() {
         let base_url = spawn_test_server(TestServerState {
             error_body: Some("sensitive upstream response".to_string()),
@@ -896,6 +915,7 @@ mod tests {
     struct TestServerState {
         completion_tokens: u32,
         error_body: Option<String>,
+        event_stream_content_type: Option<String>,
         prompt_too_long_above: Option<usize>,
         calibration_barrier: Option<Arc<Barrier>>,
         completions_before_block: Option<Arc<AtomicUsize>>,
@@ -915,6 +935,7 @@ mod tests {
             Self {
                 completion_tokens: 1,
                 error_body: None,
+                event_stream_content_type: None,
                 prompt_too_long_above: None,
                 calibration_barrier: None,
                 completions_before_block: None,
@@ -1113,8 +1134,12 @@ mod tests {
             if request.get("stream").and_then(Value::as_bool) != Some(true) {
                 return StatusCode::BAD_REQUEST.into_response();
             }
+            let content_type = state
+                .event_stream_content_type
+                .as_deref()
+                .unwrap_or("text/event-stream");
             return (
-                [("content-type", "text/event-stream")],
+                [("content-type", content_type)],
                 format!(
                     "data: {{\"object\":\"chat.completion.chunk\",\"choices\":[{{\"delta\":{{\"content\":\"2\"}}}}],\"usage\":{{\"completion_tokens\":{completion_tokens}}}}}\n\ndata: [DONE]\n\n"
                 ),

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/bringup.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/bringup.rs
@@ -1035,6 +1035,19 @@ mod tests {
             }
         }
 
+        if prompt == "1+1=" {
+            if request.get("stream").and_then(Value::as_bool) != Some(true) {
+                return StatusCode::BAD_REQUEST.into_response();
+            }
+            return (
+                [("content-type", "text/event-stream")],
+                format!(
+                    "data: {{\"object\":\"chat.completion.chunk\",\"choices\":[{{\"delta\":{{\"content\":\"2\"}}}}],\"usage\":{{\"completion_tokens\":{completion_tokens}}}}}\n\ndata: [DONE]\n\n"
+                ),
+            )
+                .into_response();
+        }
+
         Json(serde_json::json!({
             "usage": {"completion_tokens": completion_tokens}
         }))

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/bringup/upstream.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/bringup/upstream.rs
@@ -50,6 +50,24 @@ pub(crate) async fn check_upstream_health(
     false
 }
 
+async fn ensure_success(response: reqwest::Response) -> Result<reqwest::Response, BringupError> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
+
+    let body = response.bytes().await?;
+    let message = extract_error_message(&body);
+    if is_prompt_too_long(status, &message) {
+        Err(BringupError::PromptTooLong)
+    } else {
+        Err(BringupError::Api {
+            status,
+            message: message.unwrap_or_else(|| String::from_utf8_lossy(&body).into_owned()),
+        })
+    }
+}
+
 pub(super) async fn send_canary_request(
     http_client: &reqwest::Client,
     upstream_http_base_url: &str,
@@ -73,31 +91,21 @@ pub(super) async fn send_canary_request(
         .pointer("/messages/0/content")
         .and_then(serde_json::Value::as_str)
         .map_or(1, str::len);
-    let response = http_client
-        .post(upstream_endpoint(
-            upstream_http_base_url,
-            "/v1/chat/completions",
-        ))
-        .header(HEADER_REQUEST_ID, request_id)
-        .header(HEADER_MODEL, generation.model_id())
-        .header(HEADER_INPUT_TOKENS, input_tokens.to_string())
-        .timeout(timeout)
-        .json(&request)
-        .send()
-        .await?;
-    let status = response.status();
-    if !status.is_success() {
-        let body = response.bytes().await?;
-        let message = extract_error_message(&body);
-        return if is_prompt_too_long(status, &message) {
-            Err(BringupError::PromptTooLong)
-        } else {
-            Err(BringupError::Api {
-                status,
-                message: message.unwrap_or_else(|| String::from_utf8_lossy(&body).into_owned()),
-            })
-        };
-    }
+    let response = ensure_success(
+        http_client
+            .post(upstream_endpoint(
+                upstream_http_base_url,
+                "/v1/chat/completions",
+            ))
+            .header(HEADER_REQUEST_ID, request_id)
+            .header(HEADER_MODEL, generation.model_id())
+            .header(HEADER_INPUT_TOKENS, input_tokens.to_string())
+            .timeout(timeout)
+            .json(&request)
+            .send()
+            .await?,
+    )
+    .await?;
     let is_event_stream = response
         .headers()
         .get(CONTENT_TYPE)
@@ -198,26 +206,14 @@ pub(super) async fn send_completion_request(
     }
     .send()
     .await?;
-
     let status = response.status();
     observe_response_headers(&mut observer, &response, status);
+    let response = ensure_success(response).await?;
     let body = response.bytes().await?;
-    if status.is_success() {
-        let completion = serde_json::from_slice::<ChatCompletionResponse>(&body)
-            .map_err(|error| BringupError::InvalidResponse(error.to_string()))?;
-        finish_observation(&mut observer, &completion);
-        Ok(completion)
-    } else {
-        let message = extract_error_message(&body);
-        if is_prompt_too_long(status, &message) {
-            Err(BringupError::PromptTooLong)
-        } else {
-            Err(BringupError::Api {
-                status,
-                message: message.unwrap_or_else(|| String::from_utf8_lossy(&body).into_owned()),
-            })
-        }
-    }
+    let completion = serde_json::from_slice::<ChatCompletionResponse>(&body)
+        .map_err(|error| BringupError::InvalidResponse(error.to_string()))?;
+    finish_observation(&mut observer, &completion);
+    Ok(completion)
 }
 
 fn observe_response_headers(

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/bringup/upstream.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/bringup/upstream.rs
@@ -31,6 +31,8 @@ use reqwest::header::CONTENT_TYPE;
 use serde::Deserialize;
 use stargate_protocol::tunnel_contract::{HEADER_INPUT_TOKENS, HEADER_MODEL, HEADER_REQUEST_ID};
 
+const MAX_UPSTREAM_ERROR_BODY_BYTES: usize = 64 * 1024;
+
 pub(crate) async fn check_upstream_health(
     http_client: &reqwest::Client,
     upstream_http_base_url: &str,
@@ -56,16 +58,39 @@ async fn ensure_success(response: reqwest::Response) -> Result<reqwest::Response
         return Ok(response);
     }
 
-    let body = response.bytes().await?;
-    let message = extract_error_message(&body);
+    let (body, truncated) = read_error_body(response).await?;
+    let message = (!truncated).then(|| extract_error_message(&body)).flatten();
     if is_prompt_too_long(status, &message) {
         Err(BringupError::PromptTooLong)
     } else {
         Err(BringupError::Api {
             status,
-            message: message.unwrap_or_else(|| String::from_utf8_lossy(&body).into_owned()),
+            message: message.unwrap_or_else(|| {
+                if truncated {
+                    format!(
+                        "upstream returned HTTP status {status} with an error body exceeding {MAX_UPSTREAM_ERROR_BODY_BYTES} bytes"
+                    )
+                } else {
+                    format!("upstream returned HTTP status {status} without a JSON error message")
+                }
+            }),
         })
     }
+}
+
+async fn read_error_body(response: reqwest::Response) -> Result<(Vec<u8>, bool), reqwest::Error> {
+    let mut body = Vec::with_capacity(MAX_UPSTREAM_ERROR_BODY_BYTES);
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        let remaining = MAX_UPSTREAM_ERROR_BODY_BYTES.saturating_sub(body.len());
+        if chunk.len() > remaining {
+            body.extend_from_slice(&chunk[..remaining]);
+            return Ok((body, true));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok((body, false))
 }
 
 pub(super) async fn send_canary_request(
@@ -143,7 +168,7 @@ pub(super) async fn send_canary_request(
                             observed_tokens.saturating_add(delta)
                         }
                     };
-                    if observed_tokens >= u64::from(canary_max_generation_threshold) {
+                    if observed_tokens > u64::from(canary_max_generation_threshold) {
                         return Err(BringupError::RunawayGeneration {
                             tokens: u32::try_from(observed_tokens).unwrap_or(u32::MAX),
                         });

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/bringup/upstream.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/bringup/upstream.rs
@@ -15,14 +15,19 @@
 
 use std::time::Duration;
 
+use crate::DEFAULT_MAX_SSE_BUFFER_BYTES;
 use crate::generated_request_id::{GeneratedRequestKind, next_generated_request_id};
+use crate::output_token_parser::{OutputTokenParser, OutputTokenProgress};
 use crate::request_observer::{
     RequestObservationEndpoint, RequiredTunnelHeaders, TunnelRequestObserver,
 };
 use crate::runtime_state::{ModelGeneration, PylonRuntimeState};
+use crate::sse_message_stream::{SseMessage, upstream_sse_message_stream};
 use crate::upstream_health::UpstreamHealthPaths;
 use crate::upstream_url::upstream_endpoint;
+use futures::StreamExt;
 use reqwest::StatusCode;
+use reqwest::header::CONTENT_TYPE;
 use serde::Deserialize;
 use stargate_protocol::tunnel_contract::{HEADER_INPUT_TOKENS, HEADER_MODEL, HEADER_REQUEST_ID};
 
@@ -59,23 +64,91 @@ pub(super) async fn send_canary_request(
         "seed": 33,
         "temperature": 0.7,
         "top_p": 1.0,
-        "stream": false,
+        "stream": true,
+        "stream_options": {"include_usage": true},
     });
 
-    let completion = send_completion_request(
-        http_client,
-        upstream_http_base_url,
-        Some(timeout),
-        &request,
-        GeneratedRequestKind::Canary,
-        generation,
-        None,
-    )
-    .await?;
-    if completion.usage.completion_tokens == canary_max_generation_threshold {
-        return Err(BringupError::RunawayGeneration {
-            tokens: completion.usage.completion_tokens,
-        });
+    let request_id = next_generated_request_id(GeneratedRequestKind::Canary, generation);
+    let input_tokens = request
+        .pointer("/messages/0/content")
+        .and_then(serde_json::Value::as_str)
+        .map_or(1, str::len);
+    let response = http_client
+        .post(upstream_endpoint(
+            upstream_http_base_url,
+            "/v1/chat/completions",
+        ))
+        .header(HEADER_REQUEST_ID, request_id)
+        .header(HEADER_MODEL, generation.model_id())
+        .header(HEADER_INPUT_TOKENS, input_tokens.to_string())
+        .timeout(timeout)
+        .json(&request)
+        .send()
+        .await?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.bytes().await?;
+        let message = extract_error_message(&body);
+        return if is_prompt_too_long(status, &message) {
+            Err(BringupError::PromptTooLong)
+        } else {
+            Err(BringupError::Api {
+                status,
+                message: message.unwrap_or_else(|| String::from_utf8_lossy(&body).into_owned()),
+            })
+        };
+    }
+    let is_event_stream = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.starts_with("text/event-stream"));
+    if !is_event_stream {
+        return Err(BringupError::InvalidResponse(
+            "canary response is not an SSE stream".to_string(),
+        ));
+    }
+
+    let mut messages = upstream_sse_message_stream(
+        response.bytes_stream(),
+        timeout,
+        timeout,
+        DEFAULT_MAX_SSE_BUFFER_BYTES,
+    );
+    let mut output_tokens = OutputTokenParser::new();
+    let mut observed_tokens = 0_u64;
+    let mut completed = false;
+    while let Some(message) = messages.next().await {
+        match message
+            .map_err(|error| BringupError::InvalidResponse(error.to_string()))?
+            .message
+        {
+            SseMessage::Done => {
+                completed = true;
+                break;
+            }
+            SseMessage::ChatCompletionChunk { parsed } => {
+                if let Some(progress) = output_tokens.observe_json(parsed.as_ref()) {
+                    observed_tokens = match progress {
+                        OutputTokenProgress::ExplicitCumulative { tokens, .. } => tokens,
+                        OutputTokenProgress::EstimatedDelta { delta } => {
+                            observed_tokens.saturating_add(delta)
+                        }
+                    };
+                    if observed_tokens >= u64::from(canary_max_generation_threshold) {
+                        return Err(BringupError::RunawayGeneration {
+                            tokens: u32::try_from(observed_tokens).unwrap_or(u32::MAX),
+                        });
+                    }
+                }
+            }
+            SseMessage::OtherData => {}
+        }
+    }
+    if !completed || observed_tokens == 0 {
+        return Err(BringupError::InvalidResponse(
+            "canary stream must contain output and end with [DONE]".to_string(),
+        ));
     }
     Ok(())
 }

--- a/src/libraries/rust/stargate/crates/pylon-lib/src/bringup/upstream.rs
+++ b/src/libraries/rust/stargate/crates/pylon-lib/src/bringup/upstream.rs
@@ -135,7 +135,11 @@ pub(super) async fn send_canary_request(
         .headers()
         .get(CONTENT_TYPE)
         .and_then(|value| value.to_str().ok())
-        .is_some_and(|value| value.starts_with("text/event-stream"));
+        .is_some_and(|value| {
+            value.split(';').next().is_some_and(|media_type| {
+                media_type.trim().eq_ignore_ascii_case("text/event-stream")
+            })
+        });
     if !is_event_stream {
         return Err(BringupError::InvalidResponse(
             "canary response is not an SSE stream".to_string(),


### PR DESCRIPTION
## Why

MockDynamo only supports individually configured fixed timing and output behavior. That makes realistic, reproducible model and hardware simulations difficult. Pylon canaries also need to exercise the streaming response contract used by production traffic.

## What changed

- Adds an `h100-llama-3.1-8b` model and hardware profile with H100-calibrated prefill, TTFT, decode-rate, concurrency, KV-cache, and context-window behavior.
- Keeps output-length workload defaults separate from the intrinsic profile and allows callers to override the distribution, minimum, and maximum.
- Samples deterministic bounded uniform or Gaussian output lengths per request.
- Bounds generated output by the sampled length, request `max_tokens`, and remaining model context.
- Returns the short answer `2` for Pylon canary request IDs.
- Makes Pylon canary requests streaming and validates the streamed response.
- Adds `--explain-profile` output describing modeled behavior and expected rates.

## Customer Release Notes

Adds configurable MockDynamo inference profiles and streamed Pylon canaries for development and testing.

## Plan Summary

Not applicable.

## Usage

```sh
mock-dynamo --profile h100-llama-3.1-8b
mock-dynamo --explain-profile h100-llama-3.1-8b
mock-dynamo --profile h100-llama-3.1-8b \
  --output-tokens-min 64 \
  --output-tokens-max 4096 \
  --output-token-distribution gaussian
```

## Testing

- `cargo test -p mock-dynamo -p pylon-lib`
- `cargo clippy -p mock-dynamo -p pylon-lib --all-targets --all-features -- -D warnings`
- `bazel test //src/libraries/rust/stargate/crates/pylon-lib:pylon-lib_test //src/libraries/rust/stargate/crates/mock-dynamo:mock-dynamo --test_output=errors`
- `bazel build //src/libraries/rust/stargate/crates/mock-dynamo:mock-dynamo`
- `cargo fmt --all -- --check`
- `git diff --check`

No additional manual QA is required.

## Notes

- Distribution sampling is deterministic by request ID for reproducible tests.
- The existing `x-output-tokens` control remains an exact benchmark override.
- The profile models a 131,072-token context window.
- Benchmark reference: https://docs.nvidia.com/nim/benchmarking/llm/1.0.0/performance.html#llama-3-1-8b-instruct-results

## Issues

Closes #1501

## Related Pull Requests

None.

## Dependencies

None. No third-party dependency or NOTICE changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable behavior profiles, including H100/Llama 3.1 8B performance settings.
  * Added controls for output-token ranges, decode-rate distributions, context limits, and profile explanations.
  * Added deterministic canary responses and streaming usage reporting for chat completions.

* **Bug Fixes**
  * Improved output handling when context limits leave no capacity.
  * Standardized request ID fallback behavior and token total calculations.
  * Improved streaming validation, including termination, output thresholds, and unsuccessful responses.
  * Prevented oversized or non-JSON error responses from exposing sensitive content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->