### PR TITLE
fix(self-managed): bump admin token issuer proxy

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -112,7 +112,7 @@ releases:
 
   - name: admin-issuer-proxy
     chart: nvcf/helm-admin-token-issuer-proxy
-    version: 1.4.3
+    version: 1.5.1
     namespace: api-keys
     values:
       - ../global.yaml.gotmpl


### PR DESCRIPTION
## TL;DR

Bump the self-managed stack from `helm-admin-token-issuer-proxy` 1.4.3 to 1.5.1. The newer chart runs application 1.1.0, which keeps liveness process-only and reports dependency startup through readiness.

## Additional Details

### Why

The pinned proxy exits while the API Keys dependency is unavailable during a cold start. Chart 1.5.1 contains the retry and probe separation released by #1237, so the proxy can stay alive and become ready after API Keys recovers.

### What changed

Updated the `admin-issuer-proxy` chart pin in the self-managed Helmfile from 1.4.3 to 1.5.1. No values or deployment topology changed.

### Customer Release Notes

Improved self-managed control-plane startup reliability when API Keys takes longer to become available.

### Plan Summary

Upgrades one existing Helm release. No resources are added or removed.

### Usage

No operator action or configuration change is required.

### Notes

The full local BDD flow was stopped after validating the proxy because the unrelated NVCT image availability problem in #1507 prevents account bootstrap on a fresh cluster.

### References

- #1237
- #1507

### Related Pull Requests

- #1237

### Dependencies

Uses the already-published `helm-admin-token-issuer-proxy` 1.5.1 chart and application 1.1.0 image. No new third-party dependency or NOTICE change.

## For the Reviewer

The only code change is the chart version pin in `deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl`.

## For QA

### Testing

- `make -C deploy/stacks/self-managed test`
- `go test ./... -count=1` in `src/control-plane-services/admin-token-issuer-proxy`
- Rendered chart 1.5.1 and verified image tag 1.1.0, liveness `/healthz`, and readiness `/readyz`
- On a clean local k3d cluster, verified the 1.1.0 proxy stayed alive and NotReady with zero restarts while API Keys was unavailable, then became Ready on the same pod after API Keys recovered
- Removed the temporary image override and cleaned up the local cluster after testing

No additional QA is needed beyond CI.

## Issues

Relates to #1229

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the admin issuer proxy component to chart version 1.5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->