### PR TITLE
feat(nvca): stamp icms_request_id/resource_id for ledger correlation (#809)

### DIFF
--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/manifests/otel_collector_config.yaml
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/manifests/otel_collector_config.yaml
@@ -76,6 +76,11 @@ processors:
           tag_name: function_version_id
         - key: task-id
           tag_name: task_id
+        # icms-request-id correlates a Pod back to its ICMSRequest. It is carried
+        # in the Pod event's details (not the context key) so consumers can filter
+        # Pod events by icms_request_id via the /events attribute filter.
+        - key: icms-request-id
+          tag_name: icms_request_id
     pod_association:
       - sources:
           - from: resource_attribute
@@ -88,6 +93,9 @@ processors:
       - set(log.attributes["deployment_id"], resource.attributes["deployment_id"]) where resource.attributes["deployment_id"] != nil
       - set(log.attributes["gpu_specification_id"], resource.attributes["gpu_specification_id"]) where resource.attributes["gpu_specification_id"] != nil
       - set(log.attributes["instance_id"], resource.attributes["k8s.pod.name"]) where resource.attributes["k8s.pod.name"] != nil
+      # Carry icms_request_id into the Pod event so it can be correlated to its
+      # ICMSRequest. It is not a ledger context field, so it lands in event details.
+      - set(log.attributes["icms_request_id"], resource.attributes["icms_request_id"]) where resource.attributes["icms_request_id"] != nil
       - set(log.attributes["namespace"], resource.attributes["function_version_id"]) where resource.attributes["function_version_id"] != nil
       # Tasks are keyed by task-id in FnDs; override function_version_id when present.
       - set(log.attributes["namespace"], resource.attributes["task_id"]) where resource.attributes["task_id"] != nil and resource.attributes["task_id"] != ""
@@ -133,6 +141,9 @@ processors:
     error_mode: ignore
     log_statements:
       - set(log.attributes["icms_request_id"], log.body["object"]["metadata"]["annotations"]["nvcf.nvidia.io/icms-request-id"]) where log.body["object"]["metadata"]["annotations"]["nvcf.nvidia.io/icms-request-id"] != nil
+      # resource_id keys the ICMSRequest (resource) lane in the ledger context so
+      # its events are uniquely identified and directly queryable by request id.
+      - set(log.attributes["resource_id"], log.body["object"]["metadata"]["annotations"]["nvcf.nvidia.io/icms-request-id"]) where log.body["object"]["metadata"]["annotations"]["nvcf.nvidia.io/icms-request-id"] != nil
       - set(log.attributes["namespace"], log.body["object"]["metadata"]["annotations"]["nvcf.nvidia.io/function-version-id"]) where log.body["object"]["metadata"]["annotations"]["nvcf.nvidia.io/function-version-id"] != nil
       # Tasks are keyed by task-id in FnDs; override function_version_id when present.
       - set(log.attributes["namespace"], log.body["object"]["metadata"]["annotations"]["nvcf.nvidia.io/task-id"]) where log.body["object"]["metadata"]["annotations"]["nvcf.nvidia.io/task-id"] != nil and log.body["object"]["metadata"]["annotations"]["nvcf.nvidia.io/task-id"] != ""

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/otel_reconcile_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/otel_reconcile_test.go
@@ -210,11 +210,16 @@ func assertPodLaneTransforms(t *testing.T, config string) {
 		tagByKey[m["key"].(string)] = m["tag_name"].(string)
 	}
 	assert.Equal(t, "task_id", tagByKey["task-id"], "task-id label must map to task_id")
+	assert.Equal(t, "icms_request_id", tagByKey["icms-request-id"],
+		"icms-request-id label must map to icms_request_id so Pod events carry it")
 
 	var stmts []string
 	for _, s := range processors["transform"].(map[string]any)["log_statements"].([]any) {
 		stmts = append(stmts, s.(string))
 	}
+	assert.GreaterOrEqual(t, indexOfContaining(stmts,
+		`set(log.attributes["icms_request_id"], resource.attributes["icms_request_id"])`), 0,
+		"Pod lane must lift icms_request_id into event attributes")
 	fvIdx := indexOfContaining(stmts, `"namespace"], resource.attributes["function_version_id"]`)
 	taskIdx := indexOfContaining(stmts, `"namespace"], resource.attributes["task_id"]`)
 	require.GreaterOrEqual(t, fvIdx, 0, "function_version_id namespace statement missing")
@@ -287,6 +292,12 @@ func assertICMSLane(t *testing.T, config string) {
 	statusIdx := indexOfContaining(liftStmts, `"nvcf.nvidia.io/status"`)
 	if assert.GreaterOrEqual(t, statusIdx, 0, "status lift statement missing") {
 		assert.Contains(t, liftStmts[statusIdx], `set(log.attributes["icms_status"]`)
+	}
+	// resource_id keys the ICMS (resource) lane in the ledger context; it must be
+	// set from the icms-request-id annotation.
+	resourceIdx := indexOfContaining(liftStmts, `set(log.attributes["resource_id"]`)
+	if assert.GreaterOrEqual(t, resourceIdx, 0, "resource_id lift statement missing") {
+		assert.Contains(t, liftStmts[resourceIdx], `"nvcf.nvidia.io/icms-request-id"`)
 	}
 
 	synthProc, ok := processors["transform/synth-icms-event-name"].(map[string]any)


### PR DESCRIPTION
## What

Producer-side changes in the NVCA OTel collector to propagate the ICMS request id into the event ledger, so consumers can correlate an `ICMSRequest` with its Pods. This is the NVCA counterpart to the ledger changes in #1117 (`resource_id` context field) and #1119 (generic `attribute_key`/`attribute_value` filter on `GET /events`).

## Changes

`pkg/operator/reconcile/manifests/otel_collector_config.yaml`:

- **ICMS lane** (`logs/icms-events`): set `resource_id` from the `nvcf.nvidia.io/icms-request-id` annotation. This becomes the generic `resource_id` context field in the ledger, so ICMSRequest events are uniquely keyed and directly queryable by request id.
- **Pod lane** (`logs`): extract the `icms-request-id` Pod label (`k8sattributes`) and lift it into event details as `icms_request_id`. It is carried in `details.attributes` (not a context key), so Pod context strings are unchanged.

`pkg/operator/reconcile/otel_reconcile_test.go`:
- Assert the Pod lane maps `icms-request-id -> icms_request_id` and lifts it into event attributes.
- Assert the ICMS lane sets `resource_id` from the `icms-request-id` annotation.

## Why

With the ledger side ready, these were the missing producer stamps. Without them, `resource_id`/`icms_request_id` correlation queries return empty. Together they enable:

- ICMS lane: `GET /events?...&resource_id=<icms-id>` -> the ICMSRequest's lifecycle/failure events.
- Pod lane: `GET /events?...&instance_id=<pod>&attribute_key=icms_request_id&attribute_value=<icms-id>` -> the Pods belonging to that ICMS request.

The client stitches the two lanes by `icms_request_id`. No ICMS-specific concepts are baked into the ledger; `resource_id` stays generic and optional (omitted for Pods, so Pod context keys are byte-for-byte unchanged).

## Testing

- `go build ./pkg/operator/reconcile/...` and `go vet` clean.
- `go test -run TestGetOTelCollectorConfigData` passes (exercises the Pod/ICMS lane assertions).

## Related

- Depends on #1117 and #1119 (ledger side).
- Part of #809 (NVCA OTel Collector Extension for Event Ledger).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - OpenTelemetry data now includes the request ID from Pod annotations as a resource attribute.
  - Pod events propagate the request ID into event attributes.
  - ICMS request events now include a corresponding resource identifier, improving observability and request correlation.

- **Tests**
  - Added coverage confirming request IDs and resource identifiers are correctly captured in telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->