### PR TITLE
chore(nvca): remove dead /v1/bart definitions from mock ICMS service

### DIFF
--- a/src/compute-plane-services/nvca/internal/mock/icmsservice/icmsservice.go
+++ b/src/compute-plane-services/nvca/internal/mock/icmsservice/icmsservice.go
@@ -45,7 +45,6 @@ import (
 
 const (
 	clusterIsNotRegisteredMsg = "cluster is not registered: "
-	verPrefixV1Bart           = "/v1/bart"
 	verPrefixV1NVCA           = "/v1/nvca"
 )
 
@@ -80,7 +79,6 @@ func newService(ctx context.Context, addr, queueEndpoint string, priv *rsa.Priva
 		ServiceState: ServiceState{
 			BartClusters:        map[string]ClusterInfo{},
 			QueueMetadata:       map[string]ICMSCredentialResponse{},
-			QueueMetadataV1Bart: map[string]ICMSCredentialResponseV1Bart{},
 			ICMSRequestStatuses: map[string]types.ICMSAcknowledgeRequest{},
 			InstanceStatuses:    map[string]map[string]types.ICMSInstanceStatusUpdateRequest{},
 		},
@@ -171,24 +169,8 @@ type ServiceState struct {
 	BartClusters map[string]ClusterInfo `json:"bart_clusters"`
 	// Map of OAuth client ID to a registered cluster's queues.
 	QueueMetadata       map[string]ICMSCredentialResponse                           `json:"queue_metadata"`
-	QueueMetadataV1Bart map[string]ICMSCredentialResponseV1Bart                     `json:"queue_metadata_v1_bart"`
 	ICMSRequestStatuses map[string]types.ICMSAcknowledgeRequest                     `json:"icms_request_status"`
 	InstanceStatuses    map[string]map[string]types.ICMSInstanceStatusUpdateRequest `json:"instance_status"`
-}
-
-type ICMSRegistrationResponseV1 struct {
-	ClusterID      string                 `json:"clusterId,omitempty"`
-	ClusterGroupID string                 `json:"clusterGroupId,omitempty"`
-	Credentials    QueueCredentialsV1Bart `json:"credentials,omitempty"`
-}
-
-type ICMSCredentialResponseV1Bart struct {
-	Credentials QueueCredentialsV1Bart `json:"credentials,omitempty"`
-}
-
-type QueueCredentialsV1Bart struct {
-	CreationQueue    queue.MessageQueueInfo `json:"creationQueue,omitempty"`
-	TerminationQueue queue.MessageQueueInfo `json:"terminationQueue,omitempty"`
 }
 
 type ICMSRegistrationResponse struct {


### PR DESCRIPTION
## TL;DR

Removes the unused `/v1/bart` path constant and the response types reachable
only from it from the NVCA mock ICMS service. The agent registers clusters and
fetches queue credentials through `/v1/nvca`, so this is dead code and there is
no behavior change.

## Additional Details

- `verPrefixV1Bart = "/v1/bart"` was declared but never referenced by any route
  or handler.
- `ServiceState.QueueMetadataV1Bart` was initialized in `newService` but never
  read or written.
- `ICMSRegistrationResponseV1`, `ICMSCredentialResponseV1Bart`, and
  `QueueCredentialsV1Bart` had no remaining users.

Removing these clarifies which ICMS API version the agent targets and allows the
`/v1/bart` endpoints to be retired on the ICMS server side.

Out of scope: the `BartClusters` field and other historical `bart` naming in the
same file refer to the legacy service name rather than the `/v1/bart` API path,
and are left unchanged.

## For the Reviewer

Single file, deletions only. Two things worth a second look:

- `ServiceState` is JSON-serialized, so removing `QueueMetadataV1Bart` drops the
  `queue_metadata_v1_bart` key from its output. I found no consumer of that key
  anywhere in the repo, but a reviewer closer to the BDD fixtures may know of an
  external one.
- Confirming the three removed types are genuinely unreferenced: a repo-wide
  search across all Go files returns no matches for any of them.

## For QA

No QA needed. Dead code removal in a test-only mock service with no runtime
behavior change.

Verified locally:

- `bazel test //src/compute-plane-services/nvca/...`: 67 of 71 targets pass.
  The 4 failures (`internal/miniservice`, `pkg/nvca`, `pkg/operator/reconcile`,
  `pkg/storage`) reproduce identically on unmodified `main` with this change
  stashed, so they are pre-existing and not caused by this PR. They look
  macOS-local: `pkg/operator/reconcile` fails patching `os.Exit` with
  "permission denied", and `pkg/nvca` fails a metrics benchmark drift check on
  metrics not emitted on darwin.
- `go build ./...` and `go vet ./...` clean in
  `src/compute-plane-services/nvca`
- `rg --type go 'ICMSRegistrationResponseV1\b|ICMSCredentialResponseV1Bart|QueueCredentialsV1Bart|QueueMetadataV1Bart|verPrefixV1Bart'` returns no matches repo-wide
- no remaining `/v1/bart` under `src/compute-plane-services/nvca/`
- no consumer of the `queue_metadata_v1_bart` JSON key

## Issues

Closes #1510

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes. No new tests: this removes
      unreferenced declarations only, with no reachable behavior to cover.
      Existing NVCA tests continue to pass.
- [x] The documentation is up to date with these changes. No user-facing
      behavior or documented interface changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * Removed support for the legacy `/v1/bart` route and its associated queue metadata and credential response structures from the mock service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->