### PR TITLE
fix(bdd): finish stack cleanup of worker namespaces and artifacts

### DIFF
--- a/tests/bdd/AGENTS.md
+++ b/tests/bdd/AGENTS.md
@@ -145,6 +145,14 @@ logic into `dsl/`.
   Do not introduce blanket `helm list`-based uninstall or namespace
   deletion that catches topology infrastructure (`eg` in
   `envoy-gateway-system`, the namespace itself, `cert-manager`).
+  Multi-cluster stack cleanup must also apply the worker release and
+  namespace allow-lists on `k3d-ncp-local-cp`: feature Backgrounds
+  create `nvca-operator` (and its pull secret) on the control-plane
+  context, not only on compute clusters. Artifact cleanup must remove
+  Helmfile render trees under each stack `out/` directory and
+  generated values under
+  `deploy/stacks/nvcf-compute-plane/registration/`, not only
+  root-level `out/*.yaml`.
 
 ## CLI vs Helmfile install paths
 

--- a/tests/bdd/PLAN_DESTRUCTIVE_CLEANUP.md
+++ b/tests/bdd/PLAN_DESTRUCTIVE_CLEANUP.md
@@ -24,11 +24,15 @@ Concretely:
     `envoy-gateway-system` and `cert-manager`.
   - Any CRD.
 
-A failure during cleanup aborts the suite. Only NotFound is
-swallowed via `--ignore-not-found`. Timeouts, permission errors,
-and finalizer stalls propagate. An unreachable single-cluster
-kube context is excluded: `destroy-stack.sh single` skips
-cluster-resource cleanup and still runs `clean_stack_out`.
+A failure during cleanup aborts the suite. Only documented
+NotFound is swallowed via `--ignore-not-found` or an explicit
+NotFound check. A truly unreachable single-cluster kube context
+(missing context or connection refused) is also excluded:
+`destroy-stack.sh single` skips cluster-resource cleanup and
+still runs `clean_stack_out`. Permission errors, timeouts, API
+failures, missing binaries, and finalizer-patch failures
+propagate so cleanup cannot report success with resources left
+behind.
 
 ## Goals
 
@@ -214,7 +218,8 @@ with explicit kube-context flags; it belongs in the dev wrapper.
 
 ```make
 destroy-stack-single: ## Uninstall NVCF stack from one cluster; leaves k3d running
-	@CTX="k3d-$(CLUSTER_NAME)"; \
+	@set -euo pipefail; \
+	CTX="k3d-$(CLUSTER_NAME)"; \
 	if ! kubectl --context "$$CTX" cluster-info >/dev/null 2>&1; then \
 		echo "Context $$CTX unreachable; skipping cluster resources."; \
 	else \
@@ -225,8 +230,14 @@ destroy-stack-single: ## Uninstall NVCF stack from one cluster; leaves k3d runni
 	$(MAKE) _clean-stack-out
 ```
 
+`set -euo pipefail` is required so a failed nested `$(MAKE)` helper
+aborts before `_clean-stack-out` and cannot return 0. The live
+implementation is `tests/bdd/scripts/destroy-stack.sh`, which also
+classifies `cluster-info` and `kubectl get` errors: only a missing
+context or connection refused is unreachable. Other failures abort.
+
 When the single-cluster context (`k3d-$(CLUSTER_NAME)`) is
-unreachable, cluster-resource cleanup is skipped and
+truly unreachable, cluster-resource cleanup is skipped and
 `clean_stack_out` still runs. That unreachable context does not
 abort the suite.
 
@@ -239,11 +250,11 @@ use-context` anywhere; every command carries `--context` /
 
 ```make
 destroy-stack-multi: ## Uninstall NVCF stack from CP plus every discovered compute cluster
-	@command -v jq >/dev/null 2>&1 || { \
+	@set -euo pipefail; \
+	command -v jq >/dev/null 2>&1 || { \
 		echo "destroy-stack-multi requires jq; install it and retry." >&2; \
 		exit 1; \
-	}
-	@set -o pipefail; \
+	}; \
 	COMPUTES=$$(k3d cluster list -o json | jq -r '.[] | select(.name|startswith("ncp-local-compute-")) | .name'); \
 	for name in $$COMPUTES; do \
 		CTX="k3d-$$name"; \
@@ -258,17 +269,25 @@ destroy-stack-multi: ## Uninstall NVCF stack from CP plus every discovered compu
 	done; \
 	if k3d cluster get ncp-local-cp >/dev/null 2>&1; then \
 		echo ">>> Cleaning control-plane cluster k3d-ncp-local-cp"; \
-		$(MAKE) _delete-stack-crs CTX="k3d-ncp-local-cp" CR_LIST="$(STACK_CRS_WORKER)" NS_LIST="nvca-operator"; \
-		$(MAKE) _uninstall-stack-releases CTX="k3d-ncp-local-cp" RELEASE_LIST="$(STACK_RELEASES_WORKER) $(STACK_RELEASES_CP)"; \
-		$(MAKE) _delete-stack-namespaces CTX="k3d-ncp-local-cp" NS_LIST="$(STACK_NAMESPACES_WORKER) $(STACK_NAMESPACES_CP)"; \
-	fi
-	@$(MAKE) _clean-stack-out
+		if kubectl --context k3d-ncp-local-cp cluster-info >/dev/null 2>&1; then \
+			$(MAKE) _delete-stack-crs CTX="k3d-ncp-local-cp" CR_LIST="$(STACK_CRS_WORKER)" NS_LIST="nvca-operator"; \
+			$(MAKE) _uninstall-stack-releases CTX="k3d-ncp-local-cp" RELEASE_LIST="$(STACK_RELEASES_WORKER) $(STACK_RELEASES_CP)"; \
+			$(MAKE) _delete-stack-namespaces CTX="k3d-ncp-local-cp" NS_LIST="$(STACK_NAMESPACES_WORKER) $(STACK_NAMESPACES_CP)"; \
+		else \
+			echo "Context k3d-ncp-local-cp unreachable; skipping."; \
+		fi; \
+	fi; \
+	$(MAKE) _clean-stack-out
 ```
 
 The live implementation is `tests/bdd/scripts/destroy-stack.sh`, not these
-Make recipes. Multi-cluster control-plane cleanup must apply the worker
-allow-lists: feature Backgrounds create `nvca-operator` (and its pull
-secret) on `k3d-ncp-local-cp`, not only on compute clusters.
+Make recipes. `k3d cluster get ncp-local-cp` only proves the cluster
+exists; helm and kubectl cleanup still require a succeeding
+`kubectl --context k3d-ncp-local-cp cluster-info` first. Multi-cluster
+control-plane cleanup must apply the worker allow-lists: feature
+Backgrounds create `nvca-operator` (and its pull secret) on
+`k3d-ncp-local-cp`, not only on compute clusters. `set -euo pipefail`
+keeps `_clean-stack-out` from masking a failed helper.
 
 #### New internal helpers
 

--- a/tests/bdd/PLAN_DESTRUCTIVE_CLEANUP.md
+++ b/tests/bdd/PLAN_DESTRUCTIVE_CLEANUP.md
@@ -25,8 +25,10 @@ Concretely:
   - Any CRD.
 
 A failure during cleanup aborts the suite. Only NotFound is
-swallowed via `--ignore-not-found`; timeouts, permission errors,
-finalizer stalls, and unreachable kube contexts propagate.
+swallowed via `--ignore-not-found`. Timeouts, permission errors,
+and finalizer stalls propagate. An unreachable single-cluster
+kube context is excluded: `destroy-stack.sh single` skips
+cluster-resource cleanup and still runs `clean_stack_out`.
 
 ## Goals
 
@@ -214,14 +216,19 @@ with explicit kube-context flags; it belongs in the dev wrapper.
 destroy-stack-single: ## Uninstall NVCF stack from one cluster; leaves k3d running
 	@CTX="k3d-$(CLUSTER_NAME)"; \
 	if ! kubectl --context "$$CTX" cluster-info >/dev/null 2>&1; then \
-		echo "Context $$CTX unreachable; nothing to clean."; \
-		exit 0; \
+		echo "Context $$CTX unreachable; skipping cluster resources."; \
+	else \
+		$(MAKE) _delete-stack-crs    CTX="$$CTX" CR_LIST="$(STACK_CRS_WORKER)" NS_LIST="nvca-operator"; \
+		$(MAKE) _uninstall-stack-releases CTX="$$CTX" RELEASE_LIST="$(STACK_RELEASES_WORKER) $(STACK_RELEASES_CP)"; \
+		$(MAKE) _delete-stack-namespaces CTX="$$CTX" NS_LIST="$(STACK_NAMESPACES_WORKER) $(STACK_NAMESPACES_CP)"; \
 	fi; \
-	$(MAKE) _delete-stack-crs    CTX="$$CTX" CR_LIST="$(STACK_CRS_WORKER)" NS_LIST="nvca-operator"; \
-	$(MAKE) _uninstall-stack-releases CTX="$$CTX" RELEASE_LIST="$(STACK_RELEASES_WORKER) $(STACK_RELEASES_CP)"; \
-	$(MAKE) _delete-stack-namespaces CTX="$$CTX" NS_LIST="$(STACK_NAMESPACES_WORKER) $(STACK_NAMESPACES_CP)"; \
 	$(MAKE) _clean-stack-out
 ```
+
+When the single-cluster context (`k3d-$(CLUSTER_NAME)`) is
+unreachable, cluster-resource cleanup is skipped and
+`clean_stack_out` still runs. That unreachable context does not
+abort the suite.
 
 #### New target: destroy-stack-multi
 

--- a/tests/bdd/PLAN_DESTRUCTIVE_CLEANUP.md
+++ b/tests/bdd/PLAN_DESTRUCTIVE_CLEANUP.md
@@ -251,11 +251,17 @@ destroy-stack-multi: ## Uninstall NVCF stack from CP plus every discovered compu
 	done; \
 	if k3d cluster get ncp-local-cp >/dev/null 2>&1; then \
 		echo ">>> Cleaning control-plane cluster k3d-ncp-local-cp"; \
-		$(MAKE) _uninstall-stack-releases CTX="k3d-ncp-local-cp" RELEASE_LIST="$(STACK_RELEASES_CP)"; \
-		$(MAKE) _delete-stack-namespaces CTX="k3d-ncp-local-cp" NS_LIST="$(STACK_NAMESPACES_CP)"; \
+		$(MAKE) _delete-stack-crs CTX="k3d-ncp-local-cp" CR_LIST="$(STACK_CRS_WORKER)" NS_LIST="nvca-operator"; \
+		$(MAKE) _uninstall-stack-releases CTX="k3d-ncp-local-cp" RELEASE_LIST="$(STACK_RELEASES_WORKER) $(STACK_RELEASES_CP)"; \
+		$(MAKE) _delete-stack-namespaces CTX="k3d-ncp-local-cp" NS_LIST="$(STACK_NAMESPACES_WORKER) $(STACK_NAMESPACES_CP)"; \
 	fi
 	@$(MAKE) _clean-stack-out
 ```
+
+The live implementation is `tests/bdd/scripts/destroy-stack.sh`, not these
+Make recipes. Multi-cluster control-plane cleanup must apply the worker
+allow-lists: feature Backgrounds create `nvca-operator` (and its pull
+secret) on `k3d-ncp-local-cp`, not only on compute clusters.
 
 #### New internal helpers
 
@@ -321,16 +327,21 @@ _delete-stack-namespaces:
 
 ##### _clean-stack-out
 
-Runs from `deploy/stacks/self-managed/`, so the path is `out/*.yaml`.
+The script equivalent lives in `clean_stack_out` in
+`tests/bdd/scripts/destroy-stack.sh`. It removes:
 
-```make
-_clean-stack-out:
-	@echo "  clean out/"
-	@rm -f out/*.yaml
-```
+- Root-level `*.yaml` under `deploy/stacks/self-managed/out/` and
+  `deploy/stacks/nvcf-compute-plane/out/` (CLI handoff files such as
+  `control-plane-profile.yaml`).
+- Helmfile `--output-dir` render trees (subdirectories under those
+  `out/` directories). This is the explicit-path equivalent of each
+  stack's `make clean`.
+- Generated compute registration values
+  `deploy/stacks/nvcf-compute-plane/registration/*.yaml`. The
+  compute-plane `make clean` target does not remove this directory.
 
-Only `*.yaml` so developer ad-hoc text notes in the same directory
-survive.
+Ad-hoc non-yaml notes at the `out/` root survive. Do not `rm -rf` the
+`out/` directory itself, and do not delete `testdata/registration/`.
 
 ### tests/bdd/harness/cleanup.go (new file)
 

--- a/tests/bdd/README.md
+++ b/tests/bdd/README.md
@@ -206,8 +206,8 @@ the suite immediately.
 | Mode | What it destroys | Command equivalent |
 |------|------------------|--------------------|
 | unset (default) | Nothing | (no cleanup) |
-| `stack-single` | Stack-owned helm releases + namespaces on `k3d-ncp-local`; `out/*.yaml` artifacts | `tests/bdd/scripts/destroy-stack.sh single` |
-| `stack-multi` | Stack-owned releases on every `ncp-local-compute-*` then `ncp-local-cp`; `out/*.yaml` artifacts | `tests/bdd/scripts/destroy-stack.sh multi` |
+| `stack-single` | Stack-owned helm releases + namespaces on `k3d-ncp-local`; stack `out/` handoff yaml, Helmfile render trees, and compute registration values | `tests/bdd/scripts/destroy-stack.sh single` |
+| `stack-multi` | Stack-owned releases and namespaces on every `ncp-local-compute-*` then `ncp-local-cp` (including worker namespaces such as `nvca-operator` created on the control-plane cluster); same generated artifacts | `tests/bdd/scripts/destroy-stack.sh multi` |
 | `topology-single` | The `ncp-local` k3d cluster (and everything in it) | `make -C tools/ncp-local-cluster destroy CLUSTER_NAME=ncp-local` |
 | `topology-multi` | Every `ncp-local*` k3d cluster on the host | `make -C tools/ncp-local-cluster destroy-all-ncp-local` |
 
@@ -246,9 +246,13 @@ Governing rule:
   `envoy-gateway-system` installed by
   `tools/ncp-local-cluster/scripts/setup-gateway-api.sh`,
   `cert-manager`, the local fake GPU operator) are intentionally
-  off-limits and survive every stack cleanup. `out/*.yaml` handoff
-  files are removed so later `file ... should exist` assertions
-  cannot pass against stale artifacts.
+  off-limits and survive every stack cleanup. Generated stack
+  artifacts are removed so later `file ... should exist` assertions
+  cannot pass against stale files: root-level `out/*.yaml` handoff
+  files, Helmfile `--output-dir` render trees under each stack
+  `out/` directory, and compute registration values under
+  `deploy/stacks/nvcf-compute-plane/registration/`. Ad-hoc non-yaml
+  notes at the `out/` root are left in place.
 - For the nonlocal (EKS) cleanup script
   `tests/bdd/scripts/destroy-nonlocal-stack.sh`, the gateway
   ownership boundary is different: the EKS Helmfile feature

--- a/tests/bdd/cleanup_scripts_test.go
+++ b/tests/bdd/cleanup_scripts_test.go
@@ -144,6 +144,7 @@ func TestDestroyStackMultiCleansWorkerNamespacesOnControlPlane(t *testing.T) {
 		"kubectl --context k3d-ncp-local-cp delete namespace nvca-operator",
 		"kubectl --context k3d-ncp-local-cp delete namespace nvca-system",
 		"kubectl --context k3d-ncp-local-cp delete namespace nvcf-backend",
+		"kubectl --context k3d-ncp-local-cp -n nvca-operator delete nvcfbackend --all",
 		"helm --kube-context k3d-ncp-local-compute-1 uninstall nvca-operator -n nvca-operator",
 		"helm --kube-context k3d-ncp-local-cp uninstall nats -n nats-system",
 	} {
@@ -258,7 +259,12 @@ set -euo pipefail
 printf 'kubectl %s\n' "$*" >>"$FAKE_COMMAND_LOG"
 case "$*" in
   *"cluster-info"*) exit 0 ;;
+  *"get namespace nvca-operator"*) exit 0 ;;
   *"get namespace"*) exit 1 ;;
+  *"-n nvca-operator get nvcfbackend -o name"*)
+    printf 'nvcfbackend/ncp-local-cp\n'
+    ;;
+  *"-n nvca-operator get nvcfbackend"*) exit 0 ;;
   *"get nvcfbackend"*) exit 1 ;;
 esac
 `)

--- a/tests/bdd/cleanup_scripts_test.go
+++ b/tests/bdd/cleanup_scripts_test.go
@@ -145,6 +145,7 @@ func TestDestroyStackMultiCleansWorkerNamespacesOnControlPlane(t *testing.T) {
 		"kubectl --context k3d-ncp-local-cp delete namespace nvca-system",
 		"kubectl --context k3d-ncp-local-cp delete namespace nvcf-backend",
 		"kubectl --context k3d-ncp-local-cp -n nvca-operator delete nvcfbackend --all",
+		"kubectl --context k3d-ncp-local-compute-1 -n nvca-operator delete nvcfbackend --all",
 		"helm --kube-context k3d-ncp-local-compute-1 uninstall nvca-operator -n nvca-operator",
 		"helm --kube-context k3d-ncp-local-cp uninstall nats -n nats-system",
 	} {
@@ -196,6 +197,7 @@ func TestDestroyStackCleanOutRemovesHelmfileTreesAndRegistration(t *testing.T) {
 	binDir := t.TempDir()
 	writeFakeBin(t, binDir, "kubectl", `#!/usr/bin/env bash
 set -euo pipefail
+echo "The connection to the server 127.0.0.1:6443 was refused - did you specify the right host or port?" >&2
 exit 1
 `)
 	writeFakeBin(t, binDir, "helm", `#!/usr/bin/env bash
@@ -234,6 +236,63 @@ exit 0
 	if got := string(body); got != "keep me\n" {
 		t.Fatalf("ad-hoc out/ note contents = %q", got)
 	}
+}
+
+func TestDestroyStackPropagatesClusterInfoAPIFailure(t *testing.T) {
+	output := runDestroyStackSingleExpectFailure(t,
+		`#!/usr/bin/env bash
+set -euo pipefail
+echo "Error from server (Forbidden): nodes is forbidden" >&2
+exit 1
+`,
+		`#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+`)
+	if !strings.Contains(output, "Forbidden") && !strings.Contains(output, "cluster-info failed") {
+		t.Fatalf("expected cluster-info API failure to propagate, got:\n%s", output)
+	}
+}
+
+func TestDestroyStackPropagatesHelmUninstallFailure(t *testing.T) {
+	output := runDestroyStackSingleExpectFailure(t,
+		`#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  *"cluster-info"*) exit 0 ;;
+  *"get namespace"*)
+    echo 'Error from server (NotFound): namespaces "nvca-operator" not found' >&2
+    exit 1
+    ;;
+esac
+`,
+		`#!/usr/bin/env bash
+set -euo pipefail
+echo "helm uninstall failed: timeout" >&2
+exit 1
+`)
+	if !strings.Contains(output, "helm uninstall failed") && !strings.Contains(strings.ToLower(output), "exit") {
+		t.Fatalf("expected helm uninstall failure to abort cleanup, got:\n%s", output)
+	}
+}
+
+func runDestroyStackSingleExpectFailure(t *testing.T, kubectlBody, helmBody string) string {
+	t.Helper()
+
+	binDir := t.TempDir()
+	writeFakeBin(t, binDir, "kubectl", kubectlBody)
+	writeFakeBin(t, binDir, "helm", helmBody)
+
+	cmd := exec.Command("bash", "scripts/destroy-stack.sh", "single")
+	cmd.Env = append(os.Environ(),
+		"BDD_REPO_ROOT="+t.TempDir(),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+	)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected destroy-stack.sh single to fail, got success:\n%s", output)
+	}
+	return string(output)
 }
 
 func runDestroyStackMulti(t *testing.T) string {

--- a/tests/bdd/cleanup_scripts_test.go
+++ b/tests/bdd/cleanup_scripts_test.go
@@ -135,3 +135,158 @@ cat
 	}
 	return string(log)
 }
+
+func TestDestroyStackMultiCleansWorkerNamespacesOnControlPlane(t *testing.T) {
+	log := runDestroyStackMulti(t)
+
+	for _, want := range []string{
+		"helm --kube-context k3d-ncp-local-cp uninstall nvca-operator -n nvca-operator",
+		"kubectl --context k3d-ncp-local-cp delete namespace nvca-operator",
+		"kubectl --context k3d-ncp-local-cp delete namespace nvca-system",
+		"kubectl --context k3d-ncp-local-cp delete namespace nvcf-backend",
+		"helm --kube-context k3d-ncp-local-compute-1 uninstall nvca-operator -n nvca-operator",
+		"helm --kube-context k3d-ncp-local-cp uninstall nats -n nats-system",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("cleanup command log missing %q:\n%s", want, log)
+		}
+	}
+
+	for _, forbidden := range []string{
+		"delete namespace envoy-gateway-system",
+		"delete namespace cert-manager",
+		"uninstall eg ",
+		"uninstall cert-manager",
+	} {
+		if strings.Contains(log, forbidden) {
+			t.Fatalf("cleanup touched topology infrastructure %q:\n%s", forbidden, log)
+		}
+	}
+}
+
+func TestDestroyStackCleanOutRemovesHelmfileTreesAndRegistration(t *testing.T) {
+	repo := t.TempDir()
+	selfOut := filepath.Join(repo, "deploy/stacks/self-managed/out")
+	computeOut := filepath.Join(repo, "deploy/stacks/nvcf-compute-plane/out")
+	registration := filepath.Join(repo, "deploy/stacks/nvcf-compute-plane/registration")
+	helmfileTree := filepath.Join(selfOut, "helmfile.yaml-abc123-nats")
+	computeTree := filepath.Join(computeOut, "helmfile.yaml-def456-nvca-operator")
+
+	for _, dir := range []string{helmfileTree, computeTree, registration} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	files := map[string]string{
+		filepath.Join(selfOut, "control-plane-profile.yaml"):                    "profile: leftover\n",
+		filepath.Join(selfOut, "notes.txt"):                                     "keep me\n",
+		filepath.Join(helmfileTree, "nats.yaml"):                                "kind: ConfigMap\n",
+		filepath.Join(computeOut, "ncp-local-register-values.yaml"):             "clusterName: leftover\n",
+		filepath.Join(computeTree, "nvca-operator.yaml"):                        "kind: Deployment\n",
+		filepath.Join(registration, "ncp-local-register-values.yaml"):           "clusterName: leftover\n",
+		filepath.Join(registration, "ncp-local-compute-1-register-values.yaml"): "clusterName: leftover-compute\n",
+	}
+	for path, body := range files {
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	binDir := t.TempDir()
+	writeFakeBin(t, binDir, "kubectl", `#!/usr/bin/env bash
+set -euo pipefail
+exit 1
+`)
+	writeFakeBin(t, binDir, "helm", `#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+`)
+
+	cmd := exec.Command("bash", "scripts/destroy-stack.sh", "single")
+	cmd.Env = append(os.Environ(),
+		"BDD_REPO_ROOT="+repo,
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run destroy-stack.sh single: %v\n%s", err, output)
+	}
+
+	gone := []string{
+		filepath.Join(selfOut, "control-plane-profile.yaml"),
+		helmfileTree,
+		filepath.Join(computeOut, "ncp-local-register-values.yaml"),
+		computeTree,
+		filepath.Join(registration, "ncp-local-register-values.yaml"),
+		filepath.Join(registration, "ncp-local-compute-1-register-values.yaml"),
+	}
+	for _, path := range gone {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("generated artifact still present: %s (err=%v)", path, err)
+		}
+	}
+
+	kept := filepath.Join(selfOut, "notes.txt")
+	body, err := os.ReadFile(kept)
+	if err != nil {
+		t.Fatalf("ad-hoc out/ note was removed: %v", err)
+	}
+	if got := string(body); got != "keep me\n" {
+		t.Fatalf("ad-hoc out/ note contents = %q", got)
+	}
+}
+
+func runDestroyStackMulti(t *testing.T) string {
+	t.Helper()
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "commands.log")
+
+	writeFakeBin(t, binDir, "k3d", `#!/usr/bin/env bash
+set -euo pipefail
+printf 'k3d %s\n' "$*" >>"$FAKE_COMMAND_LOG"
+case "$*" in
+  "cluster list -o json")
+    printf '[{"name":"ncp-local-compute-1"},{"name":"ncp-local-cp"}]\n'
+    ;;
+  "cluster get ncp-local-cp")
+    exit 0
+    ;;
+esac
+`)
+	writeFakeBin(t, binDir, "kubectl", `#!/usr/bin/env bash
+set -euo pipefail
+printf 'kubectl %s\n' "$*" >>"$FAKE_COMMAND_LOG"
+case "$*" in
+  *"cluster-info"*) exit 0 ;;
+  *"get namespace"*) exit 1 ;;
+  *"get nvcfbackend"*) exit 1 ;;
+esac
+`)
+	writeFakeBin(t, binDir, "helm", `#!/usr/bin/env bash
+set -euo pipefail
+printf 'helm %s\n' "$*" >>"$FAKE_COMMAND_LOG"
+`)
+
+	cmd := exec.Command("bash", "scripts/destroy-stack.sh", "multi")
+	cmd.Env = append(os.Environ(),
+		"BDD_REPO_ROOT="+t.TempDir(),
+		"FAKE_COMMAND_LOG="+logPath,
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run destroy-stack.sh multi: %v\n%s", err, output)
+	}
+
+	log, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read cleanup command log: %v", err)
+	}
+	return string(log)
+}
+
+func writeFakeBin(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake %s: %v", name, err)
+	}
+}

--- a/tests/bdd/scripts/destroy-stack.sh
+++ b/tests/bdd/scripts/destroy-stack.sh
@@ -24,8 +24,10 @@
 #
 # Every kubectl and helm call carries an explicit --context /
 # --kube-context flag; no global `kubectl config use-context`
-# switching. Errors other than NotFound propagate (the recipes use
-# --ignore-not-found for that single case).
+# switching. Only documented NotFound and a truly unreachable kube
+# context (missing context or connection refused) are skipped.
+# Permission errors, timeouts, API failures, missing binaries, and
+# finalizer-patch failures abort cleanup.
 #
 # Usage:
 #   tests/bdd/scripts/destroy-stack.sh single [CLUSTER_NAME=ncp-local]
@@ -55,9 +57,19 @@ case "$mode" in
 esac
 
 # Both modes need jq: the force-clear path in delete_stack_namespaces
-# builds the /finalize subresource patch with jq.
+# builds the /finalize subresource patch with jq. kubectl and helm
+# must also be present; a missing binary is not an unreachable
+# cluster and must not be treated as a successful no-op.
 command -v jq >/dev/null 2>&1 || {
   echo "destroy-stack.sh requires jq; install it and retry." >&2
+  exit 1
+}
+command -v kubectl >/dev/null 2>&1 || {
+  echo "destroy-stack.sh requires kubectl; install it and retry." >&2
+  exit 1
+}
+command -v helm >/dev/null 2>&1 || {
+  echo "destroy-stack.sh requires helm; install it and retry." >&2
   exit 1
 }
 
@@ -138,24 +150,126 @@ STACK_CRS_WORKER=(
 
 # --- Helpers ---
 
+# Capture kubectl stdout+stderr in _kubectl_out and return kubectl's
+# exit code. Used so callers can classify NotFound / unreachable
+# without treating every non-zero as a skip.
+kubectl_capture() {
+  local rc
+  set +e
+  _kubectl_out=$(kubectl "$@" 2>&1)
+  rc=$?
+  set -e
+  return "$rc"
+}
+
+# Missing context or connection refused. Timeouts, Forbidden,
+# Unauthorized, and missing binaries are not unreachable.
+kubectl_is_unreachable() {
+  local msg="$1"
+  case "$msg" in
+    *"does not exist"*|*"connection refused"*|*"was refused"*|*"no such host"*|*"no route to host"*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+kubectl_is_not_found() {
+  local msg="$1"
+  case "$msg" in
+    *"(NotFound)"*|*" not found"*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+kubectl_is_missing_type() {
+  local msg="$1"
+  case "$msg" in
+    *"doesn't have a resource type"*|*"could not find the requested resource"*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+# Return 0 if the API answers, 1 if the context or cluster is absent.
+# Any other cluster-info failure prints the error and aborts.
+cluster_is_reachable() {
+  local ctx="$1"
+  if kubectl_capture --context "$ctx" cluster-info; then
+    return 0
+  fi
+  if kubectl_is_unreachable "$_kubectl_out"; then
+    return 1
+  fi
+  printf '%s\n' "$_kubectl_out" >&2
+  echo "cluster-info failed for $ctx" >&2
+  exit 1
+}
+
+namespace_exists() {
+  local ctx="$1"
+  local ns="$2"
+  if kubectl_capture --context "$ctx" get namespace "$ns"; then
+    return 0
+  fi
+  if kubectl_is_not_found "$_kubectl_out"; then
+    return 1
+  fi
+  printf '%s\n' "$_kubectl_out" >&2
+  echo "get namespace $ns failed on $ctx" >&2
+  exit 1
+}
+
+cr_available() {
+  local ctx="$1"
+  local ns="$2"
+  local cr="$3"
+  if kubectl_capture --context "$ctx" -n "$ns" get "$cr"; then
+    return 0
+  fi
+  if kubectl_is_missing_type "$_kubectl_out" || kubectl_is_not_found "$_kubectl_out"; then
+    return 1
+  fi
+  printf '%s\n' "$_kubectl_out" >&2
+  echo "get $cr in $ns failed on $ctx" >&2
+  exit 1
+}
+
+patch_cr_finalizers() {
+  local ctx="$1"
+  local ns="$2"
+  local cr="$3"
+  local names obj
+  names=$(kubectl --context "$ctx" -n "$ns" get "$cr" -o name)
+  while IFS= read -r obj; do
+    [[ -z "$obj" ]] && continue
+    if kubectl_capture --context "$ctx" -n "$ns" patch "$obj" \
+        --type=merge -p '{"metadata":{"finalizers":[]}}'; then
+      continue
+    fi
+    if kubectl_is_not_found "$_kubectl_out"; then
+      continue
+    fi
+    printf '%s\n' "$_kubectl_out" >&2
+    echo "patch $obj in $ns failed on $ctx" >&2
+    return 1
+  done <<< "$names"
+}
+
 delete_stack_crs() {
   local ctx="$1"
   shift
   local namespaces=("$@")
   for ns in "${namespaces[@]}"; do
-    if ! kubectl --context "$ctx" get namespace "$ns" >/dev/null 2>&1; then
+    if ! namespace_exists "$ctx" "$ns"; then
       continue
     fi
     for cr in "${STACK_CRS_WORKER[@]}"; do
-      # If the CRD is absent (a prior topology destroy wiped it, or
-      # a partial install never registered it), there is nothing to
-      # clean. Skip the finalizer patch AND the delete call -- both
-      # `kubectl get <crd>` and `kubectl delete <crd> --ignore-not-
-      # found` exit non-zero on "resource type does not exist"
-      # (--ignore-not-found covers missing instances, not missing
-      # types), and `set -o pipefail` would otherwise abort the
-      # whole script.
-      if ! kubectl --context "$ctx" -n "$ns" get "$cr" >/dev/null 2>&1; then
+      # Missing CRD or NotFound is a skip. Other get failures abort.
+      if ! cr_available "$ctx" "$ns" "$cr"; then
         continue
       fi
       # Clear finalizers BEFORE delete: the nvca-operator controller
@@ -163,12 +277,10 @@ delete_stack_crs() {
       # own finalizers, which causes the CR delete and the
       # subsequent namespace delete to hang. The stack is being
       # destroyed, so finalizer-driven reconciliation is moot.
-      kubectl --context "$ctx" -n "$ns" get "$cr" -o name 2>/dev/null | \
-        while read -r obj; do
-          kubectl --context "$ctx" -n "$ns" patch "$obj" \
-            --type=merge -p '{"metadata":{"finalizers":[]}}' \
-            >/dev/null 2>&1 || true
-        done
+      # NotFound on an individual object is fine; other patch
+      # failures abort so cleanup cannot report success with CRs
+      # still blocked.
+      patch_cr_finalizers "$ctx" "$ns" "$cr"
       echo "  delete $cr in $ns"
       kubectl --context "$ctx" -n "$ns" delete "$cr" --all \
         --ignore-not-found --timeout=60s
@@ -181,13 +293,21 @@ delete_stack_crs() {
 # namespace's own spec.finalizers can hold it in Terminating. nvca-
 # operator and nvcf-backend are the typical offenders. This clears
 # those via the /finalize subresource so namespace teardown completes.
+# NotFound means the namespace already went away. Other failures abort.
 force_clear_namespace_finalizers() {
   local ctx="$1"
   local ns="$2"
-  kubectl --context "$ctx" get namespace "$ns" -o json 2>/dev/null | \
-    jq '.spec.finalizers = []' | \
-    kubectl --context "$ctx" replace --raw "/api/v1/namespaces/$ns/finalize" -f - \
-      >/dev/null 2>&1 || true
+  local json
+  if ! json=$(kubectl --context "$ctx" get namespace "$ns" -o json 2>&1); then
+    if kubectl_is_not_found "$json"; then
+      return 0
+    fi
+    printf '%s\n' "$json" >&2
+    echo "get namespace $ns -o json failed on $ctx" >&2
+    return 1
+  fi
+  printf '%s' "$json" | jq '.spec.finalizers = []' | \
+    kubectl --context "$ctx" replace --raw "/api/v1/namespaces/$ns/finalize" -f -
 }
 
 uninstall_stack_releases() {
@@ -214,7 +334,7 @@ delete_stack_namespaces() {
     # after the controller is gone), drop into the force-clear path
     # rather than hang the BDD cleanup.
     if ! kubectl --context "$ctx" delete namespace "$ns" \
-        --ignore-not-found --wait --timeout=60s 2>/dev/null; then
+        --ignore-not-found --wait --timeout=60s; then
       echo "  force-clear finalizers on $ns (stuck Terminating)"
       force_clear_namespace_finalizers "$ctx" "$ns"
     fi
@@ -258,9 +378,7 @@ clean_stack_out() {
 
 if [[ "$mode" == "single" ]]; then
   ctx="k3d-$CLUSTER_NAME"
-  if ! kubectl --context "$ctx" cluster-info >/dev/null 2>&1; then
-    echo "Context $ctx unreachable; skipping cluster resources."
-  else
+  if cluster_is_reachable "$ctx"; then
     delete_stack_crs "$ctx" "nvca-operator"
     uninstall_stack_releases "$ctx" \
       "${STACK_RELEASES_WORKER[@]}" \
@@ -268,6 +386,8 @@ if [[ "$mode" == "single" ]]; then
     delete_stack_namespaces "$ctx" \
       "${STACK_NAMESPACES_WORKER[@]}" \
       "${STACK_NAMESPACES_CP[@]}"
+  else
+    echo "Context $ctx unreachable; skipping cluster resources."
   fi
   clean_stack_out
   exit 0
@@ -289,19 +409,20 @@ for name in "${COMPUTES[@]:-}"; do
   [[ -z "$name" ]] && continue
   ctx="k3d-$name"
   echo ">>> Cleaning compute cluster $ctx"
-  if ! kubectl --context "$ctx" cluster-info >/dev/null 2>&1; then
+  if cluster_is_reachable "$ctx"; then
+    delete_stack_crs "$ctx" "nvca-operator"
+    uninstall_stack_releases "$ctx" "${STACK_RELEASES_WORKER[@]}"
+    delete_stack_namespaces "$ctx" "${STACK_NAMESPACES_WORKER[@]}"
+  else
     echo "Context $ctx unreachable; skipping."
     continue
   fi
-  delete_stack_crs "$ctx" "nvca-operator"
-  uninstall_stack_releases "$ctx" "${STACK_RELEASES_WORKER[@]}"
-  delete_stack_namespaces "$ctx" "${STACK_NAMESPACES_WORKER[@]}"
 done
 
 if k3d cluster get ncp-local-cp >/dev/null 2>&1; then
   echo ">>> Cleaning control-plane cluster k3d-ncp-local-cp"
   ctx="k3d-ncp-local-cp"
-  if kubectl --context "$ctx" cluster-info >/dev/null 2>&1; then
+  if cluster_is_reachable "$ctx"; then
     # Worker allow-lists apply on the CP cluster too: multi-cluster
     # Backgrounds create nvca-operator (namespace + pull secret, and
     # sometimes the helm release) on k3d-ncp-local-cp. Compute clusters

--- a/tests/bdd/scripts/destroy-stack.sh
+++ b/tests/bdd/scripts/destroy-stack.sh
@@ -4,10 +4,14 @@
 #
 # Destructive stack cleanup for the BDD suite. Uninstalls every
 # stack-owned helm release and deletes every stack-owned namespace
-# on a retained k3d cluster, then clears stack handoff artifacts
-# from deploy/stacks/self-managed/out/ and
-# deploy/stacks/nvcf-compute-plane/out/. The k3d cluster itself is left
-# running so a subsequent install does not pay the cluster boot cost.
+# on a retained k3d cluster, then clears stack-generated artifacts:
+# root-level handoff yaml and Helmfile --output-dir render trees under
+# deploy/stacks/self-managed/out/ and
+# deploy/stacks/nvcf-compute-plane/out/, plus generated compute
+# registration values under
+# deploy/stacks/nvcf-compute-plane/registration/. The k3d cluster
+# itself is left running so a subsequent install does not pay the
+# cluster boot cost.
 #
 # Governing rule (see tests/bdd/PLAN_DESTRUCTIVE_CLEANUP.md and
 # tests/bdd/AGENTS.md): topology cleanup may delete topology
@@ -30,7 +34,10 @@
 # Multi-cluster mode discovers every ncp-local-compute-* cluster
 # via `k3d cluster list -o json | jq` and cleans each (worker layer
 # first to satisfy CR-finalizer ordering), then cleans
-# k3d-ncp-local-cp.
+# k3d-ncp-local-cp. Control-plane cleanup also applies the worker
+# release and namespace allow-lists: multi-cluster feature Backgrounds
+# create nvca-operator (and its pull secret) on k3d-ncp-local-cp, not
+# only on compute contexts.
 #
 # Repo root resolution: $BDD_REPO_ROOT if set, otherwise
 # `git rev-parse --show-toplevel`. The script changes directory to
@@ -63,6 +70,7 @@ STACK_OUT_DIRS=(
   "$REPO_ROOT/deploy/stacks/self-managed/out"
   "$REPO_ROOT/deploy/stacks/nvcf-compute-plane/out"
 )
+STACK_REGISTRATION_DIR="$REPO_ROOT/deploy/stacks/nvcf-compute-plane/registration"
 
 CLUSTER_NAME="${CLUSTER_NAME:-ncp-local}"
 
@@ -213,12 +221,36 @@ delete_stack_namespaces() {
   done
 }
 
+# clean_stack_out removes stack-generated handoff files. It is the
+# explicit-path equivalent of each stack's `make clean` for helmfile
+# render trees, plus compute registration values that `make clean`
+# does not cover. Root-level non-yaml notes in out/ are left in place.
 clean_stack_out() {
-  local dir
+  local dir sub
+  local restore_nullglob=0
+  if ! shopt -q nullglob; then
+    shopt -s nullglob
+    restore_nullglob=1
+  fi
+
   for dir in "${STACK_OUT_DIRS[@]}"; do
     echo "  clean $dir"
-    rm -f "$dir"/*.yaml
+    if [[ -d "$dir" ]]; then
+      rm -f "$dir"/*.yaml
+      for sub in "$dir"/*/; do
+        rm -rf "$sub"
+      done
+    fi
   done
+
+  echo "  clean $STACK_REGISTRATION_DIR"
+  if [[ -d "$STACK_REGISTRATION_DIR" ]]; then
+    rm -f "$STACK_REGISTRATION_DIR"/*.yaml
+  fi
+
+  if [[ "$restore_nullglob" -eq 1 ]]; then
+    shopt -u nullglob
+  fi
 }
 
 
@@ -227,16 +259,16 @@ clean_stack_out() {
 if [[ "$mode" == "single" ]]; then
   ctx="k3d-$CLUSTER_NAME"
   if ! kubectl --context "$ctx" cluster-info >/dev/null 2>&1; then
-    echo "Context $ctx unreachable; nothing to clean."
-    exit 0
+    echo "Context $ctx unreachable; skipping cluster resources."
+  else
+    delete_stack_crs "$ctx" "nvca-operator"
+    uninstall_stack_releases "$ctx" \
+      "${STACK_RELEASES_WORKER[@]}" \
+      "${STACK_RELEASES_CP[@]}"
+    delete_stack_namespaces "$ctx" \
+      "${STACK_NAMESPACES_WORKER[@]}" \
+      "${STACK_NAMESPACES_CP[@]}"
   fi
-  delete_stack_crs "$ctx" "nvca-operator"
-  uninstall_stack_releases "$ctx" \
-    "${STACK_RELEASES_WORKER[@]}" \
-    "${STACK_RELEASES_CP[@]}"
-  delete_stack_namespaces "$ctx" \
-    "${STACK_NAMESPACES_WORKER[@]}" \
-    "${STACK_NAMESPACES_CP[@]}"
   clean_stack_out
   exit 0
 fi
@@ -270,8 +302,19 @@ if k3d cluster get ncp-local-cp >/dev/null 2>&1; then
   echo ">>> Cleaning control-plane cluster k3d-ncp-local-cp"
   ctx="k3d-ncp-local-cp"
   if kubectl --context "$ctx" cluster-info >/dev/null 2>&1; then
-    uninstall_stack_releases "$ctx" "${STACK_RELEASES_CP[@]}"
-    delete_stack_namespaces "$ctx" "${STACK_NAMESPACES_CP[@]}"
+    # Worker allow-lists apply on the CP cluster too: multi-cluster
+    # Backgrounds create nvca-operator (namespace + pull secret, and
+    # sometimes the helm release) on k3d-ncp-local-cp. Compute clusters
+    # were cleaned above. Helm --ignore-not-found and kubectl
+    # --ignore-not-found keep this idempotent when the worker stack was
+    # never installed on the CP.
+    delete_stack_crs "$ctx" "nvca-operator"
+    uninstall_stack_releases "$ctx" \
+      "${STACK_RELEASES_WORKER[@]}" \
+      "${STACK_RELEASES_CP[@]}"
+    delete_stack_namespaces "$ctx" \
+      "${STACK_NAMESPACES_WORKER[@]}" \
+      "${STACK_NAMESPACES_CP[@]}"
   else
     echo "Context $ctx unreachable; skipping."
   fi


### PR DESCRIPTION
## TL;DR
Multi-cluster `destroy-stack.sh` left `nvca-operator` on the control-plane context, and `clean_stack_out` left Helmfile render trees plus compute registration yaml behind. This closes those gaps for #1489 without touching topology infra.

## Additional Details
Feature Backgrounds create `nvca-operator` (and its pull secret) on `k3d-ncp-local-cp`, but worker allow-lists previously ran only against compute contexts. Also:

- `clean_stack_out` only deleted root-level `out/*.yaml`
- `deploy/stacks/nvcf-compute-plane/registration/*.yaml` was never cleaned

Control-plane multi cleanup now applies worker + CP allow-lists. Artifact cleanup removes Helmfile `--output-dir` subtrees under each stack `out/` and registration yaml. `eg` / `envoy-gateway-system` / `cert-manager` stay untouched.

## For the Reviewer
Primary file: `tests/bdd/scripts/destroy-stack.sh`. Fake-binary coverage in `tests/bdd/cleanup_scripts_test.go`.

## For QA
- [x] `cd tests/bdd && go test -short ./...`
- [x] `tests/bdd/scripts/lint.sh`
- Live k3d multi destroy was not re-run in this environment.

Is QA Needed? Optional — script + fake-binary tests cover the regression; live BDD is the gold check if maintainers want it.

## Issues
Fixes #1489

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multi-cluster cleanup to remove worker resources, releases, namespaces, and operator resources from the control-plane context.
  - Cleanup now removes generated Helmfile render trees and compute-registration files across stack output directories while preserving unrelated notes and fixtures.
  - Cleanup skips only genuinely unreachable Kubernetes contexts; API, permission, timeout, tool, and finalizer failures now stop the operation instead of being reported as successful.

- **Documentation**
  - Clarified cleanup behavior, supported output locations, and preserved files.

- **Tests**
  - Added coverage for multi-cluster cleanup, generated-artifact removal, and failure propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->