### PR TITLE
fix(cli): make cluster-agent validate-deployment check the real Pod, not a mirrored CR status string

### DIFF
--- a/src/clis/nvcf-cli/internal/clusteragent/k8s_validator.go
+++ b/src/clis/nvcf-cli/internal/clusteragent/k8s_validator.go
@@ -503,7 +503,10 @@ func getMiniServiceUtilsPod(ctx context.Context, dc dynamic.Interface, cs kubern
 		return nil, fmt.Errorf("reading MiniService %s: %w", instanceID, err)
 	}
 	msNamespace, found, err := unstructured.NestedString(ms.Object, "spec", "namespace")
-	if err != nil || !found || msNamespace == "" {
+	if err != nil {
+		return nil, fmt.Errorf("MiniService %s spec.namespace: %w", instanceID, err)
+	}
+	if !found || msNamespace == "" {
 		return nil, fmt.Errorf("MiniService %s has no spec.namespace", instanceID)
 	}
 	return cs.CoreV1().Pods(msNamespace).Get(ctx, utilsPodName, metav1.GetOptions{})
@@ -531,13 +534,13 @@ func podUnhealthyReason(pod *corev1.Pod) (string, bool) {
 		}
 	}
 
-	for _, cs := range pod.Status.ContainerStatuses {
+	for _, cs := range allContainers {
 		if t := cs.State.Terminated; t != nil && t.ExitCode != 0 {
 			return fmt.Sprintf("container %s terminated: %s (exit code %d)", cs.Name, t.Reason, t.ExitCode), true
 		}
 	}
 
-	for _, cs := range pod.Status.ContainerStatuses {
+	for _, cs := range allContainers {
 		if cs.RestartCount < podReadinessRestartThreshold {
 			continue
 		}

--- a/src/clis/nvcf-cli/internal/clusteragent/k8s_validator.go
+++ b/src/clis/nvcf-cli/internal/clusteragent/k8s_validator.go
@@ -381,6 +381,7 @@ func (v *k8sValidator) ValidateDeployment(ctx context.Context, functionID, versi
 
 	var match map[string]interface{}
 	var matchVerID string
+	var matchNamespace string
 	for i := range items {
 		fid, vid := functionIdentity(items[i].Object)
 		if fid != functionID {
@@ -391,6 +392,7 @@ func (v *k8sValidator) ValidateDeployment(ctx context.Context, functionID, versi
 		}
 		match = items[i].Object
 		matchVerID = vid
+		matchNamespace = items[i].GetNamespace()
 		break
 	}
 	if match == nil {
@@ -406,16 +408,25 @@ func (v *k8sValidator) ValidateDeployment(ctx context.Context, functionID, versi
 	}
 	instances := extractInstances(match)
 	out.Checks = append(out.Checks,
-		checkPodReadiness(instances),
+		checkPodReadiness(ctx, v.cs, matchNamespace, instances),
 		checkQueueHealth(match, instances),
 		checkGPUUtilization(cc.backend),
 	)
 	return out, nil
 }
 
-// checkPodReadiness fails when no instances are running or any instance reports
-// an error/failed status.
-func checkPodReadiness(instances []Instance) CheckResult {
+// podReadinessRestartThreshold matches NVCA's own RestartCountToFailInstance
+// (internal/util/k8sutil/pod.go): the restart count past which a container's
+// last crash, not just its current state, is the relevant signal.
+const podReadinessRestartThreshold = int32(3)
+
+// checkPodReadiness fails when no instances are running or any instance's
+// backing Pod isn't ready. For Pod-backed instances this reads the actual
+// Pod (PodReady condition, container termination/restart state) instead of
+// the ICMSRequest CR's mirrored status string, which can lag or omit a crash
+// NVCA hasn't reconciled forward yet. MiniService (Helm)-backed instances
+// aren't a single Pod, so they still fall back to the CR-reported status.
+func checkPodReadiness(ctx context.Context, cs kubernetes.Interface, namespace string, instances []Instance) CheckResult {
 	res := CheckResult{Name: "pod-readiness"}
 	if len(instances) == 0 {
 		res.Status = CheckFailed
@@ -423,15 +434,101 @@ func checkPodReadiness(instances []Instance) CheckResult {
 		return res
 	}
 	for _, in := range instances {
-		if instanceUnhealthy(in) {
+		if !isPodBackedInstance(in) {
+			if instanceUnhealthy(in) {
+				res.Status = CheckFailed
+				res.Message = fmt.Sprintf("instance %s is unhealthy (status=%s lastReported=%s)", in.ID, orUnknown(in.Status), orUnknown(in.LastReportedStatus))
+				return res
+			}
+			continue
+		}
+		pod, err := cs.CoreV1().Pods(namespace).Get(ctx, in.ID, metav1.GetOptions{})
+		if err != nil {
 			res.Status = CheckFailed
-			res.Message = fmt.Sprintf("instance %s is unhealthy (status=%s lastReported=%s)", in.ID, orUnknown(in.Status), orUnknown(in.LastReportedStatus))
+			if apierrors.IsNotFound(err) {
+				res.Message = fmt.Sprintf("instance %s: pod not found", in.ID)
+			} else {
+				res.Message = fmt.Sprintf("instance %s: failed to read pod: %v", in.ID, err)
+			}
+			return res
+		}
+		if reason, unhealthy := podUnhealthyReason(pod); unhealthy {
+			res.Status = CheckFailed
+			res.Message = fmt.Sprintf("instance %s is unhealthy: %s", in.ID, reason)
 			return res
 		}
 	}
 	res.Status = CheckPassed
 	res.Message = fmt.Sprintf("%s healthy", pluralize(len(instances), "instance"))
 	return res
+}
+
+// isPodBackedInstance reports whether an instance is backed by a single Pod
+// (the empty type defaults to Pod, matching the legacy field the read-only
+// inspector already tolerates) as opposed to a MiniService (Helm) release.
+func isPodBackedInstance(in Instance) bool {
+	switch in.Type {
+	case "", "Pod":
+		return true
+	default:
+		return false
+	}
+}
+
+// podUnhealthyReason reports why a Pod isn't ready, checked in order of how
+// actionable the signal is: image pull problems, a container currently
+// terminated with a non-zero exit code, then a crash-looping container
+// (enough restarts that its last crash, not its current transient state, is
+// what matters). This mirrors the signals NVCA's own reconciler uses
+// (IsPodReady, IsPodStuckInitializing in internal/util/k8sutil/pod.go)
+// without NVCA's time-threshold gating: this is a point-in-time snapshot,
+// not a "how long do we wait before giving up" policy.
+func podUnhealthyReason(pod *corev1.Pod) (string, bool) {
+	if isPodReadyConditionTrue(pod.Status) {
+		return "", false
+	}
+
+	allContainers := make([]corev1.ContainerStatus, 0, len(pod.Status.InitContainerStatuses)+len(pod.Status.ContainerStatuses))
+	allContainers = append(allContainers, pod.Status.InitContainerStatuses...)
+	allContainers = append(allContainers, pod.Status.ContainerStatuses...)
+	for _, cs := range allContainers {
+		if w := cs.State.Waiting; w != nil && (w.Reason == "ErrImagePull" || w.Reason == "ImagePullBackOff") {
+			return fmt.Sprintf("container %s: %s (%s)", cs.Name, w.Reason, w.Message), true
+		}
+	}
+
+	for _, cs := range pod.Status.ContainerStatuses {
+		if t := cs.State.Terminated; t != nil && t.ExitCode != 0 {
+			return fmt.Sprintf("container %s terminated: %s (exit code %d)", cs.Name, t.Reason, t.ExitCode), true
+		}
+	}
+
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.RestartCount < podReadinessRestartThreshold {
+			continue
+		}
+		if t := cs.LastTerminationState.Terminated; t != nil {
+			return fmt.Sprintf("container %s restarted %d times, last exit: %s (exit code %d)", cs.Name, cs.RestartCount, t.Reason, t.ExitCode), true
+		}
+		if w := cs.LastTerminationState.Waiting; w != nil {
+			return fmt.Sprintf("container %s restarted %d times, last state: %s", cs.Name, cs.RestartCount, w.Reason), true
+		}
+	}
+
+	return fmt.Sprintf("pod condition Ready=%s", podReadyConditionStatus(pod.Status)), true
+}
+
+func isPodReadyConditionTrue(status corev1.PodStatus) bool {
+	return podReadyConditionStatus(status) == corev1.ConditionTrue
+}
+
+func podReadyConditionStatus(status corev1.PodStatus) corev1.ConditionStatus {
+	for _, c := range status.Conditions {
+		if c.Type == corev1.PodReady {
+			return c.Status
+		}
+	}
+	return corev1.ConditionUnknown
 }
 
 // checkQueueHealth maps the collapsed request phase to a verdict: ACTIVE passes,

--- a/src/clis/nvcf-cli/internal/clusteragent/k8s_validator.go
+++ b/src/clis/nvcf-cli/internal/clusteragent/k8s_validator.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 )
@@ -408,7 +409,7 @@ func (v *k8sValidator) ValidateDeployment(ctx context.Context, functionID, versi
 	}
 	instances := extractInstances(match)
 	out.Checks = append(out.Checks,
-		checkPodReadiness(ctx, v.cs, matchNamespace, instances),
+		checkPodReadiness(ctx, v.cs, v.dc, matchNamespace, instances),
 		checkQueueHealth(match, instances),
 		checkGPUUtilization(cc.backend),
 	)
@@ -420,13 +421,20 @@ func (v *k8sValidator) ValidateDeployment(ctx context.Context, functionID, versi
 // last crash, not just its current state, is the relevant signal.
 const podReadinessRestartThreshold = int32(3)
 
+// utilsPodName is the fixed name NVCA gives the sidecar Pod it uses as the
+// health signal for an entire MiniService (Helm) release: NVCA's own status
+// reconciler reduces "is this MiniService healthy" to this Pod's readiness
+// the same way checkPodReadiness does for a plain container function's Pod.
+const utilsPodName = "utils"
+
 // checkPodReadiness fails when no instances are running or any instance's
-// backing Pod isn't ready. For Pod-backed instances this reads the actual
-// Pod (PodReady condition, container termination/restart state) instead of
-// the ICMSRequest CR's mirrored status string, which can lag or omit a crash
-// NVCA hasn't reconciled forward yet. MiniService (Helm)-backed instances
-// aren't a single Pod, so they still fall back to the CR-reported status.
-func checkPodReadiness(ctx context.Context, cs kubernetes.Interface, namespace string, instances []Instance) CheckResult {
+// backing Pod isn't ready. It reads the actual Pod (PodReady condition,
+// container termination/restart state) instead of the ICMSRequest CR's
+// mirrored status string, which can lag or omit a crash NVCA hasn't
+// reconciled forward yet: for a plain container function that's the Pod
+// named after the instance ID directly; for a MiniService (Helm) instance
+// it's the "utils" Pod in the dedicated namespace the MiniService CR names.
+func checkPodReadiness(ctx context.Context, cs kubernetes.Interface, dc dynamic.Interface, namespace string, instances []Instance) CheckResult {
 	res := CheckResult{Name: "pod-readiness"}
 	if len(instances) == 0 {
 		res.Status = CheckFailed
@@ -434,7 +442,17 @@ func checkPodReadiness(ctx context.Context, cs kubernetes.Interface, namespace s
 		return res
 	}
 	for _, in := range instances {
-		if !isPodBackedInstance(in) {
+		var pod *corev1.Pod
+		var err error
+		switch {
+		case isPodBackedInstance(in):
+			pod, err = cs.CoreV1().Pods(namespace).Get(ctx, in.ID, metav1.GetOptions{})
+		case in.Type == "MiniService":
+			pod, err = getMiniServiceUtilsPod(ctx, dc, cs, in.ID)
+		default:
+			// Unrecognized instance type: don't guess which resource kind
+			// backs it. Fall back to the CR-reported status rather than
+			// silently skipping.
 			if instanceUnhealthy(in) {
 				res.Status = CheckFailed
 				res.Message = fmt.Sprintf("instance %s is unhealthy (status=%s lastReported=%s)", in.ID, orUnknown(in.Status), orUnknown(in.LastReportedStatus))
@@ -442,7 +460,6 @@ func checkPodReadiness(ctx context.Context, cs kubernetes.Interface, namespace s
 			}
 			continue
 		}
-		pod, err := cs.CoreV1().Pods(namespace).Get(ctx, in.ID, metav1.GetOptions{})
 		if err != nil {
 			res.Status = CheckFailed
 			if apierrors.IsNotFound(err) {
@@ -473,6 +490,23 @@ func isPodBackedInstance(in Instance) bool {
 	default:
 		return false
 	}
+}
+
+// getMiniServiceUtilsPod resolves a MiniService instance to its utils Pod.
+// The MiniService CR (cluster-scoped, keyed by instance ID -- the same
+// lookup killMatching's evictInstances already uses to delete it) carries
+// the dedicated namespace NVCA created for that release; the utils Pod lives
+// there under the fixed name NVCA itself relies on.
+func getMiniServiceUtilsPod(ctx context.Context, dc dynamic.Interface, cs kubernetes.Interface, instanceID string) (*corev1.Pod, error) {
+	ms, err := dc.Resource(miniServiceGVR).Get(ctx, instanceID, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("reading MiniService %s: %w", instanceID, err)
+	}
+	msNamespace, found, err := unstructured.NestedString(ms.Object, "spec", "namespace")
+	if err != nil || !found || msNamespace == "" {
+		return nil, fmt.Errorf("MiniService %s has no spec.namespace", instanceID)
+	}
+	return cs.CoreV1().Pods(msNamespace).Get(ctx, utilsPodName, metav1.GetOptions{})
 }
 
 // podUnhealthyReason reports why a Pod isn't ready, checked in order of how

--- a/src/clis/nvcf-cli/internal/clusteragent/k8s_validator.go
+++ b/src/clis/nvcf-cli/internal/clusteragent/k8s_validator.go
@@ -427,13 +427,11 @@ const podReadinessRestartThreshold = int32(3)
 // the same way checkPodReadiness does for a plain container function's Pod.
 const utilsPodName = "utils"
 
-// checkPodReadiness fails when no instances are running or any instance's
-// backing Pod isn't ready. It reads the actual Pod (PodReady condition,
-// container termination/restart state) instead of the ICMSRequest CR's
-// mirrored status string, which can lag or omit a crash NVCA hasn't
-// reconciled forward yet: for a plain container function that's the Pod
-// named after the instance ID directly; for a MiniService (Helm) instance
-// it's the "utils" Pod in the dedicated namespace the MiniService CR names.
+// checkPodReadiness reads each instance's real Pod (PodReady condition,
+// container state) instead of the ICMSRequest CR's mirrored status string,
+// which can lag or omit a crash NVCA hasn't reconciled forward yet. A
+// container function's Pod is named after the instance ID; a MiniService
+// (Helm) instance resolves to the "utils" Pod in its own namespace.
 func checkPodReadiness(ctx context.Context, cs kubernetes.Interface, dc dynamic.Interface, namespace string, instances []Instance) CheckResult {
 	res := CheckResult{Name: "pod-readiness"}
 	if len(instances) == 0 {
@@ -441,6 +439,7 @@ func checkPodReadiness(ctx context.Context, cs kubernetes.Interface, dc dynamic.
 		res.Message = "no instances running for this function version"
 		return res
 	}
+	var warnMsg string
 	for _, in := range instances {
 		var pod *corev1.Pod
 		var err error
@@ -450,9 +449,8 @@ func checkPodReadiness(ctx context.Context, cs kubernetes.Interface, dc dynamic.
 		case in.Type == "MiniService":
 			pod, err = getMiniServiceUtilsPod(ctx, dc, cs, in.ID)
 		default:
-			// Unrecognized instance type: don't guess which resource kind
-			// backs it. Fall back to the CR-reported status rather than
-			// silently skipping.
+			// Unrecognized type: don't guess the resource kind, fall back
+			// to the CR-reported status instead of silently skipping.
 			if instanceUnhealthy(in) {
 				res.Status = CheckFailed
 				res.Message = fmt.Sprintf("instance %s is unhealthy (status=%s lastReported=%s)", in.ID, orUnknown(in.Status), orUnknown(in.LastReportedStatus))
@@ -469,11 +467,24 @@ func checkPodReadiness(ctx context.Context, cs kubernetes.Interface, dc dynamic.
 			}
 			return res
 		}
-		if reason, unhealthy := podUnhealthyReason(pod); unhealthy {
+		reason, severity := podReadinessSeverity(pod)
+		switch severity {
+		case podSeverityFailed:
 			res.Status = CheckFailed
 			res.Message = fmt.Sprintf("instance %s is unhealthy: %s", in.ID, reason)
 			return res
+		case podSeverityWarning:
+			// Keep checking the rest instead of failing fast: a later
+			// instance could still be a genuine failure.
+			if warnMsg == "" {
+				warnMsg = fmt.Sprintf("instance %s not yet ready: %s", in.ID, reason)
+			}
 		}
+	}
+	if warnMsg != "" {
+		res.Status = CheckWarning
+		res.Message = warnMsg
+		return res
 	}
 	res.Status = CheckPassed
 	res.Message = fmt.Sprintf("%s healthy", pluralize(len(instances), "instance"))
@@ -492,11 +503,10 @@ func isPodBackedInstance(in Instance) bool {
 	}
 }
 
-// getMiniServiceUtilsPod resolves a MiniService instance to its utils Pod.
-// The MiniService CR (cluster-scoped, keyed by instance ID -- the same
-// lookup killMatching's evictInstances already uses to delete it) carries
-// the dedicated namespace NVCA created for that release; the utils Pod lives
-// there under the fixed name NVCA itself relies on.
+// getMiniServiceUtilsPod resolves a MiniService instance to its utils Pod:
+// the MiniService CR (cluster-scoped, same lookup evictInstances uses to
+// delete it) names the release's dedicated namespace, where the utils Pod
+// lives under the fixed name NVCA itself relies on.
 func getMiniServiceUtilsPod(ctx context.Context, dc dynamic.Interface, cs kubernetes.Interface, instanceID string) (*corev1.Pod, error) {
 	ms, err := dc.Resource(miniServiceGVR).Get(ctx, instanceID, metav1.GetOptions{})
 	if err != nil {
@@ -512,17 +522,29 @@ func getMiniServiceUtilsPod(ctx context.Context, dc dynamic.Interface, cs kubern
 	return cs.CoreV1().Pods(msNamespace).Get(ctx, utilsPodName, metav1.GetOptions{})
 }
 
-// podUnhealthyReason reports why a Pod isn't ready, checked in order of how
-// actionable the signal is: image pull problems, a container currently
-// terminated with a non-zero exit code, then a crash-looping container
-// (enough restarts that its last crash, not its current transient state, is
-// what matters). This mirrors the signals NVCA's own reconciler uses
-// (IsPodReady, IsPodStuckInitializing in internal/util/k8sutil/pod.go)
-// without NVCA's time-threshold gating: this is a point-in-time snapshot,
-// not a "how long do we wait before giving up" policy.
-func podUnhealthyReason(pod *corev1.Pod) (string, bool) {
+// podReadinessSeverityLevel classifies a not-ready Pod: ordinary startup is
+// a warning, and only a positively-identified problem (image pull failure,
+// a crash, a restart loop) is a failure.
+type podReadinessSeverityLevel int
+
+const (
+	podSeverityHealthy podReadinessSeverityLevel = iota
+	podSeverityWarning
+	podSeverityFailed
+)
+
+// podReadinessSeverity reports why a Pod isn't ready and how severe that is:
+// image pull problems, then a container terminated with a non-zero exit
+// code, then a crash loop (restarts past the threshold, judged by the last
+// crash since the container may be cycling through Waiting again by now).
+// Mirrors NVCA's own IsPodReady/IsPodStuckInitializing (internal/util/k8sutil/pod.go)
+// without its time-threshold gating, since this is a point-in-time snapshot.
+// Ready=False/Unknown with none of the above (Pending, ContainerCreating,
+// an early probe not yet passing) is ordinary rollout, so it's a warning,
+// not a failure -- consistent with queue-health's DEPLOYING handling.
+func podReadinessSeverity(pod *corev1.Pod) (string, podReadinessSeverityLevel) {
 	if isPodReadyConditionTrue(pod.Status) {
-		return "", false
+		return "", podSeverityHealthy
 	}
 
 	allContainers := make([]corev1.ContainerStatus, 0, len(pod.Status.InitContainerStatuses)+len(pod.Status.ContainerStatuses))
@@ -530,13 +552,13 @@ func podUnhealthyReason(pod *corev1.Pod) (string, bool) {
 	allContainers = append(allContainers, pod.Status.ContainerStatuses...)
 	for _, cs := range allContainers {
 		if w := cs.State.Waiting; w != nil && (w.Reason == "ErrImagePull" || w.Reason == "ImagePullBackOff") {
-			return fmt.Sprintf("container %s: %s (%s)", cs.Name, w.Reason, w.Message), true
+			return fmt.Sprintf("container %s: %s (%s)", cs.Name, w.Reason, w.Message), podSeverityFailed
 		}
 	}
 
 	for _, cs := range allContainers {
 		if t := cs.State.Terminated; t != nil && t.ExitCode != 0 {
-			return fmt.Sprintf("container %s terminated: %s (exit code %d)", cs.Name, t.Reason, t.ExitCode), true
+			return fmt.Sprintf("container %s terminated: %s (exit code %d)", cs.Name, t.Reason, t.ExitCode), podSeverityFailed
 		}
 	}
 
@@ -545,14 +567,14 @@ func podUnhealthyReason(pod *corev1.Pod) (string, bool) {
 			continue
 		}
 		if t := cs.LastTerminationState.Terminated; t != nil {
-			return fmt.Sprintf("container %s restarted %d times, last exit: %s (exit code %d)", cs.Name, cs.RestartCount, t.Reason, t.ExitCode), true
+			return fmt.Sprintf("container %s restarted %d times, last exit: %s (exit code %d)", cs.Name, cs.RestartCount, t.Reason, t.ExitCode), podSeverityFailed
 		}
 		if w := cs.LastTerminationState.Waiting; w != nil {
-			return fmt.Sprintf("container %s restarted %d times, last state: %s", cs.Name, cs.RestartCount, w.Reason), true
+			return fmt.Sprintf("container %s restarted %d times, last state: %s", cs.Name, cs.RestartCount, w.Reason), podSeverityFailed
 		}
 	}
 
-	return fmt.Sprintf("pod condition Ready=%s", podReadyConditionStatus(pod.Status)), true
+	return fmt.Sprintf("pod condition Ready=%s", podReadyConditionStatus(pod.Status)), podSeverityWarning
 }
 
 func isPodReadyConditionTrue(status corev1.PodStatus) bool {

--- a/src/clis/nvcf-cli/internal/clusteragent/k8s_validator_test.go
+++ b/src/clis/nvcf-cli/internal/clusteragent/k8s_validator_test.go
@@ -447,6 +447,36 @@ func TestValidateDeploymentPodReadinessFailsOnCrashedContainerDespiteCleanCRStat
 	}
 }
 
+// TestValidateDeploymentPodReadinessFailsOnCrashedInitContainer confirms an
+// init container's terminated state is inspected the same way as a regular
+// container's, instead of only pod.Status.ContainerStatuses -- otherwise a
+// failing init container falls through to the generic Ready=False message.
+func TestValidateDeploymentPodReadinessFailsOnCrashedInitContainer(t *testing.T) {
+	pod := fakeTerminatedPod(testRequestsNS, "inst-a", "setup", 1, "Error")
+	pod.Status.InitContainerStatuses = pod.Status.ContainerStatuses
+	pod.Status.ContainerStatuses = nil
+
+	v := newFakeValidator(nil,
+		[]runtime.Object{
+			validatorBackend(testSystemNS, agentStatusHealthy, 8, 5),
+			icmsWithInstances(testRequestsNS, "r1", "fn-1", "v1", statusInProgress, map[string]string{"inst-a": "starting"}),
+		},
+		[]runtime.Object{pod},
+	)
+
+	out, err := v.ValidateDeployment(context.Background(), "fn-1", "v1", ValidateOptions{BackendNS: testBackendNS})
+	if err != nil {
+		t.Fatalf("ValidateDeployment returned error: %v", err)
+	}
+	got := checkByName(t, out.Checks, "pod-readiness")
+	if got.Status != CheckFailed {
+		t.Errorf("pod-readiness = %s, want FAIL (%s)", got.Status, got.Message)
+	}
+	if !strings.Contains(got.Message, "setup") || !strings.Contains(got.Message, "exit code 1") {
+		t.Errorf("pod-readiness message = %q, want it to name the init container and exit code", got.Message)
+	}
+}
+
 // TestValidateDeploymentPodReadinessFailsOnCrashLoop covers the case where
 // restartPolicy: Always has already cycled the container back to Waiting by
 // the time the check runs, so its *current* state isn't Terminated -- the

--- a/src/clis/nvcf-cli/internal/clusteragent/k8s_validator_test.go
+++ b/src/clis/nvcf-cli/internal/clusteragent/k8s_validator_test.go
@@ -48,6 +48,7 @@ func newFakeValidator(httpCli *http.Client, dynObjs, k8sObjs []runtime.Object) *
 	gvrToListKind := map[schema.GroupVersionResource]string{
 		nvcfBackendGVR: "NVCFBackendList",
 		icmsRequestGVR: "ICMSRequestList",
+		miniServiceGVR: "MiniServiceList",
 	}
 	dc := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, dynObjs...)
 	cs := k8sfake.NewSimpleClientset(k8sObjs...)
@@ -490,13 +491,72 @@ func TestValidateDeploymentPodReadinessFailsWhenPodMissing(t *testing.T) {
 	}
 }
 
-// TestValidateDeploymentPodReadinessFallsBackForMiniServiceInstances confirms
-// MiniService (Helm)-backed instances -- which aren't a single Pod -- still
-// use the CR-reported status instead of attempting (and failing) a Pod fetch.
-func TestValidateDeploymentPodReadinessFallsBackForMiniServiceInstances(t *testing.T) {
+// icmsWithMiniServiceInstance builds an ICMSRequest with one MiniService-typed
+// instance, plus the MiniService CR it resolves to.
+func icmsWithMiniServiceInstance(ns, name, fid, vid, requestStatus, instanceID, crStatus, msNamespace string) (*unstructured.Unstructured, *unstructured.Unstructured) {
+	req := icmsWithInstances(ns, name, fid, vid, requestStatus, nil)
+	unstructured.SetNestedMap(req.Object, map[string]interface{}{
+		instanceID: map[string]interface{}{"id": instanceID, "type": "MiniService", "status": crStatus},
+	}, "status", "instances")
+
+	ms := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "nvca.nvcf.nvidia.io/v1alpha1",
+		"kind":       "MiniService",
+		"metadata":   map[string]interface{}{"name": instanceID},
+		"spec":       map[string]interface{}{"namespace": msNamespace},
+	}}
+	return req, ms
+}
+
+// TestValidateDeploymentPodReadinessPassesForHealthyMiniServiceInstance
+// confirms a MiniService (Helm)-backed instance is checked the same way as a
+// plain container function's Pod: resolved to its "utils" Pod via the
+// MiniService CR's spec.namespace, not just trusted from the CR status string.
+func TestValidateDeploymentPodReadinessPassesForHealthyMiniServiceInstance(t *testing.T) {
+	req, ms := icmsWithMiniServiceInstance(testRequestsNS, "r1", "fn-1", "v1", statusCompleted, "inst-a", "Active", "ms-inst-a-ns")
+
+	v := newFakeValidator(nil,
+		[]runtime.Object{validatorBackend(testSystemNS, agentStatusHealthy, 8, 5), req, ms},
+		[]runtime.Object{fakePod("ms-inst-a-ns", utilsPodName, corev1.ConditionTrue)},
+	)
+
+	out, err := v.ValidateDeployment(context.Background(), "fn-1", "v1", ValidateOptions{BackendNS: testBackendNS})
+	if err != nil {
+		t.Fatalf("ValidateDeployment returned error: %v", err)
+	}
+	if got := checkByName(t, out.Checks, "pod-readiness"); got.Status != CheckPassed {
+		t.Errorf("pod-readiness = %s, want PASS (%s)", got.Status, got.Message)
+	}
+}
+
+// TestValidateDeploymentPodReadinessFailsForCrashedMiniServiceUtilsPod is the
+// MiniService analogue of the crashed-container regression test: the CR
+// status looks clean, but the release's utils Pod has actually crashed.
+func TestValidateDeploymentPodReadinessFailsForCrashedMiniServiceUtilsPod(t *testing.T) {
+	req, ms := icmsWithMiniServiceInstance(testRequestsNS, "r1", "fn-1", "v1", statusInProgress, "inst-a", "Active", "ms-inst-a-ns")
+
+	v := newFakeValidator(nil,
+		[]runtime.Object{validatorBackend(testSystemNS, agentStatusHealthy, 8, 5), req, ms},
+		[]runtime.Object{fakeTerminatedPod("ms-inst-a-ns", utilsPodName, "utils", 1, "Error")},
+	)
+
+	out, err := v.ValidateDeployment(context.Background(), "fn-1", "v1", ValidateOptions{BackendNS: testBackendNS})
+	if err != nil {
+		t.Fatalf("ValidateDeployment returned error: %v", err)
+	}
+	if got := checkByName(t, out.Checks, "pod-readiness"); got.Status != CheckFailed {
+		t.Errorf("pod-readiness = %s, want FAIL (%s)", got.Status, got.Message)
+	}
+}
+
+// TestValidateDeploymentPodReadinessFallsBackForUnrecognizedInstanceType
+// covers a genuinely unrecognized instance type, where the check can't know
+// which resource kind backs it and falls back to the CR-reported status
+// rather than guessing or silently skipping.
+func TestValidateDeploymentPodReadinessFallsBackForUnrecognizedInstanceType(t *testing.T) {
 	req := icmsWithInstances(testRequestsNS, "r1", "fn-1", "v1", statusCompleted, nil)
 	unstructured.SetNestedMap(req.Object, map[string]interface{}{
-		"inst-a": map[string]interface{}{"id": "inst-a", "type": "MiniService", "status": "Active"},
+		"inst-a": map[string]interface{}{"id": "inst-a", "type": "SomeFutureInstanceType", "status": "Active"},
 	}, "status", "instances")
 
 	v := newFakeValidator(nil,

--- a/src/clis/nvcf-cli/internal/clusteragent/k8s_validator_test.go
+++ b/src/clis/nvcf-cli/internal/clusteragent/k8s_validator_test.go
@@ -28,6 +28,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -153,6 +154,56 @@ func icmsWithInstances(ns, name, fid, vid, requestStatus string, instanceStatuse
 		"spec":       map[string]interface{}{"functionDetails": map[string]interface{}{"functionId": fid, "functionVersionId": vid}},
 		"status":     map[string]interface{}{"requestStatus": requestStatus, "instances": insts},
 	}}
+}
+
+// fakePod builds a minimal Pod for the fake typed clientset with a given
+// PodReady condition and no container statuses (a clean-ready or
+// not-yet-scheduled case).
+func fakePod(ns, name string, ready corev1.ConditionStatus) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: ready}},
+		},
+	}
+}
+
+// fakeTerminatedPod builds a not-ready Pod whose container is currently
+// terminated with a non-zero exit code, matching a container that just
+// crashed (Pod phase stays Running under restartPolicy: Always, only the
+// container state reflects the crash).
+func fakeTerminatedPod(ns, name, containerName string, exitCode int32, reason string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionFalse}},
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:  containerName,
+				State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: exitCode, Reason: reason}},
+			}},
+		},
+	}
+}
+
+// fakeCrashLoopingPod builds a not-ready Pod whose container is currently
+// cycling (Waiting) but has restarted past the failure threshold, with its
+// last crash recorded in LastTerminationState -- the case where the
+// container is never caught mid-Terminated by a point-in-time check.
+func fakeCrashLoopingPod(ns, name, containerName string, restartCount, lastExitCode int32, lastReason string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionFalse}},
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:         containerName,
+				RestartCount: restartCount,
+				State:        corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
+				LastTerminationState: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{ExitCode: lastExitCode, Reason: lastReason},
+				},
+			}},
+		},
+	}
 }
 
 // checkByName returns the result for one check, failing the test if it is absent.
@@ -367,13 +418,108 @@ func TestValidateDeploymentPodReadinessFails(t *testing.T) {
 	}
 }
 
+// TestValidateDeploymentPodReadinessFailsOnCrashedContainerDespiteCleanCRStatus
+// is the direct regression test for the bug this fix addresses: the
+// ICMSRequest CR's mirrored status string looks healthy (NVCA hasn't
+// reconciled the crash into it yet), but the real Pod's container has
+// terminated with a non-zero exit code. pod-readiness must fail from the
+// live Pod, not the stale CR string.
+func TestValidateDeploymentPodReadinessFailsOnCrashedContainerDespiteCleanCRStatus(t *testing.T) {
+	v := newFakeValidator(nil,
+		[]runtime.Object{
+			validatorBackend(testSystemNS, agentStatusHealthy, 8, 5),
+			icmsWithInstances(testRequestsNS, "r1", "fn-1", "v1", statusInProgress, map[string]string{"inst-a": "starting"}),
+		},
+		[]runtime.Object{fakeTerminatedPod(testRequestsNS, "inst-a", "inference", 127, "Error")},
+	)
+
+	out, err := v.ValidateDeployment(context.Background(), "fn-1", "v1", ValidateOptions{BackendNS: testBackendNS})
+	if err != nil {
+		t.Fatalf("ValidateDeployment returned error: %v", err)
+	}
+	got := checkByName(t, out.Checks, "pod-readiness")
+	if got.Status != CheckFailed {
+		t.Errorf("pod-readiness = %s, want FAIL (%s)", got.Status, got.Message)
+	}
+	if !strings.Contains(got.Message, "exit code 127") {
+		t.Errorf("pod-readiness message = %q, want it to mention exit code 127", got.Message)
+	}
+}
+
+// TestValidateDeploymentPodReadinessFailsOnCrashLoop covers the case where
+// restartPolicy: Always has already cycled the container back to Waiting by
+// the time the check runs, so its *current* state isn't Terminated -- the
+// crash is only visible via RestartCount + LastTerminationState.
+func TestValidateDeploymentPodReadinessFailsOnCrashLoop(t *testing.T) {
+	v := newFakeValidator(nil,
+		[]runtime.Object{
+			validatorBackend(testSystemNS, agentStatusHealthy, 8, 5),
+			icmsWithInstances(testRequestsNS, "r1", "fn-1", "v1", statusInProgress, map[string]string{"inst-a": "starting"}),
+		},
+		[]runtime.Object{fakeCrashLoopingPod(testRequestsNS, "inst-a", "inference", 5, 127, "Error")},
+	)
+
+	out, err := v.ValidateDeployment(context.Background(), "fn-1", "v1", ValidateOptions{BackendNS: testBackendNS})
+	if err != nil {
+		t.Fatalf("ValidateDeployment returned error: %v", err)
+	}
+	got := checkByName(t, out.Checks, "pod-readiness")
+	if got.Status != CheckFailed {
+		t.Errorf("pod-readiness = %s, want FAIL (%s)", got.Status, got.Message)
+	}
+	if !strings.Contains(got.Message, "restarted 5 times") || !strings.Contains(got.Message, "exit code 127") {
+		t.Errorf("pod-readiness message = %q, want it to mention the restart count and exit code", got.Message)
+	}
+}
+
+func TestValidateDeploymentPodReadinessFailsWhenPodMissing(t *testing.T) {
+	v := newFakeValidator(nil,
+		[]runtime.Object{
+			validatorBackend(testSystemNS, agentStatusHealthy, 8, 5),
+			icmsWithInstances(testRequestsNS, "r1", "fn-1", "v1", statusInProgress, map[string]string{"inst-a": "starting"}),
+		},
+		nil,
+	)
+
+	out, err := v.ValidateDeployment(context.Background(), "fn-1", "v1", ValidateOptions{BackendNS: testBackendNS})
+	if err != nil {
+		t.Fatalf("ValidateDeployment returned error: %v", err)
+	}
+	if got := checkByName(t, out.Checks, "pod-readiness"); got.Status != CheckFailed {
+		t.Errorf("pod-readiness = %s, want FAIL (%s)", got.Status, got.Message)
+	}
+}
+
+// TestValidateDeploymentPodReadinessFallsBackForMiniServiceInstances confirms
+// MiniService (Helm)-backed instances -- which aren't a single Pod -- still
+// use the CR-reported status instead of attempting (and failing) a Pod fetch.
+func TestValidateDeploymentPodReadinessFallsBackForMiniServiceInstances(t *testing.T) {
+	req := icmsWithInstances(testRequestsNS, "r1", "fn-1", "v1", statusCompleted, nil)
+	unstructured.SetNestedMap(req.Object, map[string]interface{}{
+		"inst-a": map[string]interface{}{"id": "inst-a", "type": "MiniService", "status": "Active"},
+	}, "status", "instances")
+
+	v := newFakeValidator(nil,
+		[]runtime.Object{validatorBackend(testSystemNS, agentStatusHealthy, 8, 5), req},
+		nil,
+	)
+
+	out, err := v.ValidateDeployment(context.Background(), "fn-1", "v1", ValidateOptions{BackendNS: testBackendNS})
+	if err != nil {
+		t.Fatalf("ValidateDeployment returned error: %v", err)
+	}
+	if got := checkByName(t, out.Checks, "pod-readiness"); got.Status != CheckPassed {
+		t.Errorf("pod-readiness = %s, want PASS (%s)", got.Status, got.Message)
+	}
+}
+
 func TestValidateDeploymentQueueHealthWarnsOnDeploying(t *testing.T) {
 	v := newFakeValidator(nil,
 		[]runtime.Object{
 			validatorBackend(testSystemNS, agentStatusHealthy, 8, 5),
 			icmsWithInstances(testRequestsNS, "r1", "fn-1", "v1", statusInProgress, map[string]string{"inst-a": "Running"}),
 		},
-		nil,
+		[]runtime.Object{fakePod(testRequestsNS, "inst-a", corev1.ConditionTrue)},
 	)
 
 	out, err := v.ValidateDeployment(context.Background(), "fn-1", "", ValidateOptions{BackendNS: testBackendNS})

--- a/src/clis/nvcf-cli/internal/clusteragent/k8s_validator_test.go
+++ b/src/clis/nvcf-cli/internal/clusteragent/k8s_validator_test.go
@@ -521,6 +521,32 @@ func TestValidateDeploymentPodReadinessFailsWhenPodMissing(t *testing.T) {
 	}
 }
 
+// TestValidateDeploymentPodReadinessWarnsOnOrdinaryStartup confirms a Pod
+// that's merely Pending/ContainerCreating (Ready=False, no failure signal)
+// warns instead of failing, so validate-deployment doesn't race a normal
+// deploy's startup window.
+func TestValidateDeploymentPodReadinessWarnsOnOrdinaryStartup(t *testing.T) {
+	v := newFakeValidator(nil,
+		[]runtime.Object{
+			validatorBackend(testSystemNS, agentStatusHealthy, 8, 5),
+			icmsWithInstances(testRequestsNS, "r1", "fn-1", "v1", statusInProgress, map[string]string{"inst-a": "starting"}),
+		},
+		[]runtime.Object{fakePod(testRequestsNS, "inst-a", corev1.ConditionFalse)},
+	)
+
+	out, err := v.ValidateDeployment(context.Background(), "fn-1", "v1", ValidateOptions{BackendNS: testBackendNS})
+	if err != nil {
+		t.Fatalf("ValidateDeployment returned error: %v", err)
+	}
+	got := checkByName(t, out.Checks, "pod-readiness")
+	if got.Status != CheckWarning {
+		t.Errorf("pod-readiness = %s, want WARN (%s)", got.Status, got.Message)
+	}
+	if out.HasFailure() {
+		t.Errorf("DeploymentValidation.HasFailure() = true, want false for a warning-only result")
+	}
+}
+
 // icmsWithMiniServiceInstance builds an ICMSRequest with one MiniService-typed
 // instance, plus the MiniService CR it resolves to.
 func icmsWithMiniServiceInstance(ns, name, fid, vid, requestStatus, instanceID, crStatus, msNamespace string) (*unstructured.Unstructured, *unstructured.Unstructured) {

--- a/src/clis/nvcf-cli/internal/clusteragent/k8s_validator_test.go
+++ b/src/clis/nvcf-cli/internal/clusteragent/k8s_validator_test.go
@@ -605,6 +605,31 @@ func TestValidateDeploymentPodReadinessFailsForCrashedMiniServiceUtilsPod(t *tes
 	}
 }
 
+// TestValidateDeploymentPodReadinessWarnsOnOrdinaryMiniServiceStartup is the
+// MiniService analogue of TestValidateDeploymentPodReadinessWarnsOnOrdinaryStartup:
+// the severity classification is shared code, applied uniformly regardless
+// of which Pod (worker vs utils) it resolves to.
+func TestValidateDeploymentPodReadinessWarnsOnOrdinaryMiniServiceStartup(t *testing.T) {
+	req, ms := icmsWithMiniServiceInstance(testRequestsNS, "r1", "fn-1", "v1", statusInProgress, "inst-a", "Active", "ms-inst-a-ns")
+
+	v := newFakeValidator(nil,
+		[]runtime.Object{validatorBackend(testSystemNS, agentStatusHealthy, 8, 5), req, ms},
+		[]runtime.Object{fakePod("ms-inst-a-ns", utilsPodName, corev1.ConditionFalse)},
+	)
+
+	out, err := v.ValidateDeployment(context.Background(), "fn-1", "v1", ValidateOptions{BackendNS: testBackendNS})
+	if err != nil {
+		t.Fatalf("ValidateDeployment returned error: %v", err)
+	}
+	got := checkByName(t, out.Checks, "pod-readiness")
+	if got.Status != CheckWarning {
+		t.Errorf("pod-readiness = %s, want WARN (%s)", got.Status, got.Message)
+	}
+	if out.HasFailure() {
+		t.Errorf("DeploymentValidation.HasFailure() = true, want false for a warning-only result")
+	}
+}
+
 // TestValidateDeploymentPodReadinessFallsBackForUnrecognizedInstanceType
 // covers a genuinely unrecognized instance type, where the check can't know
 // which resource kind backs it and falls back to the CR-reported status


### PR DESCRIPTION
## TL;DR
`cluster agent validate-deployment`'s pod-readiness check reported status `PASS` with the message `"1 instance healthy"` for a Function Pod whose inference container had actually crashed (non-zero exit code, `CrashLoopBackOff`). The check never inspected the real Pod at all — it only substring-matched a free-text status string mirrored onto the `ICMSRequest` CR, which can lag behind or omit a crash NVCA hasn't reconciled forward yet. This makes the check read the actual Pod's readiness condition and container state instead, for both plain container functions and MiniService (Helm) instances.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
`checkPodReadiness` only ever checked `ICMSRequest.status.instances[id].status`/`.lastReportedStatus` for four substrings (`error`, `fail`, `terminating`, `unknown`). There was no `corev1.Pod` GET anywhere in the `validate-deployment` path, despite the check's name and documented purpose promising pod-level verification.

Also confirmed `Pod.Status.Phase` alone would not have caught this: NVCA sets `RestartPolicy: Always` on every function Pod, so `phase` stays `Running` through a crash loop — `kubectl`'s displayed "Error"/"CrashLoopBackOff" comes from container state, not Pod phase.

For a plain container function, `checkPodReadiness` now fetches the Pod by instance ID and checks, in order: the `PodReady` condition (primary signal, matching what NVCA itself gates on internally), image-pull problems (`ErrImagePull`/`ImagePullBackOff`), a container currently `Terminated` with a non-zero exit code, and a crash-looping container (`RestartCount >= 3` with `LastTerminationState.Terminated`/`Waiting`) — surfacing a specific reason/exit code instead of a generic mismatch. This mirrors the signals NVCA's own reconciler already uses (`internal/util/k8sutil/pod.go`'s `IsPodReady`/`IsPodStuckInitializing`), without porting NVCA's time-threshold gating (`WorkerDegradationTimeout` etc.), since `validate-deployment` is a point-in-time snapshot, not a reconciler deciding how long to wait before giving up.

For a MiniService (Helm) instance, there's no single Pod named after the instance ID. Instead, the MiniService CR (cluster-scoped, same lookup `killMatching`'s `evictInstances` already uses) carries `spec.namespace`, the dedicated namespace NVCA created for that release, and NVCA's own status reconciler already reduces "is this MiniService healthy" to the `PodReady` condition of a single fixed-name `"utils"` Pod in that namespace. `checkPodReadiness` now resolves that Pod the same way and reuses the same failure-reason logic.

Only a genuinely unrecognized instance type still falls back to the CR-reported status string, since the check can't know which resource kind backs it.

## For the Reviewer
Core change is in `src/clis/nvcf-cli/internal/clusteragent/k8s_validator.go`: `checkPodReadiness` (now takes `ctx`, the typed clientset, the dynamic client, and namespace), `isPodBackedInstance`, `getMiniServiceUtilsPod`, `podUnhealthyReason`, and the two small `PodReady`-condition helpers. `ValidateDeployment` now also captures the matching `ICMSRequest`'s namespace to scope the Pod lookup. Please look closely at:
- `podUnhealthyReason`'s ordering (image-pull, then currently-terminated, then restart-loop, then a generic Ready=False fallback) and whether the restart threshold (3, matching NVCA's own constant) is the right call for a CLI snapshot check.
- `getMiniServiceUtilsPod`'s reliance on the `"utils"` fixed Pod name matching NVCA's own convention (`common.UtilsPodName`) — nvcf-cli can't import NVCA's `internal/` package, so this is a local constant kept in sync by convention, not by compiler guarantee.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
9 new/updated regression tests in `k8s_validator_test.go`, covering: crashed-container, crash-loop, missing-Pod, healthy/crashed MiniService instance, and unrecognized-instance-type fallback. The crash-specific tests were confirmed to fail against the pre-fix code (reproducing the exact bug) and pass after.
`go build ./...`, `go vet ./...`, `gofmt -l`: clean. `go test ./...`: all pass, no regressions.
Live-verified the container-function path against a local self-hosted stack (k3d): deployed a function with a deliberately invalid container argument, confirmed the Pod reached `CrashLoopBackOff`, then ran `validate-deployment` and confirmed it now exits non-zero with `pod-readiness: FAIL — "container inference restarted 3 times, last exit: StartError (exit code 128)"` instead of the previous false PASS. The MiniService path is covered by unit tests only (deploying a real Helm-backed function locally is significantly heavier setup); QA may want to verify it against a real MiniService deployment.

## Issues
NO-REF

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Deployment validation now checks MiniService instances through their resolved `utils` Pod.
  - Validation detects failures in init containers, crashed containers, image pulls, terminations, and repeated restarts.
  - Missing or unhealthy required Pods are reported as validation failures.
  - Ordinary startup states produce warnings instead of failures.
  - Healthy `utils` Pods pass readiness validation.
  - Missing or invalid MiniService namespace information produces distinct diagnostics.
  - Unrecognized instance types continue to use status-based validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->