### PR TITLE
fix(nvca): identify NVMesh by the model cache class provisioner

### DIFF
--- a/docs/user/cluster-management/model-cache.md
+++ b/docs/user/cluster-management/model-cache.md
@@ -63,7 +63,7 @@ NVCA uses the first matching backend in this order:
 
 | Priority | Cluster condition | Backend | Reuse behavior |
 | --- | --- | --- | --- |
-| 1 | `nvcf-sc-30` exists | NVMesh | Durable reuse across namespaces |
+| 1 | The model cache StorageClass (`nvcf-sc` unless overridden) is provisioned by `nvmesh-csi.excelero.com` | NVMesh | Durable reuse across namespaces |
 | 2 | `nvcf-miniservice-sc` exists and supports `ReadOnlyMany` or `ReadWriteMany` | Operator-provided shared filesystem | Durable reuse across namespaces |
 | 3 | `HelmSharedStorage` is enabled | NVCA-managed Samba | Durable reuse across namespaces |
 | 4 | No shared backend is available | `emptyDir` | Pod-local caching only |

--- a/src/compute-plane-services/nvca/pkg/apis/nvca/v1/cache_types.go
+++ b/src/compute-plane-services/nvca/pkg/apis/nvca/v1/cache_types.go
@@ -71,7 +71,7 @@ type ModelCacheSpec struct {
 	CacheHandle string                `json:"cacheHandle"`
 	Encryption  *ModelCacheEncryption `json:"encryption,omitempty"`
 	// Backend selects the storage backend used to populate and expose the
-	// cache: "nvmesh" (NVMesh 3.x, nvcf-sc-30), "sharedfs" (a shared
+	// cache: "nvmesh" (the model cache class is provisioned by NVMesh), "sharedfs" (a shared
 	// filesystem class, nvcf-miniservice-sc), or "samba" (NVCA-managed Samba
 	// server). Empty is treated as "nvmesh" for backward compatibility; any
 	// other value fails the request with a terminal validation error.

--- a/src/compute-plane-services/nvca/pkg/apis/nvca/v2beta1/storage_types.go
+++ b/src/compute-plane-services/nvca/pkg/apis/nvca/v2beta1/storage_types.go
@@ -72,7 +72,7 @@ type ModelCacheSpec struct {
 	Encryption  *ModelCacheEncryption `json:"encryption,omitempty"`
 	// Backend selects the storage backend used to populate and expose the
 	// cache. Serialized values emitted by SelectHelmCacheBackend for
-	// ModelCacheRequests: "nvmesh" (NVMesh 3.x, nvcf-sc-30), "sharedfs" (a
+	// ModelCacheRequests: "nvmesh" (the model cache class is provisioned by NVMesh), "sharedfs" (a
 	// shared filesystem class, nvcf-miniservice-sc), or "samba" (NVCA-managed
 	// Samba server on block storage). "ephemeral" and "none" never reach a
 	// StorageRequest (ephemeral is a per-pod webhook fallback; none means

--- a/src/compute-plane-services/nvca/pkg/storage/cachebackend.go
+++ b/src/compute-plane-services/nvca/pkg/storage/cachebackend.go
@@ -57,9 +57,6 @@ const (
 )
 
 const (
-	// NVMeshStorageClassName, when present in the cluster, signals that
-	// NVMesh 3.x (with cross-namespace PV sharing) is installed.
-	NVMeshStorageClassName = "nvcf-sc-30"
 	// HelmCacheSharedStorageClassName is the shared storage class used for
 	// non-NVMesh cross-namespace model caching. It is either pre-provisioned
 	// by the operator or created by NVCA pointing at a Samba server.
@@ -81,14 +78,20 @@ func ModelCacheStorageClassName(override string) string {
 
 // SelectHelmCacheBackend resolves the Helm model-cache storage backend. All
 // caching is gated on CachingSupport plus the HelmModelCaching sub-gate; the
-// mechanism is then chosen by which storage class the cluster provides,
-// falling back to Samba (when HelmSharedStorage is enabled and the block class
-// Samba needs exists) and finally to a per-pod ephemeral cache:
+// mechanism is then chosen from the cluster's storage classes, falling back to
+// Samba (when HelmSharedStorage is enabled and the block class Samba needs
+// exists) and finally to a per-pod ephemeral cache:
 //
-//  1. nvcf-sc-30 present    -> NVMesh 3.x installed      -> NVMesh
-//  2. nvcf-miniservice-sc present  -> operator shared storage   -> SharedFS
+//  1. model cache class provisioned by NVMesh -> NVMesh
+//  2. nvcf-miniservice-sc present             -> operator shared storage -> SharedFS
 //  3. HelmSharedStorage on, model cache class present -> NVCA deploys Samba -> Samba
-//  4. otherwise             -> per-pod emptyDir fallback  -> Ephemeral
+//  4. otherwise                               -> per-pod emptyDir fallback -> Ephemeral
+//
+// NVMesh is identified by the provisioner on the model cache class, the same
+// way any other backend is. It was previously identified by the presence of a
+// marker class, nvcf-sc-30, which deployment templates no longer render; every
+// NVMesh deployment now runs a version with cross-namespace volume sharing, so
+// the marker distinguished nothing.
 //
 // modelCacheStorageClass is Agent.ModelCache.StorageClassName, the same config
 // value the storage controller provisions model cache volumes with; empty
@@ -104,11 +107,12 @@ func SelectHelmCacheBackend(
 		return HelmCacheBackendNone, nil
 	}
 
-	nvmeshPresent, err := storageClassExists(ctx, c, NVMeshStorageClassName)
+	dataClass := ModelCacheStorageClassName(modelCacheStorageClass)
+	provisioner, dataClassPresent, err := storageClassProvisioner(ctx, c, dataClass)
 	if err != nil {
 		return "", err
 	}
-	if nvmeshPresent {
+	if dataClassPresent && provisioner == NVMeshStorageClassProvisioner {
 		return HelmCacheBackendNVMesh, nil
 	}
 
@@ -128,11 +132,6 @@ func SelectHelmCacheBackend(
 		// threshold: the ModelCacheRequest would requeue indefinitely and block
 		// the install instead of degrading. Verify the class first and take the
 		// ephemeral cache when it is missing.
-		dataClass := ModelCacheStorageClassName(modelCacheStorageClass)
-		dataClassPresent, err := storageClassExists(ctx, c, dataClass)
-		if err != nil {
-			return "", err
-		}
 		if dataClassPresent {
 			return HelmCacheBackendSamba, nil
 		}
@@ -147,13 +146,20 @@ func SelectHelmCacheBackend(
 // storageClassExists reports whether a cluster-scoped StorageClass exists,
 // treating NotFound as a clean negative.
 func storageClassExists(ctx context.Context, c client.Client, name string) (bool, error) {
+	_, found, err := storageClassProvisioner(ctx, c, name)
+	return found, err
+}
+
+// storageClassProvisioner returns the provisioner of a cluster-scoped
+// StorageClass and whether it exists, treating NotFound as a clean negative.
+func storageClassProvisioner(ctx context.Context, c client.Client, name string) (string, bool, error) {
 	sc := &storagev1.StorageClass{}
 	switch err := c.Get(ctx, client.ObjectKey{Name: name}, sc); {
 	case apierrors.IsNotFound(err):
-		return false, nil
+		return "", false, nil
 	case err != nil:
-		return false, fmt.Errorf("get storageclass %q: %w", name, err)
+		return "", false, fmt.Errorf("get storageclass %q: %w", name, err)
 	default:
-		return true, nil
+		return sc.Provisioner, true, nil
 	}
 }

--- a/src/compute-plane-services/nvca/pkg/storage/cachebackend_samba.go
+++ b/src/compute-plane-services/nvca/pkg/storage/cachebackend_samba.go
@@ -38,8 +38,9 @@ import (
 
 // Samba-on-NVMesh model cache backend (HelmCacheBackendSamba).
 //
-// Selected when CachingSupport is on, neither nvcf-sc-30 (NVMesh 3.x) nor an
-// operator-provided nvcf-miniservice-sc exists, and HelmSharedStorage is enabled.
+// Selected when CachingSupport is on, the model cache class is not provisioned
+// by NVMesh, no operator-provided nvcf-miniservice-sc exists, and
+// HelmSharedStorage is enabled.
 //
 // Each cacheHandle gets its OWN Samba server (Deployment + Service) backed by
 // its OWN block-storage data PVC on the model cache storage class

--- a/src/compute-plane-services/nvca/pkg/storage/cachebackend_test.go
+++ b/src/compute-plane-services/nvca/pkg/storage/cachebackend_test.go
@@ -39,6 +39,17 @@ func storageClass(name string) *storagev1.StorageClass {
 	return &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: name}}
 }
 
+func storageClassWithProvisioner(name, provisioner string) *storagev1.StorageClass {
+	sc := storageClass(name)
+	sc.Provisioner = provisioner
+	return sc
+}
+
+// nvmeshClass is the model cache class as an NVMesh deployment renders it.
+func nvmeshClass() *storagev1.StorageClass {
+	return storageClassWithProvisioner(DefaultModelCacheStorageClassName, NVMeshStorageClassProvisioner)
+}
+
 func cacheBackendClient(t *testing.T, scs ...*storagev1.StorageClass) *fake.ClientBuilder {
 	t.Helper()
 	sch := runtime.NewScheme()
@@ -72,28 +83,28 @@ func TestSelectHelmCacheBackend(t *testing.T) {
 		{
 			name:  "caching disabled -> none",
 			flags: nil,
-			// nvcf-sc-30 present but caching off: still none.
-			storageClasses: []*storagev1.StorageClass{storageClass(NVMeshStorageClassName)},
+			// NVMesh class present but caching off: still none.
+			storageClasses: []*storagev1.StorageClass{nvmeshClass()},
 			want:           HelmCacheBackendNone,
 		},
 		{
 			name:  "HelmModelCaching off -> none",
 			flags: []*featureflag.FeatureFlag{featureflag.CachingSupport},
-			// CachingSupport on and nvcf-sc-30 present, but the Helm sub-gate
+			// CachingSupport on and NVMesh class present, but the Helm sub-gate
 			// is off: no backend is selected.
-			storageClasses: []*storagev1.StorageClass{storageClass(NVMeshStorageClassName)},
+			storageClasses: []*storagev1.StorageClass{nvmeshClass()},
 			want:           HelmCacheBackendNone,
 		},
 		{
 			name:           "CachingSupport off, HelmModelCaching on -> none",
 			flags:          []*featureflag.FeatureFlag{featureflag.HelmModelCaching},
-			storageClasses: []*storagev1.StorageClass{storageClass(NVMeshStorageClassName)},
+			storageClasses: []*storagev1.StorageClass{nvmeshClass()},
 			want:           HelmCacheBackendNone,
 		},
 		{
-			name:           "nvcf-sc-30 present -> nvmesh",
+			name:           "model cache class provisioned by nvmesh -> nvmesh",
 			flags:          cachingOnly,
-			storageClasses: []*storagev1.StorageClass{storageClass(NVMeshStorageClassName)},
+			storageClasses: []*storagev1.StorageClass{nvmeshClass()},
 			want:           HelmCacheBackendNVMesh,
 		},
 		{
@@ -106,7 +117,7 @@ func TestSelectHelmCacheBackend(t *testing.T) {
 			name:  "both classes present -> nvmesh wins",
 			flags: cachingOnly,
 			storageClasses: []*storagev1.StorageClass{
-				storageClass(NVMeshStorageClassName),
+				nvmeshClass(),
 				storageClass(HelmCacheSharedStorageClassName),
 			},
 			want: HelmCacheBackendNVMesh,
@@ -156,13 +167,38 @@ func TestSelectHelmCacheBackend(t *testing.T) {
 			want: HelmCacheBackendSharedFS,
 		},
 		{
-			name:  "nvcf-sc-30 takes precedence over samba",
-			flags: cachingAndSamba,
+			name:           "nvmesh class takes precedence over samba",
+			flags:          cachingAndSamba,
+			storageClasses: []*storagev1.StorageClass{nvmeshClass()},
+			want:           HelmCacheBackendNVMesh,
+		},
+		{
+			// A model cache class exists but is not NVMesh: presence alone
+			// selects nothing.
+			name:  "model cache class with another provisioner -> not nvmesh",
+			flags: cachingOnly,
 			storageClasses: []*storagev1.StorageClass{
-				storageClass(NVMeshStorageClassName),
-				storageClass(DefaultModelCacheStorageClassName),
+				storageClassWithProvisioner(DefaultModelCacheStorageClassName, "csi.weka.io"),
 			},
-			want: HelmCacheBackendNVMesh,
+			want: HelmCacheBackendEphemeral,
+		},
+		{
+			name:  "nvmesh detection honors the model cache class override",
+			flags: cachingOnly,
+			storageClasses: []*storagev1.StorageClass{
+				storageClassWithProvisioner("custom-block-sc", NVMeshStorageClassProvisioner),
+			},
+			modelCacheClass: "custom-block-sc",
+			want:            HelmCacheBackendNVMesh,
+		},
+		{
+			// The override moves the check: an NVMesh default class no longer
+			// counts when the agent is configured to use another class.
+			name:            "override set but only the nvmesh default class exists -> not nvmesh",
+			flags:           cachingOnly,
+			storageClasses:  []*storagev1.StorageClass{nvmeshClass()},
+			modelCacheClass: "custom-block-sc",
+			want:            HelmCacheBackendEphemeral,
 		},
 		{
 			// Caching off short-circuits before any class lookup.
@@ -194,27 +230,40 @@ func TestModelCacheStorageClassNameResolution(t *testing.T) {
 // Samba backing class surfaces as an error rather than silently degrading to the
 // ephemeral cache: a transient API error must be retried, not treated as an
 // absent StorageClass.
-func TestSelectHelmCacheBackend_SambaClassLookupError(t *testing.T) {
-	sch := runtime.NewScheme()
-	require.NoError(t, storagev1.AddToScheme(sch))
-	c := fake.NewClientBuilder().WithScheme(sch).
-		WithInterceptorFuncs(interceptor.Funcs{
-			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey,
-				obj client.Object, opts ...client.GetOption,
-			) error {
-				if key.Name == DefaultModelCacheStorageClassName {
-					return apierrors.NewServiceUnavailable("storageclass lookup failed")
-				}
-				return cl.Get(ctx, key, obj, opts...)
-			},
-		}).Build()
-	ff := &featureflagmock.Fetcher{EnabledFFs: []*featureflag.FeatureFlag{
-		featureflag.CachingSupport,
-		featureflag.HelmModelCaching,
-		&featureflag.HelmSharedStorage.FeatureFlag,
-	}}
+// TestSelectHelmCacheBackend_ModelCacheClassLookupError pins that a failed
+// lookup of the model cache class surfaces as an error whether or not Samba is
+// enabled. NVMesh is identified by that class's provisioner, so the class is
+// read on every selection; a transient API error must requeue rather than
+// silently pick a fallback.
+func TestSelectHelmCacheBackend_ModelCacheClassLookupError(t *testing.T) {
+	base := []*featureflag.FeatureFlag{featureflag.CachingSupport, featureflag.HelmModelCaching}
+	tests := []struct {
+		name  string
+		flags []*featureflag.FeatureFlag
+	}{
+		{name: "samba off", flags: base},
+		{name: "samba on", flags: append(append([]*featureflag.FeatureFlag{}, base...), &featureflag.HelmSharedStorage.FeatureFlag)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sch := runtime.NewScheme()
+			require.NoError(t, storagev1.AddToScheme(sch))
+			c := fake.NewClientBuilder().WithScheme(sch).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey,
+						obj client.Object, opts ...client.GetOption,
+					) error {
+						if key.Name == DefaultModelCacheStorageClassName {
+							return apierrors.NewServiceUnavailable("storageclass lookup failed")
+						}
+						return cl.Get(ctx, key, obj, opts...)
+					},
+				}).Build()
+			ff := &featureflagmock.Fetcher{EnabledFFs: tt.flags}
 
-	_, err := SelectHelmCacheBackend(t.Context(), c, ff, "")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), DefaultModelCacheStorageClassName)
+			_, err := SelectHelmCacheBackend(t.Context(), c, ff, "")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), DefaultModelCacheStorageClassName)
+		})
+	}
 }


### PR DESCRIPTION
## Why

Helm model cache backend selection identified NVMesh by the presence of a marker StorageClass, `nvcf-sc-30`. That marker no longer exists in deployment templates, and every NVMesh deployment now runs a version with cross-namespace volume sharing, so it no longer distinguishes anything. On a cluster provisioned from current templates the check fails and Helm caching silently degrades to the Samba fallback or a per-pod cache, with nothing alerting.

## What changed

NVMesh is identified the way every other backend is: by the provisioner on the model cache class (`nvcf-sc`, or the configured override). If that class is provisioned by `nvmesh-csi.excelero.com`, the backend is NVMesh. The NVMesh execution path is untouched; only its selection moved.

`NVMeshStorageClassName` is removed. `storageClassExists` is now a thin wrapper over a new `storageClassProvisioner` helper. The user doc's backend table and two API comments are updated to match.

One deliberate behavior change: the model cache class is read on every selection, not only when the Samba fallback is reachable. A transient API error on that lookup now fails selection so the reconcile requeues, instead of choosing a fallback without knowing what the class is. `TestSelectHelmCacheBackend_ModelCacheClassLookupError` pins this for both Samba states.

## Customer Release Notes

Fixed Helm model caching not detecting NVMesh on clusters where the `nvcf-sc-30` StorageClass is not present, which caused caching to fall back to a slower backend.

## Plan Summary

Not applicable.

## Usage

No operator action. Clusters whose model cache class is provisioned by NVMesh select the NVMesh backend whether or not `nvcf-sc-30` exists.

## Testing

- `TestSelectHelmCacheBackend`: 17 cases, including three new ones: a model cache class with another provisioner does not select NVMesh; the class override is honored; an NVMesh default class is ignored when an override names another class.
- Downgrading the check to presence-only fails four cases, including three existing Samba cases, so the provisioner comparison is load-bearing for existing behavior.
- `go test ./pkg/storage/... ./internal/miniservice/...` and `golangci-lint` clean.

QA not needed beyond an NVMesh cluster confirming the `nvmesh` backend is selected without `nvcf-sc-30`.

## Notes

`docs/dev/sdd-central-model-cache-service.md` still describes the marker class and is not edited here, because #1334 deletes that file in favor of one design document. Whichever of the two lands second gets a one-line update to the "What runs today" section.

## References

None.

## Related Pull Requests

- #1334 (design document), #1434 (derived readers)

## Dependencies

None.

## Issues

Relates to #1326


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved model-cache backend detection by identifying NVMesh through the configured StorageClass provisioner rather than a specific class name.
  - Updated fallback selection for non-NVMesh environments, including operator-provided Samba cache configurations.
  - Improved handling and reporting of model-cache StorageClass lookup errors.

- **Documentation**
  - Clarified the NVMesh backend requirements and provisioning behavior in model-cache documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->