### PR TITLE
test(bdd): centralize grpcurl preflight checks

### DIFF
--- a/tests/bdd/features/multi-cluster-helmfile-llm-registration-tls.feature
+++ b/tests/bdd/features/multi-cluster-helmfile-llm-registration-tls.feature
@@ -21,8 +21,6 @@ Feature: Register an LLM worker securely with a local split-cluster routing plan
       | addons.llm.requestRouter.backendRouter.pylonGrpcDialAddress | https://llm-request-router.nvcf.svc.cluster.local:50071                     |
       | observability.profile                                    | disabled                                                                     |
     And I prepare self-managed secrets file "deploy/stacks/self-managed/secrets/local-bdd-registration-tls-secrets.yaml" from template "deploy/stacks/self-managed/secrets/secrets.yaml.template" using the current NGC registry credential
-    # Explore a shared BDD preflight so feature files need not repeat this check: https://github.com/NVIDIA/nvcf/issues/1411
-    When I successfully run command "/bin/sh -c 'command -v grpcurl >/dev/null'"
     # Conflict precheck: the single-cluster topology owns the same host
     # ports. Run make -C tools/ncp-local-cluster destroy CLUSTER_NAME=ncp-local
     # before retrying. k3d v5 exits 1 when the cluster is absent.

--- a/tests/bdd/godog_test.go
+++ b/tests/bdd/godog_test.go
@@ -2366,6 +2366,9 @@ func TestMultiClusterHelmfileLLMRegistrationTLS(t *testing.T) {
 	if testing.Short() {
 		t.Skip("live run skipped under -short")
 	}
+	if err := harness.CheckExternalTools([]string{"grpcurl"}); err != nil {
+		t.Fatal(err)
+	}
 	runLiveFeature(t, "multi-cluster-helmfile-llm-registration-tls.feature")
 }
 

--- a/tests/bdd/godog_test.go
+++ b/tests/bdd/godog_test.go
@@ -1438,7 +1438,6 @@ func TestMultiClusterHelmfileLLMRegistrationTLSFeatureFileWiresToSteps(t *testin
 	t.Setenv("REPO_ROOT", "/repo-root-placeholder")
 
 	const (
-		grpcurlPreflightCommand = `/bin/sh -c 'command -v grpcurl >/dev/null'`
 		tlsHandshakeCommand     = `/bin/bash -c 'openssl s_client -connect 127.0.0.1:50071 ` +
 			`-servername llm-request-router.nvcf.svc.cluster.local -alpn h2 -verify_return_error ` +
 			`-CAfile <(kubectl --context k3d-ncp-local-cp get secret stargate-quic-tls -n nvcf ` +
@@ -1465,7 +1464,6 @@ func TestMultiClusterHelmfileLLMRegistrationTLSFeatureFileWiresToSteps(t *testin
 
 	suite := newWiringSuite(t, newFakeRunner(map[string]harness.Result{
 		"k3d cluster get ncp-local": {ExitCode: 1},
-		grpcurlPreflightCommand:     {ExitCode: 0},
 		"kubectl --context k3d-ncp-local-cp get configmap/nvcf-api-remote-config -n nvcf -o yaml": {
 			ExitCode: 0,
 			Stdout:   "worker-address: https://llm-request-router.nvcf.svc.cluster.local:50071\n",
@@ -1554,9 +1552,6 @@ func TestMultiClusterHelmfileLLMRegistrationTLSFeatureFileWiresToSteps(t *testin
 		t.Fatal("plaintext WatchStargates rejection was not exercised")
 	}
 	runs := suite.Runner.(*fakeRunner).runs
-	if !commandRanExactly(runs, grpcurlPreflightCommand) {
-		t.Fatal("grpcurl availability was not checked before the live probes")
-	}
 	if !commandRanExactly(runs, invalidAuthorityCommand) {
 		t.Fatal("invalid registration authority was not rejected before installation")
 	}

--- a/tests/bdd/harness/preflight.go
+++ b/tests/bdd/harness/preflight.go
@@ -1,0 +1,40 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package harness
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// CheckExternalTools verifies that each named executable is present in PATH.
+// It returns an error naming every missing tool so the operator knows what to
+// install before retrying the suite.
+func CheckExternalTools(names []string) error {
+	var missing []string
+	for _, name := range names {
+		if _, err := exec.LookPath(name); err != nil {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf("required external tool(s) not found in PATH: %s", strings.Join(missing, ", "))
+}

--- a/tests/bdd/harness/preflight_test.go
+++ b/tests/bdd/harness/preflight_test.go
@@ -1,0 +1,60 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package harness
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckExternalToolsNilSucceeds(t *testing.T) {
+	if err := CheckExternalTools(nil); err != nil {
+		t.Fatalf("CheckExternalTools(nil) returned error: %v", err)
+	}
+}
+
+func TestCheckExternalToolsFoundTool(t *testing.T) {
+	// "sh" is present on every supported platform.
+	if err := CheckExternalTools([]string{"sh"}); err != nil {
+		t.Fatalf("CheckExternalTools reported sh as missing: %v", err)
+	}
+}
+
+func TestCheckExternalToolsMissingToolReportsName(t *testing.T) {
+	const absent = "nvcf-bdd-tool-that-does-not-exist"
+	err := CheckExternalTools([]string{absent})
+	if err == nil {
+		t.Fatal("CheckExternalTools returned nil for a missing tool")
+	}
+	if !strings.Contains(err.Error(), absent) {
+		t.Fatalf("error does not contain tool name %q: %v", absent, err)
+	}
+}
+
+func TestCheckExternalToolsReportsAllMissing(t *testing.T) {
+	names := []string{"nvcf-bdd-absent-1", "nvcf-bdd-absent-2"}
+	err := CheckExternalTools(names)
+	if err == nil {
+		t.Fatal("CheckExternalTools returned nil for missing tools")
+	}
+	for _, name := range names {
+		if !strings.Contains(err.Error(), name) {
+			t.Errorf("error does not contain tool name %q: %v", name, err)
+		}
+	}
+}

--- a/tests/bdd/harness/suite.go
+++ b/tests/bdd/harness/suite.go
@@ -79,9 +79,6 @@ func NewSuite(t *testing.T) (*Suite, error) {
 		EnvLedger: NewEnvLedger(),
 		Cache:     NewCommandCache(),
 	}
-	if err := CheckExternalTools([]string{"grpcurl"}); err != nil {
-		return nil, err
-	}
 	// Pre-suite destructive cleanup (BDD_CLEANUP_MODE) runs BEFORE
 	// snapshotting the CLI state file. Rationale: any destructive
 	// mode invalidates the operator's pre-suite admin JWT (the cluster

--- a/tests/bdd/harness/suite.go
+++ b/tests/bdd/harness/suite.go
@@ -79,6 +79,9 @@ func NewSuite(t *testing.T) (*Suite, error) {
 		EnvLedger: NewEnvLedger(),
 		Cache:     NewCommandCache(),
 	}
+	if err := CheckExternalTools([]string{"grpcurl"}); err != nil {
+		return nil, err
+	}
 	// Pre-suite destructive cleanup (BDD_CLEANUP_MODE) runs BEFORE
 	// snapshotting the CLI state file. Rationale: any destructive
 	// mode invalidates the operator's pre-suite admin JWT (the cluster


### PR DESCRIPTION
## Why

Feature files that use grpcurl repeated an inline shell preflight in their Background:

```gherkin
When I successfully run command "/bin/sh -c 'command -v grpcurl >/dev/null'"
```

This mixes runner prerequisites into product-focused Gherkin. The comment on that line already pointed at this issue as the intended fix.

## What changed

- Added `harness.CheckExternalTools(names []string) error` in `harness/preflight.go`. It uses `exec.LookPath` to check each named tool and returns an error listing every missing executable so the operator knows what to install.
- Called `CheckExternalTools([]string{"grpcurl"})` in `TestMultiClusterHelmfileLLMRegistrationTLS`, the only live entry point whose scenarios use grpcurl. A missing tool fails that suite before any scenario runs with: `required external tool(s) not found in PATH: grpcurl`. `NewSuite` remains tool-agnostic so unrelated suites are unaffected.
- Removed the two-line grpcurl `command -v` block (step + comment) from `multi-cluster-helmfile-llm-registration-tls.feature`.
- Removed the matching `grpcurlPreflightCommand` const, fake-runner entry, and post-run assertion from the TLS wiring test in `godog_test.go`. Coverage of the preflight mechanism moves to focused unit tests in `harness/preflight_test.go`.

## Customer Release Notes

Not customer visible.

## Plan Summary

Not applicable.

## Usage

No operator action required. Install grpcurl before running the TLS registration live BDD suite.

## Testing

- `go test -short ./...` passes from `tests/bdd/` (all four packages green).
- `tests/bdd/scripts/lint.sh` reports 0 issues.
- `harness/preflight_test.go` covers nil list, present tool, single missing tool, and multiple missing tools.
- Verified on a machine without grpcurl that `CheckExternalTools([]string{"grpcurl"})` returns `required external tool(s) not found in PATH: grpcurl`.

## Notes

To extend the preflight to another tool, add a `harness.CheckExternalTools` call in the relevant live entry point.

## References

Closes #1411

## Related Pull Requests

None.

## Dependencies

None.
