### PR TITLE
fix(ratelimiter): pick up olric routing table convergence fix

### DIFF
--- a/src/invocation-plane-services/llm-api-gateway/go.mod
+++ b/src/invocation-plane-services/llm-api-gateway/go.mod
@@ -158,6 +158,6 @@ require (
 // `cas`). The fork keeps upstream's module path so this is a drop-in
 // replace with no import-site changes. Once CAS is upstreamed into
 // olric-data/olric, drop the replace and bump the require. See AGENTS.md.
-replace github.com/olric-data/olric => github.com/max007-008/olric v0.0.0-20260506001115-492943853c7b
+replace github.com/olric-data/olric => github.com/max007-008/olric v0.0.0-20260903172631-1d7a94c91260
 
 replace k8s.io/client-go v11.0.0+incompatible => k8s.io/client-go v0.34.2

--- a/src/invocation-plane-services/llm-api-gateway/go.sum
+++ b/src/invocation-plane-services/llm-api-gateway/go.sum
@@ -229,8 +229,8 @@ github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/max007-008/olric v0.0.0-20260506001115-492943853c7b h1:u1ecx6l5gNH5xF7tk1TyWY9iRBACS9yGsqZ0iW4QyKE=
-github.com/max007-008/olric v0.0.0-20260506001115-492943853c7b/go.mod h1:+ZnPpgc8JkNkza8rETCKGn0P/QPF6HhZY0EbCKAOslo=
+github.com/max007-008/olric v0.0.0-20260903172631-1d7a94c91260 h1:6ug2ACJNMB1QxrBowyXGk82prHFeDSLi3/4gvmQJtb0=
+github.com/max007-008/olric v0.0.0-20260903172631-1d7a94c91260/go.mod h1:+ZnPpgc8JkNkza8rETCKGn0P/QPF6HhZY0EbCKAOslo=
 github.com/maypok86/otter/v2 v2.3.0 h1:8H8AVVFUSzJwIegKwv1uF5aGitTY+AIrtktg7OcLs8w=
 github.com/maypok86/otter/v2 v2.3.0/go.mod h1:XgIdlpmL6jYz882/CAx1E4C1ukfgDKSaw4mWq59+7l8=
 github.com/miekg/dns v1.1.65 h1:0+tIPHzUW0GCge7IiK3guGP57VAw7hoPDfApjkMD1Fc=

--- a/src/invocation-plane-services/ratelimiter/go.mod
+++ b/src/invocation-plane-services/ratelimiter/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2
 	github.com/jellydator/ttlcache/v3 v3.4.0
 	github.com/lestrrat-go/jwx v1.2.31
-	github.com/olric-data/olric v0.7.1
+	github.com/olric-data/olric v0.7.3
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -153,3 +153,12 @@ exclude (
 )
 
 replace k8s.io/client-go v11.0.0+incompatible => k8s.io/client-go v0.34.2
+
+// olric is redirected to a fork carrying two changes that are not upstream: the
+// CompareAndSwap primitive the LLM gateway needs, and a routing table rebuild
+// that probes partitions concurrently instead of serially. The serial rebuild
+// stalled the coordinator long enough for joining pods to miss their bootstrap
+// timeout and crashloop. The fork keeps upstream's module path, so this must
+// stay identical to the replace in llm-api-gateway/go.mod; the Bazel build
+// resolves one olric for the whole workspace.
+replace github.com/olric-data/olric => github.com/max007-008/olric v0.0.0-20260903172631-1d7a94c91260

--- a/src/invocation-plane-services/ratelimiter/go.sum
+++ b/src/invocation-plane-services/ratelimiter/go.sum
@@ -235,6 +235,8 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/max007-008/olric v0.0.0-20260903172631-1d7a94c91260 h1:6ug2ACJNMB1QxrBowyXGk82prHFeDSLi3/4gvmQJtb0=
+github.com/max007-008/olric v0.0.0-20260903172631-1d7a94c91260/go.mod h1:+ZnPpgc8JkNkza8rETCKGn0P/QPF6HhZY0EbCKAOslo=
 github.com/miekg/dns v1.1.65 h1:0+tIPHzUW0GCge7IiK3guGP57VAw7hoPDfApjkMD1Fc=
 github.com/miekg/dns v1.1.65/go.mod h1:Dzw9769uoKVaLuODMDZz9M6ynFU6Em65csPuoi8G0ck=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
@@ -253,8 +255,6 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/olric-data/olric v0.7.1 h1:157u6FmLYSAOieoyuYNC5UBgoBCwjK9V+c5bKZp9w0w=
-github.com/olric-data/olric v0.7.1/go.mod h1:+ZnPpgc8JkNkza8rETCKGn0P/QPF6HhZY0EbCKAOslo=
 github.com/onsi/ginkgo/v2 v2.21.0 h1:7rg/4f3rB88pb5obDgNZrNHrQ4e6WpjonchcpuBRnZM=
 github.com/onsi/ginkgo/v2 v2.21.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/onsi/gomega v1.35.1 h1:Cwbd75ZBPxFSuZ6T+rN/WCb/gOc6YgFBXLlZLhC7Ds4=


### PR DESCRIPTION
## Why

A ratelimiter pod joining an existing cluster could fail to receive a routing
table, give up after the 10s bootstrap timeout, exit and crashloop, while
serving pods routed to owners that no longer answered. Redeploying the previous
image did not clear it, because the bad state lives in the running cluster
rather than in the image; recovery needed every pod restarted.

Root cause is in olric. `fillRoutingTable` rebuilds partition ownership by
asking each owner how many keys it holds for a partition, so empty owners can be
pruned. That probe is a blocking network round trip and it ran once per owner
per partition, sequentially, while `updateRouting` held the routing table lock
on the single cluster-event goroutine.

At the default `PartitionCount` of 271 that is 271 sequential round trips per
routing update. Healthy owners answer in microseconds so it is invisible, but
the cost is linear in probe latency, and anything above roughly 37ms per probe
pushes one routing update past a joining node's bootstrap timeout. Measured with
an injected delay:

| probe latency | fillRoutingTable |
|---|---|
| 50ms | 13.95s |
| 200ms | ~54s |

It is self-sustaining: the joining pod exits, its restart churns membership, and
that triggers another rebuild. It also explains why deleting every pod recovers
instantly, since a freshly formed ring has empty partitions and takes the early
return in `distributePrimaryCopies` with zero probes.

Note this supersedes the explanation in #1493. That change bounded the gRPC
drain so a terminating pod always broadcasts its Olric leave. It does what it
claims, verified on a deployed build, but it does not fix this: a pod that had
broadcast its leave cleanly was still being dialled by its peers minutes later,
because a clean leave removes a member from memberlist without rebuilding the
routing table.

## What changed

Bumps olric to a fork commit that probes partitions concurrently, bounds each
probe, and skips owners that already failed during the same rebuild. The 200ms
case drops from ~54s to 1.8s.

llm-api-gateway moves to the same commit because both modules resolve a single
olric through `go.work.bazel`; differing `replace` directives are a build error
and Bazel produces one repository for the module path. The ratelimiter now also
declares the `require` and `replace` directly rather than inheriting them from
the gateway, so a future olric change is visible in its own subtree instead of
arriving silently.

## Customer Release Notes

Fixed a rate limiter failure where pods starting during a rolling update could
fail to join the distributed cache cluster and crashloop, degrading rate limit
enforcement until every pod was restarted.

## Plan Summary

Not applicable

## Usage

Not applicable

## Testing

Ratelimiter and llm-api-gateway suites pass, including the gateway's
`ratelimit` and `ratelimitsync` packages that exercise CompareAndSwap.

Reproduced and verified two ways. A Go harness with three nodes, populated
partitions and an injected 200ms probe delay: a joiner with the production 10s
bootstrap timeout fails with `operation timeout` before the change and succeeds
in 3.1s after. And a local k3d deployment of three pods using the ratelimiter's
own k8s discovery: two of three pods enter CrashLoopBackOff with
`NewDMap failed after 10.000127921s: operation timeout` before, all three
healthy after, and deleting a pod from a populated ring gives a healthy
replacement in 3.8s.

The olric change carries its own unit tests for the probe bound and the
per-rebuild memoization.

## Notes

The fix lives on the fork this repo already depends on for CompareAndSwap, so
there is no new dependency, only a commit bump. It is worth upstreaming to
olric-data/olric later; the serial probe loop dates to 2021 and is untouched
upstream.

`fillRoutingTableConcurrency` is 32. A failed probe still leaves the owner in
place, since pruning on an unanswered probe would drop an owner that may hold
data.

## References

Closes #1520
Supersedes the root cause stated in #1493

## Related Pull Requests

#1494

## Dependencies

No new dependencies. Existing `github.com/max007-008/olric` replacement moves
from `v0.0.0-20260506001115-492943853c7b` to
`v0.0.0-20260903172631-1d7a94c91260`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying service components to newer dependency revisions.
  * Improved compatibility and stability for rate-limiting and request-processing services.
  * No changes to public APIs or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->