### PR TITLE
fix(vanity-gateway): stop an LLM Gateway outage from failing the probes

### DIFF
--- a/src/invocation-plane-services/vanity-gateway/README.md
+++ b/src/invocation-plane-services/vanity-gateway/README.md
@@ -271,7 +271,11 @@ v2config:
 Callers send the public `modelName`, exactly as they do for any other model on
 this host. The gateway looks the model up, rewrites the request `model` to
 `functionID/modelName`, and forwards it to `LLM_GATEWAY_ENDPOINT`, which routes
-on that prefix. Callers never see the function ID.
+on that prefix, so a caller never has to supply a function ID.
+
+Only the request is rewritten. The LLM Gateway echoes the model it was given,
+so the `model` field of the response carries `functionID/modelName` back to the
+caller.
 
 `function-id`, `function-version-id`, and `nvcf-function-id` are stripped from
 these requests. The LLM Gateway resolves the function from the model, so the

--- a/src/invocation-plane-services/vanity-gateway/README.md
+++ b/src/invocation-plane-services/vanity-gateway/README.md
@@ -428,6 +428,14 @@ curl -v localhost:10083/metrics
 `llm api gateway` check probes `/healthz` on `LLM_GATEWAY_ENDPOINT`, since the
 LLM Gateway does not serve `/health`.
 
+The two checks differ in what a failure does. A failing `nvcf api` check returns
+`503`, because that upstream serves every route. A failing `llm api gateway`
+check is reported in the response body but still returns `200`: deployments wire
+`/health` to both the readiness and liveness probes, so failing it would restart
+every pod and drop invocation-service routing when only the LLM Gateway is down.
+Requests for an LLM-routed model return `502` for as long as that upstream is
+unreachable, and everything else keeps serving.
+
 `nvcf_ai_api_gateway_shadow_requests_dropped_total` counts shadow dispatches
 dropped before replay. The `openai_model_name` label identifies the shadow
 target. The `reason` label is one of `body_read_error`, `body_rewrite_error`,

--- a/src/invocation-plane-services/vanity-gateway/README.md
+++ b/src/invocation-plane-services/vanity-gateway/README.md
@@ -273,9 +273,10 @@ this host. The gateway looks the model up, rewrites the request `model` to
 `functionID/modelName`, and forwards it to `LLM_GATEWAY_ENDPOINT`, which routes
 on that prefix, so a caller never has to supply a function ID.
 
-Only the request is rewritten. The LLM Gateway echoes the model it was given,
-so the `model` field of the response carries `functionID/modelName` back to the
-caller.
+Only the request is rewritten. On `/v1/chat/completions` the LLM Gateway echoes
+the model it was given, so the `model` field of the response, and of every
+streamed chunk, carries `functionID/modelName` back to the caller.
+`/v1/responses` and `/v1/embeddings` return the public model name instead.
 
 `function-id`, `function-version-id`, and `nvcf-function-id` are stripped from
 these requests. The LLM Gateway resolves the function from the model, so the

--- a/src/invocation-plane-services/vanity-gateway/gateway/health.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway/health.go
@@ -42,6 +42,10 @@ func healthManager(nvcfApiHost string, llmGatewayEndpoint string, transport http
 		if err != nil {
 			return nil, err
 		}
+		// /health is wired to both probes, so a gating check here would restart
+		// every pod and drop invocation-service routing when only the LLM
+		// Gateway is down. SkipOnErr reports the failure without the 503.
+		llmCheck.SkipOnErr = true
 		options = append(options, health.WithChecks(llmCheck))
 	}
 

--- a/src/invocation-plane-services/vanity-gateway/gateway/llm_gateway_director_test.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway/llm_gateway_director_test.go
@@ -21,6 +21,7 @@ import (
 	config "ai-api-gateway-service/gateway_config"
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -429,7 +430,15 @@ func TestBuildChiMux_LLMGatewayOutageDoesNotFailHealth(t *testing.T) {
 
 	code, body := probe(up.URL, down.URL)
 	assert.Equal(t, http.StatusOK, code, "an LLM Gateway outage must not fail the probes")
-	assert.Contains(t, body, "llm api gateway", "the failure must still be reported in the body")
+
+	var reported struct {
+		Status   string            `json:"status"`
+		Failures map[string]string `json:"failures"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &reported))
+	assert.Equal(t, "Partially Available", reported.Status)
+	assert.Contains(t, reported.Failures, "llm api gateway",
+		"the failed check must still be reported so alerting can see it")
 
 	code, _ = probe(down.URL, up.URL)
 	assert.Equal(t, http.StatusServiceUnavailable, code, "an nvcf api outage must still fail the probes")
@@ -547,8 +556,17 @@ func TestOpenAIDirector_LLMShortCircuitSuppressesShadow(t *testing.T) {
 			mux.ServeHTTP(rec, openAIRequest(t, "/v1/chat/completions",
 				`{"model":"`+publicModel+`","messages":[]}`))
 			assert.Equal(t, tc.want, rec.Code)
-			assert.Empty(t, llmRequests, "no shadow may be dispatched after a short circuit")
-			assert.Empty(t, nvcfRequests)
+			// Shadow dispatch runs on its own goroutine, so give it time to
+			// arrive rather than sampling the channel once.
+			for name, requests := range map[string]chan capturedRequest{
+				"LLM Gateway": llmRequests, "invocation service": nvcfRequests,
+			} {
+				select {
+				case got := <-requests:
+					t.Fatalf("a short circuit dispatched a shadow to the %s: %+v", name, got)
+				case <-time.After(200 * time.Millisecond):
+				}
+			}
 		})
 	}
 }
@@ -578,6 +596,8 @@ func TestOpenAIDirector_LLMModelLegacyShadowModelName(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	bodies := awaitRequest(t, llmRequests).body + awaitRequest(t, llmRequests).body
+	assert.Contains(t, bodies, `"model":"`+llmFunctionID+"/"+publicModel+`"`,
+		"the primary must still be dispatched with its own model")
 	assert.Contains(t, bodies, `"model":"llm-shadow-func/meta/llama-shadow"`,
 		"the legacy singular field must dispatch on an LLM entry")
 }

--- a/src/invocation-plane-services/vanity-gateway/gateway/llm_gateway_director_test.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway/llm_gateway_director_test.go
@@ -403,3 +403,37 @@ func TestOpenAIDirector_LLMModelStripsCallerRoutingHeaders(t *testing.T) {
 	assert.Equal(t, "999", received.headers.Get("NVCF-POLL-SECONDS"),
 		"poll seconds is a caller knob the invocation path honors too, not a routing header")
 }
+
+// /health is wired to both the readiness and liveness probes, so a gating LLM
+// check would restart every pod whenever the LLM Gateway is down, taking
+// invocation-service routing with it. The nvcf api is a dependency of every
+// request, so that one stays gating.
+func TestBuildChiMux_LLMGatewayOutageDoesNotFailHealth(t *testing.T) {
+	down := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(down.Close)
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(up.Close)
+
+	probe := func(nvcfEndpoint, llmEndpoint string) (int, string) {
+		mux := openAIMux(t, llmMappings(llmModelEntry()), nvcfEndpoint, llmEndpoint)
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		req.Host = openAIHost
+		mux.ServeHTTP(rec, req)
+		return rec.Code, rec.Body.String()
+	}
+
+	code, body := probe(up.URL, down.URL)
+	assert.Equal(t, http.StatusOK, code, "an LLM Gateway outage must not fail the probes")
+	assert.Contains(t, body, "llm api gateway", "the failure must still be reported in the body")
+
+	code, _ = probe(down.URL, up.URL)
+	assert.Equal(t, http.StatusServiceUnavailable, code, "an nvcf api outage must still fail the probes")
+
+	code, _ = probe(up.URL, up.URL)
+	assert.Equal(t, http.StatusOK, code, "both upstreams healthy is OK")
+}

--- a/src/invocation-plane-services/vanity-gateway/gateway/llm_gateway_director_test.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway/llm_gateway_director_test.go
@@ -437,3 +437,193 @@ func TestBuildChiMux_LLMGatewayOutageDoesNotFailHealth(t *testing.T) {
 	code, _ = probe(up.URL, up.URL)
 	assert.Equal(t, http.StatusOK, code, "both upstreams healthy is OK")
 }
+
+// Shadow targets are resolved from the same table as the primary, so an
+// invocation-service primary can shadow an LLM model. An implementation that
+// branched on the primary alone would send this shadow to the wrong upstream.
+func TestOpenAIDirector_DefaultModelShadowsToLLMGateway(t *testing.T) {
+	llmRequests := make(chan capturedRequest, 2)
+	llmBackend := captureServer(t, llmRequests, nil)
+	nvcfRequests := make(chan capturedRequest, 2)
+	nvcfBackend := captureServer(t, nvcfRequests, nil)
+
+	primary := config.ModelFunctionDetails{
+		ModelName:        "microsoft/phi-2",
+		FunctionID:       "plain-func",
+		ShadowModelNames: []string{publicModel},
+	}
+	mappings := llmMappings(llmModelEntry())
+	mappings.OpenAI.ChatCompletions["plain"] = primary
+	require.NoError(t, mappings.Validate())
+
+	mux := openAIMux(t, mappings, nvcfBackend.URL, llmBackend.URL)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, openAIRequest(t, "/v1/chat/completions",
+		`{"model":"microsoft/phi-2","messages":[{"role":"user","content":"hi"}]}`))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	primaryReq := awaitRequest(t, nvcfRequests)
+	assert.Equal(t, "plain-func", primaryReq.headers.Get("function-id"),
+		"the primary must still reach the invocation service")
+	assert.Contains(t, primaryReq.body, `"model":"microsoft/phi-2"`, "the primary is not rewritten")
+
+	shadowReq := awaitRequest(t, llmRequests)
+	assert.Contains(t, shadowReq.body, `"model":"`+llmFunctionID+"/"+publicModel+`"`,
+		"the shadow is rewritten by its own functionType and sent to the LLM Gateway")
+}
+
+// One request fans out to both upstreams when the shadow list names an LLM
+// model and an invocation-service model.
+func TestOpenAIDirector_ShadowFanOutReachesBothUpstreams(t *testing.T) {
+	llmRequests := make(chan capturedRequest, 3)
+	llmBackend := captureServer(t, llmRequests, nil)
+	nvcfRequests := make(chan capturedRequest, 3)
+	nvcfBackend := captureServer(t, nvcfRequests, nil)
+
+	primary := llmModelEntry()
+	primary.ShadowModelNames = []string{"meta/llama-shadow", "microsoft/phi-2"}
+
+	llmShadow := llmModelEntry()
+	llmShadow.ModelName = "meta/llama-shadow"
+	llmShadow.FunctionID = "llm-shadow-func"
+
+	mappings := &config.GatewayConfig{}
+	mappings.OpenAI.Host = openAIHost
+	mappings.OpenAI.ChatCompletions = map[string]config.ModelFunctionDetails{
+		"llm":        primary,
+		"llm-shadow": llmShadow,
+		"plain":      {ModelName: "microsoft/phi-2", FunctionID: "plain-func"},
+	}
+	require.NoError(t, mappings.Validate())
+
+	mux := openAIMux(t, mappings, nvcfBackend.URL, llmBackend.URL)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, openAIRequest(t, "/v1/chat/completions",
+		`{"model":"`+publicModel+`","messages":[{"role":"user","content":"hi"}]}`))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Primary plus the LLM shadow, each with its own function ID.
+	llmBodies := awaitRequest(t, llmRequests).body + awaitRequest(t, llmRequests).body
+	assert.Contains(t, llmBodies, `"model":"`+llmFunctionID+"/"+publicModel+`"`)
+	assert.Contains(t, llmBodies, `"model":"llm-shadow-func/meta/llama-shadow"`,
+		"the LLM shadow uses its own function ID, not the primary's")
+
+	plain := awaitRequest(t, nvcfRequests)
+	assert.Equal(t, "plain-func", plain.headers.Get("function-id"))
+	assert.Contains(t, plain.body, `"model":"microsoft/phi-2"`, "the invocation-service shadow is not rewritten")
+}
+
+// The status short-circuits run before shadow dispatch, so an offline or
+// expired primary must not replay traffic to either upstream.
+func TestOpenAIDirector_LLMShortCircuitSuppressesShadow(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(*config.ModelFunctionDetails)
+		want   int
+	}{
+		{"offline", func(e *config.ModelFunctionDetails) { e.OfflineMessage = "down for maintenance" }, http.StatusServiceUnavailable},
+		{"expired eol", func(e *config.ModelFunctionDetails) { e.EOL = time.Now().Add(-time.Hour) }, http.StatusGone},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			llmRequests := make(chan capturedRequest, 2)
+			llmBackend := captureServer(t, llmRequests, nil)
+			nvcfRequests := make(chan capturedRequest, 2)
+			nvcfBackend := captureServer(t, nvcfRequests, nil)
+
+			primary := llmModelEntry()
+			primary.ShadowModelNames = []string{"meta/llama-shadow"}
+			tc.mutate(&primary)
+			shadow := llmModelEntry()
+			shadow.ModelName = "meta/llama-shadow"
+
+			mappings := &config.GatewayConfig{}
+			mappings.OpenAI.Host = openAIHost
+			mappings.OpenAI.ChatCompletions = map[string]config.ModelFunctionDetails{
+				"llm": primary, "llm-shadow": shadow,
+			}
+			mux := openAIMux(t, mappings, nvcfBackend.URL, llmBackend.URL)
+
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, openAIRequest(t, "/v1/chat/completions",
+				`{"model":"`+publicModel+`","messages":[]}`))
+			assert.Equal(t, tc.want, rec.Code)
+			assert.Empty(t, llmRequests, "no shadow may be dispatched after a short circuit")
+			assert.Empty(t, nvcfRequests)
+		})
+	}
+}
+
+// The singular legacy field must dispatch on an LLM entry too.
+func TestOpenAIDirector_LLMModelLegacyShadowModelName(t *testing.T) {
+	llmRequests := make(chan capturedRequest, 2)
+	llmBackend := captureServer(t, llmRequests, nil)
+
+	primary := llmModelEntry()
+	primary.ShadowModelName = "meta/llama-shadow"
+	shadow := llmModelEntry()
+	shadow.ModelName = "meta/llama-shadow"
+	shadow.FunctionID = "llm-shadow-func"
+
+	mappings := &config.GatewayConfig{}
+	mappings.OpenAI.Host = openAIHost
+	mappings.OpenAI.ChatCompletions = map[string]config.ModelFunctionDetails{
+		"llm": primary, "llm-shadow": shadow,
+	}
+	require.NoError(t, mappings.Validate())
+
+	mux := openAIMux(t, mappings, "http://nvcf.invalid", llmBackend.URL)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, openAIRequest(t, "/v1/chat/completions",
+		`{"model":"`+publicModel+`","messages":[]}`))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	bodies := awaitRequest(t, llmRequests).body + awaitRequest(t, llmRequests).body
+	assert.Contains(t, bodies, `"model":"llm-shadow-func/meta/llama-shadow"`,
+		"the legacy singular field must dispatch on an LLM entry")
+}
+
+// Mappings are per section: functionType does not make a model reachable on
+// every route the LLM Gateway happens to serve.
+func TestOpenAIDirector_LLMModelIsNotReachableOnUnmappedEndpoints(t *testing.T) {
+	llmRequests := make(chan capturedRequest, 1)
+	llmBackend := captureServer(t, llmRequests, nil)
+
+	mux := openAIMux(t, llmMappings(llmModelEntry()), "http://nvcf.invalid", llmBackend.URL)
+
+	for _, path := range []string{"/v1/responses", "/v1/embeddings", "/v1/completions"} {
+		t.Run(path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, openAIRequest(t, path, `{"model":"`+publicModel+`","input":"hi"}`))
+			assert.Equal(t, http.StatusNotFound, rec.Code)
+			assert.Empty(t, llmRequests, "an unmapped endpoint must not reach the upstream")
+		})
+	}
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, openAIRequest(t, "/v1/chat/completions", `{"model":"`+publicModel+`"}`))
+	require.Equal(t, http.StatusOK, rec.Code, "the mapped endpoint still serves")
+}
+
+// Only the three routing headers are stripped. This pins the rest of the
+// contract, including the internal shadow tag, so a change is deliberate.
+func TestOpenAIDirector_LLMModelForwardsNonRoutingHeaders(t *testing.T) {
+	requests := make(chan capturedRequest, 1)
+	backend := captureServer(t, requests, nil)
+
+	mux := openAIMux(t, llmMappings(llmModelEntry()), "http://nvcf.invalid", backend.URL)
+	req := openAIRequest(t, "/v1/chat/completions", `{"model":"`+publicModel+`"}`)
+	req.Header.Set("Authorization", "Bearer caller-token")
+	req.Header.Set("X-Priority", "5")
+	req.Header.Set("NVCF-POLL-SECONDS", "120")
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	received := awaitRequest(t, requests)
+	assert.Equal(t, "Bearer caller-token", received.headers.Get("Authorization"))
+	assert.Equal(t, "120", received.headers.Get("NVCF-POLL-SECONDS"),
+		"a caller value passes through; the gateway injects no default here")
+	assert.Equal(t, "5", received.headers.Get("X-Priority"),
+		"the gateway does not strip X-Priority; the LLM Gateway rejects it upstream")
+}


### PR DESCRIPTION
## Why

Raised in review of the staging test request. The `llm api gateway` health check is registered whenever a model sets `functionType: LLM`, and health-go returns 503 when any check reports Unavailable:

```go
code := http.StatusOK
if c.Status == StatusUnavailable {
    code = http.StatusServiceUnavailable
}
```

Deployments wire `/health` to both the readiness and liveness probes. So an LLM Gateway outage restarts every vanity gateway pod and takes invocation-service routing down with it, even though the LLM Gateway only backs `chatCompletions`, `responses`, and `embeddings`.

The `nvcf api` check behaves the same way, but that upstream serves every route, so failing hard there is correct. This one is not.

Readiness-only would not fix it: readiness failing removes every pod from the Service, so invocation-service traffic still drops. It only avoids the restart loop.

## What changed

Sets `SkipOnErr` on the LLM Gateway check. health-go then reports `Partially Available` rather than `Unavailable`, which serves 200 with the failed check still in the response body, so the outage stays visible to alerting without gating either probe.

Requests for an LLM-routed model already return 502 while that upstream is unreachable, which is the correct blast radius: the affected requests fail and everything else keeps serving.

The `nvcf api` check is unchanged and still gating.

## Customer Release Notes

An LLM Gateway outage no longer restarts the Vanity Gateway or interrupts routes served by the invocation service.

## Plan Summary

Not applicable.

## Usage

Not applicable.

## Testing

New test asserts the asymmetry directly: an unhealthy LLM Gateway serves `/health` 200 with `llm api gateway` still named in the body, an unhealthy nvcf api still serves 503, and both healthy serves 200.

Full `gateway` and `gateway_config` suites pass.

## Notes

Not currently exposed beyond deployments that configure an LLM-routed model. The check is only registered when a model sets `functionType: LLM`.

## References

None

## Related Pull Requests

* #1022 added the check this changes

## Dependencies

None

## Issues

Relates to #1524


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - LLM Gateway health-check failures are reported without causing the vanity gateway health endpoint to return `503` or trigger pod restarts.
  - NVCF API health-check failures remain gating and can return `503`.
  - Health responses identify failed upstream checks and indicate partial availability where applicable.

- **Documentation**
  - Documented model-name behavior for chat completions, streamed responses, `/v1/responses`, and `/v1/embeddings`.
  - Documented upstream health-check behavior and its impact on routed requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->