### PR TITLE
fix(byoo-otel-collector): disable target_info on remote-write exporter

### DIFF
--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_kratos_thanos_prd.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_kratos_thanos_prd.yaml
@@ -108,6 +108,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-nvcf-metrics:
     endpoint: https://receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientCert
       key_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientKey

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_kratos_thanos_stg.yaml
@@ -108,6 +108,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://sandbox-receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_metric_subset.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_metric_subset.yaml
@@ -113,6 +113,8 @@ exporters:
     send_timestamps: true
   prometheus_remote_write/PROMETHEUS-workload-metrics-metrics:
     endpoint: https://workload-metrics.example.invalid/api/v1/write
+    target_info:
+      enabled: false
     tls:
       cert_file: /etc/byoo-otel-collector/secrets/workload-metrics-clientCert
       key_file: /etc/byoo-otel-collector/secrets/workload-metrics-clientKey

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_telemetry_endpoint_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_telemetry_endpoint_kratos_thanos_stg.yaml
@@ -108,6 +108,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://sandbox-receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_kratos_thanos_prd.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_kratos_thanos_prd.yaml
@@ -155,6 +155,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-nvcf-metrics:
     endpoint: https://receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientCert
       key_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientKey

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_kratos_thanos_stg.yaml
@@ -155,6 +155,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://sandbox-receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_telemetry_endpoint_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_telemetry_endpoint_kratos_thanos_stg.yaml
@@ -155,6 +155,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://sandbox-receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_kratos_thanos_prd.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_kratos_thanos_prd.yaml
@@ -108,6 +108,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-nvcf-metrics:
     endpoint: https://receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientCert
       key_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientKey

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_kratos_thanos_stg.yaml
@@ -108,6 +108,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://sandbox-receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_telemetry_endpoint_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_telemetry_endpoint_kratos_thanos_stg.yaml
@@ -108,6 +108,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://sandbox-receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_kratos_thanos_prd.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_kratos_thanos_prd.yaml
@@ -155,6 +155,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-nvcf-metrics:
     endpoint: https://receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientCert
       key_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientKey

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_kratos_thanos_stg.yaml
@@ -155,6 +155,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://sandbox-receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_telemetry_endpoint_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_telemetry_endpoint_kratos_thanos_stg.yaml
@@ -155,6 +155,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://sandbox-receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_function_container_kratos_thanos_prd.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_function_container_kratos_thanos_prd.yaml
@@ -138,6 +138,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-nvcf-metrics:
     endpoint: https://receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientCert
       key_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientKey

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_function_container_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_function_container_kratos_thanos_stg.yaml
@@ -138,6 +138,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://sandbox-receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_function_container_telemetry_endpoint_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_function_container_telemetry_endpoint_kratos_thanos_stg.yaml
@@ -138,6 +138,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://sandbox-receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_function_helm_kratos_thanos_prd.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_function_helm_kratos_thanos_prd.yaml
@@ -150,6 +150,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-nvcf-metrics:
     endpoint: https://receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientCert
       key_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientKey

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_function_helm_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_function_helm_kratos_thanos_stg.yaml
@@ -150,6 +150,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://sandbox-receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_function_helm_telemetry_endpoint_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_function_helm_telemetry_endpoint_kratos_thanos_stg.yaml
@@ -150,6 +150,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://sandbox-receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_task_container_kratos_thanos_prd.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_task_container_kratos_thanos_prd.yaml
@@ -138,6 +138,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-nvcf-metrics:
     endpoint: https://receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientCert
       key_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientKey

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_task_container_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_task_container_kratos_thanos_stg.yaml
@@ -138,6 +138,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://sandbox-receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_task_container_telemetry_endpoint_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_task_container_telemetry_endpoint_kratos_thanos_stg.yaml
@@ -138,6 +138,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://sandbox-receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_task_helm_kratos_thanos_prd.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_task_helm_kratos_thanos_prd.yaml
@@ -150,6 +150,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-nvcf-metrics:
     endpoint: https://receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientCert
       key_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientKey

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_task_helm_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_task_helm_kratos_thanos_stg.yaml
@@ -150,6 +150,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://sandbox-receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_task_helm_telemetry_endpoint_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/vm/config_task_helm_telemetry_endpoint_kratos_thanos_stg.yaml
@@ -150,6 +150,8 @@ receivers:
 exporters:
   prometheus_remote_write/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://sandbox-receivers.thanos.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/compute-plane-services/byoo-otel-collector/internal/otelconfig/render.go
+++ b/src/compute-plane-services/byoo-otel-collector/internal/otelconfig/render.go
@@ -460,6 +460,14 @@ func exporterMetrics(config TelemetryConfig, otelConfig *OpenTelemetryConfig) (e
 		otelConfig.Exporters[exporterId] = map[string]interface{}{
 			"endpoint": config.Telemetries.Metrics.Endpoint,
 			"tls":      exporterCredential,
+			// target_info is derived from resource attributes only. The metrics
+			// pipeline deletes service.instance.id and carries function_id,
+			// instance_id and nca_id as datapoint labels, so the generated series
+			// is identical for every collector on a cluster and unselectable by
+			// any of those labels. Emitting it only risks write conflicts.
+			"target_info": map[string]interface{}{
+				"enabled": false,
+			},
 		}
 
 	case ProviderDatadog:

--- a/src/compute-plane-services/byoo-otel-collector/internal/otelconfig/render_test.go
+++ b/src/compute-plane-services/byoo-otel-collector/internal/otelconfig/render_test.go
@@ -825,6 +825,37 @@ func TestApplyExporterHelperConfigUsesSupportedSettings(t *testing.T) {
 	assert.Empty(t, otelConfig.Exporters["unknown/example"])
 }
 
+// The remote-write exporter builds target_info from resource attributes alone.
+// The metrics pipeline deletes service.instance.id and adds the identifying
+// labels (function_id, instance_id, nca_id) as datapoint labels instead, so
+// every collector on a cluster would emit a byte-identical target_info series
+// and conflict on write. The series is also unselectable by any of those
+// labels, so nothing consumes it.
+func TestExporterMetricsDisablesTargetInfo(t *testing.T) {
+	for _, provider := range []Provider{ProviderThanos, ProviderPrometheus} {
+		t.Run(string(provider), func(t *testing.T) {
+			cfg := TelemetryConfig{
+				Telemetries: Telemetries{
+					Metrics: &Telemetry{
+						Name:     "example-metrics",
+						Protocol: ProtocolHTTP,
+						Provider: provider,
+						Endpoint: "https://metrics.example.invalid/api/v1/write",
+					},
+				},
+			}
+			otelConfig := &OpenTelemetryConfig{}
+			initializeConfigMaps(otelConfig)
+
+			exporterId, err := exporterMetrics(cfg, otelConfig)
+
+			assert.NoError(t, err)
+			assert.Equal(t, map[string]interface{}{"enabled": false},
+				otelConfig.Exporters[exporterId]["target_info"])
+		})
+	}
+}
+
 func TestGenerateExportersAndServiceAddsMetricSubsetPipeline(t *testing.T) {
 	cfg := TelemetryConfig{
 		Telemetries: Telemetries{

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_container_kratos_thanos_prd.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_container_kratos_thanos_prd.yaml
@@ -80,6 +80,8 @@ receivers:
 exporters:
   prometheusremotewrite/KRATOS_THANOS-kratos-thanos-nvcf-metrics:
     endpoint: https://prometheus-rw-prod.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientCert
       key_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientKey

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_container_kratos_thanos_stg.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_container_kratos_thanos_stg.yaml
@@ -80,6 +80,8 @@ receivers:
 exporters:
   prometheusremotewrite/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://prometheus-rw.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_helm_kratos_thanos_prd.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_helm_kratos_thanos_prd.yaml
@@ -127,6 +127,8 @@ receivers:
 exporters:
   prometheusremotewrite/KRATOS_THANOS-kratos-thanos-nvcf-metrics:
     endpoint: https://prometheus-rw-prod.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientCert
       key_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientKey

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_helm_kratos_thanos_stg.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_helm_kratos_thanos_stg.yaml
@@ -127,6 +127,8 @@ receivers:
 exporters:
   prometheusremotewrite/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://prometheus-rw.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_container_kratos_thanos_prd.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_container_kratos_thanos_prd.yaml
@@ -80,6 +80,8 @@ receivers:
 exporters:
   prometheusremotewrite/KRATOS_THANOS-kratos-thanos-nvcf-metrics:
     endpoint: https://prometheus-rw-prod.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientCert
       key_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientKey

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_container_kratos_thanos_stg.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_container_kratos_thanos_stg.yaml
@@ -80,6 +80,8 @@ receivers:
 exporters:
   prometheusremotewrite/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://prometheus-rw.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_helm_kratos_thanos_prd.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_helm_kratos_thanos_prd.yaml
@@ -127,6 +127,8 @@ receivers:
 exporters:
   prometheusremotewrite/KRATOS_THANOS-kratos-thanos-nvcf-metrics:
     endpoint: https://prometheus-rw-prod.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientCert
       key_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientKey

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_helm_kratos_thanos_stg.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_helm_kratos_thanos_stg.yaml
@@ -127,6 +127,8 @@ receivers:
 exporters:
   prometheusremotewrite/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://prometheus-rw.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/vm/config_function_container_kratos_thanos_prd.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/vm/config_function_container_kratos_thanos_prd.yaml
@@ -124,6 +124,8 @@ receivers:
 exporters:
   prometheusremotewrite/KRATOS_THANOS-kratos-thanos-nvcf-metrics:
     endpoint: https://prometheus-rw-prod.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientCert
       key_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientKey

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/vm/config_function_container_kratos_thanos_stg.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/vm/config_function_container_kratos_thanos_stg.yaml
@@ -124,6 +124,8 @@ receivers:
 exporters:
   prometheusremotewrite/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://prometheus-rw.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/vm/config_function_helm_kratos_thanos_prd.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/vm/config_function_helm_kratos_thanos_prd.yaml
@@ -136,6 +136,8 @@ receivers:
 exporters:
   prometheusremotewrite/KRATOS_THANOS-kratos-thanos-nvcf-metrics:
     endpoint: https://prometheus-rw-prod.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientCert
       key_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientKey

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/vm/config_function_helm_kratos_thanos_stg.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/vm/config_function_helm_kratos_thanos_stg.yaml
@@ -136,6 +136,8 @@ receivers:
 exporters:
   prometheusremotewrite/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://prometheus-rw.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/vm/config_task_container_kratos_thanos_prd.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/vm/config_task_container_kratos_thanos_prd.yaml
@@ -124,6 +124,8 @@ receivers:
 exporters:
   prometheusremotewrite/KRATOS_THANOS-kratos-thanos-nvcf-metrics:
     endpoint: https://prometheus-rw-prod.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientCert
       key_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientKey

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/vm/config_task_container_kratos_thanos_stg.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/vm/config_task_container_kratos_thanos_stg.yaml
@@ -124,6 +124,8 @@ receivers:
 exporters:
   prometheusremotewrite/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://prometheus-rw.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/vm/config_task_helm_kratos_thanos_prd.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/vm/config_task_helm_kratos_thanos_prd.yaml
@@ -136,6 +136,8 @@ receivers:
 exporters:
   prometheusremotewrite/KRATOS_THANOS-kratos-thanos-nvcf-metrics:
     endpoint: https://prometheus-rw-prod.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientCert
       key_file: /etc/byoo-otel-collector/secrets/kratos-thanos-nvcf-clientKey

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/vm/config_task_helm_kratos_thanos_stg.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/vm/config_task_helm_kratos_thanos_stg.yaml
@@ -136,6 +136,8 @@ receivers:
 exporters:
   prometheusremotewrite/KRATOS_THANOS-kratos-thanos-sandbox-metrics:
     endpoint: https://prometheus-rw.example.com/api/v1/receive
+    target_info:
+      enabled: false
     tls:
       ca_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-caFile
       cert_file: /etc/byoo-otel-collector/secrets/kratos-thanos-sandbox-clientCert

--- a/src/libraries/go/lib/pkg/otelconfig/config/render.go
+++ b/src/libraries/go/lib/pkg/otelconfig/config/render.go
@@ -296,6 +296,14 @@ func exporterMetrics(config TelemetryConfig, otelConfig *OpenTelemetryConfig) (e
 		otelConfig.Exporters[exporterId] = map[string]interface{}{
 			"endpoint": config.Telemetries.Metrics.Endpoint,
 			"tls":      exporterCredential,
+			// target_info is derived from resource attributes only. The metrics
+			// pipeline deletes service.instance.id and carries function_id,
+			// instance_id and nca_id as datapoint labels, so the generated series
+			// is identical for every collector on a cluster and unselectable by
+			// any of those labels. Emitting it only risks write conflicts.
+			"target_info": map[string]interface{}{
+				"enabled": false,
+			},
 		}
 
 	case ProviderDatadog:

--- a/src/libraries/go/lib/pkg/otelconfig/config/render_test.go
+++ b/src/libraries/go/lib/pkg/otelconfig/config/render_test.go
@@ -231,3 +231,34 @@ func Test_generateExportersAndService(t *testing.T) {
 		})
 	}
 }
+
+// The remote-write exporter builds target_info from resource attributes alone.
+// The metrics pipeline deletes service.instance.id and adds the identifying
+// labels (function_id, instance_id, nca_id) as datapoint labels instead, so
+// every collector on a cluster would emit a byte-identical target_info series
+// and conflict on write. The series is also unselectable by any of those
+// labels, so nothing consumes it.
+func Test_exporterMetrics_disablesTargetInfo(t *testing.T) {
+	for _, provider := range []Provider{ProviderThanos, ProviderPrometheus} {
+		t.Run(string(provider), func(t *testing.T) {
+			config := TelemetryConfig{
+				Telemetries: Telemetries{
+					Metrics: &Telemetry{
+						Name:     "example-metrics",
+						Protocol: "http",
+						Provider: provider,
+						Endpoint: "https://metrics.example.invalid/api/v1/write",
+					},
+				},
+			}
+			otelConfig := &OpenTelemetryConfig{}
+			initializeConfigMaps(otelConfig)
+
+			exporterId, err := exporterMetrics(config, otelConfig)
+
+			assert.NoError(t, err)
+			assert.Equal(t, map[string]interface{}{"enabled": false},
+				otelConfig.Exporters[exporterId]["target_info"])
+		})
+	}
+}

--- a/tools/byoo/go.mod
+++ b/tools/byoo/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require gopkg.in/yaml.v3 v3.0.1
 
 require (
+	github.com/NVIDIA/nvcf/src/libraries/go/lib v0.0.0-20260903152157-10489d7067d4 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/tools/byoo/go.sum
+++ b/tools/byoo/go.sum
@@ -1,7 +1,17 @@
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
+github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Why

The BYOO collector's Prometheus/Thanos remote-write exporter emits a `target_info` series by default (`target_info.enabled` defaults to `true` upstream), and the rendered exporter config never overrides it. In this pipeline that series carries no usable information and is a liability.

`target_info` is built from OTel *resource* attributes only. The metrics pipeline deletes `service.instance.id` via the `resource` processor, and the identifying labels (`function_id`, `instance_id`, `nca_id`) are added by `metricstransform` as *datapoint* labels, so they never reach it. `attributes/add-metadata`, which does set attributes, is wired only into the logs and traces pipelines.

What remains on the series is `job` plus the scrape target's `server.address` / `server.port` / `url.scheme`. Every collector on a cluster federates from the same in-cluster Prometheus service, so the resulting series is byte-identical across collectors and unselectable by any label a consumer would filter on.

Two consequences:

1. Identical series written from multiple collectors can conflict on ingest. A Prometheus-compatible receiver rejects the entire write request when any series in it conflicts, so unrelated metrics in the same batch are dropped. The exporter classifies a 4xx as permanent, so the batch is not retried.
2. The series publishes the internal scrape-target address into the destination tenant.

## What changed

- `target_info.enabled: false` on the exporter for the `ProviderThanos` / `ProviderPrometheus` case in both renderers: `src/compute-plane-services/byoo-otel-collector/internal/otelconfig/render.go` and `src/libraries/go/lib/pkg/otelconfig/config/render.go`.
- New tests in both packages asserting it, covering both providers. The remote-write exporter block previously had no assertions.
- Regenerated the 41 affected example configs. Every diff is exactly the two added lines.
- `tools/byoo`: added the missing `go-lib` requirement. It was `replace`d but never `require`d, so the go-lib example generator did not build.

## Customer Release Notes

BYOO metrics exports no longer emit a `target_info` series to Prometheus and Thanos destinations. The series contained no function, instance or account labels and could not be selected by them.

## Plan Summary

Not applicable.

## Usage

Not applicable.

## Testing

- `byoo-otel-collector`: `GOWORK=off go test ./...` passes.
- `go-lib`: `GOWORK=off GOFLAGS=-mod=vendor go test ./pkg/otelconfig/...` passes.
- `tools/byoo`: `GOWORK=off go build ./...` passes.
- `make update-examples` is idempotent on re-run; the 56 non-Thanos example variants regenerate byte-identical, confirming only Thanos/Prometheus providers are affected.

Pre-existing failures unrelated to this change, reproduced on a clean tree: `TestRun` and `TestRun_sidecar_deployments` in `src/libraries/go/lib/cmd/icms-translate`, and `make check-testdata` failing on BSD `sed`.

## Notes

This is a correctness and hygiene change. It removes one source of write conflicts; it is not by itself a claim that it resolves any particular ingest failure. Confirming that requires identifying the conflicting series on the receive side.

Two pre-existing `tools/byoo` problems found while making the generator build, left for follow-up:

- The `go-lib` requirement will not survive the next `go mod tidy`. The only importer lives under `testdata/`, which Go tooling ignores, so tidy drops it again. Making this durable needs the generator moved out of `testdata/` or a `tools.go`-style import outside it.
- `tools/byoo/otelconfig-update-examples` uses GNU `sed -i` (breaks on macOS) and never re-adds the SPDX header, so running it would strip headers from the committed example files. The sibling script under `byoo-otel-collector/scripts/` handles both correctly.

## References

Closes #1526

## Related Pull Requests

None

## Dependencies

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prometheus and Thanos metrics exports no longer emit `target_info` metrics, preventing conflicting or unselectable series.
  * Applied consistently across supported Kubernetes and VM configurations.

* **Tests**
  * Added coverage verifying that `target_info` emission is disabled for both Prometheus and Thanos exporters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->