### PR TITLE
fix(byoo-otel-collector): set honor_timestamps false on federated scrape jobs

### DIFF
--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_azure_monitor.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_azure_monitor.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -64,6 +66,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -78,6 +81,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_input1.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_input1.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -64,6 +66,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -78,6 +81,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_input2.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_input2.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -64,6 +66,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -78,6 +81,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_input3.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_input3.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -64,6 +66,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -78,6 +81,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_input4.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_input4.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -64,6 +66,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -78,6 +81,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_kratos_logs_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_kratos_logs_stg.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -64,6 +66,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -78,6 +81,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_kratos_thanos_prd.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_kratos_thanos_prd.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -64,6 +66,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -78,6 +81,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_kratos_thanos_stg.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -64,6 +66,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -78,6 +81,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_metric_subset.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_metric_subset.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -64,6 +66,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -78,6 +81,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_otelcollector_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_otelcollector_stg.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -64,6 +66,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -78,6 +81,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_telemetry_endpoint_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_container_telemetry_endpoint_kratos_thanos_stg.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -64,6 +66,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -78,6 +81,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_azure_monitor.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_azure_monitor.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -72,6 +74,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -125,6 +128,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_input1.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_input1.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -72,6 +74,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -125,6 +128,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_input2.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_input2.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -72,6 +74,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -125,6 +128,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_input3.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_input3.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -72,6 +74,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -125,6 +128,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_input4.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_input4.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -72,6 +74,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -125,6 +128,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_kratos_logs_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_kratos_logs_stg.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -72,6 +74,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -125,6 +128,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_kratos_thanos_prd.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_kratos_thanos_prd.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -72,6 +74,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -125,6 +128,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_kratos_thanos_stg.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -72,6 +74,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -125,6 +128,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_otelcollector_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_otelcollector_stg.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -72,6 +74,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -125,6 +128,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_telemetry_endpoint_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_function_helm_telemetry_endpoint_kratos_thanos_stg.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -72,6 +74,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -125,6 +128,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_azure_monitor.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_azure_monitor.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -64,6 +66,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -78,6 +81,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_input1.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_input1.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -64,6 +66,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -78,6 +81,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_input2.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_input2.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -64,6 +66,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -78,6 +81,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_input3.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_input3.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -64,6 +66,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -78,6 +81,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_input4.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_input4.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -64,6 +66,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -78,6 +81,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_kratos_logs_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_kratos_logs_stg.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -64,6 +66,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -78,6 +81,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_kratos_thanos_prd.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_kratos_thanos_prd.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -64,6 +66,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -78,6 +81,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_kratos_thanos_stg.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -64,6 +66,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -78,6 +81,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_otelcollector_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_otelcollector_stg.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -64,6 +66,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -78,6 +81,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_telemetry_endpoint_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_container_telemetry_endpoint_kratos_thanos_stg.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -64,6 +66,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -78,6 +81,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_azure_monitor.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_azure_monitor.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -72,6 +74,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -125,6 +128,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_input1.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_input1.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -72,6 +74,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -125,6 +128,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_input2.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_input2.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -72,6 +74,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -125,6 +128,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_input3.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_input3.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -72,6 +74,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -125,6 +128,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_input4.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_input4.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -72,6 +74,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -125,6 +128,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_kratos_logs_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_kratos_logs_stg.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -72,6 +74,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -125,6 +128,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_kratos_thanos_prd.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_kratos_thanos_prd.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -72,6 +74,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -125,6 +128,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_kratos_thanos_stg.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -72,6 +74,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -125,6 +128,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_otelcollector_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_otelcollector_stg.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -72,6 +74,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -125,6 +128,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_telemetry_endpoint_kratos_thanos_stg.yaml
+++ b/src/compute-plane-services/byoo-otel-collector/examples/otelconfigs/k8s/config_task_helm_telemetry_endpoint_kratos_thanos_stg.yaml
@@ -12,6 +12,7 @@ receivers:
     config:
       scrape_configs:
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvcf-worker
           metric_relabel_configs:
             - action: labelkeep
@@ -26,6 +27,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvca
           metric_relabel_configs:
             - action: labelkeep
@@ -72,6 +74,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -125,6 +128,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/compute-plane-services/byoo-otel-collector/generator/gen/generated_src-config-k8s-container.yaml.tmpl
+++ b/src/compute-plane-services/byoo-otel-collector/generator/gen/generated_src-config-k8s-container.yaml.tmpl
@@ -12,6 +12,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:
@@ -26,6 +27,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:
@@ -65,6 +67,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:
@@ -80,6 +83,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:

--- a/src/compute-plane-services/byoo-otel-collector/generator/gen/generated_src-config-k8s-helm.yaml.tmpl
+++ b/src/compute-plane-services/byoo-otel-collector/generator/gen/generated_src-config-k8s-helm.yaml.tmpl
@@ -13,6 +13,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:
@@ -27,6 +28,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:
@@ -72,6 +74,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:
@@ -117,6 +120,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:

--- a/src/compute-plane-services/byoo-otel-collector/internal/otelconfig/render_test.go
+++ b/src/compute-plane-services/byoo-otel-collector/internal/otelconfig/render_test.go
@@ -235,6 +235,84 @@ func TestRenderOtelConfigWithMetricSubsetPipelineMatchesExample(t *testing.T) {
 	assertYAMLConfigEqual(t, expectedCfg, gotCfg)
 }
 
+// Federated scrape jobs read samples from an upstream Prometheus that may run
+// several replicas behind a single service. Each replica keeps its own scrape
+// clock, so federated samples for the same series can arrive with timestamps
+// that move backwards. A Prometheus-compatible receiver rejects the whole write
+// request in that case, which also drops unrelated metrics batched with it.
+// honor_timestamps: false makes the collector stamp federated samples with its
+// own monotonic scrape time, so the federated path stays correct no matter how
+// the upstream Prometheus is deployed.
+func TestFederatedScrapeJobsDisableHonorTimestamps(t *testing.T) {
+	for _, backendType := range []BackendType{K8s, VM} {
+		for _, workloadType := range []WorkloadType{Container, Helm} {
+			t.Run(fmt.Sprintf("%s-%s", backendType, workloadType), func(t *testing.T) {
+				gotCfg, err := RenderOtelConfigFromBytes(
+					[]byte(`{"telemetries": {"metricsTelemetry": {"protocol": "HTTP", "provider": "PROMETHEUS", "endpoint": "https://metrics.example.invalid/api/v1/write", "name": "example-metrics"}}}`),
+					TemplateConfig{
+						BackendType:       backendType,
+						WorkloadType:      workloadType,
+						Namespace:         "sr-fake-namespace",
+						FunctionID:        "fake-function-id",
+						FunctionVersionID: "fake-function-version-id",
+						InstanceID:        "fake-instance-id",
+						ZoneName:          "fake-zone-name",
+					},
+				)
+				assert.NoError(t, err)
+
+				otelConfig := &OpenTelemetryConfig{}
+				assert.NoError(t, yaml.Unmarshal(gotCfg, otelConfig))
+
+				federatedJobs := 0
+				for _, scrapeConfig := range prometheusScrapeConfigs(t, otelConfig) {
+					if scrapeConfig["metrics_path"] != "/federate" {
+						continue
+					}
+					federatedJobs++
+					assert.Equal(t, false, scrapeConfig["honor_timestamps"],
+						"federated job %v must set honor_timestamps: false", scrapeConfig["job_name"])
+				}
+
+				if backendType == K8s {
+					assert.NotZero(t, federatedJobs, "expected the k8s template to federate")
+					return
+				}
+				// The vm templates scrape every target directly, so
+				// honor_timestamps has nothing to override there.
+				assert.Zero(t, federatedJobs, "the vm template is not expected to federate")
+			})
+		}
+	}
+}
+
+func prometheusScrapeConfigs(t *testing.T, otelConfig *OpenTelemetryConfig) []map[string]interface{} {
+	t.Helper()
+
+	prometheusReceiver, ok := otelConfig.Receivers["prometheus"]
+	if !ok {
+		t.Fatalf("rendered config has no prometheus receiver")
+	}
+	receiverConfig, ok := prometheusReceiver["config"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("prometheus receiver has no config map, got %T", prometheusReceiver["config"])
+	}
+	rawScrapeConfigs, ok := receiverConfig["scrape_configs"].([]interface{})
+	if !ok {
+		t.Fatalf("prometheus receiver has no scrape_configs list, got %T", receiverConfig["scrape_configs"])
+	}
+
+	scrapeConfigs := make([]map[string]interface{}, 0, len(rawScrapeConfigs))
+	for i, rawScrapeConfig := range rawScrapeConfigs {
+		scrapeConfig, ok := rawScrapeConfig.(map[string]interface{})
+		if !ok {
+			t.Fatalf("scrape_configs[%d] is not a map, got %T", i, rawScrapeConfig)
+		}
+		scrapeConfigs = append(scrapeConfigs, scrapeConfig)
+	}
+	return scrapeConfigs
+}
+
 func assertYAMLConfigEqual(t *testing.T, expectedYAML, actualYAML []byte) {
 	t.Helper()
 

--- a/src/compute-plane-services/byoo-otel-collector/internal/otelconfig/source_templates/src-config-k8s-container.yaml.tmpl
+++ b/src/compute-plane-services/byoo-otel-collector/internal/otelconfig/source_templates/src-config-k8s-container.yaml.tmpl
@@ -12,6 +12,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:
@@ -26,6 +27,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:
@@ -65,6 +67,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:
@@ -80,6 +83,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:

--- a/src/compute-plane-services/byoo-otel-collector/internal/otelconfig/source_templates/src-config-k8s-helm.yaml.tmpl
+++ b/src/compute-plane-services/byoo-otel-collector/internal/otelconfig/source_templates/src-config-k8s-helm.yaml.tmpl
@@ -13,6 +13,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:
@@ -27,6 +28,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:
@@ -67,6 +69,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:
@@ -95,6 +98,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:

--- a/src/compute-plane-services/byoo-otel-collector/internal/otelconfig/templates/config-k8s-container.yaml.tmpl
+++ b/src/compute-plane-services/byoo-otel-collector/internal/otelconfig/templates/config-k8s-container.yaml.tmpl
@@ -12,6 +12,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:
@@ -26,6 +27,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:
@@ -65,6 +67,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:
@@ -80,6 +83,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:

--- a/src/compute-plane-services/byoo-otel-collector/internal/otelconfig/templates/config-k8s-helm.yaml.tmpl
+++ b/src/compute-plane-services/byoo-otel-collector/internal/otelconfig/templates/config-k8s-helm.yaml.tmpl
@@ -13,6 +13,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:
@@ -27,6 +28,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:
@@ -72,6 +74,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:
@@ -117,6 +120,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_container_azure_monitor.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_container_azure_monitor.yaml
@@ -36,6 +36,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -50,6 +51,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_container_input1.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_container_input1.yaml
@@ -36,6 +36,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -50,6 +51,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_container_input2.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_container_input2.yaml
@@ -36,6 +36,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -50,6 +51,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_container_input3.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_container_input3.yaml
@@ -36,6 +36,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -50,6 +51,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_container_input4.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_container_input4.yaml
@@ -36,6 +36,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -50,6 +51,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_container_kratos_logs_stg.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_container_kratos_logs_stg.yaml
@@ -36,6 +36,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -50,6 +51,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_container_kratos_thanos_prd.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_container_kratos_thanos_prd.yaml
@@ -36,6 +36,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -50,6 +51,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_container_kratos_thanos_stg.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_container_kratos_thanos_stg.yaml
@@ -36,6 +36,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -50,6 +51,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_container_validator.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_container_validator.yaml
@@ -36,6 +36,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -50,6 +51,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_helm_azure_monitor.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_helm_azure_monitor.yaml
@@ -44,6 +44,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -97,6 +98,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_helm_input1.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_helm_input1.yaml
@@ -44,6 +44,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -97,6 +98,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_helm_input2.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_helm_input2.yaml
@@ -44,6 +44,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -97,6 +98,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_helm_input3.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_helm_input3.yaml
@@ -44,6 +44,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -97,6 +98,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_helm_input4.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_helm_input4.yaml
@@ -44,6 +44,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -97,6 +98,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_helm_kratos_logs_stg.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_helm_kratos_logs_stg.yaml
@@ -44,6 +44,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -97,6 +98,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_helm_kratos_thanos_prd.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_helm_kratos_thanos_prd.yaml
@@ -44,6 +44,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -97,6 +98,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_helm_kratos_thanos_stg.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_helm_kratos_thanos_stg.yaml
@@ -44,6 +44,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -97,6 +98,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_helm_validator.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_function_helm_validator.yaml
@@ -44,6 +44,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -97,6 +98,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_container_azure_monitor.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_container_azure_monitor.yaml
@@ -36,6 +36,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -50,6 +51,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_container_input1.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_container_input1.yaml
@@ -36,6 +36,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -50,6 +51,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_container_input2.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_container_input2.yaml
@@ -36,6 +36,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -50,6 +51,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_container_input3.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_container_input3.yaml
@@ -36,6 +36,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -50,6 +51,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_container_input4.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_container_input4.yaml
@@ -36,6 +36,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -50,6 +51,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_container_kratos_logs_stg.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_container_kratos_logs_stg.yaml
@@ -36,6 +36,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -50,6 +51,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_container_kratos_thanos_prd.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_container_kratos_thanos_prd.yaml
@@ -36,6 +36,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -50,6 +51,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_container_kratos_thanos_stg.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_container_kratos_thanos_stg.yaml
@@ -36,6 +36,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -50,6 +51,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_container_validator.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_container_validator.yaml
@@ -36,6 +36,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - action: labelkeep
@@ -50,6 +51,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_helm_azure_monitor.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_helm_azure_monitor.yaml
@@ -44,6 +44,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -97,6 +98,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_helm_input1.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_helm_input1.yaml
@@ -44,6 +44,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -97,6 +98,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_helm_input2.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_helm_input2.yaml
@@ -44,6 +44,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -97,6 +98,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_helm_input3.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_helm_input3.yaml
@@ -44,6 +44,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -97,6 +98,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_helm_input4.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_helm_input4.yaml
@@ -44,6 +44,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -97,6 +98,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_helm_kratos_logs_stg.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_helm_kratos_logs_stg.yaml
@@ -44,6 +44,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -97,6 +98,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_helm_kratos_thanos_prd.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_helm_kratos_thanos_prd.yaml
@@ -44,6 +44,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -97,6 +98,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_helm_kratos_thanos_stg.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_helm_kratos_thanos_stg.yaml
@@ -44,6 +44,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -97,6 +98,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_helm_validator.yaml
+++ b/src/libraries/go/lib/examples/otelconfig/byoo-otel-collector/k8s/config_task_helm_validator.yaml
@@ -44,6 +44,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: kube-state-metrics
           metric_relabel_configs:
             - regex: .*kube-state-metrics.*
@@ -97,6 +98,7 @@ receivers:
             - targets:
                 - nvcf-byoo-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090
         - honor_labels: true
+          honor_timestamps: false
           job_name: nvidia-dcgm-exporter
           metric_relabel_configs:
             - action: labelmap

--- a/src/libraries/go/lib/pkg/otelconfig/backendconfig/templates/config-k8s-container.yaml.tmpl
+++ b/src/libraries/go/lib/pkg/otelconfig/backendconfig/templates/config-k8s-container.yaml.tmpl
@@ -37,6 +37,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:
@@ -52,6 +53,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:

--- a/src/libraries/go/lib/pkg/otelconfig/backendconfig/templates/config-k8s-helm.yaml.tmpl
+++ b/src/libraries/go/lib/pkg/otelconfig/backendconfig/templates/config-k8s-helm.yaml.tmpl
@@ -39,6 +39,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:
@@ -67,6 +68,7 @@ receivers:
           scrape_interval: 30s
           scrape_timeout: 25s
           honor_labels: true
+          honor_timestamps: false
           metrics_path: "/federate"
           static_configs:
             - targets:

--- a/src/libraries/go/lib/pkg/otelconfig/config/render_test.go
+++ b/src/libraries/go/lib/pkg/otelconfig/config/render_test.go
@@ -119,6 +119,84 @@ func TestRenderOtelConfig(t *testing.T) {
 	}
 }
 
+// Federated scrape jobs read samples from an upstream Prometheus that may run
+// several replicas behind a single service. Each replica keeps its own scrape
+// clock, so federated samples for the same series can arrive with timestamps
+// that move backwards. A Prometheus-compatible receiver rejects the whole write
+// request in that case, which also drops unrelated metrics batched with it.
+// honor_timestamps: false makes the collector stamp federated samples with its
+// own monotonic scrape time, so the federated path stays correct no matter how
+// the upstream Prometheus is deployed.
+func TestFederatedScrapeJobsDisableHonorTimestamps(t *testing.T) {
+	for _, backendType := range []backendconfig.BackendType{backendconfig.K8s, backendconfig.VM} {
+		for _, workloadType := range []backendconfig.WorkloadType{backendconfig.Container, backendconfig.Helm} {
+			t.Run(fmt.Sprintf("%s-%s", backendType, workloadType), func(t *testing.T) {
+				gotCfg, err := RenderOtelConfigFromBytes(
+					[]byte(`{"telemetries": {"metricsTelemetry": {"protocol": "HTTP", "provider": "PROMETHEUS", "endpoint": "https://metrics.example.com/api/v1/write", "name": "example-metrics"}}}`),
+					backendconfig.TemplateConfig{
+						BackendType:       backendType,
+						WorkloadType:      workloadType,
+						Namespace:         "foo",
+						FunctionID:        "fake-function-id",
+						FunctionVersionID: "fake-function-version-id",
+						InstanceID:        "fake-instance-id",
+						ZoneName:          "fake-zone-name",
+					},
+				)
+				assert.NoError(t, err)
+
+				otelConfig := &OpenTelemetryConfig{}
+				assert.NoError(t, yaml.Unmarshal(gotCfg, otelConfig))
+
+				federatedJobs := 0
+				for _, scrapeConfig := range prometheusScrapeConfigs(t, otelConfig) {
+					if scrapeConfig["metrics_path"] != "/federate" {
+						continue
+					}
+					federatedJobs++
+					assert.Equal(t, false, scrapeConfig["honor_timestamps"],
+						"federated job %v must set honor_timestamps: false", scrapeConfig["job_name"])
+				}
+
+				if backendType == backendconfig.K8s {
+					assert.NotZero(t, federatedJobs, "expected the k8s template to federate")
+					return
+				}
+				// The vm templates scrape every target directly, so
+				// honor_timestamps has nothing to override there.
+				assert.Zero(t, federatedJobs, "the vm template is not expected to federate")
+			})
+		}
+	}
+}
+
+func prometheusScrapeConfigs(t *testing.T, otelConfig *OpenTelemetryConfig) []map[string]interface{} {
+	t.Helper()
+
+	prometheusReceiver, ok := otelConfig.Receivers["prometheus"]
+	if !ok {
+		t.Fatalf("rendered config has no prometheus receiver")
+	}
+	receiverConfig, ok := prometheusReceiver["config"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("prometheus receiver has no config map, got %T", prometheusReceiver["config"])
+	}
+	rawScrapeConfigs, ok := receiverConfig["scrape_configs"].([]interface{})
+	if !ok {
+		t.Fatalf("prometheus receiver has no scrape_configs list, got %T", receiverConfig["scrape_configs"])
+	}
+
+	scrapeConfigs := make([]map[string]interface{}, 0, len(rawScrapeConfigs))
+	for i, rawScrapeConfig := range rawScrapeConfigs {
+		scrapeConfig, ok := rawScrapeConfig.(map[string]interface{})
+		if !ok {
+			t.Fatalf("scrape_configs[%d] is not a map, got %T", i, rawScrapeConfig)
+		}
+		scrapeConfigs = append(scrapeConfigs, scrapeConfig)
+	}
+	return scrapeConfigs
+}
+
 // returns the expected OpenTelemetry YAML configuration as a byte slice
 func createExpectedOtelConfigYAMLForInternalTelemetry(tracesTelemetryName string) []byte {
 	internalTelemetryYAMLString := fmt.Sprintf(`receivers: {}

--- a/tools/byoo/go.mod
+++ b/tools/byoo/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require gopkg.in/yaml.v3 v3.0.1
 
 require (
+	github.com/NVIDIA/nvcf/src/libraries/go/lib v0.0.0-20260903173501-240210841e85 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/tools/byoo/go.sum
+++ b/tools/byoo/go.sum
@@ -1,7 +1,17 @@
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
+github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Why

The BYOO collector scrapes an in-cluster Prometheus through `/federate`. That
Prometheus commonly runs several replicas behind a single service, and we do not
control how it is deployed.

When it does, four things combine:

- The collector's scrape resolves to one replica per scrape, round-robin across
  the service endpoints.
- Each replica keeps its own scrape clock, so the same series has slightly
  different timestamps on each replica.
- `/federate` returns explicit timestamps, and the collector honors them by
  default (`honor_timestamps` defaults to `true`).
- The rendered scrape configs apply a `labelkeep` that strips
  `prometheus_replica`, so nothing downstream distinguishes the two sources.

Consecutive samples of one series can therefore carry timestamps that move
backwards. A Prometheus-compatible receiver treats that as a conflict
(out-of-order, duplicate-for-timestamp, or out-of-bounds) and rejects the entire
write request rather than the offending series, so unrelated metrics batched
with it are dropped too.

`honor_timestamps: false` makes the collector stamp federated samples with its
own scrape time. Its clock is monotonic, so this neutralizes all three conflict
classes for the federated path regardless of how the upstream Prometheus is
deployed. The tradeoff is up to one scrape interval (30s) of timestamp
imprecision, already accepted in this codebase for the `kubernetes-cadvisor`
job.

## What changed

- `honor_timestamps: false` on every federated scrape job that lacked it, in the
  k8s templates of both renderers:
  - current: `src/compute-plane-services/byoo-otel-collector/internal/otelconfig/source_templates/src-config-k8s-{container,helm}.yaml.tmpl`,
    with `generator/gen/` and `internal/otelconfig/templates/` regenerated via
    `make update-config-template`
  - legacy: `src/libraries/go/lib/pkg/otelconfig/backendconfig/templates/config-k8s-{container,helm}.yaml.tmpl`
- Scope is wider than `kube-state-metrics` and `nvidia-dcgm-exporter`. The
  current renderer's k8s templates also federate `nvcf-worker` and `nvca`, and
  those jobs were missing the setting too. They hit the same service and are
  affected identically, so they are included. `kubernetes-cadvisor` already had
  it. Four jobs per template in the current renderer, two per template in the
  legacy one, which has no `nvcf-worker` or `nvca` job.
- New test in each package asserting the invariant directly: every scrape job
  whose `metrics_path` is `/federate` must set `honor_timestamps: false`. The
  test is written against the rendered config, not the template text, and also
  asserts the `vm` templates produce no federated jobs, which pins the scoping
  decision below.
- Regenerated committed example configs: 40 in `byoo-otel-collector/examples/`
  plus the metric-subset golden, and 36 in `go-lib/examples/`. Every diff is
  exactly the added `honor_timestamps` lines; no `vm` example changed.
- `tools/byoo`: added the missing `go-lib` requirement so the go-lib example
  generator builds. It was `replace`d but never `require`d.

The `opentelemetry-collector` self-scrape job is untouched.

### Why the `vm` templates are excluded

The `vm` templates do not federate. They scrape `nvidia-dcgm-exporter`,
`kube-state-metrics` and `nvcf-worker` at `/metrics`, and the kubelet cadvisor
endpoint through a `__metrics_path__` relabel. Direct scrape targets expose no
explicit timestamps, so `honor_timestamps` has nothing to override and setting
it is a no-op. Verified by reading all four `vm` templates in both renderers: no
`/federate` path appears in any of them. The new tests assert this holds.

## Customer Release Notes

Platform metrics federated from the in-cluster Prometheus are now timestamped at
collection time by the BYOO collector rather than carrying the upstream scrape
timestamp. This makes ingest resilient to clock differences between upstream
Prometheus replicas, at the cost of up to one scrape interval (30s) of timestamp
imprecision.

## Plan Summary

Not applicable.

## Usage

Not applicable.

## Testing

- `byoo-otel-collector`: `GOWORK=off go test ./...` passes.
- `go-lib`: `GOWORK=off GOFLAGS=-mod=vendor go test ./pkg/otelconfig/...` passes.
- Both new tests were confirmed red before the template change and green after.
  Red output named exactly the jobs missing the setting: `nvcf-worker`, `nvca`,
  `kube-state-metrics`, `nvidia-dcgm-exporter` in the current renderer, and
  `kube-state-metrics`, `nvidia-dcgm-exporter` in the legacy one.
- Every regenerated artifact was diffed against the committed file before being
  overwritten. Across all 77 regenerated examples the only changed line in the
  whole diff is `+          honor_timestamps: false`. The commit is 431
  insertions and 0 deletions.
- `gofmt` and `go vet` clean on both changed test files.

Pre-existing failures unrelated to this change: `TestRun` and
`TestRun_sidecar_deployments` in `src/libraries/go/lib/cmd/icms-translate`, and
`make check-testdata` failing on BSD `sed`.

## Notes

This is not confirmed to be the cause of any specific ingest failure. The
receive-side logs that would name the conflicting series are not available to
us. The change is justified on its own merits: it makes the federated path
immune to upstream replica clock skew, which we cannot control.

Regenerating the go-lib examples surfaced an environment dependency worth
flagging. `render.go` emits `ca_file` only when the file exists on disk at the
secrets path, so a naive regeneration on a host without it silently drops that
line from four `kratos_thanos_stg` examples. The regeneration here supplied the
fixture so the committed files stay byte-accurate, but the generator is not
hermetic and a future contributor will hit this.

The four `*_validator.yaml` examples under `byoo-otel-collector/examples/` are
stale: their input `testdata/validator.json` no longer exists, so
`make update-examples` does not regenerate them and they still reflect an older
template shape. Left alone as out of scope.

## References

Closes #1529

## Related Pull Requests

- #1527 - sibling fix for the same class of write conflict, disabling
  `target_info` on the remote-write exporter. The two are independent hypotheses
  about what causes write requests to be rejected; neither depends on the other
  and either can land first.

## Dependencies

No new third-party packages. The `tools/byoo` `go.mod` / `go.sum` change adds a
requirement on the in-repo `go-lib` module, which was already wired in via a
`replace` directive. This overlaps with the same fix in #1527; whichever merges
second will need the overlap resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prometheus metrics collected from Kubernetes workloads now use collector-assigned timestamps consistently.
  - Updated monitoring configurations across container and Helm deployments, including worker, node, Kubernetes, state-metrics, and GPU exporter metrics.
  - Standardized timestamp handling across supported Kubernetes observability configurations to improve metric consistency and prevent source timestamp discrepancies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->