### PR TITLE
fix(stargate): gracefully drain Kubernetes router shutdown

### DIFF
--- a/deploy/helm/llm-request-router/llm-request-router/templates/backend-router.yaml
+++ b/deploy/helm/llm-request-router/llm-request-router/templates/backend-router.yaml
@@ -69,6 +69,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.llmRequestRouter.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ add (div (add (.Values.llmRequestRouter.shutdown.drainTimeoutMs | int) 999) 1000) 5 }}
       containers:
         - name: backend-router
           image: {{ include "llm-request-router.backendRouterImage" . }}
@@ -85,6 +86,7 @@ spec:
             - --advertised-grpc-port={{ .Values.llmRequestRouter.service.grpcPort }}
             - --grpc-pylon-dial-addr={{ include "llm-request-router.backendRouterGrpcDialAddress" . }}
             - --watch-heartbeat-ms={{ .Values.llmRequestRouter.discovery.watchHeartbeatMs }}
+            - --shutdown-drain-timeout-ms={{ .Values.llmRequestRouter.shutdown.drainTimeoutMs }}
             {{- range .Values.llmRequestRouter.discovery.remoteWatchUrls }}
             - --remote-stargate-url={{ . }}
             {{- end }}

--- a/deploy/helm/llm-request-router/llm-request-router/templates/deployment.yaml
+++ b/deploy/helm/llm-request-router/llm-request-router/templates/deployment.yaml
@@ -99,7 +99,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.llmRequestRouter.podSecurityContext | nindent 8 }}
-      terminationGracePeriodSeconds: {{ div (.Values.llmRequestRouter.shutdown.drainTimeoutMs | int) 1000 }}
+      terminationGracePeriodSeconds: {{ add (div (add (.Values.llmRequestRouter.shutdown.drainTimeoutMs | int) 999) 1000) 5 }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ include "llm-request-router.image" . }}

--- a/deploy/helm/llm-request-router/scripts/check-backend-router-render.sh
+++ b/deploy/helm/llm-request-router/scripts/check-backend-router-render.sh
@@ -42,6 +42,18 @@ assert_contains() {
   fi
 }
 
+assert_occurrences() {
+  local pattern="$1"
+  local expected="$2"
+  local message="$3"
+  local actual
+  actual="$(grep -Fc -- "$pattern" "$rendered")"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "FAIL: ${message}; rendered ${actual} occurrence(s), expected ${expected}" >&2
+    exit 1
+  fi
+}
+
 assert_render_fails() {
   local expected_error="$1"
   local error_file
@@ -193,6 +205,10 @@ assert_contains "command:" \
   "backend router must override the Stargate image entrypoint"
 assert_contains "/usr/local/bin/stargate-k8s-router" \
   "Stargate image must include the Kubernetes router binary"
+assert_occurrences "--shutdown-drain-timeout-ms=30000" "2" \
+  "both Stargate and the backend router must use the configured graceful shutdown budget"
+assert_occurrences "terminationGracePeriodSeconds: 35" "2" \
+  "both workloads must leave Kubernetes time beyond their configured drain budget"
 assert_contains "--target-service-name=llm-request-router-headless" \
   "backend router must watch the headless Service so warming pods accept pylon connections"
 assert_contains "--advertised-hostname-template={pod_name}.llm-request-router-headless.nvcf.svc.cluster.local" \

--- a/deploy/helm/llm-request-router/scripts/check-backend-router-render.sh
+++ b/deploy/helm/llm-request-router/scripts/check-backend-router-render.sh
@@ -11,8 +11,9 @@ disabled="$(mktemp)"
 external_service_account="$(mktemp)"
 wildcard_certificate="$(mktemp)"
 zero_config="$(mktemp)"
+unaligned_shutdown="$(mktemp)"
 service_monitor_namespace_file="$(mktemp)"
-trap 'rm -f "$rendered" "$disabled" "$external_service_account" "$wildcard_certificate" "$zero_config" "$service_monitor_namespace_file"' EXIT
+trap 'rm -f "$rendered" "$disabled" "$external_service_account" "$wildcard_certificate" "$zero_config" "$unaligned_shutdown" "$service_monitor_namespace_file"' EXIT
 
 helm template llm-request-router "$chart_dir" \
   --namespace nvcf \
@@ -46,8 +47,9 @@ assert_occurrences() {
   local pattern="$1"
   local expected="$2"
   local message="$3"
+  local rendered_file="${4:-$rendered}"
   local actual
-  actual="$(grep -Fc -- "$pattern" "$rendered")"
+  actual="$(grep -Fc -- "$pattern" "$rendered_file" || true)"
   if [[ "$actual" != "$expected" ]]; then
     echo "FAIL: ${message}; rendered ${actual} occurrence(s), expected ${expected}" >&2
     exit 1
@@ -209,6 +211,16 @@ assert_occurrences "--shutdown-drain-timeout-ms=30000" "2" \
   "both Stargate and the backend router must use the configured graceful shutdown budget"
 assert_occurrences "terminationGracePeriodSeconds: 35" "2" \
   "both workloads must leave Kubernetes time beyond their configured drain budget"
+
+helm template llm-request-router "$chart_dir" \
+  --namespace nvcf \
+  --set llmRequestRouter.image.repository=nvcf/stargate \
+  --set llmRequestRouter.backendRouter.enabled=true \
+  --set llmRequestRouter.shutdown.drainTimeoutMs=30001 \
+  >"$unaligned_shutdown"
+assert_occurrences "terminationGracePeriodSeconds: 36" "2" \
+  "pod grace must round a partial drain second up before adding its exit margin" \
+  "$unaligned_shutdown"
 assert_contains "--target-service-name=llm-request-router-headless" \
   "backend router must watch the headless Service so warming pods accept pylon connections"
 assert_contains "--advertised-hostname-template={pod_name}.llm-request-router-headless.nvcf.svc.cluster.local" \

--- a/src/libraries/rust/stargate/crates/stargate-forwarding/src/lib.rs
+++ b/src/libraries/rust/stargate/crates/stargate-forwarding/src/lib.rs
@@ -153,19 +153,7 @@ pub async fn forward_quic_connection(
     endpoints: &RelayEndpoints,
     peer_connect_timeout: Duration,
 ) -> Result<()> {
-    let peer_connect_timeout_ms = peer_connect_timeout.as_millis();
-    let mut resolved_addrs = tokio::time::timeout(
-        peer_connect_timeout,
-        tokio::net::lookup_host(&peer.dial_addr),
-    )
-    .await
-    .with_context(|| format!("DNS resolve peer timed out after {peer_connect_timeout_ms}ms"))?
-    .context("DNS resolve peer")?;
-    let (resolved, endpoint) = endpoints.endpoint_for_resolved_addrs(&mut resolved_addrs)?;
-    let connecting = endpoint
-        .connect(resolved, &peer.server_name)
-        .context("initiate peer QUIC connect")?;
-    let peer_connection = await_peer_connect(connecting, peer_connect_timeout).await?;
+    let peer_connection = connect_quic_peer(peer, endpoints, peer_connect_timeout).await?;
 
     info!(
         peer = %peer.dial_addr,
@@ -181,6 +169,63 @@ pub async fn forward_quic_connection(
         "QUIC connection relay finished"
     );
     Ok(())
+}
+
+pub async fn forward_quic_connection_until_shutdown<S>(
+    client_connection: quinn::Connection,
+    peer: &PeerTarget,
+    endpoints: &RelayEndpoints,
+    peer_connect_timeout: Duration,
+    shutdown: S,
+) -> Result<()>
+where
+    S: Future<Output = ()> + Send,
+{
+    tokio::pin!(shutdown);
+    let peer_connection = tokio::select! {
+        biased;
+        _ = &mut shutdown => {
+            client_connection.close(0u32.into(), b"router shutdown before relay connected");
+            return Ok(());
+        }
+        result = connect_quic_peer(peer, endpoints, peer_connect_timeout) => result?,
+    };
+
+    info!(
+        peer = %peer.dial_addr,
+        server_name = %peer.server_name,
+        "QUIC connection relay started"
+    );
+
+    relay_connections_until_shutdown(client_connection, peer_connection, shutdown).await;
+
+    info!(
+        peer = %peer.dial_addr,
+        server_name = %peer.server_name,
+        "QUIC connection relay finished"
+    );
+    Ok(())
+}
+
+async fn connect_quic_peer(
+    peer: &PeerTarget,
+    endpoints: &RelayEndpoints,
+    peer_connect_timeout: Duration,
+) -> Result<quinn::Connection> {
+    let peer_connect_timeout_ms = peer_connect_timeout.as_millis();
+    let mut resolved_addrs = tokio::time::timeout(
+        peer_connect_timeout,
+        tokio::net::lookup_host(&peer.dial_addr),
+    )
+    .await
+    .with_context(|| format!("DNS resolve peer timed out after {peer_connect_timeout_ms}ms"))?
+    .context("DNS resolve peer")?;
+    let (resolved, endpoint) = endpoints.endpoint_for_resolved_addrs(&mut resolved_addrs)?;
+    let connecting = endpoint
+        .connect(resolved, &peer.server_name)
+        .context("initiate peer QUIC connect")?;
+    let peer_connection = await_peer_connect(connecting, peer_connect_timeout).await?;
+    Ok(peer_connection)
 }
 
 async fn await_peer_connect<F, T, E>(connect: F, peer_connect_timeout: Duration) -> Result<T>
@@ -202,6 +247,32 @@ async fn relay_connections(client: quinn::Connection, peer: quinn::Connection) {
     tokio::select! {
         _ = client_to_peer => {}
         _ = peer_to_client => {}
+        _ = client.closed() => {}
+        _ = peer.closed() => {}
+    }
+}
+
+async fn relay_connections_until_shutdown<S>(
+    client: quinn::Connection,
+    peer: quinn::Connection,
+    shutdown: S,
+) where
+    S: Future<Output = ()>,
+{
+    let (drain_tx, drain_rx) = tokio::sync::watch::channel(());
+    let client_to_peer =
+        relay_direction_until_shutdown(client.clone(), peer.clone(), drain_rx.clone());
+    let peer_to_client = relay_direction_until_shutdown(peer.clone(), client.clone(), drain_rx);
+    tokio::pin!(client_to_peer, peer_to_client, shutdown);
+
+    tokio::select! {
+        biased;
+        _ = &mut shutdown => {
+            let _ = drain_tx.send(());
+            tokio::join!(&mut client_to_peer, &mut peer_to_client);
+        }
+        _ = &mut client_to_peer => {}
+        _ = &mut peer_to_client => {}
         _ = client.closed() => {}
         _ = peer.closed() => {}
     }
@@ -242,6 +313,33 @@ async fn relay_direction(acceptor: quinn::Connection, initiator: quinn::Connecti
     tasks.shutdown().await;
 }
 
+async fn relay_direction_until_shutdown(
+    acceptor: quinn::Connection,
+    initiator: quinn::Connection,
+    mut drain: tokio::sync::watch::Receiver<()>,
+) {
+    let mut tasks = tokio::task::JoinSet::new();
+    loop {
+        tokio::select! {
+            biased;
+            _ = drain.changed() => break,
+            bi = acceptor.accept_bi() => {
+                spawn_stream_relay!(tasks, bi, initiator, relay_bi_stream_until_delivered,
+                    "accept_bi failed in draining relay", "draining bi-stream relay error");
+            }
+            uni = acceptor.accept_uni() => {
+                spawn_stream_relay!(tasks, uni, initiator, relay_uni_stream_until_delivered,
+                    "accept_uni failed in draining relay", "draining uni-stream relay error");
+            }
+        }
+    }
+    while let Some(result) = tasks.join_next().await {
+        if let Err(error) = result {
+            warn!(%error, "draining stream relay task failed");
+        }
+    }
+}
+
 async fn relay_bi_stream(
     (a_send, a_recv): (quinn::SendStream, quinn::RecvStream),
     initiator: &quinn::Connection,
@@ -251,7 +349,10 @@ async fn relay_bi_stream(
         .await
         .context("open bi-stream on peer")?;
 
-    let (r1, r2) = tokio::join!(relay_stream(a_recv, b_send), relay_stream(b_recv, a_send));
+    let (r1, r2) = tokio::join!(
+        relay_stream::<false>(a_recv, b_send),
+        relay_stream::<false>(b_recv, a_send)
+    );
     r1.and(r2)
 }
 
@@ -261,12 +362,46 @@ async fn relay_uni_stream(a_recv: quinn::RecvStream, initiator: &quinn::Connecti
         .await
         .context("open uni-stream on peer")?;
 
-    relay_stream(a_recv, b_send).await
+    relay_stream::<false>(a_recv, b_send).await
 }
 
-async fn relay_stream(mut recv: quinn::RecvStream, mut send: quinn::SendStream) -> Result<()> {
+async fn relay_bi_stream_until_delivered(
+    (a_send, a_recv): (quinn::SendStream, quinn::RecvStream),
+    initiator: &quinn::Connection,
+) -> Result<()> {
+    let (b_send, b_recv) = initiator
+        .open_bi()
+        .await
+        .context("open bi-stream on peer")?;
+
+    let (r1, r2) = tokio::join!(
+        relay_stream::<true>(a_recv, b_send),
+        relay_stream::<true>(b_recv, a_send)
+    );
+    r1.and(r2)
+}
+
+async fn relay_uni_stream_until_delivered(
+    a_recv: quinn::RecvStream,
+    initiator: &quinn::Connection,
+) -> Result<()> {
+    let b_send = initiator
+        .open_uni()
+        .await
+        .context("open uni-stream on peer")?;
+
+    relay_stream::<true>(a_recv, b_send).await
+}
+
+async fn relay_stream<const CONFIRM_DELIVERY: bool>(
+    mut recv: quinn::RecvStream,
+    mut send: quinn::SendStream,
+) -> Result<()> {
     tokio::io::copy(&mut recv, &mut send).await?;
     send.finish()?;
+    if CONFIRM_DELIVERY {
+        send.stopped().await?;
+    }
     Ok(())
 }
 
@@ -689,5 +824,112 @@ mod tests {
         client_connection.close(0u32.into(), b"test complete");
         peer_task.await.unwrap();
         relay_task.abort();
+    }
+
+    #[tokio::test]
+    async fn quic_relay_shutdown_drains_admitted_stream_and_stops_accepting_new_streams() {
+        let peer_server =
+            Endpoint::server(test_server_config(), "127.0.0.1:0".parse().unwrap()).unwrap();
+        let peer_addr = peer_server.local_addr().unwrap();
+        let relay_server =
+            Endpoint::server(test_server_config(), "127.0.0.1:0".parse().unwrap()).unwrap();
+        let relay_addr = relay_server.local_addr().unwrap();
+        let relay_endpoints = build_relay_endpoints(
+            RelayEndpointConfig::default(),
+            stargate_tls::build_insecure_quic_client_config().unwrap(),
+        )
+        .expect("relay endpoints");
+
+        let (request_received_tx, request_received_rx) = tokio::sync::oneshot::channel();
+        let (send_response_tx, send_response_rx) = tokio::sync::oneshot::channel();
+        let peer_task = tokio::spawn(async move {
+            let incoming = peer_server.accept().await.expect("peer should accept");
+            let connection = incoming.await.expect("peer connection should complete");
+            let (mut send, mut recv) = connection
+                .accept_bi()
+                .await
+                .expect("peer should accept the admitted stream");
+            let body = recv.read_to_end(1024).await.expect("read request");
+            drop(recv);
+            request_received_tx
+                .send(body)
+                .expect("report admitted request");
+            send_response_rx.await.expect("release response");
+            send.write_all(b"drained response")
+                .await
+                .expect("write response");
+            send.finish().expect("finish response");
+
+            if connection.accept_bi().await.is_ok() {
+                panic!("a stream opened after shutdown must not reach the peer");
+            }
+        });
+
+        let peer = PeerTarget {
+            dial_addr: peer_addr.to_string(),
+            server_name: "stargate".to_string(),
+        };
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let mut relay_task = tokio::spawn(async move {
+            let incoming = relay_server.accept().await.expect("relay should accept");
+            let connection = incoming.await.expect("relay connection should complete");
+            forward_quic_connection_until_shutdown(
+                connection,
+                &peer,
+                &relay_endpoints,
+                Duration::from_secs(5),
+                async move {
+                    let _ = shutdown_rx.await;
+                },
+            )
+            .await
+            .expect("relay should drain cleanly");
+        });
+
+        let mut client_endpoint = Endpoint::client("127.0.0.1:0".parse().unwrap()).unwrap();
+        client_endpoint
+            .set_default_client_config(stargate_tls::build_insecure_quic_client_config().unwrap());
+        let client_connection = client_endpoint
+            .connect(relay_addr, "stargate")
+            .unwrap()
+            .await
+            .unwrap();
+        let (mut send, mut recv) = client_connection.open_bi().await.unwrap();
+        send.write_all(b"admitted request").await.unwrap();
+        send.finish().unwrap();
+        drop(send);
+
+        assert_eq!(
+            request_received_rx
+                .await
+                .expect("peer should receive request"),
+            b"admitted request"
+        );
+        shutdown_tx.send(()).expect("start relay shutdown");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), &mut relay_task)
+                .await
+                .is_err(),
+            "shutdown must wait for the admitted stream"
+        );
+
+        let (mut rejected_send, _rejected_recv) = client_connection.open_bi().await.unwrap();
+        rejected_send.write_all(b"late request").await.unwrap();
+        rejected_send.finish().unwrap();
+        send_response_tx.send(()).expect("allow response");
+
+        assert_eq!(
+            recv.read_to_end(1024).await.expect("read drained response"),
+            b"drained response"
+        );
+        drop(recv);
+        tokio::time::timeout(Duration::from_secs(2), relay_task)
+            .await
+            .expect("relay should finish after its admitted stream")
+            .expect("relay task should not panic");
+        tokio::time::timeout(Duration::from_secs(2), peer_task)
+            .await
+            .expect("peer should observe the drained connection close")
+            .expect("peer task should not panic");
     }
 }

--- a/src/libraries/rust/stargate/crates/stargate-k8s-router/src/grpc.rs
+++ b/src/libraries/rust/stargate/crates/stargate-k8s-router/src/grpc.rs
@@ -79,10 +79,15 @@ pub struct RouterControlPlane {
     watch_heartbeat_interval: Duration,
     hostname_matcher: Option<HostnameMatcher>,
     targets: watch::Receiver<TargetSnapshot>,
+    shutdown: CancellationToken,
 }
 
 impl RouterControlPlane {
-    pub fn new(config: GrpcRouterConfig, targets: watch::Receiver<TargetSnapshot>) -> Self {
+    pub fn new(
+        config: GrpcRouterConfig,
+        targets: watch::Receiver<TargetSnapshot>,
+        shutdown: CancellationToken,
+    ) -> Self {
         let hostname_matcher = HostnameMatcher::new(
             &config.advertised_hostname_template,
             &config.target_namespace,
@@ -102,6 +107,7 @@ impl RouterControlPlane {
             watch_heartbeat_interval: config.watch_heartbeat_interval,
             hostname_matcher,
             targets,
+            shutdown,
         }
     }
 
@@ -113,7 +119,12 @@ impl RouterControlPlane {
         let remote_watch_urls = self.remote_watch_urls.clone();
         let target_namespace = self.target_namespace.clone();
         let watch_heartbeat_interval = self.watch_heartbeat_interval;
-        Box::pin(async_stream::try_stream! {
+        let shutdown = self.shutdown.clone();
+        Box::pin(async_stream::stream! {
+            if shutdown.is_cancelled() {
+                yield Err(router_shutdown_status());
+                return;
+            }
             let mut heartbeat = tokio::time::interval(watch_heartbeat_interval);
             heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             let mut last_snapshot = None;
@@ -122,17 +133,22 @@ impl RouterControlPlane {
                 if snapshot.is_initialized() {
                     last_snapshot = Some(snapshot.clone());
                     heartbeat.reset();
-                    yield watch_response_from_snapshot(
+                    yield Ok(watch_response_from_snapshot(
                         &snapshot,
                         &advertised_hostname_template,
                         advertised_grpc_port,
                         &grpc_pylon_dial_addr,
                         &target_namespace,
                         &remote_watch_urls,
-                    );
+                    ));
                 }
                 loop {
                     tokio::select! {
+                        biased;
+                        _ = shutdown.cancelled() => {
+                            yield Err(router_shutdown_status());
+                            return;
+                        }
                         changed = targets.changed() => {
                             if changed.is_err() {
                                 return;
@@ -144,14 +160,14 @@ impl RouterControlPlane {
                                 .as_ref()
                                 .expect("heartbeat branch requires an initialized snapshot");
                             heartbeat.reset();
-                            yield watch_response_from_snapshot(
+                            yield Ok(watch_response_from_snapshot(
                                 snapshot,
                                 &advertised_hostname_template,
                                 advertised_grpc_port,
                                 &grpc_pylon_dial_addr,
                                 &target_namespace,
                                 &remote_watch_urls,
-                            );
+                            ));
                         }
                     }
                 }
@@ -212,6 +228,9 @@ impl StargateControlPlane for RouterControlPlane {
         &self,
         _request: Request<WatchStargatesRequest>,
     ) -> Result<Response<Self::WatchStargatesStream>, Status> {
+        if self.shutdown.is_cancelled() {
+            return Err(router_shutdown_status());
+        }
         Ok(Response::new(self.watch_stargates_stream()))
     }
 
@@ -219,6 +238,9 @@ impl StargateControlPlane for RouterControlPlane {
         &self,
         request: Request<tonic::Streaming<InferenceServerRegistration>>,
     ) -> Result<Response<Self::RegisterInferenceServerStream>, Status> {
+        if self.shutdown.is_cancelled() {
+            return Err(router_shutdown_status());
+        }
         let target = {
             let snapshot = self.targets.borrow();
             GrpcTarget::from(self.target_for_registration(&request, &snapshot)?)
@@ -234,12 +256,27 @@ impl StargateControlPlane for RouterControlPlane {
             warn!(%error, "registration stream read error, forwarding stream error");
         });
         let forwarded = Request::from_parts(metadata, extensions, inbound);
-        let mut peer_client = self.connect_target_addr(&target.grpc_addr).await?;
-        let resp = peer_client.register_inference_server(forwarded).await?;
+        let Some(resp) = self
+            .shutdown
+            .run_until_cancelled(async {
+                let mut peer_client = self.connect_target_addr(&target.grpc_addr).await?;
+                peer_client.register_inference_server(forwarded).await
+            })
+            .await
+        else {
+            return Err(router_shutdown_status());
+        };
+        let resp = resp?;
         let (metadata, mut inner, extensions) = resp.into_parts();
+        let shutdown = self.shutdown.clone();
         let stream = async_stream::stream! {
             loop {
                 tokio::select! {
+                    biased;
+                    _ = shutdown.cancelled() => {
+                        yield Err(router_shutdown_status());
+                        break;
+                    }
                     Some(error) = stream_error_rx.recv() => {
                         yield Err(error);
                         break;
@@ -264,6 +301,10 @@ impl StargateControlPlane for RouterControlPlane {
         };
         Ok(Response::from_parts(metadata, Box::pin(stream), extensions))
     }
+}
+
+fn router_shutdown_status() -> Status {
+    Status::unavailable("router is shutting down")
 }
 
 fn watch_response_from_snapshot(
@@ -305,7 +346,7 @@ pub async fn serve_grpc_router(
     shutdown: CancellationToken,
 ) -> anyhow::Result<()> {
     let incoming = TcpListenerStream::new(listener);
-    let service = RouterControlPlane::new(config, targets);
+    let service = RouterControlPlane::new(config, targets, shutdown.clone());
     Server::builder()
         .layer(MapRequestLayer::new(|mut req: http::Request<_>| {
             if let Some(authority) = req.uri().authority().cloned() {
@@ -336,7 +377,7 @@ mod tests {
     use stargate_proto::pb::stargate_control_plane_client::StargateControlPlaneClient;
     use stargate_proto::pb::stargate_control_plane_server::StargateControlPlaneServer;
     use stargate_proto::pb::{InferenceServerAck, StargateInfo};
-    use tokio_stream::wrappers::TcpListenerStream;
+    use tokio_stream::wrappers::{ReceiverStream, TcpListenerStream};
 
     use super::*;
 
@@ -359,6 +400,7 @@ mod tests {
     struct RunningServer {
         addr: SocketAddr,
         task: tokio::task::JoinHandle<()>,
+        shutdown: CancellationToken,
     }
 
     impl Drop for RunningServer {
@@ -455,11 +497,11 @@ mod tests {
             let recorder = self.recorder.clone();
             let mut inbound = request.into_inner();
             let stream = async_stream::stream! {
-                if let Some(message) = inbound.next().await {
+                while let Some(message) = inbound.next().await {
                     match message {
                         Ok(_registration) => {
                             yield Ok(InferenceServerAck {
-                                reverse_tunnel_target: stargate_id,
+                                reverse_tunnel_target: stargate_id.clone(),
                                 reverse_tunnel_pylon_dial_addr: String::new(),
                             });
                         }
@@ -493,6 +535,7 @@ mod tests {
             stargate_id: stargate_id.to_string(),
             recorder,
         };
+        let shutdown = CancellationToken::new();
         let handle = tokio::spawn(async move {
             Server::builder()
                 .add_service(StargateControlPlaneServer::new(service))
@@ -500,7 +543,11 @@ mod tests {
                 .await
                 .expect("fake stargate failed");
         });
-        RunningServer { addr, task: handle }
+        RunningServer {
+            addr,
+            task: handle,
+            shutdown,
+        }
     }
 
     async fn start_router(snapshot: TargetSnapshot) -> RunningServer {
@@ -530,7 +577,11 @@ mod tests {
                     .expect("router failed");
             }
         });
-        RunningServer { addr, task: handle }
+        RunningServer {
+            addr,
+            task: handle,
+            shutdown,
+        }
     }
 
     fn snapshot(targets: &[(&str, SocketAddr)]) -> TargetSnapshot {
@@ -589,7 +640,7 @@ mod tests {
         const BASELINE_NS_PER_OP: f64 = 276.71;
 
         let (_tx, rx) = watch::channel(synthetic_snapshot(128));
-        let router = RouterControlPlane::new(router_config(), rx);
+        let router = RouterControlPlane::new(router_config(), rx, CancellationToken::new());
         let request = request_with_authority("stargate-64.stargate.external");
         let iterations = 1_000_000usize;
         let started = Instant::now();
@@ -836,5 +887,61 @@ mod tests {
         let snapshot = first_message(response).await;
 
         assert!(snapshot.stargates.is_empty());
+    }
+
+    #[tokio::test]
+    async fn shutdown_ends_long_lived_rpc_streams_and_server_task() {
+        let fake = start_fake_stargate("stargate-1", Recorder::default()).await;
+        let (targets_tx, targets_rx) = watch::channel(snapshot(&[("stargate-1", fake.addr)]));
+        let mut router = start_router_with_receiver(targets_rx, router_config()).await;
+        let mut client = router.client("stargate-1.stargate.external");
+
+        let mut watch_stream = watch_once(&mut client).await.into_inner();
+        watch_stream
+            .message()
+            .await
+            .expect("initial WatchStargates read should succeed")
+            .expect("WatchStargates should publish an initial snapshot");
+
+        let (registration_tx, registration_rx) = tokio::sync::mpsc::channel(1);
+        registration_tx
+            .send(registration())
+            .await
+            .expect("initial registration should enqueue");
+        let mut registration_stream = client
+            .register_inference_server(Request::new(ReceiverStream::new(registration_rx)))
+            .await
+            .expect("registration should route")
+            .into_inner();
+        registration_stream
+            .message()
+            .await
+            .expect("initial registration acknowledgement should succeed")
+            .expect("registration should remain open after its first acknowledgement");
+
+        router.shutdown.cancel();
+
+        let watch_error = watch_stream
+            .message()
+            .await
+            .expect_err("shutdown should end WatchStargates with a status");
+        let registration_error = registration_stream
+            .message()
+            .await
+            .expect_err("shutdown should end RegisterInferenceServer with a status");
+        assert_eq!(watch_error.code(), tonic::Code::Unavailable);
+        assert_eq!(registration_error.code(), tonic::Code::Unavailable);
+        assert_eq!(watch_error.message(), "router is shutting down");
+        assert_eq!(registration_error.message(), "router is shutting down");
+
+        drop(watch_stream);
+        drop(registration_stream);
+        drop(client);
+        drop(registration_tx);
+        tokio::time::timeout(Duration::from_secs(1), &mut router.task)
+            .await
+            .expect("gRPC server should stop after its long-lived streams end")
+            .expect("gRPC server task should not panic");
+        drop(targets_tx);
     }
 }

--- a/src/libraries/rust/stargate/crates/stargate-k8s-router/src/main.rs
+++ b/src/libraries/rust/stargate/crates/stargate-k8s-router/src/main.rs
@@ -42,6 +42,7 @@ const DEFAULT_CONNECT_TIMEOUT_MS: u64 = 5_000;
 const DEFAULT_WATCH_HEARTBEAT_MS: u64 = 5_000;
 const DEFAULT_RELAY_MAX_IDLE_TIMEOUT_MS: u64 = 300_000;
 const DEFAULT_RELAY_KEEP_ALIVE_MS: u64 = 10_000;
+const DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS: u64 = 30_000;
 
 #[derive(Clone, Debug, PartialEq, ValueEnum)]
 enum RouterTunnelProtocol {
@@ -105,6 +106,13 @@ struct Args {
     /// QUIC keepalive interval for relayed reverse tunnels; 0 disables keepalive
     #[arg(long, default_value_t = DEFAULT_RELAY_KEEP_ALIVE_MS, value_name = "MS")]
     relay_keep_alive_ms: u64,
+    /// Maximum time to drain active work after receiving a termination signal.
+    #[arg(
+        long,
+        default_value_t = DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS,
+        value_name = "MS"
+    )]
+    shutdown_drain_timeout_ms: u64,
     #[arg(long, env = "STARGATE_TLS_CERT_PATH", value_name = "PATH")]
     tls_cert_path: Option<String>,
     #[arg(long, env = "STARGATE_TLS_KEY_PATH", value_name = "PATH")]
@@ -122,6 +130,7 @@ struct Args {
 struct RouterStartupConfig {
     listen_addr: SocketAddr,
     health_listen_addr: SocketAddr,
+    shutdown_drain_timeout: Duration,
     grpc: GrpcRouterConfig,
     target_build_config: TargetBuildConfig,
     tunnel: RouterTunnelConfig,
@@ -153,6 +162,10 @@ impl RouterStartupConfig {
         ensure!(
             args.watch_heartbeat_ms > 0,
             "--watch-heartbeat-ms must be greater than 0"
+        );
+        ensure!(
+            args.shutdown_drain_timeout_ms > 0,
+            "--shutdown-drain-timeout-ms must be greater than 0"
         );
         ensure!(
             args.allow_insecure_remote_watch_http
@@ -230,6 +243,7 @@ impl RouterStartupConfig {
         Ok(Self {
             listen_addr: args.listen_addr,
             health_listen_addr: args.health_listen_addr,
+            shutdown_drain_timeout: Duration::from_millis(args.shutdown_drain_timeout_ms),
             grpc,
             target_build_config: TargetBuildConfig {
                 service_name: args.target_service_name,
@@ -244,6 +258,7 @@ impl RouterStartupConfig {
 struct RouterRuntime {
     tasks: CriticalTaskGroup,
     critical_failure_rx: CriticalTaskFailureReceiver,
+    shutdown_drain_timeout: Duration,
 }
 
 impl RouterRuntime {
@@ -257,6 +272,7 @@ impl RouterRuntime {
         let (tasks, critical_failure_rx) = CriticalTaskGroup::new("router");
         let target_namespace = config.grpc.target_namespace.clone();
         let health_listen_addr = config.health_listen_addr;
+        let shutdown_drain_timeout = config.shutdown_drain_timeout;
 
         let build_config = config.target_build_config;
         tasks.spawn_critical("EndpointSlice watcher", move |shutdown| {
@@ -298,37 +314,68 @@ impl RouterRuntime {
         Ok(Self {
             tasks,
             critical_failure_rx,
+            shutdown_drain_timeout,
         })
     }
 
-    async fn run_until_shutdown<S>(self, signal: S) -> Result<()>
+    async fn run_until_shutdown<S, F>(self, signal: S, force_shutdown: F) -> Result<()>
     where
         S: Future<Output = std::io::Result<&'static str>>,
+        F: Future<Output = std::io::Result<&'static str>>,
     {
         tokio::pin!(signal);
-        let failure = tokio::select! {
+        let shutdown_error = tokio::select! {
             result = &mut signal => {
-                result
-                    .context("failed to receive router termination signal")
-                    .map(|signal| {
+                match result {
+                    Ok(signal) => {
                         info!(signal, "received shutdown signal");
                         None
-                    })
+                    }
+                    Err(error) => Some(anyhow::Error::new(error)
+                        .context("failed to receive router termination signal")),
+                }
             }
             failure = self.critical_failure_rx.recv_async() => {
-                failure
-                    .context("router critical failure channel closed")
-                    .map(|failure| {
+                Some(match failure {
+                    Ok(failure) => {
                         error!(error = %failure, "critical router task exited");
-                        Some(failure)
-                    })
+                        failure.into()
+                    }
+                    Err(error) => anyhow::Error::new(error)
+                        .context("router critical failure channel closed"),
+                })
             }
         };
 
         self.tasks.begin_shutdown();
-        self.tasks.wait().await;
-        if let Some(failure) = failure? {
-            return Err(failure.into());
+        tokio::pin!(force_shutdown);
+        let drain_result = tokio::select! {
+            () = self.tasks.wait() => Ok(()),
+            () = tokio::time::sleep(self.shutdown_drain_timeout) => {
+                Err(anyhow::anyhow!(
+                    "graceful shutdown timed out after {} ms",
+                    self.shutdown_drain_timeout.as_millis()
+                ))
+            }
+            result = &mut force_shutdown => {
+                match result {
+                    Ok(signal) => Err(anyhow::anyhow!(
+                        "received second {signal} during graceful shutdown"
+                    )),
+                    Err(error) => Err(anyhow::Error::new(error)
+                        .context("failed to receive second router termination signal")),
+                }
+            }
+        };
+
+        if let Err(error) = drain_result {
+            if let Some(shutdown_error) = shutdown_error {
+                return Err(shutdown_error.context(error));
+            }
+            return Err(error);
+        }
+        if let Some(error) = shutdown_error {
+            return Err(error);
         }
         info!("stargate Kubernetes router stopped cleanly");
         Ok(())
@@ -345,9 +392,18 @@ async fn main() -> Result<()> {
 
 async fn run_router(config: RouterStartupConfig) -> Result<()> {
     log_startup(&config);
-    start_router(config)
-        .await?
-        .run_until_shutdown(wait_for_termination_signal())
+    let signal = wait_for_termination_signal();
+    tokio::pin!(signal);
+    let runtime = tokio::select! {
+        runtime = start_router(config) => runtime?,
+        result = &mut signal => {
+            let signal = result.context("failed to receive router termination signal")?;
+            info!(signal, "received shutdown signal during startup");
+            return Ok(());
+        }
+    };
+    runtime
+        .run_until_shutdown(signal, wait_for_termination_signal())
         .await
 }
 
@@ -404,6 +460,7 @@ fn log_startup(config: &RouterStartupConfig) {
         quic_port_name = %config.target_build_config.quic_port_name,
         connect_timeout_ms = config.grpc.connect_timeout.as_millis(),
         watch_heartbeat_ms = config.grpc.watch_heartbeat_interval.as_millis(),
+        shutdown_drain_timeout_ms = config.shutdown_drain_timeout.as_millis(),
         relay_idle_timeout_ms = relay_idle_timeout.as_millis(),
         relay_keep_alive_ms = relay_keep_alive.map_or(0, |duration| duration.as_millis()),
         quic_insecure,
@@ -734,6 +791,8 @@ mod tests {
             "20000",
             "--relay-keep-alive-ms",
             "5000",
+            "--shutdown-drain-timeout-ms",
+            "15000",
             "--tls-cert-path",
             test_file_path(&cert),
             "--tls-key-path",
@@ -757,6 +816,7 @@ mod tests {
             "https://stargate-router.example:443"
         );
         assert_eq!(config.grpc.connect_timeout, Duration::from_millis(2500));
+        assert_eq!(config.shutdown_drain_timeout, Duration::from_millis(15000));
         assert_eq!(
             config.grpc.watch_heartbeat_interval,
             Duration::from_millis(1750)
@@ -853,10 +913,11 @@ mod tests {
         let runtime = RouterRuntime {
             tasks,
             critical_failure_rx,
+            shutdown_drain_timeout: Duration::from_secs(1),
         };
 
         let error = runtime
-            .run_until_shutdown(std::future::pending())
+            .run_until_shutdown(std::future::pending(), std::future::pending())
             .await
             .expect_err("critical task exits should fail the process");
 
@@ -876,12 +937,14 @@ mod tests {
         let runtime = RouterRuntime {
             tasks,
             critical_failure_rx,
+            shutdown_drain_timeout: Duration::from_secs(1),
         };
 
         let error = runtime
-            .run_until_shutdown(std::future::ready(Err(std::io::Error::other(
-                "signal setup failed",
-            ))))
+            .run_until_shutdown(
+                std::future::ready(Err(std::io::Error::other("signal setup failed"))),
+                std::future::pending(),
+            )
             .await
             .expect_err("signal failure should fail the process after shutdown");
 
@@ -904,8 +967,62 @@ mod tests {
 
         RouterRuntime::start(config, client)
             .await?
-            .run_until_shutdown(std::future::ready(Ok("test")))
+            .run_until_shutdown(std::future::ready(Ok("test")), std::future::pending())
             .await
+    }
+
+    #[tokio::test]
+    async fn router_runtime_bounds_graceful_shutdown() {
+        let (tasks, critical_failure_rx) = CriticalTaskGroup::new("router");
+        tasks.spawn_critical("stuck root", |_shutdown| std::future::pending());
+        let runtime = RouterRuntime {
+            tasks,
+            critical_failure_rx,
+            shutdown_drain_timeout: Duration::from_millis(10),
+        };
+
+        let error = runtime
+            .run_until_shutdown(std::future::ready(Ok("SIGTERM")), std::future::pending())
+            .await
+            .expect_err("a stuck task must not make shutdown unbounded");
+
+        assert_eq!(error.to_string(), "graceful shutdown timed out after 10 ms");
+    }
+
+    #[tokio::test]
+    async fn router_runtime_second_signal_ends_graceful_shutdown() {
+        let (tasks, critical_failure_rx) = CriticalTaskGroup::new("router");
+        tasks.spawn_critical("stuck root", |_shutdown| std::future::pending());
+        let runtime = RouterRuntime {
+            tasks,
+            critical_failure_rx,
+            shutdown_drain_timeout: Duration::from_secs(60),
+        };
+
+        let error = runtime
+            .run_until_shutdown(
+                std::future::ready(Ok("SIGTERM")),
+                std::future::ready(Ok("SIGINT")),
+            )
+            .await
+            .expect_err("a second signal must end the graceful shutdown wait");
+
+        assert_eq!(
+            error.to_string(),
+            "received second SIGINT during graceful shutdown"
+        );
+    }
+
+    #[test]
+    fn router_cli_rejects_a_zero_shutdown_drain_timeout() {
+        let error =
+            RouterStartupConfig::from_args(router_args(&["--shutdown-drain-timeout-ms", "0"]))
+                .err()
+                .expect("zero shutdown drain timeout must be rejected");
+        assert_eq!(
+            error.to_string(),
+            "--shutdown-drain-timeout-ms must be greater than 0"
+        );
     }
 
     #[test]

--- a/src/libraries/rust/stargate/crates/stargate-k8s-router/src/quic.rs
+++ b/src/libraries/rust/stargate/crates/stargate-k8s-router/src/quic.rs
@@ -21,7 +21,7 @@ use anyhow::{Context, Result};
 use quinn::{ClientConfig, Endpoint};
 use stargate_forwarding::{
     HostnameMatcher, PeerTarget, RelayEndpointConfig, RelayEndpoints, build_relay_endpoints,
-    forward_quic_connection,
+    forward_quic_connection_until_shutdown,
 };
 use tokio::sync::watch;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
@@ -140,7 +140,11 @@ impl QuicRouterRuntime {
         loop {
             tokio::select! {
                 _ = shutdown.cancelled() => {
-                    self.endpoint.close(0u32.into(), b"shutdown");
+                    self.endpoint.set_server_config(None);
+                    info!(
+                        active_connections = self.endpoint.open_connections(),
+                        "QUIC router stopped accepting new connections; draining active streams"
+                    );
                     return Ok(());
                 }
                 result = &mut reload_task => {
@@ -229,6 +233,7 @@ async fn dispatch_incoming(
     shutdown: CancellationToken,
 ) -> Result<()> {
     let connection = tokio::select! {
+        biased;
         _ = shutdown.cancelled() => return Ok(()),
         connection = incoming => connection.context("accept QUIC connection")?,
     };
@@ -269,20 +274,14 @@ async fn dispatch_incoming(
             return Ok(());
         }
     };
-    let relay = forward_quic_connection(
-        connection.clone(),
+    let relay_result = forward_quic_connection_until_shutdown(
+        connection,
         &peer,
         &relay.endpoints,
         relay.connect_timeout,
-    );
-    tokio::pin!(relay);
-    let relay_result = tokio::select! {
-        _ = shutdown.cancelled() => {
-            connection.close(0u32.into(), b"router shutdown");
-            return Ok(());
-        }
-        result = &mut relay => result,
-    };
+        shutdown.cancelled_owned(),
+    )
+    .await;
     metrics.observe_quic_connection(if relay_result.is_ok() {
         "completed"
     } else {

--- a/src/libraries/rust/stargate/crates/stargate-k8s-router/src/webtransport.rs
+++ b/src/libraries/rust/stargate/crates/stargate-k8s-router/src/webtransport.rs
@@ -144,8 +144,13 @@ impl WebTransportRouterRuntime {
         tokio::pin!(reload_task);
         loop {
             tokio::select! {
+                biased;
                 _ = shutdown.cancelled() => {
-                    self.endpoint.close(0u32.into(), b"shutdown");
+                    self.endpoint.set_server_config(None);
+                    info!(
+                        active_connections = self.endpoint.open_connections(),
+                        "WebTransport router stopped accepting new connections; draining active streams"
+                    );
                     return Ok(());
                 }
                 result = &mut reload_task => {
@@ -164,7 +169,6 @@ impl WebTransportRouterRuntime {
                     let metrics = metrics.clone();
                     let config = self.config.clone();
                     let session_shutdown = shutdown.child_token();
-                    let stream_tasks = connection_tasks.clone();
                     connection_tasks.spawn(async move {
                         if let Err(error) = dispatch_incoming(
                             incoming,
@@ -172,7 +176,6 @@ impl WebTransportRouterRuntime {
                             metrics,
                             config,
                             session_shutdown,
-                            stream_tasks,
                         ).await {
                             warn!(%error, "WebTransport router session failed");
                         }
@@ -201,9 +204,9 @@ async fn dispatch_incoming(
     metrics: Arc<RouterMetrics>,
     config: Arc<WebTransportRouterRuntimeConfig>,
     shutdown: CancellationToken,
-    connection_tasks: TaskTracker,
 ) -> Result<()> {
     let connection = tokio::select! {
+        biased;
         _ = shutdown.cancelled() => return Ok(()),
         connection = incoming => connection.context("accept downstream QUIC connection")?,
     };
@@ -235,6 +238,7 @@ async fn dispatch_incoming(
     );
     let downstream_connection = connection.clone();
     let downstream = match tokio::select! {
+        biased;
         _ = shutdown.cancelled() => {
             downstream_connection.close(0u32.into(), b"router shutdown");
             return Ok(());
@@ -257,6 +261,7 @@ async fn dispatch_incoming(
         }
     };
     let upstream = match tokio::select! {
+        biased;
         _ = shutdown.cancelled() => {
             downstream_connection.close(0u32.into(), b"router shutdown");
             return Ok(());
@@ -288,13 +293,7 @@ async fn dispatch_incoming(
             return Err(error);
         }
     };
-    match tokio::select! {
-        _ = shutdown.cancelled() => {
-            downstream_connection.close(0u32.into(), b"router shutdown");
-            return Ok(());
-        }
-        result = downstream.forward(upstream, shutdown.clone(), connection_tasks) => result,
-    } {
+    match downstream.forward(upstream, shutdown.clone()).await {
         Ok(None) => {
             metrics.observe_webtransport_session("completed");
             Ok(())
@@ -354,10 +353,9 @@ impl DownstreamSession {
         self,
         upstream: UpstreamSession,
         shutdown: CancellationToken,
-        connection_tasks: TaskTracker,
     ) -> Result<Option<RejectedDownstreamSession>> {
         if upstream.response_status.is_success() {
-            self.accept_and_bridge(upstream, shutdown, connection_tasks)
+            self.accept_and_bridge(upstream, shutdown)
                 .await
                 .map(|()| None)
         } else {
@@ -412,25 +410,36 @@ impl DownstreamSession {
         mut self,
         upstream: UpstreamSession,
         shutdown: CancellationToken,
-        connection_tasks: TaskTracker,
     ) -> Result<()> {
         let downstream_session_id = self.connect_stream.id().into_inner();
         send_downstream_response(&mut self.connect_stream, StatusCode::OK).await?;
         // Keep the accepted CONNECT and H3 session handles alive while WebTransport streams bridge.
-        let _downstream_h3 = self.h3_connection;
+        let mut downstream_h3 = self.h3_connection;
         let _downstream_connect = self.connect_stream;
         let _upstream_endpoint = upstream.quic.endpoint;
-        let _upstream_h3 = upstream.h3_connection;
+        let mut upstream_h3 = upstream.h3_connection;
         let _upstream_connect = upstream.connect_stream;
-        bridge_upstream_webtransport_streams(
+        let bridge = bridge_upstream_webtransport_streams(
             self.connection,
             upstream.quic.connection,
             upstream.session_id,
             downstream_session_id,
-            shutdown,
-            connection_tasks,
-        )
-        .await;
+            shutdown.clone(),
+        );
+        tokio::pin!(bridge);
+        tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => {
+                if let Err(error) = downstream_h3.shutdown(0).await {
+                    warn!(?error, "failed to send downstream HTTP/3 GOAWAY during drain");
+                }
+                if let Err(error) = upstream_h3.shutdown(0).await {
+                    warn!(?error, "failed to send upstream HTTP/3 GOAWAY during drain");
+                }
+                bridge.await;
+            }
+            () = &mut bridge => {}
+        }
         Ok(())
     }
 }
@@ -614,34 +623,33 @@ async fn bridge_upstream_webtransport_streams(
     upstream_session_id: u64,
     downstream_session_id: u64,
     shutdown: CancellationToken,
-    connection_tasks: TaskTracker,
 ) {
-    loop {
+    let stream_tasks = TaskTracker::new();
+    let draining = loop {
         tokio::select! {
+            biased;
             _ = shutdown.cancelled() => {
-                downstream_connection.close(0u32.into(), b"shutdown");
-                upstream_connection.close(0u32.into(), b"shutdown");
-                break;
+                break true;
             }
             _ = downstream_connection.closed() => {
                 upstream_connection.close(0u32.into(), b"downstream webtransport closed");
-                break;
+                break false;
             }
             stream = upstream_connection.accept_bi() => {
                 let Ok((upstream_send, upstream_recv)) = stream else {
                     downstream_connection.close(0u32.into(), b"upstream webtransport closed");
-                    break;
+                    break false;
                 };
                 let downstream_connection = downstream_connection.clone();
-                let stream_shutdown = shutdown.child_token();
-                connection_tasks.spawn(async move {
+                let stream_drain = shutdown.child_token();
+                stream_tasks.spawn(async move {
                     if let Err(error) = bridge_upstream_webtransport_stream(
                         downstream_connection,
                         upstream_send,
                         upstream_recv,
                         upstream_session_id,
                         downstream_session_id,
-                        stream_shutdown,
+                        stream_drain,
                     )
                     .await
                     {
@@ -650,6 +658,13 @@ async fn bridge_upstream_webtransport_streams(
                 });
             }
         }
+    };
+
+    stream_tasks.close();
+    stream_tasks.wait().await;
+    if draining {
+        downstream_connection.close(0u32.into(), b"router drained");
+        upstream_connection.close(0u32.into(), b"router drained");
     }
 }
 
@@ -659,48 +674,41 @@ async fn bridge_upstream_webtransport_stream(
     mut upstream_recv: quinn::RecvStream,
     upstream_session_id: u64,
     downstream_session_id: u64,
-    shutdown: CancellationToken,
+    drain: CancellationToken,
 ) -> Result<()> {
-    tokio::select! {
-        _ = shutdown.cancelled() => return Err(anyhow!("WebTransport stream bridge cancelled")),
-        result = tokio::time::timeout(
-            WEBTRANSPORT_STREAM_HEADER_TIMEOUT,
-            stargate_protocol::read_webtransport_bidi_header(&mut upstream_recv),
-        ) => result
-            .map_err(|_| anyhow!("timed out waiting for upstream WebTransport stream header"))
-            .and_then(|result| result.context("read upstream WebTransport stream header"))
-            .and_then(|stream_session_id| {
-                ensure!(
-                    stream_session_id == upstream_session_id,
-                    "upstream WebTransport session id mismatch: got {stream_session_id}, expected {upstream_session_id}"
-                );
-                Ok(())
-            }),
-    }
+    tokio::time::timeout(
+        WEBTRANSPORT_STREAM_HEADER_TIMEOUT,
+        stargate_protocol::read_webtransport_bidi_header(&mut upstream_recv),
+    )
+    .await
+    .map_err(|_| anyhow!("timed out waiting for upstream WebTransport stream header"))?
+    .context("read upstream WebTransport stream header")
+    .and_then(|stream_session_id| {
+        ensure!(
+            stream_session_id == upstream_session_id,
+            "upstream WebTransport session id mismatch: got {stream_session_id}, expected {upstream_session_id}"
+        );
+        Ok(())
+    })
     .inspect_err(|_| {
         reset_webtransport_stream(&mut upstream_send, &mut upstream_recv);
     })?;
 
-    let (mut downstream_send, downstream_recv) = tokio::select! {
-        _ = shutdown.cancelled() => return Err(anyhow!("WebTransport stream bridge cancelled")),
-        stream = downstream_connection.open_bi() => stream.context("open downstream WebTransport stream")?,
-    };
+    let (mut downstream_send, downstream_recv) = downstream_connection
+        .open_bi()
+        .await
+        .context("open downstream WebTransport stream")?;
     stargate_protocol::write_webtransport_bidi_header(&mut downstream_send, downstream_session_id)
         .await
         .context("write downstream WebTransport stream header")?;
 
-    tokio::select! {
-        _ = shutdown.cancelled() => Err(anyhow!("WebTransport stream bridge cancelled")),
-        result = async {
-            let (downstream_result, upstream_result) = tokio::join!(
-                copy_stream(upstream_recv, downstream_send),
-                copy_stream(downstream_recv, upstream_send),
-            );
-            downstream_result.context("copy upstream to downstream")?;
-            upstream_result.context("copy downstream to upstream")?;
-            Ok(())
-        } => result,
-    }
+    let (downstream_result, upstream_result) = tokio::join!(
+        copy_stream(upstream_recv, downstream_send, drain.clone()),
+        copy_stream(downstream_recv, upstream_send, drain),
+    );
+    downstream_result.context("copy upstream to downstream")?;
+    upstream_result.context("copy downstream to upstream")?;
+    Ok(())
 }
 
 fn reset_webtransport_stream(
@@ -711,7 +719,11 @@ fn reset_webtransport_stream(
     let _ = quinn_recv.stop(0u32.into());
 }
 
-async fn copy_stream(mut recv: quinn::RecvStream, mut send: quinn::SendStream) -> Result<()> {
+async fn copy_stream(
+    mut recv: quinn::RecvStream,
+    mut send: quinn::SendStream,
+    drain: CancellationToken,
+) -> Result<()> {
     while let Some(chunk) = recv
         .read_chunk(usize::MAX, true)
         .await
@@ -722,6 +734,11 @@ async fn copy_stream(mut recv: quinn::RecvStream, mut send: quinn::SendStream) -
             .context("write QUIC stream chunk")?;
     }
     send.finish().context("finish QUIC send stream")?;
+    if drain.is_cancelled() {
+        send.stopped()
+            .await
+            .context("wait for drained QUIC send stream acknowledgement")?;
+    }
     Ok(())
 }
 
@@ -1100,8 +1117,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn webtransport_router_shutdown_cancels_admitted_session_and_drains_tracker() -> Result<()>
-    {
+    async fn webtransport_router_shutdown_drains_admitted_session_and_tracker() -> Result<()> {
         let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
         let upstream_endpoint = Endpoint::server(
             server_config(&ServerTlsIdentity::SelfSigned)?,
@@ -1447,7 +1463,7 @@ mod tests {
 
         {
             let rejected = downstream_session
-                .forward(upstream, CancellationToken::new(), TaskTracker::new())
+                .forward(upstream, CancellationToken::new())
                 .await?
                 .expect("a non-success upstream CONNECT must not create a data bridge");
             assert_eq!(
@@ -1465,7 +1481,7 @@ mod tests {
     async fn stalled_upstream_stream_header_does_not_block_later_streams() -> Result<()> {
         let fixture = connect_bridge_fixture().await?;
 
-        let bridge_task = fixture.spawn_bridge(CancellationToken::new(), TaskTracker::new());
+        let bridge_task = fixture.spawn_bridge(CancellationToken::new());
         let (_stalled_send, _stalled_recv) = fixture.upstream_server_connection.open_bi().await?;
 
         let (mut upstream_send, _upstream_recv) =
@@ -1484,28 +1500,43 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn shutdown_closes_active_webtransport_stream_tasks_and_drains_tracker() -> Result<()> {
+    async fn shutdown_drains_active_webtransport_stream_before_closing_session() -> Result<()> {
         let fixture = connect_bridge_fixture().await?;
         let shutdown = CancellationToken::new();
-        let connection_tasks = TaskTracker::new();
-        let bridge_task = fixture.spawn_bridge(shutdown.clone(), connection_tasks.clone());
+        let mut bridge_task = fixture.spawn_bridge(shutdown.clone());
 
-        let (_upstream_send, _upstream_recv) =
+        let (mut upstream_send, mut upstream_recv) =
             open_webtransport_stream(&fixture.upstream_server_connection, UPSTREAM_SESSION_ID)
                 .await?;
-        let (_downstream_send, _downstream_recv) = fixture.accept_downstream_stream().await?;
+        let (mut downstream_send, mut downstream_recv) = fixture.accept_downstream_stream().await?;
 
         shutdown.cancel();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), &mut bridge_task)
+                .await
+                .is_err(),
+            "shutdown must wait for the active WebTransport stream"
+        );
+
+        upstream_send.write_all(b"upstream payload").await?;
+        upstream_send.finish()?;
+        assert_eq!(
+            downstream_recv.read_to_end(1024).await?,
+            b"upstream payload"
+        );
+        downstream_send.write_all(b"downstream payload").await?;
+        downstream_send.finish()?;
+        assert_eq!(
+            upstream_recv.read_to_end(1024).await?,
+            b"downstream payload"
+        );
+
         tokio::time::timeout(TEST_TIMEOUT, fixture.upstream_server_connection.closed())
             .await
-            .context("router shutdown should close the upstream WebTransport connection")?;
+            .context("drained WebTransport session should close upstream")?;
         tokio::time::timeout(TEST_TIMEOUT, bridge_task)
             .await
-            .context("stream accept loop should stop after shutdown")??;
-        connection_tasks.close();
-        tokio::time::timeout(TEST_TIMEOUT, connection_tasks.wait())
-            .await
-            .context("active stream bridge task should drain after shutdown")?;
+            .context("stream accept loop should finish after the active stream")??;
         Ok(())
     }
 
@@ -1561,7 +1592,7 @@ mod tests {
     async fn downstream_close_closes_upstream_session() -> Result<()> {
         let fixture = connect_bridge_fixture().await?;
 
-        let bridge_task = fixture.spawn_bridge(CancellationToken::new(), TaskTracker::new());
+        let bridge_task = fixture.spawn_bridge(CancellationToken::new());
 
         fixture
             .downstream_client_connection
@@ -1583,18 +1614,13 @@ mod tests {
     }
 
     impl BridgeFixture {
-        fn spawn_bridge(
-            &self,
-            shutdown: CancellationToken,
-            connection_tasks: TaskTracker,
-        ) -> tokio::task::JoinHandle<()> {
+        fn spawn_bridge(&self, shutdown: CancellationToken) -> tokio::task::JoinHandle<()> {
             tokio::spawn(bridge_upstream_webtransport_streams(
                 self.downstream_proxy_connection.clone(),
                 self.upstream_proxy_connection.clone(),
                 UPSTREAM_SESSION_ID,
                 DOWNSTREAM_SESSION_ID,
                 shutdown,
-                connection_tasks,
             ))
         }
 


### PR DESCRIPTION
## Why

Kubernetes sends SIGTERM before enforcing the pod termination deadline, but `stargate-k8s-router` previously closed its listeners and relayed connections immediately. A routine rollout could therefore interrupt in-flight inference responses and leave long-lived gRPC streams holding shutdown open.

## What changed

- Bound process shutdown with a configurable drain timeout and a second-signal fast exit.
- Stop accepting new gRPC, raw QUIC, and WebTransport work while allowing admitted stream work to finish.
- End long-lived router gRPC streams with `UNAVAILABLE` so Pylon can reconnect during the drain window.
- Send HTTP/3 GOAWAY for established WebTransport sessions, drain their tracked streams, and then close the QUIC connections.
- Derive both Stargate pod termination grace periods from the drain timeout, rounded up to seconds with a five-second exit margin.
- Add cancellation, timeout, second-signal, gRPC, QUIC, WebTransport, and Helm rendering coverage.

## Customer Release Notes

Stargate Kubernetes routers now drain active gRPC control streams, raw QUIC requests, and WebTransport requests during pod termination.

## Plan Summary

The application drain defaults to 30 seconds. Both chart workloads receive 35 seconds of Kubernetes termination grace by default. No resource or dependency changes are required.

## Usage

Use `--shutdown-drain-timeout-ms` to override the router drain budget. The Helm chart passes `llmRequestRouter.shutdown.drainTimeoutMs` to both Stargate and the backend router and derives pod grace from that value.

## Testing

Passed:

- `rustup run stable cargo fmt --manifest-path Cargo.toml -p stargate-forwarding -p stargate-k8s-router --check`
- `rustup run stable cargo test -p stargate-forwarding -p stargate-k8s-router`
- `rustup run stable cargo clippy -p stargate-forwarding -p stargate-k8s-router --all-targets -- -D warnings`
- `bazel test //src/libraries/rust/stargate/crates/stargate-forwarding:stargate-forwarding_test //src/libraries/rust/stargate/crates/stargate-k8s-router:stargate_k8s_router_test --test_output=errors`
- `deploy/helm/llm-request-router/scripts/check-backend-router-render.sh`
- `git diff --check origin/main...HEAD`

The full Cargo workspace test was attempted, but the build host ran out of disk while compiling unrelated workspace crates. The changed packages passed after regenerable Cargo artifacts were cleaned. The broader `check-multi-replica-render.sh` fails at the same pre-existing readiness validation assertion on `main`.

QA should rerun the relay pod deletion scenario under steady load to validate handoff behavior at deployment scale.

## Notes

- SIGINT and SIGTERM start the bounded drain. A second termination signal ends the wait early. SIGKILL remains immediate because applications cannot catch or defer it.
- Quinn listener configuration is removed for new handshakes without closing established connections.
- The current `h3` 0.0.8 API does not expose `WT_DRAIN_SESSION`. The implementation uses HTTP/3 GOAWAY, stops local stream admission, waits tracked streams, and then closes the session.
- The hot byte-copy loops are unchanged during normal operation. Delivery acknowledgement is awaited only after shutdown begins.

## Issues

Closes #1531

## References

- https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination-flow
- https://grpc.io/docs/guides/server-graceful-stop/
- https://www.rfc-editor.org/rfc/rfc9114.html#section-5.2
- https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3
- https://docs.rs/quinn/0.11.11/quinn/struct.Endpoint.html

## Related Pull Requests

None.

## Dependencies

None. No third-party packages or versions changed. License review and NOTICE updates are not required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable graceful shutdown draining, with a 30-second default.
  - Active QUIC and WebTransport connections now have time to finish processing during shutdown.
  - New connections and requests are rejected once shutdown begins, with clear unavailable responses.
  - Shutdown can be interrupted by a subsequent termination signal.
- **Bug Fixes**
  - Improved Kubernetes termination timing to provide sufficient time for configured request draining, including partial-second timeouts.
  - Startup now exits cleanly if interrupted before the router is ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->