### PR TITLE
fix(ratelimiter): pick up olric eviction fragment lock fix

### DIFF
--- a/src/invocation-plane-services/llm-api-gateway/go.mod
+++ b/src/invocation-plane-services/llm-api-gateway/go.mod
@@ -158,6 +158,6 @@ require (
 // `cas`). The fork keeps upstream's module path so this is a drop-in
 // replace with no import-site changes. Once CAS is upstreamed into
 // olric-data/olric, drop the replace and bump the require. See AGENTS.md.
-replace github.com/olric-data/olric => github.com/max007-008/olric v0.0.0-20260903172631-1d7a94c91260
+replace github.com/olric-data/olric => github.com/max007-008/olric v0.0.0-20260904024039-0e35b781a2f3
 
 replace k8s.io/client-go v11.0.0+incompatible => k8s.io/client-go v0.34.2

--- a/src/invocation-plane-services/llm-api-gateway/go.sum
+++ b/src/invocation-plane-services/llm-api-gateway/go.sum
@@ -229,8 +229,8 @@ github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/max007-008/olric v0.0.0-20260903172631-1d7a94c91260 h1:6ug2ACJNMB1QxrBowyXGk82prHFeDSLi3/4gvmQJtb0=
-github.com/max007-008/olric v0.0.0-20260903172631-1d7a94c91260/go.mod h1:+ZnPpgc8JkNkza8rETCKGn0P/QPF6HhZY0EbCKAOslo=
+github.com/max007-008/olric v0.0.0-20260904024039-0e35b781a2f3 h1:+gnQtIfqR9Puj59omt/vCF+BzXpVsBJaVEyHxjvTWP4=
+github.com/max007-008/olric v0.0.0-20260904024039-0e35b781a2f3/go.mod h1:+ZnPpgc8JkNkza8rETCKGn0P/QPF6HhZY0EbCKAOslo=
 github.com/maypok86/otter/v2 v2.3.0 h1:8H8AVVFUSzJwIegKwv1uF5aGitTY+AIrtktg7OcLs8w=
 github.com/maypok86/otter/v2 v2.3.0/go.mod h1:XgIdlpmL6jYz882/CAx1E4C1ukfgDKSaw4mWq59+7l8=
 github.com/miekg/dns v1.1.65 h1:0+tIPHzUW0GCge7IiK3guGP57VAw7hoPDfApjkMD1Fc=

--- a/src/invocation-plane-services/ratelimiter/go.mod
+++ b/src/invocation-plane-services/ratelimiter/go.mod
@@ -161,4 +161,4 @@ replace k8s.io/client-go v11.0.0+incompatible => k8s.io/client-go v0.34.2
 // timeout and crashloop. The fork keeps upstream's module path, so this must
 // stay identical to the replace in llm-api-gateway/go.mod; the Bazel build
 // resolves one olric for the whole workspace.
-replace github.com/olric-data/olric => github.com/max007-008/olric v0.0.0-20260903172631-1d7a94c91260
+replace github.com/olric-data/olric => github.com/max007-008/olric v0.0.0-20260904024039-0e35b781a2f3

--- a/src/invocation-plane-services/ratelimiter/go.sum
+++ b/src/invocation-plane-services/ratelimiter/go.sum
@@ -235,8 +235,8 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/max007-008/olric v0.0.0-20260903172631-1d7a94c91260 h1:6ug2ACJNMB1QxrBowyXGk82prHFeDSLi3/4gvmQJtb0=
-github.com/max007-008/olric v0.0.0-20260903172631-1d7a94c91260/go.mod h1:+ZnPpgc8JkNkza8rETCKGn0P/QPF6HhZY0EbCKAOslo=
+github.com/max007-008/olric v0.0.0-20260904024039-0e35b781a2f3 h1:+gnQtIfqR9Puj59omt/vCF+BzXpVsBJaVEyHxjvTWP4=
+github.com/max007-008/olric v0.0.0-20260904024039-0e35b781a2f3/go.mod h1:+ZnPpgc8JkNkza8rETCKGn0P/QPF6HhZY0EbCKAOslo=
 github.com/miekg/dns v1.1.65 h1:0+tIPHzUW0GCge7IiK3guGP57VAw7hoPDfApjkMD1Fc=
 github.com/miekg/dns v1.1.65/go.mod h1:Dzw9769uoKVaLuODMDZz9M6ynFU6Em65csPuoi8G0ck=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=


### PR DESCRIPTION
Fixes the rolling-update wedge in #1546.

olric's eviction scanner held the fragment lock across its whole key scan and
called `deleteOnCluster` from inside it, contacting previous owners and backups
per expired key. After a rolling update the previous-owners list still names the
departed pod, whose address blackholes on Fargate, so each call costs a full read
timeout and one scan can hold the lock for close to a minute.

`Partition.Length` takes that lock, `prepareLeftOverDataReport` walks every
partition calling it, and `updateRoutingCommandHandler` runs that report under
`updateRoutingMtx`. Routing updates queue behind eviction and stop being applied;
the coordinator pushes with no deadline while holding its own routing lock, so
the departed owner is never pruned and eviction keeps aiming at it.

The fork now collects expired keys under the lock and deletes them after
releasing it, re-checking each entry before removal so a counter revived by an
in-flight request is not dropped.

`llm-api-gateway` moves to the same commit because both modules resolve one olric
through `go.work.bazel`; differing replace directives are a build error.

## Validation

Three-node cluster, per-second TTL keys, arms differing only by the two olric files:

| full rolling update | before | after |
|---|---|---|
| partitions owned by dead pods | 155 | 0 |
| throughput | 3.5M -> 6.8k ops | 11.8M sustained |
| failed ops | 1162 | 0 |

Same result with the departed pod's address blackholed rather than refusing
connections, and again at `MaxInuse` 10MB to force the LRU eviction path.

Two regression tests in the fork, each failing without its half of the change:
worst `Partition.Length` latency during eviction is 57.4s before and 28us after;
the revival test loses the written value outright without the re-check.

Staging confirmed the mechanism on 1.17.2: a departed pod referenced 26988 times
over four continuous hours, every eviction delete failing against the node's own
address because its handler pool was blocked.

## Note

#1494 and #1520 are separate real defects worth keeping, but neither addresses
this — staging was running 1.17.2, which contains both, when it wedged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal service components to newer compatible revisions.
  * No user-facing features, workflows, or API behavior have changed.
  * Existing rate-limiting and invocation service behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->