### PR TITLE
fix(webhook):  cpu throttle issue

### DIFF
--- a/deploy/helm/nvca-operator/nvca-operator/README.md
+++ b/deploy/helm/nvca-operator/nvca-operator/README.md
@@ -101,9 +101,8 @@ This release does not wire the catalog into backend selection. Runtime use requi
 
 | Name                                | Description                                   | Value   |
 | ----------------------------------- | --------------------------------------------- | ------- |
-| `webhook.resources.limits.cpu`      | CPU limit for the nvca webhook container      | `200m`  |
 | `webhook.resources.limits.memory`   | Memory limit for the nvca webhook container   | `200Mi` |
-| `webhook.resources.requests.cpu`    | CPU request for the nvca webhook container    | `50m`   |
+| `webhook.resources.requests.cpu`    | CPU request for the nvca webhook container    | `500m`  |
 | `webhook.resources.requests.memory` | Memory request for the nvca webhook container | `50Mi`  |
 
 ### NGC Configuration

--- a/deploy/helm/nvca-operator/nvca-operator/values.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/values.yaml
@@ -245,17 +245,15 @@ agent:
       cpu: 100m
       memory: 200Mi
 ## @section Webhook Container Resource configuration
-## @param webhook.resources.limits.cpu CPU limit for the nvca webhook container
 ## @param webhook.resources.limits.memory Memory limit for the nvca webhook container
 ## @param webhook.resources.requests.cpu CPU request for the nvca webhook container
 ## @param webhook.resources.requests.memory Memory request for the nvca webhook container
 webhook:
   resources:
     limits:
-      cpu: 200m
       memory: 200Mi
     requests:
-      cpu: 50m
+      cpu: 500m
       memory: 50Mi
 ## @section NGC Configuration
 


### PR DESCRIPTION
## TL;DR

Remove the NVCA webhook container's CPU limit and raise its CPU request to 500m, since the hard CPU limit was causing  throttling under bursty admission load.

## For the Reviewer

Changed files: `deploy/helm/nvca-operator/nvca-operator/values.yaml`, `deploy/helm/nvca-operator/nvca-operator/README.md` (parameter table kept in sync).

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

QA needed: rollout to a cluster to confirm webhook latency/throttling improves under load.

## Issues

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Increased the webhook CPU request to improve available processing capacity.
  * Removed the webhook CPU limit; memory settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->