### PR TITLE
fix(admin-token-issuer-proxy): send Vault token header

### DIFF
--- a/src/control-plane-services/admin-token-issuer-proxy/internal/platform/vault/client.go
+++ b/src/control-plane-services/admin-token-issuer-proxy/internal/platform/vault/client.go
@@ -22,12 +22,15 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 
 	"github.com/NVIDIA/nvcf/src/control-plane-services/admin-token-issuer-proxy/internal/models"
 	"github.com/hashicorp/vault/api"
 )
+
+const vaultTokenHeader = "X-Vault-Token"
 
 // VaultSigner defines the interface for interacting with Vault's signing endpoint.
 type VaultSigner interface {
@@ -54,9 +57,20 @@ func NewVaultClient(addr string) (VaultSigner, error) {
 	return &VaultClient{client: client}, nil
 }
 
-// SetToken sets the Vault token for authentication
+// SetToken sets the Vault token for authentication.
 func (v *VaultClient) SetToken(token string) {
 	v.client.SetToken(token)
+
+	headers := v.client.Headers()
+	if headers == nil {
+		headers = make(http.Header)
+	}
+	if token == "" {
+		headers.Del(vaultTokenHeader)
+	} else {
+		headers.Set(vaultTokenHeader, token)
+	}
+	v.client.SetHeaders(headers)
 }
 
 // SignToken calls the Vault sign endpoint to mint a JWT

--- a/src/control-plane-services/admin-token-issuer-proxy/internal/platform/vault/client_test.go
+++ b/src/control-plane-services/admin-token-issuer-proxy/internal/platform/vault/client_test.go
@@ -32,6 +32,31 @@ import (
 	"github.com/NVIDIA/nvcf/src/control-plane-services/admin-token-issuer-proxy/internal/models"
 )
 
+func TestVaultClientSendsVaultTokenHeader(t *testing.T) {
+	const token = "test-vault-token"
+
+	receivedToken := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedToken <- r.Header.Get("X-Vault-Token")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"token":"signed-token"}}`))
+	}))
+	defer server.Close()
+
+	client, err := NewVaultClient(server.URL)
+	if err != nil {
+		t.Fatalf("NewVaultClient() returned an unexpected error: %v", err)
+	}
+	client.SetToken(token)
+
+	if _, err := client.SignToken(t.Context(), "services/example/jwt/sign", "admin-issuer-proxy"); err != nil {
+		t.Fatalf("SignToken() returned an unexpected error: %v", err)
+	}
+	if got := <-receivedToken; got != token {
+		t.Error("X-Vault-Token does not match the configured token")
+	}
+}
+
 func TestVaultClientHelpers(t *testing.T) {
 	t.Run("DecodeJWTClaims success", func(t *testing.T) {
 		claims := models.JWTClaims{


### PR DESCRIPTION
## TL;DR

Ensure the Bazel-built admin token issuer proxy sends the standard `X-Vault-Token` header so OpenBao signing succeeds.

## Additional Details

### Why

Bazel resolves the Vault API through the vendored ESS-compatible fork, which does not send `X-Vault-Token` by default. This causes the signing endpoint to return 403 even though the same source works through its normal Go build.

### What changed

- Mirror the configured token into `X-Vault-Token` while preserving other client headers.
- Remove the header when the token is cleared.
- Add an `httptest` regression covering `SetToken` followed by `SignToken`.

### Customer Release Notes

Fixed administrative token initialization failures when the proxy is built with Bazel.

### Plan Summary

Not applicable.

### Usage

No operator changes are required.

### Dependencies

None. No license or NOTICE changes.

## For the Reviewer

Review the explicit header handling in the Vault client wrapper and the request-level regression test.

## For QA

QA is not required beyond automated coverage. Validation completed:

- `go test ./... -count=1`
- `go vet ./...`
- `bazel test //src/control-plane-services/admin-token-issuer-proxy/...`
- `bazel build //src/control-plane-services/admin-token-issuer-proxy/cmd/admin-issuer-proxy:image_index`

## Issues

Closes #1549

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Vault requests now consistently include the configured authentication token.
  - Clearing the token also removes the authentication header, preventing stale credentials from being sent.

- **Tests**
  - Added coverage verifying that Vault requests send the configured authentication header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->