### PR TITLE
fix(cli): skip disabled LLM PKI lookup

### DIFF
--- a/src/clis/nvcf-cli/cmd/self_hosted_control_plane_profile.go
+++ b/src/clis/nvcf-cli/cmd/self_hosted_control_plane_profile.go
@@ -66,14 +66,19 @@ func writeControlPlaneProfile(req controlPlaneProfileWriteRequest) (string, erro
 	doc := buildControlPlaneProfile(req)
 	rootCAPEM := strings.TrimSpace(req.RootCAPEM)
 	if rootCAPEM == "" && req.SourceRootCA {
-		ctx := req.Ctx
-		if ctx == nil {
-			ctx = context.Background()
-		}
-		var err error
-		rootCAPEM, err = fetchControlPlaneRootCAPEM(ctx, req.ControlPlaneContext)
+		sourceRootCA, err := shouldSourceControlPlaneRootCA(req.StackPath, req.Env)
 		if err != nil {
 			return "", err
+		}
+		if sourceRootCA {
+			ctx := req.Ctx
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			rootCAPEM, err = fetchControlPlaneRootCAPEM(ctx, req.ControlPlaneContext)
+			if err != nil {
+				return "", err
+			}
 		}
 	}
 	if rootCAPEM != "" {
@@ -86,6 +91,66 @@ func writeControlPlaneProfile(req controlPlaneProfileWriteRequest) (string, erro
 		return "", err
 	}
 	return path, nil
+}
+
+func shouldSourceControlPlaneRootCA(stackPath, env string) (bool, error) {
+	if stackPath == "" {
+		return true, nil
+	}
+	llmEnabled := true
+	pkiEnabled := true
+	for _, name := range []string{"base.yaml", env + ".yaml"} {
+		path := filepath.Join(stackPath, "environments", name)
+		body, err := os.ReadFile(path)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return false, fmt.Errorf("reading control-plane stack values %q: %w", path, err)
+		}
+		var values struct {
+			Addons struct {
+				LLM struct {
+					Enabled yaml.Node `yaml:"enabled"`
+					PKI     struct {
+						Enabled yaml.Node `yaml:"enabled"`
+					} `yaml:"pki"`
+				} `yaml:"llm"`
+			} `yaml:"addons"`
+		}
+		if err := yaml.Unmarshal(body, &values); err != nil {
+			return false, fmt.Errorf("parsing control-plane stack values %q: %w", path, err)
+		}
+		value, set, err := parseOptionalYAMLBool(values.Addons.LLM.Enabled)
+		if err != nil {
+			return false, fmt.Errorf("parsing addons.llm.enabled in %q: %w", path, err)
+		}
+		if set {
+			llmEnabled = value
+		}
+		value, set, err = parseOptionalYAMLBool(values.Addons.LLM.PKI.Enabled)
+		if err != nil {
+			return false, fmt.Errorf("parsing addons.llm.pki.enabled in %q: %w", path, err)
+		}
+		if set {
+			pkiEnabled = value
+		}
+	}
+	return llmEnabled && pkiEnabled, nil
+}
+
+func parseOptionalYAMLBool(node yaml.Node) (bool, bool, error) {
+	if node.Kind == 0 {
+		return false, false, nil
+	}
+	switch strings.ToLower(strings.TrimSpace(node.Value)) {
+	case "true":
+		return true, true, nil
+	case "false":
+		return false, true, nil
+	default:
+		return false, false, fmt.Errorf("expected true or false, got %q", node.Value)
+	}
 }
 
 func controlPlaneProfilePath(stackPath string) string {

--- a/src/clis/nvcf-cli/cmd/self_hosted_control_plane_test.go
+++ b/src/clis/nvcf-cli/cmd/self_hosted_control_plane_test.go
@@ -502,6 +502,142 @@ func TestWriteControlPlaneProfileSourcesOpenBaoRootCA(t *testing.T) {
 	assert.Equal(t, wantFingerprint, result.Profile.TransportTLS.TrustBundleFingerprint)
 }
 
+func TestWriteControlPlaneProfileSourcesRootCAOnlyWhenLLMPKIEnabled(t *testing.T) {
+	tests := []struct {
+		name              string
+		baseValues        string
+		environmentValues string
+		wantFetch         bool
+	}{
+		{
+			name: "LLM disabled with boolean",
+			baseValues: `addons:
+  llm:
+    enabled: false
+    pki:
+      enabled: true
+`,
+			wantFetch: false,
+		},
+		{
+			name: "LLM disabled with quoted boolean",
+			baseValues: `addons:
+  llm:
+    enabled: "false"
+    pki:
+      enabled: "true"
+`,
+			wantFetch: false,
+		},
+		{
+			name: "LLM PKI disabled",
+			baseValues: `addons:
+  llm:
+    enabled: true
+    pki:
+      enabled: false
+`,
+			wantFetch: false,
+		},
+		{
+			name: "LLM PKI enabled",
+			baseValues: `addons:
+  llm:
+    enabled: true
+    pki:
+      enabled: true
+`,
+			wantFetch: true,
+		},
+		{
+			name:       "settings undeclared",
+			baseValues: "global:\n  domain: example.test\n",
+			wantFetch:  true,
+		},
+		{
+			name: "selected environment disables LLM",
+			baseValues: `addons:
+  llm:
+    enabled: true
+    pki:
+      enabled: true
+`,
+			environmentValues: `addons:
+  llm:
+    enabled: "false"
+`,
+			wantFetch: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stackDir := t.TempDir()
+			require.NoError(t, os.MkdirAll(filepath.Join(stackDir, "environments"), 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(stackDir, "environments", "base.yaml"), []byte(tc.baseValues), 0o600))
+			if tc.environmentValues != "" {
+				require.NoError(t, os.WriteFile(filepath.Join(stackDir, "environments", "local.yaml"), []byte(tc.environmentValues), 0o600))
+			}
+
+			fetched := false
+			prevFetch := fetchControlPlaneRootCAPEM
+			fetchControlPlaneRootCAPEM = func(context.Context, string) (string, error) {
+				fetched = true
+				return "", nil
+			}
+			t.Cleanup(func() { fetchControlPlaneRootCAPEM = prevFetch })
+
+			_, err := writeControlPlaneProfile(controlPlaneProfileWriteRequest{
+				StackPath:    stackDir,
+				Env:          "local",
+				SourceRootCA: true,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantFetch, fetched)
+		})
+	}
+}
+
+func TestShouldSourceControlPlaneRootCARejectsMalformedLLMSettings(t *testing.T) {
+	tests := []struct {
+		name      string
+		values    string
+		fieldPath string
+	}{
+		{
+			name: "invalid scalar",
+			values: `addons:
+  llm:
+    enabled: sometimes
+`,
+			fieldPath: "addons.llm.enabled",
+		},
+		{
+			name: "null",
+			values: `addons:
+  llm:
+    enabled: true
+    pki:
+      enabled: null
+`,
+			fieldPath: "addons.llm.pki.enabled",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stackDir := t.TempDir()
+			require.NoError(t, os.MkdirAll(filepath.Join(stackDir, "environments"), 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(stackDir, "environments", "base.yaml"), []byte(tc.values), 0o600))
+
+			_, err := shouldSourceControlPlaneRootCA(stackDir, "local")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.fieldPath)
+			assert.Contains(t, err.Error(), "expected true or false")
+		})
+	}
+}
+
 func TestRewriteURLHost(t *testing.T) {
 	cases := []struct {
 		name    string


### PR DESCRIPTION
## TL;DR

Skip the optional LLM root CA lookup during profile export when the selected self-managed environment disables LLM or LLM PKI.

## Additional Details

### Why

Profile export currently probes the LLM PKI route whenever root CA sourcing is enabled. Non-LLM deployments do not create that route, so the unnecessary lookup returns 403 and blocks compute-plane registration.

### What changed

- Resolve `addons.llm.enabled` and `addons.llm.pki.enabled` from layered base and selected-environment values.
- Accept native and quoted YAML booleans.
- Preserve the legacy lookup behavior when either setting is undeclared.
- Reject malformed values with field-specific errors.
- Cover disabled, enabled, undeclared, malformed, and environment-override cases.

### Customer Release Notes

Profile export no longer requires an LLM PKI route when LLM or its PKI integration is disabled.

### Plan Summary

Not applicable.

### Usage

No command-line changes are required.

### Dependencies

None. No license or NOTICE changes.

## For the Reviewer

Review the layered boolean resolution and backward-compatible defaults in `self_hosted_control_plane_profile.go`.

## For QA

QA is not required beyond automated coverage. Validation completed:

- Focused profile tests
- `go test ./cmd -count=1`

The focused Bazel target was interrupted during a cold dependency build before any tests executed.

## Issues

Closes #1550

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Control-plane profiles now source the root certificate authority only when the required LLM and PKI add-ons are enabled or not explicitly configured.
  - Added validation for missing, unreadable, malformed, or invalid add-on settings, with clearer errors identifying configuration fields that require Boolean values.
  - Quoted Boolean values and environment-based configuration overrides are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->