### PR TITLE
fix(llm-request-router): use compatible Stargate image

### DIFF
--- a/deploy/helm/llm-request-router/llm-request-router/Chart.yaml
+++ b/deploy/helm/llm-request-router/llm-request-router/Chart.yaml
@@ -18,4 +18,4 @@ name: helm-nvcf-llm-request-router
 description: Helm chart for the NVCF LLM Request Router backed by Stargate
 type: application
 version: 0.0.0 # managed by semantic-release
-appVersion: "0.14.2" # match the versioned stargate image tag
+appVersion: "0.15.1" # match the versioned stargate image tag

--- a/deploy/helm/llm-request-router/llm-request-router/values.yaml
+++ b/deploy/helm/llm-request-router/llm-request-router/values.yaml
@@ -43,7 +43,7 @@ llmRequestRouter:
   image:
     registry: ""
     repository: ""
-    tag: "0.14.2"
+    tag: "0.15.1"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/deploy/helm/llm-request-router/scripts/check-backend-router-render.sh
+++ b/deploy/helm/llm-request-router/scripts/check-backend-router-render.sh
@@ -331,9 +331,9 @@ if ! grep -Fq -- "serviceAccountName: external-backend-router" "$external_servic
 fi
 assert_backend_router_role_binding_subject "$external_service_account" "external-backend-router"
 
-assert_zero_config_contains "image: registry.example.invalid/nvcf/stargate:0.14.2" \
+assert_zero_config_contains "image: registry.example.invalid/nvcf/stargate:0.15.1" \
   "backend router must inherit the released Stargate image with no router image configuration"
-assert_zero_config_contains 'app.kubernetes.io/version: "0.14.2"' \
+assert_zero_config_contains 'app.kubernetes.io/version: "0.15.1"' \
   "backend router labels must identify the inherited Stargate image version"
 
 helm template llm-request-router "$chart_dir" \

--- a/deploy/helm/llm-request-router/scripts/check-multi-replica-render.sh
+++ b/deploy/helm/llm-request-router/scripts/check-multi-replica-render.sh
@@ -7,6 +7,7 @@ set -eu
 chart_dir="${1:-./llm-request-router}"
 release="${RELEASE:-llm-request-router}"
 namespace="${NAMESPACE:-nvcf}"
+compatible_stargate_version="0.15.1"
 tmp_dir="$(mktemp -d)"
 
 cleanup() {
@@ -73,6 +74,7 @@ service_field() {
 default_manifest="${tmp_dir}/default.yaml"
 render "${default_manifest}"
 
+[ "$(yq -r '.appVersion' "${chart_dir}/Chart.yaml")" = "${compatible_stargate_version}" ] || fail "chart appVersion must identify the compatible Stargate ${compatible_stargate_version} release"
 [ "$(workload_field "${default_manifest}" Deployment .kind)" = "Deployment" ] || fail "default render did not create Deployment"
 [ -z "$(workload_field "${default_manifest}" StatefulSet .kind)" ] || fail "default render also created StatefulSet"
 [ "$(workload_field "${default_manifest}" Deployment .spec.replicas)" = "3" ] || fail "default replica count is not 3"
@@ -88,6 +90,7 @@ render "${default_manifest}"
 [ -z "$(service_field "${default_manifest}" "llm-request-router-headless" '.spec.ports[] | select(.name == "http") | .port')" ] || fail "headless discovery Service must not expose request-facing HTTP"
 default_backend_kind="$(yq -r 'select(.kind == "Deployment" and .metadata.name == "llm-request-router-backend-router") | .kind' "${default_manifest}" | head -n1)"
 [ "${default_backend_kind}" = "Deployment" ] || fail "default multi-replica Deployment did not infer backend-router enablement"
+[ "$(workload_field "${default_manifest}" Deployment '.spec.template.spec.containers[0].image')" = "stargate:${compatible_stargate_version}" ] || fail "default Deployment must render the Stargate ${compatible_stargate_version} compatibility pin"
 
 default_args="$(workload_args "${default_manifest}" Deployment)"
 default_backend_args="$(backend_router_args "${default_manifest}")"
@@ -95,6 +98,8 @@ printf '%s\n' "${default_args}" | grep -qx -- "--advertised-hostname-template={p
 printf '%s\n' "${default_args}" | grep -qx -- "--grpc-pylon-dial-addr=http://llm-request-router-backend-router.${namespace}.svc.cluster.local:50071" || fail "default Deployment missing explicit inferred backend-router gRPC dial URI"
 printf '%s\n' "${default_args}" | grep -qx -- "--watch-heartbeat-ms=5000" || fail "default Deployment missing Watch heartbeat arg"
 printf '%s\n' "${default_args}" | grep -qx -- '--readiness-warmup-ms=60000' || fail "default Deployment missing 60-second readiness warm-up"
+printf '%s\n' "${default_args}" | grep -qx -- '--readiness-stabilization-sample-interval-ms=1000' || fail "default Deployment missing readiness stabilization sample interval"
+printf '%s\n' "${default_args}" | grep -qx -- '--readiness-stabilization-window=5' || fail "default Deployment missing readiness stabilization window"
 printf '%s\n' "${default_backend_args}" | grep -qx -- "--watch-heartbeat-ms=5000" || fail "backend router missing Watch heartbeat arg"
 
 multi_deployment_manifest="${tmp_dir}/multi-deployment.yaml"

--- a/deploy/stacks/self-managed/tests/llm-router-local-chart.sh
+++ b/deploy/stacks/self-managed/tests/llm-router-local-chart.sh
@@ -67,7 +67,8 @@ helm template llm-request-router "$stack_dir/../../helm/llm-request-router/llm-r
   --values "$values_file" >"$local_manifest"
 
 main_registry="$(yq -r '.llmRequestRouter.image.registry' "$values_file")"
-expected_stargate_image="${main_registry:+${main_registry}/}${main_repository}:0.14.2"
+chart_app_version="$(yq -r '.appVersion' "$stack_dir/../../helm/llm-request-router/llm-request-router/Chart.yaml")"
+expected_stargate_image="${main_registry:+${main_registry}/}${main_repository}:${chart_app_version}"
 main_image="$(yq ea -r \
   'select(.kind == "Deployment" and .metadata.name == "llm-request-router" and .metadata.namespace == "nvcf") | .spec.template.spec.containers[0].image' \
   "$local_manifest")"


### PR DESCRIPTION
## TL;DR

Pair the LLM request router chart with Stargate `0.15.1`, which supports every readiness argument rendered by the chart.

## Additional Details

### Why

Chart `1.13.0` renders readiness stabilization arguments that Stargate `0.14.2` does not recognize. Default installations therefore crash-loop unless operators override both router images.

### What changed

- Update the chart `appVersion` and default Stargate image from `0.14.2` to `0.15.1`.
- Assert the exact default image and readiness stabilization arguments in render tests.
- Keep backend-router and self-managed image inheritance checks aligned with the chart metadata.

### Customer Release Notes

Fixed default LLM request router installations that failed because the bundled Stargate image did not support the rendered readiness options.

### Plan Summary

The default Stargate image changes from `0.14.2` to `0.15.1`. No Kubernetes resources are added or removed.

### Usage

Operators using chart defaults no longer need a Stargate image override.

### Dependencies

Updates the existing Stargate image pin to `0.15.1`. No new dependency, license, or NOTICE change.

## For the Reviewer

Review the chart/image compatibility assertions in `check-multi-replica-render.sh`.

## For QA

Validation completed:

- Chart `make lint`
- `make check-backend-router-render`
- Full `make -C deploy/stacks/self-managed test`
- Focused exact image and argument render checks
- Shell syntax and diff checks

The aggregate chart `make test` reaches the new assertions, then encounters a pre-existing test that expects invalid `warmupMs` values to be rejected after that validator was removed from main.

## Issues

Closes #1551

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the deployment package and container image to version **0.15.1**.
  - Improved deployment validation to confirm that the declared application version and deployed image use the matching version.
  - Enhanced readiness checks for multi-instance deployments to verify stabilization timing.
  - Updated self-managed deployment checks to automatically use the chart’s configured application version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->