### PR TITLE
fix(cassandra): pin autoscaler-compatible migrations

### DIFF
--- a/deploy/helm/cassandra/helm/values.yaml
+++ b/deploy/helm/cassandra/helm/values.yaml
@@ -196,7 +196,9 @@ cassandra:
       # repository: must be supplied in additional values
       registry: ""
       repository: ""
-      tag: 0.17.1
+      # 0.17.1 and later drop tables used by the published function autoscaler.
+      # Advance this only with a compatible autoscaler release.
+      tag: 0.17.0
       pullPolicy: Always
 
   dbUser:

--- a/deploy/stacks/self-managed/Makefile
+++ b/deploy/stacks/self-managed/Makefile
@@ -32,3 +32,4 @@ test-published-charts:
 	@tests/llm-router-published-chart.sh
 	@tests/gateway-routes-published-chart.sh
 	@tests/openbao-published-chart.sh
+	@tests/cassandra-autoscaler-published-compatibility.sh

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -253,6 +253,12 @@ cassandra:
   # Do not use small for default cloud installs. Cassandra can OOM during
   # first boot and leave migrations in a failed or dirty state.
   resourcesPreset: "xlarge"
+  migrations:
+    image:
+      # 0.17.1 and later drop tables used by the published function autoscaler.
+      # Keep this explicit because the pinned published Cassandra chart defaults
+      # to an incompatible migration image.
+      tag: 0.17.0
   # Image overrides for the Cassandra server and dynamicSeedDiscovery containers.
   # The default image name is `cassandra` under global.image.repository.
   # Override here when pulling from a registry that uses a different path or tag.

--- a/deploy/stacks/self-managed/tests/cassandra-autoscaler-published-compatibility.sh
+++ b/deploy/stacks/self-managed/tests/cassandra-autoscaler-published-compatibility.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+: "${NVCF_PUBLISHED_CHART_REGISTRY:?NVCF_PUBLISHED_CHART_REGISTRY is required}"
+: "${NVCF_PUBLISHED_CHART_REPOSITORY:?NVCF_PUBLISHED_CHART_REPOSITORY is required}"
+
+stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+stacks_dir="$(cd "$stack_dir/.." && pwd)"
+work_dir="$(mktemp -d)"
+test_stacks_dir="$work_dir/stacks"
+test_stack_dir="$test_stacks_dir/self-managed"
+environment_name="cassandra-autoscaler-published-compatibility-test"
+secrets_file="$test_stack_dir/secrets/$environment_name-secrets.yaml"
+cassandra_manifest="$work_dir/cassandra.yaml"
+cassandra_release="$work_dir/cassandra-release.json"
+autoscaler_manifest="$work_dir/function-autoscaler.yaml"
+autoscaler_release="$work_dir/function-autoscaler-release.json"
+# These literals are the compatibility contract under test. Review and advance
+# them together only after the autoscaler no longer uses the removed tables.
+cassandra_chart_version=0.20.2
+autoscaler_chart_version=0.2.1
+migrations_image_version=0.17.0
+autoscaler_image_version=1.19.0
+trap 'rm -rf "$work_dir"' EXIT
+
+fail() {
+  echo "cassandra-autoscaler-published-compatibility: $*" >&2
+  exit 1
+}
+
+mkdir -p "$test_stacks_dir"
+cp -R "$stacks_dir"/. "$test_stacks_dir"
+cp "$test_stack_dir/secrets/secrets.yaml.template" "$secrets_file"
+
+for stack_environments in "$test_stacks_dir"/*/environments; do
+  test -d "$stack_environments" || continue
+  test -e "$stack_environments/$environment_name.yaml" ||
+    printf '{}\n' >"$stack_environments/$environment_name.yaml"
+done
+
+source_args=(
+  --state-values-set-string "global.helm.sources.registry=$NVCF_PUBLISHED_CHART_REGISTRY"
+  --state-values-set-string "global.helm.sources.repository=$NVCF_PUBLISHED_CHART_REPOSITORY"
+)
+values_args=(
+  --state-values-set-string "global.image.registry=$NVCF_PUBLISHED_CHART_REGISTRY"
+  --state-values-set-string "global.image.repository=$NVCF_PUBLISHED_CHART_REPOSITORY"
+  --state-values-set ingress.gatewayApi.controllerNamespace=gateway
+  --state-values-set ingress.gatewayApi.gateways.shared.name=shared-gw
+  --state-values-set ingress.gatewayApi.gateways.shared.namespace=gateway
+  --state-values-set ingress.gatewayApi.gateways.grpc.name=grpc-gw
+  --state-values-set ingress.gatewayApi.gateways.grpc.namespace=gateway
+)
+
+render_release() {
+  local state_file="$1"
+  local release_name="$2"
+  local release_file="$3"
+  local manifest_file="$4"
+  shift 4
+
+  (cd "$test_stack_dir" &&
+    HELMFILE_ENV="$environment_name" \
+      HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" \
+      helmfile \
+        --file "$state_file" \
+        --environment default \
+        "${source_args[@]}" \
+        "${values_args[@]}" \
+        "$@" \
+        --selector "name=$release_name" \
+        list --skip-charts --output json >"$release_file")
+
+  (cd "$test_stack_dir" &&
+    HELMFILE_ENV="$environment_name" \
+      HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" \
+      helmfile \
+        --file "$state_file" \
+        --environment default \
+        "${source_args[@]}" \
+        "${values_args[@]}" \
+        "$@" \
+        --selector "name=$release_name" \
+        template >"$manifest_file")
+}
+
+render_release \
+  helmfile.d/01-dependencies.yaml.gotmpl \
+  cassandra \
+  "$cassandra_release" \
+  "$cassandra_manifest"
+
+test "$(yq -r '.[0].chart' "$cassandra_release")" = \
+  'nvcf/helm-nvcf-cassandra' ||
+  fail "dependency Helmfile selected the wrong Cassandra chart"
+test "$(yq -r '.[0].version' "$cassandra_release")" = \
+  "$cassandra_chart_version" ||
+  fail "dependency Helmfile did not select Cassandra $cassandra_chart_version"
+
+migrations_image="$(yq ea -r '
+  select(.kind == "Job") |
+  .spec.template.spec.containers[] |
+  select(.name == "nvcf-cassandra-migrations") |
+  .image
+' "$cassandra_manifest")"
+expected_migrations_image="${NVCF_PUBLISHED_CHART_REGISTRY}/${NVCF_PUBLISHED_CHART_REPOSITORY}/nvcf-cassandra-migrations:${migrations_image_version}"
+test "$migrations_image" = "$expected_migrations_image" ||
+  fail "published Cassandra chart rendered migrations image $migrations_image, expected $expected_migrations_image"
+
+render_release \
+  helmfile.d/03-observability.yaml.gotmpl \
+  function-autoscaler \
+  "$autoscaler_release" \
+  "$autoscaler_manifest" \
+  --state-values-set observability.profile=control \
+  --state-values-set stateMetrics.enabled=true
+
+test "$(yq -r '.[0].chart' "$autoscaler_release")" = \
+  'nvcf/helm-nvcf-function-autoscaler' ||
+  fail "observability Helmfile selected the wrong function autoscaler chart"
+test "$(yq -r '.[0].version' "$autoscaler_release")" = \
+  "$autoscaler_chart_version" ||
+  fail "observability Helmfile did not select function autoscaler $autoscaler_chart_version"
+
+autoscaler_image="$(yq ea -r '
+  select(.kind == "Deployment" and .metadata.name == "function-autoscaler") |
+  .spec.template.spec.containers[] |
+  select(.name == "function-autoscaler") |
+  .image
+' "$autoscaler_manifest")"
+expected_autoscaler_image="${NVCF_PUBLISHED_CHART_REGISTRY}/${NVCF_PUBLISHED_CHART_REPOSITORY}/nvcf-function-autoscaler:${autoscaler_image_version}"
+test "$autoscaler_image" = "$expected_autoscaler_image" ||
+  fail "published autoscaler chart rendered image $autoscaler_image, expected $expected_autoscaler_image"
+
+echo "cassandra-autoscaler-published-compatibility: all checks passed"


### PR DESCRIPTION
## TL;DR

Keep Cassandra migrations at `0.17.0` until the published function autoscaler stops using the tables removed by later migration images.

## Additional Details

### Why

Migration images `0.17.1` and `0.17.2` drop three tables still used by published function autoscaler images. Applying those migrations breaks scale-from-zero discovery.

### What changed

- Restore the source Cassandra chart migration default to `0.17.0`.
- Add an explicit self-managed stack override because published Cassandra chart `0.20.2` has the unsafe default.
- Preserve the forward migration history for a future compatible release.
- Add a published-chart contract test for Cassandra `0.20.2`, migrations `0.17.0`, autoscaler chart `0.2.1`, and autoscaler image `1.19.0`.

### Customer Release Notes

Fixed scale-from-zero failures caused by applying Cassandra migrations that removed tables still used by the function autoscaler.

### Plan Summary

The Cassandra migration image selected by the stack changes from `0.17.1` to `0.17.0`. No schema rollback is executed on existing installations.

### Usage

New installs and upgrades use migration image `0.17.0` until a compatible autoscaler is published.

### Dependencies

Uses the existing migrations image at version `0.17.0`. No new dependency, license, or NOTICE change.

## For the Reviewer

Review the explicit stack override and the version-pair contract in `cassandra-autoscaler-published-compatibility.sh`.

## For QA

Validation completed:

- Cassandra Helm lint and template
- Cassandra migration execution tests
- Cassandra/OpenBao credential and image wiring tests
- Observability autoscaler test
- Full self-managed stack test suite
- Local rendering from immutable release tags
- Shell and diff checks

The registry-backed published-chart test was not run because registry credentials are not available locally. Equivalent immutable-release rendering confirmed migrations `0.17.0` and autoscaler `1.19.0`.

## Issues

Closes #1553

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Pinned Cassandra migrations to a compatible image version, preventing deployments from selecting an incompatible default.
  - Preserved compatibility with published function autoscaler releases that rely on existing Cassandra tables.

- **Tests**
  - Added automated validation to confirm that published Cassandra and function autoscaler charts use compatible versions and rendered container images.
  - Included this compatibility check in the self-managed stack’s published-chart test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->