### PR TITLE
fix(cli): retry missing OpenBao response markers

### DIFF
--- a/src/clis/nvcf-cli/internal/openbao/client.go
+++ b/src/clis/nvcf-cli/internal/openbao/client.go
@@ -61,6 +61,8 @@ type Config struct {
 // instead of a hard failure.
 var ErrPKICertificateNotFound = errors.New("openbao: pki certificate not found")
 
+var errPKICertificateHTTPStatusMissing = errors.New("OpenBao PKI response missing HTTP status")
+
 const (
 	curlHTTPStatusMarker      = "__NVCF_HTTP_STATUS__:"
 	curlHTTPContentTypeMarker = "__NVCF_HTTP_CONTENT_TYPE__:"
@@ -436,7 +438,13 @@ func readPKICertificatePEM(
 	for attempt := 1; attempt <= attempts; attempt++ {
 		response, err := read(ctx)
 		if err != nil {
-			return "", fmt.Errorf("reading OpenBao PKI certificate: %w", err)
+			if !errors.Is(err, errPKICertificateHTTPStatusMissing) || attempt == attempts {
+				return "", fmt.Errorf("reading OpenBao PKI certificate: %w", err)
+			}
+			if err := waitForPKICertificateRetry(ctx, retryDelay); err != nil {
+				return "", err
+			}
+			continue
 		}
 		pem, err := rootCAPEMFromOpenBaoResponse(response.Body)
 		if response.StatusCode != http.StatusOK {
@@ -490,7 +498,7 @@ func pkiCertificateHTTPResponseFromOutput(output string) (pkiCertificateHTTPResp
 		}
 	}
 	if !statusFound {
-		return pkiCertificateHTTPResponse{}, fmt.Errorf("OpenBao PKI response missing HTTP status")
+		return pkiCertificateHTTPResponse{}, errPKICertificateHTTPStatusMissing
 	}
 	response.Body = strings.TrimSpace(strings.Join(bodyLines, "\n"))
 	return response, nil

--- a/src/clis/nvcf-cli/internal/openbao/client_test.go
+++ b/src/clis/nvcf-cli/internal/openbao/client_test.go
@@ -139,6 +139,40 @@ func TestReadPKICertificatePEMRetriesEmptyResponse(t *testing.T) {
 	assert.Equal(t, len(responses), attempt)
 }
 
+func TestReadPKICertificatePEMRetriesMissingHTTPStatus(t *testing.T) {
+	c := NewClient(&Config{}, nil)
+	outputs := []string{
+		`pod "openbao-pki-root-ca" deleted`,
+		`{"data":{"certificate":"-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"}}` + "\n" +
+			curlHTTPStatusMarker + "200\n" +
+			curlHTTPContentTypeMarker + "application/json\n",
+	}
+	attempt := 0
+
+	got, err := readPKICertificatePEM(context.Background(), len(outputs), 0, func(context.Context) (pkiCertificateHTTPResponse, error) {
+		output := outputs[attempt]
+		attempt++
+		return pkiCertificateHTTPResponseFromOutput(c.filterKubectlOutput(output))
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, openBaoTestCertPEM, got)
+	assert.Equal(t, len(outputs), attempt)
+}
+
+func TestReadPKICertificatePEMReportsMissingHTTPStatusAfterRetries(t *testing.T) {
+	attempt := 0
+
+	_, err := readPKICertificatePEM(context.Background(), 3, 0, func(context.Context) (pkiCertificateHTTPResponse, error) {
+		attempt++
+		return pkiCertificateHTTPResponseFromOutput("")
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, 3, attempt)
+	assert.ErrorContains(t, err, "OpenBao PKI response missing HTTP status")
+}
+
 func TestReadPKICertificatePEMDoesNotRetryOpenBaoError(t *testing.T) {
 	attempt := 0
 


### PR DESCRIPTION
## TL;DR

Retry the bounded OpenBao root-CA read when a successful kubectl helper invocation loses the curl HTTP metadata markers. This prevents a transient output-framing failure from stopping control-plane profile export and compute registration.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

### Why

A fresh `TestSingleClusterHelmfile` run installed the self-managed control plane successfully, then stopped during `control-plane profile export` with `OpenBao PKI response missing HTTP status`. The kubectl helper did not report a command failure, but its captured output did not contain the curl status marker. The PKI retry loop returned parser errors immediately, so the existing bounded retry policy was not used.

### What changed

- Classify the missing HTTP status marker with an internal sentinel error.
- Retry only that transient framing error through the existing bounded PKI read loop.
- Preserve the current error after all attempts are exhausted.
- Add deterministic coverage for recovery on the next attempt and bounded final failure.

### Customer Release Notes

Self-managed control-plane profile export now retries transient OpenBao helper responses that omit HTTP metadata instead of failing immediately.

### Plan Summary

Not applicable.

### Usage

No command or configuration changes are required.

### Notes

This is narrower than #1228, which handled attach diagnostics when a valid response was captured, and #1415, which reports real OpenBao HTTP failures. It is also separate from #1550, which covers an unnecessary LLM PKI lookup.

No logging or observability contract changed.

### Dependencies

None. No third-party packages, licenses, or NOTICE content changed.

## For the Reviewer

Please verify that only the typed missing-status condition is retried. Kubectl execution errors, malformed status values, non-retryable HTTP responses, and certificate validation failures retain their existing behavior.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

Passed on commit `c2f0369790c74c535fbc4dce111b6000465e3d25`:

- `go test ./internal/openbao -run 'MissingHTTPStatus' -count=1`
- `go test ./internal/openbao -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `bazel test --remote_cache= //src/clis/nvcf-cli/...` (21/21 tests)
- `gofmt` and `git diff --check`

The two new tests failed before the implementation: the recovery case stopped after one attempt, and the exhaustion case made one attempt instead of three.

The pre-fix live BDD reproduction is recorded in #1555. A post-fix live BDD was not run because the task cluster had already been deliberately deleted after evidence capture. QA should rerun `TestSingleClusterHelmfile` from a fresh cluster to validate the complete profile-export and compute-registration flow.

## Issues

Fixes #1555

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving PKI certificates from OpenBao by retrying responses with missing HTTP status information.
  * Retries now respect configured delays and cancellation, and return a clear error when all attempts are exhausted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->