### PR TITLE
fix(nvca): mount the model cache read-only in workload containers

### DIFF
--- a/src/compute-plane-services/nvca/pkg/webhook/helm_storage_webhook.go
+++ b/src/compute-plane-services/nvca/pkg/webhook/helm_storage_webhook.go
@@ -244,15 +244,29 @@ func getModelCachePVCVolumeAppendFunc(pvcName string) podMutateFunc {
 func getModelCachePVCVolumeMountAppendFunc() podMutateFunc {
 	return func(_ context.Context, ps *corev1.PodSpec) (mod bool) {
 		for _, containers := range [][]corev1.Container{ps.InitContainers, ps.Containers} {
+			mod = forceVolumeMountsReadOnly(containers, cmnnvcastorage.ModelCachePodVolumeName) || mod
 			modModels := addVolumeMount(containers, cmnnvcastorage.ModelCachePodVolumeName,
-				cmnnvcastorage.ModelCachePodModelMountPath, false)
+				cmnnvcastorage.ModelCachePodModelMountPath, true)
 			mod = mod || modModels
 			modResources := addVolumeMount(containers, cmnnvcastorage.ModelCachePodVolumeName,
-				cmnnvcastorage.ModelCachePodResourcesMountPath, false)
+				cmnnvcastorage.ModelCachePodResourcesMountPath, true)
 			mod = mod || modResources
 		}
 		return mod
 	}
+}
+
+func forceVolumeMountsReadOnly(containers []corev1.Container, volumeName string) (mod bool) {
+	for i := range containers {
+		for j := range containers[i].VolumeMounts {
+			mount := &containers[i].VolumeMounts[j]
+			if mount.Name == volumeName && !mount.ReadOnly {
+				mount.ReadOnly = true
+				mod = true
+			}
+		}
+	}
+	return mod
 }
 
 // getEphemeralModelCacheInitAppendFunc injects a model-cache-init init
@@ -438,9 +452,13 @@ func addVolumeFunc(pvcName, volumeName string) podMutateFunc {
 func addVolumeMount(containers []corev1.Container, volumeName, mountPath string, readOnly bool) (mod bool) {
 	for i, c := range containers {
 		foundVolumeMount := false
-		for _, v := range c.VolumeMounts {
-			if v.Name == volumeName && v.MountPath == mountPath && v.ReadOnly == readOnly {
+		for j, v := range c.VolumeMounts {
+			if v.Name == volumeName && v.MountPath == mountPath {
 				foundVolumeMount = true
+				if v.ReadOnly != readOnly {
+					containers[i].VolumeMounts[j].ReadOnly = readOnly
+					mod = true
+				}
 				break
 			}
 		}

--- a/src/compute-plane-services/nvca/pkg/webhook/helm_storage_webhook_test.go
+++ b/src/compute-plane-services/nvca/pkg/webhook/helm_storage_webhook_test.go
@@ -74,8 +74,16 @@ func TestGetModelCachePVCAppend(t *testing.T) {
 					{
 						Name: "foo-init",
 						VolumeMounts: []corev1.VolumeMount{
-							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: cmnnvcastorage.ModelCachePodModelMountPath},
-							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: cmnnvcastorage.ModelCachePodResourcesMountPath},
+							{
+								Name:      cmnnvcastorage.ModelCachePodVolumeName,
+								MountPath: cmnnvcastorage.ModelCachePodModelMountPath,
+								ReadOnly:  true,
+							},
+							{
+								Name:      cmnnvcastorage.ModelCachePodVolumeName,
+								MountPath: cmnnvcastorage.ModelCachePodResourcesMountPath,
+								ReadOnly:  true,
+							},
 						},
 					},
 				},
@@ -83,8 +91,16 @@ func TestGetModelCachePVCAppend(t *testing.T) {
 					{
 						Name: "foo",
 						VolumeMounts: []corev1.VolumeMount{
-							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: cmnnvcastorage.ModelCachePodModelMountPath},
-							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: cmnnvcastorage.ModelCachePodResourcesMountPath},
+							{
+								Name:      cmnnvcastorage.ModelCachePodVolumeName,
+								MountPath: cmnnvcastorage.ModelCachePodModelMountPath,
+								ReadOnly:  true,
+							},
+							{
+								Name:      cmnnvcastorage.ModelCachePodVolumeName,
+								MountPath: cmnnvcastorage.ModelCachePodResourcesMountPath,
+								ReadOnly:  true,
+							},
 						},
 					},
 				},
@@ -138,10 +154,18 @@ func TestGetModelCachePVCAppend(t *testing.T) {
 					{
 						Name: "foo-init",
 						VolumeMounts: []corev1.VolumeMount{
-							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: "/my-models"},
-							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: "/my-resources"},
-							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: cmnnvcastorage.ModelCachePodModelMountPath},
-							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: cmnnvcastorage.ModelCachePodResourcesMountPath},
+							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: "/my-models", ReadOnly: true},
+							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: "/my-resources", ReadOnly: true},
+							{
+								Name:      cmnnvcastorage.ModelCachePodVolumeName,
+								MountPath: cmnnvcastorage.ModelCachePodModelMountPath,
+								ReadOnly:  true,
+							},
+							{
+								Name:      cmnnvcastorage.ModelCachePodVolumeName,
+								MountPath: cmnnvcastorage.ModelCachePodResourcesMountPath,
+								ReadOnly:  true,
+							},
 						},
 					},
 				},
@@ -149,10 +173,18 @@ func TestGetModelCachePVCAppend(t *testing.T) {
 					{
 						Name: "foo",
 						VolumeMounts: []corev1.VolumeMount{
-							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: "/my-models"},
-							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: "/my-resources"},
-							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: cmnnvcastorage.ModelCachePodModelMountPath},
-							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: cmnnvcastorage.ModelCachePodResourcesMountPath},
+							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: "/my-models", ReadOnly: true},
+							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: "/my-resources", ReadOnly: true},
+							{
+								Name:      cmnnvcastorage.ModelCachePodVolumeName,
+								MountPath: cmnnvcastorage.ModelCachePodModelMountPath,
+								ReadOnly:  true,
+							},
+							{
+								Name:      cmnnvcastorage.ModelCachePodVolumeName,
+								MountPath: cmnnvcastorage.ModelCachePodResourcesMountPath,
+								ReadOnly:  true,
+							},
 						},
 					},
 				},
@@ -186,8 +218,16 @@ func TestGetModelCachePVCAppend(t *testing.T) {
 					{
 						Name: "foo-init",
 						VolumeMounts: []corev1.VolumeMount{
-							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: cmnnvcastorage.ModelCachePodModelMountPath},
-							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: cmnnvcastorage.ModelCachePodResourcesMountPath},
+							{
+								Name:      cmnnvcastorage.ModelCachePodVolumeName,
+								MountPath: cmnnvcastorage.ModelCachePodModelMountPath,
+								ReadOnly:  true,
+							},
+							{
+								Name:      cmnnvcastorage.ModelCachePodVolumeName,
+								MountPath: cmnnvcastorage.ModelCachePodResourcesMountPath,
+								ReadOnly:  true,
+							},
 						},
 					},
 				},
@@ -195,8 +235,16 @@ func TestGetModelCachePVCAppend(t *testing.T) {
 					{
 						Name: "foo",
 						VolumeMounts: []corev1.VolumeMount{
-							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: cmnnvcastorage.ModelCachePodModelMountPath},
-							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: cmnnvcastorage.ModelCachePodResourcesMountPath},
+							{
+								Name:      cmnnvcastorage.ModelCachePodVolumeName,
+								MountPath: cmnnvcastorage.ModelCachePodModelMountPath,
+								ReadOnly:  true,
+							},
+							{
+								Name:      cmnnvcastorage.ModelCachePodVolumeName,
+								MountPath: cmnnvcastorage.ModelCachePodResourcesMountPath,
+								ReadOnly:  true,
+							},
 						},
 					},
 				},
@@ -235,8 +283,16 @@ func TestGetModelCachePVCAppend(t *testing.T) {
 					{
 						Name: "foo-init",
 						VolumeMounts: []corev1.VolumeMount{
-							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: cmnnvcastorage.ModelCachePodModelMountPath},
-							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: cmnnvcastorage.ModelCachePodResourcesMountPath},
+							{
+								Name:      cmnnvcastorage.ModelCachePodVolumeName,
+								MountPath: cmnnvcastorage.ModelCachePodModelMountPath,
+								ReadOnly:  true,
+							},
+							{
+								Name:      cmnnvcastorage.ModelCachePodVolumeName,
+								MountPath: cmnnvcastorage.ModelCachePodResourcesMountPath,
+								ReadOnly:  true,
+							},
 						},
 					},
 				},
@@ -244,8 +300,16 @@ func TestGetModelCachePVCAppend(t *testing.T) {
 					{
 						Name: "foo",
 						VolumeMounts: []corev1.VolumeMount{
-							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: cmnnvcastorage.ModelCachePodModelMountPath},
-							{Name: cmnnvcastorage.ModelCachePodVolumeName, MountPath: cmnnvcastorage.ModelCachePodResourcesMountPath},
+							{
+								Name:      cmnnvcastorage.ModelCachePodVolumeName,
+								MountPath: cmnnvcastorage.ModelCachePodModelMountPath,
+								ReadOnly:  true,
+							},
+							{
+								Name:      cmnnvcastorage.ModelCachePodVolumeName,
+								MountPath: cmnnvcastorage.ModelCachePodResourcesMountPath,
+								ReadOnly:  true,
+							},
 						},
 					},
 				},
@@ -303,6 +367,9 @@ func TestGetEphemeralModelCacheInitAppendFunc(t *testing.T) {
 			{Name: "MODEL_URL", Value: "https://models.example/m1"},
 		}, ic.Env)
 		assert.Len(t, ic.VolumeMounts, 3)
+		for _, mount := range ic.VolumeMounts {
+			assert.False(t, mount.ReadOnly, "ephemeral model-cache init mounts must remain writable")
+		}
 	}
 
 	assert.True(t, hasVolumeNamed(ps.Volumes, cmnnvcastorage.ModelCachePodVolumeName))
@@ -311,6 +378,9 @@ func TestGetEphemeralModelCacheInitAppendFunc(t *testing.T) {
 		assert.NotNilf(t, v.VolumeSource.EmptyDir, "volume %s should be emptyDir", v.Name)
 	}
 	assert.Len(t, ps.Containers[0].VolumeMounts, 2)
+	for _, mount := range ps.Containers[0].VolumeMounts {
+		assert.False(t, mount.ReadOnly, "ephemeral model-cache workload mounts must remain writable")
+	}
 
 	// Idempotent: a second pass does not duplicate the container, volumes, or mounts.
 	getEphemeralModelCacheInitAppendFunc("init-image:1", envSet)(t.Context(), &ps)
@@ -385,9 +455,12 @@ func TestMutate_StableVolumeOrderAcrossReadmission(t *testing.T) {
 	// First admission (CREATE).
 	_, _, err := v.mutate(ctx, pod, nvcatypes.MiniserviceMetadata{})
 	require.NoError(t, err)
+	assertModelCacheMountsReadOnly(t, pod.Spec.InitContainers)
+	assertModelCacheMountsReadOnly(t, pod.Spec.Containers)
 	wantVols := volNames(pod.Spec.Volumes)
 	wantMounts := mountSig(pod.Spec.Containers[0].VolumeMounts)
 	wantInitMounts := mountSig(pod.Spec.InitContainers[0].VolumeMounts)
+	wantPodSpec := pod.Spec.DeepCopy()
 	// Sanity: all three injected volumes are present.
 	assert.Contains(t, wantVols, cmnnvcastorage.ModelCachePodVolumeName)
 
@@ -395,7 +468,26 @@ func TestMutate_StableVolumeOrderAcrossReadmission(t *testing.T) {
 	// order must be byte-for-byte identical, or the UPDATE is rejected.
 	_, _, err = v.mutate(ctx, pod, nvcatypes.MiniserviceMetadata{})
 	require.NoError(t, err)
+	assertModelCacheMountsReadOnly(t, pod.Spec.InitContainers)
+	assertModelCacheMountsReadOnly(t, pod.Spec.Containers)
+	assert.Equal(t, *wantPodSpec, pod.Spec, "pod spec must be stable across re-admission")
 	assert.Equal(t, wantVols, volNames(pod.Spec.Volumes), "volume order must be stable across re-admission")
 	assert.Equal(t, wantMounts, mountSig(pod.Spec.Containers[0].VolumeMounts), "container mount order must be stable")
 	assert.Equal(t, wantInitMounts, mountSig(pod.Spec.InitContainers[0].VolumeMounts), "init mount order must be stable")
+}
+
+func assertModelCacheMountsReadOnly(t *testing.T, containers []corev1.Container) {
+	t.Helper()
+	for _, container := range containers {
+		count := 0
+		for _, mount := range container.VolumeMounts {
+			if mount.Name != cmnnvcastorage.ModelCachePodVolumeName {
+				continue
+			}
+			count++
+			assert.Truef(t, mount.ReadOnly, "model-cache mount %s in container %s must be read-only",
+				mount.MountPath, container.Name)
+		}
+		assert.Equalf(t, 2, count, "container %s must have both model-cache mounts", container.Name)
+	}
 }


### PR DESCRIPTION
## Why

The mutating webhook marked the model cache PVC volume source `readOnly: true` but added both matching `volumeMount` entries read-write. Kubernetes enforces read-only per mount, so a workload container could open the shared cache for writing through the mount even though the claim was read-only. On a shared filesystem the cache is one volume read by every namespace; a single writable mount can corrupt it for all of them. The design contract requires read-only at both the volume source and each mount.

## What changed

Both model cache mounts are added `readOnly: true`. An existing mount with the wrong flag is corrected on admission instead of being treated as already present. Any other mount of the model cache volume is forced read-only. The per-pod `emptyDir` fallback stays writable because its init container populates it.

## Customer Release Notes

Fixed the shared model cache being mounted writable in workload containers.

## Plan Summary

Not applicable.

## Usage

No operator action.

## Testing

- Webhook tests updated and extended: model cache mounts are read-only on CREATE and UPDATE, a read-write mount is corrected on re-admission, and the emptyDir fallback remains writable.
- Reverting the fix makes those tests fail.
- `go test ./pkg/webhook/...` and `golangci-lint` clean.

QA: none beyond CI; the admitted pod spec is asserted directly.

## Notes

Lifted from #1357, which stays open for reference. Independent of the cache binding work.

## References

None.

## Related Pull Requests

- #1434 made the reader PV's CSI source read-only; this closes the mount side.

## Dependencies

None.

## Issues

Relates to #1326


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Model-cache storage mounts are now consistently configured as read-only.
  - Existing mounts with incorrect permissions are updated instead of creating duplicate mounts.
  - Ephemeral model-cache mounts remain writable where required.
  - Reapplying the configuration now preserves stable pod settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->