### PR TITLE
fix(nvcf-cli): tolerate warning-prefixed API key responses

### DIFF
--- a/src/clis/nvcf-cli/internal/apikeys/client.go
+++ b/src/clis/nvcf-cli/internal/apikeys/client.go
@@ -243,7 +243,7 @@ func (c *Client) GenerateAPIKey(ctx context.Context, description string, expires
 
 	// Parse the response
 	var response map[string]interface{}
-	if err := json.Unmarshal(body, &response); err != nil {
+	if err := json.Unmarshal(trimAttachWarnings(body), &response); err != nil {
 		return "", fmt.Errorf("failed to parse API key response: %w", err)
 	}
 
@@ -256,6 +256,18 @@ func (c *Client) GenerateAPIKey(ctx context.Context, description string, expires
 		logging.Debug("Successfully generated API key - Length: %d", len(value))
 	}
 	return value, nil
+}
+
+func trimAttachWarnings(body []byte) []byte {
+	const warningPrefix = "warning: could not attach to pod/"
+
+	for {
+		line, rest, found := bytes.Cut(body, []byte("\n"))
+		if !found || !bytes.HasPrefix(line, []byte(warningPrefix)) {
+			return body
+		}
+		body = rest
+	}
 }
 
 func redactBearerToken(value string) string {

--- a/src/clis/nvcf-cli/internal/apikeys/client_test.go
+++ b/src/clis/nvcf-cli/internal/apikeys/client_test.go
@@ -50,6 +50,21 @@ func captureRequest(t *testing.T, cfg *Config, customScopes []string) (payload m
 	return payload, headers
 }
 
+func generateAPIKeyFromResponse(t *testing.T, responseBody string) (string, error) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(responseBody))
+	}))
+	t.Cleanup(srv.Close)
+
+	return NewClient(&Config{
+		ServiceURL: srv.URL,
+		ServiceID:  "svc-id",
+	}).GenerateAPIKey(context.Background(), "test", time.Now().Add(time.Hour), nil)
+}
+
 func policyFrom(t *testing.T, payload map[string]any) map[string]any {
 	t.Helper()
 	auths, _ := payload["authorizations"].(map[string]any)
@@ -150,4 +165,31 @@ func TestGenerateAPIKey_SetsIssuerHeaders(t *testing.T) {
 	assert.Equal(t, "my-issuer", headers.Get("Key-Issuer-Service"))
 	assert.Equal(t, "my-service-id", headers.Get("Key-Issuer-Id"))
 	assert.Equal(t, "svc@my-service.local", headers.Get("Key-Owner-Id"))
+}
+
+// --- Response parsing ---
+
+func TestGenerateAPIKey_ParsesJSONResponse(t *testing.T) {
+	key, err := generateAPIKeyFromResponse(t, `{"value":"nvapi-test-key"}`)
+
+	require.NoError(t, err)
+	assert.Equal(t, "nvapi-test-key", key)
+}
+
+func TestGenerateAPIKey_ParsesJSONAfterAttachWarnings(t *testing.T) {
+	key, err := generateAPIKeyFromResponse(t, "warning: could not attach to pod/mock\n"+
+		"warning: could not attach to pod/mock-sidecar\n"+
+		`{"value":"nvapi-test-key"}`)
+
+	require.NoError(t, err)
+	assert.Equal(t, "nvapi-test-key", key)
+}
+
+func TestGenerateAPIKey_RejectsUnexpectedResponsePrefix(t *testing.T) {
+	_, err := generateAPIKeyFromResponse(t, "notice: proxy output\n"+
+		`{"value":"nvapi-test-key"}`)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to parse API key response")
+	assert.ErrorContains(t, err, "invalid character")
 }


### PR DESCRIPTION
## Summary

- Tolerate contiguous leading attach-warning lines before a successful API-key JSON response.
- Preserve HTTP status validation and strict JSON decoding for every other response shape.
- Add regression coverage for normal, recognized warning-prefixed, and unexpectedly prefixed responses.

## Scenario

API-key generation can receive a successful `201 Created` response whose body contains a transport attach warning immediately before the JSON document:

```text
warning: could not attach to pod/example
{"id":"mock-api-key","value":"mock-api-key-value","status":"ACTIVE"}
```

The previous client attempted to decode the entire body and failed on the warning's first character. This change follows a tolerant-reader, strict-producer approach: it discards only contiguous lines matching the recognized attach-warning prefix, then applies the existing JSON decoder. Unrelated prefixes remain errors, HTTP success-status checks are unchanged, and `--json` output remains valid structured JSON.

## Ownership and compatibility handling

The warning-producing wrapper associated with this request path is not part of this repository. The in-repository API-key client calls the service directly over HTTP, and no in-repository kubectl wrapper participates in API-key generation.

Because that external layer cannot be corrected here, this change handles the known contamination at the consumer boundary. It removes only contiguous lines matching the recognized attach-warning prefix, preserves the existing HTTP status checks, and then performs normal JSON decoding. Unrelated prefixes remain parsing errors, and the CLI continues to produce valid structured JSON.

## Validation on an isolated Linux VM

All parser verification used local mock endpoints and mock values. No production API endpoints or keys were used.

### Historical reproduction

- Checked out public tag `src/clis/nvcf-cli/v1.16.2` at commit `88ba859b0ef8a66129c4398ccbc8e21200350a10`.
- Built the CLI with `bazel build --remote_cache= //src/clis/nvcf-cli:nvcf-cli`.
- Used a fresh CLI home for each mock case.
- Confirmed a JSON-only `201` response succeeded and returned the mock key.
- Confirmed a warning-prefixed `201` response failed with the reported invalid-character JSON parsing error.

### Regression and CLI verification

- `bazel test --remote_cache= //src/clis/nvcf-cli/internal/apikeys:apikeys_test --test_output=errors` passed.
- `bazel test --remote_cache= //src/clis/nvcf-cli/... --test_output=errors` passed all 21 test targets.
- The rebuilt CLI succeeded against both clean and warning-prefixed localhost mocks using separate fresh CLI homes.
- Regression tests confirm that an unrelated malformed prefix still returns a useful parse error.

### Direct k3d parser proof

- Created a uniquely named disposable k3d cluster.
- Deployed separate clean and warning-prefixed mock API services inside the cluster.
- Reached each service through its own `kubectl port-forward` and used a fresh CLI home for each case.
- Confirmed both cases succeeded and returned the mock key through the k3d network path.
- Deleted the cluster and verified that it no longer existed.

### Separate BYOO repository check

- `GOWORK=off go test ./...` passed for the BYOO performance module.
- `GOWORK=off go run ./cmd/perf render --shape both` validated both rendered shapes.
- The managed-k3d performance run was attempted separately but stopped before measurement because the configured collector image was not available to the anonymous test cluster (`403 Forbidden`). Its disposable cluster was deleted. This result is not used as proof of the parser fix.

Closes #1568



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API key generation now succeeds when responses include leading pod-attachment warning messages.
  * Unexpected response prefixes continue to be rejected, preserving validation behavior.

* **Tests**
  * Added coverage for valid responses, warning-prefixed responses, and invalid non-warning prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->