### PR TITLE
fix(event-ledger): set LOCAL_SERIAL consistency for Cassandra LWT writes

### DIFF
--- a/src/control-plane-services/event-ledger/internal/db_client/cassandra/common.go
+++ b/src/control-plane-services/event-ledger/internal/db_client/cassandra/common.go
@@ -526,6 +526,10 @@ func (p *CassandraProvider) NewConnection(config config.DBConfig) (data_access.D
 	default:
 		cluster.Consistency = gocql.LocalQuorum
 	}
+	// LWT (IF NOT EXISTS) uses serial consistency for Paxos coordination.
+	// LOCAL_SERIAL keeps Paxos within the local datacenter, avoiding
+	// cross-region round-trips that make LWT writes expensive in non-US regions.
+	cluster.SerialConsistency = gocql.LocalSerial
 
 	if config.CassandraConfig.Username != "" && config.CassandraConfig.Password != "" {
 		cluster.Authenticator = gocql.PasswordAuthenticator{


### PR DESCRIPTION
## Why

LWT inserts (`IF NOT EXISTS`) in event-ledger use Cassandra's Paxos protocol for coordination. Paxos uses the `SerialConsistency` level, not the regular read/write consistency level. When `SerialConsistency` is unset, the gocql driver defaults to global `SERIAL`, which requires Paxos quorum across all datacenters.

In non-US regions (e.g. eu-west-1), every LWT write pays a cross-Atlantic Paxos round-trip (~140ms RTT x 2 = ~300ms per write). US regions are close to the Cassandra home datacenter and see minimal overhead, which explains why the DELETE SLO regression is non-US only.

The FnDS service (pre-migration, v0.10.2) used plain inserts with a read-before-write dedup check — no Paxos involved. The monorepo event-ledger replaced this with `IF NOT EXISTS` LWT (correct for atomicity) but never set `LOCAL_SERIAL`, introducing the cross-region Paxos cost.

## What changed

Set `cluster.SerialConsistency = gocql.LocalSerial` in `cassandra/common.go:NewConnection`, immediately after the regular consistency switch block.

This keeps Paxos coordination within the local datacenter for all LWT paths:
- v1: `INSERT INTO events IF NOT EXISTS`
- v2: `INSERT INTO events_v2 IF NOT EXISTS`
- v3: `INSERT INTO events_v3 IF NOT EXISTS` + `UPDATE stats_v3 IF timestamp < ?`

## Customer Release Notes

Fixes elevated DELETE latency in non-US regions (eu-west-1 and others) caused by Cassandra lightweight transaction writes using cross-region Paxos coordination. Expected latency reduction from ~300ms to ~25ms per event-ledger write on the DELETE path.

## Plan Summary

Not applicable.

## Usage

Not applicable.

## Testing

The `SerialConsistency` setting is exercised by all existing LWT paths. No new test vectors are required as the behavior change is consistency-level routing, not logic.

Local build and lint pass. QA validation in eu-west-1 recommended before prod rollout.

## Notes

The `v1_security_test.go` test (`TestBuildEventsInsertUsesConditionalWrite`) verifies that `IF NOT EXISTS` is present and is intentional -- the LWT dedup guarantee is unchanged by this fix.

The parallel-instance-deletion improvement (making ICMS calls async/batched) is a separate follow-up and is tracked in NVCFSRE-10041.

## References

- NVCFSRE-10041
- NVBug 6718605

## Related Pull Requests

None.

## Dependencies

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Cassandra-backed operations now use local serial consistency for lightweight transactions, improving coordination within the local data center.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->