### PR TITLE
fix(cloud-tasks): pin the chart to an image tag that exists

### DIFF
--- a/deploy/helm/cloud-tasks/nvct-api/Chart.yaml
+++ b/deploy/helm/cloud-tasks/nvct-api/Chart.yaml
@@ -4,4 +4,4 @@ description: NCP Compatible deployment of NVCT API (nvct-service)
 
 type: application
 version: 0.0.0 # autoversioning enabled via release pipeline
-appVersion: "1.64.1"
+appVersion: "1.65.0"

--- a/deploy/helm/cloud-tasks/nvct-api/values.yaml
+++ b/deploy/helm/cloud-tasks/nvct-api/values.yaml
@@ -3,7 +3,7 @@ nvctApi:
     registry: "" # must be supplied
     repository: "" # must be supplied
     pullPolicy: IfNotPresent
-    tag: "1.64.1"
+    tag: "1.65.0"
 
   # Namespace to deploy the resources. The default value is the release namespace.
   namespace: ""


### PR DESCRIPTION
## Why

The self-managed stack publish lane in nvcf-internal has failed repeatedly with:

```
Could not resolve 1 artifact(s) under nvcr.io/<ns>/ncp-dev:
nvct-service-oss:1.64.1  failed to request manifest head ... not found [http 404]
```

The chart pinned `appVersion` and image tag `1.64.1`. That tag does not exist under `nvct-service-oss` and never will.

cloud-tasks `v1.64.1` was released 2026-08-27. At that point the release config had two image destinations, `nvcf-cloud-tasks` and `kaze`. The `nvct-service-oss` destination the chart reads from was added a week later, on 2026-09-03, so 1.64.1 was published under the old names only.

`v1.65.0` was released 2026-09-04, after the destination existed, and its promote job pushed successfully:

```
nvcr.io/<ns>/ncp-dev/nvct-service-oss:1.65.0: digest: sha256:2d0f394e...c9e6e1
```

## What changed

`appVersion` and the image tag move together from 1.64.1 to 1.65.0.

Applied with `tools/ci/chart-version-bumper`, which confirmed the two fields agreed before moving them:

```
cloud-tasks-helm: 1.64.1 -> 1.65.0 (appVersion and image tag agree)
```

## Customer Release Notes

Not customer visible. Fixes a release pipeline failure.

## Plan Summary

Not applicable.

## Usage

Not applicable.

## Testing

`helm lint` passes on the chart. The target tag was verified present in ncp-dev by reading the promote job log for the 1.65.0 release rather than assuming it published.

## Notes

Skipping 1.64.2 is deliberate: it was released 2026-09-04 at 01:14, still before the 2026-09-03 destination change had a release run through it, and 1.65.0 is the first version confirmed present under `nvct-service-oss`.

Worth a follow-up: nothing failed when 1.64.1 was published without the destination that the chart reads from. The chart pointed at a repository the release was not writing to, and the only signal was a stack publish failure a week later. The chart-to-service edge added in #1215 plus the bumper in #1222 close the version-drift half of this; the destination-versus-chart mismatch is a separate gap.

## References

None

## Related Merge Requests/Pull Requests

None

## Dependencies

None

Github commit:
fix(cloud-tasks): pin the chart to an image tag that exists

Co-authored-by: Balaji Ganesan <bganesan@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the nvct-api application and container image to version 1.65.0.
  * Ensures deployments use the latest release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->