### PR TITLE
feat(nvca): serve the regular model cache from a shared claim on ReadWriteMany providers

### DIFF
--- a/docs/dev/sdd-storage-agnostic-cache-architecture.md
+++ b/docs/dev/sdd-storage-agnostic-cache-architecture.md
@@ -173,8 +173,10 @@ NVMesh; `nvcf-miniservice-sc` present selects the shared-filesystem path;
 re-export of an `nvcf-sc` volume; otherwise a per-pod `emptyDir` with an init
 download. That is the path for a request with no persisted selection. A new
 request carries a selection derived from the catalog when it is created, and
-Helm backend selection follows it; the regular workflow records it but does not
-act on it yet. No controller creates a binding. Garbage collection is an idle
+Helm backend selection follows it, and the regular workflow follows a
+`ReadWriteMany` selection onto one shared claim per cache handle, populated once
+and mounted read-only by every reader; its `ReadOnlyMany` shape still takes the
+NVMesh path. No controller creates a binding. Garbage collection is an idle
 sweep keyed on a last-referenced annotation. The mutating webhook
 injects the reader PVC into workload pods as a volume named `model-data`.
 

--- a/src/compute-plane-services/nvca/pkg/nvca/BUILD.bazel
+++ b/src/compute-plane-services/nvca/pkg/nvca/BUILD.bazel
@@ -6,6 +6,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "nvca",
     srcs = [
+        "k8scomputebackend_modelcache_rwx_readonly.go",
         "modelcache_storage_selection.go",
         "agent.go",
         "agent_http_debug.go",
@@ -172,6 +173,7 @@ alias(
 go_test(
     name = "nvca_test",
     srcs = [
+        "k8scomputebackend_modelcache_rwx_readonly_test.go",
         "agent_http_debug_test.go",
         "agent_manager_test.go",
         "agent_metrics_test.go",

--- a/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend.go
@@ -670,8 +670,26 @@ func (c K8sComputeBackend) setupContainerModelCaching(ctx context.Context,
 	cachemf mutateFunc,
 ) (mf func(*corev1.Pod), roPVCName string, err error) {
 	log := core.GetLogger(ctx)
-	// setup init cache Job writer and RWMany PVC
-	mc, roPVCName := c.SetupModelCachingForRequest(ctx, rwPVC, initJob, req, cachemf)
+	var mc ModelCachingState
+	// The selection persisted at request creation decides the flow, mirroring
+	// HelmCacheBackendFromSelection. A request without one predates selections
+	// and takes the legacy path unchanged.
+	selection, present, err := regularModelCacheSelection(req)
+	switch {
+	case err != nil:
+		log.WithError(err).Errorf("invalid persisted model cache selection on request %v/%v, model caching will be disabled",
+			req.Namespace, req.Name)
+		mc = ModelCachingFailed
+	case present && selection.Mode != nvcastorage.ModelCacheSelectionDurable:
+		log.Infof("persisted model cache selection is %q for request %v/%v, skipping durable caching",
+			selection.Mode, req.Namespace, req.Name)
+		return func(*corev1.Pod) {}, "", nil
+	case present && selection.Transition == nvcastorage.ModelCacheTransitionRWXReadOnly:
+		mc, roPVCName = c.setupRWXReadOnlyModelCachingForRequest(ctx, req, rwPVC, initJob, selection)
+	default:
+		// setup init cache Job writer and RWMany PVC
+		mc, roPVCName = c.SetupModelCachingForRequest(ctx, rwPVC, initJob, req, cachemf)
+	}
 	switch mc {
 	case ModelCachingCompleted:
 		log.Infof("model caching completed, starting worker creation")
@@ -685,6 +703,15 @@ func (c K8sComputeBackend) setupContainerModelCaching(ctx context.Context,
 							ClaimName: roPVCName,
 							ReadOnly:  true,
 						},
+					}
+				}
+			}
+			// The claim may be shared by every reader in the namespace, so the
+			// mount is read-only too, not only the volume source.
+			for ci := range pod.Spec.Containers {
+				for mi := range pod.Spec.Containers[ci].VolumeMounts {
+					if pod.Spec.Containers[ci].VolumeMounts[mi].Name == ModelVolumeName {
+						pod.Spec.Containers[ci].VolumeMounts[mi].ReadOnly = true
 					}
 				}
 			}

--- a/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache.go
@@ -113,6 +113,12 @@ func (c K8sComputeBackend) CleanupModelCachingSetupArtifacts(ctx context.Context
 		return fmt.Errorf("failed to cleanup in-flight cache job: %w", err)
 	}
 
+	// A shared claim (ReadWriteMany selection) and a running shared writer are
+	// used by every request for the handle; the claim is reclaimed by the
+	// reference sweep and the writer only once it has finished.
+	if regularModelCacheKeepsSharedClaim(req) {
+		return c.cleanupSharedClaimRequestArtifacts(ctx, initJob, rwPVC.Name)
+	}
 	// cleanup InitJob & its pods, this will clear the rw-pvc also
 	backgroundDeletion := metav1.DeletePropagationBackground
 	err = c.clients.K8s.BatchV1().Jobs(c.bk8s.podInstanceNamespace).Delete(ctx, initJob.Name, metav1.DeleteOptions{
@@ -124,13 +130,6 @@ func (c K8sComputeBackend) CleanupModelCachingSetupArtifacts(ctx context.Context
 		return fmt.Errorf("failed to cleanup in-flight cache job: %w", err)
 	}
 
-	// A shared claim (ReadWriteMany selection) is mounted by every request for
-	// the handle and is reclaimed by the reference sweep once no request names
-	// it. Deleting it here would pull the cache out from under other readers.
-	if regularModelCacheKeepsSharedClaim(req) {
-		log.Debugf("leaving shared cache claim %v for the reference sweep", rwPVC.Name)
-		return nil
-	}
 	// now purge the RWPVC
 	err = c.clients.K8s.CoreV1().PersistentVolumeClaims(c.bk8s.podInstanceNamespace).Delete(ctx, rwPVC.Name, metav1.DeleteOptions{})
 	if err != nil && !errors.IsNotFound(err) {

--- a/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache.go
@@ -124,6 +124,13 @@ func (c K8sComputeBackend) CleanupModelCachingSetupArtifacts(ctx context.Context
 		return fmt.Errorf("failed to cleanup in-flight cache job: %w", err)
 	}
 
+	// A shared claim (ReadWriteMany selection) is mounted by every request for
+	// the handle and is reclaimed by the reference sweep once no request names
+	// it. Deleting it here would pull the cache out from under other readers.
+	if regularModelCacheKeepsSharedClaim(req) {
+		log.Debugf("leaving shared cache claim %v for the reference sweep", rwPVC.Name)
+		return nil
+	}
 	// now purge the RWPVC
 	err = c.clients.K8s.CoreV1().PersistentVolumeClaims(c.bk8s.podInstanceNamespace).Delete(ctx, rwPVC.Name, metav1.DeleteOptions{})
 	if err != nil && !errors.IsNotFound(err) {

--- a/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache_rwx_readonly.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache_rwx_readonly.go
@@ -114,6 +114,19 @@ func (c K8sComputeBackend) setupRWXReadOnlyModelCachingForRequest(
 			fmt.Errorf("claim %s/%s exists with access modes %v, not ReadWriteMany; refusing to share it",
 				current.Namespace, current.Name, current.Spec.AccessModes))
 	}
+	if selection.StorageClassName != "" &&
+		(current.Spec.StorageClassName == nil || *current.Spec.StorageClassName != selection.StorageClassName) {
+		// Same handle, different backend: the selection recorded one class and
+		// the claim lives on another. Mounting it would silently serve the old
+		// backend; deleting it would destroy a cache other requests may use.
+		got := "<none>"
+		if current.Spec.StorageClassName != nil {
+			got = *current.Spec.StorageClassName
+		}
+		return fail(modelcachetypes.ReasonCacheSpecInvalid,
+			fmt.Errorf("claim %s/%s is on StorageClass %q, selection recorded %q; refusing to share it",
+				current.Namespace, current.Name, got, selection.StorageClassName))
+	}
 	if current.Labels[nvcastorage.ModelCachePopulatedLabelKey] == nvcastorage.ModelCachePopulatedLabelValue {
 		record(modelcachetypes.ResultSuccess, "")
 		return ModelCachingCompleted, current.Name
@@ -132,9 +145,12 @@ func (c K8sComputeBackend) setupRWXReadOnlyModelCachingForRequest(
 		}
 		log.Infof("shared cache claim %s created on %s, writer job %s started", current.Name,
 			selection.StorageClassName, initJob.Name)
-		return ModelCachingInProgress, ""
+		// The claim exists from here on, so every in-progress result names it:
+		// the request records it as its cache reference and the reference
+		// sweep can see the claim is in use while the writer runs.
+		return ModelCachingInProgress, current.Name
 	case InitCacheJobInProgress:
-		return ModelCachingInProgress, ""
+		return ModelCachingInProgress, current.Name
 	case InitCacheJobFailed:
 		background := metav1.DeletePropagationBackground
 		if err := jobs.Delete(ctx, initJob.Name, metav1.DeleteOptions{PropagationPolicy: &background}); err != nil && !errors.IsNotFound(err) {
@@ -158,7 +174,7 @@ func (c K8sComputeBackend) setupRWXReadOnlyModelCachingForRequest(
 			if err := jobs.Delete(ctx, initJob.Name, metav1.DeleteOptions{PropagationPolicy: &background}); err != nil && !errors.IsNotFound(err) {
 				return fail(modelcachetypes.ReasonPVCSetupFailed, fmt.Errorf("delete stale writer job %s: %w", initJob.Name, err))
 			}
-			return ModelCachingInProgress, ""
+			return ModelCachingInProgress, current.Name
 		}
 		if err := c.markSharedClaimPopulated(ctx, current.Name); err != nil {
 			return fail(modelcachetypes.ReasonPVCSetupFailed, err)
@@ -168,7 +184,7 @@ func (c K8sComputeBackend) setupRWXReadOnlyModelCachingForRequest(
 			"shared cache claim %v populated", nil, current.Name)
 		return ModelCachingCompleted, current.Name
 	}
-	return ModelCachingInProgress, ""
+	return ModelCachingInProgress, current.Name
 }
 
 // sharedClaimFromArtifact turns the artifact's ReadWriteOnce writer claim into
@@ -210,6 +226,45 @@ func validateSharedClaimWriterJob(job *batchv1.Job, claimName string) error {
 	if found != 1 {
 		return fmt.Errorf("shared claim writer Job has %d %q volumes, want exactly one", found, ModelVolumeName)
 	}
+	// A volume that no container mounts writes nothing. A completed Job would
+	// then mark an empty claim populated.
+	spec := job.Spec.Template.Spec
+	for _, containers := range [][]corev1.Container{spec.InitContainers, spec.Containers} {
+		for _, ctr := range containers {
+			for _, m := range ctr.VolumeMounts {
+				if m.Name == ModelVolumeName && !m.ReadOnly {
+					return nil
+				}
+			}
+		}
+	}
+	return fmt.Errorf("shared claim writer Job has no container mounting %q read-write", ModelVolumeName)
+}
+
+// cleanupSharedClaimRequestArtifacts is request cleanup for the shared-claim
+// flow. The claim is shared and always kept for the reference sweep. The
+// writer Job is shared too while it runs: deleting it would cancel population
+// for every other request waiting on the same claim, so only a finished Job is
+// removed.
+func (c K8sComputeBackend) cleanupSharedClaimRequestArtifacts(ctx context.Context, initJob *batchv1.Job, claimName string) error {
+	log := core.GetLogger(ctx)
+	jobs := c.clients.K8s.BatchV1().Jobs(c.bk8s.podInstanceNamespace)
+	job, err := jobs.Get(ctx, initJob.Name, metav1.GetOptions{})
+	switch {
+	case errors.IsNotFound(err):
+		return nil
+	case err != nil:
+		return fmt.Errorf("get shared claim writer job %s: %w", initJob.Name, err)
+	}
+	if job.Status.CompletionTime == nil && job.Status.Failed == 0 {
+		log.Debugf("shared claim writer %v still running for claim %v, leaving it for the other readers", job.Name, claimName)
+		return nil
+	}
+	background := metav1.DeletePropagationBackground
+	if err := jobs.Delete(ctx, job.Name, metav1.DeleteOptions{PropagationPolicy: &background}); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("delete finished shared claim writer job %s: %w", job.Name, err)
+	}
+	log.Debugf("leaving shared cache claim %v for the reference sweep", claimName)
 	return nil
 }
 

--- a/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache_rwx_readonly.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache_rwx_readonly.go
@@ -241,6 +241,19 @@ func validateSharedClaimWriterJob(job *batchv1.Job, claimName string) error {
 	return fmt.Errorf("shared claim writer Job has no container mounting %q read-write", ModelVolumeName)
 }
 
+// writerJobFinished reports whether a Job reached a terminal state. A failed
+// Pod is not terminal while retries remain; only the JobComplete or JobFailed
+// condition is, with CompletionTime kept as a fallback for a completed Job
+// whose conditions have not been populated.
+func writerJobFinished(job *batchv1.Job) bool {
+	for _, cond := range job.Status.Conditions {
+		if (cond.Type == batchv1.JobComplete || cond.Type == batchv1.JobFailed) && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return job.Status.CompletionTime != nil
+}
+
 // cleanupSharedClaimRequestArtifacts is request cleanup for the shared-claim
 // flow. The claim is shared and always kept for the reference sweep. The
 // writer Job is shared too while it runs: deleting it would cancel population
@@ -256,7 +269,7 @@ func (c K8sComputeBackend) cleanupSharedClaimRequestArtifacts(ctx context.Contex
 	case err != nil:
 		return fmt.Errorf("get shared claim writer job %s: %w", initJob.Name, err)
 	}
-	if job.Status.CompletionTime == nil && job.Status.Failed == 0 {
+	if !writerJobFinished(job) {
 		log.Debugf("shared claim writer %v still running for claim %v, leaving it for the other readers", job.Name, claimName)
 		return nil
 	}

--- a/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache_rwx_readonly.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache_rwx_readonly.go
@@ -1,0 +1,247 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvca
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/core"
+
+	nvcametrics "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/metrics"
+	modelcachetypes "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/metrics/modelcachetypes"
+	nvcav2beta1 "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/v2beta1"
+	nvcastorage "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/storage"
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/types"
+)
+
+// regularModelCacheSelection parses the storage selection persisted on a
+// request when it was created. It reports whether a selection is present at
+// all; a request created before selections existed has none and takes the
+// legacy path unchanged.
+func regularModelCacheSelection(req *nvcav2beta1.ICMSRequest) (*nvcastorage.PersistedModelCacheStorageSelection, bool, error) {
+	raw := req.Annotations[nvcastorage.ModelCacheStorageSelectionAnnotationKey]
+	if raw == "" {
+		return nil, false, nil
+	}
+	selection, err := nvcastorage.ParsePersistedModelCacheStorageSelection(raw)
+	if err != nil {
+		return nil, true, fmt.Errorf("parse persisted model cache storage selection: %w", err)
+	}
+	if selection.Workflow != nvcastorage.ModelCacheWorkflowRegular {
+		return nil, true, fmt.Errorf("persisted model cache selection workflow %q is not the regular workflow",
+			selection.Workflow)
+	}
+	return selection, true, nil
+}
+
+// setupRWXReadOnlyModelCachingForRequest is the regular-workflow cache flow
+// for a provider qualified for ReadWriteMany: one claim per cache handle on
+// the selected StorageClass, populated once by the writer Job, then mounted
+// read-only by every reader in the namespace. Nothing is copied or rebound.
+//
+// The claim is shared across requests, so this function never deletes a claim
+// another request may be mounting. An unpopulated claim whose writer failed is
+// removed so the next request can retry; a populated claim is reclaimed only
+// by the reference sweep once no request names it.
+func (c K8sComputeBackend) setupRWXReadOnlyModelCachingForRequest(
+	ctx context.Context,
+	req *nvcav2beta1.ICMSRequest,
+	rwPVC *corev1.PersistentVolumeClaim,
+	initJob *batchv1.Job,
+	selection *nvcastorage.PersistedModelCacheStorageSelection,
+) (ModelCachingState, string) {
+	log := core.GetLogger(ctx)
+	metrics := nvcametrics.FromContext(ctx)
+	record := func(result, reason string) {
+		if metrics != nil {
+			metrics.RecordModelCacheResult(result, reason, string(types.HelmCacheBackendSharedFS))
+		}
+	}
+	fail := func(reason string, err error) (ModelCachingState, string) {
+		log.WithError(err).Errorf("regular model cache on a shared claim failed for request %v/%v, model caching will be disabled",
+			req.Namespace, req.Name)
+		record(modelcachetypes.ResultFailure, reason)
+		return ModelCachingFailed, ""
+	}
+	if err := validateSharedClaimWriterJob(initJob, rwPVC.Name); err != nil {
+		return fail(modelcachetypes.ReasonCacheSpecInvalid, err)
+	}
+	pvcs := c.clients.K8s.CoreV1().PersistentVolumeClaims(c.bk8s.podInstanceNamespace)
+
+	current, err := pvcs.Get(ctx, rwPVC.Name, metav1.GetOptions{})
+	switch {
+	case errors.IsNotFound(err):
+		created, err := pvcs.Create(ctx, sharedClaimFromArtifact(rwPVC, selection), metav1.CreateOptions{})
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return fail(modelcachetypes.ReasonPVCSetupFailed, fmt.Errorf("create shared cache claim %s: %w", rwPVC.Name, err))
+		}
+		if err == nil {
+			current = created
+		} else if current, err = pvcs.Get(ctx, rwPVC.Name, metav1.GetOptions{}); err != nil {
+			return fail(modelcachetypes.ReasonPVCSetupFailed, fmt.Errorf("get shared cache claim %s: %w", rwPVC.Name, err))
+		}
+	case err != nil:
+		return fail(modelcachetypes.ReasonPVCSetupFailed, fmt.Errorf("get shared cache claim %s: %w", rwPVC.Name, err))
+	}
+
+	if !slices.Contains(current.Spec.AccessModes, corev1.ReadWriteMany) {
+		// A claim of this name that is not a shared claim belongs to another
+		// flow. Refuse rather than mount or delete what is not ours.
+		return fail(modelcachetypes.ReasonCacheSpecInvalid,
+			fmt.Errorf("claim %s/%s exists with access modes %v, not ReadWriteMany; refusing to share it",
+				current.Namespace, current.Name, current.Spec.AccessModes))
+	}
+	if current.Labels[nvcastorage.ModelCachePopulatedLabelKey] == nvcastorage.ModelCachePopulatedLabelValue {
+		record(modelcachetypes.ResultSuccess, "")
+		return ModelCachingCompleted, current.Name
+	}
+
+	jobs := c.clients.K8s.BatchV1().Jobs(c.bk8s.podInstanceNamespace)
+	switch c.CheckInitCacheJobState(ctx, rwPVC.Name, initJob) {
+	case InitCacheJobNotFound:
+		job := initJob.DeepCopy()
+		if job.Spec.Template.Annotations == nil {
+			job.Spec.Template.Annotations = map[string]string{}
+		}
+		job.Spec.Template.Annotations[nvcastorage.ModelCacheWriterPVCUIDAnnotationKey] = string(current.UID)
+		if _, err := jobs.Create(ctx, job, metav1.CreateOptions{}); err != nil && !errors.IsAlreadyExists(err) {
+			return fail(modelcachetypes.ReasonPVCSetupFailed, fmt.Errorf("create writer job %s: %w", job.Name, err))
+		}
+		log.Infof("shared cache claim %s created on %s, writer job %s started", current.Name,
+			selection.StorageClassName, initJob.Name)
+		return ModelCachingInProgress, ""
+	case InitCacheJobInProgress:
+		return ModelCachingInProgress, ""
+	case InitCacheJobFailed:
+		background := metav1.DeletePropagationBackground
+		if err := jobs.Delete(ctx, initJob.Name, metav1.DeleteOptions{PropagationPolicy: &background}); err != nil && !errors.IsNotFound(err) {
+			log.WithError(err).Warnf("failed to delete failed writer job %s", initJob.Name)
+		}
+		// Unpopulated and ours to retry: remove the claim so the next request
+		// starts clean. A populated claim never reaches this branch.
+		if err := pvcs.Delete(ctx, current.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+			log.WithError(err).Warnf("failed to delete unpopulated shared cache claim %s", current.Name)
+		}
+		return fail(modelcachetypes.ReasonInitJobFailed, fmt.Errorf("writer job %s failed", initJob.Name))
+	case InitCacheJobCompleted:
+		job, err := jobs.Get(ctx, initJob.Name, metav1.GetOptions{})
+		if err != nil {
+			return fail(modelcachetypes.ReasonPVCSetupFailed, fmt.Errorf("get completed writer job %s: %w", initJob.Name, err))
+		}
+		if witness := job.Spec.Template.Annotations[nvcastorage.ModelCacheWriterPVCUIDAnnotationKey]; witness != string(current.UID) {
+			// The Job populated an earlier claim of the same name. Its
+			// completion says nothing about this claim; start a writer for it.
+			background := metav1.DeletePropagationBackground
+			if err := jobs.Delete(ctx, initJob.Name, metav1.DeleteOptions{PropagationPolicy: &background}); err != nil && !errors.IsNotFound(err) {
+				return fail(modelcachetypes.ReasonPVCSetupFailed, fmt.Errorf("delete stale writer job %s: %w", initJob.Name, err))
+			}
+			return ModelCachingInProgress, ""
+		}
+		if err := c.markSharedClaimPopulated(ctx, current.Name); err != nil {
+			return fail(modelcachetypes.ReasonPVCSetupFailed, err)
+		}
+		record(modelcachetypes.ResultSuccess, "")
+		c.bk8s.EmitICMSEventf(req, corev1.EventTypeNormal, string(types.EventCategoryModelCaching),
+			"shared cache claim %v populated", nil, current.Name)
+		return ModelCachingCompleted, current.Name
+	}
+	return ModelCachingInProgress, ""
+}
+
+// sharedClaimFromArtifact turns the artifact's ReadWriteOnce writer claim into
+// the shared claim: ReadWriteMany on the StorageClass the selection recorded.
+func sharedClaimFromArtifact(
+	rwPVC *corev1.PersistentVolumeClaim,
+	selection *nvcastorage.PersistedModelCacheStorageSelection,
+) *corev1.PersistentVolumeClaim {
+	claim := rwPVC.DeepCopy()
+	claim.Spec.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}
+	if selection.StorageClassName != "" {
+		sc := selection.StorageClassName
+		claim.Spec.StorageClassName = &sc
+	}
+	return claim
+}
+
+// validateSharedClaimWriterJob requires the writer Job to mount the shared
+// claim read-write exactly once, so a completed Job means that claim holds
+// the model.
+func validateSharedClaimWriterJob(job *batchv1.Job, claimName string) error {
+	if job == nil || claimName == "" {
+		return fmt.Errorf("shared claim writer Job or claim name is missing")
+	}
+	found := 0
+	for _, v := range job.Spec.Template.Spec.Volumes {
+		if v.Name != ModelVolumeName {
+			continue
+		}
+		found++
+		pvc := v.PersistentVolumeClaim
+		if pvc == nil || pvc.ClaimName != claimName {
+			return fmt.Errorf("shared claim writer Job volume %q does not mount claim %q", ModelVolumeName, claimName)
+		}
+		if pvc.ReadOnly {
+			return fmt.Errorf("shared claim writer Job mounts %q read-only", ModelVolumeName)
+		}
+	}
+	if found != 1 {
+		return fmt.Errorf("shared claim writer Job has %d %q volumes, want exactly one", found, ModelVolumeName)
+	}
+	return nil
+}
+
+// markSharedClaimPopulated sets the durable populated marker on the claim,
+// retrying on conflict. Readers gate on this label, never on Job state.
+func (c K8sComputeBackend) markSharedClaimPopulated(ctx context.Context, claimName string) error {
+	pvcs := c.clients.K8s.CoreV1().PersistentVolumeClaims(c.bk8s.podInstanceNamespace)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := pvcs.Get(ctx, claimName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("get shared cache claim %s: %w", claimName, err)
+		}
+		if current.Labels == nil {
+			current.Labels = map[string]string{}
+		}
+		if current.Labels[nvcastorage.ModelCachePopulatedLabelKey] == nvcastorage.ModelCachePopulatedLabelValue {
+			return nil
+		}
+		current.Labels[nvcastorage.ModelCachePopulatedLabelKey] = nvcastorage.ModelCachePopulatedLabelValue
+		if _, err := pvcs.Update(ctx, current, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("mark shared cache claim %s populated: %w", claimName, err)
+		}
+		return nil
+	})
+}
+
+// regularModelCacheKeepsSharedClaim reports whether a request's persisted
+// selection is the shared-claim flow, whose claim outlives any one request
+// and is reclaimed by the reference sweep rather than by request cleanup.
+func regularModelCacheKeepsSharedClaim(req *nvcav2beta1.ICMSRequest) bool {
+	selection, present, err := regularModelCacheSelection(req)
+	return err == nil && present &&
+		selection.Mode == nvcastorage.ModelCacheSelectionDurable &&
+		selection.Transition == nvcastorage.ModelCacheTransitionRWXReadOnly
+}

--- a/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache_rwx_readonly_test.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache_rwx_readonly_test.go
@@ -1,0 +1,301 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvca
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakek8sclient "k8s.io/client-go/kubernetes/fake"
+
+	fakebartclient "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/client/clientset/versioned/fake"
+
+	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/kubeclients"
+	nvcametrics "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/internal/metrics"
+	nvcav2beta1 "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/v2beta1"
+	featureflagmock "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/featureflag/mock"
+	nvcastorage "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/storage"
+)
+
+const (
+	rwxTestNamespace = "nvcf-backend"
+	rwxTestHandle    = "sharedhandle"
+	rwxTestClass     = "nvcf-sc"
+)
+
+// rwxTestContext carries metrics on a private registry so this file never
+// collides with other tests that register collectors in the same process.
+func rwxTestContext(t *testing.T) context.Context {
+	t.Helper()
+	m := nvcametrics.NewDefaultMetrics("cluster", "backend", "backend", "rwx-test",
+		nvcametrics.WithRegisterer(prometheus.NewRegistry()))
+	return nvcametrics.WithMetrics(newTestContext(), m)
+}
+
+// rwxTestBackend builds a compute backend over fake clientsets. req, when
+// given, is registered with the NVCA clientset so status updates made while
+// caching is in progress have an object to land on.
+func rwxTestBackend(req *nvcav2beta1.ICMSRequest, objs ...runtime.Object) (K8sComputeBackend, *fakek8sclient.Clientset) {
+	k8sClient := fakek8sclient.NewSimpleClientset(objs...)
+	var reqObjs []runtime.Object
+	if req != nil {
+		reqObjs = append(reqObjs, req)
+	}
+	clients := &kubeclients.KubeClients{K8s: k8sClient, BART: fakebartclient.NewSimpleClientset(reqObjs...)}
+	bk8s := &BackendK8sCache{
+		clients:              clients,
+		podInstanceNamespace: rwxTestNamespace,
+		featureFlagFetcher:   &featureflagmock.Fetcher{},
+	}
+	return K8sComputeBackend{clients: clients, bk8s: bk8s}, k8sClient
+}
+
+// rwxSelection is a durable regular-workflow selection for a ReadWriteMany
+// provider, shaped the way the agent persists it at request creation.
+func rwxSelection(t *testing.T) *nvcastorage.PersistedModelCacheStorageSelection {
+	t.Helper()
+	return &nvcastorage.PersistedModelCacheStorageSelection{
+		Version:             nvcastorage.ModelCacheStorageSelectionVersion,
+		Workflow:            nvcastorage.ModelCacheWorkflowRegular,
+		Mode:                nvcastorage.ModelCacheSelectionDurable,
+		StorageClassName:    rwxTestClass,
+		StorageClassUID:     "sc-uid",
+		StorageClassDigest:  "v1:sha256:" + strings.Repeat("a", 64),
+		ProfileDigest:       "sha256:" + strings.Repeat("b", 64),
+		Provider:            "weka",
+		Provisioner:         "csi.weka.io",
+		Transition:          nvcastorage.ModelCacheTransitionRWXReadOnly,
+		RequiredAccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+	}
+}
+
+func rwxRequest(t *testing.T, selection *nvcastorage.PersistedModelCacheStorageSelection) *nvcav2beta1.ICMSRequest {
+	t.Helper()
+	req := &nvcav2beta1.ICMSRequest{ObjectMeta: metav1.ObjectMeta{Name: "request", Namespace: rwxTestNamespace}}
+	if selection != nil {
+		raw, err := selection.Marshal()
+		require.NoError(t, err)
+		req.Annotations = map[string]string{nvcastorage.ModelCacheStorageSelectionAnnotationKey: raw}
+	}
+	return req
+}
+
+// rwxArtifacts mirrors what the translator emits: a ReadWriteOnce claim and a
+// writer Job mounting it read-write under the model volume name.
+func rwxArtifacts() (*corev1.PersistentVolumeClaim, *batchv1.Job) {
+	other := "some-other-class"
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "rw-pvc-" + rwxTestHandle, Namespace: rwxTestNamespace},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			StorageClassName: &other,
+		},
+	}
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "writer-job-" + rwxTestHandle, Namespace: rwxTestNamespace},
+		Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{{Name: ModelVolumeName, VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvc.Name},
+			}}},
+		}}},
+	}
+	return pvc, job
+}
+
+func boundSharedClaim(populated bool) *corev1.PersistentVolumeClaim {
+	pvc, _ := rwxArtifacts()
+	pvc.Spec.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}
+	pvc.Status.Phase = corev1.ClaimBound
+	if populated {
+		pvc.Labels = map[string]string{nvcastorage.ModelCachePopulatedLabelKey: nvcastorage.ModelCachePopulatedLabelValue}
+	}
+	return pvc
+}
+
+func TestRWXReadOnly_FirstRequestCreatesSharedClaimAndWriter(t *testing.T) {
+	ctx := rwxTestContext(t)
+	c, k8s := rwxTestBackend(nil)
+	pvc, job := rwxArtifacts()
+
+	state, claim := c.setupRWXReadOnlyModelCachingForRequest(ctx, rwxRequest(t, rwxSelection(t)), pvc, job, rwxSelection(t))
+	assert.Equal(t, ModelCachingInProgress, state)
+	assert.Empty(t, claim)
+
+	created, err := k8s.CoreV1().PersistentVolumeClaims(rwxTestNamespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}, created.Spec.AccessModes,
+		"the artifact's ReadWriteOnce claim becomes the shared ReadWriteMany claim")
+	require.NotNil(t, created.Spec.StorageClassName)
+	assert.Equal(t, rwxTestClass, *created.Spec.StorageClassName, "the claim lands on the class the selection recorded")
+
+	writer, err := k8s.BatchV1().Jobs(rwxTestNamespace).Get(ctx, job.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	_, hasWitness := writer.Spec.Template.Annotations[nvcastorage.ModelCacheWriterPVCUIDAnnotationKey]
+	assert.True(t, hasWitness, "the writer records which claim it populates")
+}
+
+func TestRWXReadOnly_CompletedWriterMarksClaimPopulated(t *testing.T) {
+	ctx := rwxTestContext(t)
+	pvc, job := rwxArtifacts()
+	done := job.DeepCopy()
+	done.Status.Succeeded = 1
+	now := metav1.Now()
+	done.Status.CompletionTime = &now
+	done.Spec.Template.Annotations = map[string]string{nvcastorage.ModelCacheWriterPVCUIDAnnotationKey: ""}
+	c, k8s := rwxTestBackend(nil, boundSharedClaim(false), done)
+
+	state, claim := c.setupRWXReadOnlyModelCachingForRequest(ctx, rwxRequest(t, rwxSelection(t)), pvc, job, rwxSelection(t))
+	assert.Equal(t, ModelCachingCompleted, state)
+	assert.Equal(t, pvc.Name, claim, "readers mount the shared claim itself")
+
+	got, err := k8s.CoreV1().PersistentVolumeClaims(rwxTestNamespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, nvcastorage.ModelCachePopulatedLabelValue, got.Labels[nvcastorage.ModelCachePopulatedLabelKey])
+}
+
+func TestRWXReadOnly_PopulatedClaimIsReusedWithoutAWriter(t *testing.T) {
+	ctx := rwxTestContext(t)
+	pvc, job := rwxArtifacts()
+	c, k8s := rwxTestBackend(nil, boundSharedClaim(true))
+
+	state, claim := c.setupRWXReadOnlyModelCachingForRequest(ctx, rwxRequest(t, rwxSelection(t)), pvc, job, rwxSelection(t))
+	assert.Equal(t, ModelCachingCompleted, state)
+	assert.Equal(t, pvc.Name, claim)
+
+	_, err := k8s.BatchV1().Jobs(rwxTestNamespace).Get(ctx, job.Name, metav1.GetOptions{})
+	assert.True(t, errors.IsNotFound(err), "a populated cache must not start another writer")
+}
+
+func TestRWXReadOnly_FailedWriterRemovesUnpopulatedClaim(t *testing.T) {
+	ctx := rwxTestContext(t)
+	pvc, job := rwxArtifacts()
+	failed := job.DeepCopy()
+	var zero int32
+	failed.Spec.BackoffLimit = &zero
+	failed.Status.Failed = 1
+	c, k8s := rwxTestBackend(nil, boundSharedClaim(false), failed)
+
+	state, _ := c.setupRWXReadOnlyModelCachingForRequest(ctx, rwxRequest(t, rwxSelection(t)), pvc, job, rwxSelection(t))
+	assert.Equal(t, ModelCachingFailed, state)
+
+	_, err := k8s.CoreV1().PersistentVolumeClaims(rwxTestNamespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+	assert.True(t, errors.IsNotFound(err), "an unpopulated claim whose writer failed is removed so the next request retries")
+	_, err = k8s.BatchV1().Jobs(rwxTestNamespace).Get(ctx, job.Name, metav1.GetOptions{})
+	assert.True(t, errors.IsNotFound(err))
+}
+
+func TestRWXReadOnly_RefusesAClaimThatIsNotShared(t *testing.T) {
+	ctx := rwxTestContext(t)
+	pvc, job := rwxArtifacts()
+	foreign := pvc.DeepCopy()
+	foreign.Status.Phase = corev1.ClaimBound
+	c, k8s := rwxTestBackend(nil, foreign)
+
+	state, _ := c.setupRWXReadOnlyModelCachingForRequest(ctx, rwxRequest(t, rwxSelection(t)), pvc, job, rwxSelection(t))
+	assert.Equal(t, ModelCachingFailed, state)
+
+	still, err := k8s.CoreV1().PersistentVolumeClaims(rwxTestNamespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+	require.NoError(t, err, "a claim that is not ours to share is neither mounted nor deleted")
+	assert.Equal(t, []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}, still.Spec.AccessModes)
+	_, err = k8s.BatchV1().Jobs(rwxTestNamespace).Get(ctx, job.Name, metav1.GetOptions{})
+	assert.True(t, errors.IsNotFound(err))
+}
+
+func TestRWXReadOnly_WriterJobMustMountTheClaimReadWrite(t *testing.T) {
+	ctx := rwxTestContext(t)
+	pvc, job := rwxArtifacts()
+	job.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ReadOnly = true
+	c, k8s := rwxTestBackend(nil)
+
+	state, _ := c.setupRWXReadOnlyModelCachingForRequest(ctx, rwxRequest(t, rwxSelection(t)), pvc, job, rwxSelection(t))
+	assert.Equal(t, ModelCachingFailed, state)
+	_, err := k8s.CoreV1().PersistentVolumeClaims(rwxTestNamespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+	assert.True(t, errors.IsNotFound(err), "an invalid writer must not create anything")
+}
+
+// The dispatch: a persisted ReadWriteMany selection routes the container
+// workflow onto the shared claim, a non-durable selection skips caching, and a
+// request with no selection is untouched here (it takes the legacy path).
+func TestSetupContainerModelCaching_FollowsPersistedSelection(t *testing.T) {
+	ctx := rwxTestContext(t)
+	pvc, job := rwxArtifacts()
+
+	t.Run("ReadWriteMany selection creates the shared claim", func(t *testing.T) {
+		req := rwxRequest(t, rwxSelection(t))
+		c, k8s := rwxTestBackend(req)
+		_, _, err := c.setupContainerModelCaching(ctx, req, pvc, job, nil)
+		require.Error(t, err, "first pass is in progress")
+		created, gerr := k8s.CoreV1().PersistentVolumeClaims(rwxTestNamespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+		require.NoError(t, gerr)
+		assert.Equal(t, []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}, created.Spec.AccessModes)
+	})
+
+	t.Run("completed shared claim mounts read-only at source and mount", func(t *testing.T) {
+		req := rwxRequest(t, rwxSelection(t))
+		c, _ := rwxTestBackend(req, boundSharedClaim(true))
+		mf, claim, err := c.setupContainerModelCaching(ctx, req, pvc, job, nil)
+		require.NoError(t, err)
+		assert.Equal(t, pvc.Name, claim)
+		pod := &corev1.Pod{Spec: corev1.PodSpec{
+			Volumes:    []corev1.Volume{{Name: ModelVolumeName}},
+			Containers: []corev1.Container{{VolumeMounts: []corev1.VolumeMount{{Name: ModelVolumeName, ReadOnly: false}}}},
+		}}
+		mf(pod)
+		require.NotNil(t, pod.Spec.Volumes[0].PersistentVolumeClaim)
+		assert.Equal(t, pvc.Name, pod.Spec.Volumes[0].PersistentVolumeClaim.ClaimName)
+		assert.True(t, pod.Spec.Volumes[0].PersistentVolumeClaim.ReadOnly)
+		assert.True(t, pod.Spec.Containers[0].VolumeMounts[0].ReadOnly, "a shared claim is never mounted writable")
+	})
+
+	t.Run("a none selection skips caching without touching the cluster", func(t *testing.T) {
+		none := rwxSelection(t)
+		none.Mode = nvcastorage.ModelCacheSelectionNone
+		none.StorageClassName, none.StorageClassUID, none.StorageClassDigest, none.ProfileDigest = "", "", "", ""
+		none.Provider, none.Provisioner, none.Transition, none.RequiredAccessModes = "", "", "", nil
+		req := rwxRequest(t, none)
+		c, k8s := rwxTestBackend(req)
+		mf, claim, err := c.setupContainerModelCaching(ctx, req, pvc, job, nil)
+		require.NoError(t, err)
+		assert.Empty(t, claim)
+		require.NotNil(t, mf)
+		assert.Empty(t, k8s.Actions(), "no Kubernetes writes for a request whose selection is none")
+	})
+}
+
+func TestRegularModelCacheKeepsSharedClaim(t *testing.T) {
+	assert.True(t, regularModelCacheKeepsSharedClaim(rwxRequest(t, rwxSelection(t))),
+		"a shared claim is left for the reference sweep, not deleted with the request")
+	assert.False(t, regularModelCacheKeepsSharedClaim(rwxRequest(t, nil)),
+		"a legacy request without a selection keeps the existing cleanup")
+	rox := rwxSelection(t)
+	rox.Transition = nvcastorage.ModelCacheTransitionROXReadOnly
+	rox.Provider, rox.Provisioner = nvcastorage.ModelCacheProviderNVMesh, nvcastorage.NVMeshStorageClassProvisioner
+	rox.RequiredAccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce, corev1.ReadOnlyMany}
+	rox.RequiredMountOptions = []string{"ro", "norecovery", "nouuid"}
+	assert.False(t, regularModelCacheKeepsSharedClaim(rwxRequest(t, rox)),
+		"the NVMesh shape keeps its per-request claim cleanup")
+}

--- a/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache_rwx_readonly_test.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache_rwx_readonly_test.go
@@ -121,13 +121,19 @@ func rwxArtifacts() (*corev1.PersistentVolumeClaim, *batchv1.Job) {
 			Volumes: []corev1.Volume{{Name: ModelVolumeName, VolumeSource: corev1.VolumeSource{
 				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvc.Name},
 			}}},
+			Containers: []corev1.Container{{Name: "writer", VolumeMounts: []corev1.VolumeMount{{Name: ModelVolumeName, MountPath: "/model"}}}},
 		}}},
 	}
 	return pvc, job
 }
 
+const rwxClaimUID = "claim-uid-1"
+
 func boundSharedClaim(populated bool) *corev1.PersistentVolumeClaim {
 	pvc, _ := rwxArtifacts()
+	pvc.UID = rwxClaimUID
+	class := rwxTestClass
+	pvc.Spec.StorageClassName = &class
 	pvc.Spec.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}
 	pvc.Status.Phase = corev1.ClaimBound
 	if populated {
@@ -143,7 +149,7 @@ func TestRWXReadOnly_FirstRequestCreatesSharedClaimAndWriter(t *testing.T) {
 
 	state, claim := c.setupRWXReadOnlyModelCachingForRequest(ctx, rwxRequest(t, rwxSelection(t)), pvc, job, rwxSelection(t))
 	assert.Equal(t, ModelCachingInProgress, state)
-	assert.Empty(t, claim)
+	assert.Equal(t, pvc.Name, claim, "an in-progress result names the claim so the request records its reference")
 
 	created, err := k8s.CoreV1().PersistentVolumeClaims(rwxTestNamespace).Get(ctx, pvc.Name, metav1.GetOptions{})
 	require.NoError(t, err)
@@ -165,7 +171,7 @@ func TestRWXReadOnly_CompletedWriterMarksClaimPopulated(t *testing.T) {
 	done.Status.Succeeded = 1
 	now := metav1.Now()
 	done.Status.CompletionTime = &now
-	done.Spec.Template.Annotations = map[string]string{nvcastorage.ModelCacheWriterPVCUIDAnnotationKey: ""}
+	done.Spec.Template.Annotations = map[string]string{nvcastorage.ModelCacheWriterPVCUIDAnnotationKey: rwxClaimUID}
 	c, k8s := rwxTestBackend(nil, boundSharedClaim(false), done)
 
 	state, claim := c.setupRWXReadOnlyModelCachingForRequest(ctx, rwxRequest(t, rwxSelection(t)), pvc, job, rwxSelection(t))
@@ -252,6 +258,10 @@ func TestSetupContainerModelCaching_FollowsPersistedSelection(t *testing.T) {
 		created, gerr := k8s.CoreV1().PersistentVolumeClaims(rwxTestNamespace).Get(ctx, pvc.Name, metav1.GetOptions{})
 		require.NoError(t, gerr)
 		assert.Equal(t, []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}, created.Spec.AccessModes)
+		updated, gerr := c.clients.BART.NvcaV2beta1().ICMSRequests(rwxTestNamespace).Get(ctx, req.Name, metav1.GetOptions{})
+		require.NoError(t, gerr)
+		assert.Equal(t, pvc.Name, updated.Status.CacheReferenceName,
+			"the request records the shared claim while the writer runs, so the reference sweep sees it in use")
 	})
 
 	t.Run("completed shared claim mounts read-only at source and mount", func(t *testing.T) {
@@ -298,4 +308,84 @@ func TestRegularModelCacheKeepsSharedClaim(t *testing.T) {
 	rox.RequiredMountOptions = []string{"ro", "norecovery", "nouuid"}
 	assert.False(t, regularModelCacheKeepsSharedClaim(rwxRequest(t, rox)),
 		"the NVMesh shape keeps its per-request claim cleanup")
+}
+
+func TestRWXReadOnly_StaleWriterWitnessDoesNotMarkANewClaim(t *testing.T) {
+	ctx := rwxTestContext(t)
+	pvc, job := rwxArtifacts()
+	done := job.DeepCopy()
+	done.Status.Succeeded = 1
+	now := metav1.Now()
+	done.Status.CompletionTime = &now
+	done.Spec.Template.Annotations = map[string]string{nvcastorage.ModelCacheWriterPVCUIDAnnotationKey: "an-earlier-claim"}
+	c, k8s := rwxTestBackend(nil, boundSharedClaim(false), done)
+
+	state, claim := c.setupRWXReadOnlyModelCachingForRequest(ctx, rwxRequest(t, rwxSelection(t)), pvc, job, rwxSelection(t))
+	assert.Equal(t, ModelCachingInProgress, state, "a Job that populated an earlier claim proves nothing about this one")
+	assert.Equal(t, pvc.Name, claim)
+
+	got, err := k8s.CoreV1().PersistentVolumeClaims(rwxTestNamespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.NotContains(t, got.Labels, nvcastorage.ModelCachePopulatedLabelKey, "the claim must not be marked populated")
+	_, err = k8s.BatchV1().Jobs(rwxTestNamespace).Get(ctx, job.Name, metav1.GetOptions{})
+	assert.True(t, errors.IsNotFound(err), "the stale writer is removed so a fresh one runs")
+}
+
+func TestRWXReadOnly_RefusesAClaimOnAnotherStorageClass(t *testing.T) {
+	ctx := rwxTestContext(t)
+	pvc, job := rwxArtifacts()
+	elsewhere := boundSharedClaim(true)
+	other := "previous-backend"
+	elsewhere.Spec.StorageClassName = &other
+	c, k8s := rwxTestBackend(nil, elsewhere)
+
+	state, _ := c.setupRWXReadOnlyModelCachingForRequest(ctx, rwxRequest(t, rwxSelection(t)), pvc, job, rwxSelection(t))
+	assert.Equal(t, ModelCachingFailed, state, "same handle on a different backend must not be mounted")
+
+	still, err := k8s.CoreV1().PersistentVolumeClaims(rwxTestNamespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+	require.NoError(t, err, "and must not be deleted either")
+	assert.Equal(t, other, *still.Spec.StorageClassName)
+	_, err = k8s.BatchV1().Jobs(rwxTestNamespace).Get(ctx, job.Name, metav1.GetOptions{})
+	assert.True(t, errors.IsNotFound(err))
+}
+
+func TestRWXReadOnly_WriterJobMustMountTheClaimInAContainer(t *testing.T) {
+	ctx := rwxTestContext(t)
+	pvc, job := rwxArtifacts()
+	job.Spec.Template.Spec.Containers[0].VolumeMounts = nil
+	c, k8s := rwxTestBackend(nil)
+
+	state, _ := c.setupRWXReadOnlyModelCachingForRequest(ctx, rwxRequest(t, rwxSelection(t)), pvc, job, rwxSelection(t))
+	assert.Equal(t, ModelCachingFailed, state, "a writer that never mounts the claim would mark an empty claim populated")
+	_, err := k8s.CoreV1().PersistentVolumeClaims(rwxTestNamespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+	assert.True(t, errors.IsNotFound(err))
+}
+
+func TestCleanupSharedClaimRequestArtifacts(t *testing.T) {
+	ctx := rwxTestContext(t)
+	pvc, job := rwxArtifacts()
+
+	t.Run("a running shared writer and the claim both survive one request's cleanup", func(t *testing.T) {
+		active := job.DeepCopy()
+		active.Status.Active = 1
+		c, k8s := rwxTestBackend(nil, boundSharedClaim(false), active)
+		require.NoError(t, c.cleanupSharedClaimRequestArtifacts(ctx, job, pvc.Name))
+		_, err := k8s.BatchV1().Jobs(rwxTestNamespace).Get(ctx, job.Name, metav1.GetOptions{})
+		require.NoError(t, err, "other requests are waiting on this writer")
+		_, err = k8s.CoreV1().PersistentVolumeClaims(rwxTestNamespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+		require.NoError(t, err, "the shared claim is reclaimed by the reference sweep, not by request cleanup")
+	})
+
+	t.Run("a finished writer is removed, the claim stays", func(t *testing.T) {
+		done := job.DeepCopy()
+		done.Status.Succeeded = 1
+		now := metav1.Now()
+		done.Status.CompletionTime = &now
+		c, k8s := rwxTestBackend(nil, boundSharedClaim(true), done)
+		require.NoError(t, c.cleanupSharedClaimRequestArtifacts(ctx, job, pvc.Name))
+		_, err := k8s.BatchV1().Jobs(rwxTestNamespace).Get(ctx, job.Name, metav1.GetOptions{})
+		assert.True(t, errors.IsNotFound(err))
+		_, err = k8s.CoreV1().PersistentVolumeClaims(rwxTestNamespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+	})
 }

--- a/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache_rwx_readonly_test.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache_rwx_readonly_test.go
@@ -376,11 +376,35 @@ func TestCleanupSharedClaimRequestArtifacts(t *testing.T) {
 		require.NoError(t, err, "the shared claim is reclaimed by the reference sweep, not by request cleanup")
 	})
 
+	t.Run("a writer with a failed pod and retries remaining is kept", func(t *testing.T) {
+		retrying := job.DeepCopy()
+		var limit int32 = 6
+		retrying.Spec.BackoffLimit = &limit
+		retrying.Status.Failed = 1
+		c, k8s := rwxTestBackend(nil, boundSharedClaim(false), retrying)
+		require.NoError(t, c.cleanupSharedClaimRequestArtifacts(ctx, job, pvc.Name))
+		_, err := k8s.BatchV1().Jobs(rwxTestNamespace).Get(ctx, job.Name, metav1.GetOptions{})
+		require.NoError(t, err, "one failed pod is not terminal while the Job still has retries")
+	})
+
+	t.Run("a terminally failed writer is removed, the claim stays", func(t *testing.T) {
+		failed := job.DeepCopy()
+		failed.Status.Failed = 7
+		failed.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobFailed, Status: corev1.ConditionTrue}}
+		c, k8s := rwxTestBackend(nil, boundSharedClaim(false), failed)
+		require.NoError(t, c.cleanupSharedClaimRequestArtifacts(ctx, job, pvc.Name))
+		_, err := k8s.BatchV1().Jobs(rwxTestNamespace).Get(ctx, job.Name, metav1.GetOptions{})
+		assert.True(t, errors.IsNotFound(err))
+		_, err = k8s.CoreV1().PersistentVolumeClaims(rwxTestNamespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+	})
+
 	t.Run("a finished writer is removed, the claim stays", func(t *testing.T) {
 		done := job.DeepCopy()
 		done.Status.Succeeded = 1
 		now := metav1.Now()
 		done.Status.CompletionTime = &now
+		done.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
 		c, k8s := rwxTestBackend(nil, boundSharedClaim(true), done)
 		require.NoError(t, c.cleanupSharedClaimRequestArtifacts(ctx, job, pvc.Name))
 		_, err := k8s.BatchV1().Jobs(rwxTestNamespace).Get(ctx, job.Name, metav1.GetOptions{})

--- a/src/compute-plane-services/nvca/pkg/storage/modelcache.go
+++ b/src/compute-plane-services/nvca/pkg/storage/modelcache.go
@@ -96,6 +96,16 @@ const (
 	// lease. It is the PVC analogue of the primaryPVLabelKey marker.
 	cachePopulatedLabelKey   = fqdnPrefix + "/modelcache-populated"
 	cachePopulatedLabelValue = "true"
+	// ModelCachePopulatedLabelKey and ModelCachePopulatedLabelValue expose the
+	// populated marker to the agent, whose regular-workflow shared claim uses
+	// the same label so one definition of "populated" serves both workflows.
+	ModelCachePopulatedLabelKey   = cachePopulatedLabelKey
+	ModelCachePopulatedLabelValue = cachePopulatedLabelValue
+	// ModelCacheWriterPVCUIDAnnotationKey, on a writer Job's pod template,
+	// records the UID of the claim the Job populated. A completed Job only
+	// proves the claim it wrote to is populated, not a later claim of the same
+	// name.
+	ModelCacheWriterPVCUIDAnnotationKey = fqdnPrefix + "/model-cache-writer-pvc-uid"
 
 	// The annotation applied to primary PV's that denotes the last time
 	// a function or task referenced it.


### PR DESCRIPTION
## Why

The persisted storage selection already drives Helm cache backend selection (#1334). The regular model cache workflow, used by functions that run as plain containers rather than Helm charts, recorded its selection and ignored it: every regular model cache took the NVMesh path, a `ReadWriteOnce` writer whose volume is later flipped to `ReadOnlyMany` and re-claimed. That path cannot work on a shared filesystem, so the regular model cache had no distributed filesystem story even after Weka or OCI FSS is enabled in the catalog.

## What changed

A request whose persisted selection is durable with the `ReadWriteMany` flow takes a shared-claim path:

- The artifact's `ReadWriteOnce` claim (the translator always emits `ReadWriteOnce`) becomes one `ReadWriteMany` claim per cache handle on the StorageClass the selection recorded.
- The writer Job populates it once. On completion the claim gets the existing populated label, the same durable marker the Helm path uses, so readers gate on the label and never on Job state.
- Every reader in the namespace mounts that same claim, read-only at both the volume source and the `volumeMount`.
- The writer Job's pod template records the UID of the claim it populated, so a completed Job from an earlier claim of the same name does not mark a new one populated.

Cleanup semantics follow from sharing: request cleanup no longer deletes the claim; the existing reference sweep (`ComputeCleanupCacheReferences`) reclaims it once no request's `CacheReferenceName` points at it. An unpopulated claim whose writer failed is removed so the next request retries cleanly. A claim of the same name that is not `ReadWriteMany` belongs to another flow and is neither mounted nor deleted.

Dispatch mirrors `HelmCacheBackendFromSelection`: durable `ReadWriteMany` takes this path, durable `ReadOnlyMany` takes the existing NVMesh path, a non-durable selection skips caching, and a request with no selection takes the legacy path unchanged.

## Customer Release Notes

Model caching for functions that run as plain containers (the regular model cache, as opposed to Helm-based functions) now works on shared filesystem storage backends enabled in the storage capability catalog.

## Plan Summary

Not applicable.

## Usage

No operator action. The path activates for requests created after a shared filesystem provisioner is qualified in the catalog.

## Testing

- Shared-claim path: first request creates the `ReadWriteMany` claim on the selection's class and a writer with the UID witness; a completed writer marks the claim populated and returns it; a populated claim is reused without a writer; a failed writer removes the unpopulated claim; a same-name claim that is not shared is refused and left alone; a writer that mounts the claim read-only is rejected before any write.
- Dispatch: a `ReadWriteMany` selection routes to the shared claim, a completed claim is mounted read-only at source and mount, a `none` selection makes no Kubernetes writes. Removing the dispatch makes the routing test fail.
- Cleanup predicate covers shared, legacy, and NVMesh-shape requests; disabling it makes the test fail.
- `go test ./pkg/nvca/ ./pkg/storage/...` and `golangci-lint` clean; Bazel deps verified per rule.

QA: a cluster run on a shared filesystem with a non-Helm function, confirming two requests for one cache handle share one claim and the second starts no writer.

## Notes

Not in this PR: the cache binding lifecycle (#1435 and its controller), which adds per-cache reference tracking on top of this. The regular `ReadOnlyMany` shape is unchanged. #1357 stays open as the reference; this is the selection-driven form of its RWX path without the binding dependency.

## References

None.

## Related Pull Requests

- #1334 selection, #1564 writer class, #1565 read-only mounts

## Dependencies

None.

## Issues

Relates to #1326


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared model-cache support for regular workflows using shared read/write storage.
  * Cache data is populated once and reused by subsequent readers through read-only mounts.
  * Storage behavior now follows the persisted cache selection, including support for disabling caching.

* **Bug Fixes**
  * Shared cache storage is retained for reference-based cleanup instead of being removed prematurely.
  * Improved handling of failed, stale, or mismatched cache-population operations.
  * Added safeguards to ensure cache writers and read-only readers use the expected storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
