### PR TITLE
fix(icms-fnds): Sending event ledger events in async mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /bazel-*
 
 # IDE / editor
+.bazelbsp/
 .idea/
 .vscode/
 *.swp

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/FunctionDeploymentStagesService.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/FunctionDeploymentStagesService.java
@@ -29,6 +29,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -81,7 +82,19 @@ public class FunctionDeploymentStagesService {
                                                                        event,
                                                                        instanceRequest.getDeploymentId(),
                                                                        instanceRequest.getGpuSpecificationId());
-                functionDeploymentStagesClient.sendFunctionDeploymentStage(fndsMessageModel);
+                CompletableFuture
+                        .runAsync(() -> functionDeploymentStagesClient
+                                .sendFunctionDeploymentStage(fndsMessageModel))
+                        .exceptionally(exception -> {
+                            log.error(
+                                    "Failed to send deployment stage to Event Ledger: "
+                                            + "instanceId={}, functionId={}, ncaId={}",
+                                    fndsMessageModel.getInstanceId(),
+                                    fndsMessageModel.getFunctionId(),
+                                    fndsMessageModel.getNcaId(),
+                                    exception);
+                            return null;
+                        });
             }
         } catch (Exception e) {
             String message = String.format("Deployment stage cannot be sent, Error: %s",
@@ -96,7 +109,6 @@ public class FunctionDeploymentStagesService {
                      e);
         }
     }
-
 
     public FndsMessageV2Model toFndsMessageModel(
             InstanceV2Entity instanceEntity, String functionId, String functionVersionId,


### PR DESCRIPTION
## TL;DR
Any higher latencies or crashes or any other issues on the Event Ledger side should not affect main flow of ICMS. To avoid any kind of EL issues we are sending messages in async mode unblocking main flow immediately.  

BUG=[nvbugs/6718605](https://nvbugspro.nvidia.com/bug/6718605)
NO-REF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment-stage event handling by processing notifications asynchronously.
  - Added clearer diagnostic logging when event delivery fails, including relevant deployment identifiers.

- **Chores**
  - Updated development-tool ignore settings to prevent local workspace artifacts from being tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->