### PR TITLE
feat(api-keys): bump colocated image tag to 1.8.0

### DIFF
--- a/deploy/helm/api-keys-colocated/api-keys/values.yaml
+++ b/deploy/helm/api-keys-colocated/api-keys/values.yaml
@@ -28,7 +28,7 @@ apikeys:
     registry: ""
     repository: ""
     pullPolicy: IfNotPresent
-    tag: "1.5.0"
+    tag: "1.8.0"
 
   imagePullSecrets: []
 

--- a/deploy/helm/api-keys-colocated/values.local.yaml
+++ b/deploy/helm/api-keys-colocated/values.local.yaml
@@ -17,4 +17,4 @@ apikeys:
   image:
     registry: ""
     repository: ""
-    tag: "1.5.0"
+    tag: "1.8.0"


### PR DESCRIPTION
## TL;DR
Bump the api-keys-colocated deployment image tag from 1.5.0 to 1.8.0 in the chart's default values and the local values override.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
Version bumps between 1.5.0 and 1.8.0:
- 1.6.0: build(cloud-tasks): add multi-arch OCI image target (no functional api-keys change)
- 1.6.1: re-release, no code change
- 1.6.2: re-release, no code change
- 1.7.0: feat(ess): add ess to monorepo (shared monorepo change, no functional api-keys change)
- 1.7.1: re-release, no code change
- 1.7.2: fix(bazel): remove Maven coexistence from Java components
- 1.7.3: fix(bazel): disable caching for Docker-backed Java tests
- 1.8.0: feat(api-keys): register event-ledger in the service id map

## For the Reviewer

version bump

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)


## Issues
Relates to #180
Relates to #181

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the API keys service to use version 1.8.0 in deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->