### PR TITLE
fix(nvca): use collector-compatible OTTL filter

### DIFF
--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/manifests/otel_collector_config.yaml
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/manifests/otel_collector_config.yaml
@@ -132,7 +132,10 @@ processors:
     logs:
       log_record:
         - resource.attributes["k8s.object.kind"] != "ICMSRequest"
-        - not(log.attributes["k8s.event.reason"] in ["InstanceCreation", "InstanceStatusUpdate", "InstanceTermination"])
+        - >-
+          log.attributes["k8s.event.reason"] != "InstanceCreation" and
+          log.attributes["k8s.event.reason"] != "InstanceStatusUpdate" and
+          log.attributes["k8s.event.reason"] != "InstanceTermination"
 
   # ICMS lane: lift nvcf.nvidia.io/* annotations stamped by NVCA (via AnnotatedEventf)
   # onto ICMSRequest Events into flat log.attributes so the FnDs exporter can read them.

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/otel_reconcile_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/otel_reconcile_test.go
@@ -249,11 +249,13 @@ func assertICMSLane(t *testing.T, config string) {
 	require.Len(t, records, 2, "filter/icms-events must have kind and reason drop conditions")
 	// First condition must drop non-ICMSRequest kinds (exclusion, not inclusion).
 	assert.Contains(t, records[0].(string), `!= "ICMSRequest"`, "filter/icms-events kind condition must drop non-ICMSRequest events")
-	// Second condition must allowlist the three supported reasons via not(...in[...]).
-	assert.Contains(t, records[1].(string), "not(", "filter/icms-events reason condition must use not() to drop unsupported reasons")
+	// Second condition must drop records outside the three supported reasons.
 	for _, reason := range []string{"InstanceCreation", "InstanceStatusUpdate", "InstanceTermination"} {
-		assert.Contains(t, records[1].(string), reason, "filter/icms-events allowlist must include reason %q", reason)
+		assert.Contains(t, records[1].(string), `!= "`+reason+`"`,
+			"filter/icms-events must retain reason %q", reason)
 	}
+	assert.NotContains(t, records[1].(string), " in ",
+		"filter/icms-events must use collector-compatible OTTL comparisons")
 	assert.NotContains(t, records[1].(string), "ModelCaching", "filter/icms-events must exclude ModelCaching")
 
 	liftProc, ok := processors["transform/lift-icms-annotations"].(map[string]any)

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/otel_reconcile_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/otel_reconcile_test.go
@@ -250,13 +250,11 @@ func assertICMSLane(t *testing.T, config string) {
 	// First condition must drop non-ICMSRequest kinds (exclusion, not inclusion).
 	assert.Contains(t, records[0].(string), `!= "ICMSRequest"`, "filter/icms-events kind condition must drop non-ICMSRequest events")
 	// Second condition must drop records outside the three supported reasons.
-	for _, reason := range []string{"InstanceCreation", "InstanceStatusUpdate", "InstanceTermination"} {
-		assert.Contains(t, records[1].(string), `!= "`+reason+`"`,
-			"filter/icms-events must retain reason %q", reason)
-	}
-	assert.NotContains(t, records[1].(string), " in ",
-		"filter/icms-events must use collector-compatible OTTL comparisons")
-	assert.NotContains(t, records[1].(string), "ModelCaching", "filter/icms-events must exclude ModelCaching")
+	expectedReasonFilter := `log.attributes["k8s.event.reason"] != "InstanceCreation" and ` +
+		`log.attributes["k8s.event.reason"] != "InstanceStatusUpdate" and ` +
+		`log.attributes["k8s.event.reason"] != "InstanceTermination"`
+	assert.Equal(t, expectedReasonFilter, records[1].(string),
+		"filter/icms-events reason condition must exactly retain the supported reasons")
 
 	liftProc, ok := processors["transform/lift-icms-annotations"].(map[string]any)
 	require.True(t, ok, "transform/lift-icms-annotations processor must be declared")


### PR DESCRIPTION
## TL;DR

Replace an unsupported OTTL list-membership expression in NVCA's generated OpenTelemetry Collector configuration with equivalent explicit comparisons. The chart-tested collector can now validate the configuration and start the NVCA event pipeline.

## Additional Details

The compute observability profile left the NVCA pod in `Init:CrashLoopBackOff` because collector `0.157.0-nv-0.2.1` rejected `in [...]` in `filter/icms-events`. Released NVCA `3.5.1` contains the same expression.

The replacement keeps the existing behavior: non-ICMS events and ICMS events with unsupported reasons are dropped, while the three supported reasons continue through the pipeline. The test now asserts each exclusion comparison and prevents the unsupported membership syntax from returning.

## For the Reviewer

Please focus on the boolean equivalence of the filter expression in `otel_collector_config.yaml`.

## For QA

- Passed `go test ./pkg/operator/reconcile -run '^TestGetOTelCollectorConfigData$' -count=1 -ldflags '-X github.com/NVIDIA/k8s-dra-driver-gpu/internal/info.version=v25.8.0'`.
- Applied the generated expression to a live self-managed compute-observability deployment using the chart-tested collector. The NVCA pod reached `3/3 Running` and the backend returned to `healthy`.
- QA is recommended in the next published NVCA image and compute-observability stack profile.

## Issues

Fixes #1552

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ICMS event filtering so instance creation, status update, and termination events are recognized explicitly.
  - Improved validation to ensure only the three supported event reasons are accepted and incomplete or unsupported filtering conditions are rejected.
  - This provides more consistent handling of supported instance lifecycle events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->