### PR TITLE
fix(container-cache): render apiVersion on the nvcf-container-cache Service

### DIFF
--- a/deploy/helm/container-cache/deploy/templates/service.yaml
+++ b/deploy/helm/container-cache/deploy/templates/service.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-{{- include "nvcf-container-cache.validateServiceType" . -}}
+{{- include "nvcf-container-cache.validateServiceType" . }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/helm/container-cache/tests/render-apiversion-test.sh
+++ b/deploy/helm/container-cache/tests/render-apiversion-test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Every rendered document must carry apiVersion and kind. A trailing "-}}" on
+# a template action placed right after the license header swallows the
+# newline and glues "apiVersion: v1" onto the last comment line; helm lint
+# accepts the result and ArgoCD then fails the sync with "groupVersion
+# shouldn't be empty". Run from the chart subtree:
+#   bash tests/render-apiversion-test.sh
+set -euo pipefail
+CHART_DIR="$(cd "$(dirname "$0")/.." && pwd)/deploy"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+check() { # $1 label, remaining args: helm --set flags
+  local label="$1"; shift
+  helm template t "$CHART_DIR" "$@" > "$TMP/$label.yaml" 2>/dev/null || fail "$label: helm template failed"
+  # A comment line that ends in "apiVersion:" is the exact symptom.
+  if grep -nE '^#.*apiVersion:' "$TMP/$label.yaml"; then fail "$label: apiVersion glued onto a comment line"; fi
+  python3 - "$TMP/$label.yaml" "$label" <<'PY'
+import sys, yaml
+path, label = sys.argv[1], sys.argv[2]
+bad = []
+n = 0
+for d in yaml.safe_load_all(open(path)):
+    if not d:
+        continue
+    n += 1
+    if not d.get("apiVersion") or not d.get("kind"):
+        bad.append((d.get("kind"), (d.get("metadata") or {}).get("name"), d.get("apiVersion")))
+if bad:
+    print(f"FAIL: {label}: documents without apiVersion/kind: {bad}", file=sys.stderr)
+    sys.exit(1)
+print(f"{label}: {n} documents, all carry apiVersion and kind")
+PY
+}
+
+check default
+check consistent-hash --set consistentHashRouting.enabled=true --set replicaCount=3
+check pvc --set persistentVolumeClaim.storageClassName=nvcf-cc-sc
+check pdb --set podDisruptionBudget.enabled=true --set podDisruptionBudget.minAvailable=1
+echo "PASS: apiVersion render tests"

--- a/deploy/helm/container-cache/tests/render-apiversion-test.sh
+++ b/deploy/helm/container-cache/tests/render-apiversion-test.sh
@@ -17,21 +17,33 @@ fail() { echo "FAIL: $*" >&2; exit 1; }
 check() { # $1 label, remaining args: helm --set flags
   local label="$1"; shift
   helm template t "$CHART_DIR" "$@" > "$TMP/$label.yaml" 2>/dev/null || fail "$label: helm template failed"
-  # A comment line that ends in "apiVersion:" is the exact symptom.
-  if grep -nE '^#.*apiVersion:' "$TMP/$label.yaml"; then fail "$label: apiVersion glued onto a comment line"; fi
   python3 - "$TMP/$label.yaml" "$label" <<'PY'
-import sys, yaml
+import re, sys, yaml
 path, label = sys.argv[1], sys.argv[2]
+text = open(path).read()
+# Raw documents, so a failure can point at the comment line the field was
+# trimmed onto. A comment that merely mentions "kind:" in a valid document is
+# not an error.
+raw_docs = [d for d in re.split(r"^---[ \t]*$", text, flags=re.M)]
 bad = []
 n = 0
-for d in yaml.safe_load_all(open(path)):
-    if not d:
+for raw in raw_docs:
+    body = [l for l in raw.splitlines() if l.strip() and not l.lstrip().startswith("#")]
+    if not body:
+        continue  # separator gap, or a template that rendered only its "# Source:" header under these values
+    d = yaml.safe_load(raw)
+    if not isinstance(d, dict):
+        bad.append(("non-mapping document", body[0][:80]))
         continue
     n += 1
-    if not d.get("apiVersion") or not d.get("kind"):
-        bad.append((d.get("kind"), (d.get("metadata") or {}).get("name"), d.get("apiVersion")))
+    for field in ("apiVersion", "kind"):
+        if not d.get(field):
+            glued = next((l.strip() for l in raw.splitlines() if l.lstrip().startswith("#") and f"{field}:" in l), None)
+            bad.append((d.get("kind"), (d.get("metadata") or {}).get("name"), f"missing {field}", f"glued onto comment: {glued}" if glued else ""))
+if n == 0:
+    bad.append(("no documents rendered", ""))
 if bad:
-    print(f"FAIL: {label}: documents without apiVersion/kind: {bad}", file=sys.stderr)
+    print(f"FAIL: {label}: {bad}", file=sys.stderr)
     sys.exit(1)
 print(f"{label}: {n} documents, all carry apiVersion and kind")
 PY

--- a/tools/ci/check-helm-charts
+++ b/tools/ci/check-helm-charts
@@ -177,29 +177,42 @@ run_step() {  # run_step <label> <command...> -> 0 on success, prints output on 
 # API server and ArgoCD then reject the object ("groupVersion shouldn't be
 # empty"). Check every rendered document for a top-level apiVersion and kind.
 check_rendered_objects() {  # check_rendered_objects <stem> <rendered file>
-    local stem="$1" rendered="$2" glued
-    glued="$(grep -nE '^#.*(apiVersion|kind):' "${rendered}" || true)"
-    if [ -n "${glued}" ]; then
-        echo "${stem}: apiVersion/kind rendered onto a comment line (a template action ending in -}} trimmed the newline):" >&2
-        echo "${glued}" | sed 's/^/  /' >&2
-        return 1
-    fi
+    local stem="$1" rendered="$2"
+    # Document-aware: a comment that merely mentions "kind:" is fine. Only when
+    # the same document lacks the top-level field is the comment line reported,
+    # as the likely place the field was trimmed onto.
     awk -v stem="${stem}" '
         function flush() {
-            if (content && (!hasapi || !haskind)) {
-                bad++
-                printf "%s: rendered document %d (%s) has no top-level %s\n", stem, n, name, (!hasapi ? "apiVersion" : "kind") > "/dev/stderr"
+            if (content) {
+                if (!hasapi) report("apiVersion", gluedapi)
+                if (!haskind) report("kind", gluedkind)
             }
-            content = 0; hasapi = 0; haskind = 0; name = "?"; n++
+            content = 0; hasapi = 0; haskind = 0; gluedapi = 0; gluedkind = 0; name = "?"; n++
+        }
+        function report(field, glued) {
+            bad++
+            if (glued) {
+                printf "%s: rendered document %d (%s) has no top-level %s; line %d has %s rendered onto a comment line (a template action ending in -}} trimmed the newline)\n", stem, n, name, field, glued, field > "/dev/stderr"
+            } else {
+                printf "%s: rendered document %d (%s) has no top-level %s\n", stem, n, name, field > "/dev/stderr"
+            }
         }
         BEGIN { n = 1; name = "?" }
         /^---/ { flush(); next }
-        /^[ \t]*#/ || /^[ \t]*$/ { next }
+        /^[ \t]*#/ {
+            if ($0 ~ /apiVersion:/ && !gluedapi) gluedapi = NR
+            if ($0 ~ /kind:/ && !gluedkind) gluedkind = NR
+            next
+        }
+        /^[ \t]*$/ { next }
         { content = 1 }
         /^apiVersion:/ { hasapi = 1 }
         /^kind:/ { haskind = 1 }
         /^  name:/ && name == "?" { name = $2 }
-        END { flush(); exit (bad ? 1 : 0) }
+        END {
+            flush()
+            exit (bad ? 1 : 0)
+        }
     ' "${rendered}"
 }
 

--- a/tools/ci/check-helm-charts
+++ b/tools/ci/check-helm-charts
@@ -41,6 +41,7 @@ chart_map=(
     "api-keys-colocated       api-keys-colocated/api-keys"
     "cassandra                cassandra/helm"
     "cloud-functions          cloud-functions/nvcf-api"
+    "container-cache          container-cache/deploy"
     "ess                      encrypted-secret-store/ess-api"
     "gateway-routes-vanity    gateway-routes/chart"
     "grpc-proxy               grpc-proxy/grpc-proxy"
@@ -170,6 +171,51 @@ run_step() {  # run_step <label> <command...> -> 0 on success, prints output on 
     return 0
 }
 
+# helm template and helm lint accept a document whose apiVersion has been
+# swallowed into a preceding comment (a template action ending in "-}}" right
+# after the license header does this), because the line is valid YAML. The
+# API server and ArgoCD then reject the object ("groupVersion shouldn't be
+# empty"). Check every rendered document for a top-level apiVersion and kind.
+check_rendered_objects() {  # check_rendered_objects <stem> <rendered file>
+    local stem="$1" rendered="$2" glued
+    glued="$(grep -nE '^#.*(apiVersion|kind):' "${rendered}" || true)"
+    if [ -n "${glued}" ]; then
+        echo "${stem}: apiVersion/kind rendered onto a comment line (a template action ending in -}} trimmed the newline):" >&2
+        echo "${glued}" | sed 's/^/  /' >&2
+        return 1
+    fi
+    awk -v stem="${stem}" '
+        function flush() {
+            if (content && (!hasapi || !haskind)) {
+                bad++
+                printf "%s: rendered document %d (%s) has no top-level %s\n", stem, n, name, (!hasapi ? "apiVersion" : "kind") > "/dev/stderr"
+            }
+            content = 0; hasapi = 0; haskind = 0; name = "?"; n++
+        }
+        BEGIN { n = 1; name = "?" }
+        /^---/ { flush(); next }
+        /^[ \t]*#/ || /^[ \t]*$/ { next }
+        { content = 1 }
+        /^apiVersion:/ { hasapi = 1 }
+        /^kind:/ { haskind = 1 }
+        /^  name:/ && name == "?" { name = $2 }
+        END { flush(); exit (bad ? 1 : 0) }
+    ' "${rendered}"
+}
+
+render_and_check() {  # render_and_check <stem> <chart dir> <values file>
+    local stem="$1" chart_dir="$2" values_file="$3" rendered
+    rendered="$(mktemp)"
+    if ! helm template "${stem}" "${chart_dir}" -f "${values_file}" >"${rendered}"; then
+        rm -f "${rendered}"
+        return 1
+    fi
+    check_rendered_objects "${stem}" "${rendered}"
+    local rc=$?
+    rm -f "${rendered}"
+    return "${rc}"
+}
+
 failed=()
 
 for stem in "${stems[@]}"; do
@@ -198,7 +244,7 @@ for stem in "${stems[@]}"; do
         run_step "${stem}: helm lint" \
             helm lint "${chart_dir}" -f "${values_file}" || chart_failed=1
         run_step "${stem}: helm template" \
-            helm template "${stem}" "${chart_dir}" -f "${values_file}" || chart_failed=1
+            render_and_check "${stem}" "${chart_dir}" "${values_file}" || chart_failed=1
     fi
 
     if [ "${chart_failed}" -eq 0 ]; then

--- a/tools/ci/helm-validate-values/container-cache.yaml
+++ b/tools/ci/helm-validate-values/container-cache.yaml
@@ -1,0 +1,8 @@
+# CI-only values for helm lint/template validation.
+# Exercise the optional surfaces so their templates render in CI too.
+replicaCount: 3
+consistentHashRouting:
+  enabled: true
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1

--- a/tools/ci/test-check-helm-charts
+++ b/tools/ci/test-check-helm-charts
@@ -123,6 +123,58 @@ run_with_fake_helm() {  # run_with_fake_helm -> sets $out and $rc
     rm -rf "${stub_dir}"
 }
 
+# A rendered document whose apiVersion was swallowed into a comment must fail
+# the chart, naming the file line. helm itself accepts this output, which is
+# how the container-cache Service shipped without an apiVersion in 0.29.0.
+make_fake_glued_helm() {  # make_fake_glued_helm -> directory holding a helm stub, printed to stdout
+    local dir; dir="$(mktemp -d)"
+    cat >"${dir}/helm" <<'STUB'
+#!/usr/bin/env bash
+# Stub helm: template emits one good document and one whose apiVersion was
+# trimmed onto the preceding comment line.
+if [ "${1:-}" = "template" ]; then
+    printf -- '---\n# Source: x/templates/a.yaml\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: good\n'
+    printf -- '---\n# Source: x/templates/b.yaml\n# limitations under the License.apiVersion: v1\nkind: Service\nmetadata:\n  name: glued\n'
+fi
+exit 0
+STUB
+    chmod +x "${dir}/helm"
+    printf '%s' "${dir}"
+}
+
+make_fake_headless_helm() {  # make_fake_headless_helm -> stub whose template emits a document with no apiVersion at all
+    local dir; dir="$(mktemp -d)"
+    cat >"${dir}/helm" <<'STUB'
+#!/usr/bin/env bash
+if [ "${1:-}" = "template" ]; then
+    printf -- '---\n# Source: x/templates/a.yaml\nkind: Service\nmetadata:\n  name: headless\nspec: {}\n'
+fi
+exit 0
+STUB
+    chmod +x "${dir}/helm"
+    printf '%s' "${dir}"
+}
+
+make_fake_tree
+stub_dir="$(make_fake_glued_helm)"
+set +e
+out="$(PATH="${stub_dir}:${PATH}" bash "${script}" --values-dir "${fake_values_dir}" --chart-root "${fake_chart_root}" 2>&1)"
+rc=$?
+set -e
+rm -rf "${stub_dir}"
+expect "apiVersion glued onto a comment fails" 1 "rendered onto a comment line"
+rm -rf "${fake_values_dir}" "${fake_chart_root}"
+
+make_fake_tree
+stub_dir="$(make_fake_headless_helm)"
+set +e
+out="$(PATH="${stub_dir}:${PATH}" bash "${script}" --values-dir "${fake_values_dir}" --chart-root "${fake_chart_root}" 2>&1)"
+rc=$?
+set -e
+rm -rf "${stub_dir}"
+expect "document without apiVersion fails" 1 "has no top-level apiVersion"
+rm -rf "${fake_values_dir}" "${fake_chart_root}"
+
 # A charts/ directory created by the run is removed entirely.
 make_fake_tree
 printf 'dependencies:\n  - name: openbao\n' >>"${fake_chart_root}/openbao/helm/Chart.yaml"


### PR DESCRIPTION
## Why

Charts 0.29.0 through 0.30.3 render the `nvcf-container-cache` Service without an `apiVersion`. The `validateServiceType` include added in #1000 ends with `-}}`, which trims the following newline, so `apiVersion: v1` is appended to the last license comment line and becomes part of the comment. `helm lint` and `helm template` accept it; ArgoCD fails the sync:

```
failed to discover server resources for group version : groupVersion shouldn't be empty
```

This blocks the first ArgoCD rollout of 0.30.3. 0.28.1 renders correctly.

Two gaps let it ship: the render checks only compared strings, never object validity, and the container-cache chart had no entry in the repo-wide chart CI, so nothing rendered it on pull requests.

## What changed

- `templates/service.yaml`: `{{- include ... -}}` becomes `{{- include ... }}` so the newline before `apiVersion: v1` survives.
- `tests/render-apiversion-test.sh`: renders the chart with default, consistent-hash, PVC and PDB settings and fails if any document lacks `apiVersion` or `kind`, or if a comment line ends with `apiVersion:`. Fails on the previous template.
- `tools/ci/check-helm-charts`: after `helm template`, every rendered document must carry a top-level `apiVersion` and `kind`; a comment line ending in `apiVersion:` or `kind:` fails the chart and prints the line. This runs for all 16 charts in the `helm charts` job.
- `tools/ci/helm-validate-values/container-cache.yaml` and a `chart_map` entry: the container-cache chart is now linted and rendered in CI, with consistent-hash routing and the PodDisruptionBudget enabled so those templates render too.
- `tools/ci/test-check-helm-charts`: two new cases, apiVersion glued onto a comment and a document with no apiVersion, both expected to fail the checker.

## Customer Release Notes

Container cache chart: the `nvcf-container-cache` Service is rendered with its `apiVersion` again, so GitOps tools can apply the chart.

## Plan Summary

No resource added or removed. The Service object is unchanged apart from now being a valid Kubernetes object.

## Usage

Not applicable.

## Testing

From the repo root: `bash tools/ci/test-check-helm-charts` (11 cases pass) and `./tools/ci/check-helm-charts` (16 charts pass). With the pre-fix `service.yaml` restored from `origin/main`, the checker fails with `container-cache: apiVersion/kind rendered onto a comment line`.

From `deploy/helm/container-cache`: `helm lint deploy`, `bash tests/render-apiversion-test.sh` (fails on the pre-fix template), `bash tests/render-consistent-hash-test.sh`, `bash tests/render-range-sanitize-test.sh`. All pass.

Not yet applied to a live cluster; the affected cluster picks up the next release through its SBOM pin.

## Notes

No other template in the chart has a trimming action directly before `apiVersion`; the CI check now guards every chart regardless.

## Issues

Closes #1585

## References

None

## Related Pull Requests

#1000 introduced the line. #1577 (emptyDir max_size) is independent.

## Dependencies

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Helm template formatting so rendered Kubernetes Service manifests remain valid and properly separated from comments.

* **Tests**
  * Added coverage for container-cache rendering across multiple configuration scenarios.
  * Added document-level validation for required Kubernetes metadata, malformed manifests, missing fields, and comment-related formatting issues.

* **Chores**
  * Expanded automated Helm chart checks to include the container-cache chart and additional deployment configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->