### PR TITLE
feat(event-ledger): bump image tag to 0.15.1

### DIFF
--- a/deploy/helm/event-ledger/Chart.yaml
+++ b/deploy/helm/event-ledger/Chart.yaml
@@ -21,4 +21,4 @@ type: application
 
 version: 0.0.0 # autoversioning enabled via release pipeline
 
-appVersion: "0.13.3"
+appVersion: "0.15.1"

--- a/deploy/helm/event-ledger/values.yaml
+++ b/deploy/helm/event-ledger/values.yaml
@@ -37,7 +37,7 @@ eventLedger:
     # Image name is chart-owned and appended to registry/repository.
     name: "nvcf-event-ledger"
     pullPolicy: IfNotPresent
-    tag: "0.13.3"
+    tag: "0.15.1"
     digest: ""
 
   imagePullSecrets: []


### PR DESCRIPTION
## TL;DR
Bump the event-ledger helm chart image tag from 0.13.3 to 0.15.1 in the chart's default values and Chart.yaml appVersion.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
Version bumps between 0.13.3 and 0.15.1:
- 0.14.0: feat(event-ledger): generic resource_id context field for non-Pod resources (#1117)
- 0.15.0: feat(event-ledger): generic attribute filter on GET /events (#1119)
- 0.15.1: fix(event-ledger): route JWT auth away from the API key evaluator (#1074)

## For the Reviewer


## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)


## Issues
Relates to #180
Relates to #181

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the event-ledger deployment to version 0.15.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->