### PR TITLE
feat(storage): take reader PV mount options from the persisted selection

### DIFF
--- a/docs/dev/sdd-storage-agnostic-cache-architecture.md
+++ b/docs/dev/sdd-storage-agnostic-cache-architecture.md
@@ -138,11 +138,13 @@ retried instead of leaving the namespace Terminating.
 Every reader is a static PV pre-bound to a claim by name. The PV is a copy of
 the writer's PV with: `storageClassName` cleared (a pre-bound pair whose classes
 differ never binds), `csi.readOnly: true` (access modes are not enforced at
-mount time), and `mountOptions` resolved per provisioner from the
-`nvca-cache-mount-options` ConfigMap. The catalog's `readerMountOptions` is the
-intended source for those options and is validated, but no reader code reads it
-yet. Only the volume handle differs by driver: NVMesh rewrites the namespace
-segment; every other driver reuses the writer's handle unchanged.
+mount time), and `mountOptions` taken from the request's persisted selection,
+which carries the catalog's `readerMountOptions`. Operator-configured options
+are appended unless they negate a required one (`rw` against `ro`). A request
+with no durable selection falls back to the per-provisioner
+`nvca-cache-mount-options` ConfigMap, so in-flight legacy requests keep their
+behavior. Only the volume handle differs by driver: NVMesh rewrites the
+namespace segment; every other driver reuses the writer's handle unchanged.
 
 A reader claim that names only a StorageClass gets a new empty volume from a
 dynamic provisioner. It binds, the pod starts, and the model is missing. That

--- a/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/core"
 	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function"
+	"github.com/sirupsen/logrus"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -606,8 +607,11 @@ func (c K8sComputeBackend) readerMountOptionsForRequest(ctx context.Context, req
 	}
 	merged, dropped := nvcastorage.MergeReaderMountOptions(selection.RequiredMountOptions, configured)
 	if len(dropped) != 0 {
-		log.Infof("ignoring configured cache mount options %v that conflict with required %v for %v/%v",
-			dropped, selection.RequiredMountOptions, req.Namespace, req.Name)
+		log.WithFields(logrus.Fields{
+			"request":  req.Namespace + "/" + req.Name,
+			"ignored":  nvcastorage.RedactMountOptionValues(dropped),
+			"required": nvcastorage.RedactMountOptionValues(selection.RequiredMountOptions),
+		}).Info("ignoring configured cache mount options that conflict with the required ones")
 	}
 	return merged
 }

--- a/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache.go
@@ -42,6 +42,7 @@ import (
 	nvcav1new "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/v1"
 	nvcav2beta1 "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/v2beta1"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/nvca/encryption"
+	nvcastorage "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/storage"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/types"
 )
 
@@ -579,6 +580,38 @@ func (c K8sComputeBackend) waitForVolumeDetach(ctx context.Context, volumeName s
    1. Name -> $LaunchSpecification.CacheHandle-ro-pvc
    2. /spec/accessModes -> ReadOnlyMany
 */
+// readerMountOptionsForRequest returns the mount options for the read-only PV
+// that serves req. A durable request carries the catalog's readerMountOptions in
+// its persisted selection; those are required and the configured options are
+// appended except where they would negate one. Requests without a durable
+// selection keep the configured options unchanged, as before.
+func (c K8sComputeBackend) readerMountOptionsForRequest(ctx context.Context, req *nvcav2beta1.ICMSRequest) []string {
+	configured := c.bk8s.csiVolumeMountOptions
+	if req == nil {
+		return configured
+	}
+	raw := req.Annotations[nvcastorage.ModelCacheStorageSelectionAnnotationKey]
+	if raw == "" {
+		return configured
+	}
+	log := core.GetLogger(ctx)
+	selection, err := nvcastorage.ParsePersistedModelCacheStorageSelection(raw)
+	if err != nil {
+		log.WithError(err).Warnf("ignoring invalid model cache selection on %v/%v for reader mount options",
+			req.Namespace, req.Name)
+		return configured
+	}
+	if selection.Mode != nvcastorage.ModelCacheSelectionDurable {
+		return configured
+	}
+	merged, dropped := nvcastorage.MergeReaderMountOptions(selection.RequiredMountOptions, configured)
+	if len(dropped) != 0 {
+		log.Infof("ignoring configured cache mount options %v that conflict with required %v for %v/%v",
+			dropped, selection.RequiredMountOptions, req.Namespace, req.Name)
+	}
+	return merged
+}
+
 func (c K8sComputeBackend) SetupPVCForReaders(ctx context.Context,
 	rwPVC *v1.PersistentVolumeClaim, initJobName string, req *nvcav2beta1.ICMSRequest, mf mutateFunc) (ROPVCSetupPhase, error) {
 	log := core.GetLogger(ctx)
@@ -695,7 +728,7 @@ func (c K8sComputeBackend) SetupPVCForReaders(ctx context.Context,
 			// set the new PVCRef
 			pvObj.Spec.ClaimRef = &newPVCRef
 			pvObj.Spec.AccessModes = ROAccessMode
-			pvObj.Spec.MountOptions = c.bk8s.csiVolumeMountOptions
+			pvObj.Spec.MountOptions = c.readerMountOptionsForRequest(ctx, req)
 
 			_, updateErr := c.clients.K8s.CoreV1().PersistentVolumes().Update(ctx, pvObj, metav1.UpdateOptions{})
 			return updateErr

--- a/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache_test.go
+++ b/src/compute-plane-services/nvca/pkg/nvca/k8scomputebackend_modelcache_test.go
@@ -19,6 +19,7 @@ package nvca
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function"
@@ -34,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	nvcav2beta1 "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/apis/nvca/v2beta1"
+	nvcastorage "github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/storage"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/nvca/pkg/types"
 )
 
@@ -380,4 +382,82 @@ func TestGetInitCacheJobFailureReason_JobNotFound(t *testing.T) {
 
 	reason := bc.k8sArtifactHelper.(K8sComputeBackend).getInitCacheJobFailureReason(ctx, nonExistentJob)
 	assert.Equal(t, "job_not_found", reason)
+}
+
+func TestReaderMountOptionsForRequest(t *testing.T) {
+	durable := func(t *testing.T, mountOptions []string) string {
+		t.Helper()
+		raw, err := (&nvcastorage.PersistedModelCacheStorageSelection{
+			Version:              nvcastorage.ModelCacheStorageSelectionVersion,
+			Workflow:             nvcastorage.ModelCacheWorkflowRegular,
+			Mode:                 nvcastorage.ModelCacheSelectionDurable,
+			StorageClassName:     nvcastorage.DefaultModelCacheStorageClassName,
+			StorageClassUID:      "uid-1",
+			StorageClassDigest:   "v1:sha256:" + strings.Repeat("a", 64),
+			ProfileDigest:        "sha256:" + strings.Repeat("b", 64),
+			Provider:             nvcastorage.ModelCacheProviderNVMesh,
+			Provisioner:          nvcastorage.NVMeshStorageClassProvisioner,
+			Transition:           nvcastorage.ModelCacheTransitionROXReadOnly,
+			RequiredAccessModes:  []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce, corev1.ReadOnlyMany},
+			RequiredMountOptions: mountOptions,
+		}).Marshal()
+		require.NoError(t, err)
+		return raw
+	}
+	ephemeral := func(t *testing.T) string {
+		t.Helper()
+		raw, err := (&nvcastorage.PersistedModelCacheStorageSelection{
+			Version:  nvcastorage.ModelCacheStorageSelectionVersion,
+			Workflow: nvcastorage.ModelCacheWorkflowHelm,
+			Mode:     nvcastorage.ModelCacheSelectionEphemeral,
+		}).Marshal()
+		require.NoError(t, err)
+		return raw
+	}
+
+	tests := []struct {
+		name       string
+		annotation string
+		configured []string
+		want       []string
+	}{
+		{
+			name:       "no selection keeps the configured options",
+			configured: []string{"noatime"},
+			want:       []string{"noatime"},
+		},
+		{
+			name:       "durable selection supplies the required options",
+			annotation: durable(t, []string{"ro", "norecovery", "nouuid"}),
+			want:       []string{"ro", "norecovery", "nouuid"},
+		},
+		{
+			name:       "configured extras follow the selection and cannot negate it",
+			annotation: durable(t, []string{"ro", "nouuid"}),
+			configured: []string{"rw", "uuid", "noatime"},
+			want:       []string{"ro", "nouuid", "noatime"},
+		},
+		{
+			name:       "ephemeral selection keeps the configured options",
+			annotation: ephemeral(t),
+			configured: []string{"noatime"},
+			want:       []string{"noatime"},
+		},
+		{
+			name:       "invalid selection keeps the configured options",
+			annotation: "{",
+			configured: []string{"noatime"},
+			want:       []string{"noatime"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := K8sComputeBackend{bk8s: &BackendK8sCache{csiVolumeMountOptions: tt.configured}}
+			req := &nvcav2beta1.ICMSRequest{ObjectMeta: metav1.ObjectMeta{Name: "req", Namespace: "ns"}}
+			if tt.annotation != "" {
+				req.Annotations = map[string]string{nvcastorage.ModelCacheStorageSelectionAnnotationKey: tt.annotation}
+			}
+			assert.Equal(t, tt.want, c.readerMountOptionsForRequest(newTestContext(), req))
+		})
+	}
 }

--- a/src/compute-plane-services/nvca/pkg/storage/modelcache.go
+++ b/src/compute-plane-services/nvca/pkg/storage/modelcache.go
@@ -688,6 +688,12 @@ func (r *Reconciler) modelCacheProvisionerName(ctx context.Context) (string, boo
 // keeping the key, so a log line stays useful for debugging without echoing
 // operator supplied values. Mount options are free form and can carry
 // credentials, a CIFS password being the obvious case.
+// RedactMountOptionValues masks the value part of key=value mount options so
+// they can be logged without leaking credentials a driver may carry there.
+func RedactMountOptionValues(opts []string) []string {
+	return redactMountOptionValues(opts)
+}
+
 func redactMountOptionValues(opts []string) []string {
 	redacted := make([]string, 0, len(opts))
 	for _, opt := range opts {

--- a/src/compute-plane-services/nvca/pkg/storage/modelcache.go
+++ b/src/compute-plane-services/nvca/pkg/storage/modelcache.go
@@ -729,21 +729,82 @@ func (r *Reconciler) resolveCacheMountOptions(ctx context.Context, pv *corev1.Pe
 	if !found {
 		return r.csiVolumeMountOptions
 	}
+	return r.mergeRequiredMountOptions(ctx, pv, defaults)
+}
 
-	log := logf.FromContext(ctx)
-	configured := make([]string, 0, len(r.csiVolumeMountOptions))
-	for _, opt := range r.csiVolumeMountOptions {
-		if i := slices.IndexFunc(defaults, func(d string) bool { return negatesMountOption(d, opt) }); i >= 0 {
-			log.Info("Ignoring configured cache mount option that conflicts with a provisioner default",
-				"pv", pv.Name,
-				"ignored", redactMountOptionValues([]string{opt}),
-				"required", redactMountOptionValues([]string{defaults[i]}))
+// resolveReaderMountOptions returns the mount options for the read-only PV that
+// serves the given StorageRequest. A durable request carries the catalog's
+// readerMountOptions in its persisted selection, so those are the required set
+// and the configured options are appended except where they would negate one.
+// Requests without a durable selection, including in-flight legacy requests,
+// keep the per-provisioner ConfigMap path.
+func (r *Reconciler) resolveReaderMountOptions(ctx context.Context,
+	st *nvcav1new.StorageRequest, pv *corev1.PersistentVolume,
+) []string {
+	required, ok := selectionReaderMountOptions(ctx, st)
+	if !ok {
+		return r.resolveCacheMountOptions(ctx, pv)
+	}
+	return r.mergeRequiredMountOptions(ctx, pv, required)
+}
+
+// selectionReaderMountOptions returns the reader mount options recorded in the
+// StorageRequest's persisted selection. ok is false when the request has no
+// selection, the selection is not durable, or it cannot be parsed; the caller
+// then falls back to the ConfigMap path so a bad annotation never strips the
+// options a driver needs.
+func selectionReaderMountOptions(ctx context.Context, st *nvcav1new.StorageRequest) ([]string, bool) {
+	if st == nil {
+		return nil, false
+	}
+	raw := st.Annotations[ModelCacheStorageSelectionAnnotationKey]
+	if raw == "" {
+		return nil, false
+	}
+	selection, err := ParsePersistedModelCacheStorageSelection(raw)
+	if err != nil {
+		logf.FromContext(ctx).Error(err, "Ignoring invalid model cache selection for reader mount options",
+			"storageRequest", client.ObjectKeyFromObject(st))
+		return nil, false
+	}
+	if selection.Mode != ModelCacheSelectionDurable {
+		return nil, false
+	}
+	return selection.RequiredMountOptions, true
+}
+
+// mergeRequiredMountOptions appends the configured options to the required
+// set, logging and dropping any configured option that would negate a required
+// one.
+func (r *Reconciler) mergeRequiredMountOptions(ctx context.Context,
+	pv *corev1.PersistentVolume, required []string,
+) []string {
+	merged, dropped := MergeReaderMountOptions(required, r.csiVolumeMountOptions)
+	if len(dropped) != 0 {
+		logf.FromContext(ctx).Info("Ignoring configured cache mount options that conflict with required ones",
+			"pv", pv.Name,
+			"ignored", redactMountOptionValues(dropped),
+			"required", redactMountOptionValues(required))
+	}
+	return merged
+}
+
+// MergeReaderMountOptions combines the options a read-only cache volume must
+// have with the operator-configured extras. Required options come first and are
+// never removed; a configured option that would negate a required one (rw
+// against ro, uuid against nouuid) is returned in dropped instead of merged.
+// The agent and the storage controller both use it so a reader PV gets the
+// same options whichever component creates it.
+func MergeReaderMountOptions(required, configured []string) (merged, dropped []string) {
+	kept := make([]string, 0, len(configured))
+	for _, opt := range configured {
+		if slices.ContainsFunc(required, func(req string) bool { return negatesMountOption(req, opt) }) {
+			dropped = append(dropped, opt)
 			continue
 		}
-		configured = append(configured, opt)
+		kept = append(kept, opt)
 	}
-
-	return mergeMountOptions(defaults, configured)
+	return mergeMountOptions(required, kept), dropped
 }
 
 // mergeMountOptions concatenates the given option lists, preserving order and
@@ -768,11 +829,11 @@ func mergeMountOptions(lists ...[]string) []string {
 // options when the volume is mounted, so a patch applies to the next mount and
 // leaves volumes that are already mounted untouched.
 func (r *Reconciler) reconcileSecondaryPVMountOptions(ctx context.Context,
-	secondaryPV *corev1.PersistentVolume,
+	st *nvcav1new.StorageRequest, secondaryPV *corev1.PersistentVolume,
 ) error {
 	log := logf.FromContext(ctx)
 
-	want := r.resolveCacheMountOptions(ctx, secondaryPV)
+	want := r.resolveReaderMountOptions(ctx, st, secondaryPV)
 	if slices.Equal(secondaryPV.Spec.MountOptions, want) {
 		return nil
 	}
@@ -917,7 +978,7 @@ func (r *Reconciler) doModelCacheNVMesh(ctx context.Context, //nolint:gocyclo
 		}
 		maps.Copy(secondaryPV.Labels, getClusterWideResourceLabels(stCopy))
 		secondaryPV.Spec.AccessModes = accessModesRO
-		secondaryPV.Spec.MountOptions = r.resolveCacheMountOptions(ctx, secondaryPV)
+		secondaryPV.Spec.MountOptions = r.resolveReaderMountOptions(ctx, stCopy, secondaryPV)
 		secondaryPV.Spec.ClaimRef = &corev1.ObjectReference{
 			APIVersion: "v1",
 			Kind:       "PersistentVolumeClaim",
@@ -943,7 +1004,7 @@ func (r *Reconciler) doModelCacheNVMesh(ctx context.Context, //nolint:gocyclo
 		log.V(1).Info("Secondary PV already exists, checking status", "pv", secondaryPV.Name)
 		// Mount options are mutable via NGC/NVCFBackend, so an existing PV can be
 		// left behind when the configuration changes.
-		if err := r.reconcileSecondaryPVMountOptions(ctx, secondaryPV); err != nil {
+		if err := r.reconcileSecondaryPVMountOptions(ctx, stCopy, secondaryPV); err != nil {
 			if k8sutil.IsTransientK8sError(err) {
 				log.V(1).Info("Transient error reconciling secondary PV mount options, will retry",
 					"pv", secondaryPV.Name)
@@ -1845,7 +1906,7 @@ func (r *Reconciler) newSharedFSReaderPV(
 	// reader attaches the same XFS filesystem as the writer and needs nouuid
 	// and norecovery or the mount fails outright. deriveReaderVolumeHandle
 	// above already handles the NVMesh driver reaching this path.
-	roPV.Spec.MountOptions = r.resolveCacheMountOptions(ctx, roPV)
+	roPV.Spec.MountOptions = r.resolveReaderMountOptions(ctx, stCopy, roPV)
 	roPV.Status = corev1.PersistentVolumeStatus{}
 	if err := r.setControlledObjectMeta(ctx, stCopy, roPV); err != nil {
 		return nil, err

--- a/src/compute-plane-services/nvca/pkg/storage/modelcache_test.go
+++ b/src/compute-plane-services/nvca/pkg/storage/modelcache_test.go
@@ -1000,7 +1000,7 @@ func TestReconcileSecondaryPVMountOptions(t *testing.T) {
 			}
 			rvBefore := stored.ResourceVersion
 
-			if err := r.reconcileSecondaryPVMountOptions(context.Background(), pv); err != nil {
+			if err := r.reconcileSecondaryPVMountOptions(context.Background(), nil, pv); err != nil {
 				t.Fatalf("reconcileSecondaryPVMountOptions() error = %v", err)
 			}
 
@@ -2119,4 +2119,223 @@ func TestNewSharedFSReaderPVResolvesMountOptions(t *testing.T) {
 		"the NVMesh handle must be rewritten for the reader namespace")
 	assert.True(t, roPV.Spec.CSI.ReadOnly,
 		"the CSI source must be read-only: access modes are not enforced by the kubelet")
+}
+
+// readerSelectionAnnotation marshals a durable selection whose reader mount
+// options come from the catalog, the shape a StorageRequest carries once the
+// agent has resolved its class against the catalog.
+func readerSelectionAnnotation(t *testing.T, provisioner string, transition string, mountOptions []string) string {
+	t.Helper()
+	selection := &PersistedModelCacheStorageSelection{
+		Version:              ModelCacheStorageSelectionVersion,
+		Workflow:             ModelCacheWorkflowRegular,
+		Mode:                 ModelCacheSelectionDurable,
+		StorageClassName:     DefaultModelCacheStorageClassName,
+		StorageClassUID:      "uid-1",
+		StorageClassDigest:   "v1:sha256:" + strings.Repeat("a", 64),
+		ProfileDigest:        "sha256:" + strings.Repeat("b", 64),
+		Provider:             "test-provider",
+		Provisioner:          provisioner,
+		Transition:           transition,
+		RequiredAccessModes:  requiredAccessModesForTransition(transition),
+		RequiredMountOptions: mountOptions,
+	}
+	raw, err := selection.Marshal()
+	require.NoError(t, err)
+	return raw
+}
+
+func storageRequestWithSelection(raw string) *nvcav1new.StorageRequest {
+	st := &nvcav1new.StorageRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "sr", Namespace: "reader-ns"},
+		Spec:       nvcav1new.StorageRequestSpec{ICMSRequestName: "req", Type: nvcav1new.ModelCacheRequest},
+	}
+	if raw != "" {
+		st.Annotations = map[string]string{ModelCacheStorageSelectionAnnotationKey: raw}
+	}
+	return st
+}
+
+func TestMergeReaderMountOptions(t *testing.T) {
+	tests := []struct {
+		name        string
+		required    []string
+		configured  []string
+		want        []string
+		wantDropped []string
+	}{
+		{
+			name:     "required only",
+			required: []string{"ro", "norecovery"},
+			want:     []string{"ro", "norecovery"},
+		},
+		{
+			name:       "configured only when nothing is required",
+			configured: []string{"noatime"},
+			want:       []string{"noatime"},
+		},
+		{
+			name:       "configured extras follow the required set without duplicates",
+			required:   []string{"ro", "nouuid"},
+			configured: []string{"nouuid", "noatime"},
+			want:       []string{"ro", "nouuid", "noatime"},
+		},
+		{
+			name:        "configured options negating a required one are dropped",
+			required:    []string{"ro", "norecovery", "nouuid"},
+			configured:  []string{"rw", "recovery", "uuid", "noatime"},
+			want:        []string{"ro", "norecovery", "nouuid", "noatime"},
+			wantDropped: []string{"rw", "recovery", "uuid"},
+		},
+		{
+			name: "empty in, empty out",
+			want: []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, dropped := MergeReaderMountOptions(tt.required, tt.configured)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantDropped, dropped)
+		})
+	}
+}
+
+func TestResolveReaderMountOptions(t *testing.T) {
+	wekaProvisioner := "csi.weka.io"
+	tests := []struct {
+		name       string
+		selection  string
+		cmData     map[string]string
+		configured []string
+		want       []string
+	}{
+		{
+			name:      "durable selection supplies the required options",
+			selection: readerSelectionAnnotation(t, wekaProvisioner, ModelCacheTransitionROXReadOnly, []string{"ro"}),
+			cmData:    nvmeshMountOptionDefaults,
+			want:      []string{"ro"},
+		},
+		{
+			name: "durable selection wins over a ConfigMap entry for the same provisioner",
+			selection: readerSelectionAnnotation(t, NVMeshStorageClassProvisioner, ModelCacheTransitionROXReadOnly,
+				[]string{"ro", "nouuid"}),
+			cmData: nvmeshMountOptionDefaults,
+			want:   []string{"ro", "nouuid"},
+		},
+		{
+			name:       "configured extras are appended after the selection's options",
+			selection:  readerSelectionAnnotation(t, wekaProvisioner, ModelCacheTransitionROXReadOnly, []string{"ro"}),
+			configured: []string{"noatime"},
+			want:       []string{"ro", "noatime"},
+		},
+		{
+			name:       "configured rw cannot negate the selection's ro",
+			selection:  readerSelectionAnnotation(t, wekaProvisioner, ModelCacheTransitionROXReadOnly, []string{"ro"}),
+			configured: []string{"rw", "noatime"},
+			want:       []string{"ro", "noatime"},
+		},
+		{
+			name:       "durable selection without reader options keeps only the configured ones",
+			selection:  readerSelectionAnnotation(t, wekaProvisioner, ModelCacheTransitionRWXReadOnly, nil),
+			cmData:     nvmeshMountOptionDefaults,
+			configured: []string{"noatime"},
+			want:       []string{"noatime"},
+		},
+		{
+			name:   "request without a selection uses the ConfigMap defaults",
+			cmData: nvmeshMountOptionDefaults,
+			want:   []string{"ro", "norecovery", "nouuid"},
+		},
+		{
+			name: "ephemeral selection uses the ConfigMap defaults",
+			selection: func() string {
+				raw, err := (&PersistedModelCacheStorageSelection{
+					Version:  ModelCacheStorageSelectionVersion,
+					Workflow: ModelCacheWorkflowHelm,
+					Mode:     ModelCacheSelectionEphemeral,
+				}).Marshal()
+				require.NoError(t, err)
+				return raw
+			}(),
+			cmData: nvmeshMountOptionDefaults,
+			want:   []string{"ro", "norecovery", "nouuid"},
+		},
+		{
+			name:      "invalid selection falls back to the ConfigMap defaults",
+			selection: "{",
+			cmData:    nvmeshMountOptionDefaults,
+			want:      []string{"ro", "norecovery", "nouuid"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The model cache class is NVMesh so the ConfigMap path has defaults to
+			// offer; the selection must be what stops them from applying.
+			objs := newMountOptionDefaultsObjects(NVMeshStorageClassProvisioner, tt.cmData)
+			c := fake.NewClientBuilder().WithScheme(mgrScheme).WithObjects(objs...).Build()
+			r := newMountOptionsReconciler(t, c, tt.configured)
+			pv := &corev1.PersistentVolume{ObjectMeta: metav1.ObjectMeta{Name: "secondary-pv-test"}}
+
+			got := r.resolveReaderMountOptions(context.Background(), storageRequestWithSelection(tt.selection), pv)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestReconcileSecondaryPVMountOptions_SelectionDriven(t *testing.T) {
+	// The PV was created from the ConfigMap defaults; the request's selection
+	// now records a smaller catalog set, so the PV must follow the selection.
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "secondary-pv-test"},
+		Spec: corev1.PersistentVolumeSpec{
+			MountOptions: []string{"ro", "norecovery", "nouuid"},
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{Driver: NVMeshStorageClassProvisioner, VolumeHandle: "handle"},
+			},
+		},
+	}
+	objs := append(newMountOptionDefaultsObjects(NVMeshStorageClassProvisioner, nvmeshMountOptionDefaults), pv)
+	c := fake.NewClientBuilder().WithScheme(mgrScheme).WithObjects(objs...).Build()
+	r := newMountOptionsReconciler(t, c, []string{"noatime"})
+	st := storageRequestWithSelection(readerSelectionAnnotation(t, NVMeshStorageClassProvisioner,
+		ModelCacheTransitionROXReadOnly, []string{"ro", "nouuid"}))
+
+	require.NoError(t, r.reconcileSecondaryPVMountOptions(context.Background(), st, pv))
+
+	got := &corev1.PersistentVolume{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "secondary-pv-test"}, got))
+	assert.Equal(t, []string{"ro", "nouuid", "noatime"}, got.Spec.MountOptions)
+}
+
+func TestNewSharedFSReaderPVTakesMountOptionsFromSelection(t *testing.T) {
+	wekaProvisioner := "csi.weka.io"
+	// No ConfigMap entry exists for this provisioner, so without the selection
+	// the reader would get only the configured options.
+	c := fake.NewClientBuilder().
+		WithScheme(mgrScheme).
+		WithRESTMapper(newTestRESTMapper(mgrScheme)).
+		WithObjects(newMountOptionDefaultsObjects(wekaProvisioner, nvmeshMountOptionDefaults)...).
+		Build()
+	r := newMountOptionsReconciler(t, c, []string{"rw", "noatime"})
+
+	writerPV := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "writer-pv"},
+		Spec: corev1.PersistentVolumeSpec{
+			Capacity:     corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+			MountOptions: []string{"rw"},
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{Driver: wekaProvisioner, VolumeHandle: "weka/v2/csivol-pvc-8e38c07d"},
+			},
+		},
+	}
+	st := storageRequestWithSelection(readerSelectionAnnotation(t, wekaProvisioner,
+		ModelCacheTransitionROXReadOnly, []string{"ro"}))
+	icmsReq := &nvcav2beta1.ICMSRequest{ObjectMeta: metav1.ObjectMeta{Name: "req", Namespace: "reader-ns"}}
+
+	roPV, err := r.newSharedFSReaderPV(context.Background(), st, icmsReq, writerPV, "ro-pvc")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ro", "noatime"}, roPV.Spec.MountOptions,
+		"the catalog's reader options are required and the configured rw must not negate them")
+	assert.True(t, roPV.Spec.CSI.ReadOnly)
 }


### PR DESCRIPTION
## Why

The storage capability catalog declares `readerMountOptions` per driver, and the validator enforces the shape (`ro` required for `roxReadOnly`), but no reader code read the field. Derived read-only PVs took their options from the `nvca-cache-mount-options` ConfigMap instead. That left the catalog half-authoritative: enabling a new provider still meant seeding a ConfigMap entry in code, which is the opposite of "enablement as data". The master design doc called this out as an open gap.

## What changed

- `pkg/storage/modelcache.go`: new `resolveReaderMountOptions(ctx, st, pv)` reads the StorageRequest's persisted selection. A durable selection's `RequiredMountOptions` (the catalog's `readerMountOptions`) is the required set; operator-configured options are appended unless they negate a required one. Requests without a durable selection, or with an unparseable one, fall back to the existing `resolveCacheMountOptions` ConfigMap path. All three reader PV sites use it: NVMesh secondary PV creation, `reconcileSecondaryPVMountOptions` (existing PVs converge to the selection), and `newSharedFSReaderPV`.
- `MergeReaderMountOptions(required, configured)` is exported so the agent and the storage controller apply the same conflict rules.
- `pkg/nvca/k8scomputebackend_modelcache.go`: `SetupPVCForReaders` sets the reader PV's mount options via `readerMountOptionsForRequest`, which reads the ICMSRequest's selection and merges the configured options the same way. Without a selection it keeps the configured options as before.
- `docs/dev/sdd-storage-agnostic-cache-architecture.md`: Readers section now describes the selection-driven path and the legacy fallback; the "no reader code reads it yet" sentence is gone.

## Customer Release Notes

Read-only model cache volumes now take their required mount options from the storage capability catalog entry recorded for the request, so a new storage provider can be enabled without a code change.

## Plan Summary

Not applicable

## Usage

Not applicable

## Testing

- `go test ./pkg/storage/ ./pkg/nvca/ ./internal/miniservice/...` pass.
- `golangci-lint run ./pkg/storage/... ./pkg/nvca/...`: 0 issues.
- New tests: `TestMergeReaderMountOptions`, `TestResolveReaderMountOptions` (selection wins over a ConfigMap entry for the same provisioner, configured `rw` cannot negate `ro`, RWX selection with no reader options, no selection / ephemeral / invalid selection all fall back to the ConfigMap), `TestReconcileSecondaryPVMountOptions_SelectionDriven`, `TestNewSharedFSReaderPVTakesMountOptionsFromSelection`, `TestReaderMountOptionsForRequest` (agent side).
- No QA needed beyond the planned qualification run on shared-filesystem hardware, which this change is a prerequisite for.

## Notes

- Behavior for legacy requests (no selection annotation) is unchanged on both paths.
- Observability: one new info log when configured options are dropped for conflicting with the selection, one error log when a selection annotation cannot be parsed. No metric or span changes.
- The `nvca-cache-mount-options` ConfigMap path stays for the fallback and can be removed once no pre-selection requests remain.

## References

None

## Related Pull Requests

- #1334 (catalog and selection layer, merged)
- #1434 (derived shared-filesystem reader PVs, merged)
- #1564, #1565, #1580 (open, independent)

## Dependencies

None

## Issues

Relates to #1326


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Reader volume mounts now honor each request’s persisted storage selection.
  * Required mount options are combined with compatible configured options; conflicting options are ignored.
  * Legacy, missing, ephemeral, or invalid selections continue using configured fallback options.
  * Shared filesystem and secondary reader volumes now apply selection-specific mount settings, including during existing-volume reconciliation.
  * Reader volumes consistently use the correct read-only mount configuration when converted for model-cache access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->