### PR TITLE
fix(cassandra): restore published autoscaler compatibility

### DIFF
--- a/migrations/cassandra/keyspaces/nvcf_autoscaler/05_restore_published_autoscaler_tables.up.sql
+++ b/migrations/cassandra/keyspaces/nvcf_autoscaler/05_restore_published_autoscaler_tables.up.sql
@@ -1,0 +1,41 @@
+-- Preserve compatibility with the latest published function-autoscaler image.
+-- Remove these tables only after every supported autoscaler image stops using
+-- them and the self-managed stack pins that compatible image.
+
+CREATE TABLE IF NOT EXISTS nvcf_autoscaler.recently_invoked_functions_history (
+    function_id                           UUID,
+    function_version_id                   UUID,
+    last_updated_at                       TIMESTAMP,
+    account_id                            TEXT STATIC,
+    num_workers                           INT STATIC,
+    last_predicted_desired_instance_count INT,
+    last_predicted_error_code             TEXT,
+    PRIMARY KEY ((function_id, function_version_id), last_updated_at)
+) WITH CLUSTERING ORDER BY (last_updated_at DESC)
+  AND default_time_to_live = 172800
+  AND compaction = {'class': 'UnifiedCompactionStrategy', 'scaling_parameters': 'T4', 'target_sstable_size': '50MiB', 'base_shard_count': '4', 'expired_sstable_check_frequency_seconds': '300'}
+  AND read_repair = 'NONE';
+
+CREATE TABLE IF NOT EXISTS nvcf_autoscaler.running_functions_without_invocations (
+    function_id         UUID,
+    function_version_id UUID,
+    last_updated_at     TIMESTAMP,
+    account_id          TEXT,
+    PRIMARY KEY ((function_id, function_version_id))
+) WITH default_time_to_live = 600
+  AND compaction = {'class': 'UnifiedCompactionStrategy', 'scaling_parameters': 'T4', 'target_sstable_size': '50MiB', 'base_shard_count': '4', 'expired_sstable_check_frequency_seconds': '300'}
+  AND read_repair = 'NONE';
+
+CREATE TABLE IF NOT EXISTS nvcf_autoscaler.running_functions_without_invocations_history (
+    function_id                           UUID,
+    function_version_id                   UUID,
+    last_updated_at                       TIMESTAMP,
+    account_id                            TEXT STATIC,
+    num_workers                           INT STATIC,
+    last_predicted_desired_instance_count INT,
+    last_predicted_error_code             TEXT,
+    PRIMARY KEY ((function_id, function_version_id), last_updated_at)
+) WITH CLUSTERING ORDER BY (last_updated_at DESC)
+  AND default_time_to_live = 172800
+  AND compaction = {'class': 'UnifiedCompactionStrategy', 'scaling_parameters': 'T4', 'target_sstable_size': '50MiB', 'base_shard_count': '4', 'expired_sstable_check_frequency_seconds': '300'}
+  AND read_repair = 'NONE';

--- a/migrations/cassandra/tests/test-execute-sqls.sh
+++ b/migrations/cassandra/tests/test-execute-sqls.sh
@@ -101,4 +101,17 @@ if ! grep -F -q 'ALTER TABLE nvct_api.tasks_v2 ADD IF NOT EXISTS health TEXT;' \
   fail "NVCT upgrade migration does not add tasks_v2.health idempotently"
 fi
 
+autoscaler_compatibility_migration="${keyspaces}/nvcf_autoscaler/05_restore_published_autoscaler_tables.up.sql"
+for table_name in \
+  recently_invoked_functions_history \
+  running_functions_without_invocations \
+  running_functions_without_invocations_history
+do
+  if ! grep -F -q \
+    "CREATE TABLE IF NOT EXISTS nvcf_autoscaler.${table_name}" \
+    "${autoscaler_compatibility_migration}"; then
+    fail "autoscaler compatibility migration does not restore ${table_name} idempotently"
+  fi
+done
+
 exit "${status}"


### PR DESCRIPTION
## Why

Cassandra migrations `0.17.2` removed three autoscaler tables that are still queried by the latest published function-autoscaler image. That prevents the self-managed stack from taking the current NVCT schema without breaking autoscaler behavior.

## What changed

Adds an idempotent migration that restores the three published-autoscaler tables and extends the migration regression test to require them.

## Customer Release Notes

Preserves function autoscaler compatibility when upgrading the self-managed Cassandra schema.

## Plan Summary

Restores three Cassandra tables. Existing rows are unaffected.

## Usage

Upgrade function autoscaler to chart `0.3.0` and image `1.21.0` before applying the new migration release.

## Testing

- `migrations/cassandra/tests/test-execute-sqls.sh`
- arm64 Cassandra migration image build
- Live observability-all autoscaler deployment and invocation with the candidate migration image

No additional QA is required beyond CI.

## Notes

Publish migrations `0.17.3` after merge, then advance the source-chart and stack pins.

## References

- Fixes #1592

## Related Pull Requests

- #1413
- #1446

## Dependencies

None. No license or NOTICE changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added autoscaler data tables for tracking invocation history, currently running functions without invocations, and related history.
  - Historical records retain prediction and worker details for up to two days; current-state records expire after ten minutes.

- **Tests**
  - Added migration validation to confirm the autoscaler tables can be recreated safely and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->