### PR TITLE
fix(bdd): bound and complete stack cleanup

### DIFF
--- a/tests/bdd/cleanup_scripts_test.go
+++ b/tests/bdd/cleanup_scripts_test.go
@@ -148,6 +148,13 @@ func TestDestroyStackMultiCleansWorkerNamespacesOnControlPlane(t *testing.T) {
 		"kubectl --context k3d-ncp-local-compute-1 -n nvca-operator delete nvcfbackend --all",
 		"helm --kube-context k3d-ncp-local-compute-1 uninstall nvca-operator -n nvca-operator",
 		"helm --kube-context k3d-ncp-local-cp uninstall nats -n nats-system",
+		"helm --kube-context k3d-ncp-local-cp uninstall default-monitors -n monitoring",
+		"helm --kube-context k3d-ncp-local-cp uninstall otel-collector -n monitoring",
+		"helm --kube-context k3d-ncp-local-cp uninstall opentelemetry-operator -n monitoring",
+		"helm --kube-context k3d-ncp-local-cp uninstall victoria-metrics -n monitoring",
+		"helm --kube-context k3d-ncp-local-cp uninstall prometheus-operator-crds -n monitoring",
+		"kubectl --context k3d-ncp-local-cp delete namespace monitoring",
+		"kubectl --context k3d-ncp-local-cp -n envoy-gateway-system delete secret llm-request-router-grpc-tls --ignore-not-found --wait --timeout=60s",
 	} {
 		if !strings.Contains(log, want) {
 			t.Fatalf("cleanup command log missing %q:\n%s", want, log)
@@ -163,6 +170,68 @@ func TestDestroyStackMultiCleansWorkerNamespacesOnControlPlane(t *testing.T) {
 		if strings.Contains(log, forbidden) {
 			t.Fatalf("cleanup touched topology infrastructure %q:\n%s", forbidden, log)
 		}
+	}
+}
+
+func TestDestroyStackForceDeletesLingeringNamespacePods(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "commands.log")
+
+	writeFakeBin(t, binDir, "kubectl", `#!/usr/bin/env bash
+set -euo pipefail
+printf 'kubectl %s\n' "$*" >>"$FAKE_COMMAND_LOG"
+case "$*" in
+  *"cluster-info"*) exit 0 ;;
+  *"-n nvca-operator get nvcfbackend"*)
+    echo 'error: the server does not have a resource type "nvcfbackend"' >&2
+    exit 1
+    ;;
+  *"delete namespace nvcf "*) exit 1 ;;
+  *"-n nvcf get pods -o name"*) printf 'pod/vanity-gateway-test\n' ;;
+  *"wait --for=delete namespace/nvcf"*) exit 0 ;;
+  *"get namespace"*)
+    echo 'Error from server (NotFound): namespaces not found' >&2
+    exit 1
+    ;;
+esac
+`)
+	writeFakeBin(t, binDir, "helm", `#!/usr/bin/env bash
+set -euo pipefail
+printf 'helm %s\n' "$*" >>"$FAKE_COMMAND_LOG"
+exit 0
+`)
+
+	cmd := exec.Command("bash", "scripts/destroy-stack.sh", "single")
+	cmd.Env = append(os.Environ(),
+		"BDD_REPO_ROOT="+t.TempDir(),
+		"FAKE_COMMAND_LOG="+logPath,
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run destroy-stack.sh single: %v\n%s", err, output)
+	}
+
+	log, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read cleanup command log: %v", err)
+	}
+	got := string(log)
+	for _, want := range []string{
+		"-n nvcf delete pod/vanity-gateway-test --force --grace-period=0 --wait=false --ignore-not-found",
+		"wait --for=delete namespace/nvcf --timeout=60s",
+		"helm --kube-context k3d-ncp-local uninstall default-monitors -n monitoring",
+		"helm --kube-context k3d-ncp-local uninstall otel-collector -n monitoring",
+		"helm --kube-context k3d-ncp-local uninstall opentelemetry-operator -n monitoring",
+		"helm --kube-context k3d-ncp-local uninstall victoria-metrics -n monitoring",
+		"helm --kube-context k3d-ncp-local uninstall prometheus-operator-crds -n monitoring",
+		"kubectl --context k3d-ncp-local delete namespace monitoring",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("cleanup command log missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "/api/v1/namespaces/nvcf/finalize") {
+		t.Fatalf("cleanup finalized a namespace that terminated after pod deletion:\n%s", got)
 	}
 }
 

--- a/tests/bdd/cleanup_scripts_test.go
+++ b/tests/bdd/cleanup_scripts_test.go
@@ -47,6 +47,9 @@ func TestDestroyNonlocalStackFinalizesEmptyEnvoyNamespace(t *testing.T) {
 	if got, want := strings.Count(log, "-n envoy-gateway-system get pods -o name"), 2; got != want {
 		t.Fatalf("Envoy pod checks = %d, want %d before finalization:\n%s", got, want, log)
 	}
+	if got, want := strings.Count(log, "wait --for=delete namespace/envoy-gateway-system --timeout=60s"), 2; got != want {
+		t.Fatalf("Envoy namespace waits = %d, want %d through finalization:\n%s", got, want, log)
+	}
 	const finalize = "replace --raw /api/v1/namespaces/envoy-gateway-system/finalize -f -"
 	if !strings.Contains(log, finalize) {
 		t.Fatalf("cleanup command log missing %q:\n%s", finalize, log)
@@ -59,6 +62,7 @@ func runDestroyNonlocalStack(t *testing.T, namespaceWaitSucceeds bool) string {
 	binDir := t.TempDir()
 	logPath := filepath.Join(binDir, "commands.log")
 	podCountPath := filepath.Join(binDir, "pod-get-count")
+	finalizePath := filepath.Join(binDir, "namespace-finalized")
 	waitResult := "fail"
 	if namespaceWaitSucceeds {
 		waitResult = "success"
@@ -81,13 +85,14 @@ case "$*" in
     fi
     ;;
   *"wait --for=delete namespace/envoy-gateway-system"*)
-    [[ "$FAKE_NAMESPACE_WAIT" == "success" ]]
+    [[ "$FAKE_NAMESPACE_WAIT" == "success" || -f "$FAKE_NAMESPACE_FINALIZED" ]]
     ;;
   *"get namespace envoy-gateway-system -o json"*)
     printf '{"spec":{"finalizers":["kubernetes"]}}\n'
     ;;
   *"replace --raw /api/v1/namespaces/envoy-gateway-system/finalize"*)
     cat >/dev/null
+    touch "$FAKE_NAMESPACE_FINALIZED"
     ;;
   *"get gateway nvcf-gateway"*|*"get gatewayclass eg"*) exit 1 ;;
 esac
@@ -122,6 +127,7 @@ cat
 		"BDD_REPO_ROOT="+t.TempDir(),
 		"FAKE_COMMAND_LOG="+logPath,
 		"FAKE_NAMESPACE_WAIT="+waitResult,
+		"FAKE_NAMESPACE_FINALIZED="+finalizePath,
 		"FAKE_POD_GET_COUNT="+podCountPath,
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 	)
@@ -232,6 +238,71 @@ exit 0
 	}
 	if strings.Contains(got, "/api/v1/namespaces/nvcf/finalize") {
 		t.Fatalf("cleanup finalized a namespace that terminated after pod deletion:\n%s", got)
+	}
+}
+
+func TestDestroyStackWaitsAfterClearingNamespaceFinalizers(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "commands.log")
+	waitCountPath := filepath.Join(binDir, "namespace-wait-count")
+
+	writeFakeBin(t, binDir, "kubectl", `#!/usr/bin/env bash
+set -euo pipefail
+printf 'kubectl %s\n' "$*" >>"$FAKE_COMMAND_LOG"
+case "$*" in
+  *"cluster-info"*) exit 0 ;;
+  *"-n nvca-operator get nvcfbackend"*)
+    echo 'error: the server does not have a resource type "nvcfbackend"' >&2
+    exit 1
+    ;;
+  *"delete namespace nvcf "*) exit 1 ;;
+  *"-n nvcf get pods -o name"*) exit 0 ;;
+  *"wait --for=delete namespace/nvcf"*)
+    count=0
+    if [[ -f "$FAKE_NAMESPACE_WAIT_COUNT" ]]; then
+      count="$(<"$FAKE_NAMESPACE_WAIT_COUNT")"
+    fi
+    count=$((count + 1))
+    printf '%s\n' "$count" >"$FAKE_NAMESPACE_WAIT_COUNT"
+    [[ "$count" -eq 2 ]]
+    ;;
+  *"get namespace nvcf -o json"*)
+    printf '{"spec":{"finalizers":["kubernetes"]}}\n'
+    ;;
+  *"replace --raw /api/v1/namespaces/nvcf/finalize"*) cat >/dev/null ;;
+  *"get namespace"*)
+    echo 'Error from server (NotFound): namespaces not found' >&2
+    exit 1
+    ;;
+esac
+`)
+	writeFakeBin(t, binDir, "helm", `#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+`)
+
+	cmd := exec.Command("bash", "scripts/destroy-stack.sh", "single")
+	cmd.Env = append(os.Environ(),
+		"BDD_REPO_ROOT="+t.TempDir(),
+		"FAKE_COMMAND_LOG="+logPath,
+		"FAKE_NAMESPACE_WAIT_COUNT="+waitCountPath,
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run destroy-stack.sh single: %v\n%s", err, output)
+	}
+
+	log, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read cleanup command log: %v", err)
+	}
+	got := string(log)
+	if count := strings.Count(got, "wait --for=delete namespace/nvcf --timeout=60s"); count != 2 {
+		t.Fatalf("namespace waits = %d, want 2 through finalization:\n%s", count, got)
+	}
+	const finalize = "replace --raw /api/v1/namespaces/nvcf/finalize -f -"
+	if !strings.Contains(got, finalize) {
+		t.Fatalf("cleanup command log missing %q:\n%s", finalize, got)
 	}
 }
 

--- a/tests/bdd/scripts/destroy-nonlocal-stack.sh
+++ b/tests/bdd/scripts/destroy-nonlocal-stack.sh
@@ -347,6 +347,11 @@ delete_stack_namespaces() {
       | jq '.spec.finalizers=[]' \
       | kubectl --context "$ctx" replace \
           --raw "/api/v1/namespaces/$ns/finalize" -f - >/dev/null
+    if ! kubectl --context "$ctx" wait --for=delete "namespace/$ns" \
+        --timeout=60s; then
+      echo "namespace $ns still exists after clearing finalizers on $ctx" >&2
+      return 1
+    fi
   done
 }
 

--- a/tests/bdd/scripts/destroy-stack.sh
+++ b/tests/bdd/scripts/destroy-stack.sh
@@ -116,6 +116,11 @@ STACK_RELEASES_CP=(
   "ingress:envoy-gateway-system"
   "llm-request-router:nvcf"
   "llm-api-gateway:nvcf"
+  "default-monitors:monitoring"
+  "otel-collector:monitoring"
+  "opentelemetry-operator:monitoring"
+  "victoria-metrics:monitoring"
+  "prometheus-operator-crds:monitoring"
 )
 
 STACK_RELEASES_WORKER=(
@@ -132,6 +137,7 @@ STACK_NAMESPACES_CP=(
   sis
   ess
   nvcf
+  monitoring
 )
 
 STACK_NAMESPACES_WORKER=(
@@ -146,6 +152,14 @@ STACK_NAMESPACES_WORKER=(
 # CR.
 STACK_CRS_WORKER=(
   nvcfbackend
+)
+
+# Stack-owned resources that live in topology-owned namespaces. Helm removes
+# the Certificate, but cert-manager intentionally leaves its generated Secret
+# without an owner reference. Delete it explicitly so a reinstalled OpenBao
+# hierarchy cannot inherit a certificate signed by the previous root CA.
+STACK_RESOURCES_CP=(
+  "secret:llm-request-router-grpc-tls:envoy-gateway-system"
 )
 
 # --- Helpers ---
@@ -307,7 +321,28 @@ force_clear_namespace_finalizers() {
     return 1
   fi
   printf '%s' "$json" | jq '.spec.finalizers = []' | \
-    kubectl --context "$ctx" replace --raw "/api/v1/namespaces/$ns/finalize" -f -
+    kubectl --context "$ctx" replace --raw "/api/v1/namespaces/$ns/finalize" -f - \
+      >/dev/null
+}
+
+force_delete_namespace_pods() {
+  local ctx="$1"
+  local ns="$2"
+  local pods pod
+  if ! pods=$(kubectl --context "$ctx" -n "$ns" get pods -o name 2>&1); then
+    if kubectl_is_not_found "$pods"; then
+      return 0
+    fi
+    printf '%s\n' "$pods" >&2
+    echo "get pods in namespace $ns failed on $ctx" >&2
+    return 1
+  fi
+  while IFS= read -r pod; do
+    [[ -z "$pod" ]] && continue
+    echo "  force-delete $pod in $ns"
+    kubectl --context "$ctx" -n "$ns" delete "$pod" \
+      --force --grace-period=0 --wait=false --ignore-not-found
+  done <<< "$pods"
 }
 
 uninstall_stack_releases() {
@@ -323,20 +358,39 @@ uninstall_stack_releases() {
   done
 }
 
+delete_stack_resources() {
+  local ctx="$1"
+  shift
+  local resources=("$@")
+  for entry in "${resources[@]}"; do
+    local kind="${entry%%:*}"
+    local rest="${entry#*:}"
+    local name="${rest%%:*}"
+    local ns="${rest#*:}"
+    echo "  delete $kind $name in $ns"
+    kubectl --context "$ctx" -n "$ns" delete "$kind" "$name" \
+      --ignore-not-found --wait --timeout=60s
+  done
+}
+
 delete_stack_namespaces() {
   local ctx="$1"
   shift
   local namespaces=("$@")
   for ns in "${namespaces[@]}"; do
     echo "  delete namespace $ns"
-    # Polite delete with a bounded wait. If the namespace is stuck
-    # Terminating (orphan finalizers on nvca-operator / nvcf-backend
-    # after the controller is gone), drop into the force-clear path
-    # rather than hang the BDD cleanup.
+    # Polite delete with a bounded wait. Disposable worker and gateway
+    # pods can inherit a longer termination grace period than this local
+    # cleanup budget, so force-delete only the pods that remain. If the
+    # namespace is still stuck, clear its finalizers as a last resort.
     if ! kubectl --context "$ctx" delete namespace "$ns" \
         --ignore-not-found --wait --timeout=60s; then
-      echo "  force-clear finalizers on $ns (stuck Terminating)"
-      force_clear_namespace_finalizers "$ctx" "$ns"
+      force_delete_namespace_pods "$ctx" "$ns"
+      if ! kubectl --context "$ctx" wait --for=delete "namespace/$ns" \
+          --timeout=60s; then
+        echo "  force-clear finalizers on $ns (stuck Terminating)"
+        force_clear_namespace_finalizers "$ctx" "$ns"
+      fi
     fi
   done
 }
@@ -383,6 +437,7 @@ if [[ "$mode" == "single" ]]; then
     uninstall_stack_releases "$ctx" \
       "${STACK_RELEASES_WORKER[@]}" \
       "${STACK_RELEASES_CP[@]}"
+    delete_stack_resources "$ctx" "${STACK_RESOURCES_CP[@]}"
     delete_stack_namespaces "$ctx" \
       "${STACK_NAMESPACES_WORKER[@]}" \
       "${STACK_NAMESPACES_CP[@]}"
@@ -433,6 +488,7 @@ if k3d cluster get ncp-local-cp >/dev/null 2>&1; then
     uninstall_stack_releases "$ctx" \
       "${STACK_RELEASES_WORKER[@]}" \
       "${STACK_RELEASES_CP[@]}"
+    delete_stack_resources "$ctx" "${STACK_RESOURCES_CP[@]}"
     delete_stack_namespaces "$ctx" \
       "${STACK_NAMESPACES_WORKER[@]}" \
       "${STACK_NAMESPACES_CP[@]}"

--- a/tests/bdd/scripts/destroy-stack.sh
+++ b/tests/bdd/scripts/destroy-stack.sh
@@ -390,6 +390,11 @@ delete_stack_namespaces() {
           --timeout=60s; then
         echo "  force-clear finalizers on $ns (stuck Terminating)"
         force_clear_namespace_finalizers "$ctx" "$ns"
+        if ! kubectl --context "$ctx" wait --for=delete "namespace/$ns" \
+            --timeout=60s; then
+          echo "namespace $ns still exists after clearing finalizers on $ctx" >&2
+          return 1
+        fi
       fi
     fi
   done


### PR DESCRIPTION
## Why

Repeated local BDD profiles can hang indefinitely when function pods or finalizers outlive namespace deletion. Cleanup also omitted observability releases and a generated LLM TLS Secret, allowing state to leak between suites.

## What changed

- Adds every stack-owned observability release and namespace to explicit cleanup allow-lists.
- Deletes the orphaned LLM router TLS Secret in the topology-owned gateway namespace.
- Bounds namespace waits, force-deletes lingering pods, and clears namespace finalizers only after both grace periods expire.
- Adds regression coverage for the allow-lists and bounded fallback behavior.

## Customer Release Notes

Not customer visible.

## Plan Summary

Cleanup remains limited to explicit stack-owned releases, namespaces, custom resources, and generated artifacts. It does not delete topology-owned clusters or shared infrastructure.

## Usage

Run `tests/bdd/scripts/destroy-stack.sh single` or `tests/bdd/scripts/destroy-stack.sh multi`.

## Testing

- `go test -short ./...` under `tests/bdd`
- Exercised between final single-cluster, multi-cluster, LLM, and observability live suites
- Verified termination of lingering NVCA namespaces, function pods, and vanity pods

No additional QA is required beyond CI.

## Notes

None.

## References

- Fixes #1589
- Fixes #1591

## Related Pull Requests

None.

## Dependencies

None. No license or NOTICE changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stack cleanup by force-deleting lingering pods and completing namespace removal.
  - Added a follow-up wait after namespace finalization, with clearer errors when deletion does not complete.
  - Added cleanup for monitoring components and stack-owned gateway TLS resources.
  - Improved resource cleanup across single-stack, multi-stack, and non-local stack destruction scenarios.
  - Expanded automated coverage for namespace cleanup and termination behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->