### PR TITLE
fix(function-autoscaler): return health details when unhealthy

### DIFF
--- a/src/control-plane-services/function-autoscaler/crates/server/src/routes/mod.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/routes/mod.rs
@@ -66,12 +66,12 @@ pub async fn get_liveness() -> (StatusCode, &'static str) {
 /// Includes Cassandra and TimeseriesDb; if e.g. TimeseriesDb is unreachable we report not ready.
 pub async fn get_readiness(
     State(health): State<Arc<Health>>,
-) -> Result<Json<HealthResponse>, StatusCode> {
+) -> (StatusCode, Json<HealthResponse>) {
     let health_info = health.get_health();
 
-    let status_str = match health_info.overall_status {
-        HealthState::Healthy => "healthy",
-        HealthState::Unhealthy => "unhealthy",
+    let (status_code, status_str) = match health_info.overall_status {
+        HealthState::Healthy => (StatusCode::OK, "healthy"),
+        HealthState::Unhealthy => (StatusCode::SERVICE_UNAVAILABLE, "unhealthy"),
     };
 
     let components: HashMap<String, ComponentHealthResponse> = health_info
@@ -80,20 +80,19 @@ pub async fn get_readiness(
         .map(|(name, component)| (name, ComponentHealthResponse::from(component)))
         .collect();
 
-    if health_info.overall_status == HealthState::Unhealthy {
-        return Err(StatusCode::SERVICE_UNAVAILABLE);
-    }
-
-    Ok(Json(HealthResponse {
-        status: status_str.to_string(),
-        message: health_info.message,
-        last_updated: health_info.last_updated,
-        components,
-    }))
+    (
+        status_code,
+        Json(HealthResponse {
+            status: status_str.to_string(),
+            message: health_info.message,
+            last_updated: health_info.last_updated,
+            components,
+        }),
+    )
 }
 
 /// Legacy overall health (same semantics as readiness).
-pub async fn get_health(state: State<Arc<Health>>) -> Result<Json<HealthResponse>, StatusCode> {
+pub async fn get_health(state: State<Arc<Health>>) -> (StatusCode, Json<HealthResponse>) {
     get_readiness(state).await
 }
 
@@ -101,6 +100,9 @@ pub async fn get_health(state: State<Arc<Health>>) -> Result<Json<HealthResponse
 mod tests {
     use super::*;
     use crate::health::Health;
+    use axum::body::to_bytes;
+    use axum::http::header::CONTENT_TYPE;
+    use axum::response::IntoResponse;
 
     #[tokio::test]
     async fn liveness_is_always_ok_even_when_cassandra_not_yet_up() {
@@ -119,9 +121,8 @@ mod tests {
         let health = Arc::new(Health::new());
         health.register_component("cassandra_client");
 
-        let result = get_readiness(State(health)).await;
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), StatusCode::SERVICE_UNAVAILABLE);
+        let (status, _) = get_readiness(State(health)).await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[tokio::test]
@@ -132,7 +133,45 @@ mod tests {
         health.set_component_healthy("cassandra_client", Some("connected".to_string()));
         health.set_component_healthy("timeseries_db_client", Some("connected".to_string()));
 
-        let result = get_readiness(State(health)).await;
-        assert!(result.is_ok());
+        let (status, _) = get_readiness(State(health)).await;
+        assert_eq!(status, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn health_returns_503_with_unhealthy_component_details() {
+        let health = Arc::new(Health::new());
+        health.register_component("cassandra_client");
+        health.register_component("timeseries_db_client");
+        health.set_component_healthy("cassandra_client", Some("connected".to_string()));
+
+        let response = get_health(State(health)).await.into_response();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            response.headers().get(CONTENT_TYPE).unwrap(),
+            "application/json"
+        );
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(body["status"], "unhealthy");
+        assert_eq!(
+            body["message"],
+            "1 component(s) unhealthy: timeseries_db_client: initializing"
+        );
+        assert!(body["last_updated"].is_u64());
+        assert_eq!(body["components"].as_object().unwrap().len(), 2);
+        assert_eq!(
+            body["components"]["timeseries_db_client"]["status"],
+            "unhealthy"
+        );
+        assert!(body["components"]["timeseries_db_client"]["last_updated"].is_u64());
+        assert_eq!(
+            body["components"]["timeseries_db_client"]["message"],
+            "initializing"
+        );
+        assert_eq!(body["components"]["cassandra_client"]["status"], "healthy");
+        assert!(body["components"]["cassandra_client"]["last_updated"].is_u64());
     }
 }


### PR DESCRIPTION
## TL;DR

Return per-component health JSON with HTTP 503 when the Function Autoscaler is unhealthy. Previously, the unhealthy response had an empty body.

## Additional Details

Status codes and health evaluation are unchanged. A regression test covers the 503 JSON response and component details.

## For the Reviewer

The change is limited to the health response handler and its tests.

## For QA

- Full test suite: 137 passed, 10 ignored

## Issues

Impacts #334 and solves the issue described in #1602 (Resolves #1602).

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for DCO compliance.
- [x] Tests cover these changes.
- [x] Documentation is up to date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Health and readiness endpoints now return HTTP 200 when healthy and HTTP 503 when unhealthy.
  - Unhealthy responses now preserve the complete health status details in the JSON payload.
  - Health responses consistently include the expected JSON content type and component information.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->