### PR TITLE
fix(function-autoscaler): default chart to image 1.21.0

### DIFF
--- a/deploy/helm/function-autoscaler/Chart.yaml
+++ b/deploy/helm/function-autoscaler/Chart.yaml
@@ -19,4 +19,4 @@ description: A Helm chart for NVCF Function Autoscaler Service
 
 type: application
 version: 0.0.0 # autoversioning enabled via release pipeline
-appVersion: "1.19.0"
+appVersion: "1.21.0"


### PR DESCRIPTION
## TL;DR

Set the Function Autoscaler chart `appVersion` to the validated `1.21.0` image so chart consumers inherit the current image tag without duplicating it in stack values.

## Additional Details

- The published chart `0.3.0` defaults to image `1.19.0`, while the self-managed stack has been explicitly overriding it to `1.21.0`.
- This change moves ownership of that default into the source chart. Explicit `functionautoscaler.image.tag` overrides remain supported.
- After this change is merged and a new chart version is published, #1413 can consume that exact chart release and remove its redundant stack-level image tag.
- The self-managed stack currently pairs autoscaler `1.21.0` with Cassandra migrations `0.17.3`, which preserves the legacy tables needed by this image. This PR does not claim to resolve the newer autoscaler compatibility work tracked by #1592.

## Customer Release Notes

The Function Autoscaler Helm chart now defaults to image version `1.21.0`.

## Plan Summary

No resource shape or count changes. Only the default Function Autoscaler image tag changes from `1.19.0` to `1.21.0`.

## Usage

No configuration changes are required. Existing explicit image tag overrides continue to take precedence.

## For the Reviewer

Please verify the chart default and explicit override behavior. The follow-up stack cleanup remains gated on publication of the generated chart release.

## For QA

Passed locally:

- `helm lint deploy/helm/function-autoscaler`
- `helm template` with no image tag override, verifying image `1.21.0`
- `helm template` with an explicit image tag override, verifying the override still wins
- `git diff --check`

No additional live-cluster QA is needed for this chart metadata-only change. The image and its Cassandra compatibility path were already exercised by the self-managed stack validation.

## Issues

Relates to #1592

## References

- https://github.com/NVIDIA/nvcf/issues/1592

## Related Pull Requests

- https://github.com/NVIDIA/nvcf/pull/1413

## Dependencies

Updates the default internal Function Autoscaler image from `1.19.0` to `1.21.0`. No third-party dependency, license family, or `NOTICE` change.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 1.21.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->