### PR TITLE
fix(function-autoscaler): fix LLM gateway discovery

### DIFF
--- a/src/control-plane-services/function-autoscaler/crates/server/src/work/discovery.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/work/discovery.rs
@@ -194,11 +194,12 @@ fn llm_gateway_discovery_query(env: &str, ignore_env: bool, shard: DiscoveryShar
         let metric_env = MetricEnvironments::from_config(env);
         format!(r#", aws_env="{}""#, metric_env.aws)
     };
+    // A group list copies labels from the left side, which has no version metadata.
     format!(
         r#"(sum by(function_id) (
             increase(llm_api_gateway_http_requests_total{{function_id=~"{function_id_regex}", function_id!="none"{env_matcher}}}[5m])
         ) > 0)
-        * on(function_id) group_right(function_version_id, nca_id)
+        * on(function_id) group_right()
         max by(function_id, function_version_id, nca_id) (
             nvcf_function_info{{function_id=~"{function_id_regex}"{env_matcher}}}
         )"#
@@ -996,6 +997,7 @@ mod tests {
                     assert_eq!(query.query.matches(&matcher).count(), 2);
                     assert_eq!(query.query.matches(r#"aws_env="prd""#).count(), 2);
                     assert!(query.query.contains("llm_api_gateway_http_requests_total"));
+                    assert!(query.query.contains("* on(function_id) group_right()"));
                 } else {
                     assert_eq!(query.query.matches(&matcher).count(), 4);
                     assert_eq!(query.query.matches(r#"aws_env="prd""#).count(), 4);

--- a/src/control-plane-services/function-autoscaler/crates/server/src/work/mod.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/work/mod.rs
@@ -663,7 +663,8 @@ async fn gather_scaling_inputs(
         }
     }
 
-    if cache_source {
+    // ControlPlane is inferred from metric absence, so a scrape race must be re-probed next cycle.
+    if cache_source && metric_source != MetricSource::ControlPlane {
         routing_cache.sources.insert(key, metric_source);
     }
 
@@ -1161,8 +1162,9 @@ mod tests {
         client: &TimeseriesDbClient,
         function_id: &Uuid,
         function_version_id: &Uuid,
-    ) -> GatheredScalingInputs {
-        gather_scaling_inputs(
+    ) -> (GatheredScalingInputs, MetricRoutingCache) {
+        let routing_cache = new_metric_routing_cache();
+        let gathered = gather_scaling_inputs(
             client,
             function_id,
             function_version_id,
@@ -1170,10 +1172,11 @@ mod tests {
             "stg",
             true,
             &ScalingSettings::default(),
-            &new_metric_routing_cache(),
+            &routing_cache,
         )
         .await
-        .expect("gather scaling inputs")
+        .expect("gather scaling inputs");
+        (gathered, routing_cache)
     }
 
     fn gateway_version(function_version_id: Uuid, current_instances: usize) -> GatewayTarget {
@@ -1388,9 +1391,14 @@ mod tests {
             .create_async()
             .await;
 
-        let gathered = gather_for_test(&ts_client(server.url()), &fid, &idle_version).await;
+        let (gathered, routing_cache) =
+            gather_for_test(&ts_client(server.url()), &fid, &idle_version).await;
 
         assert_eq!(gathered.inputs.metric_source, MetricSource::LlmGateway);
+        assert_eq!(
+            routing_cache.sources.get(&(fid, idle_version)),
+            Some(MetricSource::LlmGateway)
+        );
         assert_eq!(gathered.inputs.current_instances, 2);
         assert_eq!(gathered.inputs.utilization_samples, vec![25.0]);
         assert!(gathered.inputs.recently_invoked);
@@ -1491,9 +1499,10 @@ mod tests {
         );
     }
 
-    /// No worker or gateway series -> fall back to control-plane metrics.
+    /// No worker or gateway series -> fall back to control-plane metrics without
+    /// caching that absence-based classification.
     #[tokio::test]
-    async fn test_gather_falls_back_to_control_plane_when_other_sources_are_absent() {
+    async fn test_control_plane_fallback_is_not_cached() {
         let fid = Uuid::new_v4();
         let fvid = Uuid::new_v4();
         let mut server = mockito::Server::new_async().await;
@@ -1539,10 +1548,12 @@ mod tests {
             .create_async()
             .await;
 
-        let gathered = gather_for_test(&ts_client(server.url()), &fid, &fvid).await;
+        let (gathered, routing_cache) =
+            gather_for_test(&ts_client(server.url()), &fid, &fvid).await;
 
         assert_eq!(gathered.inputs.current_instances, 7);
         assert_eq!(gathered.inputs.metric_source, MetricSource::ControlPlane);
+        assert_eq!(routing_cache.sources.get(&(fid, fvid)), None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## TL;DR

Fix LLM gateway discovery for functions with multiple versions and allow late gateway metrics to replace the control-plane fallback.

## Additional Details

- Preserve right-side version and NCA labels with `group_right()`.
- Do not cache the absence-derived `ControlPlane` metric source.
- Cover gateway query generation and metric-source caching behavior.

## For the Reviewer

Please focus on the gateway join in `work/discovery.rs` and source caching in `work/mod.rs`.

## For QA

- `bazel test //src/control-plane-services/function-autoscaler/crates/server:rs_autoscaler_test --test_output=errors`
  - 138 passed
  - 0 failed
  - 10 ignored because they require external infrastructure
- `git diff --check`

## Issues

Relates to #15

Relates to #1601 because the absence-derived ControlPlane fallback is re-evaluated when gateway metrics appear.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved metric query results by preserving all relevant labels during gateway discovery.
  - Control-plane metric-source fallback is now re-evaluated when worker and gateway metrics are unavailable, improving recovery from changing metric conditions.
  - Worker and gateway routing selections continue to use cached results for consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->