### PR TITLE
build(openbao): update runtime to 2.6.2

### DIFF
--- a/infra/openbao/Dockerfile
+++ b/infra/openbao/Dockerfile
@@ -10,7 +10,7 @@
 # context, so the stage below compiles it from the same commit that produces
 # the image. Nothing is vendored and nothing is injected, so `docker build .`
 # here produces the same image as the release pipeline.
-ARG BAO_VERSION=2.5.5
+ARG BAO_VERSION=2.6.2
 ARG GO_VERSION=1.25
 
 FROM golang:${GO_VERSION}-alpine AS plugin-build
@@ -26,10 +26,15 @@ COPY plugins/vault-plugin-secrets-jwt/ ./
 RUN GOOS=linux GOARCH="${TARGETARCH}" CGO_ENABLED=0 \
     go build -trimpath -o /out/vault-plugin-secrets-jwt ./cmd/vault-plugin-secrets-jwt
 
-FROM openbao/openbao:${BAO_VERSION}
+FROM openbao/openbao:${BAO_VERSION}@sha256:11fd73a2102cda9c55d5d881a8c3210303146a7ec1e8ac76f526e175c6d24641
 
+# OpenBao 2.6.2 runs as the non-root openbao user by default. Escalate only
+# while installing the image's runtime packages, then restore that identity.
+USER root
 # hadolint ignore=DL3018
 RUN apk add --no-cache curl jq bash && \
     mkdir -p /openbao/plugins
 
 COPY --from=plugin-build --chmod=0555 /out/vault-plugin-secrets-jwt /openbao/plugins/vault-plugin-secrets-jwt
+
+USER openbao

--- a/infra/openbao/README.md
+++ b/infra/openbao/README.md
@@ -45,12 +45,14 @@ scripts/verify-jwt-plugin.sh    # asserts module path, target, toolchain, deps
 
 ## Building the container
 
-The `Dockerfile` defaults to the `openbao/openbao:2.5.5` base image. Override the `BAO_VERSION` build-arg to track a different upstream tag.
+The `Dockerfile` defaults to the digest-pinned `openbao/openbao:2.6.2` base
+image. Update the tag and digest together when tracking a different upstream
+release.
 
 ```bash
 docker build \
   --build-arg TARGETARCH=amd64 \
-  --build-arg BAO_VERSION=2.5.5 \
+  --build-arg BAO_VERSION=2.6.2 \
   -t <your-registry>/<your-org>/nvcf-openbao:<version> .
 ```
 
@@ -59,7 +61,7 @@ For multi-arch builds:
 ```bash
 docker buildx build \
   --platform linux/amd64,linux/arm64 \
-  --build-arg BAO_VERSION=2.5.5 \
+  --build-arg BAO_VERSION=2.6.2 \
   -t <your-registry>/<your-org>/nvcf-openbao:<version> \
   --push .
 ```


### PR DESCRIPTION
## TL;DR

- Updates the OpenBao runtime component from 2.5.5 to 2.6.2.
- Pins the reviewed multi-architecture 2.6.2 image digest.
- Keeps server and JWT-plugin dependency remediation in the separate stacked PR #1477.

## Additional Details

OpenBao 2.6.2 defaults to the non-root `openbao` user. The image elevates to root only while installing the existing runtime tools, then restores the upstream user for the final image.

No Go module, JWT plugin, OpenBao server dependency, or Alpine package-floor changes are included in this PR.

## Testing and Documentation

- Built the image for `linux/amd64` with Docker Buildx.
- Ran the built image and verified UID `100` and `OpenBao v2.6.2`.
- Ran `git diff --check`.
- Updated the image build examples to 2.6.2.

## Issues

Closes #1476

## Dependencies

OpenBao remains MPL-2.0. This PR changes the component version only and introduces no new dependency or license.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] Existing image-build coverage applies to these changes.
- [x] The documentation is up to date.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled OpenBao version to 2.6.2.
  * Improved build reproducibility by pinning the base image to a digest.
  * Updated build documentation and commands to reflect the new version.
  * Ensured the runtime uses the intended default OpenBao user after setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->