### PR TITLE
fix(charts): bump chart versions for released services

### DIFF
--- a/deploy/helm/event-ledger/Chart.yaml
+++ b/deploy/helm/event-ledger/Chart.yaml
@@ -21,4 +21,4 @@ type: application
 
 version: 0.0.0 # autoversioning enabled via release pipeline
 
-appVersion: "0.15.1"
+appVersion: "0.15.2"

--- a/deploy/helm/event-ledger/values.yaml
+++ b/deploy/helm/event-ledger/values.yaml
@@ -37,7 +37,7 @@ eventLedger:
     # Image name is chart-owned and appended to registry/repository.
     name: "nvcf-event-ledger"
     pullPolicy: IfNotPresent
-    tag: "0.15.1"
+    tag: "0.15.2"
     digest: ""
 
   imagePullSecrets: []

--- a/deploy/helm/function-autoscaler/Chart.yaml
+++ b/deploy/helm/function-autoscaler/Chart.yaml
@@ -19,4 +19,4 @@ description: A Helm chart for NVCF Function Autoscaler Service
 
 type: application
 version: 0.0.0 # autoversioning enabled via release pipeline
-appVersion: "1.21.3"
+appVersion: "1.21.4"

--- a/deploy/helm/function-autoscaler/Chart.yaml
+++ b/deploy/helm/function-autoscaler/Chart.yaml
@@ -19,4 +19,4 @@ description: A Helm chart for NVCF Function Autoscaler Service
 
 type: application
 version: 0.0.0 # autoversioning enabled via release pipeline
-appVersion: "1.21.0"
+appVersion: "1.21.2"

--- a/deploy/helm/function-autoscaler/Chart.yaml
+++ b/deploy/helm/function-autoscaler/Chart.yaml
@@ -19,4 +19,4 @@ description: A Helm chart for NVCF Function Autoscaler Service
 
 type: application
 version: 0.0.0 # autoversioning enabled via release pipeline
-appVersion: "1.21.2"
+appVersion: "1.21.3"

--- a/deploy/helm/grpc-proxy/grpc-proxy/Chart.yaml
+++ b/deploy/helm/grpc-proxy/grpc-proxy/Chart.yaml
@@ -20,4 +20,4 @@ description: Colocated gRPC proxy for NCP deployments
 type: application
 
 version: 0.0.0 # autoversioning enabled via release pipeline
-appVersion: "1.33.2"
+appVersion: "1.33.4"

--- a/deploy/helm/grpc-proxy/grpc-proxy/values.yaml
+++ b/deploy/helm/grpc-proxy/grpc-proxy/values.yaml
@@ -36,7 +36,7 @@ grpcproxy:
 
     pullPolicy: IfNotPresent
 
-    tag: "1.33.2"
+    tag: "1.33.4"
 
   # Image pull secrets for private registries
   imagePullSecrets: []

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.5.2"
+appVersion: "3.5.3"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/Chart.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "3.5.3"
+appVersion: "3.6.0"
 description: A Helm chart for the NVCF ClusterAgent Operator
 name: helm-nvca-operator
 version: 0.0.0

--- a/deploy/helm/vanity-gateway/helm-nvcf-vanity-gateway/Chart.yaml
+++ b/deploy/helm/vanity-gateway/helm-nvcf-vanity-gateway/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "1.34.1"
+appVersion: "1.34.2"
 description: Helm chart for the NVCF Vanity Gateway
 name: helm-nvcf-vanity-gateway
 type: application


### PR DESCRIPTION
Opened by `.github/workflows/chart-version-bump.yml` when `src/compute-plane-services/nvca/v3.6.0` was published.

The released tag carries the version, so this is a direct update rather than a lookup of the newest published image.

Merging this does not move the self-managed stack. A chart version reaches the stack only once the chart itself is released, and publishing that chart release is what triggers `stack-pin-bump.yml`.

Release notes: https://github.com/NVIDIA/nvcf/releases/tag/src/compute-plane-services/nvca/v3.6.0


If this pull request sits unmerged, later service releases add their bumps to the same branch, so merging it applies all of them.

Github commit:
fix(charts): bump chart versions for released services