### PR TITLE
test(self-managed): derive OpenBao chart pin expectation

### DIFF
--- a/deploy/stacks/self-managed/tests/cassandra-openbao-credential-wiring.sh
+++ b/deploy/stacks/self-managed/tests/cassandra-openbao-credential-wiring.sh
@@ -73,10 +73,25 @@ openbao_release="$(HELMFILE_ENV="$environment_name" \
     list --skip-charts --output json)"
 openbao_chart_name="$(jq -r '.[0].chart // ""' <<<"$openbao_release")"
 openbao_chart_version="$(jq -r '.[0].version // ""' <<<"$openbao_release")"
+expected_openbao_chart_version="$(awk '
+  /^[[:space:]]*- name: openbao-server([[:space:]]|$)/ {
+    in_openbao_release = 1
+    next
+  }
+  in_openbao_release && /^[[:space:]]*- name:/ { exit }
+  in_openbao_release && /^[[:space:]]*version:/ {
+    sub(/^[[:space:]]*version:[[:space:]]*/, "")
+    gsub(/[[:space:]]+$/, "")
+    print
+    exit
+  }
+' "$test_stack_dir/helmfile.d/01-dependencies.yaml.gotmpl")"
+test -n "$expected_openbao_chart_version" ||
+  fail "could not derive the default OpenBao version from the stack Helmfile"
 test "$openbao_chart_name" = 'nvcf/helm-nvcf-openbao-server' ||
   fail "expected default OpenBao chart, got ${openbao_chart_name:-missing}"
-test "$openbao_chart_version" = '0.32.1' ||
-  fail "expected default OpenBao version 0.32.1, got ${openbao_chart_version:-missing}"
+test "$openbao_chart_version" = "$expected_openbao_chart_version" ||
+  fail "expected default OpenBao version $expected_openbao_chart_version, got ${openbao_chart_version:-missing}"
 
 cassandra_password="$(yq -r '.cassandra.serviceRolePassword // ""' "$cassandra_values")"
 test -n "$cassandra_password" ||


### PR DESCRIPTION
## Summary

- derive the expected OpenBao wrapper chart version from the stack Helmfile release entry
- keep the existing assertion that `helmfile list` resolves the expected chart and version
- fail clearly when the source pin cannot be found

## Validation

- `shellcheck deploy/stacks/self-managed/tests/cassandra-openbao-credential-wiring.sh`
- `bash deploy/stacks/self-managed/tests/cassandra-openbao-credential-wiring.sh`

Closes #1622


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated deployment validation to derive the expected OpenBao chart version from the configured dependency definition.
  - Added validation to ensure the derived version is present before comparing it with the resolved release version.
  - Removed reliance on a hard-coded chart version, improving test accuracy when dependencies change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->