### PR TITLE
fix(function-autoscaler): retry failed scaling requests

### DIFF
--- a/src/control-plane-services/function-autoscaler/crates/server/src/nvcf_api/nvcf_client.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/nvcf_api/nvcf_client.rs
@@ -164,6 +164,18 @@ struct ProcessRequestCtx<'a> {
     dry_run: bool,
 }
 
+fn cached_state_after_request(
+    required_number_of_instances: i32,
+    error_code: Option<String>,
+) -> FunctionCachedState {
+    FunctionCachedState {
+        last_predicted_desired_instance_count: error_code
+            .is_none()
+            .then_some(required_number_of_instances),
+        last_predicted_error_code: error_code,
+    }
+}
+
 pub struct NvcfApiService {
     pub nvcf_api_grpc_address: String,
     nvcf_api_channel: Channel,
@@ -639,16 +651,12 @@ impl NvcfApiService {
                 }
             }
 
-            // Update in-memory cache with the latest prediction result
+            // Only successful requests become the last applied prediction. Retain failures so
+            // permanent errors can still be suppressed explicitly by the scaling loop.
             if let Some(cache) = function_state_cache {
                 cache.insert(
                     (info.function_id, info.function_version_id),
-                    FunctionCachedState {
-                        last_predicted_desired_instance_count: Some(
-                            info.required_number_of_instances,
-                        ),
-                        last_predicted_error_code: error_code,
-                    },
+                    cached_state_after_request(info.required_number_of_instances, error_code),
                 );
             }
         }
@@ -701,6 +709,23 @@ mod tests {
         assert_eq!(parse_function_status(""), None);
         assert_eq!(parse_function_status("SOME_NEW_STATUS"), None);
         assert_eq!(parse_function_status("active"), None);
+    }
+
+    #[test]
+    fn successful_request_caches_desired_instance_count() {
+        let state = cached_state_after_request(5, None);
+
+        assert_eq!(state.last_predicted_desired_instance_count, Some(5));
+        assert_eq!(state.last_predicted_error_code, None);
+    }
+
+    #[test]
+    fn failed_request_does_not_cache_desired_instance_count() {
+        let error_code = NvcfApiError::UnknownError.to_string();
+        let state = cached_state_after_request(5, Some(error_code.clone()));
+
+        assert_eq!(state.last_predicted_desired_instance_count, None);
+        assert_eq!(state.last_predicted_error_code, Some(error_code));
     }
 
     #[test]

--- a/src/control-plane-services/function-autoscaler/crates/server/src/work/mod.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/work/mod.rs
@@ -1712,6 +1712,18 @@ mod tests {
     }
 
     #[test]
+    fn test_should_retry_scaling_request_after_failure() {
+        let id = Uuid::new_v4();
+        let vid = Uuid::new_v4();
+        let cached = FunctionCachedState {
+            last_predicted_desired_instance_count: None,
+            last_predicted_error_code: Some(NvcfApiError::UnknownError.to_string()),
+        };
+
+        assert!(!should_skip_scaling_request(id, vid, Some(&cached), 5));
+    }
+
+    #[test]
     fn test_should_skip_scaling_request_with_function_not_found() {
         let id = Uuid::new_v4();
         let vid = Uuid::new_v4();


### PR DESCRIPTION
## TL;DR

Do not cache failed scaling requests as successful, allowing the next autoscaling cycle to retry them.

## Additional Details

Failed requests retain their error state but no longer populate the last successful desired count. Existing `FunctionNotFound` suppression remains unchanged.

## For QA

`bazel test //src/control-plane-services/function-autoscaler/crates/server:rs_autoscaler_test` passes.

## Issues

Relates to #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved autoscaling state handling after scaling requests.
  - Successful scaling requests now preserve the requested instance count.
  - Failed scaling requests retain the error status without an outdated desired count.
  - Scaling requests now retry correctly after an unknown error when no prior target count is available.

- **Tests**
  - Added coverage for successful and failed scaling outcomes.
  - Added regression coverage for retry behavior after unknown errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->