### PR TITLE
fix(openbao): retry failed auto-unseal attempts

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -101,6 +101,9 @@ jobs:
       - name: Run self-managed Helmfile render tests
         run: make -C deploy/stacks/self-managed test
 
+      - name: Test OpenBao auto-unseal retry behavior
+        run: bash deploy/helm/openbao/tests/auto-unseal-sidecar.sh
+
       - name: Check for uncommitted helm dependency artifacts
         run: |
           set -euo pipefail

--- a/deploy/helm/openbao/helm/values.yaml
+++ b/deploy/helm/openbao/helm/values.yaml
@@ -215,10 +215,16 @@ openbao:
               if [ -f /vault/userconfig/unseal/unseal_key ]; then
                 UNSEAL_KEY=$(cat /vault/userconfig/unseal/unseal_key)
                 if [ ! -z "$UNSEAL_KEY" ]; then
-                    echo "Unsealing OpenBao..."
-                    bao operator unseal $UNSEAL_KEY
-                    sleep 60
+                  echo "Unsealing OpenBao..."
+                  if bao operator unseal "$UNSEAL_KEY"; then
                     echo "OpenBao unsealed"
+                    sleep 60
+                    continue
+                  else
+                    echo "OpenBao unseal attempt failed; retrying in 10 seconds..."
+                    sleep 10
+                    continue
+                  fi
                 else
                   echo "Unseal key is empty, waiting..."
                 fi

--- a/deploy/helm/openbao/tests/auto-unseal-sidecar.sh
+++ b/deploy/helm/openbao/tests/auto-unseal-sidecar.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+work_dir="$(mktemp -d)"
+trap 'rm -rf "${work_dir}"' EXIT
+
+extract_auto_unseal_script() {
+  local values_file="$1"
+  local destination="$2"
+
+  awk '
+    /^            echo "Starting auto-unseal monitor\.\.\."$/ { capture = 1 }
+    capture {
+      line = $0
+      sub(/^            /, "", line)
+      print line
+    }
+    capture && /^            done$/ { exit }
+  ' "${values_file}" >"${destination}"
+
+  grep -Fq 'echo "Starting auto-unseal monitor..."' "${destination}"
+  grep -Fq "if bao operator unseal \"\$UNSEAL_KEY\"; then" "${destination}"
+}
+
+run_retry_case() {
+  local values_file="$1"
+  local case_name="$2"
+  local case_dir="${work_dir}/${case_name}"
+  local script_file="${case_dir}/auto-unseal.sh"
+  local output_file="${case_dir}/output.log"
+  local process_id
+
+  mkdir -p "${case_dir}/bin" "${case_dir}/unseal"
+  printf '%s\n' 'test-unseal-key' >"${case_dir}/unseal/unseal_key"
+
+  extract_auto_unseal_script "${values_file}" "${script_file}"
+  sed -i.bak "s#/vault/userconfig/unseal#${case_dir}/unseal#g" "${script_file}"
+
+  cat >"${case_dir}/bin/bao" <<'EOF'
+#!/bin/sh
+count_file="${AUTO_UNSEAL_TEST_DIR}/bao-count"
+count=0
+if [ -f "${count_file}" ]; then
+  count=$(cat "${count_file}")
+fi
+count=$((count + 1))
+printf '%s\n' "${count}" >"${count_file}"
+printf 'attempt:%s\n' "${count}"
+if [ "${count}" -eq 1 ]; then
+  printf '%s\n' 'simulated listener-not-ready failure' >&2
+  exit 1
+fi
+printf '%s\n' 'simulated unseal success'
+EOF
+
+  cat >"${case_dir}/bin/sleep" <<'EOF'
+#!/bin/sh
+printf 'sleep:%s\n' "$1"
+/bin/sleep 0.01
+EOF
+  chmod +x "${case_dir}/bin/bao" "${case_dir}/bin/sleep"
+
+  AUTO_UNSEAL_TEST_DIR="${case_dir}" \
+    HOSTNAME="openbao-test" \
+    PATH="${case_dir}/bin:${PATH}" \
+    /bin/sh "${script_file}" >"${output_file}" 2>&1 &
+  process_id=$!
+
+  for _ in $(seq 1 200); do
+    if grep -Fq 'OpenBao unsealed' "${output_file}"; then
+      break
+    fi
+    /bin/sleep 0.01
+  done
+
+  kill "${process_id}" 2>/dev/null || true
+  wait "${process_id}" 2>/dev/null || true
+
+  grep -Fq 'OpenBao unseal attempt failed; retrying in 10 seconds...' "${output_file}"
+  grep -Fq 'OpenBao unsealed' "${output_file}"
+
+  local first_attempt_line second_attempt_line failure_line success_line
+  first_attempt_line=$(grep -n -m1 '^attempt:1$' "${output_file}" | cut -d: -f1)
+  second_attempt_line=$(grep -n -m1 '^attempt:2$' "${output_file}" | cut -d: -f1)
+  failure_line=$(grep -n -m1 '^OpenBao unseal attempt failed;' "${output_file}" | cut -d: -f1)
+  success_line=$(grep -n -m1 '^OpenBao unsealed$' "${output_file}" | cut -d: -f1)
+
+  test "${first_attempt_line}" -lt "${failure_line}"
+  test "${failure_line}" -lt "${second_attempt_line}"
+  test "${second_attempt_line}" -lt "${success_line}"
+
+  test "$(grep '^sleep:' "${output_file}" | sed -n '1p')" = 'sleep:10'
+  test "$(grep '^sleep:' "${output_file}" | sed -n '2p')" = 'sleep:60'
+}
+
+run_retry_case \
+  "${repo_root}/deploy/helm/openbao/helm/values.yaml" \
+  chart-values
+run_retry_case \
+  "${repo_root}/deploy/helm/openbao/upgrade/values-upgrades.yaml" \
+  upgrade-values
+
+echo "OpenBao auto-unseal sidecar retry tests passed"

--- a/deploy/helm/openbao/upgrade/values-upgrades.yaml
+++ b/deploy/helm/openbao/upgrade/values-upgrades.yaml
@@ -31,9 +31,16 @@ openbao:
               if [ -f /vault/userconfig/unseal/unseal_key ]; then
                 UNSEAL_KEY=$(cat /vault/userconfig/unseal/unseal_key)
                 if [ ! -z "$UNSEAL_KEY" ]; then
-                    bao operator unseal $UNSEAL_KEY
+                  echo "Unsealing OpenBao..."
+                  if bao operator unseal "$UNSEAL_KEY"; then
+                    echo "OpenBao unsealed"
                     sleep 60
                     continue
+                  else
+                    echo "OpenBao unseal attempt failed; retrying in 10 seconds..."
+                    sleep 10
+                    continue
+                  fi
                 else
                   echo "Unseal key is empty, waiting..."
                 fi


### PR DESCRIPTION
## Summary

- retry failed OpenBao auto-unseal attempts on the 10-second polling interval
- print the unsealed success message only after `bao operator unseal` succeeds
- keep the 60-second steady-state delay after a successful unseal
- exercise the failure-to-success transition for both the chart and upgrade overlay in CI

## Tests

- `bash deploy/helm/openbao/tests/auto-unseal-sidecar.sh`
- `shellcheck deploy/helm/openbao/tests/auto-unseal-sidecar.sh`
- `helm lint deploy/helm/openbao/helm`

Closes #1625


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OpenBao automatic unsealing by validating each unseal attempt before reporting success.
  - Added clearer retry behavior: successful unseals wait 60 seconds, while failed attempts retry after 10 seconds.
  - Improved handling of unseal keys to support reliable authentication during automatic unsealing.

- **Tests**
  - Added automated coverage to verify retry timing, status handling, and log output for automatic unsealing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->