### PR TITLE
fix(openbao): refresh JWT plugin catalog on upgrade

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -117,6 +117,9 @@ jobs:
       - name: Test OpenBao auto-unseal retry behavior
         run: bash deploy/helm/openbao/tests/auto-unseal-sidecar.sh
 
+      - name: Test OpenBao plugin catalog refresh hook
+        run: bash deploy/helm/openbao/tests/plugin-catalog-refresh-hook.sh
+
       - name: Check for uncommitted helm dependency artifacts
         run: |
           set -euo pipefail

--- a/deploy/helm/openbao/helm/templates/hook-post-01-refresh-jwt-plugin-catalog.yaml
+++ b/deploy/helm/openbao/helm/templates/hook-post-01-refresh-jwt-plugin-catalog.yaml
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 {{- $serverFullname := include "nvcf-openbao.serverFullname" . }}
+{{- $hookValues := .Values.openbao.hooks.refreshJWTPluginCatalog | default .Values.openbao.hooks.migrations }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -27,7 +28,7 @@ metadata:
 spec:
   backoffLimit: 6
   template:
-    {{- with .Values.openbao.hooks.refreshJWTPluginCatalog.podAnnotations }}
+    {{- with $hookValues.podAnnotations }}
     metadata:
       annotations:
         {{- toYaml . | nindent 8 }}
@@ -38,7 +39,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.openbao.hooks.refreshJWTPluginCatalog.schedulingGates }}
+      {{- with $hookValues.schedulingGates }}
       schedulingGates:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -84,7 +85,7 @@ spec:
               mountPath: /secrets/root_token
               readOnly: true
           resources:
-            {{- toYaml .Values.openbao.hooks.refreshJWTPluginCatalog.resources | nindent 12 }}
+            {{- toYaml $hookValues.resources | nindent 12 }}
       volumes:
         - name: {{ $serverFullname }}-root-token
           secret:

--- a/deploy/helm/openbao/helm/templates/hook-post-01-refresh-jwt-plugin-catalog.yaml
+++ b/deploy/helm/openbao/helm/templates/hook-post-01-refresh-jwt-plugin-catalog.yaml
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- $serverFullname := include "nvcf-openbao.serverFullname" . }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $serverFullname }}-refresh-jwt-plugin-catalog
+  namespace: {{ include "nvcf-openbao.namespace" . }}
+  annotations:
+    helm.sh/hook: post-upgrade
+    # Refresh the catalog before migrations use the JWT secret-engine mounts.
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 6
+  template:
+    {{- with .Values.openbao.hooks.refreshJWTPluginCatalog.podAnnotations }}
+    metadata:
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    spec:
+      automountServiceAccountToken: false
+      {{- with .Values.openbao.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.openbao.hooks.refreshJWTPluginCatalog.schedulingGates }}
+      schedulingGates:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: OnFailure
+      containers:
+        - name: refresh-jwt-plugin-catalog
+          # The target server image owns the plugin binary whose digest must be
+          # registered before the OnDelete StatefulSet is manually rotated.
+          image: "{{ include "openbao.image" (dict "image" .Values.openbao.server.image "name" "openbao.server.image") }}"
+          imagePullPolicy: {{ .Values.openbao.server.image.pullPolicy }}
+          command: ["/bin/sh", "-ec"]
+          args:
+            - |-
+              plugin_name="vault-plugin-secrets-jwt"
+              plugin_path="/openbao/plugins/${plugin_name}"
+              test -x "${plugin_path}"
+
+              plugin_sha256="$(sha256sum "${plugin_path}" | awk '{print $1}')"
+              test -n "${plugin_sha256}"
+
+              export BAO_ADDR="http://{{ $serverFullname }}-active:8200"
+              export BAO_TOKEN="$(cat /secrets/root_token/root_token)"
+
+              attempt=1
+              until bao plugin register \
+                -sha256="${plugin_sha256}" \
+                -command="${plugin_name}" \
+                secret "${plugin_name}"; do
+                if [ "${attempt}" -ge 30 ]; then
+                  echo "Failed to refresh JWT plugin catalog after ${attempt} attempts" >&2
+                  exit 1
+                fi
+                echo "OpenBao is not ready for plugin registration; retrying (${attempt}/30)" >&2
+                attempt=$((attempt + 1))
+                sleep 10
+              done
+
+              # Do not reload the plugin here. Existing pods still contain the
+              # previous binary until the OnDelete StatefulSet is rotated.
+              echo "JWT plugin catalog refreshed for the target OpenBao image"
+          volumeMounts:
+            - name: {{ $serverFullname }}-root-token
+              mountPath: /secrets/root_token
+              readOnly: true
+          resources:
+            {{- toYaml .Values.openbao.hooks.refreshJWTPluginCatalog.resources | nindent 12 }}
+      volumes:
+        - name: {{ $serverFullname }}-root-token
+          secret:
+            secretName: {{ $serverFullname }}-root-token
+            items:
+              - key: root_token
+                path: root_token

--- a/deploy/helm/openbao/helm/values.yaml
+++ b/deploy/helm/openbao/helm/values.yaml
@@ -41,6 +41,16 @@ openbao:
         limits:
           cpu: 250m
           memory: 256Mi
+    refreshJWTPluginCatalog:
+      podAnnotations: {}
+      schedulingGates: []
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 250m
+          memory: 256Mi
 
   migrations:
     image:

--- a/deploy/helm/openbao/tests/plugin-catalog-refresh-hook.sh
+++ b/deploy/helm/openbao/tests/plugin-catalog-refresh-hook.sh
@@ -16,6 +16,21 @@ helm dependency build "${chart_dir}" >/dev/null
 rendered="${test_root}/rendered.yaml"
 helm template openbao "${chart_dir}" -f "${values_file}" >"${rendered}"
 
+# Helm upgrades using --reuse-values do not add newly introduced default
+# subtrees. Rendering must remain compatible with persisted pre-change values.
+legacy_values="${test_root}/legacy-values.yaml"
+awk '
+  /^    refreshJWTPluginCatalog:$/ { skip = 1; next }
+  skip && /^  [a-zA-Z]/ { skip = 0 }
+  !skip { print }
+' "${chart_source}/values.yaml" >"${legacy_values}"
+helm template openbao "${chart_dir}" -f "${legacy_values}" \
+  --set openbao.server.image.registry=example.com \
+  --set openbao.server.image.repository=nvcf/nvcf-openbao \
+  --set openbao.migrations.image.registry=example.com \
+  --set openbao.migrations.image.repository=nvcf/nvcf-openbao-migrations \
+  >/dev/null
+
 hook_document="${test_root}/refresh-hook.yaml"
 awk '
   /^---$/ {

--- a/deploy/helm/openbao/tests/plugin-catalog-refresh-hook.sh
+++ b/deploy/helm/openbao/tests/plugin-catalog-refresh-hook.sh
@@ -24,12 +24,17 @@ awk '
   skip && /^  [a-zA-Z]/ { skip = 0 }
   !skip { print }
 ' "${chart_source}/values.yaml" >"${legacy_values}"
+legacy_hook="${test_root}/legacy-refresh-hook.yaml"
 helm template openbao "${chart_dir}" -f "${legacy_values}" \
+  --set-json 'openbao.hooks.refreshJWTPluginCatalog=null' \
+  --set openbao.hooks.migrations.resources.requests.cpu=99m \
   --set openbao.server.image.registry=example.com \
   --set openbao.server.image.repository=nvcf/nvcf-openbao \
   --set openbao.migrations.image.registry=example.com \
   --set openbao.migrations.image.repository=nvcf/nvcf-openbao-migrations \
-  >/dev/null
+  --show-only templates/hook-post-01-refresh-jwt-plugin-catalog.yaml \
+  >"${legacy_hook}"
+grep -q 'cpu: 99m' "${legacy_hook}"
 
 hook_document="${test_root}/refresh-hook.yaml"
 awk '

--- a/deploy/helm/openbao/tests/plugin-catalog-refresh-hook.sh
+++ b/deploy/helm/openbao/tests/plugin-catalog-refresh-hook.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+chart_source="${repo_root}/deploy/helm/openbao/helm"
+values_file="${repo_root}/tools/ci/helm-validate-values/openbao.yaml"
+test_root="$(mktemp -d)"
+trap 'rm -rf "${test_root}"' EXIT
+
+chart_dir="${test_root}/helm"
+cp -R "${chart_source}" "${chart_dir}"
+helm dependency build "${chart_dir}" >/dev/null
+rendered="${test_root}/rendered.yaml"
+helm template openbao "${chart_dir}" -f "${values_file}" >"${rendered}"
+
+hook_document="${test_root}/refresh-hook.yaml"
+awk '
+  /^---$/ {
+    if (capture) exit
+    document = ""
+    capture = 0
+    next
+  }
+  { document = document $0 ORS }
+  /^  name: openbao-server-refresh-jwt-plugin-catalog$/ { capture = 1 }
+  END { if (capture) printf "%s", document }
+' "${rendered}" >"${hook_document}"
+
+test -s "${hook_document}"
+grep -q 'helm.sh/hook: post-upgrade' "${hook_document}"
+grep -q 'helm.sh/hook-weight: "0"' "${hook_document}"
+grep -q 'image: "example.com/nvcf/nvcf-openbao:2.5.5-nv-1.3.1"' "${hook_document}"
+grep -q 'bao plugin register' "${hook_document}"
+
+if grep -q 'bao plugin reload' "${hook_document}"; then
+  echo "plugin catalog refresh hook must not reload the plugin before pod rotation" >&2
+  exit 1
+fi
+
+migrations_weight="$(awk '
+  /^---$/ { in_migrations = 0 }
+  /^  name: openbao-server-migrations$/ { in_migrations = 1 }
+  in_migrations && /helm.sh\/hook-weight:/ { gsub(/"/, "", $2); print $2; exit }
+' "${rendered}")"
+test "${migrations_weight}" = "1"
+
+echo "OpenBao plugin catalog refresh hook render checks passed"

--- a/tools/ci/helm-validate-values/openbao.yaml
+++ b/tools/ci/helm-validate-values/openbao.yaml
@@ -5,6 +5,10 @@ global:
 openbao:
   global:
     imagePullSecrets: []
+  server:
+    image:
+      registry: example.com
+      repository: nvcf/nvcf-openbao
   migrations:
     image:
       registry: example.com


### PR DESCRIPTION
## TL;DR

- Refreshes the persisted JWT plugin catalog digest from the target OpenBao image during upgrades.
- Prevents JWT mounts from losing their backend after the `OnDelete` StatefulSet is rotated.

## Additional Details

- Runs as a `post-upgrade` hook at weight `0`, before migrations at weight `1`.
- Uses the target server image so the registered digest matches the binary new pods will load.
- Does not reload the plugin; old-version pods continue serving until operators rotate them.
- Retries registration while the active OpenBao endpoint becomes available.

## For the Reviewer

- Review the hook ordering and deliberate absence of `bao plugin reload`.
- The rendering test asserts ordering, target-image selection, registration, and no reload.

## For QA

- `bash deploy/helm/openbao/tests/plugin-catalog-refresh-hook.sh`
- `shellcheck deploy/helm/openbao/tests/plugin-catalog-refresh-hook.sh`
- `./tools/ci/check-helm-charts` (16 charts passed)
- Clean `0.32.1`/OpenBao 2.5.5 to artificial-main upgrade, standby-first rotation, JWT signing, persistence, and a no-change repeat upgrade passed.

## Issues

Fixes #1627

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an OpenBao post-upgrade process that registers the JWT secrets plugin digest before StatefulSet rotation.
  - Added configurable scheduling, annotations, image pull secrets, resource settings, and access credentials for the process.
  - Added OpenBao server image settings for Helm validation.

- **Bug Fixes**
  - Improved auto-unseal handling by quoting the unseal key and retrying failed attempts.

- **Tests**
  - Added Helm rendering coverage and CI validation for current and legacy configurations, hook behavior, ordering, and failure conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->