### PR TITLE
fix(vanity-gateway): reject conflicting route hosts

### DIFF
--- a/src/invocation-plane-services/vanity-gateway/gateway_config/gateway_config.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway_config/gateway_config.go
@@ -435,6 +435,9 @@ func isHTTPFieldNameChar(ch byte) bool {
 
 func (c *GatewayConfig) validateVanityConfig() error {
 	for vanityName, vanity := range c.Vanity {
+		if vanity.Host != "" && vanity.Host == c.OpenAI.Host {
+			return fmt.Errorf("vanity.%s.host %q conflicts with openai.host", vanityName, vanity.Host)
+		}
 		for pathKey, path := range vanity.Paths {
 			location := "vanity." + vanityName + ".paths." + pathKey
 			if path.sessionTimeoutPresent || path.SessionTimeout != nil {

--- a/src/invocation-plane-services/vanity-gateway/gateway_config/gateway_config_test.go
+++ b/src/invocation-plane-services/vanity-gateway/gateway_config/gateway_config_test.go
@@ -60,6 +60,20 @@ func TestNotifySharedReloadDropsPendingNotification(t *testing.T) {
 	}
 }
 
+func TestGatewayConfigValidateRejectsVanityHostMatchingOpenAIHost(t *testing.T) {
+	cfg := &GatewayConfig{}
+	cfg.OpenAI.Host = "api.example.com"
+	cfg.Vanity = map[string]VanityEntry{
+		"example": {
+			Host: "api.example.com",
+		},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, `vanity.example.host "api.example.com" conflicts with openai.host`)
+}
+
 func TestGatewayConfigValidateAcceptsOpenAIShadowDefaults(t *testing.T) {
 	cfg := &GatewayConfig{}
 	cfg.OpenAI.ChatCompletions = map[string]ModelFunctionDetails{


### PR DESCRIPTION
## TL;DR

Reject Vanity Gateway mappings when `openai.host` matches a
`vanity.<name>.host`. This prevents vanity route registration from silently
replacing all OpenAI-compatible routes for that host.

## Additional Details

`GatewayConfig.Validate` now reports the conflicting vanity field, host value,
and `openai.host`. Existing config loading applies this check during startup and
hot reload. An invalid initial mapping stops startup with the validation error.
An invalid reload logs the error and keeps the last valid mapping.

No dependencies changed. No license review or NOTICE update is needed.

## For the Reviewer

Please check the host collision validation and error wording in
`gateway_config.go`.

## For QA

- `go test ./...` from `src/invocation-plane-services/vanity-gateway`
- `bazel test //src/invocation-plane-services/vanity-gateway/gateway_config:gateway_config_test --test_output=streamed`

QA is not needed beyond automated coverage.

The repository-wide `helm charts` check currently fails on `main` because its
OpenBao pin assertion expects `0.32.1` while the stack uses `0.32.2`. This is
unrelated to this change and is fixed by #1623. The Vanity Gateway Bazel check
passes.

## Issues

Fixes #1632

## Related Pull Requests

- #1623 fixes the pre-existing OpenBao pin assertion failure on `main`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
