### PR TITLE
fix(vanity-gateway): label ServiceMonitor for discovery

### DIFF
--- a/deploy/helm/vanity-gateway/AGENTS.md
+++ b/deploy/helm/vanity-gateway/AGENTS.md
@@ -54,11 +54,12 @@ override is used for validation.
 on most of its sub-objects. Adding a value key requires a matching schema
 change or the render fails.
 
-The CI values only cover renders that are expected to succeed. Schema rules that
-must reject a values file are checked by render tests, run by hand:
+The CI values only cover renders that are expected to succeed. Chart-specific
+render checks run by hand:
 
 ```bash
 bash tests/chart-render/verify-llm-gateway-routing.sh
+bash tests/chart-render/verify-servicemonitor-label.sh
 ```
 
 This chart pairs with the service image source at

--- a/deploy/helm/vanity-gateway/helm-nvcf-vanity-gateway/templates/servicemonitor.yaml
+++ b/deploy/helm/vanity-gateway/helm-nvcf-vanity-gateway/templates/servicemonitor.yaml
@@ -14,15 +14,14 @@
 # limitations under the License.
 
 {{- if .Values.vanityGateway.serviceMonitor.enabled }}
+{{- $serviceMonitorLabels := merge (dict "nvcf.nvidia.com/observability-target" "true") .Values.vanityGateway.serviceMonitor.labels }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "vanity-gateway.fullname" . }}
   labels:
     {{- include "vanity-gateway.labels" . | nindent 4 }}
-    {{- with .Values.vanityGateway.serviceMonitor.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- toYaml $serviceMonitorLabels | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/deploy/helm/vanity-gateway/tests/chart-render/verify-servicemonitor-label.sh
+++ b/deploy/helm/vanity-gateway/tests/chart-render/verify-servicemonitor-label.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHART="${ROOT_DIR}/helm-nvcf-vanity-gateway"
+VALUES="${ROOT_DIR}/../../../tools/ci/helm-validate-values/vanity-gateway.yaml"
+
+label='nvcf.nvidia.com/observability-target: "true"'
+
+assert_single_label() {
+  local rendered="$1" label_count
+  label_count="$(grep -F -c -- "${label}" <<<"${rendered}" || true)"
+  if [[ "${label_count}" -ne 1 ]]; then
+    echo "FAILED: ServiceMonitor contains ${label_count} copies of ${label}" >&2
+    exit 1
+  fi
+}
+
+rendered="$(helm template vanity-gateway "${CHART}" -f "${VALUES}" --show-only templates/servicemonitor.yaml)"
+assert_single_label "${rendered}"
+
+rendered="$(helm template vanity-gateway "${CHART}" -f "${VALUES}" --show-only templates/servicemonitor.yaml \
+  --set-string 'vanityGateway.serviceMonitor.labels.nvcf\.nvidia\.com/observability-target=true' \
+  --set-string 'vanityGateway.serviceMonitor.labels.team=observability')"
+assert_single_label "${rendered}"
+grep -F -q -- 'team: observability' <<<"${rendered}"
+
+echo "ok: ServiceMonitor includes one ${label}"

--- a/deploy/helm/vanity-gateway/tests/chart-render/verify-servicemonitor-label.sh
+++ b/deploy/helm/vanity-gateway/tests/chart-render/verify-servicemonitor-label.sh
@@ -8,13 +8,18 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CHART="${ROOT_DIR}/helm-nvcf-vanity-gateway"
 VALUES="${ROOT_DIR}/../../../tools/ci/helm-validate-values/vanity-gateway.yaml"
 
+label_key='nvcf.nvidia.com/observability-target:'
 label='nvcf.nvidia.com/observability-target: "true"'
 
 assert_single_label() {
   local rendered="$1" label_count
-  label_count="$(grep -F -c -- "${label}" <<<"${rendered}" || true)"
+  label_count="$(grep -F -c -- "${label_key}" <<<"${rendered}" || true)"
   if [[ "${label_count}" -ne 1 ]]; then
-    echo "FAILED: ServiceMonitor contains ${label_count} copies of ${label}" >&2
+    echo "FAILED: ServiceMonitor contains ${label_count} copies of ${label_key}" >&2
+    exit 1
+  fi
+  if ! grep -F -q -- "${label}" <<<"${rendered}"; then
+    echo "FAILED: ServiceMonitor does not set ${label}" >&2
     exit 1
   fi
 }
@@ -23,7 +28,7 @@ rendered="$(helm template vanity-gateway "${CHART}" -f "${VALUES}" --show-only t
 assert_single_label "${rendered}"
 
 rendered="$(helm template vanity-gateway "${CHART}" -f "${VALUES}" --show-only templates/servicemonitor.yaml \
-  --set-string 'vanityGateway.serviceMonitor.labels.nvcf\.nvidia\.com/observability-target=true' \
+  --set-string 'vanityGateway.serviceMonitor.labels.nvcf\.nvidia\.com/observability-target=false' \
   --set-string 'vanityGateway.serviceMonitor.labels.team=observability')"
 assert_single_label "${rendered}"
 grep -F -q -- 'team: observability' <<<"${rendered}"


### PR DESCRIPTION
## TL;DR

Add the target allocator discovery label to every enabled Vanity Gateway ServiceMonitor. Without it, the bundled OpenTelemetry Target Allocator does not discover the monitor and Vanity Gateway metrics are not scraped.

## Additional Details

- Merge `nvcf.nvidia.com/observability-target: "true"` with user-supplied ServiceMonitor labels.
- Keep the required label authoritative and avoid duplicate keys for existing workaround values.
- Add focused render coverage for default and custom labels.
- No API, dependency, dashboard, alert, or diagram changes.

## For the Reviewer

Review the label merge precedence in `templates/servicemonitor.yaml` and the focused render assertion.

## For QA

Passed:

- `helm lint helm-nvcf-vanity-gateway -f ../../../tools/ci/helm-validate-values/vanity-gateway.yaml`
- `helm template vanity-gateway helm-nvcf-vanity-gateway -f ../../../tools/ci/helm-validate-values/vanity-gateway.yaml`
- `bash tests/chart-render/verify-llm-gateway-routing.sh`
- `bash tests/chart-render/verify-servicemonitor-label.sh`
- `./tools/ci/check-helm-charts` (16 charts)
- `git diff --check`

The required `helm charts` job passes its chart lint and render step, then inherits the current `main` failure in the unrelated OpenBao pin assertion. NVIDIA/nvcf#1622 tracks the failure and #1623 fixes it.

QA is recommended after the chart is published. Enable the ServiceMonitor and confirm the Target Allocator creates the Vanity Gateway scrape job.

## Issues

Fixes #1631

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - ServiceMonitor labels now consistently include the observability target label with the value `true`.
  - User-provided values for the observability target label are overridden to prevent incorrect configurations or duplicate entries.

- **Tests**
  - Added chart-render validation for default and customized ServiceMonitor labels, including incorrect-value handling.

- **Documentation**
  - Updated chart validation guidance to include the ServiceMonitor label check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->