### PR TITLE
fix(gateway-routes): reject duplicate HTTPRoute hostnames

### DIFF
--- a/deploy/helm/gateway-routes/README.md
+++ b/deploy/helm/gateway-routes/README.md
@@ -7,7 +7,8 @@ This repository contains the Helm chart for deploying NVCF ingress routes via th
 The chart deploys `HTTPRoute`, `GRPCRoute`, `TCPRoute`, `UDPRoute`, and
 `ReferenceGrant` resources that attach to an existing Gateway provisioned
 separately by the cluster operator, such as Envoy Gateway, Istio, Traefik, or
-Kong. Secure LLM worker routing also renders an optional cert-manager
+Kong. It also reserves enabled HTTPRoute hostnames with a Kubernetes validating
+admission policy. Secure LLM worker routing renders an optional cert-manager
 `Certificate` and an Envoy Gateway `BackendTrafficPolicy` for long-lived gRPC
 streams. The chart includes optional `PodMonitor` resources for scraping Envoy
 Gateway proxy metrics with Prometheus.
@@ -20,7 +21,7 @@ services referenced by the routes (`api`,
 
 ## Prerequisites
 
-- Kubernetes cluster
+- Kubernetes 1.30 or later
 - Helm 3.x
 - `kubectl`
 - A Gateway API compatible controller installed in the cluster
@@ -77,6 +78,8 @@ Important settings to review before deployment:
 - `llmRequestRouter.grpcTls.*` for the dedicated gRPC listener identity,
   explicit plaintext opt-in, and certificate ownership mode
 - `nvcfGatewayRoutes.routes.<route>.enabled` to toggle individual routes
+- `nvcfGatewayRoutes.hostnameConflictPolicy.enabled` to reject other
+  HTTPRoutes that reuse an enabled chart route's hostname on the shared listener
 - `nvcfGatewayRoutes.routes.nvcfApi.grpc.enabled` and
   `nvcfGatewayRoutes.routes.nvctApi.grpc.enabled` to expose API gRPC routes
 - `nvcfGatewayRoutes.routes.<http-route>.hostnames` to override the templated HTTP route hostnames
@@ -87,6 +90,11 @@ Important settings to review before deployment:
 The default values use `localhost` as the domain and assume backend services are named consistently with NVCF defaults. Override these for any shared or production environment.
 
 Enabled `HTTPRoute` entries must not share a resolved hostname because each `HTTPRoute` in this chart uses a root `PathPrefix /` match on the shared Gateway. Helm rendering fails if two enabled HTTPRoutes would claim the same hostname.
+
+The hostname conflict policy is enabled by default. It rejects create and
+update requests for another HTTPRoute that reuses a hostname reserved by this
+chart on the configured shared Gateway listener. Disable it only when another
+admission controller owns the same hostname policy.
 
 ## Routes
 

--- a/deploy/helm/gateway-routes/chart/templates/_helpers.tpl
+++ b/deploy/helm/gateway-routes/chart/templates/_helpers.tpl
@@ -95,10 +95,8 @@ chart currently route PathPrefix /, so duplicate hostnames are ambiguous.
 {{- define "nvcf-gateway.validateUniqueRootHTTPRouteHostnames" -}}
 {{- if .Values.nvcfGatewayRoutes.enabled -}}
 {{- $seenHostnames := dict -}}
-{{- $httpRouteKeys := list "nvcfApi" "nvctApi" "apiKeys" "invocation" "llmApiGateway" "llmInvocation" "vanityGateway" "sis" "nvcfUi" -}}
-{{- range $routeKey := $httpRouteKeys -}}
-  {{- $route := index $.Values.nvcfGatewayRoutes.routes $routeKey -}}
-  {{- if and $route $route.enabled -}}
+{{- range $routeKey, $route := .Values.nvcfGatewayRoutes.routes -}}
+  {{- if and (hasKey $route "hostnames") $route.enabled -}}
     {{- $routeName := tpl (toString (default $routeKey $route.name)) $ -}}
     {{- range $rawHostname := default (list) $route.hostnames -}}
       {{- $hostname := tpl (toString $rawHostname) $ | lower | trimSuffix "." -}}
@@ -110,4 +108,10 @@ chart currently route PathPrefix /, so duplicate hostnames are ambiguous.
   {{- end -}}
 {{- end -}}
 {{- end -}}
+{{- end }}
+
+{{/* Name the cluster-scoped admission resources uniquely per Helm release. */}}
+{{- define "nvcf-gateway.hostnameConflictPolicyName" -}}
+{{- $releaseID := printf "%s/%s" .Release.Namespace .Release.Name -}}
+{{- printf "%s-hostnames-%s" (.Release.Name | trunc 43 | trimSuffix "-") ($releaseID | sha256sum | trunc 8) | trunc 63 | trimSuffix "-" -}}
 {{- end }}

--- a/deploy/helm/gateway-routes/chart/templates/validatingadmissionpolicy-httproute-hostnames.yaml
+++ b/deploy/helm/gateway-routes/chart/templates/validatingadmissionpolicy-httproute-hostnames.yaml
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ $policy := .Values.nvcfGatewayRoutes.hostnameConflictPolicy | default dict -}}
+{{- if and .Values.nvcfGatewayRoutes.enabled (dig "enabled" true $policy) -}}
+{{- $routeNamespace := .Values.nvcfGatewayRoutes.gateways.shared.namespace | toString -}}
+{{- $reservedHostnames := dict -}}
+{{- range $routeKey, $route := .Values.nvcfGatewayRoutes.routes -}}
+  {{- if and (hasKey $route "hostnames") $route.enabled -}}
+    {{- $routeName := tpl (toString (default $routeKey $route.name)) $ -}}
+    {{- range $rawHostname := default (list) $route.hostnames -}}
+      {{- $hostname := tpl (toString $rawHostname) $ | lower | trimSuffix "." -}}
+      {{- $_ := set $reservedHostnames $hostname (printf "%s/%s" $routeNamespace $routeName) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if gt (len $reservedHostnames) 0 -}}
+{{- $entries := list -}}
+{{- range $hostname, $owner := $reservedHostnames -}}
+  {{- $entries = append $entries (printf "%s: %s" ($hostname | quote) ($owner | quote)) -}}
+{{- end -}}
+{{- $policyName := include "nvcf-gateway.hostnameConflictPolicyName" . -}}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ $policyName }}
+  labels:
+    {{- include "nvcf-gateway.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: Reject HTTPRoutes that reuse NVCF-managed hostnames on the shared Gateway listener.
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups:
+          - gateway.networking.k8s.io
+        apiVersions:
+          - "*"
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - httproutes
+  matchConditions:
+    - name: targets-shared-listener
+      expression: >-
+        has(object.spec.parentRefs) &&
+        object.spec.parentRefs.exists(parent,
+          (!has(parent.group) || parent.group == "gateway.networking.k8s.io") &&
+          (!has(parent.kind) || parent.kind == "Gateway") &&
+          parent.name == {{ .Values.nvcfGatewayRoutes.gateways.shared.name | quote }} &&
+          ((!has(parent.namespace) && request.namespace == {{ $routeNamespace | quote }}) ||
+           (has(parent.namespace) && parent.namespace == {{ $routeNamespace | quote }})) &&
+          (!has(parent.sectionName) || parent.sectionName == {{ .Values.nvcfGatewayRoutes.gateways.shared.listenerName | quote }}))
+  variables:
+    - name: reservedHostnames
+      expression: {{ printf "{%s}" (join ", " $entries) | quote }}
+    - name: conflictingHostnames
+      expression: >-
+        !has(object.spec.hostnames) ? [] :
+        object.spec.hostnames.filter(hostname,
+          hostname in variables.reservedHostnames &&
+          request.namespace + "/" + object.metadata.name != variables.reservedHostnames[hostname])
+  validations:
+    - expression: variables.conflictingHostnames.size() == 0
+      reason: Invalid
+      messageExpression: >-
+        "hostname \"" + variables.conflictingHostnames[0] +
+        "\" is reserved by NVCF HTTPRoute \"" +
+        variables.reservedHostnames[variables.conflictingHostnames[0]] +
+        "\" on Gateway \"{{ $routeNamespace }}/{{ .Values.nvcfGatewayRoutes.gateways.shared.name }}\" listener \"{{ .Values.nvcfGatewayRoutes.gateways.shared.listenerName }}\""
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ $policyName }}
+  labels:
+    {{- include "nvcf-gateway.labels" . | nindent 4 }}
+spec:
+  policyName: {{ $policyName }}
+  validationActions:
+    - Deny
+{{- end -}}
+{{- end }}

--- a/deploy/helm/gateway-routes/chart/values.yaml
+++ b/deploy/helm/gateway-routes/chart/values.yaml
@@ -20,6 +20,11 @@ nvcfGatewayRoutes:
   # Enable/disable ingress deployment
   enabled: true
 
+  # Reject HTTPRoutes that reuse a hostname owned by an enabled chart route on
+  # the configured shared Gateway listener. Requires Kubernetes 1.30 or later.
+  hostnameConflictPolicy:
+    enabled: true
+
   # Domain for hostname routing
   domain: "localhost"
 

--- a/deploy/helm/gateway-routes/scripts/test-render-routes.sh
+++ b/deploy/helm/gateway-routes/scripts/test-render-routes.sh
@@ -21,7 +21,8 @@ default_render="$(mktemp)"
 enabled_render="$(mktemp)"
 annotated_render="$(mktemp)"
 disabled_render="$(mktemp)"
-trap 'rm -f "$default_render" "$enabled_render" "$annotated_render" "$disabled_render"' EXIT
+hostname_conflict_error="$(mktemp)"
+trap 'rm -f "$default_render" "$enabled_render" "$annotated_render" "$disabled_render" "$hostname_conflict_error"' EXIT
 
 if ! command -v yq >/dev/null 2>&1; then
   echo "yq is required for render tests" >&2
@@ -63,6 +64,22 @@ assert_yq_eq "$repo_root/chart/values.yaml" '.nvcfGatewayRoutes.routes.grpcWorke
 assert_yq_eq "$repo_root/chart/values.yaml" '.nvcfGatewayRoutes.routes.nats | has("hostnames")' false
 
 helm template nvcf-gateway-routes "$repo_root/chart" > "$default_render"
+
+# Admission guard for chart-owned HTTPRoute hostnames.
+assert_yq_eq "$default_render" '[select(.kind == "ValidatingAdmissionPolicy")] | length' 1
+assert_yq_eq "$default_render" '[select(.kind == "ValidatingAdmissionPolicyBinding")] | length' 1
+assert_yq_eq "$default_render" 'select(.kind == "ValidatingAdmissionPolicy") | .spec.failurePolicy' Fail
+assert_yq_eq "$default_render" 'select(.kind == "ValidatingAdmissionPolicy") | .spec.matchConstraints.resourceRules[0].resources[0]' httproutes
+assert_yq_eq "$default_render" 'select(.kind == "ValidatingAdmissionPolicyBinding") | .spec.validationActions[0]' Deny
+
+reserved_hostnames="$(yq ea -r 'select(.kind == "ValidatingAdmissionPolicy") | .spec.variables[] | select(.name == "reservedHostnames") | .expression' "$default_render")"
+case "$reserved_hostnames" in
+  *'"api.localhost": "gateway/nvcf-api"'*'"events.localhost": "gateway/event-ledger"'*) ;;
+  *)
+    echo "admission policy does not reserve every enabled HTTPRoute hostname: $reserved_hostnames" >&2
+    exit 1
+    ;;
+esac
 
 # Default-enabled HTTPRoutes.
 assert_resource_count "$default_render" HTTPRoute nvcf-api gateway 1
@@ -133,10 +150,21 @@ assert_resource_field "$default_render" HTTPRoute reval gateway '.spec.rules[0].
 helm template nvcf-gateway-routes "$repo_root/chart" \
   --set nvcfGatewayRoutes.routes.reval.enabled=false \
   --set nvcfGatewayRoutes.routes.eventLedger.enabled=false \
+  --set nvcfGatewayRoutes.hostnameConflictPolicy.enabled=false \
   > "$disabled_render"
 
 assert_resource_count "$disabled_render" HTTPRoute reval gateway 0
 assert_resource_count "$disabled_render" HTTPRoute event-ledger gateway 0
+assert_yq_eq "$disabled_render" '[select(.kind == "ValidatingAdmissionPolicy")] | length' 0
+assert_yq_eq "$disabled_render" '[select(.kind == "ValidatingAdmissionPolicyBinding")] | length' 0
+
+if helm template nvcf-gateway-routes "$repo_root/chart" \
+  --set-string 'nvcfGatewayRoutes.routes.eventLedger.hostnames[0]=api.localhost' \
+  >/dev/null 2>"$hostname_conflict_error"; then
+  echo "expected duplicate HTTPRoute hostname render to fail" >&2
+  exit 1
+fi
+grep -Fq 'routes event-ledger and nvcf-api both use hostname "api.localhost"' "$hostname_conflict_error"
 
 # Default-enabled TCPRoute.
 assert_resource_count "$default_render" TCPRoute grpc gateway 1


### PR DESCRIPTION
## TL;DR

Reject exact reuse of enabled NVCF HTTPRoute hostnames on the configured shared
Gateway listener before an overlapping route can become unreachable.

## Additional Details

### Why

Gateway API intentionally merges compatible HTTPRoutes and resolves tied
matches by route precedence. Both routes can therefore report `Accepted=True`
even when only the older root-path route receives traffic. That behavior is
spec compliant, but it is unsafe for the NVCF chart because every chart-owned
HTTPRoute matches `PathPrefix /`.

### What changed

- Add a default-on `ValidatingAdmissionPolicy` and binding that deny creation or
  update of another HTTPRoute using an enabled NVCF route hostname on the
  configured shared Gateway listener.
- Include the hostname, owning route, Gateway, and listener in the rejection.
- Extend Helm render-time duplicate detection to every configured HTTPRoute,
  including newer routes that were omitted from the static list.
- Document the Kubernetes 1.30 requirement and the policy opt-out.

### Customer Release Notes

Self-managed installations now reject HTTPRoutes that reuse an enabled NVCF
route hostname on the shared Gateway listener.

### Plan Summary

The chart adds one cluster-scoped validating admission policy and one binding
per Helm release. It adds no workloads, services, storage, or images.

### Usage

The guard is enabled by default. Set
`nvcfGatewayRoutes.hostnameConflictPolicy.enabled=false` only when another
admission controller enforces equivalent hostname ownership.

### Notes

The policy rejects exact hostname reuse. Gateway API wildcard intersection and
general route precedence remain unchanged. Existing conflicts are evaluated on
their next update.

### Related Pull Requests

None.

### Dependencies

None. No third-party package, license, or NOTICE changes.

## For the Reviewer

Please focus on the admission policy match scope and CEL expressions in
`validatingadmissionpolicy-httproute-hostnames.yaml`.

## For QA

- `make test` in `deploy/helm/gateway-routes`: passed.
- Rendered chart validation with kubeconform against Kubernetes 1.32 strict
  schemas: 2 native resources valid, 12 custom resources skipped, 0 errors.
- Offline CEL evaluation covered the owning route, same-namespace conflict,
  cross-namespace conflict, different hostname, and different Gateway: passed.
- `make -C deploy/stacks/self-managed test`: gateway route checks passed, then
  the suite hit the unrelated OpenBao version assertion already failing on
  [current main](https://github.com/NVIDIA/nvcf/actions/runs/34203427383/job/101987290339):
  expected `0.32.1`, rendered `0.32.2`.
- Live cluster admission verification was not run. QA is needed on a Kubernetes
  1.30 or later self-managed control plane.

## Issues

Closes #1635

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added default hostname-conflict protection for shared Gateway HTTPRoutes.
  - Conflicting hostnames are rejected with details about the reserved route and listener.
  - Added configuration to enable or disable hostname-conflict enforcement.

- **Documentation**
  - Documented the Kubernetes 1.30+ requirement and hostname conflict policy settings.

- **Tests**
  - Expanded route rendering checks for policy generation, disabling behavior, HTTPRoute matching, and duplicate hostname failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->