### PR TITLE
feat(stargate): discount affinity prefill estimates

### DIFF
--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/cluster_comparator.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/cluster_comparator.rs
@@ -82,13 +82,17 @@ pub(crate) struct Ttft {
 pub(crate) fn ttft(
     candidate: &RoutedClusterSnapshot,
     input_tokens: Option<u64>,
+    input_tokens_scale: f64,
     priority: u32,
     ignore_queue_time: bool,
     ignore_input_processing_time: bool,
 ) -> Ttft {
     let input_tps = input_tps(candidate);
     let queue_ms = queue_delay_ms_with_tps(candidate, priority, input_tps);
-    let prefill_ms = processing_delay_ms(input_tokens.unwrap_or_default() as f64, input_tps);
+    let prefill_ms = processing_delay_ms(
+        input_tokens.unwrap_or_default() as f64 * input_tokens_scale,
+        input_tps,
+    );
     let ttft_ms = rtt_ms(candidate)
         + if ignore_queue_time { 0.0 } else { queue_ms }
         + if ignore_input_processing_time {
@@ -114,6 +118,7 @@ fn ttft_ms(candidate: &RoutedClusterSnapshot, request: &LoadBalancerRequest<'_>)
     ttft(
         candidate,
         request.input_tokens,
+        1.0,
         request.priority,
         false,
         false,

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/config.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/config.rs
@@ -195,6 +195,7 @@ pub struct WaitAndWidenAlgorithmConfig {
     pub comparator: Option<ClusterComparator>,
     pub cache_affinity_virtual_nodes: Option<usize>,
     pub cache_affinity_backend_selection_count: Option<usize>,
+    pub cache_affinity_input_tokens_scale: Option<f64>,
     pub max_queue_time_floor_ms: Option<u64>,
     pub max_queue_time_ceil_ms: Option<u64>,
     pub ttft_bucket_size_ms: Option<u64>,
@@ -203,6 +204,18 @@ pub struct WaitAndWidenAlgorithmConfig {
     pub max_queued: Option<u64>,
     pub ignore_queue_time: Option<bool>,
     pub ignore_input_processing_time: Option<bool>,
+}
+
+impl WaitAndWidenAlgorithmConfig {
+    pub(crate) fn validated_cache_affinity_input_tokens_scale(&self) -> Result<f64, String> {
+        let scale = self.cache_affinity_input_tokens_scale.unwrap_or(1.0);
+        if !(0.0..=1.0).contains(&scale) {
+            return Err(format!(
+                "cache_affinity_input_tokens_scale must be between 0.0 and 1.0, got {scale}"
+            ));
+        }
+        Ok(scale)
+    }
 }
 
 fn deserialize_present_comparator<'de, D>(
@@ -550,8 +563,17 @@ impl RawLoadBalancerAlgorithmConfig {
 
     fn into_config(self) -> Result<LoadBalancerAlgorithmConfig, String> {
         let (common, settings, consider_kv_free_tokens) = self.normalized();
-        if let LoadBalancerAlgorithmSettings::PowerOfN(config) = &settings {
-            config.validated_sample_count()?;
+        match &settings {
+            LoadBalancerAlgorithmSettings::PowerOfN(config) => {
+                config.validated_sample_count()?;
+            }
+            LoadBalancerAlgorithmSettings::WaitAndWiden(config)
+            | LoadBalancerAlgorithmSettings::PulsarWaitAndWiden(config) => {
+                config.validated_cache_affinity_input_tokens_scale()?;
+            }
+            LoadBalancerAlgorithmSettings::RoundRobin
+            | LoadBalancerAlgorithmSettings::Random
+            | LoadBalancerAlgorithmSettings::Pulsar(_) => {}
         }
         common.into_config(settings, consider_kv_free_tokens)
     }

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/factory.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/factory.rs
@@ -26,6 +26,12 @@ use super::{LoadBalancer, LoadBalancerAlgorithm, LoadBalancerAlgorithmConfig};
 pub fn create_load_balancer_with_config(
     config: &LoadBalancerAlgorithmConfig,
 ) -> anyhow::Result<Arc<dyn LoadBalancer>> {
+    if let Some(settings) = config.wait_and_widen_settings() {
+        settings
+            .validated_cache_affinity_input_tokens_scale()
+            .map_err(anyhow::Error::msg)?;
+    }
+
     if config.algorithm() == LoadBalancerAlgorithm::PulsarWaitAndWiden
         && config
             .wait_and_widen_settings()

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/pulsar_wait_and_widen.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/pulsar_wait_and_widen.rs
@@ -52,7 +52,7 @@ impl PulsarWaitAndWidenLoadBalancer {
             })
             .collect::<Vec<_>>();
         self.wait_and_widen
-            .choose_from_candidate_indices(request, candidates, &eligible)
+            .choose_from_candidate_indices(request, candidates, &eligible, 1.0)
             .map(|choice| {
                 let rank_depth = ranked_indices
                     .iter()

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/tests.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/tests.rs
@@ -1111,7 +1111,7 @@ fn legacy_algorithm_names_remain_compatible_in_detailed_configs() {
 #[test]
 fn detailed_model_config_parses_wait_and_widen_cache_affinity() {
     let router = router_from_json(
-        r#"{"default":"power-of-n","models":{"model-a":{"algorithm":"wait-and-widen","seed":"seed-1","require_cache_affinity_key":true,"cache_affinity_virtual_nodes":64,"cache_affinity_backend_selection_count":2}}}"#,
+        r#"{"default":"power-of-n","models":{"model-a":{"algorithm":"wait-and-widen","seed":"seed-1","require_cache_affinity_key":true,"cache_affinity_virtual_nodes":64,"cache_affinity_backend_selection_count":2,"cache_affinity_input_tokens_scale":0.1}}}"#,
     );
     let model_config = router.algorithm_config("model-a");
     assert_eq!(
@@ -1125,6 +1125,34 @@ fn detailed_model_config_parses_wait_and_widen_cache_affinity() {
     assert_eq!(
         wait_and_widen_config.cache_affinity_backend_selection_count,
         Some(2)
+    );
+    assert_eq!(wait_and_widen_config.cache_affinity_input_tokens_scale, 0.1);
+}
+
+#[test]
+fn wait_and_widen_rejects_cache_affinity_input_tokens_scale_outside_unit_interval() {
+    for scale in [-0.1, 1.1] {
+        assert_json_rejected::<LoadBalancerAlgorithmConfig>(
+            &format!(
+                r#"{{"algorithm":"wait-and-widen","cache_affinity_input_tokens_scale":{scale}}}"#
+            ),
+            "cache_affinity_input_tokens_scale must be between 0.0 and 1.0",
+        );
+    }
+
+    let mut config = LoadBalancerAlgorithmConfig::from(LoadBalancerAlgorithm::WaitAndWiden);
+    config
+        .wait_and_widen_settings_mut()
+        .expect("wait-and-widen config should expose mutable settings")
+        .cache_affinity_input_tokens_scale = Some(1.1);
+    let error = match create_load_balancer_with_config(&config) {
+        Ok(_) => panic!("programmatic invalid input scale should fail"),
+        Err(error) => error,
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("cache_affinity_input_tokens_scale")
     );
 }
 
@@ -1255,6 +1283,7 @@ fn wait_and_widen_config_resolves_internal_defaults() {
 
     assert_eq!(config.cache_affinity_virtual_nodes, 1);
     assert_eq!(config.cache_affinity_backend_selection_count, None);
+    assert_eq!(config.cache_affinity_input_tokens_scale, 1.0);
     assert_eq!(config.ttft_bucket_size, Duration::from_millis(20));
     assert_eq!(config.next_bucket_unlock_factor, 0.25);
     assert_eq!(config.sample_count, 1);
@@ -1959,6 +1988,60 @@ fn wait_and_widen_cache_affinity_falls_back_when_primary_is_full() {
 }
 
 #[test]
+fn wait_and_widen_affinity_prefill_discount_delays_cold_fallback_until_later_bucket() {
+    let make_config = |input_tokens_scale| {
+        let mut config = wait_and_widen_affinity_algorithm_config(8, 1, Some(2));
+        let settings = config
+            .wait_and_widen_settings_mut()
+            .expect("wait-and-widen config should expose settings");
+        settings.cache_affinity_input_tokens_scale = input_tokens_scale;
+        settings.max_queue_time_floor_ms = Some(100);
+        settings.max_queue_time_ceil_ms = Some(5_000);
+        WaitAndWidenConfig::from_algorithm_config(&config)
+    };
+
+    let target = target();
+    let affinity_key = "cached-prefix";
+    let baseline_config = make_config(None);
+    let mut candidates = [
+        priority_candidate("backend-a", 0, 10),
+        priority_candidate("backend-b", 0, 0),
+    ];
+    let request = LoadBalancerRequest {
+        request_slo: Some(Duration::from_secs(10)),
+        ..request(&target, Some(affinity_key), Some(1_000))
+    };
+    let affinity_index = cache_affinity_candidate_indices(&baseline_config, &request, &candidates)
+        .expect("cache affinity should select a backend")[0];
+    let cold_index = 1 - affinity_index;
+    candidates[affinity_index].stats.max_engine_concurrency = 1;
+    candidates[affinity_index].stats.num_running_queries = 1;
+
+    let baseline = WaitAndWidenLoadBalancer::new(baseline_config);
+    let baseline_choice = choose(&baseline, &request, &candidates);
+    assert_eq!(
+        baseline_choice.candidate.cluster_id,
+        candidates[cold_index].cluster_id
+    );
+
+    let discounted = WaitAndWidenLoadBalancer::new(make_config(Some(0.1)));
+    assert!(
+        discounted.choose_for_test(&request, &candidates).is_none(),
+        "the full affinity backend should anchor the first TTFT bucket"
+    );
+
+    let later_request = LoadBalancerRequest {
+        received_at: Instant::now() - Duration::from_secs(3),
+        ..request
+    };
+    let later_choice = choose(&discounted, &later_request, &candidates);
+    assert_eq!(
+        later_choice.candidate.cluster_id,
+        candidates[cold_index].cluster_id
+    );
+}
+
+#[test]
 fn wait_and_widen_two_affinity_candidates_still_filter_capacity() {
     let config = wait_and_widen_affinity_config(8, 2, Some(2));
     let lb = WaitAndWidenLoadBalancer::new(config.clone());
@@ -2325,15 +2408,19 @@ fn wait_and_widen_ttft_uses_priority_queue_and_ignore_flags() {
     let mut candidate = work_candidate("estimated", 7, 100.0, 999);
     candidate.stats.queue_time_estimate_ms_by_priority = HashMap::from([(4, 25)]);
 
-    let full = wait_and_widen_ttft_components(&candidate, Some(200), 4, false, false);
+    let full = wait_and_widen_ttft_components(&candidate, Some(200), 1.0, 4, false, false);
     assert_eq!(full.queue_ms, 25.0);
     assert_eq!(full.ttft_ms, 2032.0);
 
-    let ignore_queue = wait_and_widen_ttft_components(&candidate, Some(200), 4, true, false);
+    let discounted = wait_and_widen_ttft_components(&candidate, Some(200), 0.1, 4, false, false);
+    assert_eq!(discounted.queue_ms, 25.0);
+    assert_eq!(discounted.ttft_ms, 232.0);
+
+    let ignore_queue = wait_and_widen_ttft_components(&candidate, Some(200), 1.0, 4, true, false);
     assert_eq!(ignore_queue.queue_ms, 25.0);
     assert_eq!(ignore_queue.ttft_ms, 2007.0);
 
-    let ignore_prefill = wait_and_widen_ttft_components(&candidate, Some(200), 4, false, true);
+    let ignore_prefill = wait_and_widen_ttft_components(&candidate, Some(200), 1.0, 4, false, true);
     assert_eq!(ignore_prefill.queue_ms, 25.0);
     assert_eq!(ignore_prefill.ttft_ms, 32.0);
 }

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen.rs
@@ -56,6 +56,7 @@ pub(super) struct WaitAndWidenConfig {
     pub(super) seed: Option<String>,
     pub(super) cache_affinity_virtual_nodes: usize,
     pub(super) cache_affinity_backend_selection_count: Option<usize>,
+    pub(super) cache_affinity_input_tokens_scale: f64,
     queue_slo: Option<RangeInclusive<Duration>>,
     pub(super) ttft_bucket_size: Duration,
     pub(super) next_bucket_unlock_factor: f64,
@@ -79,6 +80,9 @@ impl WaitAndWidenConfig {
             cache_affinity_backend_selection_count: config
                 .cache_affinity_backend_selection_count
                 .filter(|count| *count > 0),
+            cache_affinity_input_tokens_scale: config
+                .validated_cache_affinity_input_tokens_scale()
+                .expect("wait-and-widen settings should be validated before use"),
             queue_slo: config
                 .max_queue_time_floor_ms
                 .zip(config.max_queue_time_ceil_ms)
@@ -152,11 +156,16 @@ impl LoadBalancer for WaitAndWidenLoadBalancer {
         request: &LoadBalancerRequest<'_>,
         candidates: &[RoutedClusterSnapshot],
     ) -> Option<LoadBalancerCandidateChoice> {
-        if let Some(affinity_indices) =
+        let affinity_indices =
             self.cache_affinity
-                .candidate_indices(&self.config, request, candidates)
-            && let Some(choice) =
-                self.choose_from_candidate_indices(request, candidates, affinity_indices.as_slice())
+                .candidate_indices(&self.config, request, candidates);
+        if let Some(affinity_indices) = &affinity_indices
+            && let Some(choice) = self.choose_from_candidate_indices(
+                request,
+                candidates,
+                affinity_indices.as_slice(),
+                self.config.cache_affinity_input_tokens_scale,
+            )
         {
             return Some(choice);
         }
@@ -165,8 +174,25 @@ impl LoadBalancer for WaitAndWidenLoadBalancer {
             return None;
         }
         let config = &self.config;
-        fast_path::choose_from_single_bucket(config, request, candidates)
-            .or_else(|| self.choose_from_candidate_iter(request, candidates.iter(), candidates))
+        if (affinity_indices.is_none() || config.cache_affinity_input_tokens_scale == 1.0)
+            && let Some(choice) = fast_path::choose_from_single_bucket(config, request, candidates)
+        {
+            return Some(choice);
+        }
+
+        let affinity_indices = affinity_indices.as_deref().map_or(&[][..], Vec::as_slice);
+        self.choose_from_candidate_iter(
+            request,
+            candidates.iter().enumerate().map(|(index, candidate)| {
+                let input_tokens_scale = if affinity_indices.contains(&index) {
+                    config.cache_affinity_input_tokens_scale
+                } else {
+                    1.0
+                };
+                (candidate, input_tokens_scale)
+            }),
+            candidates,
+        )
     }
 }
 
@@ -192,13 +218,17 @@ impl WaitAndWidenLoadBalancer {
         request: &LoadBalancerRequest<'_>,
         candidates: &[RoutedClusterSnapshot],
         candidate_indices: &[usize],
+        input_tokens_scale: f64,
     ) -> Option<LoadBalancerCandidateChoice> {
         if candidate_indices.is_empty() {
             return None;
         }
-        if let Some(choice) =
-            self.choose_from_two_ready_affinity_candidates(request, candidates, candidate_indices)
-        {
+        if let Some(choice) = self.choose_from_two_ready_affinity_candidates(
+            request,
+            candidates,
+            candidate_indices,
+            input_tokens_scale,
+        ) {
             return Some(choice);
         }
 
@@ -207,7 +237,9 @@ impl WaitAndWidenLoadBalancer {
         // temporary Vec for every affinity hit.
         self.choose_from_candidate_iter(
             request,
-            candidate_indices.iter().map(|index| &candidates[*index]),
+            candidate_indices
+                .iter()
+                .map(|index| (&candidates[*index], input_tokens_scale)),
             candidates,
         )
     }
@@ -217,6 +249,7 @@ impl WaitAndWidenLoadBalancer {
         request: &LoadBalancerRequest<'_>,
         candidates: &[RoutedClusterSnapshot],
         candidate_indices: &[usize],
+        input_tokens_scale: f64,
     ) -> Option<LoadBalancerCandidateChoice> {
         let &[index_a, index_b] = candidate_indices else {
             return None;
@@ -238,6 +271,7 @@ impl WaitAndWidenLoadBalancer {
             ttft(
                 candidate,
                 request.input_tokens,
+                input_tokens_scale,
                 request.priority,
                 self.config.ignore_queue_time,
                 self.config.ignore_input_processing_time,
@@ -279,27 +313,27 @@ impl WaitAndWidenLoadBalancer {
     fn choose_from_candidate_iter<'a>(
         &self,
         request: &LoadBalancerRequest<'_>,
-        candidates: impl ExactSizeIterator<Item = &'a RoutedClusterSnapshot>,
+        candidates: impl ExactSizeIterator<Item = (&'a RoutedClusterSnapshot, f64)>,
         candidate_index_source: &[RoutedClusterSnapshot],
     ) -> Option<LoadBalancerCandidateChoice> {
         // TTFT determines bucket eligibility and unlock timing. The configured
         // comparator is applied after the unlocked candidates are sampled.
         let mut ttfts = CandidateTtftAccumulator::new(&self.config, request, candidates.len());
         if let RequestExclusions::One(excluded_cluster_id) = RequestExclusions::from(request) {
-            for candidate in candidates {
+            for (candidate, input_tokens_scale) in candidates {
                 if candidate.cluster_id != excluded_cluster_id {
-                    ttfts.push_ttft(candidate);
+                    ttfts.push_ttft(candidate, input_tokens_scale);
                 }
             }
         } else if request.has_excluded_clusters() || ttfts.filters_by_queue_slo() {
-            for candidate in candidates {
+            for (candidate, input_tokens_scale) in candidates {
                 if !request.excludes_cluster(&candidate.cluster_id) {
-                    ttfts.push_ttft(candidate);
+                    ttfts.push_ttft(candidate, input_tokens_scale);
                 }
             }
         } else {
-            for candidate in candidates {
-                ttfts.push_ttft(candidate);
+            for (candidate, input_tokens_scale) in candidates {
+                ttfts.push_ttft(candidate, input_tokens_scale);
             }
         }
 

--- a/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen/estimates.rs
+++ b/src/libraries/rust/stargate/crates/stargate/src/load_balancer/wait_and_widen/estimates.rs
@@ -59,10 +59,15 @@ impl<'a> CandidateTtftAccumulator<'a> {
         self.max_queue_time_ms.is_some()
     }
 
-    pub(super) fn push_ttft(&mut self, candidate: &'a RoutedClusterSnapshot) {
+    pub(super) fn push_ttft(
+        &mut self,
+        candidate: &'a RoutedClusterSnapshot,
+        input_tokens_scale: f64,
+    ) {
         let ttft = ttft(
             candidate,
             self.input_tokens,
+            input_tokens_scale,
             self.priority,
             self.ignore_queue_time,
             self.ignore_input_processing_time,


### PR DESCRIPTION
## Why

WaitAndWiden currently estimates every candidate as if the complete request input must be prefetched. A backend selected by cache-affinity hashing can already hold most of a continuing session, so that estimate can make Stargate choose a cold global backend before the affinity backend has time to become available.

## What changed

- Add `cache_affinity_input_tokens_scale` to WaitAndWiden configuration, with a backward-compatible default of `1.0`.
- Validate the scale in the inclusive range from `0.0` through `1.0`.
- Scale only the current request prefill component for consistent-hash affinity candidates. Existing queued work and cold candidates retain their full cost.
- Use the discounted estimate in both the affinity pass and global TTFT bucketing so normal widening can unlock cold candidates later.

## Customer Release Notes

Stargate WaitAndWiden routing can discount input-prefill cost for cache-affinity candidates.

## Plan Summary

Not applicable.

## Usage

Set `cache_affinity_input_tokens_scale` on a WaitAndWiden model configuration. A value of `0.1` charges affinity candidates for 10 percent of the current request input-prefill cost. Omit the setting to preserve current behavior.

## Testing

- `cargo clippy -p stargate --all-targets -- -D warnings`
- `cargo test -p stargate --lib` (353 passed)
- Focused WaitAndWiden tests (49 passed)
- `bazel run //src/libraries/rust/stargate/crates/stargate:image_load`
- GitHub `bazel (stargate)` check
- Live us-west-2 comparison using an image built from this commit: 10 minutes per algorithm at 12 RPS, one hot affinity key plus about 1,260 short-session keys, with empty caches before each arm. Both algorithms completed without request failures or client retries. WaitAndWiden at scale `0.1` had hot/short TTFT p95 of 389/565 ms and 266 cache evictions; PowerOf2 had 166/328 ms and 227 evictions. This first trial did not show an end-to-end performance or cache-efficiency improvement from the experimental `0.1` setting.

Further performance evaluation is recommended before enabling a non-default scale broadly.

## Notes

The default remains `1.0`. No metrics, trace fields, or dashboard contracts changed.

## References

Closes #1639

## Related Pull Requests

- #1519

## Dependencies

None.