### PR TITLE
fix(stack): bump self-managed stack chart pins

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
@@ -120,7 +120,7 @@ releases:
     <<: *dependency
 
   - name: openbao-server # this name MUST not change
-    version: 0.32.3
+    version: 0.32.4
     condition: openbao.enabled # From defaults.yaml or env overrides
     namespace: vault-system
     <<: *dependency # Inherits base values from the dependency template

--- a/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
@@ -120,7 +120,7 @@ releases:
     <<: *dependency
 
   - name: openbao-server # this name MUST not change
-    version: 0.32.2
+    version: 0.32.3
     condition: openbao.enabled # From defaults.yaml or env overrides
     namespace: vault-system
     <<: *dependency # Inherits base values from the dependency template

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -193,7 +193,7 @@ releases:
       release-group: services
 
   - name: vanity-gateway
-    version: 0.4.2
+    version: 0.4.3
     namespace: nvcf
     condition: addons.vanityGateway.enabled
     inherit:

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -193,7 +193,7 @@ releases:
       release-group: services
 
   - name: vanity-gateway
-    version: 0.4.1
+    version: 0.4.2
     namespace: nvcf
     condition: addons.vanityGateway.enabled
     inherit:

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -218,7 +218,7 @@ releases:
     {{- $gatewayRoutesChartPath := dig "ingress" "gatewayApi" "chartPath" "" .Values }}
     chart: {{ $gatewayRoutesChartPath | default "nvcf/nvcf-gateway-routes" | quote }}
     {{- if not $gatewayRoutesChartPath }}
-    version: 1.18.0
+    version: 1.18.1
     {{- end }}
     needs:
       - nvcf/notary-service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -80,7 +80,7 @@ releases:
       - nvcf/api
 
   - name: grpc-proxy
-    version: 1.7.2
+    version: 1.7.3
     namespace: nvcf
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
@@ -68,7 +68,7 @@ releases:
 
   {{- if $functionAutoscalerEnabled }}
   - name: function-autoscaler
-    version: 0.3.1
+    version: 0.3.2
     namespace: nvcf
     inherit:
       - template: functionAutoscaler

--- a/deploy/stacks/self-managed/tests/cassandra-autoscaler-published-compatibility.sh
+++ b/deploy/stacks/self-managed/tests/cassandra-autoscaler-published-compatibility.sh
@@ -21,7 +21,7 @@ autoscaler_release="$work_dir/function-autoscaler-release.json"
 # These literals are the compatibility contract under test. Review and advance
 # them together only after the autoscaler no longer uses the removed tables.
 cassandra_chart_version=0.20.3
-autoscaler_chart_version=0.3.1
+autoscaler_chart_version=0.3.2
 migrations_image_version=0.17.3
 trap 'rm -rf "$work_dir"' EXIT
 

--- a/deploy/stacks/self-managed/tests/gateway-routes-local-chart.sh
+++ b/deploy/stacks/self-managed/tests/gateway-routes-local-chart.sh
@@ -30,12 +30,20 @@ default_result="$(cd "$stack_dir" && HELMFILE_ENV=base helmfile \
 
 default_chart="$(jq -r '.[0].chart // ""' <<<"$default_result")"
 default_version="$(jq -r '.[0].version // ""' <<<"$default_result")"
+expected_default_version="$(awk '
+  $1 == "-" && $2 == "name:" { release = $3 }
+  release == "ingress" && $1 == "version:" { print $2; exit }
+' "$stack_dir/helmfile.d/02-core.yaml.gotmpl")"
+test -n "$expected_default_version" || {
+  echo "gateway-routes-local-chart: could not derive the default version from the stack Helmfile" >&2
+  exit 1
+}
 test "$default_chart" = 'nvcf/nvcf-gateway-routes' || {
   echo "gateway-routes-local-chart: expected default chart, got ${default_chart:-missing}" >&2
   exit 1
 }
-test "$default_version" = '1.18.0' || {
-  echo "gateway-routes-local-chart: expected default version 1.18.0, got ${default_version:-missing}" >&2
+test "$default_version" = "$expected_default_version" || {
+  echo "gateway-routes-local-chart: expected default version $expected_default_version, got ${default_version:-missing}" >&2
   exit 1
 }
 

--- a/deploy/stacks/self-managed/tests/gateway-routes-published-chart.sh
+++ b/deploy/stacks/self-managed/tests/gateway-routes-published-chart.sh
@@ -11,7 +11,6 @@ stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 work_dir="$(mktemp -d)"
 published_manifest="$work_dir/gateway-routes.yaml"
 published_release="$work_dir/gateway-routes-release.json"
-published_version=1.18.0
 gateway_namespace=gateway
 trap 'rm -rf "$work_dir"' EXIT
 
@@ -19,6 +18,13 @@ fail() {
   echo "gateway-routes-published-chart: $*" >&2
   exit 1
 }
+
+published_version="$(awk '
+  $1 == "-" && $2 == "name:" { release = $3 }
+  release == "ingress" && $1 == "version:" { print $2; exit }
+' "$stack_dir/helmfile.d/02-core.yaml.gotmpl")"
+test -n "$published_version" ||
+  fail "could not derive the published Gateway Routes version from the stack Helmfile"
 
 source_args=(
   --state-values-set-string "global.helm.sources.registry=$NVCF_PUBLISHED_CHART_REGISTRY"

--- a/deploy/stacks/self-managed/tests/openbao-published-chart.sh
+++ b/deploy/stacks/self-managed/tests/openbao-published-chart.sh
@@ -15,13 +15,19 @@ secrets_file="$test_stack_dir/secrets/$environment_name-secrets.yaml"
 : "${NVCF_PUBLISHED_CHART_REPOSITORY:?NVCF_PUBLISHED_CHART_REPOSITORY is required}"
 published_chart_registry="$NVCF_PUBLISHED_CHART_REGISTRY"
 published_chart_repository="$NVCF_PUBLISHED_CHART_REPOSITORY"
-published_chart_version=0.32.2
 trap 'rm -rf "$work_dir"' EXIT
 
 fail() {
   echo "openbao-published-chart: $*" >&2
   exit 1
 }
+
+published_chart_version="$(awk '
+  $1 == "-" && $2 == "name:" { release = $3 }
+  release == "openbao-server" && $1 == "version:" { print $2; exit }
+' "$stack_dir/helmfile.d/01-dependencies.yaml.gotmpl")"
+test -n "$published_chart_version" ||
+  fail "could not derive the published OpenBao version from the stack Helmfile"
 
 # Match the existing Cassandra/OpenBao credential-wiring test's rendered stack
 # values, but keep that local-chart test offline and independent of registry


### PR DESCRIPTION
Opened by `.github/workflows/stack-pin-bump.yml` when `deploy/helm/vanity-gateway/v0.4.3` was published.

The released tag carries the version, so this is a direct pin update rather than a lookup of the newest published chart.

Release notes: https://github.com/NVIDIA/nvcf/releases/tag/deploy/helm/vanity-gateway/v0.4.3

If this pull request sits unmerged, later chart releases add their bumps to the same branch, so merging it applies all of them.

Github commit:
fix(stack): pin vanity-gateway/v0.4.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Maintenance**
  - Updated platform components supporting gRPC proxying, vanity routing, Gateway API routes, secure secret management, and function autoscaling.
  - These updates include the latest available fixes and improvements for the self-managed deployment stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->