### PR TITLE
feat(uploader): add a dry-run mode to the objectstore backend

### DIFF
--- a/src/compute-plane-services/request-trace-uploader/backend/objectstore/objectstore.go
+++ b/src/compute-plane-services/request-trace-uploader/backend/objectstore/objectstore.go
@@ -96,8 +96,8 @@ func newClient(cfg config.Config, transport http.RoundTripper) (backend.Client, 
 	if strings.TrimSpace(cfg.ObjectStore.Region) == "" {
 		return nil, fmt.Errorf("%s is required for the objectstore backend", config.EnvObjectStoreRegion)
 	}
-	if cfg.ObjectStore.Endpoint != "" && !strings.HasPrefix(cfg.ObjectStore.Endpoint, "https://") {
-		return nil, fmt.Errorf("%s must be an absolute https:// URL; a non-TLS endpoint would send credentials and segment data in cleartext", config.EnvObjectStoreEndpoint)
+	if !config.ValidObjectStoreEndpoint(cfg.ObjectStore.Endpoint) {
+		return nil, fmt.Errorf("%s must be an absolute https:// URL with a host; a non-https or hostless endpoint is invalid", config.EnvObjectStoreEndpoint)
 	}
 	source, err := hostname()
 	if err != nil {

--- a/src/compute-plane-services/request-trace-uploader/backend/objectstore/objectstore.go
+++ b/src/compute-plane-services/request-trace-uploader/backend/objectstore/objectstore.go
@@ -34,6 +34,8 @@ func init() {
 // Client uploads segments to a generic S3-compatible object store with one
 // synchronous PutObject call per segment.
 type Client struct {
+	// s3 is nil in dry-run mode: Submit logs the computed bucket, key, and
+	// size instead of calling the store.
 	s3     *s3.Client
 	bucket string
 	prefix string
@@ -42,6 +44,10 @@ type Client struct {
 	// two different segments: segment.Discover indexes restart from zero
 	// independently per instance, so a bare file name is not globally unique.
 	source string
+	// dryRun computes and logs what Submit would upload without calling the
+	// store or requiring credentials. See Capabilities: a dry run never
+	// exports, so its source segments are never deleted.
+	dryRun bool
 }
 
 // hostname resolves the identifier used to namespace object keys per
@@ -65,13 +71,19 @@ type credentials struct {
 // at the first upload. config.Load already rejects a non-https endpoint, but
 // New enforces it again: a config.Config can also be constructed directly,
 // bypassing Load.
+//
+// DryRun skips the credential requirement: it never calls the store, so it
+// never authenticates to one. Bucket, region, and the endpoint scheme are
+// still validated, so a dry run exercises the same configuration a real
+// upload would.
 func New(cfg config.Config) (backend.Client, error) {
 	return newClient(cfg, nil)
 }
 
 // newClient builds the backend with an optional transport override, so a test
 // can point it at an httptest.Server whose TLS certificate the default
-// transport would not trust. A nil transport uses the SDK default.
+// transport would not trust. A nil transport uses the SDK default. It is
+// unused in dry-run mode, which never constructs an S3 client.
 //
 // The resulting HTTP client always rejects a redirect to a non-https URL,
 // regardless of the transport: an https:// endpoint only bounds the first
@@ -84,13 +96,26 @@ func newClient(cfg config.Config, transport http.RoundTripper) (backend.Client, 
 	if strings.TrimSpace(cfg.ObjectStore.Region) == "" {
 		return nil, fmt.Errorf("%s is required for the objectstore backend", config.EnvObjectStoreRegion)
 	}
-	creds, err := loadCredentials(cfg.SecretsFile)
-	if err != nil {
-		return nil, err
+	if cfg.ObjectStore.Endpoint != "" && !strings.HasPrefix(cfg.ObjectStore.Endpoint, "https://") {
+		return nil, fmt.Errorf("%s must be an absolute https:// URL; a non-TLS endpoint would send credentials and segment data in cleartext", config.EnvObjectStoreEndpoint)
 	}
 	source, err := hostname()
 	if err != nil {
 		return nil, fmt.Errorf("objectstore backend: read hostname to namespace object keys: %w", err)
+	}
+
+	if cfg.ObjectStore.DryRun {
+		return &Client{
+			bucket: cfg.ObjectStore.Bucket,
+			prefix: cfg.ObjectStore.KeyPrefix,
+			source: source,
+			dryRun: true,
+		}, nil
+	}
+
+	creds, err := loadCredentials(cfg.SecretsFile)
+	if err != nil {
+		return nil, err
 	}
 
 	options := s3.Options{
@@ -105,9 +130,6 @@ func newClient(cfg config.Config, transport http.RoundTripper) (backend.Client, 
 		UsePathStyle: cfg.ObjectStore.PathStyle,
 	}
 	if cfg.ObjectStore.Endpoint != "" {
-		if !strings.HasPrefix(cfg.ObjectStore.Endpoint, "https://") {
-			return nil, fmt.Errorf("%s must be an absolute https:// URL; a non-TLS endpoint would send credentials and segment data in cleartext", config.EnvObjectStoreEndpoint)
-		}
 		options.BaseEndpoint = aws.String(cfg.ObjectStore.Endpoint)
 	}
 	options.HTTPClient = &http.Client{
@@ -154,6 +176,10 @@ func loadCredentials(path string) (credentials, error) {
 // Submit uploads the segment at request.Path and returns once the store has
 // durably accepted it. The returned id is the object key: Status looks
 // nothing up because Capabilities declares TerminalOutcomeSync.
+//
+// In dry-run mode, Submit stats the segment, computes the key, logs both
+// along with the bucket and size, and returns without opening the file or
+// contacting a store.
 func (c *Client) Submit(ctx context.Context, request backend.SubmitRequest) (string, error) {
 	info, err := os.Stat(request.Path)
 	if err != nil {
@@ -161,6 +187,16 @@ func (c *Client) Submit(ctx context.Context, request backend.SubmitRequest) (str
 	}
 	if info.Size() > maxObjectBytes {
 		return "", fmt.Errorf("objectstore backend: segment is %d bytes, over the %d byte single-object limit", info.Size(), maxObjectBytes)
+	}
+
+	key := c.key(request.Path)
+	if c.dryRun {
+		slog.Info("objectstore backend: dry run, not uploading",
+			"segment", request.Segment.Index,
+			"bucket", c.bucket,
+			"key", key,
+			"bytes", info.Size())
+		return key, nil
 	}
 
 	file, err := os.Open(request.Path)
@@ -173,7 +209,6 @@ func (c *Client) Submit(ctx context.Context, request backend.SubmitRequest) (str
 		}
 	}()
 
-	key := c.key(request.Path)
 	if _, err := c.s3.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:        aws.String(c.bucket),
 		Key:           aws.String(key),
@@ -196,6 +231,10 @@ func (c *Client) Status(context.Context, string) (backend.Status, error) {
 // call: a Submit that returns success is already durable, resubmitting the
 // same segment overwrites the same key, and segments are independent objects
 // so nothing requires in-order delivery.
+//
+// Exports is false in dry-run mode: nothing was sent anywhere, so a caller
+// must never delete a source segment on the strength of a dry-run Submit
+// succeeding, the same rule debug's Capabilities enforces for its own reads.
 func (c *Client) Capabilities() backend.Capabilities {
 	return backend.Capabilities{
 		ResubmitSafe:        true,
@@ -203,7 +242,7 @@ func (c *Client) Capabilities() backend.Capabilities {
 		OutOfOrderTolerant:  true,
 		AcceptedFormats:     []backend.Format{backend.FormatGzipJSONL},
 		MaxObjectBytes:      maxObjectBytes,
-		Exports:             true,
+		Exports:             !c.dryRun,
 	}
 }
 

--- a/src/compute-plane-services/request-trace-uploader/backend/objectstore/objectstore_test.go
+++ b/src/compute-plane-services/request-trace-uploader/backend/objectstore/objectstore_test.go
@@ -336,3 +336,99 @@ func TestCapabilitiesDeclareExportAndSyncOutcome(t *testing.T) {
 		t.Errorf("Capabilities().MaxObjectBytes = %d, want %d", caps.MaxObjectBytes, maxObjectBytes)
 	}
 }
+
+// TestNewDryRunSkipsCredentials confirms a dry run needs no secrets file: it
+// never authenticates to a store, so requiring credentials would defeat the
+// point of testing config and key computation without one.
+func TestNewDryRunSkipsCredentials(t *testing.T) {
+	cfg := baseConfig(filepath.Join(t.TempDir(), "missing.json"), "https://127.0.0.1:0")
+	cfg.ObjectStore.DryRun = true
+	if _, err := New(cfg); err != nil {
+		t.Fatalf("New() error = %v, want a dry run to skip the credentials file", err)
+	}
+}
+
+// TestNewDryRunStillRequiresBucketRegionAndHTTPS confirms a dry run still
+// validates the settings a real upload would need, so it exercises the same
+// configuration surface rather than a reduced one.
+func TestNewDryRunStillRequiresBucketRegionAndHTTPS(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*config.Config)
+	}{
+		{name: "missing bucket", mutate: func(c *config.Config) { c.ObjectStore.Bucket = "" }},
+		{name: "missing region", mutate: func(c *config.Config) { c.ObjectStore.Region = "" }},
+		{name: "http endpoint", mutate: func(c *config.Config) { c.ObjectStore.Endpoint = "http://127.0.0.1:0" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := baseConfig(filepath.Join(t.TempDir(), "missing.json"), "https://127.0.0.1:0")
+			cfg.ObjectStore.DryRun = true
+			tt.mutate(&cfg)
+			if _, err := New(cfg); err == nil {
+				t.Fatal("New() error = nil, want dry run to still validate this setting")
+			}
+		})
+	}
+}
+
+func TestSubmitDryRunLogsAndDoesNotUpload(t *testing.T) {
+	withHostname(t, "pod-a")
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("dry run must not contact the store")
+	}))
+	defer server.Close()
+
+	cfg := baseConfig(filepath.Join(t.TempDir(), "missing.json"), server.URL)
+	cfg.ObjectStore.KeyPrefix = "segments"
+	cfg.ObjectStore.DryRun = true
+	client, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	path := writeSegment(t, "fixture")
+	id, err := client.Submit(context.Background(), backend.SubmitRequest{Path: path})
+	if err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+	if id != "segments/pod-a/request-trace.000000.jsonl.gz" {
+		t.Errorf("Submit() id = %q, want the computed object key", id)
+	}
+
+	status, err := client.Status(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if status != backend.StatusSuccess {
+		t.Errorf("Status() = %v, want success", status)
+	}
+}
+
+func TestSubmitDryRunFailsOnAMissingSegment(t *testing.T) {
+	cfg := baseConfig(filepath.Join(t.TempDir(), "missing.json"), "https://127.0.0.1:0")
+	cfg.ObjectStore.DryRun = true
+	client, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	_, err = client.Submit(context.Background(), backend.SubmitRequest{Path: "/nonexistent/request-trace.000000.jsonl.gz"})
+	if err == nil {
+		t.Fatal("Submit() error = nil, want a stat failure even in dry-run mode")
+	}
+}
+
+// TestCapabilitiesDryRunDoesNotExport guards the deletion decision in
+// service.Refresh: a dry run must report Exports=false so a caller never
+// deletes a source segment on the strength of a dry-run Submit succeeding.
+func TestCapabilitiesDryRunDoesNotExport(t *testing.T) {
+	cfg := baseConfig(filepath.Join(t.TempDir(), "missing.json"), "https://127.0.0.1:0")
+	cfg.ObjectStore.DryRun = true
+	client, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if client.Capabilities().Exports {
+		t.Error("Capabilities().Exports = true, want false for a dry run")
+	}
+}

--- a/src/compute-plane-services/request-trace-uploader/backend/objectstore/objectstore_test.go
+++ b/src/compute-plane-services/request-trace-uploader/backend/objectstore/objectstore_test.go
@@ -99,6 +99,16 @@ func TestNewRejectsAnHTTPEndpoint(t *testing.T) {
 	}
 }
 
+// TestNewRejectsAnHTTPSEndpointWithNoHost guards against a scheme-only
+// endpoint: "https://" has the right prefix but no host, so a prefix check
+// alone would accept it and newClient would only fail later, deep in the SDK.
+func TestNewRejectsAnHTTPSEndpointWithNoHost(t *testing.T) {
+	cfg := baseConfig(writeSecrets(t, `{"access_key_id":"a","secret_access_key":"b"}`), "https://")
+	if _, err := New(cfg); err == nil {
+		t.Fatal("New() error = nil, want a hostless endpoint to be rejected")
+	}
+}
+
 func TestNewFailsWhenHostnameIsUnavailable(t *testing.T) {
 	original := hostname
 	hostname = func() (string, error) { return "", errors.New("no hostname") }

--- a/src/compute-plane-services/request-trace-uploader/config/config.go
+++ b/src/compute-plane-services/request-trace-uploader/config/config.go
@@ -7,6 +7,7 @@ package config
 import (
 	"fmt"
 	"math"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -94,9 +95,9 @@ type ObjectStorePolicy struct {
 	Region string
 	// Endpoint overrides the AWS endpoint resolution for an S3-compatible
 	// store that is not AWS. Empty uses the SDK default for Region. When set,
-	// it must be an absolute https:// URL: Load rejects a plain http://
-	// endpoint because it would send credentials and segment data in
-	// cleartext.
+	// it must satisfy ValidObjectStoreEndpoint: an absolute https:// URL with
+	// a host. A non-https or hostless endpoint would send credentials and
+	// segment data in cleartext, or to nowhere.
 	Endpoint string
 	// KeyPrefix is joined with each segment's file name to form its object
 	// key. Empty uploads to the bucket root.
@@ -193,8 +194,8 @@ func Load(lookup LookupFunc) (Config, []string, error) {
 	multiplier := floatValue(lookup, EnvRetryMultiplier, DefaultRetryMultiplier, 1.1, 10.0, &warnings)
 
 	objectStoreEndpoint := strings.TrimSpace(valueOrDefault(lookup, EnvObjectStoreEndpoint, ""))
-	if objectStoreEndpoint != "" && !strings.HasPrefix(objectStoreEndpoint, "https://") {
-		return Config{}, nil, fmt.Errorf("%s must be an absolute https:// URL; a non-TLS endpoint would send credentials and segment data in cleartext", EnvObjectStoreEndpoint)
+	if !ValidObjectStoreEndpoint(objectStoreEndpoint) {
+		return Config{}, nil, fmt.Errorf("%s must be an absolute https:// URL with a host; a non-https or hostless endpoint is invalid", EnvObjectStoreEndpoint)
 	}
 	objectStore := ObjectStorePolicy{
 		Bucket:    strings.TrimSpace(valueOrDefault(lookup, EnvObjectStoreBucket, "")),
@@ -264,6 +265,23 @@ func optionalName(lookup LookupFunc, name, fallback string) (string, error) {
 		return "", fmt.Errorf("%s must not contain a path separator", name)
 	}
 	return value, nil
+}
+
+// ValidObjectStoreEndpoint reports whether endpoint is a safe value for
+// ObjectStorePolicy.Endpoint: empty, meaning use the SDK default for Region,
+// or an absolute https:// URL with a nonempty host. A bare scheme such as
+// "https://" parses without error but has no host, so a prefix check alone
+// would accept it; both Load and the objectstore backend's own constructor
+// call this so the rule cannot be bypassed by constructing a Config directly.
+func ValidObjectStoreEndpoint(endpoint string) bool {
+	if endpoint == "" {
+		return true
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return false
+	}
+	return parsed.Scheme == "https" && parsed.Host != ""
 }
 
 func backendValue(lookup LookupFunc, name string) (Backend, error) {

--- a/src/compute-plane-services/request-trace-uploader/config/config.go
+++ b/src/compute-plane-services/request-trace-uploader/config/config.go
@@ -36,6 +36,7 @@ const (
 	EnvObjectStoreEndpoint  = "REQUEST_TRACE_UPLOADER_OBJECTSTORE_ENDPOINT"
 	EnvObjectStoreKeyPrefix = "REQUEST_TRACE_UPLOADER_OBJECTSTORE_KEY_PREFIX"
 	EnvObjectStorePathStyle = "REQUEST_TRACE_UPLOADER_OBJECTSTORE_PATH_STYLE"
+	EnvObjectStoreDryRun    = "REQUEST_TRACE_UPLOADER_OBJECTSTORE_DRY_RUN"
 	DefaultSecretsFile      = "/var/secrets/secrets.json"
 	DefaultHealthAddr       = ":8011"
 	DefaultSegmentPrefix    = "request-trace"
@@ -103,6 +104,11 @@ type ObjectStorePolicy struct {
 	// PathStyle selects path-style bucket addressing, which most non-AWS
 	// S3-compatible stores require.
 	PathStyle bool
+	// DryRun computes and logs the bucket, key, and size the backend would
+	// upload, but never calls the store and never requires credentials. It
+	// exists to exercise config, key computation, and hostname namespacing
+	// without a destination, the same role debug plays for the read path.
+	DryRun bool
 }
 
 // KratosPolicy bounds the asynchronous job polling that only the Kratos Bulk
@@ -196,6 +202,7 @@ func Load(lookup LookupFunc) (Config, []string, error) {
 		Endpoint:  objectStoreEndpoint,
 		KeyPrefix: strings.Trim(strings.TrimSpace(valueOrDefault(lookup, EnvObjectStoreKeyPrefix, "")), "/"),
 		PathStyle: boolValue(lookup, EnvObjectStorePathStyle, false, &warnings),
+		DryRun:    boolValue(lookup, EnvObjectStoreDryRun, false, &warnings),
 	}
 
 	return Config{

--- a/src/compute-plane-services/request-trace-uploader/config/config_test.go
+++ b/src/compute-plane-services/request-trace-uploader/config/config_test.go
@@ -133,6 +133,36 @@ func TestLoadAcceptsAnHTTPSObjectStoreEndpoint(t *testing.T) {
 	}
 }
 
+func TestLoadParsesObjectStoreDryRun(t *testing.T) {
+	cfg, _, err := Load(testLookup(map[string]string{
+		EnvSourceDir:         "/records",
+		EnvBackend:           "objectstore",
+		EnvObjectStoreDryRun: "true",
+	}))
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if !cfg.ObjectStore.DryRun {
+		t.Fatal("ObjectStore.DryRun = false, want true")
+	}
+}
+
+func TestLoadDefaultsObjectStoreDryRunToFalse(t *testing.T) {
+	cfg, warnings, err := Load(testLookup(map[string]string{
+		EnvSourceDir: "/records",
+		EnvBackend:   "objectstore",
+	}))
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if cfg.ObjectStore.DryRun {
+		t.Fatal("ObjectStore.DryRun = true, want false by default")
+	}
+}
+
 func testLookup(values map[string]string) LookupFunc {
 	return func(name string) (string, bool) {
 		value, ok := values[name]

--- a/src/compute-plane-services/request-trace-uploader/config/config_test.go
+++ b/src/compute-plane-services/request-trace-uploader/config/config_test.go
@@ -109,6 +109,7 @@ func TestLoadRejectsInvalidRequiredValues(t *testing.T) {
 		{name: "prefix with separator", env: map[string]string{EnvSourceDir: "/records", EnvBackend: "objectstore", EnvSegmentPrefix: "nested/prefix"}},
 		{name: "http objectstore endpoint", env: map[string]string{EnvSourceDir: "/records", EnvBackend: "objectstore", EnvObjectStoreEndpoint: "http://minio.internal:9000"}},
 		{name: "schemeless objectstore endpoint", env: map[string]string{EnvSourceDir: "/records", EnvBackend: "objectstore", EnvObjectStoreEndpoint: "minio.internal:9000"}},
+		{name: "hostless objectstore endpoint", env: map[string]string{EnvSourceDir: "/records", EnvBackend: "objectstore", EnvObjectStoreEndpoint: "https://"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Why

Testing the objectstore backend end to end, including hostname-based key namespacing, currently requires real bucket credentials and a reachable store. There is no way to exercise the config and key computation path standalone, the same role `backend/debug` plays for the read path.

## What changed

Adds `REQUEST_TRACE_UPLOADER_OBJECTSTORE_DRY_RUN`. When set, `Submit` stats the segment, computes the object key (bucket, prefix, hostname, segment name), logs all of it plus the size, and returns success without opening the file, building an S3 client, or requiring credentials. Bucket, region, and the https-only endpoint check are still validated, so a dry run exercises the same configuration a real upload would.

`Capabilities().Exports` is `false` in dry-run mode, the same rule `debug` already enforces for its own reads: nothing was sent anywhere, so `service.Refresh` must never delete a source segment on the strength of a dry-run `Submit` succeeding.

## Customer Release Notes

Not customer visible.

## Plan Summary

Not applicable.

## Usage

```
REQUEST_TRACE_UPLOADER_BACKEND=objectstore
REQUEST_TRACE_UPLOADER_OBJECTSTORE_BUCKET=<bucket>
REQUEST_TRACE_UPLOADER_OBJECTSTORE_REGION=<region>
REQUEST_TRACE_UPLOADER_OBJECTSTORE_DRY_RUN=true
```

No `REQUEST_TRACE_UPLOADER_SECRETS_FILE` is read in dry-run mode.

## Testing

`go build`, `go vet`, and `go test ./...` all pass for this module. New tests: dry run skips the credentials file; dry run still requires bucket, region, and an https endpoint; `Submit` logs and returns the computed key without contacting a store (the test fails if the store handler is ever invoked); `Submit` still fails on a missing source segment; `Capabilities().Exports` is false; `config.Load` parses the new env var and defaults it to false.

## Notes

Builds on #1544 (not yet merged); based on that branch. Base branch for this PR is `kpathak/feat-uploader-objectstore-backend`, not `main`.

## References

Relates to #1004

## Related Pull Requests

Builds on #1544.

## Dependencies

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added object-store dry-run mode through configuration.
  * Dry runs validate bucket, region, and HTTPS endpoint settings without loading credentials, creating a client, or uploading files.
  * Dry-run submissions report computed upload details while leaving source files unchanged.
  * Export capabilities are unavailable during dry runs.
* **Bug Fixes**
  * Object-store endpoints must now use absolute HTTPS URLs with a hostname.
  * Invalid dry-run configuration values safely fall back with a warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->