### PR TITLE
feat(uploader): add a detailed verbosity to the debug backend

### DIFF
--- a/src/compute-plane-services/request-trace-uploader/backend/debug/debug.go
+++ b/src/compute-plane-services/request-trace-uploader/backend/debug/debug.go
@@ -133,12 +133,30 @@ func (c *Client) Capabilities() backend.Capabilities {
 	}
 }
 
+// maxLoggedFieldBytes bounds a free-text metadata field before logRecord logs
+// it. Model, ToolClass, Status, and DropReason come straight from segment
+// JSON with no upstream length validation, so a malformed or adversarial
+// record could otherwise put an arbitrarily large value in a field this
+// backend treats as short metadata, inflating one log line without limit.
+const maxLoggedFieldBytes = 256
+
+// truncate bounds a string before it is logged. It cuts on a byte boundary
+// rather than a rune boundary: precise multi-byte truncation is not worth the
+// complexity for a diagnostic aid, and a split multi-byte character at the
+// boundary is still visibly marked as truncated.
+func truncate(s string) string {
+	if len(s) <= maxLoggedFieldBytes {
+		return s
+	}
+	return s[:maxLoggedFieldBytes] + "...(truncated)"
+}
+
 // logRecord logs one detailed-verbosity line for a single record. It carries
 // non-identifying metrics and metadata only: token counts, timing, model
 // name, tool class and status, and whether a payload is complete. It never
 // logs a request identifier, a session identifier, a header value, or a
 // request or response body, matching the containment rule Submit's basic
-// summary already follows.
+// summary already follows. Free-text fields are bounded by truncate.
 func logRecord(segment, index int, rec *record.Record) {
 	args := []any{
 		"segment", segment,
@@ -157,7 +175,7 @@ func logRecord(segment, index int, rec *record.Record) {
 	}
 	if req := rec.Request; req != nil {
 		if req.Model != "" {
-			args = append(args, "model", req.Model)
+			args = append(args, "model", truncate(req.Model))
 		}
 		if req.InputTokens != nil {
 			args = append(args, "input_tokens", *req.InputTokens)
@@ -180,10 +198,10 @@ func logRecord(segment, index int, rec *record.Record) {
 	}
 	if tool := rec.Tool; tool != nil {
 		if tool.ToolClass != "" {
-			args = append(args, "tool_class", tool.ToolClass)
+			args = append(args, "tool_class", truncate(tool.ToolClass))
 		}
 		if tool.Status != "" {
-			args = append(args, "status", tool.Status)
+			args = append(args, "status", truncate(tool.Status))
 		}
 		if tool.DurationMS != nil {
 			args = append(args, "duration_ms", *tool.DurationMS)
@@ -192,10 +210,10 @@ func logRecord(segment, index int, rec *record.Record) {
 	if payload := rec.Payload; payload != nil {
 		args = append(args, "payload_complete", payload.Complete)
 		if payload.Model != "" {
-			args = append(args, "model", payload.Model)
+			args = append(args, "model", truncate(payload.Model))
 		}
 		if payload.DropReason != "" {
-			args = append(args, "drop_reason", payload.DropReason)
+			args = append(args, "drop_reason", truncate(payload.DropReason))
 		}
 	}
 	slog.Info("debug backend read a record", args...)

--- a/src/compute-plane-services/request-trace-uploader/backend/debug/debug.go
+++ b/src/compute-plane-services/request-trace-uploader/backend/debug/debug.go
@@ -8,6 +8,12 @@
 // credentials, a bucket, or a namespace. Selecting it reads each closed
 // segment, reports what was in it, and reports success without transmitting
 // anything or deleting the source.
+//
+// config.EnvDebugVerbosity controls how much it logs. The default,
+// config.DebugVerbosityBasic, logs one summary line per segment.
+// config.DebugVerbosityDetailed adds one line per record. Both levels omit
+// request identifiers, session identifiers, header values, and request or
+// response bodies: verbosity changes resolution, not what is safe to log.
 package debug
 
 import (
@@ -26,17 +32,25 @@ func init() {
 }
 
 // Client reports segments instead of exporting them.
-type Client struct{}
+type Client struct {
+	verbosity config.DebugVerbosity
+}
 
-// New builds the debug backend.
-func New(config.Config) (backend.Client, error) { return &Client{}, nil }
+// New builds the debug backend. Unset or unrecognized verbosity behaves as
+// config.DebugVerbosityBasic: an empty Config, such as one built directly in
+// a test rather than through config.Load, still gets the safe default.
+func New(cfg config.Config) (backend.Client, error) {
+	return &Client{verbosity: cfg.DebugVerbosity}, nil
+}
 
 // Submit reads the segment and reports what it contains.
 //
-// It reports counts and shapes only. Request identifiers, session
-// identifiers, header values, and record bodies are deliberately absent: this
-// is a diagnostic aid, and its output is subject to the same containment rules
-// as any other uploader log.
+// At config.DebugVerbosityBasic, the default, it reports counts and shapes
+// only. At config.DebugVerbosityDetailed it also logs one line per record
+// with non-identifying metrics and metadata. Neither level ever logs a
+// request identifier, a session identifier, a header value, or a request or
+// response body: this is a diagnostic aid, and its output is subject to the
+// same containment rules as any other uploader log regardless of verbosity.
 func (c *Client) Submit(ctx context.Context, request backend.SubmitRequest) (string, error) {
 	reader, err := record.Open(request.Path)
 	if err != nil {
@@ -48,6 +62,7 @@ func (c *Client) Submit(ctx context.Context, request backend.SubmitRequest) (str
 	withSession := 0
 	withHeaders := 0
 	incomplete := 0
+	index := 0
 
 	// A segment can hold many records, so a scan must not outlive a shutdown.
 	// The check runs before each advance and once more after the loop, so a
@@ -73,6 +88,10 @@ func (c *Client) Submit(ctx context.Context, request backend.SubmitRequest) (str
 		if rec.Payload != nil && !rec.Payload.Complete {
 			incomplete++
 		}
+		if c.verbosity == config.DebugVerbosityDetailed {
+			logRecord(request.Segment.Index, index, rec)
+		}
+		index++
 	}
 	if err := reader.Err(); err != nil {
 		return "", fmt.Errorf("debug backend: %w", err)
@@ -112,6 +131,74 @@ func (c *Client) Capabilities() backend.Capabilities {
 		AcceptedFormats:     []backend.Format{backend.FormatGzipJSONL},
 		Exports:             false,
 	}
+}
+
+// logRecord logs one detailed-verbosity line for a single record. It carries
+// non-identifying metrics and metadata only: token counts, timing, model
+// name, tool class and status, and whether a payload is complete. It never
+// logs a request identifier, a session identifier, a header value, or a
+// request or response body, matching the containment rule Submit's basic
+// summary already follows.
+func logRecord(segment, index int, rec *record.Record) {
+	args := []any{
+		"segment", segment,
+		"record", index,
+		"event_type", rec.EventType,
+		"bytes", len(rec.Raw),
+	}
+	if _, ok := rec.RequestID(); ok {
+		args = append(args, "has_request_id", true)
+	}
+	if _, ok := rec.SessionID(); ok {
+		args = append(args, "has_session_id", true)
+	}
+	if len(rec.Headers()) > 0 {
+		args = append(args, "has_headers", true)
+	}
+	if req := rec.Request; req != nil {
+		if req.Model != "" {
+			args = append(args, "model", req.Model)
+		}
+		if req.InputTokens != nil {
+			args = append(args, "input_tokens", *req.InputTokens)
+		}
+		if req.OutputTokens != nil {
+			args = append(args, "output_tokens", *req.OutputTokens)
+		}
+		if req.CachedTokens != nil {
+			args = append(args, "cached_tokens", *req.CachedTokens)
+		}
+		if req.TTFTMS != nil {
+			args = append(args, "ttft_ms", *req.TTFTMS)
+		}
+		if req.TotalTimeMS != nil {
+			args = append(args, "total_time_ms", *req.TotalTimeMS)
+		}
+		if req.QueueDepth != nil {
+			args = append(args, "queue_depth", *req.QueueDepth)
+		}
+	}
+	if tool := rec.Tool; tool != nil {
+		if tool.ToolClass != "" {
+			args = append(args, "tool_class", tool.ToolClass)
+		}
+		if tool.Status != "" {
+			args = append(args, "status", tool.Status)
+		}
+		if tool.DurationMS != nil {
+			args = append(args, "duration_ms", *tool.DurationMS)
+		}
+	}
+	if payload := rec.Payload; payload != nil {
+		args = append(args, "payload_complete", payload.Complete)
+		if payload.Model != "" {
+			args = append(args, "model", payload.Model)
+		}
+		if payload.DropReason != "" {
+			args = append(args, "drop_reason", payload.DropReason)
+		}
+	}
+	slog.Info("debug backend read a record", args...)
 }
 
 // formatCounts renders the per-event-type counts in a stable order so log

--- a/src/compute-plane-services/request-trace-uploader/backend/debug/debug_test.go
+++ b/src/compute-plane-services/request-trace-uploader/backend/debug/debug_test.go
@@ -8,14 +8,27 @@ import (
 	"compress/gzip"
 	"context"
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/request-trace-uploader/backend"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/request-trace-uploader/config"
 	"github.com/NVIDIA/nvcf/src/compute-plane-services/request-trace-uploader/segment"
 )
+
+// captureLogs redirects the default slog logger to a buffer for the duration
+// of a test, so a test can assert on what was, or was not, logged.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(original) })
+	return &buf
+}
 
 func writeSegment(t *testing.T, lines ...string) string {
 	t.Helper()
@@ -134,5 +147,102 @@ func TestSubmitOnAnEmptySegmentSucceeds(t *testing.T) {
 	}
 	if id == "" {
 		t.Fatal("Submit() returned an empty id")
+	}
+}
+
+func TestNewDefaultsToBasicVerbosity(t *testing.T) {
+	client, err := New(config.Config{Backend: config.BackendDebug})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	debugClient, ok := client.(*Client)
+	if !ok {
+		t.Fatalf("New() returned %T, want *Client", client)
+	}
+	if debugClient.verbosity == config.DebugVerbosityDetailed {
+		t.Error("New() with an unset verbosity behaved as detailed, want basic")
+	}
+}
+
+// sensitiveFixture carries a request identifier, a session identifier, and a
+// header value in a spot each event type actually places one, plus
+// non-identifying metrics that detailed verbosity is allowed to log.
+func sensitiveFixture(t *testing.T) string {
+	t.Helper()
+	return writeSegment(t,
+		`{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":1,"request":{"request_id":"req-secret-id","model":"llama-70b","input_tokens":10,"output_tokens":20}}`,
+		`{"schema":"dynamo.request.trace.v1","event_type":"tool_start","event_time_unix_ms":2,"agent_context":{"session_id":"session-secret-id"},"tool":{"tool_call_id":"tool-secret-id","tool_class":"search","status":"ok"}}`,
+		`{"schema":"dynamo.request.trace.v1","event_type":"request_payload","event_time_unix_ms":3,"payload":{"request_id":"req-secret-id","payload_complete":true,"http_request_headers":{"nvcf-ncaid":"header-secret-value"}}}`,
+	)
+}
+
+func TestSubmitBasicVerbosityLogsOnlyTheSummary(t *testing.T) {
+	path := sensitiveFixture(t)
+	logs := captureLogs(t)
+
+	client := &Client{verbosity: config.DebugVerbosityBasic}
+	if _, err := client.Submit(context.Background(), backend.SubmitRequest{
+		Segment: segment.Segment{Index: 0, Path: path},
+		Path:    path,
+	}); err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+
+	output := logs.String()
+	if !strings.Contains(output, "debug backend read a segment") {
+		t.Error("basic verbosity did not log the segment summary")
+	}
+	if strings.Contains(output, "debug backend read a record") {
+		t.Error("basic verbosity logged a per-record line, want summary only")
+	}
+}
+
+func TestSubmitDetailedVerbosityLogsPerRecord(t *testing.T) {
+	path := sensitiveFixture(t)
+	logs := captureLogs(t)
+
+	client := &Client{verbosity: config.DebugVerbosityDetailed}
+	if _, err := client.Submit(context.Background(), backend.SubmitRequest{
+		Segment: segment.Segment{Index: 0, Path: path},
+		Path:    path,
+	}); err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+
+	output := logs.String()
+	if got := strings.Count(output, "debug backend read a record"); got != 3 {
+		t.Errorf("detailed verbosity logged %d per-record lines, want 3", got)
+	}
+	if !strings.Contains(output, "debug backend read a segment") {
+		t.Error("detailed verbosity did not also log the segment summary")
+	}
+	for _, want := range []string{"model=llama-70b", "input_tokens=10", "output_tokens=20", "tool_class=search", "status=ok"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("detailed verbosity output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+// TestSubmitDetailedVerbosityNeverLogsIdentifyingValues is the containment
+// guarantee: detailed verbosity adds resolution, not exposure. A request
+// identifier, a session identifier, and a header value must never appear in
+// the log regardless of verbosity.
+func TestSubmitDetailedVerbosityNeverLogsIdentifyingValues(t *testing.T) {
+	path := sensitiveFixture(t)
+	logs := captureLogs(t)
+
+	client := &Client{verbosity: config.DebugVerbosityDetailed}
+	if _, err := client.Submit(context.Background(), backend.SubmitRequest{
+		Segment: segment.Segment{Index: 0, Path: path},
+		Path:    path,
+	}); err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+
+	output := logs.String()
+	for _, forbidden := range []string{"req-secret-id", "session-secret-id", "tool-secret-id", "header-secret-value"} {
+		if strings.Contains(output, forbidden) {
+			t.Errorf("detailed verbosity leaked an identifying value %q:\n%s", forbidden, output)
+		}
 	}
 }

--- a/src/compute-plane-services/request-trace-uploader/backend/debug/debug_test.go
+++ b/src/compute-plane-services/request-trace-uploader/backend/debug/debug_test.go
@@ -246,3 +246,31 @@ func TestSubmitDetailedVerbosityNeverLogsIdentifyingValues(t *testing.T) {
 		}
 	}
 }
+
+// TestSubmitDetailedVerbosityTruncatesOversizedFields guards against an
+// unbounded log line: Model has no length validation upstream, so a
+// malformed or adversarial record could otherwise put an arbitrarily large
+// value there.
+func TestSubmitDetailedVerbosityTruncatesOversizedFields(t *testing.T) {
+	huge := strings.Repeat("a", 5000)
+	path := writeSegment(t,
+		`{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":1,"request":{"request_id":"req-1","model":"`+huge+`"}}`,
+	)
+	logs := captureLogs(t)
+
+	client := &Client{verbosity: config.DebugVerbosityDetailed}
+	if _, err := client.Submit(context.Background(), backend.SubmitRequest{
+		Segment: segment.Segment{Index: 0, Path: path},
+		Path:    path,
+	}); err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+
+	output := logs.String()
+	if strings.Contains(output, huge) {
+		t.Error("detailed verbosity logged an oversized field without truncation")
+	}
+	if !strings.Contains(output, "...(truncated)") {
+		t.Error("detailed verbosity did not mark the oversized field as truncated")
+	}
+}

--- a/src/compute-plane-services/request-trace-uploader/config/config.go
+++ b/src/compute-plane-services/request-trace-uploader/config/config.go
@@ -38,6 +38,7 @@ const (
 	EnvObjectStoreKeyPrefix = "REQUEST_TRACE_UPLOADER_OBJECTSTORE_KEY_PREFIX"
 	EnvObjectStorePathStyle = "REQUEST_TRACE_UPLOADER_OBJECTSTORE_PATH_STYLE"
 	EnvObjectStoreDryRun    = "REQUEST_TRACE_UPLOADER_OBJECTSTORE_DRY_RUN"
+	EnvDebugVerbosity       = "REQUEST_TRACE_UPLOADER_DEBUG_VERBOSITY"
 	DefaultSecretsFile      = "/var/secrets/secrets.json"
 	DefaultHealthAddr       = ":8011"
 	DefaultSegmentPrefix    = "request-trace"
@@ -65,6 +66,24 @@ const (
 	BackendDebug Backend = "debug"
 )
 
+// DebugVerbosity controls how much the debug backend logs per segment.
+type DebugVerbosity string
+
+const (
+	// DebugVerbosityBasic logs one summary line per segment: counts and
+	// shapes only. This is the default, and matches the containment rule
+	// every uploader backend follows: no request identifiers, session
+	// identifiers, header values, or record bodies in a log line.
+	DebugVerbosityBasic DebugVerbosity = "basic"
+	// DebugVerbosityDetailed adds one line per record with its index, event
+	// type, and byte size, plus the non-identifying metrics and metadata
+	// each record type carries (tokens, timing, model, tool class and
+	// status). It still never logs a request identifier, a session
+	// identifier, a header value, or a request or response body: verbosity
+	// changes resolution, not the containment rule.
+	DebugVerbosityDetailed DebugVerbosity = "detailed"
+)
+
 // LookupFunc obtains one environment setting.
 type LookupFunc func(string) (string, bool)
 
@@ -74,17 +93,18 @@ type LookupFunc func(string) (string, bool)
 // uploader scans a single prefix. Record classification comes from event_type
 // on each record, which the parsing increment adds.
 type Config struct {
-	SourceDir     string
-	SegmentPrefix string
-	Backend       Backend
-	SecretsFile   string
-	StateDir      string
-	QuarantineDir string
-	HealthAddr    string
-	ScanInterval  time.Duration
-	RetryPolicy   RetryPolicy
-	Kratos        KratosPolicy
-	ObjectStore   ObjectStorePolicy
+	SourceDir      string
+	SegmentPrefix  string
+	Backend        Backend
+	SecretsFile    string
+	StateDir       string
+	QuarantineDir  string
+	HealthAddr     string
+	ScanInterval   time.Duration
+	RetryPolicy    RetryPolicy
+	Kratos         KratosPolicy
+	ObjectStore    ObjectStorePolicy
+	DebugVerbosity DebugVerbosity
 }
 
 // ObjectStorePolicy configures the generic S3-compatible backend. Bucket and
@@ -205,6 +225,7 @@ func Load(lookup LookupFunc) (Config, []string, error) {
 		PathStyle: boolValue(lookup, EnvObjectStorePathStyle, false, &warnings),
 		DryRun:    boolValue(lookup, EnvObjectStoreDryRun, false, &warnings),
 	}
+	debugVerbosity := debugVerbosityValue(lookup, EnvDebugVerbosity, &warnings)
 
 	return Config{
 		SourceDir:     sourceDir,
@@ -227,7 +248,8 @@ func Load(lookup LookupFunc) (Config, []string, error) {
 			MaximumBackoff:   maximumBackoff,
 			Multiplier:       multiplier,
 		},
-		ObjectStore: objectStore,
+		ObjectStore:    objectStore,
+		DebugVerbosity: debugVerbosity,
 	}, warnings, nil
 }
 
@@ -295,6 +317,25 @@ func backendValue(lookup LookupFunc, name string) (Backend, error) {
 		return Backend(value), nil
 	default:
 		return "", fmt.Errorf("%s must be one of %q, %q, or %q", name, BackendObjectStore, BackendKratos, BackendDebug)
+	}
+}
+
+// debugVerbosityValue reads the debug backend's log verbosity. An unknown
+// value falls back to DebugVerbosityBasic with a warning rather than a hard
+// error: this only changes logging, not correctness, so it does not belong
+// with the required-value checks that fail Load outright.
+func debugVerbosityValue(lookup LookupFunc, name string, warnings *[]string) DebugVerbosity {
+	value, ok := lookup(name)
+	value = strings.TrimSpace(value)
+	if !ok || value == "" {
+		return DebugVerbosityBasic
+	}
+	switch DebugVerbosity(value) {
+	case DebugVerbosityBasic, DebugVerbosityDetailed:
+		return DebugVerbosity(value)
+	default:
+		*warnings = append(*warnings, name)
+		return DebugVerbosityBasic
 	}
 }
 

--- a/src/compute-plane-services/request-trace-uploader/config/config_test.go
+++ b/src/compute-plane-services/request-trace-uploader/config/config_test.go
@@ -164,6 +164,56 @@ func TestLoadDefaultsObjectStoreDryRunToFalse(t *testing.T) {
 	}
 }
 
+func TestLoadDefaultsDebugVerbosityToBasic(t *testing.T) {
+	cfg, warnings, err := Load(testLookup(map[string]string{
+		EnvSourceDir: "/records",
+		EnvBackend:   "debug",
+	}))
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if cfg.DebugVerbosity != DebugVerbosityBasic {
+		t.Fatalf("debug verbosity = %q, want %q", cfg.DebugVerbosity, DebugVerbosityBasic)
+	}
+}
+
+func TestLoadAcceptsDetailedDebugVerbosity(t *testing.T) {
+	cfg, warnings, err := Load(testLookup(map[string]string{
+		EnvSourceDir:      "/records",
+		EnvBackend:        "debug",
+		EnvDebugVerbosity: "detailed",
+	}))
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if cfg.DebugVerbosity != DebugVerbosityDetailed {
+		t.Fatalf("debug verbosity = %q, want %q", cfg.DebugVerbosity, DebugVerbosityDetailed)
+	}
+}
+
+func TestLoadFallsBackForInvalidDebugVerbosity(t *testing.T) {
+	cfg, warnings, err := Load(testLookup(map[string]string{
+		EnvSourceDir:      "/records",
+		EnvBackend:        "debug",
+		EnvDebugVerbosity: "verbose",
+	}))
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.DebugVerbosity != DebugVerbosityBasic {
+		t.Fatalf("debug verbosity = %q, want the safe default %q", cfg.DebugVerbosity, DebugVerbosityBasic)
+	}
+	if len(warnings) != 1 || warnings[0] != EnvDebugVerbosity {
+		t.Fatalf("warnings = %v, want [%q]", warnings, EnvDebugVerbosity)
+	}
+}
+
 func testLookup(values map[string]string) LookupFunc {
 	return func(name string) (string, bool) {
 		value, ok := values[name]


### PR DESCRIPTION
## Why

The debug backend's one-line-per-segment summary is enough to confirm wiring, but not enough to see which specific record in a segment looked wrong. There was no way to get more resolution without editing code.

## What changed

Adds `REQUEST_TRACE_UPLOADER_DEBUG_VERBOSITY` with two values: `basic` (default, unchanged) and `detailed`. Detailed adds one log line per record with its index, event type, byte size, and the non-identifying metrics and metadata each record type carries: token counts, timing, model name, tool class and status, payload completeness.

Both levels keep the same containment rule the backend already documented: a request identifier, a session identifier, a header value, or a request or response body is never logged, at either verbosity. Detailed changes resolution, not what is safe to log. A test asserts this directly by feeding the backend a fixture with a request ID, a session ID, and a header value, running detailed verbosity, and confirming none of the three actual values appear anywhere in the captured log output.

An unset or unrecognized verbosity falls back to `basic` with a config warning, the same pattern already used for other optional policy values: this only changes logging, not correctness, so it does not belong with the required-value checks that fail `Load` outright.

## Customer Release Notes

Not customer visible.

## Plan Summary

Not applicable.

## Usage

```
REQUEST_TRACE_UPLOADER_BACKEND=debug
REQUEST_TRACE_UPLOADER_DEBUG_VERBOSITY=detailed
```

## Testing

`go build`, `go vet`, and `go test ./...` all pass for this module. New tests: `New` defaults to basic when verbosity is unset; basic verbosity logs only the segment summary; detailed verbosity logs one line per record plus the summary and includes the expected non-identifying fields; detailed verbosity never logs the actual request identifier, session identifier, or header value from the fixture; `config.Load` defaults, accepts, and falls back with a warning for an invalid verbosity value.

## Notes

None.

## References

Relates to #1004

## Related Pull Requests

None.

## Dependencies

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable debug logging with basic and detailed verbosity levels.
  * Detailed logs include per-record metrics and metadata while redacting identifying information.
  * Added object-store dry-run configuration.
  * Added validation requiring object-store endpoints to be empty or secure absolute HTTPS URLs.
  * Verbosity can be configured through an environment setting; missing or invalid values default to basic logging with a warning.
  * Free-text metadata in logs is limited to 256 bytes and marked when truncated.

* **Tests**
  * Added coverage for verbosity defaults, validation, detailed logging, redaction, endpoint validation, and truncation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->