### PR TITLE
fix(function-autoscaler): skip scaling without instance data

### DIFF
--- a/src/control-plane-services/function-autoscaler/crates/server/src/metrics/mod.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/metrics/mod.rs
@@ -156,6 +156,11 @@ const AUTOSCALING_UTILIZATION_DATA_AGE: Metric = Metric {
         "Age in milliseconds of utilization data when successfully processing scaling requests",
 };
 
+const AUTOSCALING_MISSING_CURRENT_INSTANCES_TOTAL: Metric = Metric {
+    name: "nvcf_autoscaler.processing.missing_current_instances_total",
+    description: "Total scaling cycles skipped because current instance data was unavailable",
+};
+
 const NVCF_API_REQUEST_DURATION: Metric = Metric {
     name: "nvcf_autoscaler.nvcf_api.request_duration_milliseconds",
     description: "Duration of NVCF API requests in milliseconds (includes count via _count)",
@@ -180,7 +185,7 @@ const GAUGES: [Metric; 11] = [
     AUTOSCALING_HEALTH_COMPONENT_STATUS,
 ];
 
-const COUNTERS: [Metric; 9] = [
+const COUNTERS: [Metric; 10] = [
     AUTOSCALING_REQUESTS_QUEUED_TOTAL,
     AUTOSCALING_REQUESTS_REJECTED_TOTAL,
     AUTOSCALING_REQUESTS_PROCESSED_TOTAL,
@@ -190,6 +195,7 @@ const COUNTERS: [Metric; 9] = [
     AUTOSCALING_DISTRIBUTED_LOCK,
     AUTOSCALING_DISTRIBUTED_LOCK_ACQUISITION_FAILURES_TOTAL,
     AUTOSCALING_TSDB_REQUESTS_TOTAL,
+    AUTOSCALING_MISSING_CURRENT_INSTANCES_TOTAL,
 ];
 
 const HISTOGRAMS: [Metric; 5] = [
@@ -214,6 +220,10 @@ pub fn record_request_processed() {
 
 pub fn record_request_rate_limited() {
     counter!(AUTOSCALING_REQUESTS_RATE_LIMITED_TOTAL.name).increment(1);
+}
+
+pub fn record_missing_current_instances() {
+    counter!(AUTOSCALING_MISSING_CURRENT_INSTANCES_TOTAL.name).increment(1);
 }
 
 pub fn update_queue_metrics(current_size: usize, capacity: usize) {

--- a/src/control-plane-services/function-autoscaler/crates/server/src/work/mod.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/work/mod.rs
@@ -254,7 +254,7 @@ async fn get_byoc_instance_count(
     function_version_id: &Uuid,
     env: &str,
     ignore_env: bool,
-) -> Result<usize> {
+) -> Result<Option<usize>> {
     let env_suffix = if ignore_env {
         String::new()
     } else {
@@ -323,20 +323,14 @@ async fn get_byoc_instance_count(
                             timestamp,
                             value_str
                         );
-                        return Ok(count.round() as usize);
+                        return Ok(Some(count.round() as usize));
                     }
                 }
             }
         }
     }
 
-    tracing::debug!(
-        "No instance count data from TimeseriesDb for BYOC function {}:{}, returning 0",
-        function_id,
-        function_version_id
-    );
-    // No data found - return 0
-    Ok(0)
+    Ok(None)
 }
 
 async fn llm_gateway_metrics_present(
@@ -580,11 +574,11 @@ async fn gather_scaling_inputs(
     ignore_env: bool,
     scaling_settings: &ScalingSettings,
     routing_cache: &MetricRoutingCache,
-) -> Result<GatheredScalingInputs> {
+) -> Result<Option<GatheredScalingInputs>> {
     let key = (*function_id, *function_version_id);
     let cached_source = routing_cache.sources.get(&key);
     let mut metric_source = cached_source.unwrap_or(MetricSource::WorkerThreads);
-    let mut current_instances = 0;
+    let mut current_instances = None;
     let mut gateway_target = None;
     let mut cache_source = cached_source.is_none();
 
@@ -599,7 +593,7 @@ async fn gather_scaling_inputs(
         )
         .await
         {
-            Ok(Some(count)) => current_instances = count,
+            Ok(Some(count)) => current_instances = Some(count),
             Ok(None) if cached_source.is_none() => {
                 metric_source = if llm_gateway_metrics_present(
                     timeseries_db_client,
@@ -617,7 +611,7 @@ async fn gather_scaling_inputs(
             Ok(None) => {}
             Err(error) => {
                 tracing::warn!(
-                    "TimeseriesDb worker count failed for {}:{} (nca_id={}), using 0: {}",
+                    "TimeseriesDb worker count failed for {}:{} (nca_id={}): {}",
                     function_id,
                     function_version_id,
                     nca_id,
@@ -639,7 +633,7 @@ async fn gather_scaling_inputs(
                 routing_cache,
             )
             .await?;
-            current_instances = target.total_current_instances;
+            current_instances = Some(target.total_current_instances);
             gateway_target = Some(target);
         }
         MetricSource::ControlPlane => {
@@ -653,12 +647,12 @@ async fn gather_scaling_inputs(
             .await
             .unwrap_or_else(|error| {
                 tracing::warn!(
-                    "CP instance count failed for {}:{}, using 0: {}",
+                    "CP instance count failed for {}:{}: {}",
                     function_id,
                     function_version_id,
                     error
                 );
-                0
+                None
             });
         }
     }
@@ -667,6 +661,17 @@ async fn gather_scaling_inputs(
     if cache_source && metric_source != MetricSource::ControlPlane {
         routing_cache.sources.insert(key, metric_source);
     }
+
+    let Some(current_instances) = current_instances else {
+        metrics::record_missing_current_instances();
+        tracing::warn!(
+            "Skipping scaling cycle for {}:{} because current instance data is unavailable from {:?}",
+            function_id,
+            function_version_id,
+            metric_source,
+        );
+        return Ok(None);
+    };
 
     let raw_utilization = get_function_utilization_history(
         timeseries_db_client,
@@ -702,7 +707,7 @@ async fn gather_scaling_inputs(
         .is_empty()
     };
 
-    Ok(GatheredScalingInputs {
+    Ok(Some(GatheredScalingInputs {
         inputs: ScalingInputs {
             metric_source,
             current_instances,
@@ -710,7 +715,7 @@ async fn gather_scaling_inputs(
             recently_invoked,
         },
         gateway_target,
-    })
+    }))
 }
 
 // Function that creates or removes our node entry in Cassandra based on readiness.
@@ -877,6 +882,9 @@ async fn make_scaling_requests(
                             function.function_id, function.function_version_id
                         )
                     })?;
+                    let Some(gathered) = gathered else {
+                        return Ok(());
+                    };
 
                     if gathered.gateway_target.as_ref().is_some_and(|target| {
                         target.function_version_id != function.function_version_id
@@ -1175,7 +1183,8 @@ mod tests {
             &routing_cache,
         )
         .await
-        .expect("gather scaling inputs");
+        .expect("gather scaling inputs")
+        .expect("current instance data");
         (gathered, routing_cache)
     }
 
@@ -1587,14 +1596,122 @@ mod tests {
             get_byoc_instance_count(&client, &fid, &fvid, "prd", false)
                 .await
                 .expect("prod cp instance count"),
-            3
+            Some(3)
         );
         assert_eq!(
             get_byoc_instance_count(&client, &fid, &fvid, "stg", false)
                 .await
                 .expect("stage cp instance count"),
-            3
+            Some(3)
         );
+    }
+
+    #[tokio::test]
+    async fn test_byoc_instance_count_distinguishes_missing_from_zero() {
+        let fid = Uuid::new_v4();
+        let fvid = Uuid::new_v4();
+
+        let mut empty_server = mockito::Server::new_async().await;
+        let _empty = empty_server
+            .mock("GET", "/api/v1/query_range")
+            .match_query(mockito::Matcher::Regex(
+                "nvcf_function_instances_current".into(),
+            ))
+            .with_status(200)
+            .with_body(vm_empty())
+            .expect(1)
+            .create_async()
+            .await;
+
+        assert_eq!(
+            get_byoc_instance_count(
+                &ts_client(empty_server.url()),
+                &fid,
+                &fvid,
+                "stg",
+                true,
+            )
+            .await
+            .expect("missing cp instance count"),
+            None
+        );
+
+        let mut zero_server = mockito::Server::new_async().await;
+        let _zero = zero_server
+            .mock("GET", "/api/v1/query_range")
+            .match_query(mockito::Matcher::Regex(
+                "nvcf_function_instances_current".into(),
+            ))
+            .with_status(200)
+            .with_body(vm_series(
+                &format!(r#""function_id":"{fid}","function_version_id":"{fvid}""#),
+                "0",
+            ))
+            .expect(1)
+            .create_async()
+            .await;
+
+        assert_eq!(
+            get_byoc_instance_count(
+                &ts_client(zero_server.url()),
+                &fid,
+                &fvid,
+                "stg",
+                true,
+            )
+            .await
+            .expect("zero cp instance count"),
+            Some(0)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_gather_scaling_inputs_skips_when_instance_count_is_missing() {
+        let fid = Uuid::new_v4();
+        let fvid = Uuid::new_v4();
+        let mut server = mockito::Server::new_async().await;
+
+        let _worker = server
+            .mock("GET", "/api/v1/query_range")
+            .match_query(mockito::Matcher::Regex("worker_thread_count_total".into()))
+            .with_status(200)
+            .with_body(vm_empty())
+            .expect(1)
+            .create_async()
+            .await;
+        let _gateway = server
+            .mock("GET", "/api/v1/query_range")
+            .match_query(mockito::Matcher::Regex("http_requests_total".into()))
+            .with_status(200)
+            .with_body(vm_empty())
+            .expect(1)
+            .create_async()
+            .await;
+        let _control_plane = server
+            .mock("GET", "/api/v1/query_range")
+            .match_query(mockito::Matcher::Regex(
+                "nvcf_function_instances_current".into(),
+            ))
+            .with_status(200)
+            .with_body(vm_empty())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let gathered = gather_scaling_inputs(
+            &ts_client(server.url()),
+            &fid,
+            &fvid,
+            "nca",
+            "stg",
+            true,
+            &ScalingSettings::default(),
+            &new_metric_routing_cache(),
+        )
+        .await
+        .expect("gather scaling inputs");
+
+        assert!(gathered.is_none());
     }
 
     /// Happy path: worker count, utilization, and recent invocations are gathered
@@ -1632,7 +1749,8 @@ mod tests {
             &routing_cache,
         )
         .await
-        .expect("gather inputs");
+        .expect("gather inputs")
+        .expect("current instance data");
         let inputs = gathered.inputs;
 
         assert_eq!(inputs.current_instances, 5);


### PR DESCRIPTION
## TL;DR

Skip a function's scaling cycle when its current-instance telemetry is missing instead of treating the missing value as zero.

## Additional Details

A successful but empty timeseries response currently becomes an instance count of zero. If metrics collection stops while the backend remains available, this can make an active function appear idle and eventually allow it to scale to zero.

This change:

- represents a missing current-instance count as `None`;
- stops input gathering before the scaling decision when the count is unavailable;
- preserves an explicit observed count of zero as valid input for normal scale-from-zero and scale-to-zero behavior;
- emits a warning and counter when a cycle is skipped because the instance count is missing; and
- adds regression coverage for missing and explicit-zero instance data.

It does not introduce general freshness validation for every autoscaling metric, and it does not change the LLM gateway's partial-metric fallback behavior.

## For the Reviewer

Please focus on the distinction between an absent instance-count series and an explicit zero in `work/mod.rs`, and verify that missing data cannot reach the scaling decision as zero.

## For QA

- `bazel test //src/control-plane-services/function-autoscaler/crates/server:rs_autoscaler_test --test_output=errors`
  - passed
- `git diff --check`
  - passed

## Issues

Relates to #15

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved autoscaling reliability by distinguishing between zero active instances and unavailable instance data.
  - Scaling cycles are now skipped when current-instance information cannot be retrieved, preventing incorrect scaling decisions.
  - Added monitoring for skipped scaling cycles caused by unavailable instance data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->