### PR TITLE
docs(release): describe release automation as live, not pending cutover

### DIFF
--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -25,9 +25,16 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Keep GitHub release automation inert until the migration cutover is ready.
-  # Set the repository variable NVCF_GITHUB_AUTO_TAGGING_ENABLED=true after
-  # GitHub has the required path-format release anchors.
+  # Release automation is live. This repository is the sole tag and release
+  # authority, and both variables are set in repository settings
+  # (NVCF_GITHUB_AUTO_TAGGING_ENABLED=true, NVCF_GITHUB_RELEASE_DRY_RUN=false).
+  #
+  # The literals below are NOT the behavior here. They are the fallback for a
+  # context that has neither variable set -- a fork, or a re-created repository
+  # -- where defaulting to dry-run keeps a misconfigured checkout from cutting
+  # real releases against someone else's registries. Read the repository
+  # variables to see what actually runs; do not read these defaults as the
+  # current mode.
   NVCF_GITHUB_AUTO_TAGGING_ENABLED: ${{ vars.NVCF_GITHUB_AUTO_TAGGING_ENABLED || 'false' }}
   NVCF_GITHUB_RELEASE_DRY_RUN: ${{ vars.NVCF_GITHUB_RELEASE_DRY_RUN || 'true' }}
   NVCF_GITHUB_RELEASE_DRAFT: ${{ vars.NVCF_GITHUB_RELEASE_DRAFT || 'false' }}

--- a/docs/dev/github-release-process.md
+++ b/docs/dev/github-release-process.md
@@ -1,27 +1,29 @@
 # GitHub Release Automation
 
-The public GitHub workflow in `.github/workflows/release-tags.yml`
-prepares NVCF release automation before the GitHub cutover. It is
-configured to run in dry-run mode by default, so the workflow can be
-validated without creating GitHub tags or releases.
+The public GitHub workflow in `.github/workflows/release-tags.yml` runs
+NVCF release automation. The cutover is complete: this repository is
+the sole tag and release authority, publishing is live, and a merge to
+`main` cuts real tags and GitHub Releases for every registered service.
 
-## Dry-run gate
+## Publish gate
 
 The workflow reads these repository variables:
 
-- `NVCF_GITHUB_AUTO_TAGGING_ENABLED`: defaults to `false`. When
-  `false`, the workflow always runs in dry-run mode even if another
-  variable is misconfigured.
-- `NVCF_GITHUB_RELEASE_DRY_RUN`: defaults to `true`. When `true`,
-  branch pushes compute proposed service tags and tag pushes validate
-  release tags, but nothing is written to GitHub. Set this to `false`
-  only after `NVCF_GITHUB_AUTO_TAGGING_ENABLED=true`.
-- `NVCF_GITHUB_RELEASE_DRAFT`: defaults to `false`. When release
-  creation is enabled, `true` creates draft GitHub releases.
+- `NVCF_GITHUB_AUTO_TAGGING_ENABLED`: set to `true`. When `false`, the
+  workflow forces dry-run mode even if another variable says otherwise.
+- `NVCF_GITHUB_RELEASE_DRY_RUN`: set to `false`. When `true`, branch
+  pushes compute proposed service tags and tag pushes validate release
+  tags, but nothing is written to GitHub.
+- `NVCF_GITHUB_RELEASE_DRAFT`: unset, so `false`. When `true`, releases
+  are created as drafts.
 
-Do not set `NVCF_GITHUB_AUTO_TAGGING_ENABLED=true` or
-`NVCF_GITHUB_RELEASE_DRY_RUN=false` until the GitHub commit graph has
-release anchors for each service being cut over.
+The literal fallbacks in the workflow's `env:` block are `false` and
+`true` respectively, which reads as dry-run. **Those are not the
+behavior here.** They are the safe default for a context with neither
+variable set -- a fork, or a re-created repository -- so a misconfigured
+checkout cannot cut real releases. The values above are what runs; they
+live in repository settings rather than in source, so confirm them there
+rather than inferring the mode from the workflow file.
 
 Publish mode also requires the `NV_GITHUB_TOKEN` repository
 secret. It must be a GitHub token that can push tags and create
@@ -29,18 +31,10 @@ releases. Tags pushed with the default `GITHUB_TOKEN` do not start the
 follow-up tag workflow, so the workflow fails publish mode when this
 secret is missing.
 
-## Cutover order
+## Release path
 
-1. Keep GitHub release automation dry-run-only while the repository is
-   still being anchored.
-2. Recreate any missing GitHub anchors with path-format tags and
-   `refs/notes/semantic-release` notes on the GitHub commit graph.
-3. Enable GitHub auto-tagging and publish by setting
-   `NVCF_GITHUB_AUTO_TAGGING_ENABLED=true` and
-   `NVCF_GITHUB_RELEASE_DRY_RUN=false`.
-
-After step 3, GitHub is the sole tag and release authority. The active
-release path is:
+GitHub is the sole tag and release authority. The active release path
+is:
 
 ```text
 NVIDIA/nvcf -> GitLab mirror -> scheduled internal release dispatcher -> image release pipeline
@@ -314,16 +308,23 @@ Anchoring at the start would hand semantic-release every commit the
 service ever had, where a single historical breaking change could force
 a major.
 
-## Cutover anchors
+## Anchors
 
 GitHub release publishing needs both the latest service tag and the
 matching `refs/notes/semantic-release` entry on the GitHub commit
 graph. `.oss-allowlist` mirrors files, not Git refs, tags, or notes.
 
-If the GitHub mirror is a snapshot with different commit SHAs from the
-prior release source, do not copy old refs verbatim. Recreate the
-latest service tags and semantic-release notes on the GitHub commits
-that represent the released content, then enable publish mode.
+This came up first during the cutover, when the mirror was a snapshot
+with different commit SHAs from the prior release source: old refs could
+not be copied verbatim, so the latest service tags and semantic-release
+notes were recreated on the GitHub commits representing the released
+content. That work is done.
+
+It still applies to any release line arriving without usable history --
+most often a newly registered service or chart, which is covered in
+detail under "Seeding and pinning service or chart versions" below. Do not copy refs from another
+source; create the anchor on the GitHub commit that represents the
+released content.
 
 Use the helper below to create one path-format anchor locally. The
 version may be a dev prerelease, release candidate, or stable release:

--- a/docs/dev/github-release-process.md
+++ b/docs/dev/github-release-process.md
@@ -492,8 +492,8 @@ exactly the version tags under that service path.
 
 Seeding tags only establishes the version floor. Nothing publishes a
 GitHub Release until `NVCF_GITHUB_AUTO_TAGGING_ENABLED=true` and
-`NVCF_GITHUB_RELEASE_DRY_RUN=false`, as described in the dry-run gate
+`NVCF_GITHUB_RELEASE_DRY_RUN=false`, as described in the Publish gate
 above. A tag pushed with the `NV_GITHUB_TOKEN` secret, or another
 workflow-capable token, starts the tag workflow, but it stays inert
-while the dry-run gate is on. Tags pushed with the default
-`GITHUB_TOKEN` do not trigger the follow-up workflow.
+if either variable is unset, falling back to dry-run. Tags pushed
+with the default `GITHUB_TOKEN` do not trigger the follow-up workflow.


### PR DESCRIPTION
## Why

Auto-tagging has been enabled on this repository since 2026-07-14 and releases are cut on every merge to `main`:

```
NVCF_GITHUB_AUTO_TAGGING_ENABLED = true    (updated 2026-07-14)
NVCF_GITHUB_RELEASE_DRY_RUN      = false   (updated 2026-07-14)
```

Two places still described it as switched off pending a migration. That is the most misleading way for this particular doc to be wrong: a reader planning a release concludes that pushing a tag produces nothing, goes looking for a gate to open, and either waits or asks for a change that has already been made. It cost exactly that detour before this PR.

## What changed

**`.github/workflows/release-tags.yml`** — the `env:` comment said to keep the automation inert and to set `NVCF_GITHUB_AUTO_TAGGING_ENABLED=true` "after GitHub has the required path-format release anchors".

The literal `|| 'false'` / `|| 'true'` fallbacks **stay**. They are the right default for a context with neither variable set — a fork, or a re-created repository — where dry-run keeps a misconfigured checkout from publishing against someone else's registries. Only the comment changes, to say they are a fallback rather than the current mode. No behavior change.

**`docs/dev/github-release-process.md`** —

- The intro said the workflow "prepares NVCF release automation before the GitHub cutover" and "is configured to run in dry-run mode by default".
- "Dry-run gate" listed the variables by their pre-cutover defaults and instructed the reader *not* to enable them yet. It is now "Publish gate", listing the live values, with the fallback-vs-actual distinction called out explicitly.
- "Cutover order" was a three-step plan whose final step is enabling what has been enabled for two months. Replaced by "Release path", keeping the pipeline diagram that followed it.
- "Cutover anchors" → "Anchors". The content is unchanged and still correct — it is how a release line with no usable history gets seeded — but it is no longer framed as one-time migration work, and it now points at the seeding section that covers the ongoing case.
- Fixed a cross-reference to "Seeding a version", which is not the title of any section (it is "Seeding and pinning service or chart versions").

**`RELEASE.md` needed no change.** It deliberately describes the two variables without asserting their values and tells the reader to check repository settings — which stays correct however the variables are set.

## Testing

Documentation and one comment block only; no executable change.

- `actionlint .github/workflows/release-tags.yml` — clean.
- Variable values above read from `GET /repos/NVIDIA/nvcf/actions/variables/{name}`.
- Cross-checked against `GET /repos/NVIDIA/nvcf/releases`, which shows path-format releases published continuously through today, confirming publish mode is live rather than merely configured.
- `tools/ci/check-docs` requires `node`/`fern-api`, not available in this environment. Ran the parts that do not: the `<img>` self-closing tag scan across `docs` and `fern` (clean), and `./tools/ci/check-doc-version-sync` (advisory; passed with a warning, since this worktree has no `imports.yaml`). `fern check` itself was not run; CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the GitHub release process to reflect active automated publishing of tags and GitHub Releases after merges to `main`.
  - Documented repository settings for auto-tagging, dry-run mode, draft releases, and required publishing credentials.
  - Clarified safe defaults and verification steps for unconfigured environments.
  - Updated guidance for recreating release anchors, including newly registered services or charts and released GitHub commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
