### PR TITLE
fix(stack): pull notary from the nvcf-notary image repository

### DIFF
--- a/deploy/stacks/self-managed/Makefile
+++ b/deploy/stacks/self-managed/Makefile
@@ -26,6 +26,7 @@ test:
 	@tests/icms-condition-wiring.sh
 	@tests/nats-placement-tags.sh
 	@tests/nats-tls-wiring.sh
+	@tests/notary-image-repository.sh
 
 test-published-charts:
 	@: "$${NVCF_PUBLISHED_CHART_REGISTRY:?NVCF_PUBLISHED_CHART_REGISTRY is required}"

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -781,7 +781,7 @@ notary:
   {{- end }}
   image:
     registry: {{ .Values.global.image.registry }}
-    repository: {{ .Values.global.image.repository }}/notary-service
+    repository: {{ .Values.global.image.repository }}/nvcf-notary
   {{- with include "nvcf.nodeSelector" (dict "type" "controlplane" "selectors" .Values.global.nodeSelectors) }}
   {{- . | nindent 2 }}
   {{- end }}

--- a/deploy/stacks/self-managed/tests/notary-image-repository.sh
+++ b/deploy/stacks/self-managed/tests/notary-image-repository.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Test that the notary release pulls its image from <global.image.repository>/nvcf-notary.
+#
+# The release lane publishes the notary image as nvcf-notary. The stack used to
+# point at notary-service, a repository that stopped receiving tags at 1.9.4, so
+# every stack release from the 1.14.0 chart bump onward referenced an image that
+# does not exist and the stack package failed to resolve it.
+set -euo pipefail
+
+stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+work_dir="$(mktemp -d)"
+test_stack_dir="$work_dir/self-managed"
+environment_name="notary-image-repository-test"
+environment_file="$test_stack_dir/environments/$environment_name.yaml"
+secrets_file="$test_stack_dir/secrets/$environment_name-secrets.yaml"
+trap 'rm -rf "$work_dir"' EXIT
+
+fail() {
+  echo "notary-image-repository: $*" >&2
+  exit 1
+}
+
+mkdir -p "$test_stack_dir"
+cp -R "$stack_dir"/. "$test_stack_dir"
+printf '{}\n' >"$secrets_file"
+
+cat >"$environment_file" <<'YAML'
+global:
+  image:
+    registry: nvcr.io
+    repository: test/nvcf
+YAML
+
+values_file="$work_dir/notary-values.yaml"
+render_log="$work_dir/write-values.log"
+if ! HELMFILE_ENV="$environment_name" HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" \
+  helmfile \
+    --file "$test_stack_dir/helmfile.d/02-core.yaml.gotmpl" \
+    --environment default \
+    --state-values-set ingress.gatewayApi.controllerNamespace=envoy-gateway-system \
+    --state-values-set ingress.gatewayApi.gateways.shared.name=shared-gw \
+    --state-values-set ingress.gatewayApi.gateways.shared.namespace=envoy-gateway-system \
+    --state-values-set ingress.gatewayApi.gateways.grpc.name=grpc-gw \
+    --state-values-set ingress.gatewayApi.gateways.grpc.namespace=envoy-gateway-system \
+    --selector name=notary-service \
+    write-values \
+    --output-file-template "$values_file" 2>"$render_log"; then
+  cat "$render_log" >&2
+  fail "helmfile could not render the notary release"
+fi
+test -s "$values_file" || fail "helmfile wrote no values to $values_file"
+
+# Rendered values are normalized YAML with sorted keys, so the notary image
+# block reads registry -> repository -> tag on adjacent lines.
+block="$(grep -B1 -A1 -F 'repository: test/nvcf/nvcf-notary' "$values_file" || true)"
+[[ -n "$block" ]] || fail "notary image repository is not <global.image.repository>/nvcf-notary"
+grep -q '^[[:space:]]*registry: nvcr.io$' <<<"$block" ||
+  fail "notary image registry is not global.image.registry"
+if grep -qF 'repository: test/nvcf/notary-service' "$values_file"; then
+  fail "notary still references the retired notary-service image repository"
+fi
+
+echo "notary-image-repository: ok"


### PR DESCRIPTION
## Why

Every self-managed stack release since v0.13.3 fails to package. The stack SBOM step resolves each shipped image against ncp-dev and cannot find `notary-service:1.14.0`.

The notary release lane publishes the image as `nvcf-notary` (1.12.1 through 1.14.0 are present). The stack still pointed `notary.image.repository` at `notary-service`, a repository that stopped receiving tags at 1.9.4. The mismatch was latent until #1446 moved the notary chart to image 1.14.0.

The same release also fails on two upstream images (alpine-k8s 1.37.0, nats-server-config-reloader 0.24.0) bumped by #1413 without a mirror entry. That is fixed on the release side, not in this repo.

## What changed

- `deploy/stacks/self-managed/global.yaml.gotmpl`: notary image repository `<global.image.repository>/nvcf-notary`.
- `deploy/stacks/self-managed/tests/notary-image-repository.sh`: renders the notary release and asserts the repository is `nvcf-notary` under the configured registry, and that `notary-service` is gone. Wired into `make test`.

## Testing

`make -C deploy/stacks/self-managed test`: all 24 tests pass with helmfile v1.1.0. The new test fails when the repository is reverted to `notary-service`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the self-managed deployment to use the `nvcf-notary` image repository.

* **Tests**
  * Added integration coverage to verify the rendered Notary image uses the expected repository and registry.
  * Included the new validation in the self-managed stack test target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->