### PR TITLE
fix(nvca): AND NVLink clique requirement into existing node affinity

### DIFF
--- a/src/compute-plane-services/nvca/pkg/dra/dra.go
+++ b/src/compute-plane-services/nvca/pkg/dra/dra.go
@@ -203,12 +203,6 @@ func SetPreferredNVLinkDomainSchedulingParameters(keyToHash string, objs ...clie
 		},
 		TopologyKey: GPUCliqueNodeLabel,
 	}
-	cliqueNodeSelTerm := corev1.NodeSelectorTerm{
-		MatchExpressions: []corev1.NodeSelectorRequirement{{
-			Key:      GPUCliqueNodeLabel,
-			Operator: corev1.NodeSelectorOpExists,
-		}},
-	}
 
 	itrf := func(pts *corev1.PodTemplateSpec) {
 		ps := &pts.Spec
@@ -229,16 +223,7 @@ func SetPreferredNVLinkDomainSchedulingParameters(keyToHash string, objs ...clie
 				PodAffinityTerm: podAffinityTerm,
 			},
 		)
-		if ps.Affinity.NodeAffinity == nil {
-			ps.Affinity.NodeAffinity = &corev1.NodeAffinity{}
-		}
-		if ps.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
-			ps.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{}
-		}
-		ps.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(
-			ps.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
-			cliqueNodeSelTerm,
-		)
+		requireGPUCliqueNode(ps.Affinity)
 	}
 	iterPodSpecs(itrf, objs...)
 }
@@ -265,12 +250,6 @@ func SetRequiredNVLinkDomainSchedulingParameters(
 		},
 		TopologyKey: GPUCliqueNodeLabel,
 	}
-	cliqueNodeSelTerm := corev1.NodeSelectorTerm{
-		MatchExpressions: []corev1.NodeSelectorRequirement{{
-			Key:      GPUCliqueNodeLabel,
-			Operator: corev1.NodeSelectorOpExists,
-		}},
-	}
 
 	itrf := func(pts *corev1.PodTemplateSpec) {
 		ps := &pts.Spec
@@ -288,19 +267,56 @@ func SetRequiredNVLinkDomainSchedulingParameters(
 			ps.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
 			podAffinityTerm,
 		)
-		if ps.Affinity.NodeAffinity == nil {
-			ps.Affinity.NodeAffinity = &corev1.NodeAffinity{}
-		}
-		if ps.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
-			ps.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{}
-		}
-		ps.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(
-			ps.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
-			cliqueNodeSelTerm,
-		)
+		requireGPUCliqueNode(ps.Affinity)
 	}
 
 	iterPodSpecs(itrf, objs...)
+}
+
+var gpuCliqueNodeSelectorRequirement = corev1.NodeSelectorRequirement{
+	Key:      GPUCliqueNodeLabel,
+	Operator: corev1.NodeSelectorOpExists,
+}
+
+// requireGPUCliqueNode narrows the required node affinity of a Pod so that it
+// only admits nodes carrying a GPU clique label.
+//
+// Kubernetes ORs NodeSelectorTerms, so the requirement is ANDed into every
+// existing term instead of being appended as a term of its own. An appended
+// clique-only term would give the Pod an alternative way to satisfy required
+// node affinity and let it bypass constraints it already carries, such as a
+// hostname restriction. The merge is idempotent so that repeated admission
+// does not accumulate duplicate requirements.
+func requireGPUCliqueNode(a *corev1.Affinity) {
+	if a.NodeAffinity == nil {
+		a.NodeAffinity = &corev1.NodeAffinity{}
+	}
+	if a.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		a.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{}
+	}
+	ns := a.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	if len(ns.NodeSelectorTerms) == 0 {
+		ns.NodeSelectorTerms = []corev1.NodeSelectorTerm{{
+			MatchExpressions: []corev1.NodeSelectorRequirement{gpuCliqueNodeSelectorRequirement},
+		}}
+		return
+	}
+	for i := range ns.NodeSelectorTerms {
+		term := &ns.NodeSelectorTerms[i]
+		if hasGPUCliqueRequirement(term.MatchExpressions) {
+			continue
+		}
+		term.MatchExpressions = append(term.MatchExpressions, gpuCliqueNodeSelectorRequirement)
+	}
+}
+
+func hasGPUCliqueRequirement(reqs []corev1.NodeSelectorRequirement) bool {
+	for _, req := range reqs {
+		if req.Key == GPUCliqueNodeLabel && req.Operator == corev1.NodeSelectorOpExists {
+			return true
+		}
+	}
+	return false
 }
 
 type iterPodTemplateSpecFunc func(*corev1.PodTemplateSpec)

--- a/src/compute-plane-services/nvca/pkg/dra/dra_test.go
+++ b/src/compute-plane-services/nvca/pkg/dra/dra_test.go
@@ -173,6 +173,130 @@ func Test_containerRequestsStaticGPU(t *testing.T) {
 	}
 }
 
+func TestNVLinkDomainSchedulingParametersNarrowRequiredNodeAffinity(t *testing.T) {
+	cliqueReq := corev1.NodeSelectorRequirement{
+		Key:      GPUCliqueNodeLabel,
+		Operator: corev1.NodeSelectorOpExists,
+	}
+	hostnameReq := corev1.NodeSelectorRequirement{
+		Key:      "kubernetes.io/hostname",
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   []string{"selected-node-a", "selected-node-b"},
+	}
+	instanceTypeReq := corev1.NodeSelectorRequirement{
+		Key:      "nvidia.com/instance-type",
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   []string{"gb200"},
+	}
+	nameField := corev1.NodeSelectorRequirement{
+		Key:      "metadata.name",
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   []string{"selected-node-a"},
+	}
+	newRequiredNodeAffinity := func(terms ...corev1.NodeSelectorTerm) *corev1.Affinity {
+		return &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: terms,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		affinity *corev1.Affinity
+		applyN   int
+		want     []corev1.NodeSelectorTerm
+	}{
+		{
+			name:   "no affinity yields a single clique term",
+			applyN: 1,
+			want: []corev1.NodeSelectorTerm{{
+				MatchExpressions: []corev1.NodeSelectorRequirement{cliqueReq},
+			}},
+		},
+		{
+			name:     "empty required selector yields a single clique term",
+			affinity: newRequiredNodeAffinity(),
+			applyN:   1,
+			want: []corev1.NodeSelectorTerm{{
+				MatchExpressions: []corev1.NodeSelectorRequirement{cliqueReq},
+			}},
+		},
+		{
+			name: "clique requirement is ANDed into an existing hostname term",
+			affinity: newRequiredNodeAffinity(corev1.NodeSelectorTerm{
+				MatchExpressions: []corev1.NodeSelectorRequirement{hostnameReq},
+			}),
+			applyN: 1,
+			want: []corev1.NodeSelectorTerm{{
+				MatchExpressions: []corev1.NodeSelectorRequirement{hostnameReq, cliqueReq},
+			}},
+		},
+		{
+			name: "every existing term gets the clique requirement",
+			affinity: newRequiredNodeAffinity(
+				corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{hostnameReq}},
+				corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{instanceTypeReq}},
+			),
+			applyN: 1,
+			want: []corev1.NodeSelectorTerm{
+				{MatchExpressions: []corev1.NodeSelectorRequirement{hostnameReq, cliqueReq}},
+				{MatchExpressions: []corev1.NodeSelectorRequirement{instanceTypeReq, cliqueReq}},
+			},
+		},
+		{
+			name: "existing match fields are preserved",
+			affinity: newRequiredNodeAffinity(corev1.NodeSelectorTerm{
+				MatchFields: []corev1.NodeSelectorRequirement{nameField},
+			}),
+			applyN: 1,
+			want: []corev1.NodeSelectorTerm{{
+				MatchExpressions: []corev1.NodeSelectorRequirement{cliqueReq},
+				MatchFields:      []corev1.NodeSelectorRequirement{nameField},
+			}},
+		},
+		{
+			name: "repeated mutation does not duplicate the clique requirement",
+			affinity: newRequiredNodeAffinity(corev1.NodeSelectorTerm{
+				MatchExpressions: []corev1.NodeSelectorRequirement{hostnameReq},
+			}),
+			applyN: 3,
+			want: []corev1.NodeSelectorTerm{{
+				MatchExpressions: []corev1.NodeSelectorRequirement{hostnameReq, cliqueReq},
+			}},
+		},
+	}
+
+	setters := []struct {
+		name  string
+		apply func(pod *corev1.Pod)
+	}{
+		{
+			name:  "preferred",
+			apply: func(pod *corev1.Pod) { SetPreferredNVLinkDomainSchedulingParameters("foo", pod) },
+		},
+		{
+			name:  "required",
+			apply: func(pod *corev1.Pod) { SetRequiredNVLinkDomainSchedulingParameters("foo", "0", pod) },
+		},
+	}
+
+	for _, setter := range setters {
+		for _, tt := range tests {
+			t.Run(setter.name+"/"+tt.name, func(t *testing.T) {
+				pod := &corev1.Pod{Spec: corev1.PodSpec{Affinity: tt.affinity.DeepCopy()}}
+				for i := 0; i < tt.applyN; i++ {
+					setter.apply(pod)
+				}
+				got := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+				assert.Equal(t, tt.want, got.NodeSelectorTerms)
+			})
+		}
+	}
+}
+
 func TestTransformNVLinkOptimizedDRAObjects(t *testing.T) {
 	type spec struct {
 		name       string

--- a/src/compute-plane-services/nvca/pkg/webhook/miniservice_mutating_webhook_test.go
+++ b/src/compute-plane-services/nvca/pkg/webhook/miniservice_mutating_webhook_test.go
@@ -544,21 +544,14 @@ func TestMiniserviceOperatorWebhook_PodSpecCreateThenUpdate_IsIdempotentOrderPre
 				},
 			},
 		},
+		// The NVLink clique requirement narrows the pre-existing term instead of
+		// being ORed alongside it as a term of its own.
 		NodeAffinity: &corev1.NodeAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 				NodeSelectorTerms: []corev1.NodeSelectorTerm{
 					{
 						MatchExpressions: []corev1.NodeSelectorRequirement{
 							{Key: "baz", Operator: corev1.NodeSelectorOpIn, Values: []string{"buf"}},
-							{
-								Key:      "nvca.nvcf.nvidia.io/instance-type",
-								Operator: corev1.NodeSelectorOpIn,
-								Values:   []string{"ON-PREM.GPU.A100"},
-							},
-						},
-					},
-					{
-						MatchExpressions: []corev1.NodeSelectorRequirement{
 							{
 								Key:      nvcfdra.GPUCliqueNodeLabel,
 								Operator: corev1.NodeSelectorOpExists,


### PR DESCRIPTION
## TL;DR

The NVCA MiniService mutating webhook appended a `NodeSelectorTerm` containing
only `nvidia.com/gpu.clique Exists` when applying NVLink DRA scheduling.
Kubernetes ORs `NodeSelectorTerms`, so that appended term gave a Pod a second,
weaker way to satisfy required node affinity and let it bypass hard constraints
it already carried, such as `kubernetes.io/hostname In [...]`.

This ANDs the clique requirement into every existing term instead, so it
narrows required node affinity rather than offering an alternative to it.

## Additional Details

Observed in an NVLink-optimized multi-worker deployment: the MiniService and
Grove resources still carried the requested node lists, but admitted Pods could
land on nodes assigned to a different worker role.

The MiniService webhook applies the NVLink DRA mutation before `mutatePodSpec`
adds instance-type affinity. That ordering is why admitted Pods ended up with
the instance-type requirement in both the original hostname term and the
appended clique term, while the hostname restriction stayed bypassable.

`SetPreferredNVLinkDomainSchedulingParameters` and
`SetRequiredNVLinkDomainSchedulingParameters` both had the same append, so both
now share a single `requireGPUCliqueNode` helper that:

- adds `nvidia.com/gpu.clique Exists` to every existing `NodeSelectorTerm`, so
  it is ANDed with that term's existing expressions and fields
- creates one clique-only term when no required terms exist
- preserves existing `matchExpressions` and `matchFields`
- is idempotent, so repeated admission does not accumulate duplicates

Behavior when a Pod has no pre-existing required node affinity is unchanged.

## For the Reviewer

Main file is `src/compute-plane-services/nvca/pkg/dra/dra.go`.

`pkg/webhook/miniservice_mutating_webhook_test.go` has one updated expectation.
That test previously asserted the buggy two-term output, where the clique term
carried the instance-type requirement alongside a `baz In [buf]` term that
could be skipped. It now expects the single narrowed term
`[baz In [buf], gpu.clique Exists, instance-type In [ON-PREM.GPU.A100]]`, which
is the behavior the issue asks for.

This PR does not change the pod-affinity term appends in the same two
functions. Repeated admission still appends duplicate `PodAffinityTerm`s there.
That is pre-existing and out of scope here, but worth a follow-up if repeat
admission is a real path.

## For QA

Run from `src/compute-plane-services/nvca`:

```
go test ./pkg/dra/... ./pkg/webhook/... \
    -ldflags '-X github.com/NVIDIA/k8s-dra-driver-gpu/internal/info.version=v25.8.0'
```

What I ran:

- New `TestNVLinkDomainSchedulingParametersNarrowRequiredNodeAffinity` covers
  both the preferred and required paths against: no affinity, empty required
  selector, an existing hostname term, multiple existing terms, preserved
  `matchFields`, and repeated mutation. Confirmed it fails on the pre-fix code
  (8 of 12 subtests) and passes after.
- Full nvca unit suite passes. `pkg/operator/reconcile` is excluded: it fails
  locally on macOS with `Failed to patch os.Exit due to an error: permission
  denied`, which is environmental. That package has no dependency on `pkg/dra`.
- `gofmt`, `go vet`, and `golangci-lint` clean on the changed packages. The
  remaining `goconst` findings in `pkg/webhook` are pre-existing and in files
  this PR does not touch.

QA needed: yes, ideally a scheduling check on an NVLink-optimized multi-worker
deployment to confirm admitted Pods stay within their requested node lists.

## Issues

Closes #1644

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GPU and NVLink scheduling affinity handling by applying GPU clique requirements to existing node-selection rules.
  - Preserved existing node-selection criteria while avoiding duplicate GPU clique requirements.
  - Ensured scheduling behaves consistently when node affinity is absent, empty, or applied repeatedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->