### PR TITLE
fix(nvca-operator): sync webhook CPU throttle fix to source, add CI drift check

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -98,6 +98,19 @@ jobs:
       - name: Lint and render every chart with a CI values file
         run: ./tools/ci/check-helm-charts
 
+      - name: Check NVCA Operator chart is synced with its monorepo source
+        # Pins the version fields to whatever is already committed in the
+        # vendored chart, so this only fails on real content drift between
+        # src/compute-plane-services/nvca/deployments/nvca-operator and
+        # deploy/helm/nvca-operator/nvca-operator, not on pending version bumps.
+        run: |
+          set -euo pipefail
+          cd deploy/helm/nvca-operator
+          NVCA_VERSION="$(yq '.selfManaged.nvcaVersion' nvca-operator/values.yaml)" \
+          NVCA_OPERATOR_VERSION="$(yq '.appVersion' nvca-operator/Chart.yaml)" \
+          NVCA_SHARED_STORAGE_IMAGE_TAG="$(yq '.selfManaged.sharedStorage.imageTag' nvca-operator/values.yaml)" \
+            make check-vendor-chart
+
       - name: Run self-managed Helmfile render tests
         run: make -C deploy/stacks/self-managed test
 

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/README.md
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/README.md
@@ -101,9 +101,8 @@ This release does not wire the catalog into backend selection. Runtime use requi
 
 | Name                                | Description                                   | Value   |
 | ----------------------------------- | --------------------------------------------- | ------- |
-| `webhook.resources.limits.cpu`      | CPU limit for the nvca webhook container      | `200m`  |
 | `webhook.resources.limits.memory`   | Memory limit for the nvca webhook container   | `200Mi` |
-| `webhook.resources.requests.cpu`    | CPU request for the nvca webhook container    | `50m`   |
+| `webhook.resources.requests.cpu`    | CPU request for the nvca webhook container    | `500m`  |
 | `webhook.resources.requests.memory` | Memory request for the nvca webhook container | `50Mi`  |
 
 ### NGC Configuration

--- a/src/compute-plane-services/nvca/deployments/nvca-operator/values.yaml
+++ b/src/compute-plane-services/nvca/deployments/nvca-operator/values.yaml
@@ -264,17 +264,15 @@ agent:
       cpu: 100m
       memory: 200Mi
 ## @section Webhook Container Resource configuration
-## @param webhook.resources.limits.cpu CPU limit for the nvca webhook container
 ## @param webhook.resources.limits.memory Memory limit for the nvca webhook container
 ## @param webhook.resources.requests.cpu CPU request for the nvca webhook container
 ## @param webhook.resources.requests.memory Memory request for the nvca webhook container
 webhook:
   resources:
     limits:
-      cpu: 200m
       memory: 200Mi
     requests:
-      cpu: 50m
+      cpu: 500m
       memory: 50Mi
 
 ## @section NGC Configuration


### PR DESCRIPTION
## TL;DR

- #1548 raised the nvca webhook's CPU request from `50m` to `500m` and dropped its CPU limit (`200m`) entirely, to fix throttling under bursty admission load — but it only edited the vendored chart at `deploy/helm/nvca-operator`, not the monorepo source chart at `src/compute-plane-services/nvca/deployments/nvca-operator`.
- That left the two out of sync: `make check-vendor-chart` has been failing on `main` since #1548 merged. #970 (open, unrelated BYOO feature) re-ran `make vendor-chart` and, as a side effect, would have silently reverted the throttle fix back to `50m`/`200m` limit on merge.
- This PR brings the monorepo source chart in line with the already-fixed vendored chart, and adds the missing CI check so this class of drift is caught going forward instead of relying on someone stumbling into it.

## Changes

- `src/compute-plane-services/nvca/deployments/nvca-operator/values.yaml` + `README.md`: apply #1548's webhook resource fix (drop `resources.limits.cpu`, `resources.requests.cpu` → `500m`) to match the vendored chart.
- `.github/workflows/build-test.yml`: add a `make check-vendor-chart` step to the `helm-charts` job. Version fields (`NVCA_VERSION`, `NVCA_OPERATOR_VERSION`, `NVCA_SHARED_STORAGE_IMAGE_TAG`) are read from the currently committed vendored chart rather than hardcoded, so the check only fails on real content drift, not on pending version bumps.

## For the Reviewer

`make check-vendor-chart` now passes locally with these changes. Ran with the same env derivation the new CI step uses:

```
NVCA_VERSION="$(yq '.selfManaged.nvcaVersion' deploy/helm/nvca-operator/nvca-operator/values.yaml)" \
NVCA_OPERATOR_VERSION="$(yq '.appVersion' deploy/helm/nvca-operator/nvca-operator/Chart.yaml)" \
NVCA_SHARED_STORAGE_IMAGE_TAG="$(yq '.selfManaged.sharedStorage.imageTag' deploy/helm/nvca-operator/nvca-operator/values.yaml)" \
  make -C deploy/helm/nvca-operator check-vendor-chart
```

## For QA

QA needed: No. This is a chart-value sync plus a CI-only addition; no runtime behavior changes beyond what #1548 already shipped.

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the NVCA Operator webhook CPU request to improve reliability under load.
  * Removed the webhook CPU limit while retaining its memory settings.

* **Documentation**
  * Updated the webhook resource documentation to reflect the revised CPU configuration.

* **Tests**
  * Added CI validation to ensure the vendored NVCA Operator Helm chart matches its source version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->