### PR TITLE
fix(cloud-functions): Upper bound for autoscaler configuration threshold

### DIFF
--- a/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/function/deployment/dto/AutoscalingConfigurationDto.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/main/java/com/nvidia/nvcf/rest/function/deployment/dto/AutoscalingConfigurationDto.java
@@ -28,6 +28,7 @@ import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import jakarta.validation.Payload;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -64,7 +65,7 @@ public record AutoscalingConfigurationDto(
             @Schema(description = "Scaling threshold (0-100) as a percentage of utilization" +
                     "upon which the number of current instances are multiplied with the" +
                     "specified factor.")
-            @NotNull @PositiveOrZero Integer threshold,
+            @NotNull @PositiveOrZero @Max(100) Integer threshold,
 
             @Schema(description = "Stickiness window configuration")
             @Nullable @Valid StickinessWindow stickiness

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/rest/function/deployment/AutoscalingConfigurationTest.java
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/test/java/com/nvidia/nvcf/rest/function/deployment/AutoscalingConfigurationTest.java
@@ -116,6 +116,8 @@ class AutoscalingConfigurationTest {
             "fixtures/autoscaler/config/invalid_missing_threshold.json";
     private static final String CONFIG_NEGATIVE_THRESHOLD_JSON =
             "fixtures/autoscaler/config/invalid_negative_threshold.json";
+    private static final String CONFIG_THRESHOLD_ABOVE_100_JSON =
+            "fixtures/autoscaler/config/invalid_threshold_above_100.json";
     private static final String CONFIG_MISSING_FACTOR_JSON =
             "fixtures/autoscaler/config/invalid_missing_factor.json";
     private static final String CONFIG_SCALE_UP_FACTOR_LTE_1_JSON =
@@ -307,13 +309,16 @@ class AutoscalingConfigurationTest {
                              HttpStatus.BAD_REQUEST),
                 // 10. scaleUpDetails negative threshold: 400
                 Arguments.of(readFileAsString(CONFIG_NEGATIVE_THRESHOLD_JSON),
+                              HttpStatus.BAD_REQUEST),
+                // 11. scaleUpDetails threshold above 100: 400
+                Arguments.of(readFileAsString(CONFIG_THRESHOLD_ABOVE_100_JSON),
                              HttpStatus.BAD_REQUEST),
-                // 11. scaleUpDetails missing factor: 400
+                // 12. scaleUpDetails missing factor: 400
                 Arguments.of(readFileAsString(CONFIG_MISSING_FACTOR_JSON), HttpStatus.BAD_REQUEST),
-                // 12. scaleUpDetails factor <= 1.0: 400
+                // 13. scaleUpDetails factor <= 1.0: 400
                 Arguments.of(readFileAsString(CONFIG_SCALE_UP_FACTOR_LTE_1_JSON),
-                             HttpStatus.BAD_REQUEST),
-                // 13. scaleDownDetails factor >= 1.0: 400
+                              HttpStatus.BAD_REQUEST),
+                // 14. scaleDownDetails factor >= 1.0: 400
                 Arguments.of(readFileAsString(CONFIG_SCALE_DOWN_FACTOR_GTE_1_JSON),
                              HttpStatus.BAD_REQUEST)
         );

--- a/src/control-plane-services/cloud-functions/nvcf-core/src/test/resources/fixtures/autoscaler/config/invalid_threshold_above_100.json
+++ b/src/control-plane-services/cloud-functions/nvcf-core/src/test/resources/fixtures/autoscaler/config/invalid_threshold_above_100.json
@@ -1,0 +1,7 @@
+{
+  "scaleUpDetails": {
+    "metric": "worker_utilization",
+    "factor": 1.5,
+    "threshold": 101
+  }
+}


### PR DESCRIPTION
Closes #1642



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Autoscaling thresholds are now limited to a maximum of 100.
  - Configurations with thresholds above 100 are rejected with a `400 Bad Request` response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->