### PR TITLE
fix(function-autoscaler): honor configured runtime settings

### DIFF
--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -157,6 +157,9 @@ observability:
 
 # Defaults consumed only for the control and all observability profiles.
 functionAutoscaler:
+  # Additional application settings. Environment variables use `__` between
+  # nested keys, for example SCALING__LOOKBACK_SECONDS.
+  env: {}
   region: local
   cassandra:
     contactPoints: cassandra.cassandra-system.svc.cluster.local

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -897,6 +897,32 @@ stateMetrics:
 {{- $bundledPromqlEndpoint := printf "http://vmsingle.%s.svc.cluster.local:8428" $victoriaMetricsNamespace }}
 {{- $promqlEndpoint := ternary $bundledPromqlEndpoint (dig "metricsBackend" "promqlEndpoint" "" .Values) (eq $metricsBackendMode "install") }}
 functionautoscaler:
+  {{- $configuredFunctionAutoscalerEnv := dig "functionAutoscaler" "env" dict .Values }}
+  {{- if not (kindIs "map" $configuredFunctionAutoscalerEnv) }}
+  {{- fail "functionAutoscaler.env must be a map" }}
+  {{- end }}
+  {{- $functionAutoscalerEnv := dict
+        "CONFIG" "/etc/server/config/settings-local.yaml"
+        "SECRETS_PATH" "/vault/secrets/secrets.json"
+        "REGION" (dig "functionAutoscaler" "region" "local" .Values)
+        "CASSANDRA__CONTACT_POINTS" (dig "functionAutoscaler" "cassandra" "contactPoints" "cassandra.cassandra-system.svc.cluster.local" .Values)
+        "CASSANDRA__IS_DEVELOPMENT" (printf "%v" (dig "functionAutoscaler" "cassandra" "isDevelopment" false .Values))
+        "NVCF_API__NVCF_API_GRPC_ADDRESS" (dig "functionAutoscaler" "nvcfApi" "grpcAddress" "http://api.nvcf.svc.cluster.local:9090" .Values)
+        "NVCF_API__DISABLE_AUTH" (printf "%v" (dig "functionAutoscaler" "nvcfApi" "disableAuth" true .Values))
+        "NVCF_API__DRY_RUN" (printf "%v" (dig "functionAutoscaler" "nvcfApi" "dryRun" false .Values))
+        "TIMESERIES_DB__TIMESERIES_DB_URL" (required "metricsBackend.promqlEndpoint is required for control and all profiles" $promqlEndpoint)
+        "TIMESERIES_DB__AUTH_MODE" (dig "metricsBackend" "authentication" "mode" "none" .Values)
+        "TIMESERIES_DB__IGNORE_ENV" (printf "%v" (dig "functionAutoscaler" "timeseriesDb" "ignoreEnv" true .Values)) -}}
+  {{- with dig "metricsBackend" "authentication" "authnEndpoint" "" .Values }}
+  {{- $_ := set $functionAutoscalerEnv "TIMESERIES_DB__AUTHN_URL" . }}
+  {{- end }}
+  {{- with dig "metricsBackend" "authentication" "clientCertificatePath" "" .Values }}
+  {{- $_ := set $functionAutoscalerEnv "TIMESERIES_DB__CLIENT_CERTIFICATE_PATH" . }}
+  {{- end }}
+  {{- with dig "metricsBackend" "authentication" "clientPrivateKeyPath" "" .Values }}
+  {{- $_ := set $functionAutoscalerEnv "TIMESERIES_DB__CLIENT_PRIVATE_KEY_PATH" . }}
+  {{- end }}
+  {{- $functionAutoscalerEnv = mergeOverwrite $functionAutoscalerEnv (deepCopy $configuredFunctionAutoscalerEnv) }}
   namespace: nvcf
   fullnameOverride: function-autoscaler
   {{- if .Values.global.imagePullSecrets }}
@@ -910,26 +936,7 @@ functionautoscaler:
     tag: {{ . | quote }}
     {{- end }}
   env:
-    CONFIG: /etc/server/config/settings-local.yaml
-    SECRETS_PATH: /vault/secrets/secrets.json
-    REGION: {{ dig "functionAutoscaler" "region" "local" .Values | quote }}
-    CASSANDRA__CONTACT_POINTS: {{ dig "functionAutoscaler" "cassandra" "contactPoints" "cassandra.cassandra-system.svc.cluster.local" .Values | quote }}
-    CASSANDRA__IS_DEVELOPMENT: {{ dig "functionAutoscaler" "cassandra" "isDevelopment" false .Values | quote }}
-    NVCF_API__NVCF_API_GRPC_ADDRESS: {{ dig "functionAutoscaler" "nvcfApi" "grpcAddress" "http://api.nvcf.svc.cluster.local:9090" .Values | quote }}
-    NVCF_API__DISABLE_AUTH: {{ dig "functionAutoscaler" "nvcfApi" "disableAuth" true .Values | quote }}
-    NVCF_API__DRY_RUN: {{ dig "functionAutoscaler" "nvcfApi" "dryRun" false .Values | quote }}
-    TIMESERIES_DB__TIMESERIES_DB_URL: {{ required "metricsBackend.promqlEndpoint is required for control and all profiles" $promqlEndpoint | quote }}
-    TIMESERIES_DB__AUTH_MODE: {{ dig "metricsBackend" "authentication" "mode" "none" .Values | quote }}
-    TIMESERIES_DB__IGNORE_ENV: {{ dig "functionAutoscaler" "timeseriesDb" "ignoreEnv" true .Values | quote }}
-    {{- with dig "metricsBackend" "authentication" "authnEndpoint" "" .Values }}
-    TIMESERIES_DB__AUTHN_URL: {{ . | quote }}
-    {{- end }}
-    {{- with dig "metricsBackend" "authentication" "clientCertificatePath" "" .Values }}
-    TIMESERIES_DB__CLIENT_CERTIFICATE_PATH: {{ . | quote }}
-    {{- end }}
-    {{- with dig "metricsBackend" "authentication" "clientPrivateKeyPath" "" .Values }}
-    TIMESERIES_DB__CLIENT_PRIVATE_KEY_PATH: {{ . | quote }}
-    {{- end }}
+    {{- toYaml $functionAutoscalerEnv | nindent 4 }}
   {{- with include "nvcf.nodeSelector" (dict "type" "controlplane" "selectors" .Values.global.nodeSelectors) }}
   {{- . | nindent 2 }}
   {{- end }}

--- a/deploy/stacks/self-managed/tests/observability-autoscaler.sh
+++ b/deploy/stacks/self-managed/tests/observability-autoscaler.sh
@@ -116,6 +116,29 @@ for expected in \
     fail "control profile did not render autoscaler value: $expected"
 done
 
+write_autoscaler_values "$work_dir/custom-autoscaler-values.yaml" \
+  --state-values-set-string functionAutoscaler.env.SCALING__LOOKBACK_SECONDS=90 \
+  --state-values-set-string functionAutoscaler.env.SCALING__SCALE_TO_ZERO_IDLE_TIMEOUT_SECONDS=300 \
+  --state-values-set-string functionAutoscaler.env.NVCF_API__DRY_RUN=true
+
+custom_autoscaler_values="$work_dir/custom-autoscaler-values.yaml"
+for expected in \
+  'SCALING__LOOKBACK_SECONDS: "90"' \
+  'SCALING__SCALE_TO_ZERO_IDLE_TIMEOUT_SECONDS: "300"' \
+  'NVCF_API__DRY_RUN: "true"'; do
+  grep -q "$expected" "$custom_autoscaler_values" ||
+    fail "custom autoscaler env did not render or override defaults: $expected"
+done
+
+if write_autoscaler_values "$work_dir/invalid-autoscaler-values.yaml" \
+  --state-values-set-string functionAutoscaler.env=invalid \
+  >"$work_dir/invalid-autoscaler-env.log" 2>&1; then
+  fail "non-map functionAutoscaler.env was accepted"
+fi
+grep -q 'functionAutoscaler.env must be a map' \
+  "$work_dir/invalid-autoscaler-env.log" ||
+  fail "invalid functionAutoscaler.env did not return the expected error"
+
 helm template function-autoscaler "$repo_dir/deploy/helm/function-autoscaler" \
   --namespace nvcf \
   --values "$autoscaler_values" \

--- a/docs/user/autoscaling/observability.md
+++ b/docs/user/autoscaling/observability.md
@@ -53,8 +53,6 @@ server:
   envfilter_directive: "server=info,rs_autoscaler=debug,rs_autoscaler::cassandra=warn,info"
 ```
 
-The same syntax applies to `server.tracing.logging_envfilter_directive` if you separate logging and tracing filters.
-
 Useful target prefixes:
 
 | Target | Covers |

--- a/docs/user/configure-autoscaling.md
+++ b/docs/user/configure-autoscaling.md
@@ -36,6 +36,21 @@ Constraints:
 - `minInstances` must be `>= 0`. Setting `minInstances: 0` allows the function to scale to zero when idle. The scale-to-zero idle timeout is set on the platform and is not configurable per function.
 - `maxInstances` must be `> 0` and `>= minInstances`.
 
+The platform default scale-to-zero idle timeout is 1,800 seconds. Self-managed
+operators can override application settings in their environment file. For
+example, set the platform-wide idle timeout to five minutes:
+
+```yaml
+functionAutoscaler:
+  env:
+    SCALING__SCALE_TO_ZERO_IDLE_TIMEOUT_SECONDS: "300"
+```
+
+Environment variable names use `__` between nested settings keys. The timeout
+is evaluated from the last observed invocation; metric scraping and the
+autoscaler reconciliation loop can add a short delay before an instance is
+removed.
+
 With no other configuration, the deployment uses the platform's default scaling policy. The platform adds and removes instances within the `[minInstances, maxInstances]` bounds based on observed utilization.
 
 ## Update Scaling Bounds on an Existing Deployment

--- a/src/control-plane-services/function-autoscaler/crates/server/resources/settings-local.yaml
+++ b/src/control-plane-services/function-autoscaler/crates/server/resources/settings-local.yaml
@@ -3,32 +3,19 @@
 
 server:
   ip_address: 0.0.0.0
-  port: '50052'
+  port: 8080
   metrics:
     enabled: true
     exporters:
     - exporter: prometheus
-      protocol: http
       endpoint: 0.0.0.0:41338
-    service_name: nvcf-autoscaler
-    meter_name: null
-    resource_attributes: null
   tracing:
     endpoint_ip: http://localhost
     endpoint_port: 4317
     headers: {}
-    tracing_envfilter_directive: rs_autoscaler=trace,reqwest_tracing=trace
-    logging_envfilter_directive: server=trace,rs_autoscaler=trace,rs_autoscaler::nvcf_api=debug,rs_autoscaler::cassandra=trace,otel=debug,info
-    logging_nonblocking_output: true
   envfilter_directive: server=info,rs_autoscaler=debug,rs_autoscaler::work=debug,rs_autoscaler::nvcf_api=debug,rs_autoscaler::cassandra=warn,info
-  tonic:
-    initial_connection_window_size: 65535
-    initial_stream_window_size: 65535
-    max_decoding_message_size: 4194304
-    request_timeout: 30
 region: local
 secrets_path: "local_env/vault/secrets.json"
-tracing_key: ""
 nvcf_api:
   oauth2_token_api_address: ""
   oauth2_token_scope: "autoscaler:auth"

--- a/src/control-plane-services/function-autoscaler/crates/server/src/cassandra/cassandra_service.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/cassandra/cassandra_service.rs
@@ -114,6 +114,10 @@ pub struct CassandraServiceManager {
     health_check_cache_ttl: Duration,
 }
 
+fn health_check_cache_ttl(config: &CassandraSettings) -> Duration {
+    Duration::from_secs(config.health_check_cache_ttl_seconds)
+}
+
 impl CassandraServiceManager {
     pub async fn new(
         config: &CassandraSettings,
@@ -124,7 +128,7 @@ impl CassandraServiceManager {
             secrets_watcher,
             current_session: Arc::new(Mutex::new(None)),
             health_check_cache: Mutex::new(None),
-            health_check_cache_ttl: Duration::from_secs(30),
+            health_check_cache_ttl: health_check_cache_ttl(config),
         };
 
         // Create initial service
@@ -819,6 +823,16 @@ mod tests {
 
     static INIT: Once = Once::new();
     static TEMP_DIR: OnceLock<TempDir> = OnceLock::new();
+
+    #[test]
+    fn health_check_cache_ttl_uses_configured_value() {
+        let settings = CassandraSettings {
+            health_check_cache_ttl_seconds: 17,
+            ..Default::default()
+        };
+
+        assert_eq!(health_check_cache_ttl(&settings), Duration::from_secs(17));
+    }
 
     fn init_temp_dir() {
         INIT.call_once(|| {

--- a/src/control-plane-services/function-autoscaler/crates/server/src/scaling/mod.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/scaling/mod.rs
@@ -55,7 +55,7 @@ fn default_cassandra_page_size() -> i32 {
 fn default_policy_cache_max_capacity() -> u64 {
     10_000
 }
-fn default_discovery_recently_invoked_lookback_minutes() -> i64 {
+fn default_discovery_recently_invoked_lookback_minutes() -> u64 {
     5
 }
 
@@ -107,7 +107,7 @@ pub struct ScalingSettings {
     #[serde(default = "default_policy_cache_max_capacity")]
     pub policy_cache_max_capacity: u64,
     #[serde(default = "default_discovery_recently_invoked_lookback_minutes")]
-    pub discovery_recently_invoked_lookback_minutes: i64,
+    pub discovery_recently_invoked_lookback_minutes: u64,
     #[serde(skip)]
     pub policy_cache: Option<Arc<policy_cache::PolicyCache>>,
 }

--- a/src/control-plane-services/function-autoscaler/crates/server/src/server.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/server.rs
@@ -42,20 +42,19 @@ const NODE_HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(30);
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let project_name = env!("CARGO_PKG_NAME");
+    let (_cli_args, config) = settings::parse_settings();
+
     let node_id = gethostname::gethostname()
         .into_string()
         .unwrap_or_else(|_| uuid::Uuid::new_v4().to_string());
-    let region: String = std::env::var("AWS_REGION").unwrap_or_default();
     tracing::info!("Node ID: {}", node_id);
-    let node_id = if !region.is_empty() {
-        format!("{}.{}", node_id, region)
+    let node_id = if !config.region.is_empty() {
+        format!("{}.{}", node_id, config.region)
     } else {
         node_id
     };
     // Initialize shutdown signal
     let shutdown = Arc::new(AtomicBool::new(false));
-
-    let (_cli_args, config) = settings::parse_settings();
 
     let secrets_path = config
         .secrets_path
@@ -63,7 +62,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .ok_or("secrets_path is required but not provided in configuration")?;
 
     let metrics_settings = &config.server.metrics;
-    metrics::init_metrics(metrics_settings).expect("failed initializing metrics");
+    if metrics_settings.is_enabled() {
+        metrics::init_metrics(metrics_settings).expect("failed initializing metrics");
+    }
 
     let secrets_file_watcher = Arc::new(SecretFileWatcher::new(secrets_path).await?);
 
@@ -250,6 +251,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let timeseries_db_env_discover = config.timeseries_db.env.clone();
     let timeseries_db_ignore_env = config.timeseries_db.ignore_env;
     let lock_manager_discover = Arc::clone(&lock_manager);
+    let discovery_recently_invoked_lookback = Duration::from_secs(
+        config
+            .scaling
+            .discovery_recently_invoked_lookback_minutes
+            .checked_mul(60)
+            .ok_or("scaling.discovery_recently_invoked_lookback_minutes is too large")?,
+    );
     let discovery_task = tokio::spawn(async move {
         let jitter_millis = rand::rng().random_range(0..5000);
         let discovery_interval =
@@ -268,6 +276,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 &timeseries_db_env_discover,
                 timeseries_db_ignore_env,
                 config.scaling.discovery_lock_duration.as_secs() as i32,
+                discovery_recently_invoked_lookback,
             )
             .await
             {
@@ -327,14 +336,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    // Main app on 8080
+    // Main app
     let app = Router::new()
         .route("/health", get(routes::get_health))
         .route("/admin/health/liveness", get(routes::get_liveness))
         .route("/admin/health/readiness", get(routes::get_readiness))
         .with_state(health.clone())
         .fallback(handler_404);
-    let addr = SocketAddr::from(([0, 0, 0, 0], 8080));
+    let addr = config
+        .server
+        .listen_addr()
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))?;
 
     let shutdown_clone = shutdown.clone();
     let shutdown_signal = async move {

--- a/src/control-plane-services/function-autoscaler/crates/server/src/settings/README.md
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/settings/README.md
@@ -15,95 +15,38 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# 1. Application inputs
+# Application settings
 
-Inputs are important for configuring your run-time application.  When it comes to providing inputs, 
-you have a lot of flexibility.  You can define configuration settings or command-line arguments.
-Consequently, you can specify their values from any of the source below, in order of precedence:
+The function autoscaler loads settings from an optional YAML, JSON, or TOML
+file and then applies environment-variable overrides. Environment variables
+have the highest precedence.
 
- 1. Config file (supported formats are Json, Toml, Yaml)
- 2. Environment variable override config file
- 3. Command line parameters override environment variables and config file
+## Configuration file
 
-We provide a helper function to parse all of these input sources at once and resolve their precedence
-order.
-```
-let (args, settings) = parse_args::<AppCliArgs, AppSettings>().unwrap();
-```
-where `AppCliArgs` and `AppSettings` are custom structs that you define.  We describe these in more
-detail below.
+Pass a settings file with `--config` or the `CONFIG` environment variable:
 
-- [Configuration settings](#11-configuration-settings)
-- [Environment variables](#12-environment-variables)
-- [Command-line arguments](#13-command-line-arguments)
-
-## 1.1. Configuration settings
-
-Configuration settings are created via a struct definition.  In this example:
-```
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct AppSettings {
-    // Basic server settings
-    pub(crate) server: ServerSettings,
-    // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-    // Add your own settings below. These are just a few examples.
-    // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-    pub(crate) custom_1: Option<String>,
-    pub(crate) custom_2: Option<Vec<f64>>,
-}
-```
-We import the basic settings for a server app, `ServerSettings`, then add two
-custom settings, `custom_1` and `custom_2`.  To specify default values, implement
-the default trait for `AppSettings`.
-
-Calling `parse_args` returns the setting values from merging all input sources. 
-
-To export settings into a config file, run the app with the `generate` option:
-```
-cargo run --bin server -- -g settings.toml
-```
-To import settings form a config file, run the app with the `config` option:
-```
-cargo run --bin server -- -c settings.toml
+```bash
+cargo run --bin server -- --config crates/server/resources/settings-local.yaml
 ```
 
-## 1.2. Environment variables
+The bundled `resources/settings-local.yaml` shows the supported structure.
+Settings omitted from a file use their Rust defaults when the corresponding
+settings type defines one.
 
-Any setting can be overridden by an environment variable with the same path name.  In this
-example,
-```
-SERVER__TONIC__INITIAL_STREAM_WINDOW_SIZE=1234 cargo run --bin server
-```
-the environment variable `SERVER__TONIC__INITIAL_STREAM_WINDOW_SIZE` is
-translated into the setting `server.tonic.initial_stream_window_size`.  If such a
-setting exists (it does because it's provided as a default server setting), then
-its value is set to `1234`.
+## Environment variables
 
-## 1.3. Command-line arguments
+Use uppercase field names and `__` between nested keys. For example:
 
-Command-line args similarly created via a struct definition.  
+```bash
+SCALING__LOOKBACK_SECONDS=90 \
+SCALING__SCALE_TO_ZERO_IDLE_TIMEOUT_SECONDS=300 \
+SERVER__PORT=8083 \
+cargo run --bin server
 ```
-#[derive(Parser, Debug, Serialize, Deserialize)]
-#[command(version, about, long_about = None)]
-pub(crate) struct AppCliArgs {
-    // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-    // Add your own CLI args below.  These are just a few example types.
-    // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-    #[arg(long, value_name = "STRING", help = "A string")]
-    pub(crate) string_arg: Option<String>,
 
-    #[arg(long, value_name = "BOOL", help = "A boolean flag")]
-    pub(crate) flag_arg: Option<bool>,
+These values map to `scaling.lookback_seconds`,
+`scaling.scale_to_zero_idle_timeout_seconds`, and `server.port`. Environment
+variables override values loaded from the configuration file.
 
-    #[arg(long, value_name = "FLOAT", help = "A 3D vector", num_args = 3)]
-    pub(crate) vector_arg: Option<Vec<f32>>,
-}
-```
-We use the standard `clap` crate to parse the command line.  Thus, you can use the `clap arg`
-decorator to interpret the struct attributes as cli args.  See [docs](https://docs.rs/clap/latest/clap/#macros).
-
-```
-Any setting can be overridden on the command line by passing it as an override at the end of the command:
-```
-cargo run --bin server -- --port 50002 -c settings.toml -- tonic_settings.request_timeout=100
-```
+The command-line interface selects the configuration file; it does not accept
+arbitrary setting overrides. Use environment variables for per-run overrides.

--- a/src/control-plane-services/function-autoscaler/crates/server/src/settings/mod.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/settings/mod.rs
@@ -32,7 +32,7 @@ pub use server_settings::{MetricsSettings, OtelResourceSettings, ServerSettings,
 pub struct AppSettings {
     #[serde(default)]
     pub server: ServerSettings,
-    #[serde(default)]
+    #[serde(default = "default_region")]
     pub region: String,
     pub secrets_path: Option<PathBuf>,
     #[serde(default)]
@@ -42,28 +42,28 @@ pub struct AppSettings {
     #[serde(default)]
     pub scaling: ScalingSettings,
     #[serde(default)]
-    pub tracing_key: String,
-    #[serde(default)]
     pub nvcf_api: NvcfApiSettings,
+}
+
+fn default_region() -> String {
+    std::env::var("AWS_REGION").unwrap_or_else(|_| "us-west-1".to_string())
 }
 
 impl Default for AppSettings {
     fn default() -> Self {
-        let region = "us-west-1".to_string();
+        let region = default_region();
         let cassandra = CassandraSettings::default();
         let timeseries_db = TimeseriesDbSettings::default();
         let scaling = ScalingSettings::default();
-        let tracing_key = "tracing-key".to_string();
         let secrets_path = Some(PathBuf::from("local_env/vault/secrets.json"));
 
         AppSettings {
-            server: ServerSettings::default_with_service_name(env!("CARGO_PKG_NAME").to_string()),
+            server: ServerSettings::default(),
             region,
             secrets_path,
             cassandra,
             timeseries_db,
             scaling,
-            tracing_key,
             nvcf_api: NvcfApiSettings::default(),
         }
     }
@@ -77,31 +77,8 @@ pub struct AppCliArgs {
     pub config: Option<PathBuf>,
 }
 
-impl AppSettings {
-    pub fn new(
-        region: &str,
-        cassandra: CassandraSettings,
-        timeseries_db: TimeseriesDbSettings,
-        scaling: ScalingSettings,
-        tracing_key: &str,
-        secrets_path: &str,
-        nvcf_api: NvcfApiSettings,
-    ) -> Self {
-        AppSettings {
-            server: ServerSettings::default_with_service_name(env!("CARGO_PKG_NAME").to_string()),
-            region: region.to_string(),
-            secrets_path: Some(PathBuf::from(secrets_path)),
-            cassandra,
-            timeseries_db,
-            scaling,
-            tracing_key: tracing_key.to_string(),
-            nvcf_api,
-        }
-    }
-}
-
 /// Load settings from config file (if -c/--config given) and environment variables.
-/// Env vars use __ as separator, e.g. SERVER__METRICS__SERVICE_NAME=nvcf-autoscaler.
+/// Env vars use __ as separator, e.g. SCALING__LOOKBACK_SECONDS=90.
 pub fn parse_settings() -> (AppCliArgs, AppSettings) {
     let args = AppCliArgs::parse();
 
@@ -125,8 +102,8 @@ pub fn parse_settings() -> (AppCliArgs, AppSettings) {
         }
     };
 
-    // When no config file was provided, merge with defaults for missing values
-    if args.config.is_none() && settings.region.is_empty() {
+    // When no config file was provided, use the local default secrets path.
+    if args.config.is_none() {
         let defaults = AppSettings::default();
         if settings.secrets_path.is_none() {
             settings.secrets_path = defaults.secrets_path;
@@ -134,11 +111,6 @@ pub fn parse_settings() -> (AppCliArgs, AppSettings) {
         if settings.region.is_empty() {
             settings.region = defaults.region;
         }
-    }
-
-    // Default service name for metrics if not set
-    if settings.server.metrics.service_name.is_none() {
-        settings.server.metrics.service_name = Some(env!("CARGO_PKG_NAME").to_string());
     }
 
     // Inject OpenTelemetry resource attributes for all spans
@@ -166,12 +138,9 @@ pub fn parse_settings() -> (AppCliArgs, AppSettings) {
         ),
         (
             opentelemetry_semantic_conventions::resource::CLOUD_REGION,
-            std::env::var("AWS_REGION").unwrap_or_else(|_| "unknown".to_string()),
+            settings.region.clone(),
         ),
-        (
-            "host.dc",
-            std::env::var("AWS_REGION").unwrap_or_else(|_| "unknown".to_string()),
-        ),
+        ("host.dc", settings.region.clone()),
     ]);
     settings.server.resource = Some(resource);
 

--- a/src/control-plane-services/function-autoscaler/crates/server/src/settings/server_settings.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/settings/server_settings.rs
@@ -18,23 +18,41 @@
 //! Server-side config types (metrics, tracing, resource) used when loading app settings.
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr};
+
+const DEFAULT_SERVER_IP_ADDRESS: &str = "0.0.0.0";
+const DEFAULT_SERVER_PORT: u16 = 8080;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MetricsExporter {
     pub exporter: String,
-    pub protocol: String,
     pub endpoint: String,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MetricsSettings {
+    #[serde(default)]
     pub enabled: Option<bool>,
+    #[serde(default)]
     pub exporters: Vec<MetricsExporter>,
-    pub service_name: Option<String>,
-    pub meter_name: Option<String>,
-    pub resource_attributes: Option<serde_json::Value>,
     #[serde(default = "default_metrics_idle_timeout")]
     pub idle_timeout_seconds: u64,
+}
+
+impl Default for MetricsSettings {
+    fn default() -> Self {
+        Self {
+            enabled: None,
+            exporters: Vec::new(),
+            idle_timeout_seconds: default_metrics_idle_timeout(),
+        }
+    }
+}
+
+impl MetricsSettings {
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.unwrap_or(true)
+    }
 }
 
 fn default_metrics_idle_timeout() -> u64 {
@@ -43,20 +61,12 @@ fn default_metrics_idle_timeout() -> u64 {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TracingSettings {
+    #[serde(default)]
     pub endpoint_ip: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_u16")]
     pub endpoint_port: Option<u16>,
+    #[serde(default)]
     pub headers: Option<HashMap<String, String>>,
-    pub tracing_envfilter_directive: Option<String>,
-    pub logging_envfilter_directive: Option<String>,
-    pub logging_nonblocking_output: Option<bool>,
-}
-
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct TonicSettings {
-    pub initial_connection_window_size: Option<u32>,
-    pub initial_stream_window_size: Option<u32>,
-    pub max_decoding_message_size: Option<u32>,
-    pub request_timeout: Option<u32>,
 }
 
 /// OpenTelemetry resource attributes (key-value pairs for spans).
@@ -76,23 +86,97 @@ impl OtelResourceSettings {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ServerSettings {
+    #[serde(default)]
     pub ip_address: Option<String>,
-    pub port: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_u16")]
+    pub port: Option<u16>,
+    #[serde(default)]
     pub metrics: MetricsSettings,
+    #[serde(default)]
     pub tracing: TracingSettings,
+    #[serde(default)]
     pub resource: Option<OtelResourceSettings>,
+    #[serde(default)]
     pub envfilter_directive: Option<String>,
-    pub tonic: Option<TonicSettings>,
 }
 
 impl ServerSettings {
-    pub fn default_with_service_name(service_name: String) -> Self {
-        Self {
-            metrics: MetricsSettings {
-                service_name: Some(service_name),
-                ..Default::default()
-            },
-            ..Default::default()
-        }
+    pub fn listen_addr(&self) -> Result<SocketAddr, String> {
+        let ip_address = self
+            .ip_address
+            .as_deref()
+            .unwrap_or(DEFAULT_SERVER_IP_ADDRESS)
+            .parse::<IpAddr>()
+            .map_err(|error| format!("invalid server.ip_address: {error}"))?;
+
+        Ok(SocketAddr::new(
+            ip_address,
+            self.port.unwrap_or(DEFAULT_SERVER_PORT),
+        ))
+    }
+}
+
+fn deserialize_optional_u16<'de, D>(deserializer: D) -> Result<Option<u16>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde_json::Value;
+
+    match Value::deserialize(deserializer)? {
+        Value::Null => Ok(None),
+        Value::Number(number) => number
+            .as_u64()
+            .and_then(|value| u16::try_from(value).ok())
+            .map(Some)
+            .ok_or_else(|| serde::de::Error::custom(format!("port out of u16 range: {number}"))),
+        Value::String(value) if value.trim().is_empty() => Ok(None),
+        Value::String(value) => value
+            .trim()
+            .parse::<u16>()
+            .map(Some)
+            .map_err(|_| serde::de::Error::custom(format!("invalid port: {value:?}"))),
+        value => Err(serde::de::Error::custom(format!(
+            "expected integer or string for port, got {value}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_address_uses_runtime_defaults() {
+        assert_eq!(
+            ServerSettings::default().listen_addr().unwrap(),
+            "0.0.0.0:8080".parse().unwrap()
+        );
+    }
+
+    #[test]
+    fn server_address_uses_configured_values() {
+        let settings: ServerSettings =
+            serde_json::from_str(r#"{"ip_address":"127.0.0.1","port":"8083"}"#).unwrap();
+
+        assert_eq!(
+            settings.listen_addr().unwrap(),
+            "127.0.0.1:8083".parse().unwrap()
+        );
+    }
+
+    #[test]
+    fn metrics_are_enabled_by_default() {
+        assert!(MetricsSettings::default().is_enabled());
+        assert_eq!(
+            MetricsSettings::default().idle_timeout_seconds,
+            default_metrics_idle_timeout()
+        );
+    }
+
+    #[test]
+    fn metrics_can_be_disabled() {
+        let settings: MetricsSettings = serde_json::from_str(r#"{"enabled":false}"#).unwrap();
+
+        assert!(!settings.is_enabled());
     }
 }

--- a/src/control-plane-services/function-autoscaler/crates/server/src/work/discovery.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/work/discovery.rs
@@ -34,9 +34,9 @@ use super::MetricEnvironments;
 
 pub const LOCK_NAME_FUNCTION_DISCOVERY: &str = "function_discovery";
 
-/// Lookback window (minutes) for "recently invoked" in discovery. Functions with no invocations
+/// Lookback window for "recently invoked" in discovery. Functions with no invocations
 /// in this window are moved from recently_invoked to running_functions.
-pub const DISCOVERY_RECENTLY_INVOKED_LOOKBACK_MINUTES: i64 = 5;
+pub const DISCOVERY_RECENTLY_INVOKED_LOOKBACK: StdDuration = StdDuration::from_secs(5 * 60);
 const DISCOVERY_QUERY_CONCURRENCY: usize = 4;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -112,21 +112,21 @@ struct RecentInvocationQuery {
 const QUERY_INVOCATION_SERVICE: &str = r#"(
     sum by (function_id, function_version_id, nca_id) (function_request{env_filter} > 0)
     and
-    sum by (function_id, function_version_id, nca_id) (function_request{env_filter} unless function_request{env_filter} offset 5m)
+    sum by (function_id, function_version_id, nca_id) (function_request{env_filter} unless function_request{env_filter} offset {lookback_seconds}s)
     )
     or
     (
-    sum by (function_id, function_version_id, nca_id) (increase(function_request{env_filter}[5m]) > 0)
+    sum by (function_id, function_version_id, nca_id) (increase(function_request{env_filter}[{lookback_seconds}s]) > 0)
 )"#;
 
 const QUERY_GRPC_PROXY: &str = r#"(
     sum by (function_id, function_version_id, nca_id) (function_request_total{env_filter} > 0)
     and
-    sum by (function_id, function_version_id, nca_id) (function_request_total{env_filter} unless function_request_total{env_filter} offset 5m)
+    sum by (function_id, function_version_id, nca_id) (function_request_total{env_filter} unless function_request_total{env_filter} offset {lookback_seconds}s)
     )
     or
     (
-    sum by (function_id, function_version_id, nca_id) (increase(function_request_total{env_filter}[5m]) > 0)
+    sum by (function_id, function_version_id, nca_id) (increase(function_request_total{env_filter}[{lookback_seconds}s]) > 0)
 )"#;
 
 #[derive(Debug)]
@@ -165,6 +165,7 @@ fn get_timeseries_db_query(
     ignore_env: bool,
     function_version_filter: Option<Uuid>,
     shard: Option<DiscoveryShard>,
+    lookback: StdDuration,
 ) -> String {
     let mut matchers = Vec::new();
     if !ignore_env {
@@ -183,10 +184,17 @@ fn get_timeseries_db_query(
     } else {
         format!("{{{}}}", matchers.join(", "))
     };
-    template.replace("{env_filter}", &selector)
+    template
+        .replace("{env_filter}", &selector)
+        .replace("{lookback_seconds}", &lookback.as_secs().max(1).to_string())
 }
 
-fn llm_gateway_discovery_query(env: &str, ignore_env: bool, shard: DiscoveryShard) -> String {
+fn llm_gateway_discovery_query(
+    env: &str,
+    ignore_env: bool,
+    shard: DiscoveryShard,
+    lookback: StdDuration,
+) -> String {
     let function_id_regex = shard.function_id_regex();
     let env_matcher = if ignore_env {
         String::new()
@@ -197,12 +205,13 @@ fn llm_gateway_discovery_query(env: &str, ignore_env: bool, shard: DiscoveryShar
     // A group list copies labels from the left side, which has no version metadata.
     format!(
         r#"(sum by(function_id) (
-            increase(llm_api_gateway_http_requests_total{{function_id=~"{function_id_regex}", function_id!="none"{env_matcher}}}[5m])
+            increase(llm_api_gateway_http_requests_total{{function_id=~"{function_id_regex}", function_id!="none"{env_matcher}}}[{lookback_seconds}s])
         ) > 0)
         * on(function_id) group_right()
         max by(function_id, function_version_id, nca_id) (
             nvcf_function_info{{function_id=~"{function_id_regex}"{env_matcher}}}
-        )"#
+        )"#,
+        lookback_seconds = lookback.as_secs().max(1),
     )
 }
 
@@ -210,6 +219,7 @@ fn recent_invocation_queries(
     env: &str,
     ignore_env: bool,
     function_version_filter: Option<Uuid>,
+    lookback: StdDuration,
 ) -> Vec<RecentInvocationQuery> {
     let shards: Vec<Option<DiscoveryShard>> = if function_version_filter.is_some() {
         vec![None]
@@ -228,6 +238,7 @@ fn recent_invocation_queries(
                 ignore_env,
                 function_version_filter,
                 shard,
+                lookback,
             ),
         });
         queries.push(RecentInvocationQuery {
@@ -239,6 +250,7 @@ fn recent_invocation_queries(
                 ignore_env,
                 function_version_filter,
                 shard,
+                lookback,
             ),
         });
         if function_version_filter.is_none() {
@@ -246,7 +258,7 @@ fn recent_invocation_queries(
             queries.push(RecentInvocationQuery {
                 source: InvocationMetricSource::LlmGateway,
                 shard: Some(shard),
-                query: llm_gateway_discovery_query(env, ignore_env, shard),
+                query: llm_gateway_discovery_query(env, ignore_env, shard, lookback),
             });
         }
     }
@@ -271,6 +283,7 @@ async fn fetch_function_state(
     timeseries_db_client: &TimeseriesDbClient,
     env: &str,
     timeseries_db_ignore_env: bool,
+    recently_invoked_lookback: StdDuration,
 ) -> Result<(FunctionState, Vec<ActiveFunctionDetails>)> {
     let range = [i64::MIN, i64::MAX];
     let page_size = 2000;
@@ -280,8 +293,13 @@ async fn fetch_function_state(
         .await?;
 
     let timeseries_db_active_functions =
-        fetch_timeseries_db_active_functions(timeseries_db_client, env, timeseries_db_ignore_env)
-            .await?;
+        fetch_timeseries_db_active_functions(
+            timeseries_db_client,
+            env,
+            timeseries_db_ignore_env,
+            recently_invoked_lookback,
+        )
+        .await?;
 
     let state = FunctionState {
         db_recently_invoked: db_recently_invoked
@@ -300,6 +318,7 @@ async fn fetch_timeseries_db_active_functions(
     timeseries_db_client: &TimeseriesDbClient,
     env: &str,
     timeseries_db_ignore_env: bool,
+    recently_invoked_lookback: StdDuration,
 ) -> Result<Vec<ActiveFunctionDetails>> {
     tracing::info!("Getting recently invoked and running functions...");
     let query_semaphore = Arc::new(Semaphore::new(DISCOVERY_QUERY_CONCURRENCY));
@@ -308,7 +327,7 @@ async fn fetch_timeseries_db_active_functions(
         get_recently_invoked_functions_with_semaphore(
             timeseries_db_client,
             None,
-            DISCOVERY_RECENTLY_INVOKED_LOOKBACK_MINUTES,
+            recently_invoked_lookback,
             env,
             timeseries_db_ignore_env,
             Some(query_semaphore),
@@ -445,6 +464,7 @@ pub async fn discover_new_functions(
     env: &str,
     timeseries_db_ignore_env: bool,
     lock_duration_seconds: i32,
+    recently_invoked_lookback: StdDuration,
 ) -> Result<(), FunctionDiscoveryError> {
     // Step 1: Acquire or renew discovery lock (persistent leader pattern)
     let function_discovery_start_time = Instant::now();
@@ -483,6 +503,7 @@ pub async fn discover_new_functions(
         timeseries_db_client,
         env,
         timeseries_db_ignore_env,
+        recently_invoked_lookback,
     )
     .await
     .map_err(FunctionDiscoveryError::from)?;
@@ -522,14 +543,14 @@ pub async fn discover_new_functions(
 pub async fn get_recently_invoked_functions(
     timeseries_db_client: &TimeseriesDbClient,
     function_version_id_filter: Option<Uuid>,
-    lookback_period_minutes: i64,
+    lookback: StdDuration,
     env: &str,
     timeseries_db_ignore_env: bool,
 ) -> Result<Vec<ActiveFunctionDetails>> {
     get_recently_invoked_functions_with_semaphore(
         timeseries_db_client,
         function_version_id_filter,
-        lookback_period_minutes,
+        lookback,
         env,
         timeseries_db_ignore_env,
         None,
@@ -540,17 +561,21 @@ pub async fn get_recently_invoked_functions(
 async fn get_recently_invoked_functions_with_semaphore(
     timeseries_db_client: &TimeseriesDbClient,
     function_version_id_filter: Option<Uuid>,
-    lookback_period_minutes: i64,
+    lookback: StdDuration,
     env: &str,
     timeseries_db_ignore_env: bool,
     query_semaphore: Option<Arc<Semaphore>>,
 ) -> Result<Vec<ActiveFunctionDetails>> {
     let end_time = Utc::now();
-    let start_time = end_time - Duration::minutes(lookback_period_minutes);
+    let start_time = end_time;
     let step = StdDuration::from_secs(60); // 1 minute step
 
-    let queries =
-        recent_invocation_queries(env, timeseries_db_ignore_env, function_version_id_filter);
+    let queries = recent_invocation_queries(
+        env,
+        timeseries_db_ignore_env,
+        function_version_id_filter,
+        lookback,
+    );
     let query_count = queries.len();
     tracing::info!(
         query_count,
@@ -981,7 +1006,12 @@ mod tests {
 
     #[test]
     fn discovery_queries_cover_four_fixed_shards_for_all_sources() {
-        let queries = recent_invocation_queries("prod", false, None);
+        let queries = recent_invocation_queries(
+            "prod",
+            false,
+            None,
+            DISCOVERY_RECENTLY_INVOKED_LOOKBACK,
+        );
         assert_eq!(queries.len(), 12);
 
         for shard in DiscoveryShard::ALL {
@@ -1008,7 +1038,12 @@ mod tests {
 
     #[test]
     fn gateway_discovery_omits_environment_when_configured() {
-        let queries = recent_invocation_queries("stg", true, None);
+        let queries = recent_invocation_queries(
+            "stg",
+            true,
+            None,
+            DISCOVERY_RECENTLY_INVOKED_LOOKBACK,
+        );
         for query in queries
             .iter()
             .filter(|query| matches!(query.source, InvocationMetricSource::LlmGateway))
@@ -1020,12 +1055,19 @@ mod tests {
     #[test]
     fn per_function_recent_invocation_queries_are_not_sharded() {
         let function_version_id = Uuid::new_v4();
-        let queries = recent_invocation_queries("stg", true, Some(function_version_id));
+        let queries = recent_invocation_queries(
+            "stg",
+            true,
+            Some(function_version_id),
+            StdDuration::from_secs(90),
+        );
 
         assert_eq!(queries.len(), 2);
         for query in queries {
             assert!(query.shard.is_none());
             assert!(!query.query.contains("function_id=~"));
+            assert!(query.query.contains("offset 90s"));
+            assert!(query.query.contains("[90s]"));
             assert_eq!(
                 query
                     .query
@@ -1098,7 +1140,7 @@ mod tests {
         let functions = get_recently_invoked_functions(
             &ts_client(server.url()),
             None,
-            DISCOVERY_RECENTLY_INVOKED_LOOKBACK_MINUTES,
+            DISCOVERY_RECENTLY_INVOKED_LOOKBACK,
             "stg",
             true,
         )
@@ -1144,7 +1186,7 @@ mod tests {
         let result = get_recently_invoked_functions(
             &ts_client(server.url()),
             Some(function_version_id),
-            DISCOVERY_RECENTLY_INVOKED_LOOKBACK_MINUTES,
+            DISCOVERY_RECENTLY_INVOKED_LOOKBACK,
             "stg",
             true,
         )
@@ -1186,9 +1228,14 @@ mod tests {
             .create_async()
             .await;
 
-        let functions = fetch_timeseries_db_active_functions(&ts_client(server.url()), "stg", true)
-            .await
-            .expect("worker results should survive invocation discovery failure");
+        let functions = fetch_timeseries_db_active_functions(
+            &ts_client(server.url()),
+            "stg",
+            true,
+            DISCOVERY_RECENTLY_INVOKED_LOOKBACK,
+        )
+        .await
+        .expect("worker results should survive invocation discovery failure");
 
         assert_eq!(functions.len(), 1);
         assert_eq!(functions[0].function_id, function_id);

--- a/src/control-plane-services/function-autoscaler/crates/server/src/work/mod.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/work/mod.rs
@@ -130,11 +130,11 @@ async fn get_function_utilization_history(
     env: &str,
     metric_source: MetricSource,
     ignore_env: bool,
-    lookback_minutes: i64,
+    lookback: StdDuration,
     utilization_window_seconds: u64,
 ) -> Result<Vec<(i64, String)>> {
     let end_time = Utc::now();
-    let start_time = end_time - Duration::minutes(lookback_minutes);
+    let start_time = end_time - Duration::from_std(lookback)?;
     let step = TIMESERIES_DB_QUERY_STEP;
 
     let metric_env = MetricEnvironments::from_config(env);
@@ -477,12 +477,12 @@ async fn get_gateway_target(
 async fn llm_gateway_recently_invoked(
     timeseries_db_client: &TimeseriesDbClient,
     function_id: &Uuid,
-    lookback_seconds: u64,
+    lookback: StdDuration,
     env: &str,
     ignore_env: bool,
 ) -> Result<bool> {
     let end_time = Utc::now();
-    let lookback_seconds = lookback_seconds.max(1);
+    let lookback_seconds = lookback.as_secs().max(1);
     let env_suffix = if ignore_env {
         String::new()
     } else {
@@ -495,7 +495,7 @@ async fn llm_gateway_recently_invoked(
     let response = timeseries_db_client
         .query_range(
             &query,
-            end_time - Duration::minutes(1),
+            end_time,
             end_time,
             TIMESERIES_DB_QUERY_STEP,
         )
@@ -675,7 +675,7 @@ async fn gather_scaling_inputs(
         env,
         metric_source,
         ignore_env,
-        scaling_settings.lookback.as_secs() as i64 / 60,
+        scaling_settings.lookback,
         scaling_settings.utilization_window_seconds,
     )
     .await?;
@@ -685,7 +685,7 @@ async fn gather_scaling_inputs(
         llm_gateway_recently_invoked(
             timeseries_db_client,
             function_id,
-            scaling_settings.scale_to_zero_idle_timeout.as_secs(),
+            scaling_settings.scale_to_zero_idle_timeout,
             env,
             ignore_env,
         )
@@ -694,7 +694,7 @@ async fn gather_scaling_inputs(
         !get_recently_invoked_functions(
             timeseries_db_client,
             Some(*function_version_id),
-            scaling_settings.scale_to_zero_idle_timeout.as_secs() as i64 / 60,
+            scaling_settings.scale_to_zero_idle_timeout,
             env,
             ignore_env,
         )
@@ -1277,7 +1277,7 @@ mod tests {
             "stg",
             MetricSource::ControlPlane,
             true,
-            5,
+            StdDuration::from_secs(5 * 60),
             60,
         )
         .await
@@ -1319,7 +1319,7 @@ mod tests {
                 configured_env,
                 MetricSource::ControlPlane,
                 false,
-                5,
+                StdDuration::from_secs(5 * 60),
                 60,
             )
             .await
@@ -1473,7 +1473,7 @@ mod tests {
                 "prod",
                 MetricSource::LlmGateway,
                 false,
-                5,
+                StdDuration::from_secs(5 * 60),
                 70,
             )
             .await
@@ -1493,7 +1493,13 @@ mod tests {
             .create_async()
             .await;
         assert!(
-            llm_gateway_recently_invoked(&ts_client(server.url()), &fid, 0, "prod", false)
+            llm_gateway_recently_invoked(
+                &ts_client(server.url()),
+                &fid,
+                StdDuration::ZERO,
+                "prod",
+                false,
+            )
                 .await
                 .expect("gateway recent invocation query")
         );

--- a/src/control-plane-services/function-autoscaler/local_env/AGENTS.md
+++ b/src/control-plane-services/function-autoscaler/local_env/AGENTS.md
@@ -34,6 +34,7 @@ stack). It binds three ports:
 ```
 TIMESERIES_DB__TIMESERIES_DB_URL=http://localhost:8428 \
 TIMESERIES_DB__DISABLE_AUTH=true \
+SERVER__PORT=8083 \
 cargo run --bin server
 ```
 
@@ -55,14 +56,13 @@ The README's bare `cargo run` does not work without these.
 
 ## Port Conflict on 8080
 
-`crates/server/src/server.rs:328` hardcodes the main HTTP listener to
-`8080` and ignores `ServerSettings.port`. On dev machines that run
+The main HTTP listener defaults to `8080`. On dev machines that run
 `k3d-ncp-local-serverlb`, `:8080` is already taken and the autoscaler will
 exit with `AddrInUse`.
 
-Workaround used here: patched `server.rs:328` from `8080` to `8083` for
-local runs. Do not commit. A proper fix is to read
-`ServerSettings.ip_address` and `ServerSettings.port` from the config.
+The run command above sets `SERVER__PORT=8083` so local runs do not conflict
+with the cluster load balancer. `SERVER__IP_ADDRESS` can similarly override
+the default `0.0.0.0` bind address.
 
 ## Mock Server Function Categories
 


### PR DESCRIPTION
## TL;DR

Honor the function autoscaler's configured timing and runtime settings.

Scale-to-zero checks previously combined the configured idle timeout with a
fixed five-minute PromQL window. This delayed scale-to-zero beyond the configured
value. Self-managed deployments also had no general way to override autoscaler
application settings.

## Additional Details

- Use the configured idle timeout as the PromQL invocation window.
- Evaluate recent-invocation queries once at the current timestamp instead of
  compounding inner and outer lookback windows.
- Preserve second-level precision for utilization and idle timeouts.
- Use `scaling.discovery_recently_invoked_lookback_minutes` instead of a
  hardcoded five-minute discovery window.
- Add `functionAutoscaler.env` to the self-managed stack, with custom values
  overriding stack defaults.
- Honor the Cassandra health-cache TTL, configured region, metrics enablement,
  and server listen address.
- Remove legacy settings that had no runtime implementation.
- Document the platform default and self-managed scale-to-zero override.

The default scale-to-zero idle timeout remains 1,800 seconds.

## For the Reviewer

Please focus on:

- `work/discovery.rs`: PromQL window and instant-query behavior.
- `work/mod.rs`: duration propagation without minute truncation.
- `global.yaml.gotmpl`: merge precedence for `functionAutoscaler.env`.
- `settings/server_settings.rs`: runtime configuration wiring and removal of
  unused settings.

The settings cleanup is broader than the original scale-to-zero defect. It can
be moved to a follow-up PR if a narrower change is preferred.

## For QA

Validation completed:

- `bazel test //src/control-plane-services/function-autoscaler/crates/server:rs_autoscaler_test`
- `bazel build //src/control-plane-services/function-autoscaler/crates/server:server`
- `helm lint deploy/helm/function-autoscaler`
- Rendered the self-managed Helmfile values and final Helm manifests with
  custom autoscaler environment overrides.
- `fern check`
- `git diff --check`
- Shell syntax validation for the updated stack test.

The complete `observability-autoscaler.sh` test was not run because `yq` is not
installed in the local environment. Its affected Helmfile and Helm rendering
paths were exercised manually.

QA is recommended with a short idle timeout, for example:

```yaml
functionAutoscaler:
  env:
    SCALING__SCALE_TO_ZERO_IDLE_TIMEOUT_SECONDS: "300"
```

Confirm that an idle function becomes eligible for scale-to-zero after
approximately five minutes plus normal scrape and reconciliation delay.

## Issues

Relates to #15

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Self-managed deployments can provide custom autoscaler environment settings, including nested values.
  - Server IP address and port can be configured, with validation and sensible defaults.
  - Autoscaler discovery and scaling windows now follow configured timing values.
  - Cassandra health-check caching respects the configured duration.
- **Bug Fixes**
  - Improved configuration validation and handling of invalid values.
  - Metrics initialization now follows the enabled/disabled setting.
- **Documentation**
  - Added guidance for configuration files, environment-variable overrides, and scale-to-zero timing.
- **Tests**
  - Added coverage for environment overrides, validation, server addresses, metrics, and timing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->