### PR TITLE
ci: add markdownlint config and a reporting lint job

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -50,7 +50,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
+          # Node 20 reached end of life on 2026-03-24, and markdownlint-cli
+          # 0.49.1 declares engines.node >=22, so 20 would install with a
+          # warning and run unsupported.
+          node-version: '24'
 
       - name: Install markdownlint-cli
         env:
@@ -66,6 +69,24 @@ jobs:
         run: |
           set -uo pipefail
 
+          # markdownlint exits 0 clean, 1 for lint findings, and 2 or above
+          # for an execution error (unwritable output, bad config, unexpected
+          # failure). xargs collapses every one of those non-zero codes to
+          # 123, so calling it directly would make a broken run look like a
+          # pile of findings and publish a meaningless count.
+          #
+          # This wrapper records the real status of each invocation and always
+          # exits 0, so xargs cannot mask it.
+          status_file="${RUNNER_TEMP}/status.txt"
+          : > "${status_file}"
+          cat > "${RUNNER_TEMP}/mdl.sh" <<SH
+          #!/usr/bin/env bash
+          markdownlint "\$@"
+          printf '%s\n' "\$?" >> "${status_file}"
+          exit 0
+          SH
+          chmod +x "${RUNNER_TEMP}/mdl.sh"
+
           # Git-tracked files only, minus the vendored trees excluded by
           # .markdownlintignore. A bare '**/*.md' would also walk build
           # output and node_modules.
@@ -75,7 +96,25 @@ jobs:
           # has no -a. -0 keeps paths containing whitespace intact.
           git ls-files '*.md' > "${RUNNER_TEMP}/tracked.txt"
           tr '\n' '\0' < "${RUNNER_TEMP}/tracked.txt" \
-            | xargs -0 markdownlint > "${RUNNER_TEMP}/out.txt" 2>&1 || true
+            | xargs -0 "${RUNNER_TEMP}/mdl.sh" > "${RUNNER_TEMP}/out.txt" 2>&1
+
+          # Worst status across invocations, 0 if xargs never ran the wrapper.
+          worst="$(sort -rn "${status_file}" | head -1)"
+          worst="${worst:-0}"
+
+          if [ "${worst}" -gt 1 ]; then
+            echo "::error::markdownlint failed to execute (exit ${worst})"
+            cat "${RUNNER_TEMP}/out.txt"
+            {
+              echo "## Markdown lint"
+              echo
+              echo "markdownlint failed to execute (exit ${worst})."
+              echo "No violation count was produced."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            # Lint findings stay non-blocking, but a job that cannot produce a
+            # trustworthy number has nothing to report and must not pass green.
+            exit 1
+          fi
 
           total="$(wc -l < "${RUNNER_TEMP}/out.txt" | tr -d ' ')"
           files="$(cut -d: -f1 "${RUNNER_TEMP}/out.txt" | sort -u | wc -l | tr -d ' ')"
@@ -83,7 +122,7 @@ jobs:
           {
             echo "## Markdown lint"
             echo
-            echo "Reporting only. This job does not fail the build yet."
+            echo "Reporting only. Lint findings do not fail the build yet."
             echo
             echo "- violations: ${total}"
             echo "- files: ${files}"

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Report markdownlint violations for first-party markdown.
+#
+# Reporting only, on purpose. The tree has not been cleaned up yet, so this
+# job records the current state in the run summary instead of gating on it.
+# It is the first half of the work: agree the ruleset here, clean up
+# incrementally, then flip this job to blocking once the count reaches zero.
+# A reporting job that never becomes blocking decays into noise, so treat the
+# count in the summary as a number that is supposed to go down.
+
+name: Markdown Lint
+
+on:
+  push:
+    branches: [main, 'release-**']
+    paths:
+      - '**/*.md'
+      - '.markdownlint.json'
+      - '.markdownlintignore'
+      - '.github/workflows/markdown-lint.yml'
+  pull_request:
+    branches: [main, 'release-**']
+    paths:
+      - '**/*.md'
+      - '.markdownlint.json'
+      - '.markdownlintignore'
+      - '.github/workflows/markdown-lint.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: markdown-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  markdownlint:
+    name: Lint markdown
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+
+      - name: Install markdownlint-cli
+        env:
+          # Pinned so a markdownlint release that adds or tightens a rule
+          # cannot move the reported count with no commit here to explain it.
+          # Bump deliberately, and note the count change in the pull request.
+          MARKDOWNLINT_CLI_VERSION: "0.49.1"
+        run: |
+          set -euo pipefail
+          npm install -g "markdownlint-cli@${MARKDOWNLINT_CLI_VERSION}"
+
+      - name: Run markdownlint
+        run: |
+          set -uo pipefail
+
+          # Git-tracked files only, minus the vendored trees excluded by
+          # .markdownlintignore. A bare '**/*.md' would also walk build
+          # output and node_modules.
+          #
+          # The file list goes through stdin rather than xargs -a so this is
+          # the same command contributors can run on macOS, where BSD xargs
+          # has no -a. -0 keeps paths containing whitespace intact.
+          git ls-files '*.md' > "${RUNNER_TEMP}/tracked.txt"
+          tr '\n' '\0' < "${RUNNER_TEMP}/tracked.txt" \
+            | xargs -0 markdownlint > "${RUNNER_TEMP}/out.txt" 2>&1 || true
+
+          total="$(wc -l < "${RUNNER_TEMP}/out.txt" | tr -d ' ')"
+          files="$(cut -d: -f1 "${RUNNER_TEMP}/out.txt" | sort -u | wc -l | tr -d ' ')"
+
+          {
+            echo "## Markdown lint"
+            echo
+            echo "Reporting only. This job does not fail the build yet."
+            echo
+            echo "- violations: ${total}"
+            echo "- files: ${files}"
+            echo
+            echo "### By rule"
+            echo
+            echo '```text'
+            grep -oE 'MD[0-9]{3}' "${RUNNER_TEMP}/out.txt" \
+              | sort | uniq -c | sort -rn | head -20
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          echo "markdownlint: ${total} violations across ${files} files"

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,11 @@
+{
+  "default": true,
+  "MD004": { "style": "dash" },
+  "MD013": false,
+  "MD024": false,
+  "MD025": false,
+  "MD033": false,
+  "MD034": false,
+  "MD036": false,
+  "MD060": false
+}

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,7 @@
+# Third-party markdown this repository does not own and cannot fix.
+#
+# Listing git-tracked files is not enough on its own here: vendor/ is tracked,
+# and 609 of the 1394 tracked .md files are vendored Go dependencies. Two of
+# them ship their own .markdownlint.yaml, tuned for a different project.
+vendor/
+third_party/


### PR DESCRIPTION
## TL;DR

The repository has no markdown linting, so markdown problems are caught only in
review, one instance at a time. This adds the ruleset and a reporting-only CI
job. It does not clean anything up yet.

Deliberately split in two. Agreeing the ruleset is a small, reviewable change.
The cleanup it implies is 894 hand fixes across 254 files, and mixing the two
would bury the ruleset discussion in a large mechanical diff.

Reporting only means this job does not fail the build. That is a temporary
state, not the destination: a reporting job that never becomes blocking decays
into noise. The number in the run summary is meant to go down, and the job
flips to blocking when it reaches zero. That intent is written into the
workflow header so it is not lost.

## Additional Details

Measured over the 785 first-party tracked `.md` files, excluding 609 vendored
and 3 `third_party/` files:

| Stage | Violations |
| --- | --- |
| markdownlint default rules | 22258 |
| with this ruleset | 4815, across 400 files |
| after `markdownlint --fix` | 894, across 254 files |

`MD013` alone is 12054 of the default total, and `MD060` another 3438. Both are
purely cosmetic. What is left after `--fix` is not: 408 fenced code blocks with
no language tag, plus broken link fragments and malformed tables.

### Ruleset

Measured against this repository rather than copied from elsewhere. Disabled
rules, with hit counts at the default ruleset:

| Rule | Hits | Why it is off |
| --- | --- | --- |
| `MD013` line-length | 12054 | Long tables, URLs, and copy-and-run commands that wrapping breaks. |
| `MD060` table-column-style | 3438 | Cosmetic pipe alignment. |
| `MD033` no-inline-html | 1272 | Fern MDX components under `docs/`. Load-bearing here, not decorative. |
| `MD034` no-bare-urls | 390 | Intentional in reference tables, where the URL is the content. |
| `MD036` no-emphasis-as-heading | 329 | Fires on field labels used as pseudo-headings. |
| `MD024` no-duplicate-heading | 220 | Repeated per-section headings are intentional. |
| `MD025` single-h1 | 220 | See below. |

`MD004` is pinned to `dash` rather than left on `consistent`. `consistent`
matches whatever the first bullet in each file uses, which would fragment the
tree; dash is already dominant here at 7045 occurrences against 141.

### Two findings worth a reviewer's attention

Almost no `MD025` hit is a real second title, and the reasons are both
structural:

1. Chart READMEs open with an SPDX license header written as markdown `#`
   lines. In `deploy/helm/event-ledger/README.md` the first 14 lines are the
   Apache header, and every one of them parses as a top-level heading. This is
   also a rendering issue independent of lint: those lines display as headings
   on GitHub.
2. Under `docs/`, an MDX close tag immediately followed by a fence with no
   blank line between them makes CommonMark treat the fence as part of the HTML
   block. In `docs/v0.5/terraform-installation.md`, `</Accordion>` is followed
   directly by an ```` ```hcl ```` fence, so the HCL inside is parsed as
   markdown and its comments are reported as headings. That single file
   accounts for 72 of the 220.

The second one matters for the cleanup stage: it means a share of the reported
`docs/` violations are parse artifacts rather than real defects, and that
inserting the blank lines `MD031` already asks for should resolve the cascade.
Fern renders these files correctly today; this is a CommonMark limitation, not
a docs bug.

### Vendored trees

Listing git-tracked files is not sufficient in this repository. `vendor/` is
tracked, and 609 of the 1394 tracked `.md` files are vendored Go dependencies.
Two of them ship their own `.markdownlint.yaml`, tuned for another project.
`.markdownlintignore` excludes `vendor/` and `third_party/` for that reason,
and the file records it so the exclusion is not mistaken for a preference.

### Dependency

`markdownlint-cli` 0.49.1, MIT, which is in `.allowed-licenses.txt`. It is
installed inside the workflow only and is not added to any package manifest or
shipped artifact, so `NOTICE` is unaffected. The version is pinned so a release
that adds or tightens a rule cannot move the reported count with no commit here
to explain it.

## For the Reviewer

The file worth reviewing is `.markdownlint.json`. Everything else follows from
it. If you disagree with a disabled rule, that is the change to make now, while
the tree is still untouched and re-measuring is cheap.

`.github/workflows/markdown-lint.yml` follows the shape of the existing
validate workflows: pinned action SHAs, `persist-credentials: false`,
`concurrency` group, `permissions: contents: read`, and a pinned tool version
in `env`.

## For QA

No QA needed. CI-only change, no runtime or shipped-artifact impact.

Verified locally:

- `actionlint` passes on the new workflow and on the whole `.github/workflows`
  tree, run with `SHELLCHECK_OPTS="--severity=warning"` as the actionlint
  workflow does.
- The workflow's `run` block was extracted from the YAML and executed directly,
  rather than retyped, to confirm it exits 0 and renders the summary. Output:
  `markdownlint: 4815 violations across 400 files`.
- `.markdownlintignore` was confirmed to filter nested vendored paths: all 1394
  tracked `.md` files are passed to markdownlint and zero violations are
  reported from `vendor/` or `third_party/`.
- The 4815 figure reconciles with the measurement above: it is the 5035 counted
  with `MD025` enabled, minus that rule's 220 hits.

No tests are added. This is a CI and configuration change with no code under
test.

## Issues

Relates to #1664

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated Markdown lint reporting for pushes, pull requests, and manual workflow runs.
  * Reports violation totals, affected files, and common rule issues in workflow logs and summaries.

* **Chores**
  * Added project-wide Markdown linting configuration with standardized list formatting.
  * Excluded third-party Markdown directories from lint checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->