### PR TITLE
fix(nvca): AND NVLink clique requirement into existing node affinity

### DIFF
--- a/src/compute-plane-services/nvca/pkg/dra/dra.go
+++ b/src/compute-plane-services/nvca/pkg/dra/dra.go
@@ -203,12 +203,6 @@ func SetPreferredNVLinkDomainSchedulingParameters(keyToHash string, objs ...clie
 		},
 		TopologyKey: GPUCliqueNodeLabel,
 	}
-	cliqueNodeSelTerm := corev1.NodeSelectorTerm{
-		MatchExpressions: []corev1.NodeSelectorRequirement{{
-			Key:      GPUCliqueNodeLabel,
-			Operator: corev1.NodeSelectorOpExists,
-		}},
-	}
 
 	itrf := func(pts *corev1.PodTemplateSpec) {
 		ps := &pts.Spec
@@ -229,16 +223,7 @@ func SetPreferredNVLinkDomainSchedulingParameters(keyToHash string, objs ...clie
 				PodAffinityTerm: podAffinityTerm,
 			},
 		)
-		if ps.Affinity.NodeAffinity == nil {
-			ps.Affinity.NodeAffinity = &corev1.NodeAffinity{}
-		}
-		if ps.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
-			ps.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{}
-		}
-		ps.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(
-			ps.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
-			cliqueNodeSelTerm,
-		)
+		requireGPUCliqueNode(ps.Affinity)
 	}
 	iterPodSpecs(itrf, objs...)
 }
@@ -265,12 +250,6 @@ func SetRequiredNVLinkDomainSchedulingParameters(
 		},
 		TopologyKey: GPUCliqueNodeLabel,
 	}
-	cliqueNodeSelTerm := corev1.NodeSelectorTerm{
-		MatchExpressions: []corev1.NodeSelectorRequirement{{
-			Key:      GPUCliqueNodeLabel,
-			Operator: corev1.NodeSelectorOpExists,
-		}},
-	}
 
 	itrf := func(pts *corev1.PodTemplateSpec) {
 		ps := &pts.Spec
@@ -288,19 +267,56 @@ func SetRequiredNVLinkDomainSchedulingParameters(
 			ps.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
 			podAffinityTerm,
 		)
-		if ps.Affinity.NodeAffinity == nil {
-			ps.Affinity.NodeAffinity = &corev1.NodeAffinity{}
-		}
-		if ps.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
-			ps.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{}
-		}
-		ps.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(
-			ps.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
-			cliqueNodeSelTerm,
-		)
+		requireGPUCliqueNode(ps.Affinity)
 	}
 
 	iterPodSpecs(itrf, objs...)
+}
+
+var gpuCliqueNodeSelectorRequirement = corev1.NodeSelectorRequirement{
+	Key:      GPUCliqueNodeLabel,
+	Operator: corev1.NodeSelectorOpExists,
+}
+
+// requireGPUCliqueNode narrows the required node affinity of a Pod so that it
+// only admits nodes carrying a GPU clique label.
+//
+// Kubernetes ORs NodeSelectorTerms, so the requirement is ANDed into every
+// existing term instead of being appended as a term of its own. An appended
+// clique-only term would give the Pod an alternative way to satisfy required
+// node affinity and let it bypass constraints it already carries, such as a
+// hostname restriction. The merge is idempotent so that repeated admission
+// does not accumulate duplicate requirements.
+func requireGPUCliqueNode(a *corev1.Affinity) {
+	if a.NodeAffinity == nil {
+		a.NodeAffinity = &corev1.NodeAffinity{}
+	}
+	if a.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		a.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{}
+	}
+	ns := a.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	if len(ns.NodeSelectorTerms) == 0 {
+		ns.NodeSelectorTerms = []corev1.NodeSelectorTerm{{
+			MatchExpressions: []corev1.NodeSelectorRequirement{gpuCliqueNodeSelectorRequirement},
+		}}
+		return
+	}
+	for i := range ns.NodeSelectorTerms {
+		term := &ns.NodeSelectorTerms[i]
+		if hasGPUCliqueRequirement(term.MatchExpressions) {
+			continue
+		}
+		term.MatchExpressions = append(term.MatchExpressions, gpuCliqueNodeSelectorRequirement)
+	}
+}
+
+func hasGPUCliqueRequirement(reqs []corev1.NodeSelectorRequirement) bool {
+	for _, req := range reqs {
+		if req.Key == GPUCliqueNodeLabel && req.Operator == corev1.NodeSelectorOpExists {
+			return true
+		}
+	}
+	return false
 }
 
 type iterPodTemplateSpecFunc func(*corev1.PodTemplateSpec)

--- a/src/compute-plane-services/nvca/pkg/dra/dra_test.go
+++ b/src/compute-plane-services/nvca/pkg/dra/dra_test.go
@@ -173,6 +173,130 @@ func Test_containerRequestsStaticGPU(t *testing.T) {
 	}
 }
 
+func TestNVLinkDomainSchedulingParametersNarrowRequiredNodeAffinity(t *testing.T) {
+	cliqueReq := corev1.NodeSelectorRequirement{
+		Key:      GPUCliqueNodeLabel,
+		Operator: corev1.NodeSelectorOpExists,
+	}
+	hostnameReq := corev1.NodeSelectorRequirement{
+		Key:      "kubernetes.io/hostname",
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   []string{"selected-node-a", "selected-node-b"},
+	}
+	instanceTypeReq := corev1.NodeSelectorRequirement{
+		Key:      "nvidia.com/instance-type",
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   []string{"gb200"},
+	}
+	nameField := corev1.NodeSelectorRequirement{
+		Key:      "metadata.name",
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   []string{"selected-node-a"},
+	}
+	newRequiredNodeAffinity := func(terms ...corev1.NodeSelectorTerm) *corev1.Affinity {
+		return &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: terms,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		affinity *corev1.Affinity
+		applyN   int
+		want     []corev1.NodeSelectorTerm
+	}{
+		{
+			name:   "no affinity yields a single clique term",
+			applyN: 1,
+			want: []corev1.NodeSelectorTerm{{
+				MatchExpressions: []corev1.NodeSelectorRequirement{cliqueReq},
+			}},
+		},
+		{
+			name:     "empty required selector yields a single clique term",
+			affinity: newRequiredNodeAffinity(),
+			applyN:   1,
+			want: []corev1.NodeSelectorTerm{{
+				MatchExpressions: []corev1.NodeSelectorRequirement{cliqueReq},
+			}},
+		},
+		{
+			name: "clique requirement is ANDed into an existing hostname term",
+			affinity: newRequiredNodeAffinity(corev1.NodeSelectorTerm{
+				MatchExpressions: []corev1.NodeSelectorRequirement{hostnameReq},
+			}),
+			applyN: 1,
+			want: []corev1.NodeSelectorTerm{{
+				MatchExpressions: []corev1.NodeSelectorRequirement{hostnameReq, cliqueReq},
+			}},
+		},
+		{
+			name: "every existing term gets the clique requirement",
+			affinity: newRequiredNodeAffinity(
+				corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{hostnameReq}},
+				corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{instanceTypeReq}},
+			),
+			applyN: 1,
+			want: []corev1.NodeSelectorTerm{
+				{MatchExpressions: []corev1.NodeSelectorRequirement{hostnameReq, cliqueReq}},
+				{MatchExpressions: []corev1.NodeSelectorRequirement{instanceTypeReq, cliqueReq}},
+			},
+		},
+		{
+			name: "existing match fields are preserved",
+			affinity: newRequiredNodeAffinity(corev1.NodeSelectorTerm{
+				MatchFields: []corev1.NodeSelectorRequirement{nameField},
+			}),
+			applyN: 1,
+			want: []corev1.NodeSelectorTerm{{
+				MatchExpressions: []corev1.NodeSelectorRequirement{cliqueReq},
+				MatchFields:      []corev1.NodeSelectorRequirement{nameField},
+			}},
+		},
+		{
+			name: "repeated mutation does not duplicate the clique requirement",
+			affinity: newRequiredNodeAffinity(corev1.NodeSelectorTerm{
+				MatchExpressions: []corev1.NodeSelectorRequirement{hostnameReq},
+			}),
+			applyN: 3,
+			want: []corev1.NodeSelectorTerm{{
+				MatchExpressions: []corev1.NodeSelectorRequirement{hostnameReq, cliqueReq},
+			}},
+		},
+	}
+
+	setters := []struct {
+		name  string
+		apply func(pod *corev1.Pod)
+	}{
+		{
+			name:  "preferred",
+			apply: func(pod *corev1.Pod) { SetPreferredNVLinkDomainSchedulingParameters("foo", pod) },
+		},
+		{
+			name:  "required",
+			apply: func(pod *corev1.Pod) { SetRequiredNVLinkDomainSchedulingParameters("foo", "0", pod) },
+		},
+	}
+
+	for _, setter := range setters {
+		for _, tt := range tests {
+			t.Run(setter.name+"/"+tt.name, func(t *testing.T) {
+				pod := &corev1.Pod{Spec: corev1.PodSpec{Affinity: tt.affinity.DeepCopy()}}
+				for i := 0; i < tt.applyN; i++ {
+					setter.apply(pod)
+				}
+				got := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+				assert.Equal(t, tt.want, got.NodeSelectorTerms)
+			})
+		}
+	}
+}
+
 func TestTransformNVLinkOptimizedDRAObjects(t *testing.T) {
 	type spec struct {
 		name       string

--- a/src/compute-plane-services/nvca/pkg/webhook/miniservice_mutating_webhook_test.go
+++ b/src/compute-plane-services/nvca/pkg/webhook/miniservice_mutating_webhook_test.go
@@ -544,21 +544,14 @@ func TestMiniserviceOperatorWebhook_PodSpecCreateThenUpdate_IsIdempotentOrderPre
 				},
 			},
 		},
+		// The NVLink clique requirement narrows the pre-existing term instead of
+		// being ORed alongside it as a term of its own.
 		NodeAffinity: &corev1.NodeAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 				NodeSelectorTerms: []corev1.NodeSelectorTerm{
 					{
 						MatchExpressions: []corev1.NodeSelectorRequirement{
 							{Key: "baz", Operator: corev1.NodeSelectorOpIn, Values: []string{"buf"}},
-							{
-								Key:      "nvca.nvcf.nvidia.io/instance-type",
-								Operator: corev1.NodeSelectorOpIn,
-								Values:   []string{"ON-PREM.GPU.A100"},
-							},
-						},
-					},
-					{
-						MatchExpressions: []corev1.NodeSelectorRequirement{
 							{
 								Key:      nvcfdra.GPUCliqueNodeLabel,
 								Operator: corev1.NodeSelectorOpExists,


### PR DESCRIPTION
The NVLink DRA mutation appended a NodeSelectorTerm containing only the nvidia.com/gpu.clique Exists requirement. Kubernetes ORs NodeSelectorTerms, so that appended term gave a Pod an alternative way to satisfy required node affinity and let it bypass pre-existing hard constraints such as a kubernetes.io/hostname restriction. In NVLink-optimized multi-worker deployments this let admitted Pods land on nodes assigned to a different worker role even though the MiniService and Grove resources still carried the requested node lists.

Merge the clique requirement into every existing NodeSelectorTerm instead, so it narrows each term rather than offering an alternative to it. Existing matchExpressions and matchFields are preserved, a single clique-only term is still created when no required terms exist, and the merge is idempotent across repeated admission. Both the preferred and required NVLink-domain paths share the same behavior.

Closes #1644



(cherry picked from commit 0cb3243584a1476e713d14713994113912531321)

## TL;DR
<!--Provide a brief description of what changed and why it is needed.-->

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
<!-- - explain the problem, requirement, review comment, or CI blocker driving this MR -->
<!-- - explain how the changed pieces connect -->
<!-- - link upstream MRs/PRs, tickets, bugs, or related reviews when relevant -->
<!-- - any limitations or possible things missing from this PR -->

## For the Reviewer
<!--mention reviewers you wish to review this MR-->
<!--call out specific files that should be looked at closely-->
<!--anything you need answered pertaining to this review-->

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
<!--list steps you took to verify this change-->
<!--Is QA Needed?-->

## Issues
<!--
Required: add a valid NVIDIA/nvcf issue reference below.
Accepted: "Closes #123", "Fixes #123", "Resolves NVIDIA/nvcf#123",
"Relates to #123", or last-resort "NO-REF".
Do not use Jira/private tracker keys, private bug IDs, private URLs, title-only
refs, other-repo refs, or commented-out template examples. If context is
private, create a generic public issue without private details.
-->


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
