### PR TITLE
fix(observability): scrape function autoscaler metrics

### DIFF
--- a/deploy/stacks/observability/README.md
+++ b/deploy/stacks/observability/README.md
@@ -128,8 +128,10 @@ kind renders all targets from values.
 
 All default monitors carry
 `nvcf.nvidia.com/observability-target: "true"` for Target Allocator discovery.
-Compute defaults select NVCA in `nvca-system`, DCGM pods by their NVCA metrics
-label, and NVCA-managed workload pods by `icms-request-id`.
+Control-plane defaults scrape `state-metrics`, `invocation-service`,
+`grpc-proxy`, `llm-api-gateway`, and `function-autoscaler` in `nvcf`.
+Compute defaults select NVCA in `nvca-system`, DCGM pods by their NVCA
+metrics label, and NVCA-managed workload pods by `icms-request-id`.
 
 The default observability namespace is `monitoring`. A different namespace
 also requires NetworkPolicy reachability to the collector.

--- a/deploy/stacks/observability/charts/nvcf-default-monitors/values.yaml
+++ b/deploy/stacks/observability/charts/nvcf-default-monitors/values.yaml
@@ -33,6 +33,13 @@ controlPlane:
       selector:
         app.kubernetes.io/instance: state-metrics
         app.kubernetes.io/name: helm-nvcf-state-metrics
+    # The shared stack owns this ServiceMonitor. The application chart owns
+    # the metrics port and service labels.
+    - name: function-autoscaler
+      enabled: true
+      selector:
+        app.kubernetes.io/instance: function-autoscaler
+        app.kubernetes.io/name: helm-nvcf-function-autoscaler
     - name: grpc-proxy
       enabled: true
       selector:

--- a/deploy/stacks/observability/environments/base.yaml
+++ b/deploy/stacks/observability/environments/base.yaml
@@ -133,6 +133,13 @@ defaultMonitors:
         selector:
           app.kubernetes.io/instance: state-metrics
           app.kubernetes.io/name: helm-nvcf-state-metrics
+      # The shared stack owns this ServiceMonitor. The application chart owns
+      # the metrics port and service labels.
+      - name: function-autoscaler
+        enabled: true
+        selector:
+          app.kubernetes.io/instance: function-autoscaler
+          app.kubernetes.io/name: helm-nvcf-function-autoscaler
       - name: invocation-service
         enabled: true
         selector:

--- a/deploy/stacks/observability/tests/profile-defaults.sh
+++ b/deploy/stacks/observability/tests/profile-defaults.sh
@@ -139,7 +139,7 @@ grep -q '^    - key: icms-request-id$' "$worker_monitor_manifest" ||
 grep -q '^      operator: Exists$' "$worker_monitor_manifest" ||
   fail "worker PodMonitor label expression must use Exists"
 
-for monitor in state-metrics invocation-service grpc-proxy llm-api-gateway; do
+for monitor in state-metrics function-autoscaler invocation-service grpc-proxy llm-api-gateway; do
   grep -q "nvcf-default-monitors-$monitor" "$chart_control_manifests" ||
     fail "monitor chart control defaults are missing $monitor monitor"
   grep -q "nvcf-default-monitors-$monitor" $control_manifests ||
@@ -155,6 +155,27 @@ for monitor in state-metrics invocation-service grpc-proxy llm-api-gateway; do
     fail "compute profile rendered $monitor control-plane monitor"
   fi
 done
+
+autoscaler_monitor_manifest="$work_dir/chart-function-autoscaler-servicemonitor.yaml"
+sed -n '/name: nvcf-default-monitors-function-autoscaler/,/^---$/p' \
+  "$chart_control_manifests" >"$autoscaler_monitor_manifest"
+grep -q '^    nvcf.nvidia.com/observability-target: "true"$' \
+  "$autoscaler_monitor_manifest" ||
+  fail "function autoscaler monitor must carry the Target Allocator discovery label"
+grep -q '^      app.kubernetes.io/instance: function-autoscaler$' \
+  "$autoscaler_monitor_manifest" ||
+  fail "function autoscaler monitor must select the function-autoscaler release"
+grep -q '^      app.kubernetes.io/name: helm-nvcf-function-autoscaler$' \
+  "$autoscaler_monitor_manifest" ||
+  fail "function autoscaler monitor must select the function-autoscaler service"
+grep -q '^      - nvcf$' "$autoscaler_monitor_manifest" ||
+  fail "function autoscaler monitor must discover the nvcf namespace"
+grep -q '^    - port: "metrics"$' "$autoscaler_monitor_manifest" ||
+  fail "function autoscaler monitor must scrape the named metrics port"
+grep -q '^      path: "/metrics"$' "$autoscaler_monitor_manifest" ||
+  fail "function autoscaler monitor must scrape the metrics path"
+grep -q '^      interval: "30s"$' "$autoscaler_monitor_manifest" ||
+  fail "function autoscaler monitor must use the default scrape interval"
 
 for monitor in nvca dcgm worker; do
   grep -q "nvcf-default-monitors-$monitor" "$chart_compute_manifests" ||

--- a/docs/user/autoscaling/observability.md
+++ b/docs/user/autoscaling/observability.md
@@ -3,8 +3,9 @@
 The Function Autoscaler emits structured logs, Prometheus metrics, and
 OpenTelemetry spans. The chart exposes its Prometheus exporter through the
 `function-autoscaler` service on the `metrics` port, which defaults to `41338`.
-The shared stack's default monitors do not include this service. Add a monitor
-or scrape target for it to collect these metrics.
+The shared stack creates a ServiceMonitor for this endpoint when
+`observability.profile` is `control` or `all`. The `compute` and
+`disabled` profiles do not create it.
 
 These service metrics describe the autoscaler itself. They are separate from
 the function metrics that the autoscaler reads from VictoriaMetrics or an

--- a/tests/bdd/features/observability-all.feature
+++ b/tests/bdd/features/observability-all.feature
@@ -129,6 +129,7 @@ Feature: Install local Helmfile observability for both planes
     Then these Kubernetes resources should exist in namespace "monitoring" using context "k3d-ncp-local":
       | kind           | name                                             |
       | ServiceMonitor | nvcf-default-monitors-state-metrics              |
+      | ServiceMonitor | nvcf-default-monitors-function-autoscaler        |
       | ServiceMonitor | nvcf-default-monitors-grpc-proxy                  |
       | ServiceMonitor | nvcf-default-monitors-llm-api-gateway             |
       | ServiceMonitor | nvcf-default-monitors-invocation-service          |

--- a/tests/bdd/features/observability-compute.feature
+++ b/tests/bdd/features/observability-compute.feature
@@ -154,6 +154,7 @@ Feature: Install local Helmfile observability with the compute profile
     Then these Kubernetes resources should not exist in namespace "monitoring" using context "k3d-ncp-local-compute-1":
       | kind           | name                                             |
       | ServiceMonitor | nvcf-default-monitors-state-metrics              |
+      | ServiceMonitor | nvcf-default-monitors-function-autoscaler        |
       | ServiceMonitor | nvcf-default-monitors-grpc-proxy                  |
       | ServiceMonitor | nvcf-default-monitors-llm-api-gateway             |
       | ServiceMonitor | nvcf-default-monitors-invocation-service          |

--- a/tests/bdd/features/observability-control.feature
+++ b/tests/bdd/features/observability-control.feature
@@ -65,6 +65,7 @@ Feature: Install local Helmfile observability with the control profile
     Then these Kubernetes resources should exist in namespace "monitoring" using context "k3d-ncp-local":
       | kind           | name                                             |
       | ServiceMonitor | nvcf-default-monitors-state-metrics              |
+      | ServiceMonitor | nvcf-default-monitors-function-autoscaler        |
       | ServiceMonitor | nvcf-default-monitors-grpc-proxy                  |
       | ServiceMonitor | nvcf-default-monitors-llm-api-gateway             |
       | ServiceMonitor | nvcf-default-monitors-invocation-service          |


### PR DESCRIPTION
## TL;DR

Add the Function Autoscaler to the shared default monitors so the `control`
and `all` profiles collect its Prometheus metrics without a custom
ServiceMonitor.

## Additional Details

The self-hosted stack deploys the Function Autoscaler with a metrics endpoint
on the named `metrics` port, but the default control-plane monitor list omitted
the service. The exporter remained healthy while its metrics were absent from
the bundled backend.

This change adds the monitor contract to both the Helmfile defaults and the
`nvcf-default-monitors` chart defaults. The ServiceMonitor selects the stock
`function-autoscaler` service labels, discovers it in the `nvcf` namespace,
and carries the Target Allocator discovery label. The monitor remains disabled
for `compute` and `disabled` profiles.

Profile tests cover the rendered selector, namespace, named port, path,
interval, discovery label, profile gating, and explicit override behavior.
BDD expectations cover presence for `control` and `all` and absence for
`compute`. The stack README and operator documentation now describe the
default behavior.

## For the Reviewer

- Ensure the two source lists remain identical because Helm replaces lists
  rather than merging their entries.
- Review `profile-defaults.sh` for the rendered ServiceMonitor contract.
- Review the control, all, and compute BDD resource expectations.

## For QA

- `make test` from `deploy/stacks/observability`: passed.
- `go test -count=1 -short ./...` from `tests/bdd`: passed.
- `tests/bdd/scripts/lint.sh` with repository-pinned `golangci-lint` v2.3.0
  and Go 1.24.0: passed with zero issues.
- `fern check`: passed with zero errors.
- Kubernetes server-side dry-run against a local k3d cluster: passed.
- Live local validation confirmed
  `nvcf_autoscaler_health_overall_status{job="function-autoscaler"} 1` in
  VictoriaMetrics after one scrape interval.

QA needed: no additional manual QA. The rendered and live collection paths
were validated locally.

## Issues

Fixes #1211

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic monitoring for Function Autoscaler metrics when using the control or all observability profiles.
  * Added validation for the monitor's service selectors, namespace, metrics endpoint, and scrape settings.

* **Documentation**
  * Updated autoscaling observability guidance to reflect automatic monitor creation.
  * Clarified that compute and disabled profiles do not create this monitor.

* **Tests**
  * Added coverage confirming monitor presence for control and all profiles, and absence for compute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
