### PR TITLE
docs(vanity-gateway): document chat header limitation

### DIFF
--- a/src/invocation-plane-services/vanity-gateway/README.md
+++ b/src/invocation-plane-services/vanity-gateway/README.md
@@ -282,8 +282,8 @@ streamed chunk, carries `functionID/modelName` back to the caller.
 these requests. The LLM Gateway resolves the function from the model, so the
 gateway sets none of them, and a caller-supplied value is removed rather than
 forwarded: the mapping is what decides which function a caller reaches.
-`Authorization`, `NVCF-POLL-SECONDS`, and the caller's other headers pass
-through unchanged.
+Vanity Gateway passes `Authorization`, `NVCF-POLL-SECONDS`, and the caller's
+other headers to the LLM Gateway.
 
 Config validation rejects `functionType: LLM` outside the three supported
 sections, and rejects `usePexec`, `outgoingPathOverride`, and `sessionTimeout`
@@ -492,5 +492,9 @@ docker run --gpus all -p 8080:80 -v $PWD:/data --pull always ghcr.io/huggingface
 
 ## Known Limitations
 
+- For `functionType: LLM` models, the LLM Gateway does not forward inbound
+  headers on `/v1/chat/completions` to the function container. This includes
+  mapping `customHeaders` and the `NVCF-Shadow` marker. Do not rely on these
+  headers in the function container for this endpoint.
 - HTTP polling invocations that last longer than 20 minutes return a `504 Timeout` error when using OpenAI-compatible endpoints. This does not apply to Vanity URL routes.
 - Streaming invocations that last longer than 5 minutes return a `502 Timeout` error when using OpenAI-compatible endpoints. This does not apply to Vanity URL routes.


### PR DESCRIPTION
## TL;DR

Document that the LLM Gateway does not forward inbound headers on `/v1/chat/completions` to an LLM function container. Clarify that Vanity Gateway still passes caller headers to the LLM Gateway.

## Additional Details

The existing README implies that caller headers and mapping `customHeaders` reach the function container. The limitation also affects the `NVCF-Shadow` marker. This PR documents current behavior only and does not change runtime code.

## For the Reviewer

Review `src/invocation-plane-services/vanity-gateway/README.md` for endpoint scope and wording.

## For QA

- `npx --yes markdownlint-cli@0.49.1 src/invocation-plane-services/vanity-gateway/README.md`
- `git diff --check`
- QA not needed. Documentation-only change.

## Issues

Closes #1681

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes. Documentation validated with targeted markdown lint.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that the Vanity Gateway forwards authorization, polling, and other caller headers to the LLM Gateway.
  - Documented a limitation: inbound headers, including custom mappings and `NVCF-Shadow`, are not forwarded to function containers for chat completions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->