### PR TITLE
feat(self-managed): opt-in Tier-2 zone topology spread under HA (#989)

### DIFF
--- a/deploy/helm/cassandra/helm/templates/statefulset.yaml
+++ b/deploy/helm/cassandra/helm/templates/statefulset.yaml
@@ -41,6 +41,9 @@ spec:
       {{- with .Values.cassandra.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.cassandra.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.cassandra.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/helm/cassandra/helm/values.yaml
+++ b/deploy/helm/cassandra/helm/values.yaml
@@ -156,6 +156,11 @@ cassandra:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Pod topology spread constraints. Empty by default; the self-managed Helmfile
+  # sets these (zone spread across topology.kubernetes.io/zone) via
+  # highAvailability.tier2.topologySpread when HA is on. Requires a
+  # WaitForFirstConsumer StorageClass so each zonal PV binds in the pod's zone.
+  topologySpreadConstraints: []
 
   hooks:
     initializeCluster:

--- a/deploy/helm/cloud-functions/nvcf-api/templates/poddisruptionbudget.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/templates/poddisruptionbudget.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.api.podDisruptionBudget.enabled }}
+{{- $pdbMinAvail := .Values.api.podDisruptionBudget.minAvailable | toString }}
+{{- $pdbMaxUnavail := .Values.api.podDisruptionBudget.maxUnavailable | toString }}
+{{- if and (ne $pdbMinAvail "") (ne $pdbMaxUnavail "") }}
+{{- fail "podDisruptionBudget: set exactly one of minAvailable or maxUnavailable, not both" }}
+{{- end }}
+{{- if and (eq $pdbMinAvail "") (eq $pdbMaxUnavail "") }}
+{{- fail "podDisruptionBudget: set exactly one of minAvailable or maxUnavailable" }}
+{{- end }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "nvcf-api.fullname" . }}
+  namespace: {{ include "nvcf-api.namespace" . }}
+  labels: {{- include "nvcf-api.labels" . | nindent 4 }}
+spec:
+  {{- if ne $pdbMinAvail "" }}
+  minAvailable: {{ .Values.api.podDisruptionBudget.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ .Values.api.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "nvcf-api.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/cloud-functions/nvcf-api/values.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/values.yaml
@@ -26,6 +26,16 @@ api:
   # This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
   replicaCount: 1
 
+  # PodDisruptionBudget for the API. Disabled by default; the self-managed
+  # Helmfile enables it (minAvailable 1) via highAvailability.stateless when HA
+  # is on. See deploy/stacks/self-managed/global.yaml.gotmpl.
+  podDisruptionBudget:
+    enabled: false
+    # minAvailable and maxUnavailable are mutually exclusive; set exactly one.
+    # Accepts an integer or a percentage string (e.g. 1 or "50%").
+    minAvailable: ""
+    maxUnavailable: ""
+
   # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
   image:
     registry: "" # must be supplied

--- a/deploy/stacks/self-managed/Makefile
+++ b/deploy/stacks/self-managed/Makefile
@@ -27,6 +27,7 @@ test:
 	@tests/nats-placement-tags.sh
 	@tests/nats-tls-wiring.sh
 	@tests/notary-image-repository.sh
+	@tests/ha-value-wiring.sh
 
 test-published-charts:
 	@: "$${NVCF_PUBLISHED_CHART_REGISTRY:?NVCF_PUBLISHED_CHART_REGISTRY is required}"

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -772,8 +772,26 @@ highAvailability:
       enabled: true
       minAvailable: 1
 
+  # Tier-2 quorum services (Cassandra, NATS, OpenBao). Under HA their peers get
+  # hostname pod anti-affinity (matching app.kubernetes.io/instance per release)
+  # so the 3 quorum members land on distinct nodes. whenUnsatisfiable follows
+  # mode: ha-preferred → preferred/soft (stays schedulable on small pools),
+  # ha-enforced → required/hard. The upstream OpenBao chart ships a hard
+  # anti-affinity by default that the stack disables for single-node installs;
+  # this re-enables it (soft/hard by mode) under HA. Set enabled: false to keep
+  # the chart defaults.
+  tier2:
+    podAntiAffinity:
+      enabled: true
+
   nats:
     replicas: 3
+    # JetStream stream replica factor (RF). Applied under HA to the stream
+    # creators — nvcf-api and invocation-service — so the worker/result streams
+    # they declare are replicated across the NATS cluster (survives a node
+    # loss). RF must be <= nats.replicas. Default 2 per the SDD.
+    jetstream:
+      replicaFactor: 2
     podDisruptionBudget:
       enabled: true
       merge:

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -714,3 +714,81 @@ grpcproxy:
   # an external compute-worker endpoint.
   natsServiceURL: ""
   workerConnectBaseURL: ""
+
+# =============================================================================
+# Control-plane high availability
+# =============================================================================
+# Resilience settings are exposed as a single highAvailability: block in
+# self-managed Helmfile environment values.
+# deploy/stacks/self-managed/global.yaml.gotmpl maps highAvailability.* onto
+# chart values (replicaCount, affinity, PDB, update strategy).
+#
+# deploy/stacks/self-managed/
+# ├── environments/<env>.yaml     # highAvailability: configuration
+# └── global.yaml.gotmpl          # value mapping to charts
+#
+# mode: none         (default) — keep existing env/chart replica and PDB values
+#                                (local / CI / BDD).
+#       ha-preferred           — HA sizing below; hostname anti-affinity is
+#                                preferred (still schedule if a second node/AZ
+#                                has no capacity). Requires ≥3 schedulable nodes.
+#       ha-enforced            — same HA sizing; hostname anti-affinity is
+#                                required (second replica stays Pending rather
+#                                than packing). Requires ≥3 schedulable nodes.
+#
+# In-scope charts MUST expose the required value hooks. Leave mode: none
+# for single-node installs.
+# =============================================================================
+highAvailability:
+  mode: none
+
+  # Stateless control-plane Deployments: nvcf-api, invocation-service,
+  # grpc-proxy, admin-token-issuer-proxy, and llm-api-gateway (when the LLM
+  # addon is enabled). Active-active; no application leader election.
+  stateless:
+    replicaCount: 2
+    podAntiAffinity:
+      enabled: true
+    # Spread replicas across availability zones. Nodes MUST be labelled
+    # topology.kubernetes.io/zone=<az>. whenUnsatisfiable follows mode:
+    # ha-preferred → ScheduleAnyway, ha-enforced → DoNotSchedule.
+    topologySpread:
+      enabled: true
+      maxSkew: 1
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+
+  # Hot-path helper Deployments raised to 2 replicas under HA so a single pod
+  # loss does not immediately hurt request/auth traffic: rateLimiter,
+  # nats-auth-callout. Reuse stateless.podAntiAffinity (hostname spread) and
+  # stateless.topologySpread (zone spread).
+  hotPath:
+    replicaCount: 2
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
+
+  nats:
+    replicas: 3
+    podDisruptionBudget:
+      enabled: true
+      merge:
+        spec:
+          minAvailable: 2
+
+  openbao:
+    ha:
+      enabled: true
+      replicas: 3
+    injector:
+      replicas: 2
+
+  cassandra:
+    replicaCount: 3
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 2

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -783,6 +783,25 @@ highAvailability:
   tier2:
     podAntiAffinity:
       enabled: true
+    # Zone topology spread for the 3 quorum peers across
+    # topology.kubernetes.io/zone (Cassandra, NATS, OpenBao). OPT-IN (default
+    # off) because it depends on operator-provided infrastructure:
+    #   * a StorageClass with volumeBindingMode: WaitForFirstConsumer, so each
+    #     pod's zonal PersistentVolume is created in the zone the scheduler
+    #     picks. With Immediate binding the PV zone is fixed first and pods can
+    #     land Pending when the spread constraint disagrees.
+    #   * capacity in >= 3 AZs. A 3-member quorum only survives an AZ loss if no
+    #     single AZ holds a majority; with 2 AZs one zone holds 2 of 3, so
+    #     losing it breaks quorum.
+    # whenUnsatisfiable defaults to ScheduleAnyway (soft) so a short AZ never
+    # leaves a peer Pending. Set strict: true ONLY on >= 3-AZ clusters to make
+    # it DoNotSchedule (hard). NOTE: for Cassandra, data-level AZ diversity also
+    # requires rack = AZ on the nodes (image/entrypoint side), not just pod
+    # spread; see docs/v0.6.1/high-availability.md.
+    topologySpread:
+      enabled: false
+      maxSkew: 1
+      strict: false
 
   nats:
     replicas: 3

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -161,6 +161,35 @@ podAntiAffinity:
 {{- end -}}
 {{- end -}}
 
+{{/* Zone topology spread for a Tier-2 quorum release (Cassandra, NATS,
+     OpenBao) so the 3 quorum peers land in distinct availability zones. Matches
+     app.kubernetes.io/instance = release name on topology.kubernetes.io/zone.
+     OPT-IN: gated by highAvailability.tier2.topologySpread.enabled (default
+     false) because correct behaviour depends on operator infrastructure — a
+     StorageClass with volumeBindingMode: WaitForFirstConsumer (so each zonal PV
+     is created in the zone the scheduler picks) and capacity in >= 3 AZs.
+     whenUnsatisfiable defaults to ScheduleAnyway (soft) so a short AZ never
+     leaves a peer Pending; set topologySpread.strict: true (>= 3-AZ clusters
+     only) for DoNotSchedule (hard). Emits only the constraint list items (no
+     topologySpreadConstraints: key) so callers can nest it as a list (Cassandra
+     value, NATS podTemplate.merge.spec) or a string (OpenBao
+     server.topologySpreadConstraints). Context: dict "Values" $.Values
+     "instance" "<release-instance>" */}}
+{{- define "nvcf.ha.tier2TopologySpread" -}}
+{{- $haMode := dig "highAvailability" "mode" "none" .Values | toString -}}
+{{- if or (eq $haMode "ha-preferred") (eq $haMode "ha-enforced") -}}
+{{- $ts := dig "highAvailability" "tier2" "topologySpread" dict .Values -}}
+{{- if dig "enabled" false $ts -}}
+- maxSkew: {{ dig "maxSkew" 1 $ts }}
+  topologyKey: topology.kubernetes.io/zone
+  whenUnsatisfiable: {{ if dig "strict" false $ts }}DoNotSchedule{{ else }}ScheduleAnyway{{ end }}
+  labelSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .instance | quote }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- $haMode := dig "highAvailability" "mode" "none" .Values | toString }}
 {{- if not (has $haMode (list "none" "ha-preferred" "ha-enforced")) }}
 {{- fail (printf "highAvailability.mode must be none, ha-preferred, or ha-enforced, got %q" $haMode) }}
@@ -203,6 +232,10 @@ cassandra:
   {{- if $haEnabled }}
   {{- with include "nvcf.ha.tier2Affinity" (dict "Values" .Values "instance" "cassandra") }}
   affinity:
+    {{- . | nindent 4 }}
+  {{- end }}
+  {{- with include "nvcf.ha.tier2TopologySpread" (dict "Values" .Values "instance" "cassandra") }}
+  topologySpreadConstraints:
     {{- . | nindent 4 }}
   {{- end }}
   {{- end }}
@@ -339,6 +372,12 @@ openbao:
     affinity: |
       {{- . | nindent 6 }}
     {{- end }}
+    {{- with include "nvcf.ha.tier2TopologySpread" (dict "Values" .Values "instance" "openbao-server") }}
+    # String form: the OpenBao chart tpl-renders server.topologySpreadConstraints
+    # under a topologySpreadConstraints: key. Opt-in via tier2.topologySpread.
+    topologySpreadConstraints: |
+      {{- . | nindent 6 }}
+    {{- end }}
     {{- end }}
     image:
       registry: {{ .Values.global.image.registry }}
@@ -404,10 +443,12 @@ nats:
   {{- $natsNs := include "nvcf.nodeSelector" (dict "type" "controlplane" "selectors" .Values.global.nodeSelectors) -}}
   {{- $natsTol := include "nvcf.tolerations" (dict "type" "controlplane" "tolerations" .Values.global.tolerations) -}}
   {{- $natsAffinity := "" -}}
+  {{- $natsTopoSpread := "" -}}
   {{- if $haEnabled -}}
   {{- $natsAffinity = include "nvcf.ha.tier2Affinity" (dict "Values" .Values "instance" "nats") -}}
+  {{- $natsTopoSpread = include "nvcf.ha.tier2TopologySpread" (dict "Values" .Values "instance" "nats") -}}
   {{- end -}}
-  {{- if or $natsNs $natsTol $natsAffinity }}
+  {{- if or $natsNs $natsTol $natsAffinity $natsTopoSpread }}
   podTemplate:
     merge:
       spec:
@@ -419,6 +460,10 @@ nats:
         {{- end }}
         {{- with $natsAffinity }}
         affinity:
+          {{- . | nindent 10 }}
+        {{- end }}
+        {{- with $natsTopoSpread }}
+        topologySpreadConstraints:
           {{- . | nindent 10 }}
         {{- end }}
   {{- end }}

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -43,6 +43,9 @@ stateless — nvcf-api, invocation, grpc-proxy, admin-token-issuer-proxy, and
   topology spread, PDB.
 hotPath   — rateLimiter, nats-auth-callout: 2 replicas + anti-affinity +
   zone topology spread + PDB.
+tier2     — Cassandra, NATS, OpenBao: quorum sizing (3) + PDB + hostname pod
+  anti-affinity so the 3 peers land on distinct nodes. NATS JetStream RF is
+  applied to the stream creators (nvcf-api, invocation) via their env.
 
 In-scope charts MUST expose the required value hooks.
 */}}
@@ -54,6 +57,14 @@ In-scope charts MUST expose the required value hooks.
      nats-auth-callout) under HA. Defaults to 2. */}}
 {{- define "nvcf.ha.hotPathReplicaCount" -}}
 {{- dig "highAvailability" "hotPath" "replicaCount" 2 . -}}
+{{- end -}}
+
+{{/* JetStream stream replica factor (RF) under HA. Applied to the stream
+     creators — nvcf-api (Java, nvcf.nats.replicas) and invocation (Rust,
+     nats_properties.replicas) — via their env so the streams they declare are
+     replicated across the NATS cluster. Defaults to 2 per the SDD. */}}
+{{- define "nvcf.ha.natsStreamReplicas" -}}
+{{- dig "highAvailability" "nats" "jetstream" "replicaFactor" 2 . -}}
 {{- end -}}
 
 {{/* Soft/hard pod anti-affinity on hostname for a Helm release instance name.
@@ -111,6 +122,45 @@ topologySpreadConstraints:
 {{- end -}}
 {{- end -}}
 
+{{/* Hostname pod anti-affinity for a Tier-2 quorum release (Cassandra, NATS,
+     OpenBao) so the 3 quorum peers land on distinct nodes. Matches
+     app.kubernetes.io/instance = release name. ha-preferred → preferred (soft,
+     stays schedulable on small pools), ha-enforced → required (hard). Emits the
+     podAntiAffinity body only (no affinity: wrapper) so callers can nest it as a
+     map (Cassandra affinity, NATS podTemplate.merge.spec.affinity) or a string
+     (OpenBao server.affinity). Gated by highAvailability.tier2.podAntiAffinity.
+     Context: dict "Values" $.Values "instance" "<release-instance>" */}}
+{{- define "nvcf.ha.tier2Affinity" -}}
+{{- $haMode := dig "highAvailability" "mode" "none" .Values | toString -}}
+{{- if or (eq $haMode "ha-preferred") (eq $haMode "ha-enforced") -}}
+{{- $paa := dig "highAvailability" "tier2" "podAntiAffinity" dict .Values -}}
+{{- if dig "enabled" true $paa -}}
+podAntiAffinity:
+{{- if eq $haMode "ha-enforced" }}
+  requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchExpressions:
+          - key: app.kubernetes.io/instance
+            operator: In
+            values:
+              - {{ .instance | quote }}
+      topologyKey: kubernetes.io/hostname
+{{- else }}
+  preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/instance
+              operator: In
+              values:
+                - {{ .instance | quote }}
+        topologyKey: kubernetes.io/hostname
+{{- end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- $haMode := dig "highAvailability" "mode" "none" .Values | toString }}
 {{- if not (has $haMode (list "none" "ha-preferred" "ha-enforced")) }}
 {{- fail (printf "highAvailability.mode must be none, ha-preferred, or ha-enforced, got %q" $haMode) }}
@@ -149,6 +199,12 @@ cassandra:
   {{- end }}
   {{- with include "nvcf.tolerations" (dict "type" "cassandra" "tolerations" .Values.global.tolerations) }}
   {{- . | nindent 2 }}
+  {{- end }}
+  {{- if $haEnabled }}
+  {{- with include "nvcf.ha.tier2Affinity" (dict "Values" .Values "instance" "cassandra") }}
+  affinity:
+    {{- . | nindent 4 }}
+  {{- end }}
   {{- end }}
   persistence:
     size: {{ .Values.global.storageSize | default "10Gi" }}
@@ -276,6 +332,14 @@ openbao:
     podDisruptionBudget:
       minAvailable: {{ dig "openbao" "injector" "podDisruptionBudget" "minAvailable" 1 .Values }}
   server:
+    {{- if $haEnabled }}
+    {{- with include "nvcf.ha.tier2Affinity" (dict "Values" .Values "instance" "openbao-server") }}
+    # String form: the OpenBao chart tpl-renders server.affinity. The wrapper
+    # sets it to "" for single-node installs; HA re-enables hostname spread.
+    affinity: |
+      {{- . | nindent 6 }}
+    {{- end }}
+    {{- end }}
     image:
       registry: {{ .Values.global.image.registry }}
       repository: {{ .Values.global.image.repository }}/nvcf-openbao
@@ -339,7 +403,11 @@ nats:
       repository: {{ .Values.global.image.repository }}/alpine-k8s
   {{- $natsNs := include "nvcf.nodeSelector" (dict "type" "controlplane" "selectors" .Values.global.nodeSelectors) -}}
   {{- $natsTol := include "nvcf.tolerations" (dict "type" "controlplane" "tolerations" .Values.global.tolerations) -}}
-  {{- if or $natsNs $natsTol }}
+  {{- $natsAffinity := "" -}}
+  {{- if $haEnabled -}}
+  {{- $natsAffinity = include "nvcf.ha.tier2Affinity" (dict "Values" .Values "instance" "nats") -}}
+  {{- end -}}
+  {{- if or $natsNs $natsTol $natsAffinity }}
   podTemplate:
     merge:
       spec:
@@ -348,6 +416,10 @@ nats:
         {{- end }}
         {{- with $natsTol }}
         {{- . | nindent 8 }}
+        {{- end }}
+        {{- with $natsAffinity }}
+        affinity:
+          {{- . | nindent 10 }}
         {{- end }}
   {{- end }}
 
@@ -727,6 +799,11 @@ api:
   {{- if .Values.global.observability.tracing.enabled }}
   {{- $_ := set $apiEnv "MANAGEMENT_OTLP_TRACING_ENDPOINT" (printf "%s://%s:%v/v1/traces" .Values.global.observability.tracing.collectorProtocol .Values.global.observability.tracing.collectorEndpoint .Values.global.observability.tracing.collectorPort) }}
   {{- end }}
+  {{- if $haEnabled }}
+  {{- /* JetStream RF for the worker/result streams this service declares
+         (nvcf.nats.replicas → NVCF_NATS_REPLICAS via Spring relaxed binding). */}}
+  {{- $_ := set $apiEnv "NVCF_NATS_REPLICAS" (include "nvcf.ha.natsStreamReplicas" .Values) }}
+  {{- end }}
   {{- $apiEnv = mergeOverwrite $apiEnv $renderedApiEnv }}
   env:
     {{- toYaml $apiEnv | nindent 4 }}
@@ -749,6 +826,11 @@ invocation:
   {{- end }}
   {{- with $invocationWorkerBaseURL }}
   {{- $_ := set $invocationEnv "WORKER_STREAM_PROPERTIES__SELF_ADDRESS" . }}
+  {{- end }}
+  {{- if $haEnabled }}
+  {{- /* JetStream RF for the streams this service declares
+         (nats_properties.replicas → NATS_PROPERTIES__REPLICAS). */}}
+  {{- $_ := set $invocationEnv "NATS_PROPERTIES__REPLICAS" (include "nvcf.ha.natsStreamReplicas" .Values) }}
   {{- end }}
   {{- $invocationEnv = mergeOverwrite $invocationEnv (deepCopy $configuredInvocationEnv) }}
   fullnameOverride: invocation-service

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -24,6 +24,99 @@ tolerations:
 {{- end -}}
 {{- end -}}
 
+{{/*
+highAvailability helpers.
+
+global.yaml.gotmpl maps highAvailability.* onto chart values (replicaCount,
+affinity, PDB, update strategy).
+
+highAvailability.mode:
+  none          — keep existing env/chart defaults (local / CI / BDD).
+  ha-preferred  — HA sizing; preferred hostname anti-affinity.
+  ha-enforced   — HA sizing; required hostname anti-affinity.
+
+Requires ≥3 schedulable nodes unless mode is none. Nested keys under
+stateless/hotPath/nats/openbao/cassandra override those defaults.
+
+stateless — nvcf-api, invocation, grpc-proxy, admin-token-issuer-proxy, and
+  llm-api-gateway (LLM addon): replicaCount, hostname anti-affinity, zone
+  topology spread, PDB.
+hotPath   — rateLimiter, nats-auth-callout: 2 replicas + anti-affinity +
+  zone topology spread + PDB.
+
+In-scope charts MUST expose the required value hooks.
+*/}}
+{{- define "nvcf.ha.statelessReplicaCount" -}}
+{{- dig "highAvailability" "stateless" "replicaCount" 2 . -}}
+{{- end -}}
+
+{{/* Replica count for hot-path helper Deployments (rateLimiter,
+     nats-auth-callout) under HA. Defaults to 2. */}}
+{{- define "nvcf.ha.hotPathReplicaCount" -}}
+{{- dig "highAvailability" "hotPath" "replicaCount" 2 . -}}
+{{- end -}}
+
+{{/* Soft/hard pod anti-affinity on hostname for a Helm release instance name.
+     Context: dict "Values" $.Values "instance" "<release-instance>" */}}
+{{- define "nvcf.ha.statelessAffinity" -}}
+{{- $haMode := dig "highAvailability" "mode" "none" .Values | toString -}}
+{{- if or (eq $haMode "ha-preferred") (eq $haMode "ha-enforced") -}}
+{{- $paa := dig "highAvailability" "stateless" "podAntiAffinity" dict .Values -}}
+{{- if dig "enabled" true $paa -}}
+affinity:
+  podAntiAffinity:
+{{- if eq $haMode "ha-enforced" }}
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/instance
+              operator: In
+              values:
+                - {{ .instance | quote }}
+        topologyKey: kubernetes.io/hostname
+{{- else }}
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/instance
+                operator: In
+                values:
+                  - {{ .instance | quote }}
+          topologyKey: kubernetes.io/hostname
+{{- end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Zone-level topology spread for a Helm release instance name. Spreads
+     replicas across topology.kubernetes.io/zone. whenUnsatisfiable follows the
+     mode: ha-preferred → ScheduleAnyway (best effort), ha-enforced →
+     DoNotSchedule (hard). Nodes MUST carry topology.kubernetes.io/zone.
+     Context: dict "Values" $.Values "instance" "<release-instance>" */}}
+{{- define "nvcf.ha.statelessTopologySpread" -}}
+{{- $haMode := dig "highAvailability" "mode" "none" .Values | toString -}}
+{{- if or (eq $haMode "ha-preferred") (eq $haMode "ha-enforced") -}}
+{{- $ts := dig "highAvailability" "stateless" "topologySpread" dict .Values -}}
+{{- if dig "enabled" true $ts -}}
+topologySpreadConstraints:
+  - maxSkew: {{ dig "maxSkew" 1 $ts }}
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: {{ if eq $haMode "ha-enforced" }}DoNotSchedule{{ else }}ScheduleAnyway{{ end }}
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/instance: {{ .instance | quote }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- $haMode := dig "highAvailability" "mode" "none" .Values | toString }}
+{{- if not (has $haMode (list "none" "ha-preferred" "ha-enforced")) }}
+{{- fail (printf "highAvailability.mode must be none, ha-preferred, or ha-enforced, got %q" $haMode) }}
+{{- end }}
+{{- $haEnabled := or (eq $haMode "ha-preferred") (eq $haMode "ha-enforced") }}
+
 cassandra:
   global:
     {{- if .Values.global.imagePullSecrets }}
@@ -36,12 +129,19 @@ cassandra:
     defaultStorageClass: {{ .Values.global.storageClass }}
     {{- end }}
 
-  replicaCount: {{ dig "cassandra" "replicaCount" 3 .Values }}
+  replicaCount: {{ if $haEnabled }}{{ dig "highAvailability" "cassandra" "replicaCount" 3 .Values }}{{ else }}{{ dig "cassandra" "replicaCount" 3 .Values }}{{ end }}
   resourcesPreset: {{ dig "cassandra" "resourcesPreset" "xlarge" .Values }}
 
+  {{- if $haEnabled }}
+  {{- with dig "highAvailability" "cassandra" "podDisruptionBudget" dict .Values }}
+  podDisruptionBudget:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- else }}
   {{- with dig "cassandra" "podDisruptionBudget" dict .Values }}
   podDisruptionBudget:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 
   {{- with include "nvcf.nodeSelector" (dict "type" "cassandra" "selectors" .Values.global.nodeSelectors) }}
@@ -155,7 +255,7 @@ openbao:
     {{- with include "nvcf.tolerations" (dict "type" "vault" "tolerations" .Values.global.tolerations) }}
     {{- . | nindent 4 }}
     {{- end }}
-    replicas: {{ .Values.openbao.injector.replicas }}
+    replicas: {{ if $haEnabled }}{{ dig "highAvailability" "openbao" "injector" "replicas" 2 .Values }}{{ else }}{{ .Values.openbao.injector.replicas }}{{ end }}
     {{- $nvcfUiEnabled := dig "addons" "nvcfUi" "enabled" false .Values }}
     {{- with dig "openbao" "injector" "webhook" dict .Values }}
     webhook:
@@ -193,6 +293,10 @@ openbao:
       size: {{ .Values.global.storageSize | default "10Gi" }}
 
     ha:
+      {{- if $haEnabled }}
+      enabled: {{ dig "highAvailability" "openbao" "ha" "enabled" true .Values }}
+      replicas: {{ dig "highAvailability" "openbao" "ha" "replicas" 3 .Values }}
+      {{- end }}
       {{- with dig "openbao" "server" "ha" "disruptionBudget" dict .Values }}
       disruptionBudget:
         {{- toYaml . | nindent 8 }}
@@ -262,6 +366,11 @@ nats:
       {{- if kindIs "bool" $allowNonTls }}
       allow_non_tls: {{ $allowNonTls }}
       {{- end }}
+    {{- if $haEnabled }}
+    cluster:
+      enabled: true
+      replicas: {{ dig "highAvailability" "nats" "replicas" 3 .Values }}
+    {{- end }}
     {{- if .Values.global.storageClass }}
     jetstream:
       fileStore:
@@ -274,9 +383,16 @@ nats:
         {{- toYaml . | nindent 8 }}
     {{- end }}
 
+  {{- if $haEnabled }}
+  {{- with dig "highAvailability" "nats" "podDisruptionBudget" dict .Values }}
+  podDisruptionBudget:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- else }}
   {{- with dig "nats" "podDisruptionBudget" dict .Values }}
   podDisruptionBudget:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 
 apikeys:
@@ -308,6 +424,15 @@ apikeys:
   {{- end }}
 
 natsAuthCalloutService:
+  {{- if $haEnabled }}
+  replicaCount: {{ include "nvcf.ha.hotPathReplicaCount" .Values }}
+  {{- end }}
+  {{- with include "nvcf.ha.statelessAffinity" (dict "Values" .Values "instance" "nats-auth-callout-service") }}
+  {{- . | nindent 2 }}
+  {{- end }}
+  {{- with include "nvcf.ha.statelessTopologySpread" (dict "Values" .Values "instance" "nats-auth-callout-service") }}
+  {{- . | nindent 2 }}
+  {{- end }}
   {{- if .Values.global.imagePullSecrets }}
   imagePullSecrets:
     {{- toYaml .Values.global.imagePullSecrets | nindent 4 }}
@@ -483,6 +608,9 @@ natsAuthCalloutService:
 {{- $apiRemoteConfigData = mergeOverwrite $apiRemoteConfigData $stackApiRemoteConfigData }}
 api:
   fullnameOverride: nvcf-api
+  {{- if $haEnabled }}
+  replicaCount: {{ include "nvcf.ha.statelessReplicaCount" .Values }}
+  {{- end }}
   {{- if .Values.global.imagePullSecrets }}
   imagePullSecrets:
     {{- toYaml .Values.global.imagePullSecrets | nindent 4 }}
@@ -500,6 +628,23 @@ api:
   {{- end }}
   {{- with include "nvcf.tolerations" (dict "type" "controlplane" "tolerations" .Values.global.tolerations) }}
   {{- . | nindent 2 }}
+  {{- end }}
+  {{- with include "nvcf.ha.statelessAffinity" (dict "Values" .Values "instance" "api") }}
+  {{- . | nindent 2 }}
+  {{- end }}
+  {{- with include "nvcf.ha.statelessTopologySpread" (dict "Values" .Values "instance" "api") }}
+  {{- . | nindent 2 }}
+  {{- end }}
+  {{- if $haEnabled }}
+  {{- with dig "highAvailability" "stateless" "podDisruptionBudget" dict .Values }}
+  podDisruptionBudget:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- else }}
+  {{- with dig "api" "podDisruptionBudget" dict .Values }}
+  podDisruptionBudget:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
   {{- if $apiRemoteConfigData }}
   remoteConfig:
@@ -607,6 +752,9 @@ invocation:
   {{- end }}
   {{- $invocationEnv = mergeOverwrite $invocationEnv (deepCopy $configuredInvocationEnv) }}
   fullnameOverride: invocation-service
+  {{- if $haEnabled }}
+  replicaCount: {{ include "nvcf.ha.statelessReplicaCount" .Values }}
+  {{- end }}
   {{- if .Values.global.imagePullSecrets }}
   imagePullSecrets:
     {{- toYaml .Values.global.imagePullSecrets | nindent 4 }}
@@ -618,6 +766,12 @@ invocation:
   {{- . | nindent 2 }}
   {{- end }}
   {{- with include "nvcf.tolerations" (dict "type" "controlplane" "tolerations" .Values.global.tolerations) }}
+  {{- . | nindent 2 }}
+  {{- end }}
+  {{- with include "nvcf.ha.statelessAffinity" (dict "Values" .Values "instance" "invocation-service") }}
+  {{- . | nindent 2 }}
+  {{- end }}
+  {{- with include "nvcf.ha.statelessTopologySpread" (dict "Values" .Values "instance" "invocation-service") }}
   {{- . | nindent 2 }}
   {{- end }}
 
@@ -634,9 +788,16 @@ invocation:
     baggageAttributeAllowlist:
     {{- toYaml . | nindent 6 }}
   {{- end }}
+  {{- if $haEnabled }}
+  {{- with dig "highAvailability" "stateless" "podDisruptionBudget" dict .Values }}
+  podDisruptionBudget:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- else }}
   {{- with dig "invocation" "podDisruptionBudget" dict .Values }}
   podDisruptionBudget:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 
 nvctApi:
@@ -685,6 +846,9 @@ nvctApi:
 
 grpcproxy:
   fullnameOverride: grpc-proxy
+  {{- if $haEnabled }}
+  replicaCount: {{ include "nvcf.ha.statelessReplicaCount" .Values }}
+  {{- end }}
   {{- if .Values.global.imagePullSecrets }}
   imagePullSecrets:
     {{- toYaml .Values.global.imagePullSecrets | nindent 4 }}
@@ -697,6 +861,19 @@ grpcproxy:
   {{- end }}
   {{- with include "nvcf.tolerations" (dict "type" "controlplane" "tolerations" .Values.global.tolerations) }}
   {{- . | nindent 2 }}
+  {{- end }}
+  {{- if $haEnabled }}
+  {{- $grpcAffinity := include "nvcf.ha.statelessAffinity" (dict "Values" .Values "instance" "grpc-proxy") }}
+  {{- $grpcTopologySpread := include "nvcf.ha.statelessTopologySpread" (dict "Values" .Values "instance" "grpc-proxy") }}
+  {{- if or $grpcAffinity $grpcTopologySpread }}
+  deployment:
+    {{- with $grpcAffinity }}
+    {{- . | nindent 4 }}
+    {{- end }}
+    {{- with $grpcTopologySpread }}
+    {{- . | nindent 4 }}
+    {{- end }}
+  {{- end }}
   {{- end }}
   {{- with $grpcProxyWorkerConnectBaseURL }}
   workerConnectBaseURL: {{ . | quote }}
@@ -719,9 +896,16 @@ grpcproxy:
     RATE_LIMIT_ENABLED: "true"
     RATE_LIMIT_ADDR: "http://ratelimiter.nvcf.svc.cluster.local:7777"
     {{- end }}
+  {{- if $haEnabled }}
+  {{- with dig "highAvailability" "stateless" "podDisruptionBudget" dict .Values }}
+  podDisruptionBudget:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- else }}
   {{- with dig "grpcproxy" "podDisruptionBudget" dict .Values }}
   podDisruptionBudget:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 
 rateLimiter:
@@ -736,14 +920,27 @@ rateLimiter:
   nodeSelector:
     {{ .Values.global.nodeSelectors.controlplane.key }}: {{ .Values.global.nodeSelectors.controlplane.value }}
   {{- end }}
-  replicaCount: {{ .Values.rateLimiter.replicaCount }}
+  replicaCount: {{ if $haEnabled }}{{ include "nvcf.ha.hotPathReplicaCount" .Values }}{{ else }}{{ .Values.rateLimiter.replicaCount }}{{ end }}
+  {{- with include "nvcf.ha.statelessAffinity" (dict "Values" .Values "instance" "ratelimiter") }}
+  {{- . | nindent 2 }}
+  {{- end }}
+  {{- with include "nvcf.ha.statelessTopologySpread" (dict "Values" .Values "instance" "ratelimiter") }}
+  {{- . | nindent 2 }}
+  {{- end }}
   {{- if .Values.global.observability.tracing.enabled }}
   env:
     OTEL_EXPORTER_OTLP_ENDPOINT: "{{ .Values.global.observability.tracing.collectorProtocol }}://{{ .Values.global.observability.tracing.collectorEndpoint }}:{{ .Values.global.observability.tracing.collectorPort }}"
   {{- end }}
+  {{- if $haEnabled }}
+  {{- with dig "highAvailability" "hotPath" "podDisruptionBudget" dict .Values }}
+  podDisruptionBudget:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- else }}
   {{- with dig "rateLimiter" "podDisruptionBudget" dict .Values }}
   podDisruptionBudget:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 
 ess:
@@ -837,6 +1034,9 @@ sis:
 
 adminIssuerProxy:
   fullnameOverride: admin-token-issuer-proxy
+  {{- if $haEnabled }}
+  replicaCount: {{ include "nvcf.ha.statelessReplicaCount" .Values }}
+  {{- end }}
   {{- if .Values.global.imagePullSecrets }}
   imagePullSecrets:
     {{- toYaml .Values.global.imagePullSecrets | nindent 4 }}
@@ -853,6 +1053,12 @@ adminIssuerProxy:
   {{- with include "nvcf.tolerations" (dict "type" "controlplane" "tolerations" .Values.global.tolerations) }}
   {{- . | nindent 2 }}
   {{- end }}
+  {{- with include "nvcf.ha.statelessAffinity" (dict "Values" .Values "instance" "admin-token-issuer-proxy") }}
+  {{- . | nindent 2 }}
+  {{- end }}
+  {{- with include "nvcf.ha.statelessTopologySpread" (dict "Values" .Values "instance" "admin-token-issuer-proxy") }}
+  {{- . | nindent 2 }}
+  {{- end }}
   gateway:
     enabled: true
     namespace: {{ .Values.ingress.gatewayApi.gateways.shared.namespace }}
@@ -860,9 +1066,16 @@ adminIssuerProxy:
       name: {{ required "ingress.gatewayApi.gateways.shared.name is required" .Values.ingress.gatewayApi.gateways.shared.name }}
     hostname: "api-keys.{{ .Values.global.domain }}"
     path: "/v1/admin/keys"
+  {{- if $haEnabled }}
+  {{- with dig "highAvailability" "stateless" "podDisruptionBudget" dict .Values }}
+  podDisruptionBudget:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- else }}
   {{- with dig "adminIssuerProxy" "podDisruptionBudget" dict .Values }}
   podDisruptionBudget:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 
 stateMetrics:
@@ -995,6 +1208,12 @@ llmApiGateway:
   {{- with include "nvcf.tolerations" (dict "type" "controlplane" "tolerations" .Values.global.tolerations) }}
   {{- . | nindent 2 }}
   {{- end }}
+  {{- with include "nvcf.ha.statelessAffinity" (dict "Values" .Values "instance" "llm-api-gateway") }}
+  {{- . | nindent 2 }}
+  {{- end }}
+  {{- with include "nvcf.ha.statelessTopologySpread" (dict "Values" .Values "instance" "llm-api-gateway") }}
+  {{- . | nindent 2 }}
+  {{- end }}
   {{- if dig "addons" "llm" "gateway" "auth" "grpcInsecure" false .Values }}
   config:
     nvcfGrpcInsecure: true
@@ -1009,9 +1228,16 @@ llmApiGateway:
       {{- if .Values.global.observability.tracing.enabled }}
       endpoint: "{{ .Values.global.observability.tracing.collectorProtocol }}://{{ .Values.global.observability.tracing.collectorEndpoint }}:{{ .Values.global.observability.tracing.collectorPort }}"
       {{- end }}
+  {{- if $haEnabled }}
+  {{- with dig "highAvailability" "stateless" "podDisruptionBudget" dict .Values }}
+  podDisruptionBudget:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- else }}
   {{- with dig "llmApiGateway" "podDisruptionBudget" dict .Values }}
   podDisruptionBudget:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 
 {{- $pylonGrpcDialAddress := dig "addons" "llm" "requestRouter" "backendRouter" "pylonGrpcDialAddress" "" .Values | default "" | toString | trim }}

--- a/deploy/stacks/self-managed/tests/ha-value-wiring.sh
+++ b/deploy/stacks/self-managed/tests/ha-value-wiring.sh
@@ -77,6 +77,21 @@ if awk '/^rateLimiter:/{p=1;next} /^[a-zA-Z]/{p=0} p' "$work_dir/ratelimiter-off
   fail "ratelimiter: HA affinity leaked while highAvailability.mode=none"
 fi
 
+# Tier-2 (#989): anti-affinity must not leak into the quorum charts when off.
+render_chart_values cassandra "$work_dir/cassandra-off.yaml" "$deps" || fail "render cassandra (ha none)"
+if grep -q "podAntiAffinity:" "$work_dir/cassandra-off.yaml"; then
+  fail "cassandra: Tier-2 anti-affinity leaked while highAvailability.mode=none"
+fi
+
+# JetStream RF (#989): the RF env must not leak into the stream creators when off.
+if awk '/^api:/{p=1;next} /^[a-zA-Z]/{p=0} p' "$work_dir/api-off.yaml" | grep -q "NVCF_NATS_REPLICAS:"; then
+  fail "api: JetStream RF env leaked while highAvailability.mode=none"
+fi
+render_chart_values invocation-service "$work_dir/invocation-off.yaml" "$core" || fail "render invocation (ha none)"
+if grep -q "NATS_PROPERTIES__REPLICAS:" "$work_dir/invocation-off.yaml"; then
+  fail "invocation: JetStream RF env leaked while highAvailability.mode=none"
+fi
+
 echo "== highAvailability ha-preferred: stateless / quorum sizing =="
 write_env <<'EOF'
 highAvailability:
@@ -96,20 +111,34 @@ grep -q "whenUnsatisfiable: ScheduleAnyway" "$work_dir/api-on.yaml" ||
   fail "api: expected ScheduleAnyway topology spread when highAvailability.mode=ha-preferred"
 awk '/^api:/{p=1;next} /^[a-zA-Z]/{p=0} p' "$work_dir/api-on.yaml" | grep -q "podDisruptionBudget:" ||
   fail "api: expected podDisruptionBudget when highAvailability.mode=ha-preferred"
+grep -q 'NVCF_NATS_REPLICAS: "2"' "$work_dir/api-on.yaml" ||
+  fail "api: expected JetStream RF NVCF_NATS_REPLICAS=2 when highAvailability.mode=ha-preferred"
+
+render_chart_values invocation-service "$work_dir/invocation-on.yaml" "$core" || fail "render invocation (ha-preferred)"
+grep -q 'NATS_PROPERTIES__REPLICAS: "2"' "$work_dir/invocation-on.yaml" ||
+  fail "invocation: expected JetStream RF NATS_PROPERTIES__REPLICAS=2 when highAvailability.mode=ha-preferred"
 
 render_chart_values cassandra "$work_dir/cassandra-on.yaml" "$deps" || fail "render cassandra (ha-preferred)"
 grep -E "replicaCount:[[:space:]]*3" "$work_dir/cassandra-on.yaml" >/dev/null ||
   fail "cassandra: expected replicaCount 3 when highAvailability.mode=ha-preferred"
 grep -A2 "podDisruptionBudget:" "$work_dir/cassandra-on.yaml" | grep -q "enabled: true" ||
   fail "cassandra: expected HA PDB enabled"
+grep -q "podAntiAffinity:" "$work_dir/cassandra-on.yaml" ||
+  fail "cassandra: expected Tier-2 anti-affinity when highAvailability.mode=ha-preferred"
+grep -q "preferredDuringSchedulingIgnoredDuringExecution:" "$work_dir/cassandra-on.yaml" ||
+  fail "cassandra: expected preferred Tier-2 anti-affinity when highAvailability.mode=ha-preferred"
 
 render_chart_values openbao-server "$work_dir/openbao-on.yaml" "$deps" || fail "render openbao (ha-preferred)"
 grep -A5 "^[[:space:]]*ha:" "$work_dir/openbao-on.yaml" | grep -E "replicas:[[:space:]]*3" >/dev/null ||
   fail "openbao: expected server.ha.replicas 3 when highAvailability.mode=ha-preferred"
+grep -q "podAntiAffinity:" "$work_dir/openbao-on.yaml" ||
+  fail "openbao: expected Tier-2 anti-affinity when highAvailability.mode=ha-preferred"
 
 render_chart_values nats "$work_dir/nats-on.yaml" "$deps" || fail "render nats (ha-preferred)"
 grep -A5 "cluster:" "$work_dir/nats-on.yaml" | grep -E "replicas:[[:space:]]*3" >/dev/null ||
   fail "nats: expected config.cluster.replicas 3 when highAvailability.mode=ha-preferred"
+grep -q "podAntiAffinity:" "$work_dir/nats-on.yaml" ||
+  fail "nats: expected Tier-2 anti-affinity when highAvailability.mode=ha-preferred"
 
 # Hot-path helpers (#988): rateLimiter + nats-auth-callout to 2 replicas.
 render_chart_values ratelimiter "$work_dir/ratelimiter-on.yaml" "$core" --state-values-set rateLimiter.enabled=true ||
@@ -143,6 +172,10 @@ grep -q "requiredDuringSchedulingIgnoredDuringExecution:" "$work_dir/api-enforce
   fail "api: expected required anti-affinity when highAvailability.mode=ha-enforced"
 grep -q "whenUnsatisfiable: DoNotSchedule" "$work_dir/api-enforced.yaml" ||
   fail "api: expected DoNotSchedule topology spread when highAvailability.mode=ha-enforced"
+
+render_chart_values cassandra "$work_dir/cassandra-enforced.yaml" "$deps" || fail "render cassandra (ha-enforced)"
+grep -q "requiredDuringSchedulingIgnoredDuringExecution:" "$work_dir/cassandra-enforced.yaml" ||
+  fail "cassandra: expected required Tier-2 anti-affinity when highAvailability.mode=ha-enforced"
 
 render_chart_values ratelimiter "$work_dir/ratelimiter-enforced.yaml" "$core" --state-values-set rateLimiter.enabled=true ||
   fail "render ratelimiter (ha-enforced)"

--- a/deploy/stacks/self-managed/tests/ha-value-wiring.sh
+++ b/deploy/stacks/self-managed/tests/ha-value-wiring.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Test that highAvailability values thread from environment files through
+# global.yaml.gotmpl into chart values for stateless / quorum releases.
+set -euo pipefail
+
+stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+work_dir="$(mktemp -d)"
+test_stack_dir="$work_dir/self-managed"
+environment_name="ha-value-wiring-test"
+environment_file="$test_stack_dir/environments/$environment_name.yaml"
+secrets_file="$test_stack_dir/secrets/$environment_name-secrets.yaml"
+trap 'rm -rf "$work_dir"' EXIT
+
+fail() {
+  echo "ha-value-wiring: $*" >&2
+  exit 1
+}
+
+mkdir -p "$test_stack_dir"
+cp -R "$stack_dir"/. "$test_stack_dir"
+printf '{}\n' >"$secrets_file"
+
+render_chart_values() {
+  local release="$1"
+  local output_file="$2"
+  local helmfile_file="$3"
+  shift 3
+
+  # global.yaml.gotmpl evaluates adminIssuerProxy gateway refs for every release.
+  HELMFILE_ENV="$environment_name" \
+    HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" \
+    helmfile \
+      --file "$helmfile_file" \
+      --environment default \
+      --state-values-set ingress.gatewayApi.controllerNamespace=envoy-gateway-system \
+      --state-values-set ingress.gatewayApi.gateways.shared.name=shared-gw \
+      --state-values-set ingress.gatewayApi.gateways.shared.namespace=envoy-gateway-system \
+      --state-values-set ingress.gatewayApi.gateways.grpc.name=grpc-gw \
+      --state-values-set ingress.gatewayApi.gateways.grpc.namespace=envoy-gateway-system \
+      --selector "name=$release" \
+      "$@" \
+      write-values \
+      --output-file-template "$output_file"
+}
+
+write_env() {
+  cat >"$environment_file"
+}
+
+deps="$test_stack_dir/helmfile.d/01-dependencies.yaml.gotmpl"
+core="$test_stack_dir/helmfile.d/02-core.yaml.gotmpl"
+
+echo "== highAvailability mode none: chart defaults / base values unchanged =="
+write_env <<'EOF'
+highAvailability:
+  mode: none
+EOF
+
+render_chart_values api "$work_dir/api-off.yaml" "$core" || fail "render api (ha none)"
+# HA must not inject replicaCount into the api values when disabled.
+if awk '/^api:/{p=1;next} /^[a-zA-Z]/{p=0} p' "$work_dir/api-off.yaml" | grep -q "replicaCount:"; then
+  fail "api: HA replicaCount leaked while highAvailability.mode=none"
+fi
+if awk '/^api:/{p=1;next} /^[a-zA-Z]/{p=0} p' "$work_dir/api-off.yaml" | grep -q "podAntiAffinity:"; then
+  fail "api: HA affinity leaked while highAvailability.mode=none"
+fi
+if awk '/^api:/{p=1;next} /^[a-zA-Z]/{p=0} p' "$work_dir/api-off.yaml" | grep -q "topologySpreadConstraints:"; then
+  fail "api: topology spread leaked while highAvailability.mode=none"
+fi
+if awk '/^api:/{p=1;next} /^[a-zA-Z]/{p=0} p' "$work_dir/api-off.yaml" | grep -q "podDisruptionBudget:"; then
+  fail "api: PDB leaked while highAvailability.mode=none"
+fi
+
+render_chart_values ratelimiter "$work_dir/ratelimiter-off.yaml" "$core" --state-values-set rateLimiter.enabled=true ||
+  fail "render ratelimiter (ha none)"
+if awk '/^rateLimiter:/{p=1;next} /^[a-zA-Z]/{p=0} p' "$work_dir/ratelimiter-off.yaml" | grep -q "podAntiAffinity:"; then
+  fail "ratelimiter: HA affinity leaked while highAvailability.mode=none"
+fi
+
+echo "== highAvailability ha-preferred: stateless / quorum sizing =="
+write_env <<'EOF'
+highAvailability:
+  mode: ha-preferred
+EOF
+
+render_chart_values api "$work_dir/api-on.yaml" "$core" || fail "render api (ha-preferred)"
+grep -E "replicaCount:[[:space:]]*2" "$work_dir/api-on.yaml" >/dev/null ||
+  fail "api: expected replicaCount 2 when highAvailability.mode=ha-preferred"
+grep -q "preferredDuringSchedulingIgnoredDuringExecution:" "$work_dir/api-on.yaml" ||
+  fail "api: expected preferred anti-affinity when highAvailability.mode=ha-preferred"
+grep -q "topologySpreadConstraints:" "$work_dir/api-on.yaml" ||
+  fail "api: expected topologySpreadConstraints when highAvailability.mode=ha-preferred"
+grep -q "topology.kubernetes.io/zone" "$work_dir/api-on.yaml" ||
+  fail "api: expected zone topologyKey when highAvailability.mode=ha-preferred"
+grep -q "whenUnsatisfiable: ScheduleAnyway" "$work_dir/api-on.yaml" ||
+  fail "api: expected ScheduleAnyway topology spread when highAvailability.mode=ha-preferred"
+awk '/^api:/{p=1;next} /^[a-zA-Z]/{p=0} p' "$work_dir/api-on.yaml" | grep -q "podDisruptionBudget:" ||
+  fail "api: expected podDisruptionBudget when highAvailability.mode=ha-preferred"
+
+render_chart_values cassandra "$work_dir/cassandra-on.yaml" "$deps" || fail "render cassandra (ha-preferred)"
+grep -E "replicaCount:[[:space:]]*3" "$work_dir/cassandra-on.yaml" >/dev/null ||
+  fail "cassandra: expected replicaCount 3 when highAvailability.mode=ha-preferred"
+grep -A2 "podDisruptionBudget:" "$work_dir/cassandra-on.yaml" | grep -q "enabled: true" ||
+  fail "cassandra: expected HA PDB enabled"
+
+render_chart_values openbao-server "$work_dir/openbao-on.yaml" "$deps" || fail "render openbao (ha-preferred)"
+grep -A5 "^[[:space:]]*ha:" "$work_dir/openbao-on.yaml" | grep -E "replicas:[[:space:]]*3" >/dev/null ||
+  fail "openbao: expected server.ha.replicas 3 when highAvailability.mode=ha-preferred"
+
+render_chart_values nats "$work_dir/nats-on.yaml" "$deps" || fail "render nats (ha-preferred)"
+grep -A5 "cluster:" "$work_dir/nats-on.yaml" | grep -E "replicas:[[:space:]]*3" >/dev/null ||
+  fail "nats: expected config.cluster.replicas 3 when highAvailability.mode=ha-preferred"
+
+# Hot-path helpers (#988): rateLimiter + nats-auth-callout to 2 replicas.
+render_chart_values ratelimiter "$work_dir/ratelimiter-on.yaml" "$core" --state-values-set rateLimiter.enabled=true ||
+  fail "render ratelimiter (ha-preferred)"
+awk '/^rateLimiter:/{p=1;next} /^[a-zA-Z]/{p=0} p' "$work_dir/ratelimiter-on.yaml" | grep -E "replicaCount:[[:space:]]*2" >/dev/null ||
+  fail "ratelimiter: expected replicaCount 2 when highAvailability.mode=ha-preferred"
+awk '/^rateLimiter:/{p=1;next} /^[a-zA-Z]/{p=0} p' "$work_dir/ratelimiter-on.yaml" | grep -q "preferredDuringSchedulingIgnoredDuringExecution:" ||
+  fail "ratelimiter: expected preferred anti-affinity when highAvailability.mode=ha-preferred"
+awk '/^rateLimiter:/{p=1;next} /^[a-zA-Z]/{p=0} p' "$work_dir/ratelimiter-on.yaml" | grep -q "topology.kubernetes.io/zone" ||
+  fail "ratelimiter: expected zone topology spread when highAvailability.mode=ha-preferred"
+
+render_chart_values nats-auth-callout-service "$work_dir/natsauth-on.yaml" "$core" ||
+  fail "render nats-auth-callout (ha-preferred)"
+awk '/^natsAuthCalloutService:/{p=1;next} /^[a-zA-Z]/{p=0} p' "$work_dir/natsauth-on.yaml" | grep -E "replicaCount:[[:space:]]*2" >/dev/null ||
+  fail "nats-auth-callout: expected replicaCount 2 when highAvailability.mode=ha-preferred"
+
+# llm-api-gateway (#987): stateless anti-affinity when the LLM addon is on.
+render_chart_values llm-api-gateway "$work_dir/llmgw-on.yaml" "$core" --state-values-set addons.llm.enabled=true ||
+  fail "render llm-api-gateway (ha-preferred)"
+awk '/^llmApiGateway:/{p=1;next} /^[a-zA-Z]/{p=0} p' "$work_dir/llmgw-on.yaml" | grep -q "preferredDuringSchedulingIgnoredDuringExecution:" ||
+  fail "llm-api-gateway: expected preferred anti-affinity when highAvailability.mode=ha-preferred"
+
+echo "== highAvailability ha-enforced: required anti-affinity =="
+write_env <<'EOF'
+highAvailability:
+  mode: ha-enforced
+EOF
+
+render_chart_values api "$work_dir/api-enforced.yaml" "$core" || fail "render api (ha-enforced)"
+grep -q "requiredDuringSchedulingIgnoredDuringExecution:" "$work_dir/api-enforced.yaml" ||
+  fail "api: expected required anti-affinity when highAvailability.mode=ha-enforced"
+grep -q "whenUnsatisfiable: DoNotSchedule" "$work_dir/api-enforced.yaml" ||
+  fail "api: expected DoNotSchedule topology spread when highAvailability.mode=ha-enforced"
+
+render_chart_values ratelimiter "$work_dir/ratelimiter-enforced.yaml" "$core" --state-values-set rateLimiter.enabled=true ||
+  fail "render ratelimiter (ha-enforced)"
+awk '/^rateLimiter:/{p=1;next} /^[a-zA-Z]/{p=0} p' "$work_dir/ratelimiter-enforced.yaml" | grep -q "requiredDuringSchedulingIgnoredDuringExecution:" ||
+  fail "ratelimiter: expected required anti-affinity when highAvailability.mode=ha-enforced"
+
+echo "== highAvailability invalid mode fails render =="
+write_env <<'EOF'
+highAvailability:
+  mode: best-effort
+EOF
+if render_chart_values api "$work_dir/api-bad.yaml" "$core" 2>"$work_dir/api-bad.err"; then
+  fail "api: invalid highAvailability.mode should fail helmfile render"
+fi
+grep -q "highAvailability.mode" "$work_dir/api-bad.err" ||
+  fail "api: expected fail message to mention highAvailability.mode"
+
+echo "ha-value-wiring: ok"

--- a/deploy/stacks/self-managed/tests/ha-value-wiring.sh
+++ b/deploy/stacks/self-managed/tests/ha-value-wiring.sh
@@ -127,6 +127,13 @@ grep -q "podAntiAffinity:" "$work_dir/cassandra-on.yaml" ||
   fail "cassandra: expected Tier-2 anti-affinity when highAvailability.mode=ha-preferred"
 grep -q "preferredDuringSchedulingIgnoredDuringExecution:" "$work_dir/cassandra-on.yaml" ||
   fail "cassandra: expected preferred Tier-2 anti-affinity when highAvailability.mode=ha-preferred"
+# Zone topology spread is opt-in: no zone constraint in the cassandra block
+# unless tier2.topologySpread.enabled (the chart ships an empty default list).
+# NOTE: the write-values file holds every release's values, so scope to the
+# cassandra: block — stateless releases carry their own (expected) zone spread.
+if awk '/^cassandra:/{p=1;next} /^[a-zA-Z]/{p=0} p' "$work_dir/cassandra-on.yaml" | grep -q "topology.kubernetes.io/zone"; then
+  fail "cassandra: Tier-2 zone spread leaked without tier2.topologySpread.enabled"
+fi
 
 render_chart_values openbao-server "$work_dir/openbao-on.yaml" "$deps" || fail "render openbao (ha-preferred)"
 grep -A5 "^[[:space:]]*ha:" "$work_dir/openbao-on.yaml" | grep -E "replicas:[[:space:]]*3" >/dev/null ||
@@ -160,6 +167,43 @@ render_chart_values llm-api-gateway "$work_dir/llmgw-on.yaml" "$core" --state-va
   fail "render llm-api-gateway (ha-preferred)"
 awk '/^llmApiGateway:/{p=1;next} /^[a-zA-Z]/{p=0} p' "$work_dir/llmgw-on.yaml" | grep -q "preferredDuringSchedulingIgnoredDuringExecution:" ||
   fail "llm-api-gateway: expected preferred anti-affinity when highAvailability.mode=ha-preferred"
+
+echo "== highAvailability tier-2 zone topology spread (opt-in) =="
+write_env <<'EOF'
+highAvailability:
+  mode: ha-preferred
+  tier2:
+    topologySpread:
+      enabled: true
+EOF
+
+# Scope assertions to each release's own block (the write-values file holds all).
+render_chart_values cassandra "$work_dir/cassandra-spread.yaml" "$deps" || fail "render cassandra (zone spread)"
+awk '/^cassandra:/{p=1;next} /^[a-zA-Z]/{p=0} p' "$work_dir/cassandra-spread.yaml" | grep -q "topology.kubernetes.io/zone" ||
+  fail "cassandra: expected Tier-2 zone spread when tier2.topologySpread.enabled=true"
+awk '/^cassandra:/{p=1;next} /^[a-zA-Z]/{p=0} p' "$work_dir/cassandra-spread.yaml" | grep -q "whenUnsatisfiable: ScheduleAnyway" ||
+  fail "cassandra: expected soft (ScheduleAnyway) Tier-2 spread by default"
+
+render_chart_values openbao-server "$work_dir/openbao-spread.yaml" "$deps" || fail "render openbao (zone spread)"
+awk '/^openbao:/{p=1;next} /^[a-zA-Z]/{p=0} p' "$work_dir/openbao-spread.yaml" | grep -q "topology.kubernetes.io/zone" ||
+  fail "openbao: expected Tier-2 zone spread when tier2.topologySpread.enabled=true"
+
+render_chart_values nats "$work_dir/nats-spread.yaml" "$deps" || fail "render nats (zone spread)"
+awk '/^nats:/{p=1;next} /^[a-zA-Z]/{p=0} p' "$work_dir/nats-spread.yaml" | grep -q "topology.kubernetes.io/zone" ||
+  fail "nats: expected Tier-2 zone spread when tier2.topologySpread.enabled=true"
+
+# strict: true -> hard (DoNotSchedule), for >= 3-AZ clusters.
+write_env <<'EOF'
+highAvailability:
+  mode: ha-enforced
+  tier2:
+    topologySpread:
+      enabled: true
+      strict: true
+EOF
+render_chart_values cassandra "$work_dir/cassandra-spread-strict.yaml" "$deps" || fail "render cassandra (strict spread)"
+awk '/^cassandra:/{p=1;next} /^[a-zA-Z]/{p=0} p' "$work_dir/cassandra-spread-strict.yaml" | grep -q "whenUnsatisfiable: DoNotSchedule" ||
+  fail "cassandra: expected hard (DoNotSchedule) Tier-2 spread when strict=true"
 
 echo "== highAvailability ha-enforced: required anti-affinity =="
 write_env <<'EOF'

--- a/docs/v0.6.1/high-availability.md
+++ b/docs/v0.6.1/high-availability.md
@@ -1,0 +1,237 @@
+# High Availability
+
+This guide explains how to run the self-hosted NVCF control plane in a
+high-availability (HA) topology so that it survives the loss of a single node
+or availability zone (AZ). It covers the cluster prerequisites you must provide,
+how to turn HA on, what each service does under HA, and how to validate the
+result.
+
+HA is opt-in. Single-node installs (local, CI, small proofs of concept) should
+leave it off and are unaffected by anything in this guide.
+
+## Overview
+
+HA is controlled by a single switch in your Helmfile environment values,
+`highAvailability.mode`. The self-managed stack maps that mode onto per-chart
+values (replica counts, pod anti-affinity, zone topology spread, pod disruption
+budgets, and data-durability settings) in
+`deploy/stacks/self-managed/global.yaml.gotmpl`.
+
+| `highAvailability.mode` | Behavior |
+| --- | --- |
+| `none` (default) | Keep existing single-replica chart/env values. Nothing in this guide applies. Use for local, CI, and single-node installs. |
+| `ha-preferred` | HA sizing (multiple replicas, quorum services at 3). Node/AZ spread is a **preference**: if a second node or AZ has no capacity, pods still schedule (co-located) rather than staying `Pending`. |
+| `ha-enforced` | Same HA sizing, but node/AZ spread is **required**: a replica that cannot land on a distinct node/AZ stays `Pending` instead of packing onto an occupied one. |
+
+`ha-preferred` is the recommended starting point: it gives you the full HA
+topology while degrading gracefully on a constrained cluster. Move to
+`ha-enforced` once you have confirmed your node pools have capacity in every AZ
+and you want hard placement guarantees.
+
+## Cluster prerequisites
+
+HA depends on infrastructure the **operator** provides. The stack cannot create
+nodes or AZs for you — it only schedules against what you label.
+
+### 1. Node count
+
+Both HA modes require **at least 3 schedulable nodes** in the pool(s) that host
+control-plane and quorum workloads. The quorum services (Cassandra, NATS,
+OpenBao) run 3 replicas that must land on 3 distinct nodes.
+
+### 2. Availability-zone labels
+
+To spread replicas across failure domains, the scheduler uses the standard
+Kubernetes well-known label on your nodes:
+
+```
+topology.kubernetes.io/zone=<az>
+```
+
+You (the operator) must ensure this label is present on every node. Managed
+Kubernetes services (EKS, AKS, GKE) apply it automatically. On bare-metal or
+custom clusters, set it yourself, for example:
+
+```bash
+kubectl label node <node-name> topology.kubernetes.io/zone=az-1
+```
+
+If the label is absent, zone topology spread has nothing to spread across. In
+`ha-preferred` this silently degrades to node-level spread only; in
+`ha-enforced` zone-constrained pods can stay `Pending`. Aim for capacity in
+**at least two AZs** (three is better for the quorum services).
+
+### 3. Dedicated node pools (recommended)
+
+For predictable placement and isolation, give the stateful quorum services their
+own node pools and label them with `nvcf.nvidia.com/workload`. Configure the
+selectors under `global.nodeSelectors` in your environment file:
+
+| Pool | Selector value | Hosts |
+| --- | --- | --- |
+| `controlplane` | `control-plane` | Stateless + hot-path Deployments |
+| `cassandra` | `cassandra` | Cassandra StatefulSet |
+| `vault` | `vault` | OpenBao StatefulSet |
+
+Each dedicated pool must itself have **capacity in each AZ** — a 3-node
+Cassandra pool concentrated in one AZ cannot spread across zones no matter what
+the stack requests. If you run a single shared pool, use `global.nodeSelectors.all`
+instead and size it to hold every replica on distinct nodes/AZs.
+
+## Enabling HA
+
+Set the mode in your environment file (for example
+`deploy/stacks/self-managed/environments/<env>.yaml`):
+
+```yaml
+highAvailability:
+  mode: ha-preferred
+```
+
+That single line activates all of the defaults documented below. Every knob
+under `highAvailability` has a sensible default; override only what you need.
+Then apply the stack as usual:
+
+```bash
+helmfile -e <env> apply
+```
+
+An invalid mode fails the render fast with a clear error, so a typo cannot
+silently disable HA.
+
+## What HA changes, by tier
+
+### Stateless control-plane services
+
+Active-active Deployments with no leader election: `nvcf-api`,
+`invocation-service`, `grpc-proxy`, `admin-token-issuer-proxy`, and
+`llm-api-gateway` (when the LLM addon is enabled).
+
+Under HA each of these gets:
+
+- **2 replicas** (`highAvailability.stateless.replicaCount`).
+- **Hostname pod anti-affinity** so the two replicas never share a node.
+- **Zone topology spread** (`topology.kubernetes.io/zone`, `maxSkew: 1`) so they
+  land in different AZs when zones are labelled.
+- **A PodDisruptionBudget** (`minAvailable: 1`) so voluntary disruptions
+  (drains, upgrades) never take the last replica.
+- **A surge rolling-update strategy** (`maxSurge: 1`, `maxUnavailable: 0`) so a
+  new pod is Ready before an old one is removed.
+
+### Hot-path helper services
+
+`rateLimiter` and `nats-auth-callout` sit on the request/auth hot path, so under
+HA they are raised to **2 replicas** (`highAvailability.hotPath.replicaCount`)
+with their own PDB (`minAvailable: 1`). They reuse the stateless hostname
+anti-affinity and zone spread.
+
+### Tier-2 quorum services (data durability)
+
+`Cassandra`, `NATS`, and `OpenBao` run as **3-replica quorum StatefulSets** with:
+
+- **Hostname pod anti-affinity** so the 3 peers land on 3 distinct nodes
+  (`highAvailability.tier2.podAntiAffinity`). Following the mode, this is
+  preferred (soft) under `ha-preferred` and required (hard) under `ha-enforced`.
+  OpenBao's upstream chart ships a hard anti-affinity that the stack disables for
+  single-node installs and re-enables (soft/hard by mode) under HA.
+- **PodDisruptionBudgets** sized to preserve quorum (`minAvailable: 2`).
+
+Beyond placement, HA also raises the data-durability settings:
+
+#### NATS JetStream replica factor
+
+Streams default to a single replica. Under HA the stack sets the JetStream
+replica factor (RF) to **2** (`highAvailability.nats.jetstream.replicaFactor`)
+on the two services that create streams — `nvcf-api` (via `NVCF_NATS_REPLICAS`)
+and `invocation-service` (via `NATS_PROPERTIES__REPLICAS`). With RF=2 the
+worker/result streams are replicated across the NATS cluster and survive the
+loss of the node hosting the leader. RF must be `<= highAvailability.nats.replicas`.
+
+#### Cassandra replication and consistency
+
+The Cassandra keyspaces are created with `NetworkTopologyStrategy` and a
+replication factor equal to `highAvailability.cassandra.replicaCount` (3 under
+HA), and the control-plane services read/write at `LOCAL_QUORUM`. This is the
+correct configuration for both single-DC and multi-AZ deployments:
+
+- **Single datacenter:** RF=3 with `LOCAL_QUORUM` tolerates the loss of one
+  replica for reads and writes.
+- **Multi-AZ:** because replicas are placed with `NetworkTopologyStrategy`,
+  labelling nodes by rack/AZ makes Cassandra distribute the 3 replicas across
+  AZs automatically; `LOCAL_QUORUM` then keeps the cluster available through the
+  loss of a single AZ.
+
+No stack change is required to select the strategy — it is
+`NetworkTopologyStrategy` in all cases. To get true cross-AZ placement, ensure
+the Cassandra nodes carry AZ labels (see the prerequisites above).
+
+## Validation
+
+After applying HA, confirm replicas are spread as expected.
+
+Check that quorum peers landed on distinct nodes and AZs:
+
+```bash
+# Nodes and their AZ labels
+kubectl get nodes -L topology.kubernetes.io/zone
+
+# Cassandra / NATS / OpenBao pods with their nodes
+kubectl -n cassandra-system get pods -o wide
+kubectl -n nats-system get pods -o wide
+kubectl -n vault-system get pods -o wide
+```
+
+Confirm the stateless Deployments scaled and spread:
+
+```bash
+kubectl -n nvcf get deploy nvcf-api invocation-service -o wide
+kubectl -n nvcf get pods -o wide -l app.kubernetes.io/instance=nvcf-api
+```
+
+Confirm the JetStream RF took effect (streams report `Replicas: 2`):
+
+```bash
+kubectl -n nats-system exec -it nats-0 -- nats stream ls
+kubectl -n nats-system exec -it nats-0 -- nats stream info <stream-name>
+```
+
+Confirm Cassandra keyspace replication:
+
+```bash
+kubectl -n cassandra-system exec -it cassandra-0 -- \
+  cqlsh -e "SELECT keyspace_name, replication FROM system_schema.keyspaces;"
+```
+
+If any pod is stuck `Pending` under `ha-enforced`, it usually means a node pool
+lacks capacity in a second node/AZ. Add capacity, or drop to `ha-preferred` to
+let it schedule while you rebalance.
+
+## Recovery objectives and failure behavior
+
+With HA enabled and capacity in at least two AZs:
+
+- **Single node loss:** Stateless and hot-path Deployments keep serving from
+  their surviving replica; the scheduler recreates the lost pod on another node
+  (and the PDB prevents drains from removing the last one). Quorum services
+  (Cassandra RF=3/`LOCAL_QUORUM`, NATS RF=2, OpenBao 3-node Raft) retain quorum
+  with 2 of 3 members and continue serving reads and writes.
+- **Single AZ loss:** With replicas spread across AZs, the control plane stays
+  available on the surviving AZ(s). Recovery time is dominated by pod
+  reschedule/restart time on the healthy AZ rather than any manual failover.
+- **Two simultaneous quorum-member losses:** A 3-member quorum service loses
+  quorum and pauses writes until a member returns. This is why three AZs (or at
+  least three nodes across two AZs, with the third member able to reschedule) is
+  the durable target.
+
+HA reduces recovery to automatic rescheduling within surviving failure domains;
+it does not replace backups. Continue to back up Cassandra and OpenBao per the
+[Control Plane Operations](./control-plane-operations.md) runbooks.
+
+## Related
+
+- [Control Plane Operations](./control-plane-operations.md) — service reference,
+  key rotation, and upgrade runbooks.
+- [Infrastructure Sizing](./infrastructure-sizing.md) — node pool sizing
+  guidance.
+- [Helmfile Installation](./helmfile-installation.md) — how environment values
+  and `global.yaml.gotmpl` are applied.

--- a/docs/v0.6.1/high-availability.md
+++ b/docs/v0.6.1/high-availability.md
@@ -65,7 +65,24 @@ If the label is absent, zone topology spread has nothing to spread across. In
 
 For predictable placement and isolation, give the stateful quorum services their
 own node pools and label them with `nvcf.nvidia.com/workload`. Configure the
-selectors under `global.nodeSelectors` in your environment file:
+selectors under `global.nodeSelectors` and **set `enabled: true`** — the
+selectors ship disabled (`global.nodeSelectors.enabled: false`) and are a no-op
+until you turn them on:
+
+```yaml
+global:
+  nodeSelectors:
+    enabled: true                 # required; selectors are ignored when false
+    controlplane:
+      key: nvcf.nvidia.com/workload
+      value: control-plane
+    cassandra:
+      key: nvcf.nvidia.com/workload
+      value: cassandra
+    vault:
+      key: nvcf.nvidia.com/workload
+      value: vault
+```
 
 | Pool | Selector value | Hosts |
 | --- | --- | --- |
@@ -73,10 +90,14 @@ selectors under `global.nodeSelectors` in your environment file:
 | `cassandra` | `cassandra` | Cassandra StatefulSet |
 | `vault` | `vault` | OpenBao StatefulSet |
 
-Each dedicated pool must itself have **capacity in each AZ** — a 3-node
-Cassandra pool concentrated in one AZ cannot spread across zones no matter what
-the stack requests. If you run a single shared pool, use `global.nodeSelectors.all`
-instead and size it to hold every replica on distinct nodes/AZs.
+Each dedicated pool must span the availability zones — that is, have **capacity
+in every AZ you want to spread across** (both zones in a 2-AZ cluster, all three
+in a 3-AZ cluster). A 3-node Cassandra pool concentrated in one AZ cannot spread
+across zones no matter what the stack requests, and with `enabled: false` the
+pods fall back to default scheduling regardless of your labels. If you run a
+single shared pool instead, set `global.nodeSelectors.enabled: true` with
+`global.nodeSelectors.all` and size it to hold every replica on distinct
+nodes/AZs.
 
 ## Enabling HA
 
@@ -135,6 +156,54 @@ anti-affinity and zone spread.
   OpenBao's upstream chart ships a hard anti-affinity that the stack disables for
   single-node installs and re-enables (soft/hard by mode) under HA.
 - **PodDisruptionBudgets** sized to preserve quorum (`minAvailable: 2`).
+
+#### Zone spread for the quorum pods (opt-in)
+
+By default the quorum peers are only guaranteed distinct **nodes**, not distinct
+**zones** — three nodes can all be in one AZ, so a single-AZ loss could still
+break quorum. To spread the three peers across `topology.kubernetes.io/zone`,
+enable:
+
+```yaml
+highAvailability:
+  tier2:
+    topologySpread:
+      enabled: true      # off by default
+      maxSkew: 1
+      strict: false      # ScheduleAnyway (soft). Set true only on >= 3 AZs.
+```
+
+This is **opt-in** because, unlike the stateless tier, it depends on
+infrastructure you must provide:
+
+- **StorageClass `volumeBindingMode: WaitForFirstConsumer`.** Each quorum pod has
+  a zonal PersistentVolume, and a zonal disk can only attach to a node in its own
+  AZ. With `WaitForFirstConsumer`, the scheduler places the pod first (honoring
+  the spread constraint) and the PV is then created in that pod's zone. With
+  `Immediate` binding the PV's zone is chosen up front and the pod is pinned to
+  it, which fights the spread constraint and can leave pods `Pending`. The stack
+  cannot set this for you — it is a property of the StorageClass you supply.
+- **Capacity in at least 3 AZs.** A 3-member quorum only survives an AZ loss if
+  no single AZ holds a majority. With only 2 AZs one zone inevitably holds 2 of
+  3 members, and losing that zone breaks quorum. On a 2-AZ cluster leave zone
+  spread off (or keep `strict: false`).
+
+`whenUnsatisfiable` defaults to `ScheduleAnyway` (soft) so a temporarily short
+AZ never leaves a peer `Pending`. Only set `strict: true` — which makes it
+`DoNotSchedule` (hard) — on clusters you know have capacity in ≥3 AZs.
+
+**Cassandra needs one more thing: rack = AZ.** Spreading the *pods* across zones
+does not by itself make the *data* zone-diverse. `NetworkTopologyStrategy`
+replicates by **rack**, and Cassandra's rack is assigned by the image entrypoint,
+not by the pod's Kubernetes zone. Unless each pod's Cassandra rack is set to its
+AZ, RF=3 can still place all three data replicas in one rack. Map rack to AZ on
+the Cassandra nodes to get true cross-AZ data placement; NATS and OpenBao (Raft)
+replicate per member and need only the pod spread.
+
+Once a quorum pod's PV is created in a zone it is pinned there for the life of
+that StatefulSet ordinal — steady-state placement stays spread, but a pod whose
+AZ is lost cannot reschedule elsewhere until the AZ returns (its two peers carry
+quorum in the meantime).
 
 Beyond placement, HA also raises the data-durability settings:
 

--- a/docs/v0.6.1/index.md
+++ b/docs/v0.6.1/index.md
@@ -10,6 +10,8 @@ This guide provides information for deploying and operating NVCF in self-managed
   : Connect GPU clusters to the NVCF control plane.
 - [Configuration](./optional-enhancements.md)
   : Configure gateway routing, registries, and optional enhancements.
+- [High Availability](./high-availability.md)
+  : Run the control plane across nodes and availability zones to survive node/AZ loss.
 - [Using Cloud Functions](./api.md)
   : Create and invoke functions using the NVCF API and CLI.
 - [Managed (Legacy)](../ngc-managed/cluster-management/ngc-managed.md)


### PR DESCRIPTION
> **📚 Stacked PR — review & merge order: #996 → #1679 → #1683.**
> **Step 3 of 3**, stacked on #1679. Review **only** the top commit [`5db366840`](https://github.com/NVIDIA/nvcf/pull/1683/commits/5db366840) — the two lower commits belong to #996 and #1679 and disappear as they merge. **Merge last.**

---

Part of the **Self-Hosted Control-Plane Resiliency** epic (#985), extending #989.

Stacked on #1679 (Tier-2 anti-affinity + JetStream RF + HA docs). Base is `shobham/989-tier2-anti-affinity` so the diff stays focused; retarget up the stack as the lower PRs merge.

## What this PR does

Adds **zone-level** spread for the Tier-2 quorum services. #1679 guarantees the 3 Cassandra/NATS/OpenBao peers land on distinct **nodes**; this makes them land in distinct **availability zones** so a single-AZ loss can't take a quorum.

New helper `nvcf.ha.tier2TopologySpread` emits a `topology.kubernetes.io/zone` spread constraint per release, gated behind a new **opt-in** knob:

```yaml
highAvailability:
  tier2:
    topologySpread:
      enabled: false     # default OFF
      maxSkew: 1
      strict: false      # ScheduleAnyway (soft); true => DoNotSchedule (>= 3 AZ only)
```

Per-chart wiring (each exposes the knob differently):

| Service | How |
| --- | --- |
| NATS | `podTemplate.merge.spec.topologySpreadConstraints` |
| OpenBao | `server.topologySpreadConstraints` (tpl string) |
| Cassandra | new `topologySpreadConstraints` block in the wrapper StatefulSet + `cassandra.topologySpreadConstraints` value |

## Why opt-in (default off)

Correct behavior depends on operator-provided infrastructure that the value layer can't guarantee:

- **StorageClass `volumeBindingMode: WaitForFirstConsumer`** — each quorum pod has a zonal PV; only delayed binding lets the scheduler place the pod (honoring spread) and then create the PV in that pod's zone. With `Immediate` binding the PV zone is fixed first and pods can go `Pending`.
- **Capacity in ≥3 AZs** — a 3-member quorum only survives an AZ loss if no single AZ holds a majority. With 2 AZs one zone holds 2 of 3, so losing it breaks quorum. Hence soft (`ScheduleAnyway`) default and `strict` opt-in for ≥3-AZ clusters.

**Cassandra caveat (documented, not wired):** pod zone spread doesn't make the *data* zone-diverse — `NetworkTopologyStrategy` replicates by **rack**, assigned by the image entrypoint. True cross-AZ data placement also needs **rack = AZ** on the nodes. NATS/OpenBao (Raft) replicate per member and need only the pod spread.

## Testing

- `make test` in `deploy/stacks/self-managed` (all green). `ha-value-wiring.sh` now asserts: no zone constraint in the cassandra block by default; `topology.kubernetes.io/zone` present for Cassandra/NATS/OpenBao when enabled; `ScheduleAnyway` by default and `DoNotSchedule` under `strict: true`.
- `helm template` of the Cassandra chart confirms the new StatefulSet block renders.

## Docs

Adds a "Zone spread for the quorum pods (opt-in)" section to `docs/v0.6.1/high-availability.md` covering the `WaitForFirstConsumer`, ≥3-AZ, and rack=AZ requirements and the disk-pinning-on-zone-failure caveat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable high-availability modes for self-managed deployments: none, preferred, and enforced.
  * Added replica sizing, anti-affinity, zone spreading, disruption budgets, quorum settings, and durable messaging options across supported services.
  * Added optional Cassandra topology spreading and API disruption budget configuration.

* **Documentation**
  * Added a high-availability operations guide covering prerequisites, configuration, resilience, and validation.

* **Tests**
  * Added end-to-end validation for high-availability settings and rendered deployment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->