### PR TITLE
fix(observability): order VictoriaMetrics after CRDs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -114,6 +114,9 @@ jobs:
       - name: Run self-managed Helmfile render tests
         run: make -C deploy/stacks/self-managed test
 
+      - name: Run observability Helmfile profile tests
+        run: make -C deploy/stacks/observability test
+
       - name: Test OpenBao auto-unseal retry behavior
         run: bash deploy/helm/openbao/tests/auto-unseal-sidecar.sh
 

--- a/deploy/stacks/observability/helmfile.d/01-observability.yaml.gotmpl
+++ b/deploy/stacks/observability/helmfile.d/01-observability.yaml.gotmpl
@@ -185,6 +185,10 @@ releases:
     chart: nvcf/victoria-metrics-single
     version: {{ dig "victoriaMetrics" "version" "0.45.0" .Values | quote }}
     namespace: {{ $victoriaMetricsNamespace }}
+    {{- if $prometheusOperatorCrdsEnabled }}
+    needs:
+      - {{ dig "prometheusOperatorCrds" "namespace" $observabilityNamespace .Values }}/prometheus-operator-crds
+    {{- end }}
     values:
       - ../values/victoria-metrics.yaml.gotmpl
     labels:

--- a/deploy/stacks/observability/tests/profile-defaults.sh
+++ b/deploy/stacks/observability/tests/profile-defaults.sh
@@ -22,6 +22,50 @@ profile_releases() {
     sort
 }
 
+# `show-dag` eagerly prepares the placeholder OCI charts. Debug rendering of
+# `list --skip-charts` keeps this test offline while preserving `needs` edges.
+render_release_state() {
+  local output_name="$1"
+  shift
+  local log_file="$work_dir/$output_name.log"
+  local state_file="$work_dir/$output_name.yaml"
+
+  if ! HELMFILE_ENV=local HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" \
+    helmfile \
+      --file "$stack_dir/helmfile.d" \
+      --log-level debug \
+      --environment default \
+      "$@" \
+      list --skip-charts --output json >"$log_file" 2>&1; then
+    cat "$log_file" >&2
+    fail "could not render the $output_name Helmfile state"
+  fi
+
+  awk '
+    /^rendering result of ".*":$/ { print "---"; capture = 1; next }
+    capture && /^[[:space:]]*[0-9]+: / {
+      sub(/^[[:space:]]*[0-9]+: ?/, "")
+      print
+      next
+    }
+    capture { capture = 0 }
+  ' "$log_file" >"$state_file"
+
+  test -s "$state_file" || fail "could not recover the $output_name Helmfile state"
+}
+
+release_needs() {
+  local state_file="$1"
+  local release_name="$2"
+
+  NVCF_RELEASE_NAME="$release_name" yq ea -r '
+    select(.releases != null) |
+    .releases[] |
+    select(.name == strenv(NVCF_RELEASE_NAME)) |
+    .needs[]?
+  ' "$state_file"
+}
+
 render_monitors() {
   local profile="$1"
   local output_dir="$work_dir/$profile"
@@ -98,6 +142,18 @@ for profile in control compute all; do
   test "$(profile_releases "$profile")" = "$enabled_releases" ||
     fail "$profile profile did not render the enabled release set exactly once"
 done
+
+render_release_state crds-installed \
+  --state-values-set observability.profile=control
+test "$(release_needs "$work_dir/crds-installed.yaml" victoria-metrics)" = \
+  "monitoring/prometheus-operator-crds" ||
+  fail "victoria-metrics must wait for stack-installed Prometheus Operator CRDs"
+
+render_release_state crds-existing \
+  --state-values-set observability.profile=control \
+  --state-values-set observability.components.prometheusOperatorCrds.mode=existing
+test -z "$(release_needs "$work_dir/crds-existing.yaml" victoria-metrics)" ||
+  fail "victoria-metrics must not depend on a CRD release the stack does not install"
 
 for profile in control compute all; do
   render_monitors "$profile"

--- a/deploy/stacks/observability/tests/profile-defaults.sh
+++ b/deploy/stacks/observability/tests/profile-defaults.sh
@@ -10,6 +10,7 @@ fail() {
   exit 1
 }
 
+# List enabled releases for the selected observability profile.
 profile_releases() {
   local profile="$1"
   HELMFILE_ENV=local helmfile \
@@ -22,8 +23,9 @@ profile_releases() {
     sort
 }
 
-# `show-dag` eagerly prepares the placeholder OCI charts. Debug rendering of
-# `list --skip-charts` keeps this test offline while preserving `needs` edges.
+# Render the evaluated Helmfile state without downloading charts, then recover
+# its YAML documents in "$work_dir/<output_name>.yaml". `show-dag` cannot be
+# used here because it eagerly prepares the placeholder OCI charts.
 render_release_state() {
   local output_name="$1"
   shift
@@ -54,6 +56,7 @@ render_release_state() {
   test -s "$state_file" || fail "could not recover the $output_name Helmfile state"
 }
 
+# Print the `needs` entries for a named release from a rendered Helmfile state.
 release_needs() {
   local state_file="$1"
   local release_name="$2"
@@ -66,6 +69,7 @@ release_needs() {
   ' "$state_file"
 }
 
+# Render default monitor manifests for the selected observability profile.
 render_monitors() {
   local profile="$1"
   local output_dir="$work_dir/$profile"


### PR DESCRIPTION
## TL;DR

Make VictoriaMetrics wait for the Prometheus Operator CRD release when the observability stack owns that release. Add deterministic rendered-release-graph coverage for both stack-managed and externally managed CRD modes, and run the observability profile suite in CI.

## Additional Details

VictoriaMetrics enables a `ServiceMonitor` by default. Previously, Helmfile could place `victoria-metrics` and `prometheus-operator-crds` in the same install group. On a clean cluster, VictoriaMetrics could therefore submit its ServiceMonitor before Kubernetes knew that resource kind.

This change:

- adds a `needs` edge from `victoria-metrics` to the configured `prometheus-operator-crds` release;
- emits the dependency only when this stack installs the CRDs;
- leaves `mode=existing` without a dependency on an absent Helm release;
- verifies the evaluated Helmfile release graph without pulling the placeholder OCI charts; and
- adds the observability profile suite to the Helm charts CI job.

## For the Reviewer

Please verify:

- the conditional dependency follows the configured Prometheus Operator CRD namespace;
- stack-managed mode renders exactly the expected dependency;
- externally managed mode renders no dependency on an unowned release; and
- the rendered-state test remains offline and deterministic.

## For QA

### Committed automated coverage

Passed:

```bash
make -C deploy/stacks/observability test
```

The release graph changes as expected:

- before: CRDs and VictoriaMetrics were both in group 1;
- after: CRDs are in group 1, VictoriaMetrics is in group 2, and the OTel Collector remains downstream in group 3.

### Additional local clean-cluster validation

The live comparison rebuilt `k3d-ncp-local` for each revision. An unmodified pre-fix run succeeded once, confirming the race is timing-dependent. A test-only wrapper was then used to delay only the CRD release by 180 seconds for both runs:

- pre-fix: failed because the `ServiceMonitor` kind was unavailable;
- fixed: `TestObservabilityControl` passed all 14 steps.

The delay was used only for validation and is not included in this PR.

QA status: clean-cluster validation completed locally; no additional QA is requested.

## Issues

Fixes #1687

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved observability stack deployment ordering: Victoria Metrics now waits for Prometheus Operator CRDs when they are managed by the stack.
  - Avoided adding an unnecessary dependency when Prometheus Operator CRDs are managed externally.

- **Tests**
  - Added coverage for both managed and externally managed CRD configurations.
  - Added observability Helmfile profile tests to the Helm charts continuous integration checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
