### PR TITLE
fix(byoo-otel-collector): release a collector version bump as fix, not chore

### DIFF
--- a/src/compute-plane-services/byoo-otel-collector/AGENTS.md
+++ b/src/compute-plane-services/byoo-otel-collector/AGENTS.md
@@ -53,6 +53,13 @@ The upstream part comes from `otel-collector-build.yaml`; do not add a `VERSION`
 file or a CI gate that requires one. `RELEASE_SERIES_START` anchors the first
 wrapper release and must remain in the repository.
 
+Commit a collector version bump as `fix(byoo-otel-collector):`, not
+`chore(byoo-otel-collector):`. `chore` commits are not release-worthy (see
+`RELEASE_RULES` in `tools/ci/github-release`), so a `chore` bump only
+synthesizes a compatibility tag anchor and never triggers the image build and
+push. Because the upstream version is embedded directly in the published tag
+and image, every bump must ship a real image, not just update the pin in git.
+
 ## Local Gotchas
 
 - Generated templates and examples are committed. Regenerate and commit them


### PR DESCRIPTION
## Why
The OpenTelemetry Collector v0.160.0 bump (#1674) was committed as `chore(byoo-otel-collector)`. This repo's `RELEASE_RULES` in `tools/ci/github-release` only treats `feat`/`fix`/`perf` as release-worthy, so the release automation for that merge only synthesized a compatibility tag anchor (`v0.160.0-nv-0.2.3`) and logged "no release-worthy commits" - it never built or pushed an actual container image. The pin in `otel-collector-build.yaml` says v0.160.0, but the last real published image is still `0.157.0-nv-0.2.3`. Since the composite tag format (`v${upstream_version}-nv-${version}`) bakes the collector version directly into the shipped image identity, a chore-typed bump silently breaks the correspondence between "what's pinned in git" and "what's actually deployed."

## What changed
Documented in `src/compute-plane-services/byoo-otel-collector/AGENTS.md` that collector version bumps must be committed as `fix(byoo-otel-collector):`, not `chore(byoo-otel-collector):`, matching how prior dependency bumps in this same build config (e.g. `fix(otel): update x/crypto to v0.56.0`) were already classified.

This commit is itself `fix`-typed, so merging it is expected to trigger the release automation to cut a real release off the current `otel-collector-build.yaml` pin (v0.160.0) and build/push the corresponding image, closing the gap left by #1674.

## Customer Release Notes
Fixes the BYOO OpenTelemetry Collector image publish so it actually ships v0.160.0.

## Plan Summary
No infrastructure/Terraform changes. Docs-only change to commit-type guidance; the release/image build itself is triggered by the release automation on merge, not by this PR's diff.

## Usage
Not applicable.

## Testing
Docs-only change; no build/test commands apply. Verification is external: confirm after merge that release automation cuts a new `src/compute-plane-services/byoo-otel-collector/v0.160.0-nv-0.2.x` tag and that the corresponding image is built and pushed.

## Notes
Follow-up: once the new image is confirmed published, bump the NVCA operator chart's `otelCollector.imageTag` defaults (`deploy/helm/nvca-operator`, `src/compute-plane-services/nvca/deployments/nvca-operator`, `deploy/stacks/nvcf-compute-plane/environments/base.yaml`) to the new tag, matching the prior pattern (#1247).

## References
Closes #1691

## Related Pull Requests
Follow-up to #1674

## Dependencies
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for publishing collector image updates with the required commit prefix.
  * Clarified that version bumps labeled as routine maintenance do not trigger image build and publishing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->