### PR TITLE
fix(observability): make worker PodMonitor targets resolvable

### DIFF
--- a/deploy/stacks/observability/charts/nvcf-default-monitors/values.yaml
+++ b/deploy/stacks/observability/charts/nvcf-default-monitors/values.yaml
@@ -92,5 +92,5 @@ computePlane:
           operator: Exists
     interval: 30s
     path: /metrics
-    port: metrics
+    port: worker-metrics
     labels: {}

--- a/deploy/stacks/observability/environments/base.yaml
+++ b/deploy/stacks/observability/environments/base.yaml
@@ -186,5 +186,5 @@ defaultMonitors:
             operator: Exists
       interval: 30s
       path: /metrics
-      port: metrics
+      port: worker-metrics
       labels: {}

--- a/deploy/stacks/observability/tests/profile-defaults.sh
+++ b/deploy/stacks/observability/tests/profile-defaults.sh
@@ -198,6 +198,8 @@ grep -q '^    - key: icms-request-id$' "$worker_monitor_manifest" ||
   fail "worker PodMonitor must select NVCA-managed workload pods"
 grep -q '^      operator: Exists$' "$worker_monitor_manifest" ||
   fail "worker PodMonitor label expression must use Exists"
+grep -q '^      port: "worker-metrics"$' "$worker_monitor_manifest" ||
+  fail "worker PodMonitor must scrape the named worker metrics port"
 
 for monitor in state-metrics function-autoscaler invocation-service grpc-proxy llm-api-gateway; do
   grep -q "nvcf-default-monitors-$monitor" "$chart_control_manifests" ||

--- a/deploy/stacks/observability/tests/profile-defaults.sh
+++ b/deploy/stacks/observability/tests/profile-defaults.sh
@@ -5,12 +5,13 @@ stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 work_dir="$(mktemp -d)"
 trap 'rm -rf "$work_dir"' EXIT
 
+# fail reports an assertion failure and exits the test script.
 fail() {
   echo "profile-defaults: $*" >&2
   exit 1
 }
 
-# List enabled releases for the selected observability profile.
+# profile_releases lists enabled releases for the selected observability profile.
 profile_releases() {
   local profile="$1"
   HELMFILE_ENV=local helmfile \
@@ -23,7 +24,7 @@ profile_releases() {
     sort
 }
 
-# Render the evaluated Helmfile state without downloading charts, then recover
+# render_release_state renders the Helmfile state without downloading charts, then recovers
 # its YAML documents in "$work_dir/<output_name>.yaml". `show-dag` cannot be
 # used here because it eagerly prepares the placeholder OCI charts.
 render_release_state() {
@@ -56,7 +57,7 @@ render_release_state() {
   test -s "$state_file" || fail "could not recover the $output_name Helmfile state"
 }
 
-# Print the `needs` entries for a named release from a rendered Helmfile state.
+# release_needs prints the dependencies for a named release from rendered Helmfile state.
 release_needs() {
   local state_file="$1"
   local release_name="$2"
@@ -69,7 +70,7 @@ release_needs() {
   ' "$state_file"
 }
 
-# Render default monitor manifests for the selected observability profile.
+# render_monitors renders default monitor manifests for the selected observability profile.
 render_monitors() {
   local profile="$1"
   local output_dir="$work_dir/$profile"
@@ -82,6 +83,7 @@ render_monitors() {
     template --output-dir "$output_dir" >/dev/null
 }
 
+# render_monitor_overrides renders monitor manifests with explicit plane-level overrides.
 render_monitor_overrides() {
   local profile="$1"
   local output_name="$2"
@@ -99,6 +101,7 @@ render_monitor_overrides() {
     template --output-dir "$output_dir" >/dev/null
 }
 
+# render_compute_monitor_override renders compute monitors with the worker monitor disabled.
 render_compute_monitor_override() {
   local output_dir="$work_dir/compute-worker-disabled"
 

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/manifests/netpol/allow-ingress-monitoring.yaml
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/manifests/netpol/allow-ingress-monitoring.yaml
@@ -28,6 +28,8 @@ spec:
       protocol: TCP
     - port: 8888
       protocol: TCP
+    - port: 9089
+      protocol: TCP
     - port: 10103
       protocol: TCP
     - port: 18888

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/nvcaagent_reconcile_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/nvcaagent_reconcile_test.go
@@ -2496,6 +2496,7 @@ func TestGetNetworkPoliciesDataEmptyDDCSIPList(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, got, len(expNPNames))
 	assertNetworkPolicyAllowsTCPPort(t, got[IngressNetworkPolicyNameKey], IngressNetworkPolicyNameKey, 8888)
+	assertNetworkPolicyAllowsTCPPort(t, got[IngressNetworkPolicyNameKey], IngressNetworkPolicyNameKey, 9089)
 	b := &bytes.Buffer{}
 	require.NoError(t, err)
 	for _, k := range expNPNames {
@@ -2529,6 +2530,7 @@ func TestGetNetworkPoliciesDataWithDDCSIPList(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, got, len(expNPNames))
 	assertNetworkPolicyAllowsTCPPort(t, got[IngressNetworkPolicyNameKey], IngressNetworkPolicyNameKey, 8888)
+	assertNetworkPolicyAllowsTCPPort(t, got[IngressNetworkPolicyNameKey], IngressNetworkPolicyNameKey, 9089)
 	b := &bytes.Buffer{}
 	require.NoError(t, err)
 	for _, k := range expNPNames {

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/nvcaagent_reconcile_test.go
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/nvcaagent_reconcile_test.go
@@ -2473,6 +2473,7 @@ func TestGetInternalPersistentStorageConfig(t *testing.T) {
 	}
 }
 
+// TestGetNetworkPoliciesDataEmptyDDCSIPList verifies generated network policies without DDCS CIDRs.
 func TestGetNetworkPoliciesDataEmptyDDCSIPList(t *testing.T) {
 	expNPNames := []string{
 		EgressNetworkPolicyNameKey,
@@ -2506,6 +2507,7 @@ func TestGetNetworkPoliciesDataEmptyDDCSIPList(t *testing.T) {
 	assert.Equal(t, stripSPDXHeaders(readTestdataFile(t, filepath.Join("testdata", "netpols.yaml"))), stripSPDXHeaders(b.String()))
 }
 
+// TestGetNetworkPoliciesDataWithDDCSIPList verifies generated network policies with DDCS CIDRs.
 func TestGetNetworkPoliciesDataWithDDCSIPList(t *testing.T) {
 	expNPNames := []string{
 		EgressNetworkPolicyNameKey,

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/testdata/netpols.yaml
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/testdata/netpols.yaml
@@ -74,6 +74,8 @@ spec:
       protocol: TCP
     - port: 8888
       protocol: TCP
+    - port: 9089
+      protocol: TCP
     - port: 10103
       protocol: TCP
     - port: 18888

--- a/src/compute-plane-services/nvca/pkg/operator/reconcile/testdata/netpols_with_ddcs.yaml
+++ b/src/compute-plane-services/nvca/pkg/operator/reconcile/testdata/netpols_with_ddcs.yaml
@@ -80,6 +80,8 @@ spec:
       protocol: TCP
     - port: 8888
       protocol: TCP
+    - port: 9089
+      protocol: TCP
     - port: 10103
       protocol: TCP
     - port: 18888

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/common/translator.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/common/translator.go
@@ -31,12 +31,14 @@ import (
 )
 
 const (
-	UtilsHealthPort int32 = 8080
+	UtilsHealthPort  int32 = 8080
+	UtilsMetricsPort int32 = 8010
 
-	UtilsContainerName = "utils"
-	UtilsPodName       = "utils"
-	InitContainerName  = "init"
-	ESSContainerName   = "ess"
+	UtilsContainerName   = "utils"
+	UtilsMetricsPortName = "worker-metrics"
+	UtilsPodName         = "utils"
+	InitContainerName    = "init"
+	ESSContainerName     = "ess"
 
 	TermLogPath = "/dev/termination-log"
 	DevShmPath  = "/dev/shm"
@@ -328,6 +330,16 @@ func AddNVIDIAGPUNoScheduleToleration(podSpec *corev1.PodSpec) (added bool) {
 		Operator: corev1.TolerationOpExists,
 		Effect:   corev1.TaintEffectNoSchedule,
 	})
+}
+
+// MutateUtilsContainer exposes the worker metrics endpoint and configures the health probes.
+func MutateUtilsContainer(containerSpec *corev1.Container) {
+	containerSpec.Ports = append(containerSpec.Ports, corev1.ContainerPort{
+		Name:          UtilsMetricsPortName,
+		ContainerPort: UtilsMetricsPort,
+		Protocol:      corev1.ProtocolTCP,
+	})
+	MutateUtilsProbes(containerSpec)
 }
 
 func MutateUtilsProbes(containerSpec *corev1.Container) {

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/common/translator.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/common/translator.go
@@ -334,7 +334,7 @@ func AddNVIDIAGPUNoScheduleToleration(podSpec *corev1.PodSpec) (added bool) {
 	})
 }
 
-// MutateUtilsContainer exposes the worker metrics endpoint and configures the health probes.
+// MutateUtilsContainer declares the worker metrics port and configures the health probes.
 func MutateUtilsContainer(containerSpec *corev1.Container) {
 	containerSpec.Ports = append(containerSpec.Ports, corev1.ContainerPort{
 		Name:          WorkerMetricsPortName,

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/common/translator.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/common/translator.go
@@ -31,7 +31,8 @@ import (
 )
 
 const (
-	UtilsHealthPort  int32 = 8080
+	UtilsHealthPort int32 = 8080
+	// UtilsMetricsPort is the TCP port exposed by worker-utils for Prometheus metrics.
 	UtilsMetricsPort int32 = 8010
 
 	UtilsContainerName = "utils"

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/common/translator.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/common/translator.go
@@ -34,11 +34,12 @@ const (
 	UtilsHealthPort  int32 = 8080
 	UtilsMetricsPort int32 = 8010
 
-	UtilsContainerName   = "utils"
-	UtilsMetricsPortName = "worker-metrics"
-	UtilsPodName         = "utils"
-	InitContainerName    = "init"
-	ESSContainerName     = "ess"
+	UtilsContainerName = "utils"
+	// WorkerMetricsPortName is the shared named port used by worker PodMonitor targets.
+	WorkerMetricsPortName = "worker-metrics"
+	UtilsPodName          = "utils"
+	InitContainerName     = "init"
+	ESSContainerName      = "ess"
 
 	TermLogPath = "/dev/termination-log"
 	DevShmPath  = "/dev/shm"
@@ -335,7 +336,7 @@ func AddNVIDIAGPUNoScheduleToleration(podSpec *corev1.PodSpec) (added bool) {
 // MutateUtilsContainer exposes the worker metrics endpoint and configures the health probes.
 func MutateUtilsContainer(containerSpec *corev1.Container) {
 	containerSpec.Ports = append(containerSpec.Ports, corev1.ContainerPort{
-		Name:          UtilsMetricsPortName,
+		Name:          WorkerMetricsPortName,
 		ContainerPort: UtilsMetricsPort,
 		Protocol:      corev1.ProtocolTCP,
 	})

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
@@ -29,8 +29,9 @@ import (
 )
 
 const (
-	LLMWorkerContainerName       = "llm-worker"
-	llmMetricsPort         int32 = 9089
+	LLMWorkerContainerName = "llm-worker"
+	// llmMetricsPort is the TCP port exposed by Pylon for Prometheus metrics.
+	llmMetricsPort int32 = 9089
 
 	//nolint:gosec
 	llmCredentialManagerImageEnv = "LLM_CREDENTIAL_MANAGER_IMAGE"

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
@@ -29,7 +29,8 @@ import (
 )
 
 const (
-	LLMWorkerContainerName = "llm-worker"
+	LLMWorkerContainerName       = "llm-worker"
+	llmMetricsPort         int32 = 9089
 
 	//nolint:gosec
 	llmCredentialManagerImageEnv = "LLM_CREDENTIAL_MANAGER_IMAGE"
@@ -169,8 +170,13 @@ func newLLMRouterClientContainer(
 		Name:            LLMWorkerContainerName,
 		Image:           llmRouterClientImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
-		Args:            args,
-		Env:             common.SortEnvs(envs),
+		Ports: []corev1.ContainerPort{{
+			Name:          common.WorkerMetricsPortName,
+			ContainerPort: llmMetricsPort,
+			Protocol:      corev1.ProtocolTCP,
+		}},
+		Args: args,
+		Env:  common.SortEnvs(envs),
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
@@ -82,6 +82,7 @@ func upstreamHealthPath(allEnvSet map[string]string) string {
 	return path
 }
 
+// newLLMRouterClientContainer builds the Pylon sidecar for an LLM worker.
 func newLLMRouterClientContainer(
 	ls *LaunchSpecification,
 	allEnvSet map[string]string,

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_container.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_container.go
@@ -431,7 +431,7 @@ func translateContainer(t CreationQueueMessage, tcfg TranslateConfig) (objs []me
 				VolumeMounts:    utilsContainerVolumeMounts,
 			}
 			// mutate startup / liveness / readiness probes
-			common.MutateUtilsProbes(&utilsContainer)
+			common.MutateUtilsContainer(&utilsContainer)
 			pod.Spec.Containers = append(pod.Spec.Containers, utilsContainer)
 		} else {
 			// llm functions don't have a utils container. they have a router client container instead.

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_container.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_container.go
@@ -33,6 +33,8 @@ import (
 	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/otelconfig/backendconfig"
 )
 
+// translateContainer converts a container function request into Kubernetes resources.
+//
 //nolint:gocyclo // complex function with many conditional branches
 func translateContainer(t CreationQueueMessage, tcfg TranslateConfig) (objs []metav1.Object, err error) {
 	if err := tcfg.ValidateContainer(); err != nil {

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_container_utdep.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_container_utdep.go
@@ -32,12 +32,8 @@ import (
 	translateutil "github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/util"
 )
 
-/*
-Container Functions will be translated as the following set of artifacts
-  - an inference Pod
-  - a utils deployment
-  - a service endpoint for inference
-*/
+// translateContainerUtilsDeploy converts a container function request into an
+// inference pod, a worker-utils deployment, and an inference service.
 func translateContainerUtilsDeploy(t CreationQueueMessage, tcfg TranslateConfig) (objs []metav1.Object, err error) {
 	if err := tcfg.ValidateContainer(); err != nil {
 		return nil, fmt.Errorf("invalid container translate config: %v", err)
@@ -285,6 +281,7 @@ func translateContainerUtilsDeploy(t CreationQueueMessage, tcfg TranslateConfig)
 	return objs, nil
 }
 
+// getUtilsDeploymentAndSecrets builds the worker-utils deployment and registry secrets.
 func getUtilsDeploymentAndSecrets(t CreationQueueMessage, tcfg TranslateConfig) (objs []metav1.Object, err error) {
 	// Fail if LLS is enabled for utils pod as a separate pod from the inference pod
 	if t.Details.FunctionType == FunctionTypeStreaming {

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_container_utdep.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_container_utdep.go
@@ -553,7 +553,7 @@ func getUtilsDeploymentAndSecrets(t CreationQueueMessage, tcfg TranslateConfig) 
 		VolumeMounts:    utilsContainerVolumeMounts,
 	}
 	// mutate startup / liveness / readiness probes
-	common.MutateUtilsProbes(&utilsContainer)
+	common.MutateUtilsContainer(&utilsContainer)
 	utilsPod.Spec.Containers = append(utilsPod.Spec.Containers, utilsContainer)
 
 	replicas := int32(1)

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_helm.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_helm.go
@@ -351,7 +351,7 @@ func translateHelmChart(t CreationQueueMessage, tcfg TranslateConfig) (objs []me
 			VolumeMounts:    utilsContainerVolumeMounts,
 		}
 		// mutate startup / liveness / readiness probes
-		common.MutateUtilsProbes(&utilsContainer)
+		common.MutateUtilsContainer(&utilsContainer)
 		utilsPod.Spec.Containers = append(utilsPod.Spec.Containers, utilsContainer)
 	} else {
 		// llm functions don't have a utils container. they have a router client container instead.

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_helm.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_helm.go
@@ -31,6 +31,8 @@ import (
 	translateutil "github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/util"
 )
 
+// translateHelmChart converts a Helm function request into Kubernetes resources.
+//
 //nolint:gocyclo // complex function with many conditional branches
 func translateHelmChart(t CreationQueueMessage, tcfg TranslateConfig) (objs []metav1.Object, err error) {
 	// Fail if LLS is enabled for utils pod as a separate pod from the inference pod

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_helm_utdep.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_helm_utdep.go
@@ -319,7 +319,7 @@ func translateHelmChartUtilsDeploy(t CreationQueueMessage, tcfg TranslateConfig)
 		VolumeMounts:    utilsContainerVolumeMounts,
 	}
 	// mutate startup / liveness / readiness probes
-	common.MutateUtilsProbes(&utilsContainer)
+	common.MutateUtilsContainer(&utilsContainer)
 	utilsPod.Spec.Containers = append(utilsPod.Spec.Containers, utilsContainer)
 
 	replicas := int32(1)

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_helm_utdep.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_helm_utdep.go
@@ -30,6 +30,8 @@ import (
 	translateutil "github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/util"
 )
 
+// translateHelmChartUtilsDeploy builds Helm workload resources with worker-utils
+// in a separate deployment.
 func translateHelmChartUtilsDeploy(t CreationQueueMessage, tcfg TranslateConfig) (objs []metav1.Object, err error) {
 	// Fail if LLS is enabled for utils pod as a separate pod from the inference pod
 	if t.Details.FunctionType == FunctionTypeStreaming {

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/task/translate.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/task/translate.go
@@ -435,7 +435,7 @@ func translateContainer(t CreationQueueMessage, tcfg TranslateConfig) (objs []me
 			VolumeMounts:    utilsContainerVolumeMounts,
 		}
 		// mutate startup / liveness / readiness probes
-		common.MutateUtilsProbes(&utilsContainer)
+		common.MutateUtilsContainer(&utilsContainer)
 		pod.Spec.Containers = append(pod.Spec.Containers, utilsContainer)
 
 		// Setup telemetry for the pod

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/task/translate.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/task/translate.go
@@ -37,6 +37,8 @@ import (
 // TODO: k8s version considerations.
 // For now, all task Pod features are supported by all recent k8s versions
 
+// translateContainer converts a container task request into Kubernetes resources.
+//
 //nolint:gocyclo // complex function with many conditional branches
 func translateContainer(t CreationQueueMessage, tcfg TranslateConfig) (objs []metav1.Object, err error) {
 	tcfg.Default()

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/task/translate_helm.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/task/translate_helm.go
@@ -31,6 +31,8 @@ import (
 	translateutil "github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/util"
 )
 
+// translateHelmChart converts a Helm task request into Kubernetes resources.
+//
 //nolint:gocyclo // complex function with many conditional branches
 func translateHelmChart(t CreationQueueMessage, tcfg TranslateConfig) (objs []metav1.Object, err error) {
 	if err := tcfg.ValidateHelmChart(); err != nil {

--- a/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/task/translate_helm.go
+++ b/src/compute-plane-services/nvca/vendor/github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/task/translate_helm.go
@@ -356,7 +356,7 @@ func translateHelmChart(t CreationQueueMessage, tcfg TranslateConfig) (objs []me
 		VolumeMounts:    utilsContainerVolumeMounts,
 	}
 	// mutate startup / liveness / readiness probes
-	common.MutateUtilsProbes(&utilsContainer)
+	common.MutateUtilsContainer(&utilsContainer)
 	utilsPod.Spec.Containers = append(utilsPod.Spec.Containers, utilsContainer)
 
 	if hasTelemetries {

--- a/src/libraries/go/lib/pkg/icms-translate/translate/common/translator.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/common/translator.go
@@ -31,12 +31,14 @@ import (
 )
 
 const (
-	UtilsHealthPort int32 = 8080
+	UtilsHealthPort  int32 = 8080
+	UtilsMetricsPort int32 = 8010
 
-	UtilsContainerName = "utils"
-	UtilsPodName       = "utils"
-	InitContainerName  = "init"
-	ESSContainerName   = "ess"
+	UtilsContainerName   = "utils"
+	UtilsMetricsPortName = "worker-metrics"
+	UtilsPodName         = "utils"
+	InitContainerName    = "init"
+	ESSContainerName     = "ess"
 
 	TermLogPath = "/dev/termination-log"
 	DevShmPath  = "/dev/shm"
@@ -328,6 +330,16 @@ func AddNVIDIAGPUNoScheduleToleration(podSpec *corev1.PodSpec) (added bool) {
 		Operator: corev1.TolerationOpExists,
 		Effect:   corev1.TaintEffectNoSchedule,
 	})
+}
+
+// MutateUtilsContainer exposes the worker metrics endpoint and configures the health probes.
+func MutateUtilsContainer(containerSpec *corev1.Container) {
+	containerSpec.Ports = append(containerSpec.Ports, corev1.ContainerPort{
+		Name:          UtilsMetricsPortName,
+		ContainerPort: UtilsMetricsPort,
+		Protocol:      corev1.ProtocolTCP,
+	})
+	MutateUtilsProbes(containerSpec)
 }
 
 func MutateUtilsProbes(containerSpec *corev1.Container) {

--- a/src/libraries/go/lib/pkg/icms-translate/translate/common/translator.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/common/translator.go
@@ -334,7 +334,7 @@ func AddNVIDIAGPUNoScheduleToleration(podSpec *corev1.PodSpec) (added bool) {
 	})
 }
 
-// MutateUtilsContainer exposes the worker metrics endpoint and configures the health probes.
+// MutateUtilsContainer declares the worker metrics port and configures the health probes.
 func MutateUtilsContainer(containerSpec *corev1.Container) {
 	containerSpec.Ports = append(containerSpec.Ports, corev1.ContainerPort{
 		Name:          WorkerMetricsPortName,

--- a/src/libraries/go/lib/pkg/icms-translate/translate/common/translator.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/common/translator.go
@@ -31,7 +31,8 @@ import (
 )
 
 const (
-	UtilsHealthPort  int32 = 8080
+	UtilsHealthPort int32 = 8080
+	// UtilsMetricsPort is the TCP port exposed by worker-utils for Prometheus metrics.
 	UtilsMetricsPort int32 = 8010
 
 	UtilsContainerName = "utils"

--- a/src/libraries/go/lib/pkg/icms-translate/translate/common/translator.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/common/translator.go
@@ -34,11 +34,12 @@ const (
 	UtilsHealthPort  int32 = 8080
 	UtilsMetricsPort int32 = 8010
 
-	UtilsContainerName   = "utils"
-	UtilsMetricsPortName = "worker-metrics"
-	UtilsPodName         = "utils"
-	InitContainerName    = "init"
-	ESSContainerName     = "ess"
+	UtilsContainerName = "utils"
+	// WorkerMetricsPortName is the shared named port used by worker PodMonitor targets.
+	WorkerMetricsPortName = "worker-metrics"
+	UtilsPodName          = "utils"
+	InitContainerName     = "init"
+	ESSContainerName      = "ess"
 
 	TermLogPath = "/dev/termination-log"
 	DevShmPath  = "/dev/shm"
@@ -335,7 +336,7 @@ func AddNVIDIAGPUNoScheduleToleration(podSpec *corev1.PodSpec) (added bool) {
 // MutateUtilsContainer exposes the worker metrics endpoint and configures the health probes.
 func MutateUtilsContainer(containerSpec *corev1.Container) {
 	containerSpec.Ports = append(containerSpec.Ports, corev1.ContainerPort{
-		Name:          UtilsMetricsPortName,
+		Name:          WorkerMetricsPortName,
 		ContainerPort: UtilsMetricsPort,
 		Protocol:      corev1.ProtocolTCP,
 	})

--- a/src/libraries/go/lib/pkg/icms-translate/translate/common/translator_test.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/common/translator_test.go
@@ -94,7 +94,7 @@ func TestMutateUtilsContainer(t *testing.T) {
 	MutateUtilsContainer(&container)
 
 	assert.Equal(t, []corev1.ContainerPort{{
-		Name:          UtilsMetricsPortName,
+		Name:          WorkerMetricsPortName,
 		ContainerPort: UtilsMetricsPort,
 		Protocol:      corev1.ProtocolTCP,
 	}}, container.Ports)

--- a/src/libraries/go/lib/pkg/icms-translate/translate/common/translator_test.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/common/translator_test.go
@@ -88,6 +88,7 @@ func TestAddNVIDIAGPUNoScheduleToleration(t *testing.T) {
 	}
 }
 
+// TestMutateUtilsContainer verifies the worker-utils metrics port and health probes.
 func TestMutateUtilsContainer(t *testing.T) {
 	container := corev1.Container{}
 

--- a/src/libraries/go/lib/pkg/icms-translate/translate/common/translator_test.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/common/translator_test.go
@@ -88,6 +88,21 @@ func TestAddNVIDIAGPUNoScheduleToleration(t *testing.T) {
 	}
 }
 
+func TestMutateUtilsContainer(t *testing.T) {
+	container := corev1.Container{}
+
+	MutateUtilsContainer(&container)
+
+	assert.Equal(t, []corev1.ContainerPort{{
+		Name:          UtilsMetricsPortName,
+		ContainerPort: UtilsMetricsPort,
+		Protocol:      corev1.ProtocolTCP,
+	}}, container.Ports)
+	assert.NotNil(t, container.StartupProbe)
+	assert.NotNil(t, container.ReadinessProbe)
+	assert.NotNil(t, container.LivenessProbe)
+}
+
 func TestMergeTolerations(t *testing.T) {
 	t.Run("adds_new_tolerations_and_skips_exact_duplicates", func(t *testing.T) {
 		noExecuteSeconds := int64(30)

--- a/src/libraries/go/lib/pkg/icms-translate/translate/common/translator_test.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/common/translator_test.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// TestAddNVIDIAGPUNoScheduleToleration verifies that the GPU toleration is added only when absent.
 func TestAddNVIDIAGPUNoScheduleToleration(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
@@ -29,8 +29,9 @@ import (
 )
 
 const (
-	LLMWorkerContainerName       = "llm-worker"
-	llmMetricsPort         int32 = 9089
+	LLMWorkerContainerName = "llm-worker"
+	// llmMetricsPort is the TCP port exposed by Pylon for Prometheus metrics.
+	llmMetricsPort int32 = 9089
 
 	//nolint:gosec
 	llmCredentialManagerImageEnv = "LLM_CREDENTIAL_MANAGER_IMAGE"

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
@@ -29,7 +29,8 @@ import (
 )
 
 const (
-	LLMWorkerContainerName = "llm-worker"
+	LLMWorkerContainerName       = "llm-worker"
+	llmMetricsPort         int32 = 9089
 
 	//nolint:gosec
 	llmCredentialManagerImageEnv = "LLM_CREDENTIAL_MANAGER_IMAGE"
@@ -169,8 +170,13 @@ func newLLMRouterClientContainer(
 		Name:            LLMWorkerContainerName,
 		Image:           llmRouterClientImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
-		Args:            args,
-		Env:             common.SortEnvs(envs),
+		Ports: []corev1.ContainerPort{{
+			Name:          common.WorkerMetricsPortName,
+			ContainerPort: llmMetricsPort,
+			Protocol:      corev1.ProtocolTCP,
+		}},
+		Args: args,
+		Env:  common.SortEnvs(envs),
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/llm.go
@@ -82,6 +82,7 @@ func upstreamHealthPath(allEnvSet map[string]string) string {
 	return path
 }
 
+// newLLMRouterClientContainer builds the Pylon sidecar for an LLM worker.
 func newLLMRouterClientContainer(
 	ls *LaunchSpecification,
 	allEnvSet map[string]string,

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/llm_test.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/llm_test.go
@@ -57,6 +57,7 @@ func healthPathArgs(args []string) []string {
 	return healthPaths
 }
 
+// TestNewLLMRouterClientContainer verifies Pylon configuration and validation.
 func TestNewLLMRouterClientContainer(t *testing.T) {
 	type spec struct {
 		name       string

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/llm_test.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/llm_test.go
@@ -381,6 +381,11 @@ func TestNewLLMRouterClientContainer(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+			assert.Equal(t, []corev1.ContainerPort{{
+				Name:          common.WorkerMetricsPortName,
+				ContainerPort: llmMetricsPort,
+				Protocol:      corev1.ProtocolTCP,
+			}}, c.Ports)
 			tt.validate(t, c)
 		})
 	}

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_container.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_container.go
@@ -431,7 +431,7 @@ func translateContainer(t CreationQueueMessage, tcfg TranslateConfig) (objs []me
 				VolumeMounts:    utilsContainerVolumeMounts,
 			}
 			// mutate startup / liveness / readiness probes
-			common.MutateUtilsProbes(&utilsContainer)
+			common.MutateUtilsContainer(&utilsContainer)
 			pod.Spec.Containers = append(pod.Spec.Containers, utilsContainer)
 		} else {
 			// llm functions don't have a utils container. they have a router client container instead.

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_container.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_container.go
@@ -33,6 +33,8 @@ import (
 	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/otelconfig/backendconfig"
 )
 
+// translateContainer converts a container function request into Kubernetes resources.
+//
 //nolint:gocyclo // complex function with many conditional branches
 func translateContainer(t CreationQueueMessage, tcfg TranslateConfig) (objs []metav1.Object, err error) {
 	if err := tcfg.ValidateContainer(); err != nil {

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_container_utdep.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_container_utdep.go
@@ -32,12 +32,8 @@ import (
 	translateutil "github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/util"
 )
 
-/*
-Container Functions will be translated as the following set of artifacts
-  - an inference Pod
-  - a utils deployment
-  - a service endpoint for inference
-*/
+// translateContainerUtilsDeploy converts a container function request into an
+// inference pod, a worker-utils deployment, and an inference service.
 func translateContainerUtilsDeploy(t CreationQueueMessage, tcfg TranslateConfig) (objs []metav1.Object, err error) {
 	if err := tcfg.ValidateContainer(); err != nil {
 		return nil, fmt.Errorf("invalid container translate config: %v", err)
@@ -285,6 +281,7 @@ func translateContainerUtilsDeploy(t CreationQueueMessage, tcfg TranslateConfig)
 	return objs, nil
 }
 
+// getUtilsDeploymentAndSecrets builds the worker-utils deployment and registry secrets.
 func getUtilsDeploymentAndSecrets(t CreationQueueMessage, tcfg TranslateConfig) (objs []metav1.Object, err error) {
 	// Fail if LLS is enabled for utils pod as a separate pod from the inference pod
 	if t.Details.FunctionType == FunctionTypeStreaming {

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_container_utdep.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_container_utdep.go
@@ -553,7 +553,7 @@ func getUtilsDeploymentAndSecrets(t CreationQueueMessage, tcfg TranslateConfig) 
 		VolumeMounts:    utilsContainerVolumeMounts,
 	}
 	// mutate startup / liveness / readiness probes
-	common.MutateUtilsProbes(&utilsContainer)
+	common.MutateUtilsContainer(&utilsContainer)
 	utilsPod.Spec.Containers = append(utilsPod.Spec.Containers, utilsContainer)
 
 	replicas := int32(1)

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_helm.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_helm.go
@@ -351,7 +351,7 @@ func translateHelmChart(t CreationQueueMessage, tcfg TranslateConfig) (objs []me
 			VolumeMounts:    utilsContainerVolumeMounts,
 		}
 		// mutate startup / liveness / readiness probes
-		common.MutateUtilsProbes(&utilsContainer)
+		common.MutateUtilsContainer(&utilsContainer)
 		utilsPod.Spec.Containers = append(utilsPod.Spec.Containers, utilsContainer)
 	} else {
 		// llm functions don't have a utils container. they have a router client container instead.

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_helm.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_helm.go
@@ -31,6 +31,8 @@ import (
 	translateutil "github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/util"
 )
 
+// translateHelmChart converts a Helm function request into Kubernetes resources.
+//
 //nolint:gocyclo // complex function with many conditional branches
 func translateHelmChart(t CreationQueueMessage, tcfg TranslateConfig) (objs []metav1.Object, err error) {
 	// Fail if LLS is enabled for utils pod as a separate pod from the inference pod

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_helm_utdep.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_helm_utdep.go
@@ -319,7 +319,7 @@ func translateHelmChartUtilsDeploy(t CreationQueueMessage, tcfg TranslateConfig)
 		VolumeMounts:    utilsContainerVolumeMounts,
 	}
 	// mutate startup / liveness / readiness probes
-	common.MutateUtilsProbes(&utilsContainer)
+	common.MutateUtilsContainer(&utilsContainer)
 	utilsPod.Spec.Containers = append(utilsPod.Spec.Containers, utilsContainer)
 
 	replicas := int32(1)

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_helm_utdep.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_helm_utdep.go
@@ -30,6 +30,8 @@ import (
 	translateutil "github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/util"
 )
 
+// translateHelmChartUtilsDeploy builds Helm workload resources with worker-utils
+// in a separate deployment.
 func translateHelmChartUtilsDeploy(t CreationQueueMessage, tcfg TranslateConfig) (objs []metav1.Object, err error) {
 	// Fail if LLS is enabled for utils pod as a separate pod from the inference pod
 	if t.Details.FunctionType == FunctionTypeStreaming {

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_tolerations_test.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_tolerations_test.go
@@ -34,6 +34,8 @@ import (
 	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/common"
 )
 
+// TestTranslateContainer_AppliesConfiguredTolerations verifies configured
+// tolerations on container function pods.
 func TestTranslateContainer_AppliesConfiguredTolerations(t *testing.T) {
 	customToleration := corev1.Toleration{
 		Key:      "dedicated",

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_tolerations_test.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_tolerations_test.go
@@ -175,6 +175,7 @@ func TestTranslateHelmChartLLM_AddsRouterAndCredentialContainers(t *testing.T) {
 	require.Len(t, utilsPod.Spec.Containers, 2)
 
 	router := findContainerByName(t, utilsPod.Spec.Containers, LLMWorkerContainerName)
+	assertLLMMetricsPort(t, router)
 	assert.Equal(t, "nvcr.io/nvidia/router:latest", router.Image)
 	assert.Contains(t, router.Args, "--upstream-http-base-url=http://inference-svc:8080")
 	assert.Contains(t, router.Args, "--stargate-address=llm-router.example.com:443")
@@ -234,6 +235,7 @@ func TestTranslateContainerLLM_AddsRouterAndCredentialContainers(t *testing.T) {
 	assert.Equal(t, "nvcr.io/nvidia/function:latest", findContainerByName(t, pod.Spec.Containers, inferenceContainerName).Image)
 
 	router := findContainerByName(t, pod.Spec.Containers, LLMWorkerContainerName)
+	assertLLMMetricsPort(t, router)
 	assert.Equal(t, "nvcr.io/nvidia/router:latest", router.Image)
 	assert.Contains(t, router.Args, "--upstream-http-base-url=http://127.0.0.1:8080")
 	assert.Contains(t, router.Args, "--stargate-address=llm-router.example.com:443")
@@ -688,8 +690,17 @@ func assertTolerationsMatch(t *testing.T, got []corev1.Toleration, want ...corev
 func assertUtilsMetricsPort(t *testing.T, container corev1.Container) {
 	t.Helper()
 	assert.Equal(t, []corev1.ContainerPort{{
-		Name:          common.UtilsMetricsPortName,
+		Name:          common.WorkerMetricsPortName,
 		ContainerPort: common.UtilsMetricsPort,
+		Protocol:      corev1.ProtocolTCP,
+	}}, container.Ports)
+}
+
+func assertLLMMetricsPort(t *testing.T, container corev1.Container) {
+	t.Helper()
+	assert.Equal(t, []corev1.ContainerPort{{
+		Name:          common.WorkerMetricsPortName,
+		ContainerPort: llmMetricsPort,
 		Protocol:      corev1.ProtocolTCP,
 	}}, container.Ports)
 }

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_tolerations_test.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_tolerations_test.go
@@ -104,6 +104,9 @@ func TestTranslateContainerUtilsDeploy_AppliesConfiguredTolerations(t *testing.T
 			Effect:   corev1.TaintEffectNoSchedule,
 		},
 	)
+	assertUtilsMetricsPort(t, findContainerByName(
+		t, utilsDeployment.Spec.Template.Spec.Containers, common.UtilsContainerName,
+	))
 }
 
 func TestTranslateHelmChartUtilsDeploy_AppliesConfiguredTolerations(t *testing.T) {
@@ -132,6 +135,9 @@ func TestTranslateHelmChartUtilsDeploy_AppliesConfiguredTolerations(t *testing.T
 			Effect:   corev1.TaintEffectNoSchedule,
 		},
 	)
+	assertUtilsMetricsPort(t, findContainerByName(
+		t, utilsDeployment.Spec.Template.Spec.Containers, common.UtilsContainerName,
+	))
 }
 
 func TestTranslateHelmChartLLM_AddsRouterAndCredentialContainers(t *testing.T) {
@@ -376,6 +382,7 @@ func TestTranslateContainerWithCacheAndSecrets(t *testing.T) {
 	require.NoError(t, err)
 
 	pod := findPodByName(t, objs, "0-request")
+	assertUtilsMetricsPort(t, findContainerByName(t, pod.Spec.Containers, common.UtilsContainerName))
 	assert.Equal(t, "value", envSliceToMap(findContainerByName(t, pod.Spec.Containers, inferenceContainerName).Env)["INFERENCE_ENV"])
 	assert.Equal(t, "ess", findContainerByName(t, pod.Spec.Containers, "ess").Name)
 	require.Len(t, pod.Spec.InitContainers, 2)
@@ -409,7 +416,7 @@ func TestTranslateHelmChartWithCacheAndSecrets(t *testing.T) {
 
 	pod := findPodByName(t, objs, common.UtilsPodName)
 	assert.Equal(t, "ess", findContainerByName(t, pod.Spec.Containers, "ess").Name)
-	assert.Equal(t, common.UtilsContainerName, findContainerByName(t, pod.Spec.Containers, common.UtilsContainerName).Name)
+	assertUtilsMetricsPort(t, findContainerByName(t, pod.Spec.Containers, common.UtilsContainerName))
 	require.Len(t, pod.Spec.InitContainers, 2)
 	assert.Equal(t, "ess-init", pod.Spec.InitContainers[1].Name)
 	assert.NotNil(t, findObjectByName(t, objs, "rw-pvc-helm-function-cache"))
@@ -676,4 +683,13 @@ func findObjectByName(t *testing.T, objs []metav1.Object, name string) metav1.Ob
 func assertTolerationsMatch(t *testing.T, got []corev1.Toleration, want ...corev1.Toleration) {
 	t.Helper()
 	assert.ElementsMatch(t, want, got)
+}
+
+func assertUtilsMetricsPort(t *testing.T, container corev1.Container) {
+	t.Helper()
+	assert.Equal(t, []corev1.ContainerPort{{
+		Name:          common.UtilsMetricsPortName,
+		ContainerPort: common.UtilsMetricsPort,
+		Protocol:      corev1.ProtocolTCP,
+	}}, container.Ports)
 }

--- a/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_tolerations_test.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/function/translate_tolerations_test.go
@@ -68,6 +68,8 @@ func TestTranslateContainer_AppliesConfiguredTolerations(t *testing.T) {
 	)
 }
 
+// TestTranslateContainerUtilsDeploy_AppliesConfiguredTolerations verifies
+// tolerations and metrics in split deployment mode.
 func TestTranslateContainerUtilsDeploy_AppliesConfiguredTolerations(t *testing.T) {
 	customToleration := corev1.Toleration{
 		Key:      "workload-type",
@@ -109,6 +111,8 @@ func TestTranslateContainerUtilsDeploy_AppliesConfiguredTolerations(t *testing.T
 	))
 }
 
+// TestTranslateHelmChartUtilsDeploy_AppliesConfiguredTolerations verifies Helm
+// tolerations and worker metrics.
 func TestTranslateHelmChartUtilsDeploy_AppliesConfiguredTolerations(t *testing.T) {
 	customToleration := corev1.Toleration{
 		Key:      "workload-type",
@@ -140,6 +144,8 @@ func TestTranslateHelmChartUtilsDeploy_AppliesConfiguredTolerations(t *testing.T
 	))
 }
 
+// TestTranslateHelmChartLLM_AddsRouterAndCredentialContainers verifies the Helm
+// LLM sidecars and metrics port.
 func TestTranslateHelmChartLLM_AddsRouterAndCredentialContainers(t *testing.T) {
 	msg := newHelmFunctionMessage()
 	msg.Details.FunctionType = FunctionTypeLLM
@@ -201,6 +207,8 @@ func TestTranslateHelmChartLLM_AddsRouterAndCredentialContainers(t *testing.T) {
 	require.NotNil(t, findVolumeByName(t, utilsPod.Spec.Volumes, "llm").EmptyDir)
 }
 
+// TestTranslateContainerLLM_AddsRouterAndCredentialContainers verifies the
+// container LLM sidecars and metrics port.
 func TestTranslateContainerLLM_AddsRouterAndCredentialContainers(t *testing.T) {
 	msg := newContainerFunctionMessage()
 	msg.Details.FunctionType = FunctionTypeLLM
@@ -358,6 +366,8 @@ func TestTranslateNonLLMFunctionsDoNotAddCredentialManager(t *testing.T) {
 	}
 }
 
+// TestTranslateContainerWithCacheAndSecrets verifies cache, secret, and
+// worker-utils resources for container functions.
 func TestTranslateContainerWithCacheAndSecrets(t *testing.T) {
 	msg := newContainerFunctionMessage()
 	msg.LaunchSpecification.EnvironmentB64 = encodeTextEnv(map[string]string{
@@ -393,6 +403,8 @@ func TestTranslateContainerWithCacheAndSecrets(t *testing.T) {
 	assert.NotNil(t, findObjectByName(t, objs, "writer-job-function-cache"))
 }
 
+// TestTranslateHelmChartWithCacheAndSecrets verifies cache, secret, and
+// worker-utils resources for Helm functions.
 func TestTranslateHelmChartWithCacheAndSecrets(t *testing.T) {
 	msg := newHelmFunctionMessage()
 	msg.LaunchSpecification.EnvironmentB64 = encodeTextEnv(map[string]string{
@@ -687,6 +699,7 @@ func assertTolerationsMatch(t *testing.T, got []corev1.Toleration, want ...corev
 	assert.ElementsMatch(t, want, got)
 }
 
+// assertUtilsMetricsPort verifies the named worker-utils metrics port.
 func assertUtilsMetricsPort(t *testing.T, container corev1.Container) {
 	t.Helper()
 	assert.Equal(t, []corev1.ContainerPort{{
@@ -696,6 +709,7 @@ func assertUtilsMetricsPort(t *testing.T, container corev1.Container) {
 	}}, container.Ports)
 }
 
+// assertLLMMetricsPort verifies the named Pylon metrics port.
 func assertLLMMetricsPort(t *testing.T, container corev1.Container) {
 	t.Helper()
 	assert.Equal(t, []corev1.ContainerPort{{

--- a/src/libraries/go/lib/pkg/icms-translate/translate/task/translate.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/task/translate.go
@@ -435,7 +435,7 @@ func translateContainer(t CreationQueueMessage, tcfg TranslateConfig) (objs []me
 			VolumeMounts:    utilsContainerVolumeMounts,
 		}
 		// mutate startup / liveness / readiness probes
-		common.MutateUtilsProbes(&utilsContainer)
+		common.MutateUtilsContainer(&utilsContainer)
 		pod.Spec.Containers = append(pod.Spec.Containers, utilsContainer)
 
 		// Setup telemetry for the pod

--- a/src/libraries/go/lib/pkg/icms-translate/translate/task/translate.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/task/translate.go
@@ -37,6 +37,8 @@ import (
 // TODO: k8s version considerations.
 // For now, all task Pod features are supported by all recent k8s versions
 
+// translateContainer converts a container task request into Kubernetes resources.
+//
 //nolint:gocyclo // complex function with many conditional branches
 func translateContainer(t CreationQueueMessage, tcfg TranslateConfig) (objs []metav1.Object, err error) {
 	tcfg.Default()

--- a/src/libraries/go/lib/pkg/icms-translate/translate/task/translate_all_test.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/task/translate_all_test.go
@@ -57,6 +57,7 @@ func TestTranslateContainerCreatesTaskPod(t *testing.T) {
 	assert.Equal(t, string(common.UploadResult), envValue(utilsContainer.Env, resultHandlingStratEnvKey))
 }
 
+// TestTranslateContainerWithCacheAndSecrets verifies cache and secret resources for a container task.
 func TestTranslateContainerWithCacheAndSecrets(t *testing.T) {
 	msg := newTaskMessage(false)
 	msg.LaunchSpecification.EnvironmentB64 = encodeTaskTextEnv(map[string]string{

--- a/src/libraries/go/lib/pkg/icms-translate/translate/task/translate_all_test.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/task/translate_all_test.go
@@ -346,7 +346,7 @@ func findTaskContainerByName(t *testing.T, containers []corev1.Container, name s
 func assertTaskUtilsMetricsPort(t *testing.T, container corev1.Container) {
 	t.Helper()
 	assert.Equal(t, []corev1.ContainerPort{{
-		Name:          common.UtilsMetricsPortName,
+		Name:          common.WorkerMetricsPortName,
 		ContainerPort: common.UtilsMetricsPort,
 		Protocol:      corev1.ProtocolTCP,
 	}}, container.Ports)

--- a/src/libraries/go/lib/pkg/icms-translate/translate/task/translate_all_test.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/task/translate_all_test.go
@@ -51,6 +51,7 @@ func TestTranslateContainerCreatesTaskPod(t *testing.T) {
 	assert.Equal(t, corev1.RestartPolicyNever, pod.Spec.RestartPolicy)
 
 	utilsContainer := findTaskContainerByName(t, pod.Spec.Containers, common.UtilsContainerName)
+	assertTaskUtilsMetricsPort(t, utilsContainer)
 	assert.Equal(t, "nvcr.io/nvidia/utils:latest", utilsContainer.Image)
 	assert.Equal(t, string(common.UploadResult), envValue(utilsContainer.Env, resultHandlingStratEnvKey))
 }
@@ -107,6 +108,7 @@ func TestTranslateHelmChartCreatesUtilsPod(t *testing.T) {
 	assert.Equal(t, "nvcr.io/nvidia/init:latest", pod.Spec.InitContainers[0].Image)
 
 	utilsContainer := findTaskContainerByName(t, pod.Spec.Containers, common.UtilsContainerName)
+	assertTaskUtilsMetricsPort(t, utilsContainer)
 	assert.Equal(t, "nvcr.io/nvidia/utils:latest", utilsContainer.Image)
 	assert.Equal(t, "request-task", envValue(utilsContainer.Env, "INSTANCE_ID"))
 	assert.Equal(t, string(common.UploadResult), envValue(utilsContainer.Env, resultHandlingStratEnvKey))
@@ -339,6 +341,15 @@ func findTaskContainerByName(t *testing.T, containers []corev1.Container, name s
 
 	t.Fatalf("container %q not found", name)
 	return corev1.Container{}
+}
+
+func assertTaskUtilsMetricsPort(t *testing.T, container corev1.Container) {
+	t.Helper()
+	assert.Equal(t, []corev1.ContainerPort{{
+		Name:          common.UtilsMetricsPortName,
+		ContainerPort: common.UtilsMetricsPort,
+		Protocol:      corev1.ProtocolTCP,
+	}}, container.Ports)
 }
 
 func findTaskVolumeByName(t *testing.T, volumes []corev1.Volume, name string) corev1.VolumeSource {

--- a/src/libraries/go/lib/pkg/icms-translate/translate/task/translate_all_test.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/task/translate_all_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/common"
 )
 
+// TestTranslateContainerCreatesTaskPod verifies resources generated for a container task.
 func TestTranslateContainerCreatesTaskPod(t *testing.T) {
 	objs, err := Translate(
 		newTaskMessage(false),
@@ -88,6 +89,7 @@ func TestTranslateContainerWithCacheAndSecrets(t *testing.T) {
 	assert.NotNil(t, findTaskJobByName(t, objs, "writer-job-cache-handle"))
 }
 
+// TestTranslateHelmChartCreatesUtilsPod verifies resources generated for a Helm task.
 func TestTranslateHelmChartCreatesUtilsPod(t *testing.T) {
 	objs, err := Translate(
 		newTaskMessage(true),
@@ -343,6 +345,7 @@ func findTaskContainerByName(t *testing.T, containers []corev1.Container, name s
 	return corev1.Container{}
 }
 
+// assertTaskUtilsMetricsPort verifies the named worker-utils metrics port for tasks.
 func assertTaskUtilsMetricsPort(t *testing.T, container corev1.Container) {
 	t.Helper()
 	assert.Equal(t, []corev1.ContainerPort{{

--- a/src/libraries/go/lib/pkg/icms-translate/translate/task/translate_helm.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/task/translate_helm.go
@@ -31,6 +31,8 @@ import (
 	translateutil "github.com/NVIDIA/nvcf/src/libraries/go/lib/pkg/icms-translate/translate/util"
 )
 
+// translateHelmChart converts a Helm task request into Kubernetes resources.
+//
 //nolint:gocyclo // complex function with many conditional branches
 func translateHelmChart(t CreationQueueMessage, tcfg TranslateConfig) (objs []metav1.Object, err error) {
 	if err := tcfg.ValidateHelmChart(); err != nil {

--- a/src/libraries/go/lib/pkg/icms-translate/translate/task/translate_helm.go
+++ b/src/libraries/go/lib/pkg/icms-translate/translate/task/translate_helm.go
@@ -356,7 +356,7 @@ func translateHelmChart(t CreationQueueMessage, tcfg TranslateConfig) (objs []me
 		VolumeMounts:    utilsContainerVolumeMounts,
 	}
 	// mutate startup / liveness / readiness probes
-	common.MutateUtilsProbes(&utilsContainer)
+	common.MutateUtilsContainer(&utilsContainer)
 	utilsPod.Spec.Containers = append(utilsPod.Spec.Containers, utilsContainer)
 
 	if hasTelemetries {

--- a/src/libraries/go/lib/testdata/icms-translate/function/container/basic/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/container/basic/exp.yaml
@@ -280,6 +280,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/function/container/basic/exp_utdep.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/container/basic/exp_utdep.yaml
@@ -491,6 +491,10 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         name: utils
+        ports:
+        - containerPort: 8010
+          name: worker-metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 2
           httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/function/container/cache/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/container/cache/exp.yaml
@@ -453,6 +453,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/function/container/cache/exp_utdep.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/container/cache/exp_utdep.yaml
@@ -479,6 +479,10 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         name: utils
+        ports:
+        - containerPort: 8010
+          name: worker-metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 2
           httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/function/container/ess/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/container/ess/exp.yaml
@@ -309,6 +309,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/function/container/ess/exp_utdep.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/container/ess/exp_utdep.yaml
@@ -487,6 +487,10 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         name: utils
+        ports:
+        - containerPort: 8010
+          name: worker-metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 2
           httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/function/container/llm/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/container/llm/exp.yaml
@@ -270,6 +270,10 @@ spec:
     image: nvcr.io/0651155215864979/ncp-dev/stargate-client:0.4.0
     imagePullPolicy: IfNotPresent
     name: llm-worker
+    ports:
+    - containerPort: 9089
+      name: worker-metrics
+      protocol: TCP
     resources:
       limits:
         cpu: "1"

--- a/src/libraries/go/lib/testdata/icms-translate/function/container/lls/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/container/lls/exp.yaml
@@ -284,6 +284,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/function/container/no-cred/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/container/no-cred/exp.yaml
@@ -242,6 +242,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/function/container/no-cred/exp_utdep.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/container/no-cred/exp_utdep.yaml
@@ -449,6 +449,10 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         name: utils
+        ports:
+        - containerPort: 8010
+          name: worker-metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 2
           httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/function/container/otel-ess/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/container/otel-ess/exp.yaml
@@ -319,6 +319,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/function/container/otel/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/container/otel/exp.yaml
@@ -313,6 +313,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/function/container/tolerations/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/container/tolerations/exp.yaml
@@ -280,6 +280,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/function/container/tolerations/exp_utdep.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/container/tolerations/exp_utdep.yaml
@@ -495,6 +495,10 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         name: utils
+        ports:
+        - containerPort: 8010
+          name: worker-metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 2
           httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/function/helmchart/basic/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/helmchart/basic/exp.yaml
@@ -242,6 +242,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/function/helmchart/basic/exp_utdep.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/helmchart/basic/exp_utdep.yaml
@@ -282,6 +282,10 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         name: utils
+        ports:
+        - containerPort: 8010
+          name: worker-metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 2
           httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/function/helmchart/cache/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/helmchart/cache/exp.yaml
@@ -372,6 +372,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/function/helmchart/cache/exp_utdep.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/helmchart/cache/exp_utdep.yaml
@@ -406,6 +406,10 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         name: utils
+        ports:
+        - containerPort: 8010
+          name: worker-metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 2
           httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/function/helmchart/ess/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/helmchart/ess/exp.yaml
@@ -231,6 +231,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/function/helmchart/ess/exp_utdep.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/helmchart/ess/exp_utdep.yaml
@@ -239,6 +239,10 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         name: utils
+        ports:
+        - containerPort: 8010
+          name: worker-metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 2
           httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/function/helmchart/llm/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/helmchart/llm/exp.yaml
@@ -238,6 +238,10 @@ spec:
     image: nvcr.io/nvcf-core/stargate-client:0.4.0
     imagePullPolicy: IfNotPresent
     name: llm-worker
+    ports:
+    - containerPort: 9089
+      name: worker-metrics
+      protocol: TCP
     resources:
       limits:
         cpu: "1"

--- a/src/libraries/go/lib/testdata/icms-translate/function/helmchart/no-cred/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/helmchart/no-cred/exp.yaml
@@ -169,6 +169,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/function/helmchart/no-cred/exp_utdep.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/helmchart/no-cred/exp_utdep.yaml
@@ -209,6 +209,10 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         name: utils
+        ports:
+        - containerPort: 8010
+          name: worker-metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 2
           httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/function/helmchart/otel-ess/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/helmchart/otel-ess/exp.yaml
@@ -296,6 +296,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/function/helmchart/otel/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/function/helmchart/otel/exp.yaml
@@ -290,6 +290,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/task/container/basic-icms/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/task/container/basic-icms/exp.yaml
@@ -277,6 +277,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/task/container/basic/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/task/container/basic/exp.yaml
@@ -277,6 +277,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/task/container/cache/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/task/container/cache/exp.yaml
@@ -452,6 +452,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/task/container/emptyargs/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/task/container/emptyargs/exp.yaml
@@ -267,6 +267,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/task/container/ess/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/task/container/ess/exp.yaml
@@ -312,6 +312,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/task/container/no-cred/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/task/container/no-cred/exp.yaml
@@ -243,6 +243,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/task/container/otel-ess/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/task/container/otel-ess/exp.yaml
@@ -316,6 +316,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/task/container/otel/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/task/container/otel/exp.yaml
@@ -316,6 +316,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/task/helmchart/basic/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/task/helmchart/basic/exp.yaml
@@ -236,6 +236,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/task/helmchart/cache/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/task/helmchart/cache/exp.yaml
@@ -374,6 +374,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/task/helmchart/ess/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/task/helmchart/ess/exp.yaml
@@ -235,6 +235,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/task/helmchart/no-cred/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/task/helmchart/no-cred/exp.yaml
@@ -203,6 +203,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/task/helmchart/otel-ess/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/task/helmchart/otel-ess/exp.yaml
@@ -231,6 +231,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:

--- a/src/libraries/go/lib/testdata/icms-translate/task/helmchart/otel/exp.yaml
+++ b/src/libraries/go/lib/testdata/icms-translate/task/helmchart/otel/exp.yaml
@@ -292,6 +292,10 @@ spec:
       successThreshold: 1
       timeoutSeconds: 1
     name: utils
+    ports:
+    - containerPort: 8010
+      name: worker-metrics
+      protocol: TCP
     readinessProbe:
       failureThreshold: 2
       httpGet:


### PR DESCRIPTION
## TL;DR

Make worker PodMonitor endpoints resolvable by exposing the shared `worker-metrics` port name on generated worker containers: port 8010 for worker-utils and port 9089 for LLM Pylon.

## Additional Details

The worker PodMonitor selected NVCF workload pods but referenced a named port that those pods did not declare. Prometheus Operator target discovery therefore discarded the selected pods, leaving self-hosted `compute` and `all` profiles without worker metrics.

This change:

- declares `worker-metrics:8010/TCP` on utils containers generated for function and task workloads;
- declares `worker-metrics:9089/TCP` on LLM Pylon containers;
- covers container, Helm, and SidecarAsDeployment translation paths;
- changes both the chart defaults and Helmfile environment defaults to the same port name;
- permits Pylon port 9089 through the monitoring NetworkPolicy;
- uses a distinct name to avoid ambiguity with optional OTel sidecar `metrics` ports;
- synchronizes NVCA's vendored translator; and
- updates generated fixtures and focused regression tests.

## For the Reviewer

- Ensure the two PodMonitor source lists remain identical.
- Confirm utils workers map `worker-metrics` to port 8010 and LLM Pylon maps it to port 9089.
- Confirm the monitoring NetworkPolicy permits port 9089.
- Confirm the NVCA vendor copies remain synchronized with the source translator.

## For QA

Passed locally:

- Go 1.25 tests for the common, function, and task translation packages.
- Exact generated-manifest comparisons for both LLM translation paths.
- Focused NVCA NetworkPolicy rendering tests for configurations with and without DDCS IPs.
- `make test` from `deploy/stacks/observability`.
- NVCA package compilation against the synchronized vendored translator.
- Repository-pinned golangci-lint against changed lines: zero issues.
- `git diff --check`.

A live k3d smoke test confirmed that the Target Allocator resolved a generated worker-utils `worker-metrics` endpoint at port 8010 and VictoriaMetrics reported `up=1`. All temporary smoke-test resources were removed afterward.

QA needed: yes. Please verify worker metrics collection for both a normal worker-utils workload and an LLM workload with a self-hosted `compute` or `all` profile.

## Issues

Fixes #1694, covering worker-utils metrics on port 8010 and LLM Pylon metrics on port 9089.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Utility containers expose worker metrics over TCP port 8010 with health checks.
  * LLM router containers expose worker metrics over TCP port 9089.
  * Monitoring scrapes worker metrics across compute-plane deployments.

* **Bug Fixes**
  * Updated monitoring network access and configuration to use the correct worker metrics endpoints.

* **Tests**
  * Added coverage for metrics ports, protocols, monitoring access, and health checks across supported deployment types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

