### PR TITLE
feat(nvca-operator): auto-bump BYOO otel collector image tag on release

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -109,6 +109,7 @@ jobs:
           NVCA_VERSION="$(yq '.selfManaged.nvcaVersion' nvca-operator/values.yaml)" \
           NVCA_OPERATOR_VERSION="$(yq '.appVersion' nvca-operator/Chart.yaml)" \
           NVCA_SHARED_STORAGE_IMAGE_TAG="$(yq '.selfManaged.sharedStorage.imageTag' nvca-operator/values.yaml)" \
+          NVCA_OTEL_COLLECTOR_IMAGE_TAG="$(yq '.otelCollector.imageTag' nvca-operator/values.yaml)" \
             make check-vendor-chart
 
       - name: Run self-managed Helmfile render tests

--- a/ai-tooling/dev/skills/nvca-chart-release/SKILL.md
+++ b/ai-tooling/dev/skills/nvca-chart-release/SKILL.md
@@ -40,7 +40,15 @@ Propagates Helm chart changes through the native monorepo paths:
    NVCA_OPERATOR_VERSION=<operator-image-tag>
    NVCA_VERSION=<agent-image-tag>
    NVCA_SHARED_STORAGE_IMAGE_TAG=<shared-storage-tag>
+   NVCA_OTEL_COLLECTOR_IMAGE_TAG=<byoo-otel-collector-image-tag>
    ```
+
+   `NVCA_OTEL_COLLECTOR_IMAGE_TAG` is normally left alone: it moves on its own
+   when `byoo-otel-collector` releases, driven by `tools/chart-version-bumper`
+   against the vendored chart directly rather than through this source-first
+   flow. Set it explicitly only when vendoring by hand; otherwise pass the
+   value already committed in `deploy/helm/nvca-operator/nvca-operator/values.yaml`
+   (`otelCollector.imageTag`) so an unrelated vendor run does not revert it.
 
 4. Vendor and validate from `deploy/helm/nvca-operator`:
 

--- a/deploy/helm/nvca-operator/nvca-operator/values.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/values.yaml
@@ -37,7 +37,7 @@ nvcaImage:
 otelCollector:
   enabled: false
   imageRepository: ""
-  imageTag: 0.157.0-nv-0.2.1
+  imageTag: 0.160.0-nv-0.2.4
   resources:
     limits:
       cpu: 1000m
@@ -225,7 +225,7 @@ agent:
   ## @param agent.byooOtelCollector.imageTag BYOO OpenTelemetry Collector image tag.
   byooOtelCollector:
     imageRepository: ""
-    imageTag: "0.157.0-nv-0.2.1"
+    imageTag: "0.160.0-nv-0.2.4"
   ## Environment variable overrides for function workloads.
   ## Available keys: INIT_CONTAINER, UTILS_CONTAINER, OTEL_CONTAINER, BYOO_OTEL_COLLECTOR_CONTAINER,
   ##                 NICLLS_CONTAINER, ESS_AGENT_CONTAINER, INFERENCE_CONTAINER
@@ -340,7 +340,7 @@ helmManaged:
   otelCollector:
     enabled: false
     imageRepository: ""
-    imageTag: 0.157.0-nv-0.2.1
+    imageTag: 0.160.0-nv-0.2.4
 ## @section Self Managed NVCF Backend Configuration
 ## Only used when ngcConfig.clusterSource is "self-managed"
 ## All values below are under the 'selfManaged:' key, e.g. 'selfManaged.nvcaVersion'
@@ -364,7 +364,7 @@ selfManaged:
   otelCollector:
     enabled: false
     imageRepository: ""
-    imageTag: 0.157.0-nv-0.2.1
+    imageTag: 0.160.0-nv-0.2.4
   ## @param selfManaged.icmsServiceURL URL of the ICMS service for self-managed clusters. Override with the endpoint generated during cluster registration.
   icmsServiceURL: "http://icms.example.invalid:8080"
   ## @param selfManaged.icmsServiceHostHeaderOverride Optional Host header override for selfManaged.icmsServiceURL.

--- a/deploy/helm/nvca-operator/scripts/ci_vendor_nvca_operator_chart
+++ b/deploy/helm/nvca-operator/scripts/ci_vendor_nvca_operator_chart
@@ -275,6 +275,15 @@ main() {
     # regardless of which NVCA Operator the chart is actually wired to.
     update_yaml_key ".appVersion = \"${NVCA_OPERATOR_VERSION:?"NVCA_OPERATOR_VERSION is not set"}\"" "${TARGET_DIR}/Chart.yaml"
     update_yaml_key ".selfManaged.sharedStorage.imageTag = \"${NVCA_SHARED_STORAGE_IMAGE_TAG:?"NVCA_SHARED_STORAGE_IMAGE_TAG is not set"}\"" "${TARGET_DIR}/values.yaml"
+    # The BYOO otel collector sidecar's image tag moves independently of the
+    # monorepo source, driven by tools/chart-version-bumper against this
+    # vendored copy directly when byoo-otel-collector releases. Without this
+    # override the plain source copy above would carry it back to whatever
+    # the source chart still has, discarding that bump on the next vendor run.
+    update_yaml_key ".otelCollector.imageTag = \"${NVCA_OTEL_COLLECTOR_IMAGE_TAG:?"NVCA_OTEL_COLLECTOR_IMAGE_TAG is not set"}\"" "${TARGET_DIR}/values.yaml"
+    update_yaml_key ".agent.byooOtelCollector.imageTag = \"${NVCA_OTEL_COLLECTOR_IMAGE_TAG:?"NVCA_OTEL_COLLECTOR_IMAGE_TAG is not set"}\"" "${TARGET_DIR}/values.yaml"
+    update_yaml_key ".helmManaged.otelCollector.imageTag = \"${NVCA_OTEL_COLLECTOR_IMAGE_TAG:?"NVCA_OTEL_COLLECTOR_IMAGE_TAG is not set"}\"" "${TARGET_DIR}/values.yaml"
+    update_yaml_key ".selfManaged.otelCollector.imageTag = \"${NVCA_OTEL_COLLECTOR_IMAGE_TAG:?"NVCA_OTEL_COLLECTOR_IMAGE_TAG is not set"}\"" "${TARGET_DIR}/values.yaml"
     update_yaml_key ".nameOverride = \"nvca-operator\"" "${TARGET_DIR}/values.yaml"
     update_yaml_key ".fullnameOverride = \"nvca-operator\"" "${TARGET_DIR}/values.yaml"
     

--- a/deploy/helm/nvca-operator/tests/otel_collector_compatibility_test.sh
+++ b/deploy/helm/nvca-operator/tests/otel_collector_compatibility_test.sh
@@ -7,7 +7,6 @@ set -euo pipefail
 chart_root="$(cd "$(dirname "$0")/.." && pwd)"
 workspace_root="$(cd "${chart_root}/../../.." && pwd)"
 config_template="${workspace_root}/src/compute-plane-services/nvca/pkg/operator/reconcile/manifests/otel_collector_config.yaml"
-compatible_tag="0.157.0-nv-0.2.1"
 tmp_dir="$(mktemp -d)"
 
 # Remove rendered test inputs even when image validation fails.
@@ -54,6 +53,13 @@ if [[ "${operator_repository}" != "${expected_repository}" ]]; then
   exit 1
 fi
 
+# The source of truth for the compatible tag is the chart itself, not a
+# literal here: otelCollector.imageTag, agent.byooOtelCollector.imageTag,
+# helmManaged.otelCollector.imageTag, and selfManaged.otelCollector.imageTag
+# move together on every collector release (tools/chart-version-bumper
+# refuses rather than bump them if they ever disagree), so any one of them is
+# the value every path below must resolve to.
+compatible_tag="$(yq -r '.otelCollector.imageTag' "${chart_root}/nvca-operator/values.yaml")"
 for selected_tag in "${operator_tag}" "${backend_tag}" "${helm_managed_tag}"; do
   if [[ "${selected_tag}" != "${compatible_tag}" ]]; then
     echo "expected every collector path to select ${compatible_tag}, got ${selected_tag}" >&2

--- a/deploy/helm/nvca-operator/tests/self_managed_nvca_image_reference_test.sh
+++ b/deploy/helm/nvca-operator/tests/self_managed_nvca_image_reference_test.sh
@@ -189,6 +189,7 @@ helm template nvca-operator "${repo_root}/nvca-operator" \
 
 nvca_image_repository="$(yq -r '.nvcaImage.repositoryOverride' "${repo_root}/values.release-sbom.yaml")"
 nvca_version="$(yq -r '.selfManaged.nvcaVersion' "${repo_root}/nvca-operator/values.yaml")"
+byoo_otel_collector_tag="$(yq -r '.agent.byooOtelCollector.imageTag' "${repo_root}/nvca-operator/values.yaml")"
 image_credential_helper_repository="$(yq -r '.selfManaged.imageCredHelper.imageRepository' "${repo_root}/values.release-sbom.yaml")"
 image_credential_helper_tag="$(yq -r '.selfManaged.imageCredHelper.imageTag' "${repo_root}/nvca-operator/values.yaml")"
 samba_repository="$(yq -r '.selfManaged.sharedStorage.imageRepository' "${repo_root}/values.release-sbom.yaml")"
@@ -207,12 +208,12 @@ if [[ "${byoo_function_image}" != "${byoo_task_image}" ]]; then
   exit 1
 fi
 
-if [[ "${byoo_function_image}" != "nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector:0.157.0-nv-0.2.1" ]]; then
+if [[ "${byoo_function_image}" != "nvcr.io/nvidia/nvcf-byoc/byoo-otel-collector:${byoo_otel_collector_tag}" ]]; then
   echo "unexpected BYOO collector default: ${byoo_function_image}" >&2
   exit 1
 fi
 
-if [[ "${stage_byoo_function_image}" != "stg.nvcr.io/nv-cf/nvcf-core/byoo-otel-collector:0.157.0-nv-0.2.1" || \
+if [[ "${stage_byoo_function_image}" != "stg.nvcr.io/nv-cf/nvcf-core/byoo-otel-collector:${byoo_otel_collector_tag}" || \
   "${stage_byoo_task_image}" != "${stage_byoo_function_image}" ]]; then
   echo "expected BYOO collector defaults to use the staging image repository" >&2
   exit 1

--- a/deploy/helm/nvca-operator/tests/vendor_chart_image_tag_test.sh
+++ b/deploy/helm/nvca-operator/tests/vendor_chart_image_tag_test.sh
@@ -36,6 +36,7 @@ chart_root="${fixture_root}/deploy/helm/nvca-operator"
 NVCA_OPERATOR_VERSION="3.2.11" \
 NVCA_VERSION="3.2.11" \
 NVCA_SHARED_STORAGE_IMAGE_TAG="1.0.5" \
+NVCA_OTEL_COLLECTOR_IMAGE_TAG="0.160.0-nv-0.2.4" \
   "${chart_root}/scripts/ci_vendor_nvca_operator_chart" >/dev/null
 
 actual_tag="$(yq -r '.image.tag' "${chart_root}/nvca-operator/values.yaml")"

--- a/src/compute-plane-services/byoo-otel-collector/AGENTS.md
+++ b/src/compute-plane-services/byoo-otel-collector/AGENTS.md
@@ -53,6 +53,13 @@ The upstream part comes from `otel-collector-build.yaml`; do not add a `VERSION`
 file or a CI gate that requires one. `RELEASE_SERIES_START` anchors the first
 wrapper release and must remain in the repository.
 
+Commit a collector version bump as `fix(byoo-otel-collector):`, not
+`chore(byoo-otel-collector):`. `chore` commits are not release-worthy (see
+`RELEASE_RULES` in `tools/ci/github-release`), so a `chore` bump only
+synthesizes a compatibility tag anchor and never triggers the image build and
+push. Because the upstream version is embedded directly in the published tag
+and image, every bump must ship a real image, not just update the pin in git.
+
 ## Local Gotchas
 
 - Generated templates and examples are committed. Regenerate and commit them

--- a/tools/chart-service-edge/main.go
+++ b/tools/chart-service-edge/main.go
@@ -101,9 +101,9 @@ func Audit(meta *Metadata, strict bool, out, errOut io.Writer) int {
 			continue
 		}
 		var unknown []string
-		for _, s := range c.Deploys {
-			if !serviceIDs[s] {
-				unknown = append(unknown, s)
+		for _, d := range c.Deploys {
+			if !serviceIDs[d.Service] {
+				unknown = append(unknown, d.Service)
 			}
 		}
 		if len(unknown) > 0 {
@@ -116,7 +116,11 @@ func Audit(meta *Metadata, strict bool, out, errOut io.Writer) int {
 	for _, c := range declared {
 		target := "(no first-party image)"
 		if len(c.Deploys) > 0 {
-			target = strings.Join(c.Deploys, ", ")
+			names := make([]string, len(c.Deploys))
+			for i, d := range c.Deploys {
+				names[i] = d.Service
+			}
+			target = strings.Join(names, ", ")
 		}
 		fmt.Fprintf(out, "  %-26s -> %s\n", c.ID, target)
 	}

--- a/tools/chart-service-edge/main_test.go
+++ b/tools/chart-service-edge/main_test.go
@@ -201,3 +201,15 @@ func repoRoot(t *testing.T) string {
 	t.Fatalf("could not find %s above the test directory", MetadataPath)
 	return ""
 }
+
+func TestEmptyStringDeployEntryIsRejected(t *testing.T) {
+	// Mirrors the same fix in tools/chart-version-bumper/metadata.go:
+	// json.Unmarshal decodes "" into a Go string without error, so the
+	// string-form branch must reject it explicitly rather than silently
+	// producing a Deploy with no service id.
+	var m Metadata
+	err := json.Unmarshal([]byte(`{"services":[{"id":"c","path":"deploy/helm/c","deploys":[""]}]}`), &m)
+	if err == nil {
+		t.Fatal("an empty string-form deploys entry must fail to decode")
+	}
+}

--- a/tools/chart-service-edge/metadata.go
+++ b/tools/chart-service-edge/metadata.go
@@ -45,6 +45,9 @@ type Deploy struct {
 func (d *Deploy) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err == nil {
+		if s == "" {
+			return fmt.Errorf("deploys entry: empty service id")
+		}
 		*d = Deploy{Service: s}
 		return nil
 	}

--- a/tools/chart-service-edge/metadata.go
+++ b/tools/chart-service-edge/metadata.go
@@ -24,9 +24,42 @@ type Entry struct {
 	Path string `json:"path"`
 	// Deploys is nil when the key is absent and non-nil empty when the chart
 	// declares it ships no first-party image. That distinction is the whole
-	// point of the audit, so it must survive decoding: a []string does exactly
+	// point of the audit, so it must survive decoding: a []Deploy does exactly
 	// that, where a map lookup or a len() test would flatten the two together.
-	Deploys []string `json:"deploys"`
+	Deploys []Deploy `json:"deploys"`
+}
+
+// Deploy is one service a chart ships. A plain JSON string names the service
+// and lets chart-version-bumper's single appVersion/image-tag agreement
+// decide which values.yaml line belongs to it. A chart with more than one
+// first-party image cannot use that evidence, so a deploy entry may instead
+// be an object naming the exact values.yaml paths (dotted, for example
+// "otelCollector.imageTag") that carry that service's tag. This tool only
+// audits which service ids are declared, so it does not care which shape a
+// given entry takes; UnmarshalJSON exists so decoding either shape succeeds.
+type Deploy struct {
+	Service     string
+	ValuesPaths []string
+}
+
+func (d *Deploy) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err == nil {
+		*d = Deploy{Service: s}
+		return nil
+	}
+	var obj struct {
+		Service     string   `json:"service"`
+		ValuesPaths []string `json:"values_paths"`
+	}
+	if err := json.Unmarshal(b, &obj); err != nil {
+		return fmt.Errorf("deploys entry: %w", err)
+	}
+	if obj.Service == "" {
+		return fmt.Errorf("deploys entry missing \"service\"")
+	}
+	*d = Deploy{Service: obj.Service, ValuesPaths: obj.ValuesPaths}
+	return nil
 }
 
 // Metadata is the decoded release metadata file.

--- a/tools/chart-version-bumper/chart.go
+++ b/tools/chart-version-bumper/chart.go
@@ -24,6 +24,10 @@ const (
 	ActionRefuse
 	// ActionSkip moves nothing because there is no chart to move.
 	ActionSkip
+	// ActionValuesPaths moves exactly the declared values.yaml paths.
+	// appVersion is left alone: in a multi-image chart it belongs to whichever
+	// other service, if any, uses the default single-image evidence.
+	ActionValuesPaths
 )
 
 // Floating tags are not pins. Replacing one with a version is a behaviour
@@ -59,6 +63,12 @@ var (
 	// # keeps commented lines out.
 	inlineImageRE = regexp.MustCompile(`(?m)^(?:[^#\n]*[\s{,])?image:[ \t]*[^ \t\n#].*$`)
 	keyLineRE     = regexp.MustCompile(`^(\s*)([A-Za-z0-9_.-]+):`)
+	// A scalar key: value line, indent and key captured with the trailing
+	// colon and whitespace so a rewrite can splice the new value back in
+	// without disturbing indentation or a trailing comment. Mirrors
+	// appVersionRE's shape for the same reason: quotes around the value are
+	// optional on read and always added on write.
+	scalarValueRE = regexp.MustCompile(`^(\s*[A-Za-z0-9_.-]+:\s*)"?([^"\s#]*)"?(.*)$`)
 )
 
 // An imageTag is a tag: entry that sits directly under an image: key, together
@@ -96,6 +106,52 @@ func imageTags(lines []string) []imageTag {
 		}
 	}
 	return out
+}
+
+// resolveValuesPath finds the line holding the scalar value at a dotted path,
+// for example "otelCollector.imageTag", in values.yaml.
+//
+// Matching walks the full ancestor chain rather than taking the nearest
+// parent alone, because a chart with more than one image can hold the same
+// leaf key more than once under different parents (otelCollector.imageTag
+// and helmManaged.otelCollector.imageTag both end in imageTag): a
+// nearest-parent match cannot tell those apart, only the full path can.
+func resolveValuesPath(lines []string, path string) (line int, value string, err error) {
+	segments := strings.Split(path, ".")
+	type frame struct {
+		indent int
+		key    string
+	}
+	var stack []frame
+	for i, l := range lines {
+		m := keyLineRE.FindStringSubmatch(l)
+		if m == nil {
+			continue
+		}
+		indent := len(m[1])
+		key := m[2]
+		for len(stack) > 0 && stack[len(stack)-1].indent >= indent {
+			stack = stack[:len(stack)-1]
+		}
+		if len(stack) == len(segments)-1 && key == segments[len(stack)] {
+			full := true
+			for depth, f := range stack {
+				if f.key != segments[depth] {
+					full = false
+					break
+				}
+			}
+			if full {
+				vm := scalarValueRE.FindStringSubmatch(l)
+				if vm == nil || vm[2] == "" {
+					return 0, "", fmt.Errorf("values path %q: line %d has no scalar value", path, i+1)
+				}
+				return i, vm[2], nil
+			}
+		}
+		stack = append(stack, frame{indent: indent, key: key})
+	}
+	return 0, "", fmt.Errorf("values path %q not found", path)
 }
 
 // A Plan is what to do for one chart.
@@ -257,6 +313,82 @@ func Apply(root string, chart Entry, version string, p Plan) error {
 		m := tagLineRE.FindStringSubmatch(lines[it.line])
 		suffix := lines[it.line][len(m[0]):]
 		lines[it.line] = fmt.Sprintf("%stag: %q%s", m[1], version, suffix)
+	}
+	return writeFilePreservingMode(valuesYAML, strings.Join(lines, "\n"))
+}
+
+// PlanForValuesPaths decides what to do for a chart whose deploy edge names
+// the exact values.yaml paths holding this service's tag, rather than relying
+// on appVersion agreement. appVersion is never part of this plan: in a
+// multi-image chart it belongs to whichever other service, if any, uses the
+// default single-image evidence.
+func PlanForValuesPaths(root string, chart Entry, version string, paths []string) (Plan, error) {
+	chartYAML, valuesYAML := ChartFiles(root, chart.Path)
+	if chartYAML == "" {
+		return Plan{Action: ActionSkip, Detail: fmt.Sprintf("no Chart.yaml under %s", chart.Path)}, nil
+	}
+	b, err := os.ReadFile(valuesYAML)
+	if err != nil {
+		return Plan{}, fmt.Errorf("read %s: %w", valuesYAML, err)
+	}
+	lines := strings.Split(string(b), "\n")
+	values := make([]string, len(paths))
+	for i, p := range paths {
+		_, v, err := resolveValuesPath(lines, p)
+		if err != nil {
+			return Plan{ActionRefuse, err.Error(), "", nil}, nil
+		}
+		values[i] = v
+	}
+
+	// The declared paths are the ownership evidence here, in place of the
+	// appVersion agreement the default path uses. If they disagree, that
+	// evidence is broken: something already drifted, and moving every path to
+	// the same new version would paper over it rather than report it.
+	current := values[0]
+	for _, v := range values[1:] {
+		if v != current {
+			return Plan{
+				ActionRefuse,
+				fmt.Sprintf("declared values paths disagree: %s", describePaths(paths, values)),
+				"",
+				values,
+			}, nil
+		}
+	}
+	if floating[current] {
+		return Plan{ActionRefuse, "image tag is floating (" + current + ")", current, values}, nil
+	}
+	return Plan{ActionValuesPaths, "declared values path(s): " + strings.Join(paths, ", "), current, values}, nil
+}
+
+// describePaths pairs each declared path with the value found there, for a
+// refusal message that shows exactly where the disagreement is.
+func describePaths(paths, values []string) string {
+	parts := make([]string, len(paths))
+	for i, p := range paths {
+		parts[i] = fmt.Sprintf("%s=%s", p, values[i])
+	}
+	return strings.Join(parts, ", ")
+}
+
+// ApplyValuesPaths writes the released version to every path this deploy edge
+// named, and nothing else: appVersion and any other image in the chart are
+// left alone.
+func ApplyValuesPaths(root string, chart Entry, version string, paths []string) error {
+	_, valuesYAML := ChartFiles(root, chart.Path)
+	b, err := os.ReadFile(valuesYAML)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", valuesYAML, err)
+	}
+	lines := strings.Split(string(b), "\n")
+	for _, p := range paths {
+		line, _, err := resolveValuesPath(lines, p)
+		if err != nil {
+			return err
+		}
+		m := scalarValueRE.FindStringSubmatch(lines[line])
+		lines[line] = fmt.Sprintf("%s%q%s", m[1], version, m[3])
 	}
 	return writeFilePreservingMode(valuesYAML, strings.Join(lines, "\n"))
 }

--- a/tools/chart-version-bumper/main.go
+++ b/tools/chart-version-bumper/main.go
@@ -102,7 +102,13 @@ func Run(root, tag string, write bool, out, errOut io.Writer) (int, error) {
 
 	refused := 0
 	for _, chart := range charts {
-		p, err := PlanFor(root, chart, version)
+		var p Plan
+		var err error
+		if len(chart.ValuesPaths) > 0 {
+			p, err = PlanForValuesPaths(root, chart.Entry, version, chart.ValuesPaths)
+		} else {
+			p, err = PlanFor(root, chart.Entry, version)
+		}
 		if err != nil {
 			return 1, err
 		}
@@ -119,7 +125,12 @@ func Run(root, tag string, write bool, out, errOut io.Writer) (int, error) {
 			}
 			fmt.Fprintf(out, "  %s: %s -> %s (%s)\n", chart.ID, p.Current, version, p.Detail)
 			if write {
-				if err := Apply(root, chart, version, p); err != nil {
+				if len(chart.ValuesPaths) > 0 {
+					err = ApplyValuesPaths(root, chart.Entry, version, chart.ValuesPaths)
+				} else {
+					err = Apply(root, chart.Entry, version, p)
+				}
+				if err != nil {
 					return 1, err
 				}
 			}

--- a/tools/chart-version-bumper/main_test.go
+++ b/tools/chart-version-bumper/main_test.go
@@ -218,7 +218,7 @@ func TestApplyRewritesOnlyTheTagLinesMatchingAppVersion(t *testing.T) {
 	]}`)
 	f.chart(t, "multi", "1.0.0", "app:\n  image:\n    tag: \"1.0.0\"\nsidecar:\n  image:\n    tag: \"3.3.3\"")
 
-	chart := Entry{ID: "multi", Path: "deploy/helm/multi", Deploys: []string{"svc"}}
+	chart := Entry{ID: "multi", Path: "deploy/helm/multi", Deploys: []Deploy{{Service: "svc"}}}
 	if err := Apply(f.root, chart, "2.0.0", Plan{Action: ActionBoth, Current: "1.0.0"}); err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
@@ -357,8 +357,16 @@ func TestRealChartsResolve(t *testing.T) {
 			t.Errorf("chart %s declares an edge but no Chart.yaml was found under %s", e.ID, e.Path)
 			continue
 		}
-		if _, err := PlanFor(root, e, "9.9.9"); err != nil {
-			t.Errorf("planning %s failed: %v", e.ID, err)
+		for _, d := range e.Deploys {
+			if len(d.ValuesPaths) > 0 {
+				if _, err := PlanForValuesPaths(root, e, "9.9.9", d.ValuesPaths); err != nil {
+					t.Errorf("planning %s (%s values paths) failed: %v", e.ID, d.Service, err)
+				}
+				continue
+			}
+			if _, err := PlanFor(root, e, "9.9.9"); err != nil {
+				t.Errorf("planning %s failed: %v", e.ID, err)
+			}
 		}
 		seen++
 	}
@@ -419,7 +427,7 @@ func TestAMissingValuesFileLeavesChartYamlAlone(t *testing.T) {
 
 	// With values.yaml gone the chart plans appversion-only, so force the
 	// both-file path directly to exercise the ordering.
-	chart := Entry{ID: "c", Path: "deploy/helm/c", Deploys: []string{"svc"}}
+	chart := Entry{ID: "c", Path: "deploy/helm/c", Deploys: []Deploy{{Service: "svc"}}}
 	err := Apply(f.root, chart, "2.0.0", Plan{Action: ActionBoth, Current: "1.0.0"})
 	if err == nil {
 		t.Fatal("Apply should fail when values.yaml cannot be read")
@@ -534,4 +542,162 @@ func TestBlockImageIsStillAccepted(t *testing.T) {
 	if got := f.read(t, "c", "values.yaml"); !strings.Contains(got, `tag: "2.0.0"`) {
 		t.Fatalf("image tag did not move:\n%s", got)
 	}
+}
+
+func TestValuesPathBumpsOnlyItsOwnFieldInAMultiImageChart(t *testing.T) {
+	// nvca-operator's real shape: one appVersion-owning service (nvca) plus a
+	// sidecar (byoo-otel-collector) whose tag lives at its own values.yaml
+	// path. The declared path must move, appVersion must not, and the other
+	// service's image must not.
+	f := newFixture(t, `{"services":[
+	 {"id":"nvca","path":"src/nvca"},
+	 {"id":"sidecar","path":"src/sidecar"},
+	 {"id":"c","path":"deploy/helm/c","deploys":["nvca",{"service":"sidecar","values_paths":["otelCollector.imageTag"]}]}
+	]}`)
+	f.chart(t, "c", "3.0.0", "image:\n  tag: \"3.0.0\"\notelCollector:\n  imageTag: 0.157.0-nv-0.2.1\n")
+
+	code, out, errOut := f.run(t, "src/sidecar/v0.160.0-nv-0.2.4", true)
+	if code != 0 {
+		t.Fatalf("want a clean bump, got %d\n%s%s", code, out, errOut)
+	}
+	if !strings.Contains(out, "c: 0.157.0-nv-0.2.1 -> 0.160.0-nv-0.2.4 (declared values path(s): otelCollector.imageTag)") {
+		t.Fatalf("plan output did not describe the values-path bump:\n%s", out)
+	}
+	values := f.read(t, "c", "values.yaml")
+	if !strings.Contains(values, "imageTag: \"0.160.0-nv-0.2.4\"") {
+		t.Fatalf("the declared path did not move:\n%s", values)
+	}
+	if !strings.Contains(values, "tag: \"3.0.0\"") {
+		t.Fatalf("the other service's image must be left alone:\n%s", values)
+	}
+	if got := f.read(t, "c", "Chart.yaml"); !strings.Contains(got, `appVersion: "3.0.0"`) {
+		t.Fatalf("appVersion belongs to the other service and must not move:\n%s", got)
+	}
+}
+
+func TestValuesPathsAllMoveTogether(t *testing.T) {
+	// A service can own more than one field in the same chart, as nvca-operator
+	// does with four separate otelCollector.imageTag-shaped fields.
+	f := newFixture(t, `{"services":[
+	 {"id":"sidecar","path":"src/sidecar"},
+	 {"id":"c","path":"deploy/helm/c","deploys":[{"service":"sidecar","values_paths":["a.tag","b.tag"]}]}
+	]}`)
+	f.chart(t, "c", "0.0.0", "a:\n  tag: \"1.0.0\"\nb:\n  tag: \"1.0.0\"\n")
+
+	if code, _, errOut := f.run(t, "src/sidecar/v2.0.0", true); code != 0 {
+		t.Fatalf("want a clean bump, got %d\n%s", code, errOut)
+	}
+	values := f.read(t, "c", "values.yaml")
+	if strings.Count(values, `tag: "2.0.0"`) != 2 {
+		t.Fatalf("both declared paths should have moved:\n%s", values)
+	}
+}
+
+func TestValuesPathsDisagreeRefusesRatherThanForcingAgreement(t *testing.T) {
+	f := newFixture(t, `{"services":[
+	 {"id":"sidecar","path":"src/sidecar"},
+	 {"id":"c","path":"deploy/helm/c","deploys":[{"service":"sidecar","values_paths":["a.tag","b.tag"]}]}
+	]}`)
+	f.chart(t, "c", "0.0.0", "a:\n  tag: \"1.0.0\"\nb:\n  tag: \"9.9.9\"\n")
+	before := f.read(t, "c", "values.yaml")
+
+	code, _, errOut := f.run(t, "src/sidecar/v2.0.0", true)
+	if code != RefusedExit {
+		t.Fatalf("want refusal, got %d", code)
+	}
+	if !strings.Contains(errOut, "declared values paths disagree") {
+		t.Fatalf("want the disagreement reason:\n%s", errOut)
+	}
+	if after := f.read(t, "c", "values.yaml"); after != before {
+		t.Fatalf("nothing may be written on a refusal:\n%s", after)
+	}
+}
+
+func TestValuesPathNotFoundIsAClearRefusal(t *testing.T) {
+	f := newFixture(t, `{"services":[
+	 {"id":"sidecar","path":"src/sidecar"},
+	 {"id":"c","path":"deploy/helm/c","deploys":[{"service":"sidecar","values_paths":["missing.tag"]}]}
+	]}`)
+	f.chart(t, "c", "0.0.0", "a:\n  tag: \"1.0.0\"\n")
+
+	code, _, errOut := f.run(t, "src/sidecar/v2.0.0", false)
+	if code != RefusedExit {
+		t.Fatalf("want refusal, got %d", code)
+	}
+	if !strings.Contains(errOut, `values path "missing.tag" not found`) {
+		t.Fatalf("want the not-found reason:\n%s", errOut)
+	}
+}
+
+func TestValuesPathDistinguishesRepeatedLeafKeysByFullAncestry(t *testing.T) {
+	// Two fields both end in "imageTag", nested under different parents. A
+	// nearest-parent-only match cannot tell them apart; this is why
+	// resolveValuesPath walks the full path instead.
+	f := newFixture(t, `{"services":[
+	 {"id":"sidecar","path":"src/sidecar"},
+	 {"id":"c","path":"deploy/helm/c","deploys":[{"service":"sidecar","values_paths":["helmManaged.otelCollector.imageTag"]}]}
+	]}`)
+	f.chart(t, "c", "0.0.0",
+		"otelCollector:\n  imageTag: 0.157.0-nv-0.2.1\nhelmManaged:\n  otelCollector:\n    imageTag: 0.157.0-nv-0.2.1\n")
+
+	if code, _, errOut := f.run(t, "src/sidecar/v0.160.0-nv-0.2.4", true); code != 0 {
+		t.Fatalf("want a clean bump, got %d\n%s", code, errOut)
+	}
+	values := f.read(t, "c", "values.yaml")
+	if !strings.Contains(values, "otelCollector:\n  imageTag: 0.157.0-nv-0.2.1") {
+		t.Fatalf("the top-level field was not declared, so it must be left alone verbatim:\n%s", values)
+	}
+	if !strings.Contains(values, "    imageTag: \"0.160.0-nv-0.2.4\"") {
+		t.Fatalf("the declared nested field did not move:\n%s", values)
+	}
+}
+
+func TestValuesPathRerunIsANoOp(t *testing.T) {
+	f := newFixture(t, `{"services":[
+	 {"id":"sidecar","path":"src/sidecar"},
+	 {"id":"c","path":"deploy/helm/c","deploys":[{"service":"sidecar","values_paths":["otelCollector.imageTag"]}]}
+	]}`)
+	f.chart(t, "c", "0.0.0", "otelCollector:\n  imageTag: 1.0.0\n")
+	f.run(t, "src/sidecar/v2.0.0", true)
+	before := f.read(t, "c", "values.yaml")
+
+	code, out, _ := f.run(t, "src/sidecar/v2.0.0", true)
+	if code != 0 {
+		t.Fatalf("a repeat run should be clean, got %d", code)
+	}
+	if !strings.Contains(out, "already 2.0.0") {
+		t.Fatalf("it should say the chart is already there:\n%s", out)
+	}
+	if after := f.read(t, "c", "values.yaml"); after != before {
+		t.Fatalf("a repeat run rewrote the file:\n%s\n---\n%s", before, after)
+	}
+}
+
+func TestDeployEntryAcceptsBothStringAndObjectShapesInOneList(t *testing.T) {
+	// nvca-operator's real declaration mixes a bare string (nvca, default
+	// appVersion evidence) with an object (byoo-otel-collector, explicit
+	// paths) in the same deploys list.
+	m := decodeMetadata(t, `{"services":[
+	 {"id":"c","path":"deploy/helm/c","deploys":["nvca",{"service":"sidecar","values_paths":["a.tag"]}]}
+	]}`)
+	entry := m.Services[0]
+	if len(entry.Deploys) != 2 {
+		t.Fatalf("want 2 deploy entries, got %d", len(entry.Deploys))
+	}
+	if entry.Deploys[0].Service != "nvca" || len(entry.Deploys[0].ValuesPaths) != 0 {
+		t.Fatalf("the string form should decode as a bare service with no paths: %+v", entry.Deploys[0])
+	}
+	if entry.Deploys[1].Service != "sidecar" || strings.Join(entry.Deploys[1].ValuesPaths, ",") != "a.tag" {
+		t.Fatalf("the object form should decode its service and paths: %+v", entry.Deploys[1])
+	}
+}
+
+func decodeMetadata(t *testing.T, body string) *Metadata {
+	t.Helper()
+	f := newFixture(t, body)
+	m, err := LoadMetadata(f.root)
+	if err != nil {
+		t.Fatalf("metadata did not decode: %v", err)
+	}
+	return m
 }

--- a/tools/chart-version-bumper/main_test.go
+++ b/tools/chart-version-bumper/main_test.go
@@ -701,3 +701,15 @@ func decodeMetadata(t *testing.T, body string) *Metadata {
 	}
 	return m
 }
+
+func TestEmptyStringDeployEntryIsRejected(t *testing.T) {
+	// json.Unmarshal happily decodes "" (and null) into a Go string without
+	// error, so the string-form branch must reject it explicitly. Otherwise a
+	// typo'd `"deploys": [""]` silently becomes a Deploy with no service id:
+	// ChartsDeploying then finds no match for anything and the run reports
+	// "nothing to do" with exit 0 instead of failing on the bad metadata.
+	f := newFixture(t, `{"services":[{"id":"c","path":"deploy/helm/c","deploys":[""]}]}`)
+	if _, err := LoadMetadata(f.root); err == nil {
+		t.Fatal("an empty string-form deploys entry must fail to decode")
+	}
+}

--- a/tools/chart-version-bumper/metadata.go
+++ b/tools/chart-version-bumper/metadata.go
@@ -21,7 +21,44 @@ const ChartPrefix = "deploy/helm/"
 type Entry struct {
 	ID      string   `json:"id"`
 	Path    string   `json:"path"`
-	Deploys []string `json:"deploys"`
+	Deploys []Deploy `json:"deploys"`
+}
+
+// Deploy is one service a chart ships. A plain JSON string names the service
+// and leaves ValuesPaths empty, so PlanFor/Apply use the default evidence: the
+// chart's single image tag agrees with its appVersion, or it does not.
+//
+// A chart that ships more than one first-party image cannot use that
+// evidence: several tags could equal the old appVersion, or none could,
+// without saying which one is this service's. For that case a deploy entry
+// is an object naming ValuesPaths, the exact values.yaml paths (dotted, for
+// example "otelCollector.imageTag") that carry this service's tag. Those
+// paths move to the released version and nothing else does: appVersion is
+// left alone, because in a multi-image chart it belongs to whichever other
+// service (if any) uses the default single-image evidence.
+type Deploy struct {
+	Service     string
+	ValuesPaths []string
+}
+
+func (d *Deploy) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err == nil {
+		*d = Deploy{Service: s}
+		return nil
+	}
+	var obj struct {
+		Service     string   `json:"service"`
+		ValuesPaths []string `json:"values_paths"`
+	}
+	if err := json.Unmarshal(b, &obj); err != nil {
+		return fmt.Errorf("deploys entry: %w", err)
+	}
+	if obj.Service == "" {
+		return fmt.Errorf("deploys entry missing \"service\"")
+	}
+	*d = Deploy{Service: obj.Service, ValuesPaths: obj.ValuesPaths}
+	return nil
 }
 
 // Metadata is the decoded release metadata file.
@@ -71,16 +108,26 @@ func (m *Metadata) ServiceForTag(tag string) (serviceID, version string, err err
 	return bestID, tag[len(bestPath)+2:], nil
 }
 
-// ChartsDeploying returns the chart entries that declare they deploy serviceID.
-func (m *Metadata) ChartsDeploying(serviceID string) []Entry {
-	var out []Entry
+// ChartDeploy pairs a chart entry with how the released service's tag is
+// found in it. ValuesPaths is empty for the default appVersion/image-tag
+// agreement evidence, and holds the declared dotted paths when the deploy
+// edge named them explicitly.
+type ChartDeploy struct {
+	Entry
+	ValuesPaths []string
+}
+
+// ChartsDeploying returns the chart entries that declare they deploy
+// serviceID, one ChartDeploy per chart.
+func (m *Metadata) ChartsDeploying(serviceID string) []ChartDeploy {
+	var out []ChartDeploy
 	for _, e := range m.Services {
 		if !strings.HasPrefix(e.Path, ChartPrefix) {
 			continue
 		}
-		for _, s := range e.Deploys {
-			if s == serviceID {
-				out = append(out, e)
+		for _, d := range e.Deploys {
+			if d.Service == serviceID {
+				out = append(out, ChartDeploy{Entry: e, ValuesPaths: d.ValuesPaths})
 				break
 			}
 		}

--- a/tools/chart-version-bumper/metadata.go
+++ b/tools/chart-version-bumper/metadata.go
@@ -44,6 +44,9 @@ type Deploy struct {
 func (d *Deploy) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err == nil {
+		if s == "" {
+			return fmt.Errorf("deploys entry: empty service id")
+		}
 		*d = Deploy{Service: s}
 		return nil
 	}

--- a/tools/ci/github-release-subprojects.json
+++ b/tools/ci/github-release-subprojects.json
@@ -267,7 +267,16 @@
       "service_name": "helm-nvca-operator",
       "legacy_tag_prefix": "helm-nvca-operator-v",
       "deploys": [
-        "nvca"
+        "nvca",
+        {
+          "service": "byoo-otel-collector",
+          "values_paths": [
+            "otelCollector.imageTag",
+            "agent.byooOtelCollector.imageTag",
+            "helmManaged.otelCollector.imageTag",
+            "selfManaged.otelCollector.imageTag"
+          ]
+        }
       ]
     },
     {


### PR DESCRIPTION
## Why
byoo-otel-collector's v0.160.0 upgrade (#1674) landed as `chore`, so it never actually published a new image (#1692 fixed that going forward). Once #1692 published the real release (`src/compute-plane-services/byoo-otel-collector/v0.160.0-nv-0.2.4`), this repo's existing `chart-version-bump` automation (runs on every GitHub `release: published` event) tried to reach the NVCA operator chart and reported:

```
no chart declares that it deploys byoo-otel-collector; nothing to do
```

`nvca-operator`'s `deploys` edge in `tools/ci/github-release-subprojects.json` only names `"nvca"`. Declaring `byoo-otel-collector` too isn't enough by itself: `chart-version-bumper` identifies which `values.yaml` line belongs to a released service purely by matching it against the chart's single `appVersion`, and `nvca-operator` ships more than one first-party image (the operator binary and the otel collector sidecar), so that single-image heuristic can't tell which of several tags is whose.

## What changed
- **`tools/chart-version-bumper`**: a `deploys` entry may now be an object naming explicit `values.yaml` paths (dotted, e.g. `otelCollector.imageTag`) that carry a given service's tag, alongside the existing plain-string form for the single-image default. Declared paths move to the released version; `appVersion` and every other field are left alone. Paths that disagree with each other, or that can't be found, refuse rather than guess. `chart-service-edge`'s audit tool gets the same `Deploy` type so it keeps decoding both shapes.
- **`tools/ci/github-release-subprojects.json`**: `nvca-operator` now also declares `byoo-otel-collector`, naming its four otel-collector-sidecar fields (`otelCollector.imageTag`, `agent.byooOtelCollector.imageTag`, `helmManaged.otelCollector.imageTag`, `selfManaged.otelCollector.imageTag`).
- Ran the bumper against the real release tag and applied it: `deploy/helm/nvca-operator/nvca-operator/values.yaml`'s four fields move from `0.157.0-nv-0.2.1` to `0.160.0-nv-0.2.4`.
- **Vendoring fix (required, not optional)**: `deploy/helm/nvca-operator/nvca-operator` is regenerated wholesale from `src/compute-plane-services/nvca/deployments/nvca-operator` on every `make vendor-chart`, and CI's "chart is synced with its monorepo source" check runs that regeneration on every PR. Confirmed locally that this silently reverted the bump. Three fields already survive this (`nvcaVersion`, chart `appVersion`, `sharedStorage.imageTag`) because the vendor script re-applies them from whatever's already committed in the vendored copy; added the same treatment for the four otel collector fields via a new `NVCA_OTEL_COLLECTOR_IMAGE_TAG` override in `ci_vendor_nvca_operator_chart`, wired into the CI step and the local `vendor_chart_image_tag_test.sh` that invoke it.
- Fixed two release-checklist test scripts (`otel_collector_compatibility_test.sh`, `self_managed_nvca_image_reference_test.sh`) that hardcoded the prior tag as a literal, so they now read the expected value from `values.yaml` instead (this repo's documented version-pin-assertion convention). Neither runs in current GitHub Actions CI; both are part of the manual NVCA release checklist per `ai-tooling/dev/skills/nvca-chart-release`.
- Updated that skill doc to document the new `NVCA_OTEL_COLLECTOR_IMAGE_TAG` input.

## Customer Release Notes
Not customer visible: chart default catches up to an already-published collector image; no runtime behavior change until the chart is next installed or upgraded.

## Plan Summary
`deploy/helm/nvca-operator/nvca-operator/values.yaml`: `otelCollector.imageTag`, `agent.byooOtelCollector.imageTag`, `helmManaged.otelCollector.imageTag`, `selfManaged.otelCollector.imageTag` move from `0.157.0-nv-0.2.1` to `0.160.0-nv-0.2.4`. No other chart fields change.

## Usage
Going forward, a byoo-otel-collector release automatically opens a chart-version-bump PR against this chart (existing `chart-version-bump.yml` automation, now unblocked for this edge). Manual vendoring (`make vendor-chart` in `deploy/helm/nvca-operator`) requires `NVCA_OTEL_COLLECTOR_IMAGE_TAG` in addition to the three previously-required version inputs; see the updated `nvca-chart-release` skill.

## Testing
- `go test -C tools/chart-service-edge ./...` and `go test -C tools/chart-version-bumper ./...`, including new tests for the multi-image/values-paths behavior (agreement, disagreement refusal, not-found refusal, rerun no-op, repeated-leaf-key disambiguation, mixed string/object `deploys` decoding).
- `python3 tools/ci/test-github-release.py` (unaffected, still 46/46).
- Ran `go run -C tools/chart-version-bumper . --tag src/compute-plane-services/byoo-otel-collector/v0.160.0-nv-0.2.4 --write` against the real repo tree and reviewed the resulting diff.
- `deploy/helm/nvca-operator/tests/vendor_chart_image_tag_test.sh` passes.
- Ran `make check-vendor-chart` (with the new env var) against a real commit of the bump and confirmed it passes cleanly; separately confirmed (before the vendor-script fix) that it silently reverts the bump without it.
- Ran the two updated test scripts (`otel_collector_compatibility_test.sh`, `self_managed_nvca_image_reference_test.sh`) against the bumped chart; the latter passes end-to-end, the former passes every assertion up to its `docker run` step (no Docker available in this environment to pull and validate the published image itself). QA recommended: running these two scripts with Docker available, and confirming a fresh chart install/upgrade picks up the new collector image correctly.

## Notes
This chart-version-bumper/chart-service-edge multi-image capability is reusable: any future chart that ships more than one first-party image can declare the same `values_paths` shape instead of being stuck on the single-image heuristic.

## References
Closes #1696

## Related Pull Requests
Follow-up to #1674 and #1692

## Dependencies
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Chart release tooling now supports updating multiple explicitly declared image-value paths, including charts with multiple collector images.
  - Deployment metadata supports service entries with optional value paths.

- **Updates**
  - OpenTelemetry Collector images used by the NVCA Operator and its deployment modes are updated to version `0.160.0-nv-0.2.4`.
  - Release automation keeps collector image versions synchronized across relevant chart configurations.

- **Documentation**
  - Added guidance for collector version bumps and release-triggering changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->