### PR TITLE
fix(tools): scan every stack in stack-pin-resolver, not just self-managed

### DIFF
--- a/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
+++ b/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
@@ -166,7 +166,7 @@ releases:
     # The chart appVersion owns the operator image version. Compute-plane base
     # values own the NVCA application version used by this stack.
     chart: nvcf/helm-nvca-operator
-    version: 1.22.2
+    version: 1.24.0
     namespace: nvca-operator
     values:
       - ../global.yaml.gotmpl

--- a/tools/stack-pin-resolver/main.go
+++ b/tools/stack-pin-resolver/main.go
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Command stack-pin-resolver resolves which self-managed stack pins a released
-// chart, and edits them.
+// Command stack-pin-resolver resolves which stack pins (across every stack
+// under deploy/stacks, not just self-managed) a released chart, and edits
+// them.
 //
 //	stack-pin-resolver --audit
 //	stack-pin-resolver --tag deploy/helm/nats/v0.8.0 [--write]

--- a/tools/stack-pin-resolver/main_test.go
+++ b/tools/stack-pin-resolver/main_test.go
@@ -586,3 +586,55 @@ func TestDigDefaultExtractsTheLastQuotedArgument(t *testing.T) {
 		t.Fatalf("want the last quoted argument as the resolved version:\n%s%s", out, errOut)
 	}
 }
+
+func TestDigDefaultThatIsNotAVersionIsUnresolved(t *testing.T) {
+	// dig accepts any quoted string as its default, not just a version. A
+	// floating value like "latest", or an empty default, must be reported
+	// unresolved rather than accepted as a legitimate pin, matching what a
+	// plain (non-templated) version line already requires.
+	for _, bad := range []string{`"latest"`, `""`} {
+		body := "releases:\n  - name: alpha\n    version: {{ dig \"x\" \"version\" " + bad + " .Values | quote }}\n"
+		f := newStack(t, stackMeta, map[string]string{"00-stack.yaml.gotmpl": body})
+		code, out, errOut := f.audit(t)
+		if code != 1 {
+			t.Errorf("default %s: want unresolved, got exit %d\n%s", bad, code, out)
+		}
+		if !strings.Contains(errOut, "not a recognisable pin") {
+			t.Errorf("default %s: want the unreadable-pin reason, got %q", bad, errOut)
+		}
+	}
+}
+
+func TestWritePinRefusesADigExpressionEditedSinceLoadStack(t *testing.T) {
+	// LoadStack resolves the version from whatever dig(...) expression it
+	// reads. If that line is edited to a different key or default before
+	// WritePin runs, rewriting its new default would silently overwrite a
+	// value this run never saw or reported, only because the edited line
+	// still happens to match the dig-default shape.
+	f := newStack(t, stackMeta, map[string]string{
+		"00-stack.yaml.gotmpl": "releases:\n  - name: alpha\n" +
+			"    version: {{ dig \"x\" \"version\" \"1.0.0\" .Values | quote }}\n",
+	})
+	releases, err := LoadStack(f.root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(releases) != 1 || !releases[0].DigDefault {
+		t.Fatalf("fixture did not resolve as expected: %+v", releases)
+	}
+	r := releases[0]
+
+	// Something else edits the same line to a different key/default between
+	// LoadStack and WritePin.
+	f.fileAt(t, defaultStackDir, "00-stack.yaml.gotmpl",
+		"releases:\n  - name: alpha\n    version: {{ dig \"y\" \"version\" \"9.9.9\" .Values | quote }}\n")
+
+	if err := WritePin(f.root, r, "2.0.0"); err == nil {
+		t.Fatal("WritePin must refuse a dig expression that changed since LoadStack")
+	} else if !strings.Contains(err.Error(), "no longer the dig-default version pin this run resolved") {
+		t.Fatalf("want the changed-expression reason, got: %v", err)
+	}
+	if got := f.read(t, "00-stack.yaml.gotmpl"); !strings.Contains(got, `"9.9.9"`) {
+		t.Fatalf("the edited line must be left alone:\n%s", got)
+	}
+}

--- a/tools/stack-pin-resolver/main_test.go
+++ b/tools/stack-pin-resolver/main_test.go
@@ -16,6 +16,11 @@ import (
 // tests below care most about unresolved releases being loud, and about a
 // rewrite landing on exactly one line.
 
+// defaultStackDir is the stack every existing test fixture writes into
+// unless it names another one. Any directory matching StacksGlob would do;
+// this one is just a stand-in for "some stack".
+const defaultStackDir = "deploy/stacks/self-managed/helmfile.d"
+
 type stackFixture struct{ root string }
 
 func newStack(t *testing.T, metadata string, files map[string]string) *stackFixture {
@@ -27,16 +32,23 @@ func newStack(t *testing.T, metadata string, files map[string]string) *stackFixt
 	if err := os.WriteFile(filepath.Join(f.root, MetadataPath), []byte(metadata), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	dir := filepath.Join(f.root, HelmfileDir)
+	for name, body := range files {
+		f.fileAt(t, defaultStackDir, name, body)
+	}
+	return f
+}
+
+// fileAt writes a helmfile into an arbitrary stack directory, for tests that
+// need a release to live in a stack other than defaultStackDir.
+func (f *stackFixture) fileAt(t *testing.T, stackDir, name, body string) {
+	t.Helper()
+	dir := filepath.Join(f.root, stackDir)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	for name, body := range files {
-		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
-			t.Fatal(err)
-		}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
 	}
-	return f
 }
 
 func (f *stackFixture) audit(t *testing.T) (int, string, string) {
@@ -61,7 +73,12 @@ func (f *stackFixture) bump(t *testing.T, tag string, write bool) (int, string, 
 
 func (f *stackFixture) read(t *testing.T, name string) string {
 	t.Helper()
-	b, err := os.ReadFile(filepath.Join(f.root, HelmfileDir, name))
+	return f.readAt(t, defaultStackDir, name)
+}
+
+func (f *stackFixture) readAt(t *testing.T, stackDir, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(f.root, stackDir, name))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +91,8 @@ const stackMeta = `{"services":[
  {"id":"reval","path":"deploy/helm/reval","service_name":"helm-reval"},
  {"id":"router","path":"deploy/helm/router","service_name":"helm-nvcf-llm-request-router"},
  {"id":"orphan","path":"deploy/helm/orphan","service_name":"helm-nvcf-orphan"},
- {"id":"nameless","path":"deploy/helm/nameless"}
+ {"id":"nameless","path":"deploy/helm/nameless"},
+ {"id":"nvca-operator","path":"deploy/helm/nvca-operator","service_name":"helm-nvca-operator"}
 ]}`
 
 // alpha and beta are both pinned at 1.0.0 on purpose: a rewrite that is merely
@@ -483,5 +501,88 @@ func TestBumpReportsTheSemverStepOfThePin(t *testing.T) {
 	_, out, _ := f.bump(t, "deploy/helm/alpha/v1.0.0", false)
 	if strings.Contains(out, "bump:") {
 		t.Errorf("already-pinned run must not report a level:\n%s", out)
+	}
+}
+
+func TestReleaseInAnotherStackIsFound(t *testing.T) {
+	// nvca-operator's real bug: its pin lives only in
+	// deploy/stacks/nvcf-compute-plane, and a resolver hardcoded to
+	// deploy/stacks/self-managed never saw it, so a real release
+	// ("no stack release pins helm-nvca-operator") reported success on
+	// nothing moving. Scanning every stack is the fix; this pins it down.
+	//
+	// alpha (in the default stack from stackFile) and nvca-operator (only in
+	// the other stack) pin unrelated charts, so bumping nvca-operator must
+	// leave the default stack's file byte-identical: that is the proof both
+	// stacks were scanned independently rather than one masking the other.
+	f := newStack(t, stackMeta, map[string]string{"00-stack.yaml.gotmpl": stackFile})
+	before := f.read(t, "00-stack.yaml.gotmpl")
+	otherStack := "deploy/stacks/nvcf-compute-plane/helmfile.d"
+	f.fileAt(t, otherStack, "02-nvca.yaml.gotmpl", "releases:\n  - name: nvca-operator\n    chart: nvcf/helm-nvca-operator\n    version: 1.22.2\n")
+
+	code, out, errOut := f.bump(t, "deploy/helm/nvca-operator/v1.24.0", true)
+	if code != 0 {
+		t.Fatalf("want a clean bump, got %d\n%s%s", code, out, errOut)
+	}
+	if !strings.Contains(out, "nvca-operator: 1.22.2 -> 1.24.0") {
+		t.Fatalf("the release in the other stack should have moved:\n%s", out)
+	}
+	if got := f.readAt(t, otherStack, "02-nvca.yaml.gotmpl"); !strings.Contains(got, "version: 1.24.0") {
+		t.Fatalf("the other stack's file was not rewritten:\n%s", got)
+	}
+	if got := f.read(t, "00-stack.yaml.gotmpl"); got != before {
+		t.Fatalf("the default stack must be untouched:\n%s", got)
+	}
+}
+
+func TestAuditListsReleasesFromEveryStack(t *testing.T) {
+	f := newStack(t, stackMeta, map[string]string{"00-stack.yaml.gotmpl": stackFile})
+	f.fileAt(t, "deploy/stacks/nvcf-compute-plane/helmfile.d", "02-nvca.yaml.gotmpl",
+		"releases:\n  - name: nvca-operator\n    chart: nvcf/helm-nvca-operator\n    version: 1.22.2\n")
+	_, out, _ := f.audit(t)
+	if !strings.Contains(out, "nvca-operator") {
+		t.Fatalf("audit must list releases from every stack, not just the default one:\n%s", out)
+	}
+}
+
+func TestDigDefaultVersionResolvesAndBumps(t *testing.T) {
+	// The observability stack's real shape: version is templated so an
+	// environment file can override it, with a literal default embedded in
+	// the dig(...) call. That default is this chart's actual shipped version
+	// absent an override, and the one an automated bump must move.
+	body := "releases:\n  - name: victoria-metrics\n    chart: nvcf/victoria-metrics-single\n" +
+		"    version: {{ dig \"victoriaMetrics\" \"version\" \"0.45.0\" .Values | quote }}\n"
+	f := newStack(t, `{"services":[{"id":"vm","path":"deploy/helm/victoria-metrics-single","service_name":"victoria-metrics-single"}]}`,
+		map[string]string{"00-stack.yaml.gotmpl": body})
+
+	if code, out, errOut := f.audit(t); code != 0 {
+		t.Fatalf("a dig-default version must resolve, got %d\n%s%s", code, out, errOut)
+	} else if !strings.Contains(out, "0.45.0") {
+		t.Fatalf("audit should report the dig default as the current version:\n%s", out)
+	}
+
+	code, out, errOut := f.bump(t, "deploy/helm/victoria-metrics-single/v0.46.0", true)
+	if code != 0 {
+		t.Fatalf("want a clean bump, got %d\n%s%s", code, out, errOut)
+	}
+	if !strings.Contains(out, "victoria-metrics: 0.45.0 -> 0.46.0") {
+		t.Fatalf("plan output did not describe the dig-default bump:\n%s", out)
+	}
+	got := f.read(t, "00-stack.yaml.gotmpl")
+	want := "    version: {{ dig \"victoriaMetrics\" \"version\" \"0.46.0\" .Values | quote }}\n"
+	if !strings.Contains(got, want) {
+		t.Fatalf("the dig default should have moved and the template preserved:\n%s", got)
+	}
+}
+
+func TestDigDefaultExtractsTheLastQuotedArgument(t *testing.T) {
+	// dig takes one or more path keys before its default. The capture must
+	// land on the default (the argument immediately before .Values), not an
+	// earlier key that also happens to be quoted.
+	body := "releases:\n  - name: alpha\n    version: {{ dig \"a\" \"b\" \"c\" \"9.9.9\" .Values | quote }}\n"
+	f := newStack(t, stackMeta, map[string]string{"00-stack.yaml.gotmpl": body})
+	_, out, errOut := f.audit(t)
+	if !strings.Contains(out, "9.9.9") {
+		t.Fatalf("want the last quoted argument as the resolved version:\n%s%s", out, errOut)
 	}
 }

--- a/tools/stack-pin-resolver/stack.go
+++ b/tools/stack-pin-resolver/stack.go
@@ -79,6 +79,14 @@ type Release struct {
 	// scalar. WritePin then replaces only the quoted default inside that
 	// expression, leaving the surrounding template untouched.
 	DigDefault bool
+	// DigExpression is the exact value half of the version line (m[2] in
+	// LoadStack) when DigDefault is set. WritePin requires the line to still
+	// hold this exact text before rewriting: matching digVersionDefaultRE
+	// again only proves the current line looks like *some* dig(...) default,
+	// not that it is still the same one LoadStack read. Without this, an
+	// edit that changed which key or default the expression names between
+	// LoadStack and WritePin would have its new default silently overwritten.
+	DigExpression string
 }
 
 // ChartNameForRelease returns the chart a stack release pins.
@@ -158,14 +166,20 @@ func LoadStack(root string) ([]Release, error) {
 			fieldIndent := blk.indent + 2
 			versionLine, version, malformed := -1, "", ""
 			digDefault := false
+			digExpression := ""
 			for i, line := range body {
 				m := versionLineRE.FindStringSubmatch(line)
 				if m == nil || len(m[1])-len("version:")-countTrailingSpace(m[1]) != fieldIndent {
 					continue
 				}
 				if !versionValueRE.MatchString(m[2]) {
-					if dm := digVersionDefaultRE.FindStringSubmatch(m[2]); dm != nil {
-						versionLine, version, digDefault = blk.start+i, dm[1], true
+					// The extracted default must itself pass the same version
+					// check a plain scalar would: dig accepts any quoted
+					// string, so "latest" or "" would otherwise resolve as a
+					// legitimate pin and either report false success or have
+					// Bump overwrite it with something that was never a version.
+					if dm := digVersionDefaultRE.FindStringSubmatch(m[2]); dm != nil && versionValueRE.MatchString(dm[1]) {
+						versionLine, version, digDefault, digExpression = blk.start+i, dm[1], true, m[2]
 						break
 					}
 					// A release-level version that cannot be read is reported.
@@ -183,7 +197,10 @@ func LoadStack(root string) ([]Release, error) {
 				continue
 			}
 
-			r := Release{Name: blk.name, File: relPath, Version: version, VersionLine: versionLine, DigDefault: digDefault}
+			r := Release{
+				Name: blk.name, File: relPath, Version: version, VersionLine: versionLine,
+				DigDefault: digDefault, DigExpression: digExpression,
+			}
 			if malformed != "" {
 				r.Unresolved = fmt.Sprintf("version is not a recognisable pin: %s", malformed)
 				out = append(out, r)
@@ -250,13 +267,20 @@ func WritePin(root string, r Release, version string) error {
 		return fmt.Errorf("%s: line %d in %s is no longer a version pin", r.Release(), r.VersionLine+1, path)
 	}
 	if r.DigDefault {
+		// Require the exact expression LoadStack read, not just something
+		// that still matches the dig-default shape: shape alone cannot tell
+		// this expression apart from one edited to name a different key or
+		// default between LoadStack and WritePin, and rewriting that one
+		// would overwrite a value this run never resolved or reported.
+		if m[2] != r.DigExpression {
+			return fmt.Errorf("%s: line %d in %s is no longer the dig-default version pin this run resolved", r.Release(), r.VersionLine+1, path)
+		}
 		// Replace only the quoted default inside the dig(...) expression, so
 		// the template around it, and any environment override it still
-		// respects, survive the bump untouched.
+		// respects, survive the bump untouched. The match cannot fail: m[2]
+		// is byte-identical to r.DigExpression, which LoadStack only set
+		// after this same regex matched it.
 		idx := digVersionDefaultRE.FindStringSubmatchIndex(m[2])
-		if idx == nil {
-			return fmt.Errorf("%s: line %d in %s is no longer a dig-default version pin", r.Release(), r.VersionLine+1, path)
-		}
 		lines[r.VersionLine] = m[1] + m[2][:idx[2]] + version + m[2][idx[3]:] + m[3]
 	} else {
 		lines[r.VersionLine] = m[1] + version + m[3]

--- a/tools/stack-pin-resolver/stack.go
+++ b/tools/stack-pin-resolver/stack.go
@@ -12,8 +12,12 @@ import (
 	"strings"
 )
 
-// HelmfileDir holds the self-managed stack's release definitions.
-const HelmfileDir = "deploy/stacks/self-managed/helmfile.d"
+// StacksGlob matches every stack's release definitions. A chart is not
+// necessarily deployed by the self-managed stack: nvca-operator, for
+// example, is pinned only in deploy/stacks/nvcf-compute-plane. Scanning every
+// stack instead of one hardcoded directory is what lets Audit's "no chart
+// resolves to this release" check mean what it says.
+const StacksGlob = "deploy/stacks/*/helmfile.d"
 
 var (
 	nameRE  = regexp.MustCompile(`^(\s+)- name:\s*(\S+)`)
@@ -38,11 +42,26 @@ var (
 	// The default is the chart used unless an operator overrides it, so it is
 	// the one an automated bump should follow.
 	defaultChartRE = regexp.MustCompile(`default\s+"([^"]+)"`)
+	// A version line templated the same way an environment can override any
+	// other release field:
+	//   version: {{ dig "prometheusOperatorCrds" "version" "31.0.1" .Values | quote }}
+	// dig's last argument before .Values is its default, used unless an
+	// environment file sets prometheusOperatorCrds.version. That default is
+	// the version this chart actually ships at absent an override, so it is
+	// the value an automated bump reads and rewrites. The non-capturing group
+	// consumes every earlier quoted dig key so the capture always lands on the
+	// last one.
+	digVersionDefaultRE = regexp.MustCompile(`dig\s+(?:"[^"]*"\s+)*"([^"]*)"\s+\.Values`)
 )
 
 // A Release is one pinned entry in the stack.
 type Release struct {
 	Name string
+	// File is the helmfile path relative to root, for example
+	// deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl. Kept
+	// relative to root, not just the basename, so WritePin can reconstruct
+	// the full path directly: a release can live in any stack, not only the
+	// one a caller happens to be thinking about.
 	File string
 	// Chart is the published chart name this release pins, empty when
 	// Unresolved is set.
@@ -55,6 +74,11 @@ type Release struct {
 	// VersionLine is the index into the file's lines holding the pin, so the
 	// rewrite can replace exactly that line and nothing else.
 	VersionLine int
+	// DigDefault is set when the version pin is a
+	// `dig ... "<default>" .Values` template expression rather than a plain
+	// scalar. WritePin then replaces only the quoted default inside that
+	// expression, leaving the surrounding template untouched.
+	DigDefault bool
 }
 
 // ChartNameForRelease returns the chart a stack release pins.
@@ -108,7 +132,7 @@ func lastPathSegment(s string) string {
 // lookahead, and Go's regexp engine has none. Tracking line numbers also lets
 // the rewrite replace one exact line instead of reconstructing a block.
 func LoadStack(root string) ([]Release, error) {
-	paths, err := filepath.Glob(filepath.Join(root, HelmfileDir, "*.yaml.gotmpl"))
+	paths, err := filepath.Glob(filepath.Join(root, StacksGlob, "*.yaml.gotmpl"))
 	if err != nil {
 		return nil, err
 	}
@@ -116,6 +140,10 @@ func LoadStack(root string) ([]Release, error) {
 
 	var out []Release
 	for _, path := range paths {
+		relPath, err := filepath.Rel(root, path)
+		if err != nil {
+			return nil, fmt.Errorf("relativize %s: %w", path, err)
+		}
 		b, err := os.ReadFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("read %s: %w", path, err)
@@ -129,12 +157,17 @@ func LoadStack(root string) ([]Release, error) {
 			// pin would rewrite an unrelated key.
 			fieldIndent := blk.indent + 2
 			versionLine, version, malformed := -1, "", ""
+			digDefault := false
 			for i, line := range body {
 				m := versionLineRE.FindStringSubmatch(line)
 				if m == nil || len(m[1])-len("version:")-countTrailingSpace(m[1]) != fieldIndent {
 					continue
 				}
 				if !versionValueRE.MatchString(m[2]) {
+					if dm := digVersionDefaultRE.FindStringSubmatch(m[2]); dm != nil {
+						versionLine, version, digDefault = blk.start+i, dm[1], true
+						break
+					}
 					// A release-level version that cannot be read is reported.
 					// Skipping it would drop a real pin silently, which is the
 					// failure this tool exists to prevent.
@@ -150,7 +183,7 @@ func LoadStack(root string) ([]Release, error) {
 				continue
 			}
 
-			r := Release{Name: blk.name, File: filepath.Base(path), Version: version, VersionLine: versionLine}
+			r := Release{Name: blk.name, File: relPath, Version: version, VersionLine: versionLine, DigDefault: digDefault}
 			if malformed != "" {
 				r.Unresolved = fmt.Sprintf("version is not a recognisable pin: %s", malformed)
 				out = append(out, r)
@@ -201,7 +234,7 @@ func countTrailingSpace(s string) int {
 
 // WritePin replaces the version on a single release's pin line.
 func WritePin(root string, r Release, version string) error {
-	path := filepath.Join(root, HelmfileDir, r.File)
+	path := filepath.Join(root, r.File)
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("read %s: %w", path, err)
@@ -216,7 +249,18 @@ func WritePin(root string, r Release, version string) error {
 		// would corrupt the stack, so stop instead.
 		return fmt.Errorf("%s: line %d in %s is no longer a version pin", r.Release(), r.VersionLine+1, path)
 	}
-	lines[r.VersionLine] = m[1] + version + m[3]
+	if r.DigDefault {
+		// Replace only the quoted default inside the dig(...) expression, so
+		// the template around it, and any environment override it still
+		// respects, survive the bump untouched.
+		idx := digVersionDefaultRE.FindStringSubmatchIndex(m[2])
+		if idx == nil {
+			return fmt.Errorf("%s: line %d in %s is no longer a dig-default version pin", r.Release(), r.VersionLine+1, path)
+		}
+		lines[r.VersionLine] = m[1] + m[2][:idx[2]] + version + m[2][idx[3]:] + m[3]
+	} else {
+		lines[r.VersionLine] = m[1] + version + m[3]
+	}
 
 	mode := os.FileMode(0o644)
 	if fi, err := os.Stat(path); err == nil {


### PR DESCRIPTION
## Why
`stack-pin-bump.yml` failed on every recent `nvca-operator` chart release, including `v1.23.0` and `v1.23.1` (both predating the otelcol work in #1674/#1692/#1697), with `no stack release pins helm-nvca-operator`. Root cause: `tools/stack-pin-resolver`'s `HelmfileDir` constant was hardcoded to `deploy/stacks/self-managed/helmfile.d`, but `nvca-operator`'s actual pin lives only in `deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl` (stale at `version: 1.22.2`, well behind the `v1.24.0` cut by #1697).

## What changed
- `StacksGlob = "deploy/stacks/*/helmfile.d"` replaces the single hardcoded `HelmfileDir`. `Release.File` now holds the path relative to repo root (not just a basename), so `WritePin` can reconstruct the correct path for a release living in any stack.
- Scanning every stack surfaced a second, previously invisible gap: `TestRealStackResolvesCompletely` (an audit-completeness regression test against the real checked-in stack) started failing, because the observability stack's `prometheus-operator-crds`, `opentelemetry-operator`, and `victoria-metrics` releases pin their version through a templated `dig "key" "version" "<default>" .Values | quote` expression, not a plain scalar - the audit had simply never been able to see them before. Added resolution and a byte-precise rewrite of the quoted default inside that expression, mirroring how `ChartNameForRelease` already resolves a chart line's `default "..."` form. The surrounding template (and the environment override it still respects) is left untouched.
- Applied the bump this unblocks: `deploy/stacks/nvcf-compute-plane`'s `nvca-operator` pin moves from `1.22.2` to `1.24.0`, matching the version already cut by #1697.

## Customer Release Notes
Not customer visible: internal release tooling fix plus a stack pin catching up to an already-published chart version.

## Plan Summary
`deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl`: `nvca-operator` release `version` moves from `1.22.2` to `1.24.0`. No other stack files change (observability's three dig-default releases are now correctly *resolved*, not rewritten - their versions did not change).

## Usage
`go run ./tools/stack-pin-resolver --audit` now reports 31 releases across all three stacks with 0 unresolved (previously it only ever saw whichever releases happened to live in `deploy/stacks/self-managed`).

## Testing
- `go test ./tools/stack-pin-resolver/...`, including new tests: a release resolved and bumped from a non-self-managed stack, audit listing releases from every stack, dig-default version resolution and a bump that only rewrites the quoted default, and a case with multiple quoted `dig` keys to confirm the capture lands on the last one (the default), not an earlier key.
- Ran `go run ./tools/stack-pin-resolver --audit` and `--tag deploy/helm/nvca-operator/v1.24.0 [--write]` against the real repo tree; the plan and diff are exactly the one-line version bump shown above.
- `bash tools/ci/test-check-helm-charts` and `./tools/ci/check-helm-charts` (lints and renders all 16 charts, including `nvca-operator`) both pass.

## Notes
Follow-up to #1697, which cut the `nvca-operator` chart release this stack pin was stuck unable to reach.

## References
Closes #1700

## Related Pull Requests
Follow-up to #1697

## Dependencies
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Updated the NVCA Operator to version 1.24.0.

- **Improvements**
  - Stack pin resolution now discovers and updates releases across all deployment stacks.
  - Supports resolving and updating versions defined through templated defaults while preserving surrounding configuration.
  - Audit and version-bumping workflows now cover releases across multiple stacks.
  - Version-bumping results now include the detected semantic-version increment in machine-readable output.

- **Bug Fixes**
  - Prevents updates when a templated version expression has changed since it was loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->