### PR TITLE
fix(release): register the infra/openbao and infra/cassandra image sources

### DIFF
--- a/tools/ci/github-release-subprojects.json
+++ b/tools/ci/github-release-subprojects.json
@@ -215,6 +215,11 @@
       "legacy_tag_prefix": "helm-nvcf-cassandra-v"
     },
     {
+      "id": "cassandra-image",
+      "path": "infra/cassandra",
+      "service_name": "nvcf-cassandra"
+    },
+    {
       "id": "api-keys-colocated",
       "path": "deploy/helm/api-keys-colocated",
       "service_name": "helm-nvcf-api-keys",
@@ -225,6 +230,11 @@
       "path": "deploy/helm/openbao",
       "service_name": "helm-nvcf-openbao-server",
       "legacy_tag_prefix": "helm-nvcf-openbao-server-v"
+    },
+    {
+      "id": "openbao-image",
+      "path": "infra/openbao",
+      "service_name": "nvcf-openbao"
     },
     {
       "id": "cert-manager",

--- a/tools/ci/test-github-release.py
+++ b/tools/ci/test-github-release.py
@@ -881,6 +881,58 @@ class GithubReleaseTest(unittest.TestCase):
         self.assertFalse(self.github_release.should_process_auto_service(nvca, "grpc-proxy", "main", "main"))
         self.assertTrue(self.github_release.should_process_auto_service(grpc_proxy, "grpc-proxy", "main", "main"))
 
+    # Image sources that live beside a chart of the same name. Each pair
+    # releases independently: the chart from deploy/helm/<name>, the image
+    # from infra/<name>. The image tag prefix is what the internal publishing
+    # configuration dispatches on, so it is pinned here.
+    INFRA_IMAGE_SOURCES = (
+        ("openbao-image", "infra/openbao", "openbao", "deploy/helm/openbao"),
+        ("cassandra-image", "infra/cassandra", "cassandra", "deploy/helm/cassandra"),
+    )
+
+    def test_infra_image_sources_release_independently_of_their_charts(self):
+        root = SCRIPT_PATH.parents[2]
+        metadata = json.loads(SCRIPT_PATH.with_name("github-release-subprojects.json").read_text())
+        by_id = {service["id"]: service for service in metadata["services"]}
+        self.assertEqual(len(by_id), len(metadata["services"]), "service ids must be unique")
+
+        for image_id, image_path, chart_id, chart_path in self.INFRA_IMAGE_SOURCES:
+            with self.subTest(image=image_id):
+                image, chart = by_id[image_id], by_id[chart_id]
+                self.assertEqual(image["path"], image_path)
+                self.assertEqual(chart["path"], chart_path)
+                self.assertNotEqual(image["service_name"], chart["service_name"])
+                # Default tag format from the path: this exact prefix is what
+                # the internal image lane is configured to dispatch on.
+                self.assertEqual(self.github_release.tag_prefix(image, root), f"{image_path}/v")
+                self.assertEqual(self.github_release.tag_prefix(chart, root), f"{chart_path}/v")
+
+    def test_release_worthy_infra_commit_touches_the_image_stream_only(self):
+        # A fix under infra/openbao must release infra/openbao/v* and leave the
+        # deploy/helm/openbao stream untouched, and the reverse.
+        image = {"id": "openbao-image", "path": "infra/openbao", "service_name": "nvcf-openbao"}
+        chart = {"id": "openbao", "path": "deploy/helm/openbao", "service_name": "helm-nvcf-openbao-server"}
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.init_repo(root)
+            for path in (image["path"], chart["path"]):
+                (root / path).mkdir(parents=True)
+                (root / path / "README.md").write_text(f"{path}\n")
+            self.commit_all(root, "seed openbao chart and image")
+            git(root, "tag", "infra/openbao/v1.3.1")
+            git(root, "tag", "deploy/helm/openbao/v0.32.2")
+
+            (root / image["path"] / "README.md").write_text("fix(openbao): bump grpc\n")
+            self.commit_all(root, "fix(openbao): bump grpc")
+
+            self.assertTrue(self.github_release.releases_a_version("fix(openbao): bump grpc"))
+            with chdir(root), contextlib.redirect_stdout(io.StringIO()):
+                self.assertFalse(self.github_release.only_generated_changes(root, image, []))
+                self.assertTrue(self.github_release.only_generated_changes(root, chart, []))
+                self.assertEqual(
+                    self.github_release.latest_service_tag(image, root), "infra/openbao/v1.3.1"
+                )
+
     def test_no_service_uses_the_retired_version_file_model(self):
         metadata = json.loads(SCRIPT_PATH.with_name("github-release-subprojects.json").read_text())
         for service in metadata["services"]:


### PR DESCRIPTION
## Why

The release catalog registers the OpenBao and Cassandra Helm charts (deploy/helm/openbao, deploy/helm/cassandra) but not the image sources beside them (infra/openbao, infra/cassandra), which version independently. Fix commits merged under both paths (#1477 and #1677 for OpenBao; #1611 and #1678 for Cassandra). The release-tags run completed green without evaluating either path, so no infra/*/v* tag was cut and no replacement image was published. ncp-dev still serves nvcf-openbao 1.3.1 and cassandra 5.0.9-nv-2.0.2.

## What changed

- `tools/ci/github-release-subprojects.json`: two entries, `openbao-image` at `infra/openbao` and `cassandra-image` at `infra/cassandra`, each with its own `service_name`. The chart entries are unchanged. The default tag format from the path gives `infra/<name>/v${version}`, which is the prefix the internal image lane dispatches on and matches the existing `infra/openbao/v1.3.1` and `infra/cassandra/v2.0.2` tags, both reachable from main, so no `initial_version` is needed.
- `tools/ci/test-github-release.py`:
  - a catalog invariant that both image sources are registered, ids are unique, the chart and image `service_name`s differ, and the derived tag prefixes are exactly `infra/openbao/v` and `infra/cassandra/v`;
  - a repo-fixture test that a `fix(openbao)` commit under `infra/openbao` is release-worthy for the image entry, is a no-op for the chart entry, and anchors on `infra/openbao/v1.3.1`.

## Testing

`python3 tools/ci/test-github-release.py`: 48 tests pass (46 before, plus the two above).

## Notes

Merging this to main triggers release-tags, which evaluates both paths and cuts the missed patches (expected `infra/openbao/v1.3.2` and `infra/cassandra/v2.0.3`). The internal lane then dispatches the image builds. No manual backfill needed.

Closes #1705
Closes #1706


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Improvements**
  - Cassandra and OpenBao infrastructure images now have dedicated release configuration.
  - Infrastructure images can be released independently from similarly named Helm charts.
  - Infrastructure-only updates are isolated to the corresponding image release stream and do not trigger chart releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->