### PR TITLE
fix(function-autoscaler): enable custom policies by default

### DIFF
--- a/docs/user/configure-autoscaling.md
+++ b/docs/user/configure-autoscaling.md
@@ -11,7 +11,7 @@ All requests require an `NVCF_TOKEN` (JWT) with the `deploy_function` scope.
 
 ## Scope of Autoscaling
 
-The function autoscaler operates per function version. It produces a single desired instance count for a given `(functionId, versionId)` pair; the GPU specification ID and deployment ID are not part of its decision. The `PATCH /v2/nvcf/deployments/.../gpu-specifications/{gpuSpecificationId}` endpoint is per-spec on the wire, but the resulting scaling decision applies at the function-version level. If a deployment has more than one GPU specification, set the autoscaling policy consistently across its specs.
+The function autoscaler operates per function version. It produces a single desired instance count for a given `(functionId, versionId)` pair; the GPU specification ID and deployment ID are not part of its decision. The `PATCH /v2/nvcf/deployments/.../gpu-specifications/{gpuSpecificationId}` endpoint is per-spec on the wire, but the resulting scaling decision applies at the function-version level. If a deployment has more than one GPU specification, set the autoscaling policy consistently across its specs. If the control plane returns conflicting custom policies for the specs, the autoscaler logs a warning and uses the platform defaults for that function version.
 
 ## Set Scaling Bounds at Deploy Time
 
@@ -82,7 +82,7 @@ The body must include at least one of `minInstances`, `maxInstances`, `autoscali
 
 ## Customize the Autoscaling Policy
 
-By default, every deployment uses the platform's autoscaling policy. To override it with per-function scale-up and scale-down behavior, send an `autoscalingConfiguration` block on the `PATCH` request.
+By default, the self-hosted function autoscaler checks for a per-function custom policy. When no custom policy exists, or the policy cannot be fetched, it uses the platform defaults. To set per-function scale-up and scale-down behavior, send an `autoscalingConfiguration` block on the `PATCH` request.
 
 ```bash
 curl -s -X PATCH "https://${GATEWAY_ADDR}/v2/nvcf/deployments/${DEPLOYMENT_ID}/gpu-specifications/${GPU_SPEC_ID}" \
@@ -160,7 +160,7 @@ curl -s -X PATCH "https://${GATEWAY_ADDR}/v2/nvcf/deployments/${DEPLOYMENT_ID}/g
   }'
 ```
 
-The GPU spec uses the platform's autoscaling policy on the next scaling cycle.
+The function version uses the platform's autoscaling policy after the policy cache refreshes. The default cache lifetime is five minutes.
 
 ## See Also
 

--- a/src/control-plane-services/function-autoscaler/crates/server/resources/settings-local.yaml
+++ b/src/control-plane-services/function-autoscaler/crates/server/resources/settings-local.yaml
@@ -51,11 +51,12 @@ scaling:
   lookback_seconds: 600
   decay_factor: 0.1
   policy:
-    type: Static
+    type: Custom
     settings:
-      scaling_thresholds:
+      ttl_seconds: 300
+      default_thresholds:
         scale_up_threshold: 70.0
         scale_down_threshold: 30.0
-      scaling_factors:
+      default_factors:
         scale_up_factor: 1.2
         scale_down_factor: 0.8

--- a/src/control-plane-services/function-autoscaler/crates/server/resources/settings-local.yaml
+++ b/src/control-plane-services/function-autoscaler/crates/server/resources/settings-local.yaml
@@ -54,6 +54,7 @@ scaling:
     type: Custom
     settings:
       ttl_seconds: 300
+      request_timeout_seconds: 30
       default_thresholds:
         scale_up_threshold: 70.0
         scale_down_threshold: 30.0

--- a/src/control-plane-services/function-autoscaler/crates/server/src/scaling/mod.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/scaling/mod.rs
@@ -58,6 +58,9 @@ fn default_policy_cache_max_capacity() -> u64 {
 fn default_policy_cache_ttl_seconds() -> u64 {
     300
 }
+fn default_policy_request_timeout_seconds() -> u64 {
+    30
+}
 fn default_discovery_recently_invoked_lookback_minutes() -> u64 {
     5
 }
@@ -241,6 +244,8 @@ pub enum ScalingPolicy {
 pub struct CustomScalingPolicyConfig {
     #[serde(rename = "ttl_seconds")]
     pub ttl_seconds: u64,
+    #[serde(default = "default_policy_request_timeout_seconds")]
+    pub request_timeout_seconds: u64,
     // Fallback defaults when custom policy fetch fails
     pub default_thresholds: ScalingThresholds,
     pub default_factors: ScalingFactors,
@@ -250,6 +255,7 @@ impl Default for CustomScalingPolicyConfig {
     fn default() -> Self {
         Self {
             ttl_seconds: default_policy_cache_ttl_seconds(),
+            request_timeout_seconds: default_policy_request_timeout_seconds(),
             default_thresholds: ScalingThresholds::default(),
             default_factors: ScalingFactors::default(),
         }
@@ -505,6 +511,7 @@ mod tests {
             panic!("default scaling policy should be Custom");
         };
         assert_eq!(config.ttl_seconds, 300);
+        assert_eq!(config.request_timeout_seconds, 30);
         assert_eq!(config.default_thresholds, ScalingThresholds::default());
         assert_eq!(config.default_factors, ScalingFactors::default());
     }

--- a/src/control-plane-services/function-autoscaler/crates/server/src/scaling/mod.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/scaling/mod.rs
@@ -55,6 +55,9 @@ fn default_cassandra_page_size() -> i32 {
 fn default_policy_cache_max_capacity() -> u64 {
     10_000
 }
+fn default_policy_cache_ttl_seconds() -> u64 {
+    300
+}
 fn default_discovery_recently_invoked_lookback_minutes() -> u64 {
     5
 }
@@ -119,7 +122,7 @@ impl Default for ScalingSettings {
             discover_new_functions_interval: default_discover_interval(),
             decay_factor: 0.0,
             lookback: default_lookback(),
-            policy: ScalingPolicy::Static(StaticScalingPolicy::default()),
+            policy: ScalingPolicy::Custom(CustomScalingPolicyConfig::default()),
             discovery_lock_duration: default_discovery_lock_duration(),
             scale_to_zero_idle_timeout: default_scale_to_zero_idle_timeout(),
             utilization_window_seconds: default_utilization_window_seconds(),
@@ -197,7 +200,7 @@ impl ScalingSettings {
 /// Stickiness window for scaling decisions.
 /// Scaling only triggers if utilization was past the threshold for at least
 /// `required_minutes` out of the last `window_minutes`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Stickiness {
     pub window_minutes: u32,
     pub required_minutes: u32,
@@ -243,13 +246,23 @@ pub struct CustomScalingPolicyConfig {
     pub default_factors: ScalingFactors,
 }
 
+impl Default for CustomScalingPolicyConfig {
+    fn default() -> Self {
+        Self {
+            ttl_seconds: default_policy_cache_ttl_seconds(),
+            default_thresholds: ScalingThresholds::default(),
+            default_factors: ScalingFactors::default(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct StaticScalingPolicy {
     pub scaling_thresholds: ScalingThresholds,
     pub scaling_factors: ScalingFactors,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(default)]
 pub struct ScalingThresholds {
     pub scale_up_threshold: f32,
@@ -265,7 +278,7 @@ impl Default for ScalingThresholds {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(default)]
 pub struct ScalingFactors {
     pub scale_up_factor: f32,
@@ -483,6 +496,18 @@ pub fn decide_scaling(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn default_settings_enable_custom_policy_lookup() {
+        let settings = ScalingSettings::default();
+
+        let ScalingPolicy::Custom(config) = settings.policy else {
+            panic!("default scaling policy should be Custom");
+        };
+        assert_eq!(config.ttl_seconds, 300);
+        assert_eq!(config.default_thresholds, ScalingThresholds::default());
+        assert_eq!(config.default_factors, ScalingFactors::default());
+    }
 
     fn default_policy() -> ResolvedScalingPolicy {
         ResolvedScalingPolicy {

--- a/src/control-plane-services/function-autoscaler/crates/server/src/scaling/policy_cache.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/scaling/policy_cache.rs
@@ -52,6 +52,7 @@ impl PolicyCache {
         grpc_endpoint: String,
         oauth2_client: Arc<OAuth2Client>,
         ttl_seconds: u64,
+        request_timeout_seconds: u64,
         max_capacity: u64,
         default_thresholds: ScalingThresholds,
         default_factors: ScalingFactors,
@@ -61,7 +62,13 @@ impl PolicyCache {
             .time_to_live(Duration::from_secs(ttl_seconds))
             .build();
 
-        let grpc_client = Arc::new(PolicyClient::new_lazy(grpc_endpoint, oauth2_client)?);
+        let grpc_client = Arc::new(PolicyClient::new_lazy(
+            grpc_endpoint,
+            oauth2_client,
+            Duration::from_secs(request_timeout_seconds),
+            default_thresholds.clone(),
+            default_factors.clone(),
+        )?);
 
         Ok(Self {
             cache,
@@ -188,6 +195,7 @@ mod tests {
             "http://localhost:50051".to_string(),
             oauth2_client,
             86400,
+            30,
             10000,
             ScalingThresholds::default(),
             ScalingFactors::default(),
@@ -204,6 +212,7 @@ mod tests {
             "http://localhost:50051".to_string(),
             oauth2_client,
             86400,
+            30,
             10000,
             ScalingThresholds::default(),
             ScalingFactors::default(),
@@ -223,6 +232,7 @@ mod tests {
             "http://localhost:50051".to_string(),
             oauth2_client,
             86400,
+            30,
             10000,
             ScalingThresholds::default(),
             ScalingFactors::default(),

--- a/src/control-plane-services/function-autoscaler/crates/server/src/scaling/policy_cache.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/scaling/policy_cache.rs
@@ -86,11 +86,20 @@ impl PolicyCache {
 
         // Cache miss - fetch from gRPC
         match self.fetch_from_grpc(function_version_id).await {
-            Ok(config) => {
+            Ok(Some(config)) => {
                 // Store in cache
                 self.cache.insert(function_version_id, config.clone()).await;
                 tracing::info!(
                     "Successfully fetched and cached custom policy for function_version_id: {}",
+                    function_version_id
+                );
+                Ok(config)
+            }
+            Ok(None) => {
+                let config = self.get_default_config(function_version_id);
+                self.cache.insert(function_version_id, config.clone()).await;
+                tracing::debug!(
+                    "Cached platform-default policy for function_version_id: {}",
                     function_version_id
                 );
                 Ok(config)
@@ -107,7 +116,10 @@ impl PolicyCache {
     }
 
     /// Fetch policy from gRPC service
-    async fn fetch_from_grpc(&self, function_version_id: Uuid) -> Result<CustomScalingConfig> {
+    async fn fetch_from_grpc(
+        &self,
+        function_version_id: Uuid,
+    ) -> Result<Option<CustomScalingConfig>> {
         self.grpc_client.fetch_policy(function_version_id).await
     }
 

--- a/src/control-plane-services/function-autoscaler/crates/server/src/scaling/policy_client.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/scaling/policy_client.rs
@@ -21,7 +21,9 @@ use crate::nvcf_api::oauth2_client::OAuth2Client;
 use anyhow::{bail, Context, Result};
 use chrono::Utc;
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::Arc;
+use std::time::Duration;
 use tonic::metadata::MetadataValue;
 use tonic::transport::Channel;
 use uuid::Uuid;
@@ -33,6 +35,7 @@ pub mod nvcf_proto {
 
 use nvcf_proto::{
     autoscaler_client::AutoscalerClient, AutoscalingConfiguration, DeploymentConfigurationRequest,
+    DeploymentConfigurationResponse,
 };
 
 /// gRPC client for fetching custom scaling policies.
@@ -41,15 +44,27 @@ use nvcf_proto::{
 pub struct PolicyClient {
     channel: Channel,
     oauth2_client: Arc<OAuth2Client>,
+    request_timeout: Duration,
+    default_thresholds: ScalingThresholds,
+    default_factors: ScalingFactors,
 }
 
 impl PolicyClient {
     /// Create a PolicyClient with lazy connection (connects on first use).
-    pub fn new_lazy(endpoint: String, oauth2_client: Arc<OAuth2Client>) -> Result<Self> {
+    pub fn new_lazy(
+        endpoint: String,
+        oauth2_client: Arc<OAuth2Client>,
+        request_timeout: Duration,
+        default_thresholds: ScalingThresholds,
+        default_factors: ScalingFactors,
+    ) -> Result<Self> {
         let channel = lazy_grpc_channel(&endpoint)?;
         Ok(Self {
             channel,
             oauth2_client,
+            request_timeout,
+            default_thresholds,
+            default_factors,
         })
     }
 
@@ -83,31 +98,69 @@ impl PolicyClient {
         });
 
         // Make gRPC call
-        let response = client
-            .request_deployment_configuration(request)
-            .await
-            .context("gRPC call to NVCF RequestDeploymentConfiguration failed")?
-            .into_inner();
+        let response = await_policy_response(
+            client.request_deployment_configuration(request),
+            self.request_timeout,
+        )
+        .await?
+        .into_inner();
 
-        resolve_policy(function_version_id, response.configs)
+        resolve_policy(
+            function_version_id,
+            response.configs,
+            &self.default_thresholds,
+            &self.default_factors,
+        )
     }
+}
+
+async fn await_policy_response<F>(
+    response: F,
+    request_timeout: Duration,
+) -> Result<tonic::Response<DeploymentConfigurationResponse>>
+where
+    F: Future<
+        Output = std::result::Result<
+            tonic::Response<DeploymentConfigurationResponse>,
+            tonic::Status,
+        >,
+    >,
+{
+    tokio::time::timeout(request_timeout, response)
+        .await
+        .with_context(|| {
+            format!("gRPC RequestDeploymentConfiguration timed out after {request_timeout:?}")
+        })?
+        .context("gRPC call to NVCF RequestDeploymentConfiguration failed")
 }
 
 fn resolve_policy(
     function_version_id: Uuid,
     configs: HashMap<String, AutoscalingConfiguration>,
+    default_thresholds: &ScalingThresholds,
+    default_factors: &ScalingFactors,
 ) -> Result<Option<CustomScalingConfig>> {
     let mut configs = configs.into_iter();
     let Some((first_gpu_spec_id, first_gpu_config)) = configs.next() else {
         return Ok(None);
     };
 
-    let policy = parse_policy(function_version_id, &first_gpu_config)?;
+    let policy = parse_policy(
+        function_version_id,
+        &first_gpu_config,
+        default_thresholds,
+        default_factors,
+    )?;
     let mut gpu_spec_ids = vec![first_gpu_spec_id];
     let mut has_conflict = false;
 
     for (gpu_spec_id, gpu_config) in configs {
-        let candidate = parse_policy(function_version_id, &gpu_config)?;
+        let candidate = parse_policy(
+            function_version_id,
+            &gpu_config,
+            default_thresholds,
+            default_factors,
+        )?;
         gpu_spec_ids.push(gpu_spec_id);
         if !same_policy(&policy, &candidate) {
             has_conflict = true;
@@ -137,23 +190,24 @@ fn same_policy(left: &CustomScalingConfig, right: &CustomScalingConfig) -> bool 
 fn parse_policy(
     function_version_id: Uuid,
     gpu_config: &AutoscalingConfiguration,
+    default_thresholds: &ScalingThresholds,
+    default_factors: &ScalingFactors,
 ) -> Result<CustomScalingConfig> {
-    // Extract scale-up details
-    let scale_up = gpu_config
-        .scale_up_details
-        .as_ref()
-        .context("No scale_up_details in GPU config")?;
+    let scale_up = gpu_config.scale_up_details.as_ref();
+    let scale_down = gpu_config.scale_down_details.as_ref();
 
-    // Extract scale-down details
-    let scale_down = gpu_config
-        .scale_down_details
-        .as_ref()
-        .context("No scale_down_details in GPU config")?;
-
-    let scale_up_threshold = scale_up.threshold as f32;
-    let scale_down_threshold = scale_down.threshold as f32;
-    let scale_up_factor = scale_up.factor;
-    let scale_down_factor = scale_down.factor;
+    let scale_up_threshold = scale_up
+        .map(|details| details.threshold as f32)
+        .unwrap_or(default_thresholds.scale_up_threshold);
+    let scale_down_threshold = scale_down
+        .map(|details| details.threshold as f32)
+        .unwrap_or(default_thresholds.scale_down_threshold);
+    let scale_up_factor = scale_up
+        .map(|details| details.factor)
+        .unwrap_or(default_factors.scale_up_factor);
+    let scale_down_factor = scale_down
+        .map(|details| details.factor)
+        .unwrap_or(default_factors.scale_down_factor);
 
     // Validate thresholds: up must be greater than down
     if scale_up_threshold <= scale_down_threshold {
@@ -192,31 +246,35 @@ fn parse_policy(
     };
 
     // Extract stickiness windows (optional)
-    let scale_up_stickiness = scale_up.stickiness.as_ref().and_then(|s| {
-        let window = s.size.as_ref()?.seconds as u32 / 60;
-        let required = s.threshold.as_ref()?.seconds as u32 / 60;
-        if window > 0 && required > 0 {
-            Some(Stickiness {
-                window_minutes: window,
-                required_minutes: required,
-            })
-        } else {
-            None
-        }
-    });
+    let scale_up_stickiness = scale_up
+        .and_then(|details| details.stickiness.as_ref())
+        .and_then(|s| {
+            let window = s.size.as_ref()?.seconds as u32 / 60;
+            let required = s.threshold.as_ref()?.seconds as u32 / 60;
+            if window > 0 && required > 0 {
+                Some(Stickiness {
+                    window_minutes: window,
+                    required_minutes: required,
+                })
+            } else {
+                None
+            }
+        });
 
-    let scale_down_stickiness = scale_down.stickiness.as_ref().and_then(|s| {
-        let window = s.size.as_ref()?.seconds as u32 / 60;
-        let required = s.threshold.as_ref()?.seconds as u32 / 60;
-        if window > 0 && required > 0 {
-            Some(Stickiness {
-                window_minutes: window,
-                required_minutes: required,
-            })
-        } else {
-            None
-        }
-    });
+    let scale_down_stickiness = scale_down
+        .and_then(|details| details.stickiness.as_ref())
+        .and_then(|s| {
+            let window = s.size.as_ref()?.seconds as u32 / 60;
+            let required = s.threshold.as_ref()?.seconds as u32 / 60;
+            if window > 0 && required > 0 {
+                Some(Stickiness {
+                    window_minutes: window,
+                    required_minutes: required,
+                })
+            } else {
+                None
+            }
+        });
 
     tracing::info!(
             "Fetched NVCF policy for function_version_id {}: thresholds=[up:{}, down:{}], factors=[up:{}, down:{}], stickiness_up={:?}, stickiness_down={:?}",
@@ -243,6 +301,15 @@ fn parse_policy(
 mod tests {
     use super::*;
     use nvcf_proto::ScalingDetails;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    struct DropProbe(Arc<AtomicBool>);
+
+    impl Drop for DropProbe {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
 
     fn config(scale_up_threshold: i32, scale_down_threshold: i32) -> AutoscalingConfiguration {
         AutoscalingConfiguration {
@@ -261,9 +328,20 @@ mod tests {
         }
     }
 
+    fn resolve(
+        configs: HashMap<String, AutoscalingConfiguration>,
+    ) -> Result<Option<CustomScalingConfig>> {
+        resolve_policy(
+            Uuid::new_v4(),
+            configs,
+            &ScalingThresholds::default(),
+            &ScalingFactors::default(),
+        )
+    }
+
     #[test]
     fn empty_configs_use_platform_defaults() {
-        let result = resolve_policy(Uuid::new_v4(), HashMap::new()).unwrap();
+        let result = resolve(HashMap::new()).unwrap();
 
         assert!(result.is_none());
     }
@@ -273,9 +351,14 @@ mod tests {
         let function_version_id = Uuid::new_v4();
         let configs = HashMap::from([("gpu-spec-1".to_string(), config(75, 25))]);
 
-        let result = resolve_policy(function_version_id, configs)
-            .unwrap()
-            .unwrap();
+        let result = resolve_policy(
+            function_version_id,
+            configs,
+            &ScalingThresholds::default(),
+            &ScalingFactors::default(),
+        )
+        .unwrap()
+        .unwrap();
 
         assert_eq!(result.function_version_id, function_version_id);
         assert_eq!(result.scaling_thresholds.scale_up_threshold, 75.0);
@@ -289,7 +372,7 @@ mod tests {
             ("gpu-spec-2".to_string(), config(75, 25)),
         ]);
 
-        let result = resolve_policy(Uuid::new_v4(), configs).unwrap();
+        let result = resolve(configs).unwrap();
 
         assert!(result.is_some());
     }
@@ -301,8 +384,59 @@ mod tests {
             ("gpu-spec-2".to_string(), config(80, 20)),
         ]);
 
-        let result = resolve_policy(Uuid::new_v4(), configs).unwrap();
+        let result = resolve(configs).unwrap();
 
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn scale_up_only_uses_scale_down_defaults() {
+        let mut custom = config(75, 25);
+        custom.scale_down_details = None;
+        let configs = HashMap::from([("gpu-spec-1".to_string(), custom)]);
+
+        let result = resolve(configs).unwrap().unwrap();
+
+        assert_eq!(result.scaling_thresholds.scale_up_threshold, 75.0);
+        assert_eq!(result.scaling_factors.scale_up_factor, 1.5);
+        assert_eq!(result.scaling_thresholds.scale_down_threshold, 30.0);
+        assert_eq!(result.scaling_factors.scale_down_factor, 0.8);
+    }
+
+    #[test]
+    fn scale_down_only_uses_scale_up_defaults() {
+        let mut custom = config(75, 25);
+        custom.scale_up_details = None;
+        let configs = HashMap::from([("gpu-spec-1".to_string(), custom)]);
+
+        let result = resolve(configs).unwrap().unwrap();
+
+        assert_eq!(result.scaling_thresholds.scale_up_threshold, 70.0);
+        assert_eq!(result.scaling_factors.scale_up_factor, 1.2);
+        assert_eq!(result.scaling_thresholds.scale_down_threshold, 25.0);
+        assert_eq!(result.scaling_factors.scale_down_factor, 0.5);
+    }
+
+    #[tokio::test]
+    async fn stalled_request_times_out_and_is_cancelled() {
+        let dropped = Arc::new(AtomicBool::new(false));
+        let probe = DropProbe(Arc::clone(&dropped));
+        let stalled_request = async move {
+            let _probe = probe;
+            std::future::pending::<
+                std::result::Result<
+                    tonic::Response<DeploymentConfigurationResponse>,
+                    tonic::Status,
+                >,
+            >()
+            .await
+        };
+
+        let error = await_policy_response(stalled_request, Duration::from_millis(1))
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("timed out"));
+        assert!(dropped.load(Ordering::SeqCst));
     }
 }

--- a/src/control-plane-services/function-autoscaler/crates/server/src/scaling/policy_client.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/scaling/policy_client.rs
@@ -20,6 +20,7 @@ use crate::nvcf_api::lazy_grpc_channel;
 use crate::nvcf_api::oauth2_client::OAuth2Client;
 use anyhow::{bail, Context, Result};
 use chrono::Utc;
+use std::collections::HashMap;
 use std::sync::Arc;
 use tonic::metadata::MetadataValue;
 use tonic::transport::Channel;
@@ -30,7 +31,9 @@ pub mod nvcf_proto {
     tonic::include_proto!("nvcf");
 }
 
-use nvcf_proto::{autoscaler_client::AutoscalerClient, DeploymentConfigurationRequest};
+use nvcf_proto::{
+    autoscaler_client::AutoscalerClient, AutoscalingConfiguration, DeploymentConfigurationRequest,
+};
 
 /// gRPC client for fetching custom scaling policies.
 /// Maintains a persistent channel to avoid reconnecting on every request.
@@ -51,7 +54,10 @@ impl PolicyClient {
     }
 
     /// Fetch custom scaling policy for a function version from the NVCF service
-    pub async fn fetch_policy(&self, function_version_id: Uuid) -> Result<CustomScalingConfig> {
+    pub async fn fetch_policy(
+        &self,
+        function_version_id: Uuid,
+    ) -> Result<Option<CustomScalingConfig>> {
         // Get a fresh JWT token via OAuth2 client credentials
         let jwt_token = self
             .oauth2_client
@@ -83,94 +89,136 @@ impl PolicyClient {
             .context("gRPC call to NVCF RequestDeploymentConfiguration failed")?
             .into_inner();
 
-        // Get the first GPU config from the map
-        let gpu_config = response
-            .configs
-            .values()
-            .next()
-            .context("No GPU configs returned in response")?;
+        resolve_policy(function_version_id, response.configs)
+    }
+}
 
-        // Extract scale-up details
-        let scale_up = gpu_config
-            .scale_up_details
-            .as_ref()
-            .context("No scale_up_details in GPU config")?;
+fn resolve_policy(
+    function_version_id: Uuid,
+    configs: HashMap<String, AutoscalingConfiguration>,
+) -> Result<Option<CustomScalingConfig>> {
+    let mut configs = configs.into_iter();
+    let Some((first_gpu_spec_id, first_gpu_config)) = configs.next() else {
+        return Ok(None);
+    };
 
-        // Extract scale-down details
-        let scale_down = gpu_config
-            .scale_down_details
-            .as_ref()
-            .context("No scale_down_details in GPU config")?;
+    let policy = parse_policy(function_version_id, &first_gpu_config)?;
+    let mut gpu_spec_ids = vec![first_gpu_spec_id];
+    let mut has_conflict = false;
 
-        let scale_up_threshold = scale_up.threshold as f32;
-        let scale_down_threshold = scale_down.threshold as f32;
-        let scale_up_factor = scale_up.factor;
-        let scale_down_factor = scale_down.factor;
+    for (gpu_spec_id, gpu_config) in configs {
+        let candidate = parse_policy(function_version_id, &gpu_config)?;
+        gpu_spec_ids.push(gpu_spec_id);
+        if !same_policy(&policy, &candidate) {
+            has_conflict = true;
+        }
+    }
 
-        // Validate thresholds: up must be greater than down
-        if scale_up_threshold <= scale_down_threshold {
-            bail!(
+    if has_conflict {
+        gpu_spec_ids.sort();
+        tracing::warn!(
+            function_version_id = %function_version_id,
+            gpu_spec_ids = ?gpu_spec_ids,
+            "Conflicting custom autoscaling policies; using platform defaults"
+        );
+        return Ok(None);
+    }
+
+    Ok(Some(policy))
+}
+
+fn same_policy(left: &CustomScalingConfig, right: &CustomScalingConfig) -> bool {
+    left.scaling_thresholds == right.scaling_thresholds
+        && left.scaling_factors == right.scaling_factors
+        && left.scale_up_stickiness == right.scale_up_stickiness
+        && left.scale_down_stickiness == right.scale_down_stickiness
+}
+
+fn parse_policy(
+    function_version_id: Uuid,
+    gpu_config: &AutoscalingConfiguration,
+) -> Result<CustomScalingConfig> {
+    // Extract scale-up details
+    let scale_up = gpu_config
+        .scale_up_details
+        .as_ref()
+        .context("No scale_up_details in GPU config")?;
+
+    // Extract scale-down details
+    let scale_down = gpu_config
+        .scale_down_details
+        .as_ref()
+        .context("No scale_down_details in GPU config")?;
+
+    let scale_up_threshold = scale_up.threshold as f32;
+    let scale_down_threshold = scale_down.threshold as f32;
+    let scale_up_factor = scale_up.factor;
+    let scale_down_factor = scale_down.factor;
+
+    // Validate thresholds: up must be greater than down
+    if scale_up_threshold <= scale_down_threshold {
+        bail!(
                 "Invalid thresholds from gRPC for {}: scale_up_threshold ({}) must be > scale_down_threshold ({})",
                 function_version_id,
                 scale_up_threshold,
                 scale_down_threshold,
             );
-        }
+    }
 
-        // Validate factors: up must increase, down must decrease
-        if scale_up_factor <= 1.0 {
-            bail!(
-                "Invalid scale_up_factor from gRPC for {}: {} (must be > 1.0)",
-                function_version_id,
-                scale_up_factor,
-            );
-        }
-        if scale_down_factor <= 0.0 || scale_down_factor >= 1.0 {
-            bail!(
-                "Invalid scale_down_factor from gRPC for {}: {} (must be in (0, 1))",
-                function_version_id,
-                scale_down_factor,
-            );
-        }
-
-        let thresholds = ScalingThresholds {
-            scale_up_threshold,
-            scale_down_threshold,
-        };
-
-        let factors = ScalingFactors {
+    // Validate factors: up must increase, down must decrease
+    if scale_up_factor <= 1.0 {
+        bail!(
+            "Invalid scale_up_factor from gRPC for {}: {} (must be > 1.0)",
+            function_version_id,
             scale_up_factor,
+        );
+    }
+    if scale_down_factor <= 0.0 || scale_down_factor >= 1.0 {
+        bail!(
+            "Invalid scale_down_factor from gRPC for {}: {} (must be in (0, 1))",
+            function_version_id,
             scale_down_factor,
-        };
+        );
+    }
 
-        // Extract stickiness windows (optional)
-        let scale_up_stickiness = scale_up.stickiness.as_ref().and_then(|s| {
-            let window = s.size.as_ref()?.seconds as u32 / 60;
-            let required = s.threshold.as_ref()?.seconds as u32 / 60;
-            if window > 0 && required > 0 {
-                Some(Stickiness {
-                    window_minutes: window,
-                    required_minutes: required,
-                })
-            } else {
-                None
-            }
-        });
+    let thresholds = ScalingThresholds {
+        scale_up_threshold,
+        scale_down_threshold,
+    };
 
-        let scale_down_stickiness = scale_down.stickiness.as_ref().and_then(|s| {
-            let window = s.size.as_ref()?.seconds as u32 / 60;
-            let required = s.threshold.as_ref()?.seconds as u32 / 60;
-            if window > 0 && required > 0 {
-                Some(Stickiness {
-                    window_minutes: window,
-                    required_minutes: required,
-                })
-            } else {
-                None
-            }
-        });
+    let factors = ScalingFactors {
+        scale_up_factor,
+        scale_down_factor,
+    };
 
-        tracing::info!(
+    // Extract stickiness windows (optional)
+    let scale_up_stickiness = scale_up.stickiness.as_ref().and_then(|s| {
+        let window = s.size.as_ref()?.seconds as u32 / 60;
+        let required = s.threshold.as_ref()?.seconds as u32 / 60;
+        if window > 0 && required > 0 {
+            Some(Stickiness {
+                window_minutes: window,
+                required_minutes: required,
+            })
+        } else {
+            None
+        }
+    });
+
+    let scale_down_stickiness = scale_down.stickiness.as_ref().and_then(|s| {
+        let window = s.size.as_ref()?.seconds as u32 / 60;
+        let required = s.threshold.as_ref()?.seconds as u32 / 60;
+        if window > 0 && required > 0 {
+            Some(Stickiness {
+                window_minutes: window,
+                required_minutes: required,
+            })
+        } else {
+            None
+        }
+    });
+
+    tracing::info!(
             "Fetched NVCF policy for function_version_id {}: thresholds=[up:{}, down:{}], factors=[up:{}, down:{}], stickiness_up={:?}, stickiness_down={:?}",
             function_version_id,
             thresholds.scale_up_threshold,
@@ -181,13 +229,80 @@ impl PolicyClient {
             scale_down_stickiness,
         );
 
-        Ok(CustomScalingConfig {
-            function_version_id,
-            scaling_thresholds: thresholds,
-            scaling_factors: factors,
-            scale_up_stickiness,
-            scale_down_stickiness,
-            fetched_at: Utc::now(),
-        })
+    Ok(CustomScalingConfig {
+        function_version_id,
+        scaling_thresholds: thresholds,
+        scaling_factors: factors,
+        scale_up_stickiness,
+        scale_down_stickiness,
+        fetched_at: Utc::now(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nvcf_proto::ScalingDetails;
+
+    fn config(scale_up_threshold: i32, scale_down_threshold: i32) -> AutoscalingConfiguration {
+        AutoscalingConfiguration {
+            scale_up_details: Some(ScalingDetails {
+                metric: "worker_utilization".to_string(),
+                factor: 1.5,
+                threshold: scale_up_threshold,
+                stickiness: None,
+            }),
+            scale_down_details: Some(ScalingDetails {
+                metric: "worker_utilization".to_string(),
+                factor: 0.5,
+                threshold: scale_down_threshold,
+                stickiness: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn empty_configs_use_platform_defaults() {
+        let result = resolve_policy(Uuid::new_v4(), HashMap::new()).unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn single_config_uses_custom_policy() {
+        let function_version_id = Uuid::new_v4();
+        let configs = HashMap::from([("gpu-spec-1".to_string(), config(75, 25))]);
+
+        let result = resolve_policy(function_version_id, configs)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.function_version_id, function_version_id);
+        assert_eq!(result.scaling_thresholds.scale_up_threshold, 75.0);
+        assert_eq!(result.scaling_thresholds.scale_down_threshold, 25.0);
+    }
+
+    #[test]
+    fn identical_configs_use_custom_policy() {
+        let configs = HashMap::from([
+            ("gpu-spec-1".to_string(), config(75, 25)),
+            ("gpu-spec-2".to_string(), config(75, 25)),
+        ]);
+
+        let result = resolve_policy(Uuid::new_v4(), configs).unwrap();
+
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn conflicting_configs_use_platform_defaults() {
+        let configs = HashMap::from([
+            ("gpu-spec-1".to_string(), config(75, 25)),
+            ("gpu-spec-2".to_string(), config(80, 20)),
+        ]);
+
+        let result = resolve_policy(Uuid::new_v4(), configs).unwrap();
+
+        assert!(result.is_none());
     }
 }

--- a/src/control-plane-services/function-autoscaler/crates/server/src/server.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/server.rs
@@ -403,7 +403,11 @@ async fn initialize_scaling_settings(
                 "Using Custom scaling policy - per-function configs from gRPC endpoint: {}",
                 nvcf_api_grpc_address
             );
-            tracing::info!("Cache configuration: TTL={}s", config.ttl_seconds);
+            tracing::info!(
+                "Policy cache configuration: TTL={}s, request timeout={}s",
+                config.ttl_seconds,
+                config.request_timeout_seconds,
+            );
 
             // Create OAuth2 client for gRPC auth (same auth mechanism as NVCF API)
             let oauth2_client = match OAuth2Client::new(
@@ -425,6 +429,7 @@ async fn initialize_scaling_settings(
                 nvcf_api_grpc_address,
                 oauth2_client,
                 config.ttl_seconds,
+                config.request_timeout_seconds,
                 settings.policy_cache_max_capacity,
                 config.default_thresholds.clone(),
                 config.default_factors.clone(),


### PR DESCRIPTION
## TL;DR

Enable per-function custom autoscaling policies by default while preserving the
platform policy as the safe fallback.

## Additional Details

- Change the default and local configuration from `Static` to `Custom`.
- Use and cache the platform defaults when no custom policy exists.
- Apply a custom policy when all returned GPU-spec configurations agree.
- Log a warning and use the platform defaults when GPU-spec policies conflict.
- Document the function-version scope and five-minute cache behavior.

## For the Reviewer

Please focus on policy resolution in `scaling/policy_client.rs`, particularly
the fallback behavior for multiple GPU specifications.

## For QA

- `bazel test //src/control-plane-services/function-autoscaler/crates/server:rs_autoscaler_test`
  - 150 passed
  - 0 failed
  - 10 ignored because they require external infrastructure
- `fern check`
- `git diff --check`

## Issues

Relates to #15

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Autoscaling supports custom policies across GPU configurations.
  * Consistent custom policies are applied across configurations.
  * Missing, incomplete, unavailable, or conflicting policies fall back to platform defaults.
  * Policy requests now use a 30-second timeout, while platform defaults refresh every five minutes.
* **Documentation**
  * Updated autoscaling guidance to explain custom-policy behavior, warnings, partial configurations, and fallback to defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->