### PR TITLE
test(bdd): configure upstream images through stack values

### DIFF
--- a/tests/bdd/features/single-cluster-helmfile-upstream-images.feature
+++ b/tests/bdd/features/single-cluster-helmfile-upstream-images.feature
@@ -21,41 +21,17 @@ Feature: Install a local single-cluster stack with upstream supporting images
     Then the command exit code should be 1
     Given I copy the file "deploy/stacks/self-managed/Makefile.dist" to "deploy/stacks/self-managed/Makefile"
     And I prepare Helmfile environment "local-bdd" for stack "self-managed" from fixture "tests/bdd/fixtures/self-managed-local-bdd.yaml" with values:
-      | global.imagePullSecrets[0].name | nvcr-pull-secret                     |
-      | global.helm.sources.repository  | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM} |
-      | global.image.repository         | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM} |
-      | observability.profile           | disabled                             |
+      | global.imagePullSecrets[0].name       | nvcr-pull-secret                     |
+      | global.helm.sources.repository        | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM} |
+      | global.image.repository               | ${SAMPLE_NGC_ORG}/${SAMPLE_NGC_TEAM} |
+      | observability.profile                 | disabled                             |
+      | nats.reloader.image.registry          | docker.io                            |
+      | nats.reloader.image.repository        | natsio/nats-server-config-reloader   |
+      | nats.reloader.image.tag               | 0.24.0                               |
+      | api.accountBootstrap.image.registry   | docker.io                            |
+      | api.accountBootstrap.image.repository | alpine/k8s                           |
+      | api.accountBootstrap.image.tag        | 1.37.0                               |
     And I prepare self-managed secrets file "deploy/stacks/self-managed/secrets/local-bdd-secrets.yaml" from template "deploy/stacks/self-managed/secrets/secrets.yaml.template" using the current NGC registry credential
-    And I substitute a block in file "deploy/stacks/self-managed/global.yaml.gotmpl":
-      """
-        reloader:
-          image:
-            registry: {{ .Values.global.image.registry }}
-            repository: {{ .Values.global.image.repository }}/nats-server-config-reloader
-            tag: "0.24.0"
-      ---
-        reloader:
-          image:
-            registry: docker.io
-            repository: natsio/nats-server-config-reloader
-            tag: "0.24.0"
-      """
-    And I substitute a block in file "deploy/stacks/self-managed/global.yaml.gotmpl":
-      """
-        accountBootstrap:
-          image:
-            registry: {{ .Values.global.image.registry }}
-            repository: {{ .Values.global.image.repository }}/alpine-k8s
-            tag: 1.37.0
-            pullPolicy: IfNotPresent
-      ---
-        accountBootstrap:
-          image:
-            registry: docker.io
-            repository: alpine/k8s
-            tag: "1.37.0"
-            pullPolicy: IfNotPresent
-      """
     And a single-cluster ncp-local cluster is running
     And the "nvcr-pull-secret" image pull secret exists in namespaces:
       | cassandra-system |


### PR DESCRIPTION
## TL;DR

Configure the upstream supporting images through existing self-managed stack
values instead of rewriting `global.yaml.gotmpl` with exact multiline text
substitutions. This keeps the BDD scenario focused on rendered and installed
behavior when the stack template is refactored.

## Additional Details

### Why

`TestSingleClusterHelmfileUpstreamImages` failed during setup because its exact
template blocks no longer matched current `main`. The public image settings are
already exposed as supported Helmfile environment values, so editing the stack
template in place is unnecessary and brittle.

### What changed

- Set the NATS config reloader image through `nats.reloader.image.*` values.
- Set the API account bootstrap image through
  `api.accountBootstrap.image.*` values.
- Remove the two exact multiline substitutions of `global.yaml.gotmpl`.

### Customer Release Notes

Not customer visible.

### Plan Summary

Not applicable. The rendered image references and installed resources are
unchanged.

### Usage

Not applicable.

### Dependencies

None. No license review or NOTICE update is required.

## For the Reviewer

Please focus on the Helmfile values passed in
`single-cluster-helmfile-upstream-images.feature` and confirm that the scenario
should exercise the public overrides without modifying the stack template.

## For QA

QA is not needed beyond the local validation already completed.

- `TestSingleClusterHelmfileUpstreamImages`: passed twice, 27 of 27 steps.
- Full local non-EKS k3d matrix: 12 passed; one unrelated transient PKI
  registration HTTP 500 was waived after the same test passed earlier and
  later registration workflows passed.
- `go test -short -count=1 ./...`: passed after the final rebase.
- `tests/bdd/scripts/lint.sh`: passed with 0 issues.
- `git diff --check`: passed.
- EKS-only tests were outside the requested local k3d scope.

## Issues

Closes #1709

## Related Pull Requests

None.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated deployment test scenarios to configure required service images through Helmfile environment values.
  - Removed legacy file-replacement steps used to set these image references.
  - Test coverage now reflects the current configuration workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->