### PR TITLE
fix(cassandra): make Maven downloads configurable

### DIFF
--- a/infra/cassandra/Dockerfile
+++ b/infra/cassandra/Dockerfile
@@ -31,7 +31,8 @@ RUN mkdir /tmp/java-libraries && \
       case "${checksum}" in \#*|'') continue ;; esac; \
       destination="/tmp/java-libraries/${artifact_path##*/}"; \
       curl -fsSLo "${destination}" \
-        --retry 5 --retry-all-errors --retry-delay 5 --retry-max-time 120 \
+        --retry 5 --retry-all-errors --retry-delay 5 \
+        --retry-max-time 120 --max-time 120 \
         "${MAVEN_REPOSITORY_BASE%/}/${artifact_path#/}" && \
       printf '%s  %s\n' "${checksum}" "${destination}" | sha256sum -c - || exit 1; \
     done < /tmp/java-libraries.lock

--- a/infra/cassandra/Dockerfile
+++ b/infra/cassandra/Dockerfile
@@ -1,11 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+ARG MAVEN_REPOSITORY_BASE=https://repo.maven.apache.org/maven2
+
 # yq is used by the chart's conf initContainer to deep-merge cassandra.yaml
 # overrides onto the image default. Fetch it in a native build stage (no
 # emulation) and verify it against a pinned checksum.
 FROM --platform=$BUILDPLATFORM alpine:3.21 AS yq-downloader
 ARG TARGETARCH
+ARG MAVEN_REPOSITORY_BASE
 ARG YQ_VERSION=v4.53.6
 ARG YQ_LINUX_AMD64_SHA256=c5f056448f973ae7d39b5401949648a78f2dc1947d6a8eb65be60d5c504b9385
 ARG YQ_LINUX_ARM64_SHA256=88a1016bc1d657375a35864e4f44b6f333df8ff97b559f51bba0adcb2169df09
@@ -24,14 +27,17 @@ RUN apk add --no-cache curl && \
 # checksum-pinned replacement set without adding build tools to the final image.
 COPY java-libraries.lock /tmp/java-libraries.lock
 RUN mkdir /tmp/java-libraries && \
-    while read -r checksum url; do \
+    while read -r checksum artifact_path; do \
       case "${checksum}" in \#*|'') continue ;; esac; \
-      destination="/tmp/java-libraries/${url##*/}"; \
-      curl -fsSLo "${destination}" "${url}" && \
+      destination="/tmp/java-libraries/${artifact_path##*/}"; \
+      curl -fsSLo "${destination}" \
+        --retry 5 --retry-all-errors --retry-delay 5 --retry-max-time 120 \
+        "${MAVEN_REPOSITORY_BASE%/}/${artifact_path#/}" && \
       printf '%s  %s\n' "${checksum}" "${destination}" | sha256sum -c - || exit 1; \
     done < /tmp/java-libraries.lock
 
 FROM --platform=$BUILDPLATFORM alpine:3.21 AS exporter-repacker
+ARG MAVEN_REPOSITORY_BASE
 RUN apk add --no-cache curl unzip zip
 
 # The release build supplies a compatible exporter agent. Replace the complete

--- a/infra/cassandra/README.md
+++ b/infra/cassandra/README.md
@@ -53,6 +53,19 @@ docker build -t <your-registry>/<your-org>/nvcf-cassandra:<version> .
 
 To build with the exporter agent enabled, see the "Exporter agent jar" section above.
 
+Java dependency overlays are downloaded from Maven Central by default. Builders
+can route those checksum-verified downloads through a compatible repository
+manager by setting `MAVEN_REPOSITORY_BASE`:
+
+```bash
+docker build \
+  --build-arg MAVEN_REPOSITORY_BASE=https://repository.example.com/maven2 \
+  -t <your-registry>/<your-org>/nvcf-cassandra:<version> .
+```
+
+The repository must expose Maven-layout paths. Changing the repository base does
+not change the pinned artifact versions or SHA-256 verification.
+
 For multi-arch builds:
 
 ```bash

--- a/infra/cassandra/java-libraries.lock
+++ b/infra/cassandra/java-libraries.lock
@@ -1,21 +1,21 @@
-# SHA-256 and Maven Central URL for Cassandra runtime dependency overlays.
+# SHA-256 and repository-relative path for Cassandra runtime dependency overlays.
 # Jackson annotations follows the upstream family's major.minor versioning.
-53ca085f4a150f703f49e1aabd935bd03b43e1ea3d55d135438292af22cef56b  https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar
-4b40a06396f239f8de2da57419adde6e94e5edc18a2171d471ea05eeed4e5c2d  https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.21.4/jackson-core-2.21.4.jar
-3888e9e69ab66fbacaacc9aea0e9ffbf15368288e4aca468b024dba11c09fbf9  https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.21.4/jackson-databind-2.21.4.jar
-d1ac4b98b70304e56448423589fde5e775b100889643ad1ead62cc7811633684  https://repo.maven.apache.org/maven2/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.21.4/jackson-datatype-jsr310-2.21.4.jar
-3c21d10662148be5e1dc37adea6866faf0e43096a2174c2ef12a4553b45c3af2  https://repo.maven.apache.org/maven2/io/netty/netty-all/4.1.137.Final/netty-all-4.1.137.Final.jar
-f474b14c7734f15e0540394cb6f39d67777b7581a42919e4ac89d253d4efd929  https://repo.maven.apache.org/maven2/io/netty/netty-buffer/4.1.137.Final/netty-buffer-4.1.137.Final.jar
-9987b6a660b0a6b1f0d791485dae33180b3d1c63687c006fe6d3fd025e9e3798  https://repo.maven.apache.org/maven2/io/netty/netty-codec/4.1.137.Final/netty-codec-4.1.137.Final.jar
-d31926b01adcc07af86f5e27b81b6d6c115df17d366e835d1fc3f5a1924e7e52  https://repo.maven.apache.org/maven2/io/netty/netty-common/4.1.137.Final/netty-common-4.1.137.Final.jar
-d0e4c6ee4779f59f6ab2fb5d388e4f57147c82270164b37945764bb9bda96a44  https://repo.maven.apache.org/maven2/io/netty/netty-handler/4.1.137.Final/netty-handler-4.1.137.Final.jar
-843de10c4cef34cbc1a5344090f1b57db532fbebf141559862da675f6b656df4  https://repo.maven.apache.org/maven2/io/netty/netty-handler-proxy/4.1.137.Final/netty-handler-proxy-4.1.137.Final.jar
-6a85347e2d598d28da934cc4d8f68b9990ab7052d8366876b820adfa9a5a81df  https://repo.maven.apache.org/maven2/io/netty/netty-handler-ssl-ocsp/4.1.137.Final/netty-handler-ssl-ocsp-4.1.137.Final.jar
-b4cf2aeedd9fc7c8c439bbfe574f63cfe5b83392e88bbc07ca0e8424b7cff955  https://repo.maven.apache.org/maven2/io/netty/netty-resolver/4.1.137.Final/netty-resolver-4.1.137.Final.jar
-6251adc2a2921572382732a2db188d4f4f2251fd6ebb49c5d44bbf33d6bfb1a7  https://repo.maven.apache.org/maven2/io/netty/netty-transport/4.1.137.Final/netty-transport-4.1.137.Final.jar
-55049554b799dc8e53bf234fffa36e001f7b5b65c32994b9bd59fc6356f1c52f  https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-epoll/4.1.137.Final/netty-transport-classes-epoll-4.1.137.Final.jar
-88d0ac216f9c7be690a9d0157778570d6f4c61f885863da1fccec7fcaee35557  https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-kqueue/4.1.137.Final/netty-transport-classes-kqueue-4.1.137.Final.jar
-b2eb04dbb6ec6cc8fc00aed37bb86b7aed1ccb87722eda44c90652a7d41fbdfe  https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-epoll/4.1.137.Final/netty-transport-native-epoll-4.1.137.Final.jar
-82fb63a2dc90c0bddb81e04065a1c06fb4c5be722ad5d64b46491daf8b6f9a01  https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-epoll/4.1.137.Final/netty-transport-native-epoll-4.1.137.Final-linux-aarch_64.jar
-185db6053e0e9573d36fa4eb6567b26139afaa4daa7bf5a068e661568304542b  https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-epoll/4.1.137.Final/netty-transport-native-epoll-4.1.137.Final-linux-x86_64.jar
-8056e7637f9948f953314894cf995ab664711b66c73c4cd5b593ae84f0b1048c  https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-unix-common/4.1.137.Final/netty-transport-native-unix-common-4.1.137.Final.jar
+53ca085f4a150f703f49e1aabd935bd03b43e1ea3d55d135438292af22cef56b  com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar
+4b40a06396f239f8de2da57419adde6e94e5edc18a2171d471ea05eeed4e5c2d  com/fasterxml/jackson/core/jackson-core/2.21.4/jackson-core-2.21.4.jar
+3888e9e69ab66fbacaacc9aea0e9ffbf15368288e4aca468b024dba11c09fbf9  com/fasterxml/jackson/core/jackson-databind/2.21.4/jackson-databind-2.21.4.jar
+d1ac4b98b70304e56448423589fde5e775b100889643ad1ead62cc7811633684  com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.21.4/jackson-datatype-jsr310-2.21.4.jar
+3c21d10662148be5e1dc37adea6866faf0e43096a2174c2ef12a4553b45c3af2  io/netty/netty-all/4.1.137.Final/netty-all-4.1.137.Final.jar
+f474b14c7734f15e0540394cb6f39d67777b7581a42919e4ac89d253d4efd929  io/netty/netty-buffer/4.1.137.Final/netty-buffer-4.1.137.Final.jar
+9987b6a660b0a6b1f0d791485dae33180b3d1c63687c006fe6d3fd025e9e3798  io/netty/netty-codec/4.1.137.Final/netty-codec-4.1.137.Final.jar
+d31926b01adcc07af86f5e27b81b6d6c115df17d366e835d1fc3f5a1924e7e52  io/netty/netty-common/4.1.137.Final/netty-common-4.1.137.Final.jar
+d0e4c6ee4779f59f6ab2fb5d388e4f57147c82270164b37945764bb9bda96a44  io/netty/netty-handler/4.1.137.Final/netty-handler-4.1.137.Final.jar
+843de10c4cef34cbc1a5344090f1b57db532fbebf141559862da675f6b656df4  io/netty/netty-handler-proxy/4.1.137.Final/netty-handler-proxy-4.1.137.Final.jar
+6a85347e2d598d28da934cc4d8f68b9990ab7052d8366876b820adfa9a5a81df  io/netty/netty-handler-ssl-ocsp/4.1.137.Final/netty-handler-ssl-ocsp-4.1.137.Final.jar
+b4cf2aeedd9fc7c8c439bbfe574f63cfe5b83392e88bbc07ca0e8424b7cff955  io/netty/netty-resolver/4.1.137.Final/netty-resolver-4.1.137.Final.jar
+6251adc2a2921572382732a2db188d4f4f2251fd6ebb49c5d44bbf33d6bfb1a7  io/netty/netty-transport/4.1.137.Final/netty-transport-4.1.137.Final.jar
+55049554b799dc8e53bf234fffa36e001f7b5b65c32994b9bd59fc6356f1c52f  io/netty/netty-transport-classes-epoll/4.1.137.Final/netty-transport-classes-epoll-4.1.137.Final.jar
+88d0ac216f9c7be690a9d0157778570d6f4c61f885863da1fccec7fcaee35557  io/netty/netty-transport-classes-kqueue/4.1.137.Final/netty-transport-classes-kqueue-4.1.137.Final.jar
+b2eb04dbb6ec6cc8fc00aed37bb86b7aed1ccb87722eda44c90652a7d41fbdfe  io/netty/netty-transport-native-epoll/4.1.137.Final/netty-transport-native-epoll-4.1.137.Final.jar
+82fb63a2dc90c0bddb81e04065a1c06fb4c5be722ad5d64b46491daf8b6f9a01  io/netty/netty-transport-native-epoll/4.1.137.Final/netty-transport-native-epoll-4.1.137.Final-linux-aarch_64.jar
+185db6053e0e9573d36fa4eb6567b26139afaa4daa7bf5a068e661568304542b  io/netty/netty-transport-native-epoll/4.1.137.Final/netty-transport-native-epoll-4.1.137.Final-linux-x86_64.jar
+8056e7637f9948f953314894cf995ab664711b66c73c4cd5b593ae84f0b1048c  io/netty/netty-transport-native-unix-common/4.1.137.Final/netty-transport-native-unix-common-4.1.137.Final.jar

--- a/infra/cassandra/scripts/repack-exporter-netty.sh
+++ b/infra/cassandra/scripts/repack-exporter-netty.sh
@@ -5,7 +5,7 @@
 set -eu
 
 NETTY_VERSION=4.1.137.Final
-MAVEN_CENTRAL_URL=https://repo1.maven.org/maven2/io/netty
+MAVEN_REPOSITORY_BASE=${MAVEN_REPOSITORY_BASE:-https://repo.maven.apache.org/maven2}
 NETTY_ARTIFACTS='netty-buffer f474b14c7734f15e0540394cb6f39d67777b7581a42919e4ac89d253d4efd929
 netty-codec 9987b6a660b0a6b1f0d791485dae33180b3d1c63687c006fe6d3fd025e9e3798
 netty-codec-http 0535bb5a736472bef5c948d15eb273c4ab9f796656fc7c5d6b982ad92bddbd49
@@ -100,7 +100,8 @@ while read -r artifact checksum; do
     [ -n "${artifact}" ] || continue
     jar=${downloads_dir}/${artifact}-${NETTY_VERSION}.jar
     curl -fsSLo "${jar}" \
-        "${MAVEN_CENTRAL_URL}/${artifact}/${NETTY_VERSION}/${artifact}-${NETTY_VERSION}.jar"
+        --retry 5 --retry-all-errors --retry-delay 5 --retry-max-time 120 \
+        "${MAVEN_REPOSITORY_BASE%/}/io/netty/${artifact}/${NETTY_VERSION}/${artifact}-${NETTY_VERSION}.jar"
     printf '%s  %s\n' "${checksum}" "${jar}" | sha256sum -c -
 
     # Only copy Netty-owned entries. This keeps the exporter implementation,

--- a/infra/cassandra/scripts/repack-exporter-netty.sh
+++ b/infra/cassandra/scripts/repack-exporter-netty.sh
@@ -100,7 +100,8 @@ while read -r artifact checksum; do
     [ -n "${artifact}" ] || continue
     jar=${downloads_dir}/${artifact}-${NETTY_VERSION}.jar
     curl -fsSLo "${jar}" \
-        --retry 5 --retry-all-errors --retry-delay 5 --retry-max-time 120 \
+        --retry 5 --retry-all-errors --retry-delay 5 \
+        --retry-max-time 120 --max-time 120 \
         "${MAVEN_REPOSITORY_BASE%/}/io/netty/${artifact}/${NETTY_VERSION}/${artifact}-${NETTY_VERSION}.jar"
     printf '%s  %s\n' "${checksum}" "${jar}" | sha256sum -c -
 


### PR DESCRIPTION
## TL;DR

Make Cassandra Java dependency downloads repository-configurable and resilient to transient HTTP failures while retaining Maven Central as the public default.

## Additional Details

- Store repository-relative paths in `java-libraries.lock` and compose URLs from `MAVEN_REPOSITORY_BASE`.
- Apply the same repository base to runtime overlays and exporter Netty repacking.
- Retry failed downloads up to five times, limit retry scheduling to two minutes, and cap each transfer attempt at two minutes.
- Preserve every dependency version and SHA-256 verification.

No new or updated dependencies, license review, or NOTICE change is required.

## For the Reviewer

Please focus on build-argument scope across the downloader and exporter-repacker stages, and on the standalone script's Maven Central fallback.

## For QA

Built the downloader stage with an alternate Maven-layout repository; all 19 pinned artifacts passed checksum verification. Ran the existing exporter repack test through that repository; all eight Netty artifacts passed checksum verification. Shell syntax and `git diff --check` also pass. Additional QA is not needed.

## Issues

Closes #1711
