### PR TITLE
fix(cassandra): retry Maven downloads and allow a repository base override

### DIFF
--- a/infra/cassandra/AGENTS.md
+++ b/infra/cassandra/AGENTS.md
@@ -31,6 +31,9 @@ docker build -t nvcf-cassandra:dev infra/cassandra
 # multi-arch
 docker buildx build --platform linux/amd64,linux/arm64 -t <ref> infra/cassandra
 
+# download retry and checksum policy unit test (local server, no network)
+infra/cassandra/scripts/fetch-verified-test.sh
+
 # exporter dependency unit test (downloads checksum-pinned Netty jars)
 infra/cassandra/scripts/repack-exporter-netty-test.sh
 ```

--- a/infra/cassandra/AGENTS.md
+++ b/infra/cassandra/AGENTS.md
@@ -21,6 +21,9 @@ Container image that runs Apache Cassandra for NVCF, built on the official
   combination. It replaces the jar's exact shaded Netty module set with
   checksum-pinned artifacts through `scripts/repack-exporter-netty.sh` and fails
   on an unexpected layout.
+- Maven downloads default to Maven Central. To route them through a caching
+  repository manager pass `--build-arg MAVEN_REPOSITORY_BASE=<base>`; the
+  artifact paths from `java-libraries.lock` and the SHA-256 checks are unchanged.
 
 ## Build
 
@@ -33,6 +36,9 @@ docker buildx build --platform linux/amd64,linux/arm64 -t <ref> infra/cassandra
 
 # download retry and checksum policy unit test (local server, no network)
 infra/cassandra/scripts/fetch-verified-test.sh
+
+# repository-base override and lock handling unit test (local server, no network)
+infra/cassandra/scripts/fetch-java-libraries-test.sh
 
 # exporter dependency unit test (downloads checksum-pinned Netty jars)
 infra/cassandra/scripts/repack-exporter-netty-test.sh

--- a/infra/cassandra/Dockerfile
+++ b/infra/cassandra/Dockerfile
@@ -23,12 +23,11 @@ RUN apk add --no-cache curl && \
 # Jackson and Netty versions can lag security-only patch releases. Download a
 # checksum-pinned replacement set without adding build tools to the final image.
 COPY java-libraries.lock /tmp/java-libraries.lock
+COPY scripts/fetch-verified.sh /usr/local/bin/fetch-verified
 RUN mkdir /tmp/java-libraries && \
     while read -r checksum url; do \
       case "${checksum}" in \#*|'') continue ;; esac; \
-      destination="/tmp/java-libraries/${url##*/}"; \
-      curl -fsSLo "${destination}" "${url}" && \
-      printf '%s  %s\n' "${checksum}" "${destination}" | sha256sum -c - || exit 1; \
+      fetch-verified "${checksum}" "${url}" "/tmp/java-libraries/${url##*/}" || exit 1; \
     done < /tmp/java-libraries.lock
 
 FROM --platform=$BUILDPLATFORM alpine:3.21 AS exporter-repacker
@@ -40,6 +39,7 @@ RUN apk add --no-cache curl unzip zip
 ARG EXPORTER_JAR=files/.gitkeep
 ARG EXPORTER_JAVAAGENT=""
 COPY ${EXPORTER_JAR} /tmp/exporter-input.jar
+COPY scripts/fetch-verified.sh /usr/local/bin/fetch-verified
 COPY scripts/repack-exporter-netty.sh /usr/local/bin/repack-exporter-netty
 RUN if [ -s /tmp/exporter-input.jar ] && [ -z "${EXPORTER_JAVAAGENT}" ]; then \
       echo "EXPORTER_JAR and EXPORTER_JAVAAGENT must be set together" >&2; \

--- a/infra/cassandra/Dockerfile
+++ b/infra/cassandra/Dockerfile
@@ -22,13 +22,15 @@ RUN apk add --no-cache curl && \
 # Cassandra 5.0.9 is still the latest supported 5.0 release, but its bundled
 # Jackson and Netty versions can lag security-only patch releases. Download a
 # checksum-pinned replacement set without adding build tools to the final image.
+# The lock pins public Maven Central URLs. A release build can route the same
+# artifact paths through a caching repository manager with
+# --build-arg MAVEN_REPOSITORY_BASE=<base>; checksums are verified either way.
+ARG MAVEN_REPOSITORY_BASE=https://repo.maven.apache.org/maven2
 COPY java-libraries.lock /tmp/java-libraries.lock
 COPY scripts/fetch-verified.sh /usr/local/bin/fetch-verified
-RUN mkdir /tmp/java-libraries && \
-    while read -r checksum url; do \
-      case "${checksum}" in \#*|'') continue ;; esac; \
-      fetch-verified "${checksum}" "${url}" "/tmp/java-libraries/${url##*/}" || exit 1; \
-    done < /tmp/java-libraries.lock
+COPY scripts/fetch-java-libraries.sh /usr/local/bin/fetch-java-libraries
+RUN MAVEN_REPOSITORY_BASE="${MAVEN_REPOSITORY_BASE}" \
+    fetch-java-libraries /tmp/java-libraries.lock /tmp/java-libraries
 
 FROM --platform=$BUILDPLATFORM alpine:3.21 AS exporter-repacker
 RUN apk add --no-cache curl unzip zip
@@ -38,6 +40,9 @@ RUN apk add --no-cache curl unzip zip
 # the agent implementation, manifest, and unrelated dependencies.
 ARG EXPORTER_JAR=files/.gitkeep
 ARG EXPORTER_JAVAAGENT=""
+# Same override as the java-libraries stage; the Netty jars default to Maven
+# Central's canonical host when it is not set.
+ARG MAVEN_REPOSITORY_BASE=""
 COPY ${EXPORTER_JAR} /tmp/exporter-input.jar
 COPY scripts/fetch-verified.sh /usr/local/bin/fetch-verified
 COPY scripts/repack-exporter-netty.sh /usr/local/bin/repack-exporter-netty
@@ -49,6 +54,7 @@ RUN if [ -s /tmp/exporter-input.jar ] && [ -z "${EXPORTER_JAVAAGENT}" ]; then \
       echo "EXPORTER_JAR and EXPORTER_JAVAAGENT must be set together" >&2; \
       exit 1; \
     fi && \
+    MAVEN_REPOSITORY_BASE="${MAVEN_REPOSITORY_BASE}" \
     repack-exporter-netty /tmp/exporter-input.jar /tmp/cassandra-exporter-agent.jar
 
 FROM cassandra:5.0.9@sha256:d35e159439b302146f964919904f84fd3c2cebf347272b8cb8c4368c1cf200e5

--- a/infra/cassandra/scripts/fetch-java-libraries-test.sh
+++ b/infra/cassandra/scripts/fetch-java-libraries-test.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# fetch-java-libraries against a local repository: the base is swapped while
+# the artifact path and checksum are kept, and an entry outside the public
+# base is refused.
+set -eu
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+work_dir=$(mktemp -d)
+server_pid=""
+cleanup() {
+    [ -n "${server_pid}" ] && kill "${server_pid}" 2>/dev/null || true
+    rm -rf "${work_dir}"
+}
+trap cleanup EXIT HUP INT TERM
+fail() { echo "fetch-java-libraries-test: $*" >&2; exit 1; }
+
+# A local "repository manager" serving the same artifact paths Maven Central would.
+repo=${work_dir}/repo
+mkdir -p "${repo}/com/example/one/1.0/" "${repo}/com/example/two/2.0/"
+printf 'one\n' > "${repo}/com/example/one/1.0/one-1.0.jar"
+printf 'two\n' > "${repo}/com/example/two/2.0/two-2.0.jar"
+sha_one=$(sha256sum "${repo}/com/example/one/1.0/one-1.0.jar" | cut -d' ' -f1)
+sha_two=$(sha256sum "${repo}/com/example/two/2.0/two-2.0.jar" | cut -d' ' -f1)
+python3 -u -m http.server --bind 127.0.0.1 --directory "${repo}" 0 > "${work_dir}/server.log" 2>&1 &
+server_pid=$!
+port=""
+for _ in $(seq 1 50); do
+    port=$(sed -n 's/.*port \([0-9]*\).*/\1/p' "${work_dir}/server.log" | head -n1)
+    [ -n "${port}" ] && break
+    sleep 0.1
+done
+[ -n "${port}" ] || fail "test server did not start"
+base="http://127.0.0.1:${port}"
+
+cat > "${work_dir}/good.lock" <<LOCK
+# comment line
+${sha_one}  https://repo.maven.apache.org/maven2/com/example/one/1.0/one-1.0.jar
+${sha_two}  https://repo.maven.apache.org/maven2/com/example/two/2.0/two-2.0.jar
+LOCK
+export FETCH_RETRIES=2 FETCH_RETRY_DELAY=1
+
+# 1. Base override: both artifacts come from the local repository, verified.
+MAVEN_REPOSITORY_BASE="${base}/" "${script_dir}/fetch-java-libraries.sh" "${work_dir}/good.lock" "${work_dir}/out" ||
+    fail "download through the overridden base failed"
+cmp -s "${work_dir}/out/one-1.0.jar" "${repo}/com/example/one/1.0/one-1.0.jar" || fail "one-1.0.jar differs"
+cmp -s "${work_dir}/out/two-2.0.jar" "${repo}/com/example/two/2.0/two-2.0.jar" || fail "two-2.0.jar differs"
+
+# 2. An entry outside the public base is refused before any request is made.
+cat > "${work_dir}/foreign.lock" <<LOCK
+${sha_one}  https://example.invalid/maven2/com/example/one/1.0/one-1.0.jar
+LOCK
+if MAVEN_REPOSITORY_BASE="${base}" "${script_dir}/fetch-java-libraries.sh" "${work_dir}/foreign.lock" "${work_dir}/out2" 2>"${work_dir}/err"; then
+    fail "an entry outside the public base was fetched"
+fi
+grep -q 'not under https://repo.maven.apache.org/maven2' "${work_dir}/err" || fail "refusal did not name the public base"
+[ ! -e "${work_dir}/out2/one-1.0.jar" ] || fail "refused entry was downloaded"
+
+# 3. A checksum mismatch still fails through the base override.
+cat > "${work_dir}/bad.lock" <<LOCK
+${sha_two}  https://repo.maven.apache.org/maven2/com/example/one/1.0/one-1.0.jar
+LOCK
+if MAVEN_REPOSITORY_BASE="${base}" "${script_dir}/fetch-java-libraries.sh" "${work_dir}/bad.lock" "${work_dir}/out3" 2>/dev/null; then
+    fail "checksum mismatch was accepted"
+fi
+[ ! -e "${work_dir}/out3/one-1.0.jar" ] || fail "mismatched download was left on disk"
+
+echo "fetch-java-libraries-test: all checks passed"

--- a/infra/cassandra/scripts/fetch-java-libraries.sh
+++ b/infra/cassandra/scripts/fetch-java-libraries.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Download every artifact in a java-libraries.lock into a directory, through
+# the repository the build selects, verifying each SHA-256.
+#
+# The lock pins public Maven Central URLs so the source stays self-contained.
+# A release build can point MAVEN_REPOSITORY_BASE at a caching repository
+# manager instead; the artifact path and checksum are kept and only the base
+# is swapped. An entry outside the public base fails the build rather than
+# bypassing the selected repository.
+#
+# usage: fetch-java-libraries <lock-file> <destination-dir>
+set -eu
+
+[ "$#" -eq 2 ] || {
+    echo "usage: $0 <lock-file> <destination-dir>" >&2
+    exit 2
+}
+lock=$1
+destination_dir=$2
+
+public_base=https://repo.maven.apache.org/maven2
+base=${MAVEN_REPOSITORY_BASE:-${public_base}}
+base=${base%/}
+
+fetch_verified=$(dirname -- "$0")/fetch-verified
+[ -x "${fetch_verified}" ] || fetch_verified=$(dirname -- "$0")/fetch-verified.sh
+[ -x "${fetch_verified}" ] || {
+    echo "missing required command: fetch-verified" >&2
+    exit 1
+}
+
+mkdir -p "${destination_dir}"
+while read -r checksum url; do
+    case "${checksum}" in \#*|'') continue ;; esac
+    case "${url}" in
+        "${public_base}"/*) ;;
+        *)
+            echo "lock entry is not under ${public_base}, refusing to fetch it: ${url}" >&2
+            exit 1
+            ;;
+    esac
+    "${fetch_verified}" "${checksum}" "${base}/${url#"${public_base}"/}" "${destination_dir}/${url##*/}"
+done < "${lock}"

--- a/infra/cassandra/scripts/fetch-verified-test.sh
+++ b/infra/cassandra/scripts/fetch-verified-test.sh
@@ -77,6 +77,18 @@ if "${fetch}" "${good_sha}" "${base}/40/slow.jar" "${work_dir}/out3.jar" 2>/dev/
 fi
 [ ! -e "${work_dir}/out3.jar" ] || fail "failed download was left on disk"
 
+# 3b. FETCH_RETRIES is the request budget, first request included: two 429s
+#     need a third request, so a budget of two fails and a budget of three
+#     succeeds against the same server behaviour.
+if FETCH_RETRIES=2 "${fetch}" "${good_sha}" "${base}/2/budget-two.jar" "${work_dir}/out3b.jar" 2>/dev/null; then
+    fail "a budget of two requests must not absorb two 429s"
+fi
+FETCH_RETRIES=3 "${fetch}" "${good_sha}" "${base}/2/budget-three.jar" "${work_dir}/out3c.jar" ||
+    fail "a budget of three requests must absorb two 429s"
+if FETCH_RETRIES=0 "${fetch}" "${good_sha}" "${base}/0/zero.jar" "${work_dir}/out3d.jar" 2>/dev/null; then
+    fail "FETCH_RETRIES=0 must be rejected"
+fi
+
 # 4. Permanent 404: not transient, so it fails at once and leaves nothing behind.
 start=$(date +%s)
 if "${fetch}" "${good_sha}" "${base}/0/missing" "${work_dir}/out4.jar" 2>/dev/null; then

--- a/infra/cassandra/scripts/fetch-verified-test.sh
+++ b/infra/cassandra/scripts/fetch-verified-test.sh
@@ -38,6 +38,11 @@ class H(http.server.BaseHTTPRequestHandler):
         seen[self.path] += 1
         if self.path.endswith("/missing"):
             self.send_response(404); self.end_headers(); return
+        if self.path.endswith("/stall"):
+            # Headers, one byte, then silence: a transfer that never ends.
+            self.send_response(200); self.send_header("Content-Length", str(len(body))); self.end_headers()
+            self.wfile.write(body[:1]); self.wfile.flush()
+            import time; time.sleep(30); return
         if seen[self.path] <= limit:
             self.send_response(429); self.send_header("Retry-After", "0"); self.end_headers(); return
         self.send_response(200); self.send_header("Content-Length", str(len(body))); self.end_headers()
@@ -79,5 +84,15 @@ if "${fetch}" "${good_sha}" "${base}/0/missing" "${work_dir}/out4.jar" 2>/dev/nu
 fi
 [ ! -e "${work_dir}/out4.jar" ] || fail "404 download was left on disk"
 [ $(( $(date +%s) - start )) -lt 3 ] || fail "a 404 was retried; only transient responses should be"
+
+# 5. A transfer that stalls after the headers is cut off by the per-attempt
+#    cap, retried, and finally fails, without hanging the build and without
+#    leaving the partial file behind.
+start=$(date +%s)
+if FETCH_MAX_TIME=1 FETCH_RETRIES=1 "${fetch}" "${good_sha}" "${base}/0/stall" "${work_dir}/out5.jar" 2>/dev/null; then
+    fail "a stalled transfer should not succeed"
+fi
+[ ! -e "${work_dir}/out5.jar" ] || fail "stalled download was left on disk"
+[ $(( $(date +%s) - start )) -lt 10 ] || fail "a stalled transfer was not cut off by FETCH_MAX_TIME"
 
 echo "fetch-verified-test: all checks passed"

--- a/infra/cassandra/scripts/fetch-verified-test.sh
+++ b/infra/cassandra/scripts/fetch-verified-test.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# fetch-verified against a local server that rate-limits first: the download
+# must survive a burst of 429s, still reject a bad checksum, and give up on a
+# permanent failure without leaving a file behind.
+set -eu
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+work_dir=$(mktemp -d)
+server_pid=""
+cleanup() {
+    [ -n "${server_pid}" ] && kill "${server_pid}" 2>/dev/null || true
+    rm -rf "${work_dir}"
+}
+trap cleanup EXIT HUP INT TERM
+
+fail() {
+    echo "fetch-verified-test: $*" >&2
+    exit 1
+}
+
+printf 'pinned artifact body\n' > "${work_dir}/artifact.jar"
+good_sha=$(sha256sum "${work_dir}/artifact.jar" | cut -d' ' -f1)
+bad_sha=0000000000000000000000000000000000000000000000000000000000000000
+
+# The server answers 429 to the first N requests for a path, then 200. N is
+# the leading path segment, so one server covers every case.
+cat > "${work_dir}/server.py" <<'PY'
+import http.server, os, sys, collections
+body = open(sys.argv[2], "rb").read()
+seen = collections.Counter()
+class H(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *a): pass
+    def do_GET(self):
+        limit = int(self.path.split("/")[1])
+        seen[self.path] += 1
+        if self.path.endswith("/missing"):
+            self.send_response(404); self.end_headers(); return
+        if seen[self.path] <= limit:
+            self.send_response(429); self.send_header("Retry-After", "0"); self.end_headers(); return
+        self.send_response(200); self.send_header("Content-Length", str(len(body))); self.end_headers()
+        self.wfile.write(body)
+srv = http.server.HTTPServer(("127.0.0.1", 0), H)
+open(sys.argv[1], "w").write(str(srv.server_address[1]))
+srv.serve_forever()
+PY
+python3 "${work_dir}/server.py" "${work_dir}/port" "${work_dir}/artifact.jar" &
+server_pid=$!
+for _ in $(seq 1 50); do [ -s "${work_dir}/port" ] && break; sleep 0.1; done
+[ -s "${work_dir}/port" ] || fail "test server did not start"
+base="http://127.0.0.1:$(cat "${work_dir}/port")"
+
+export FETCH_RETRIES=4 FETCH_RETRY_DELAY=1 FETCH_RETRY_MAX_TIME=30
+fetch=${script_dir}/fetch-verified.sh
+
+# 1. Two 429s, then 200: succeeds and the file matches.
+"${fetch}" "${good_sha}" "${base}/2/ok.jar" "${work_dir}/out1.jar" ||
+    fail "download did not survive two 429 responses"
+cmp -s "${work_dir}/out1.jar" "${work_dir}/artifact.jar" || fail "downloaded content differs"
+
+# 2. Same server behaviour, wrong checksum: fails and leaves nothing behind.
+if "${fetch}" "${bad_sha}" "${base}/1/bad.jar" "${work_dir}/out2.jar" 2>/dev/null; then
+    fail "checksum mismatch was accepted"
+fi
+[ ! -e "${work_dir}/out2.jar" ] || fail "mismatched download was left on disk"
+
+# 3. More 429s than retries: fails, bounded, nothing left behind.
+if "${fetch}" "${good_sha}" "${base}/40/slow.jar" "${work_dir}/out3.jar" 2>/dev/null; then
+    fail "an endless 429 stream should exhaust the retries"
+fi
+[ ! -e "${work_dir}/out3.jar" ] || fail "failed download was left on disk"
+
+# 4. Permanent 404: not transient, so it fails at once and leaves nothing behind.
+start=$(date +%s)
+if "${fetch}" "${good_sha}" "${base}/0/missing" "${work_dir}/out4.jar" 2>/dev/null; then
+    fail "a 404 should fail"
+fi
+[ ! -e "${work_dir}/out4.jar" ] || fail "404 download was left on disk"
+[ $(( $(date +%s) - start )) -lt 3 ] || fail "a 404 was retried; only transient responses should be"
+
+echo "fetch-verified-test: all checks passed"

--- a/infra/cassandra/scripts/fetch-verified.sh
+++ b/infra/cassandra/scripts/fetch-verified.sh
@@ -15,9 +15,11 @@
 #
 # usage: fetch-verified <sha256> <url> <destination>
 #
-# FETCH_RETRIES (default 8) bounds the attempts and FETCH_RETRY_MAX_TIME
-# (default 600, seconds) caps the whole download. FETCH_RETRY_DELAY, when set,
-# replaces the exponential backoff with a fixed delay; the tests use it.
+# FETCH_RETRIES (default 8) bounds the attempts, FETCH_MAX_TIME (default 120,
+# seconds) caps one attempt so a stalled transfer is cut off and retried rather
+# than hanging the build, and FETCH_RETRY_MAX_TIME (default 600, seconds) caps
+# the whole download. FETCH_RETRY_DELAY, when set, replaces the exponential
+# backoff with a fixed delay; the tests use it.
 set -eu
 
 [ "$#" -eq 3 ] || {
@@ -29,7 +31,9 @@ url=$2
 destination=$3
 
 rm -f "${destination}"
-set -- --retry "${FETCH_RETRIES:-8}" --retry-max-time "${FETCH_RETRY_MAX_TIME:-600}"
+set -- --retry "${FETCH_RETRIES:-8}" \
+       --max-time "${FETCH_MAX_TIME:-120}" \
+       --retry-max-time "${FETCH_RETRY_MAX_TIME:-600}"
 [ -z "${FETCH_RETRY_DELAY:-}" ] || set -- "$@" --retry-delay "${FETCH_RETRY_DELAY}"
 if ! curl -fsSL "$@" -o "${destination}" "${url}"; then
     echo "download failed after retries: ${url}" >&2

--- a/infra/cassandra/scripts/fetch-verified.sh
+++ b/infra/cassandra/scripts/fetch-verified.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Download one artifact, retrying transient failures, and verify its SHA-256
+# before it is allowed to exist at the destination.
+#
+# Maven Central answers 429 during release builds, and a single curl attempt
+# turned that into a failed image build with valid inputs. curl retries the
+# transient responses (408, 429, 5xx, timeouts) on its own once asked, backing
+# off exponentially from one second and honouring Retry-After, so the loop
+# lives in curl rather than here. A 404 or a checksum mismatch is not
+# transient and fails at once. The checksum check is unchanged: a download
+# that does not match is deleted and the build fails.
+#
+# usage: fetch-verified <sha256> <url> <destination>
+#
+# FETCH_RETRIES (default 8) bounds the attempts and FETCH_RETRY_MAX_TIME
+# (default 600, seconds) caps the whole download. FETCH_RETRY_DELAY, when set,
+# replaces the exponential backoff with a fixed delay; the tests use it.
+set -eu
+
+[ "$#" -eq 3 ] || {
+    echo "usage: $0 <sha256> <url> <destination>" >&2
+    exit 2
+}
+checksum=$1
+url=$2
+destination=$3
+
+rm -f "${destination}"
+set -- --retry "${FETCH_RETRIES:-8}" --retry-max-time "${FETCH_RETRY_MAX_TIME:-600}"
+[ -z "${FETCH_RETRY_DELAY:-}" ] || set -- "$@" --retry-delay "${FETCH_RETRY_DELAY}"
+if ! curl -fsSL "$@" -o "${destination}" "${url}"; then
+    echo "download failed after retries: ${url}" >&2
+    rm -f "${destination}"
+    exit 1
+fi
+if ! printf '%s  %s\n' "${checksum}" "${destination}" | sha256sum -c - >/dev/null; then
+    echo "checksum mismatch for ${url}" >&2
+    rm -f "${destination}"
+    exit 1
+fi

--- a/infra/cassandra/scripts/fetch-verified.sh
+++ b/infra/cassandra/scripts/fetch-verified.sh
@@ -15,7 +15,9 @@
 #
 # usage: fetch-verified <sha256> <url> <destination>
 #
-# FETCH_RETRIES (default 8) bounds the attempts, FETCH_MAX_TIME (default 120,
+# FETCH_RETRIES (default 8) is the total number of requests allowed, the
+# first one included; curl counts retries after the first, so it is passed one
+# fewer. FETCH_MAX_TIME (default 120,
 # seconds) caps one attempt so a stalled transfer is cut off and retried rather
 # than hanging the build, and FETCH_RETRY_MAX_TIME (default 600, seconds) caps
 # the whole download. FETCH_RETRY_DELAY, when set, replaces the exponential
@@ -30,8 +32,13 @@ checksum=$1
 url=$2
 destination=$3
 
+attempts=${FETCH_RETRIES:-8}
+case "${attempts}" in
+    ''|*[!0-9]*|0) echo "FETCH_RETRIES must be a whole number of at least 1, got '${attempts}'" >&2; exit 2 ;;
+esac
+
 rm -f "${destination}"
-set -- --retry "${FETCH_RETRIES:-8}" \
+set -- --retry "$((attempts - 1))" \
        --max-time "${FETCH_MAX_TIME:-120}" \
        --retry-max-time "${FETCH_RETRY_MAX_TIME:-600}"
 [ -z "${FETCH_RETRY_DELAY:-}" ] || set -- "$@" --retry-delay "${FETCH_RETRY_DELAY}"

--- a/infra/cassandra/scripts/repack-exporter-netty.sh
+++ b/infra/cassandra/scripts/repack-exporter-netty.sh
@@ -5,7 +5,10 @@
 set -eu
 
 NETTY_VERSION=4.1.137.Final
-MAVEN_CENTRAL_URL=https://repo1.maven.org/maven2/io/netty
+# MAVEN_REPOSITORY_BASE lets a release build route the downloads through a
+# caching repository manager; the artifact paths and checksums do not change.
+MAVEN_CENTRAL_URL=${MAVEN_REPOSITORY_BASE:-https://repo1.maven.org/maven2}
+MAVEN_CENTRAL_URL=${MAVEN_CENTRAL_URL%/}/io/netty
 NETTY_ARTIFACTS='netty-buffer f474b14c7734f15e0540394cb6f39d67777b7581a42919e4ac89d253d4efd929
 netty-codec 9987b6a660b0a6b1f0d791485dae33180b3d1c63687c006fe6d3fd025e9e3798
 netty-codec-http 0535bb5a736472bef5c948d15eb273c4ab9f796656fc7c5d6b982ad92bddbd49

--- a/infra/cassandra/scripts/repack-exporter-netty.sh
+++ b/infra/cassandra/scripts/repack-exporter-netty.sh
@@ -30,6 +30,14 @@ for tool in awk basename cp curl dirname find grep mkdir mktemp mv rm sed sha256
         exit 1
     }
 done
+# Sibling of this script both in the repository and under /usr/local/bin in
+# the image, so the download policy lives in one place.
+fetch_verified=$(dirname -- "$0")/fetch-verified
+[ -x "${fetch_verified}" ] || fetch_verified=$(dirname -- "$0")/fetch-verified.sh
+[ -x "${fetch_verified}" ] || {
+    echo "missing required command: fetch-verified" >&2
+    exit 1
+}
 
 [ -f "${input}" ] || {
     echo "exporter input does not exist: ${input}" >&2
@@ -99,9 +107,9 @@ printf '%s\n' "${NETTY_ARTIFACTS}" |
 while read -r artifact checksum; do
     [ -n "${artifact}" ] || continue
     jar=${downloads_dir}/${artifact}-${NETTY_VERSION}.jar
-    curl -fsSLo "${jar}" \
-        "${MAVEN_CENTRAL_URL}/${artifact}/${NETTY_VERSION}/${artifact}-${NETTY_VERSION}.jar"
-    printf '%s  %s\n' "${checksum}" "${jar}" | sha256sum -c -
+    "${fetch_verified}" "${checksum}" \
+        "${MAVEN_CENTRAL_URL}/${artifact}/${NETTY_VERSION}/${artifact}-${NETTY_VERSION}.jar" \
+        "${jar}"
 
     # Only copy Netty-owned entries. This keeps the exporter implementation,
     # manifest, and all unrelated shaded dependencies byte-for-byte intact.


### PR DESCRIPTION
## Why

`infra/cassandra/Dockerfile` downloaded each checksum-pinned Java overlay from Maven Central with one `curl` call against a hard-coded URL. Two problems from #1711: Maven Central returns HTTP 429 under load, so a release build failed on the first 429 with valid inputs (the internal image build for the 2.0.3 tag failed four times today at exactly this step), and release infrastructure had no way to route the downloads through a caching repository manager.

## What changed

- `scripts/fetch-verified.sh` (new): `fetch-verified <sha256> <url> <dest>`. curl retries transient responses (408, 429, 5xx, timeouts) with exponential backoff from one second, honouring `Retry-After`. `FETCH_RETRIES` is the total request budget (default 8, first request included), `FETCH_MAX_TIME` caps one attempt (default 120s) so a stalled transfer is cut off and retried, `FETCH_RETRY_MAX_TIME` caps the whole download (default 600s). A 404 is not transient and fails at once. The SHA-256 check is unchanged; a mismatch or failed download deletes the destination and exits non-zero.
- `scripts/fetch-java-libraries.sh` (new): fetches every `java-libraries.lock` entry through `MAVEN_REPOSITORY_BASE`, defaulting to Maven Central. Only the base is swapped; the artifact path and checksum are kept. A lock entry that is not under the public base is refused, so nothing bypasses the selected repository.
- `Dockerfile`: `ARG MAVEN_REPOSITORY_BASE` in the java-libraries and exporter stages, both using the helpers. yq is untouched (GitHub, not Maven).
- `scripts/repack-exporter-netty.sh`: Netty jars go through `fetch-verified` and honour `MAVEN_REPOSITORY_BASE`.
- `AGENTS.md`: documents the build argument and the two new tests.

No dependency versions, lock URLs or checksums change. The public default stays Maven Central; a release build selects its repository with `--build-arg MAVEN_REPOSITORY_BASE=<base>`, which the internal lane already supports through per-service build args.

## Testing

- `scripts/fetch-verified-test.sh` (local server): two 429s then 200 succeeds; wrong checksum fails and leaves no file; an endless 429 stream exhausts the budget; a budget of two fails on two 429s and a budget of three succeeds; `FETCH_RETRIES=0` is rejected; a 404 fails in under three seconds; a transfer that stalls after the headers is cut off.
- `scripts/fetch-java-libraries-test.sh` (local repository): both entries download through the overridden base with matching content; an entry outside the public base is refused before any request; a checksum mismatch through the override still fails.
- `scripts/repack-exporter-netty-test.sh` against live Maven Central currently fails with 429 from this host, which is the bug itself; noted in the comments.

Closes #1711


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cassandra dependency and Netty downloads now support configurable Maven repository sources.
  * Downloads use SHA-256 verification, preserve locked artifact paths, and reject artifacts outside the approved repository base.
  * Downloads retry temporary failures, enforce timeouts, remove incomplete files after failed attempts, and apply retry settings as a total request budget including the initial request.

* **Tests**
  * Added local coverage for repository overrides, lock handling, retries, timeouts, checksum mismatches, missing files, stalled transfers, and request limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->