### PR TITLE
test(ci): stop git housekeeping racing the lock property test teardown

### DIFF
--- a/tools/ci/test-bazel-lock-touches-java-properties
+++ b/tools/ci/test-bazel-lock-touches-java-properties
@@ -28,6 +28,7 @@ import itertools
 import json
 import pathlib
 import random
+import os
 import subprocess
 import sys
 import tempfile
@@ -154,6 +155,17 @@ def git(repo, *args):
 def main():
     rng = random.Random(20260818)
     failures = []
+    # 800 commits in a throwaway repo is enough for git to decide on
+    # housekeeping. `git commit` then forks `gc --auto`/`maintenance` into the
+    # background and detaches, and that process is still writing under .git
+    # when TemporaryDirectory tears the repo down, which fails the whole run
+    # with "Directory not empty: '.git'". Nothing here needs packing, so turn
+    # the background work off for every git the test and the tool spawn.
+    os.environ.update({
+        "GIT_CONFIG_COUNT": "2",
+        "GIT_CONFIG_KEY_0": "gc.auto", "GIT_CONFIG_VALUE_0": "0",
+        "GIT_CONFIG_KEY_1": "maintenance.auto", "GIT_CONFIG_VALUE_1": "false",
+    })
     with tempfile.TemporaryDirectory() as repo:
         git(repo, "init", "-q", ".")
         git(repo, "config", "user.email", "t@example.com")


### PR DESCRIPTION
## Why

The `bazel` workflow failed on `chore/chart-version-bumps` (run 34418975387) and `chore/stack-pin-bumps` while main stayed green. The failing job is `detect changed subtrees`, step `Test CI shell helpers`:

```
File ".../tools/ci/test-bazel-lock-touches-java-properties", line 157, in main
File "/usr/lib/python3.12/tempfile.py", line 1085, in __exit__
OSError: [Errno 39] Directory not empty: '.git'
```

The test makes 800 commits in a temporary repository. git forks `gc --auto` / `maintenance` into the background and detaches; that process is still writing under `.git` when `TemporaryDirectory` tears the tree down. The failure depends on timing, which is why it hits some runs and not others.

## What changed

`tools/ci/test-bazel-lock-touches-java-properties` sets `gc.auto=0` and `maintenance.auto=false` through `GIT_CONFIG_*` before creating the repository, so no git spawned by the test or by the tool under test does background work. Nothing in the test needs packing.

## Testing

The test passes twice in a row locally (400 generated cases each). The race cannot be forced on demand; the change removes its cause rather than tolerating it.

NO-REF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temporary repository cleanup reliability by preventing background Git maintenance processes from interfering with automated tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->