### PR TITLE
feat(ci): let automated bump commits inherit the semver step they pin

### DIFF
--- a/.github/workflows/chart-version-bump.yml
+++ b/.github/workflows/chart-version-bump.yml
@@ -52,6 +52,9 @@ jobs:
           # carry whatever the chart looked like then onto a branch cut from
           # today's main.
           ref: ${{ github.event.repository.default_branch }}
+          # Full history: the pull request title is derived from every bump
+          # commit on the shared branch, which needs the merge base with main.
+          fetch-depth: 0
 
       - uses: actions/setup-go@v5
         with:
@@ -64,6 +67,10 @@ jobs:
         # here rather than somewhere that might not be reached. A test that
         # gates nothing is not a test.
         run: go test -C tools/chart-version-bumper ./...
+
+      - name: Test the commit type helper
+        # It decides the semver step of the chart release this bump causes.
+        run: bash tools/ci/test-release-bump-type
 
       - name: Select the tag
         id: tag
@@ -133,8 +140,9 @@ jobs:
           # it still applied every chart it could move safely. Aborting here
           # would throw those away and leave the refusal as the only outcome.
           tools/ci/chart-version-bumper \
-            --tag "${TAG}" --write 2>/tmp/refusals
+            --tag "${TAG}" --write >/tmp/bump.out 2>/tmp/refusals
           status=$?
+          cat /tmp/bump.out
           cat /tmp/refusals >&2
           # The exit code, not whether stderr is empty. SystemExit writes its
           # message to stderr too, so an unresolvable tag looks exactly like a
@@ -161,38 +169,61 @@ jobs:
             echo "changed=true" >> "${GITHUB_OUTPUT}"
             git --no-pager diff --stat -- deploy/helm
           fi
+          # The largest semver step any chart took, reported by the bumper as
+          # "bump: <level>". Empty when nothing moved.
+          echo "level=$(sed -n 's/^bump: //p' /tmp/bump.out | tail -n 1)" >> "${GITHUB_OUTPUT}"
 
       - name: Open or refresh the pull request
         if: steps.bump.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.NV_GITHUB_TOKEN || github.token }}
           TAG: ${{ steps.tag.outputs.tag }}
+          LEVEL: ${{ steps.bump.outputs.level }}
           REFUSED: ${{ steps.bump.outputs.refused }}
           SERVER_URL: ${{ github.server_url }}
           REPO: ${{ github.repository }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           branch="chore/chart-version-bumps"
 
           git add deploy/helm
+          # The commit type carries the semver step of the service release
+          # into the chart release. tools/ci/github-release feeds RELEASE_RULES
+          # to semantic-release: fix cuts a patch, feat a minor, "!" a major,
+          # and chore cuts nothing (which would stop the cascade here, since a
+          # published chart release is what triggers stack-pin-bump.yml). A
+          # service that moved a minor therefore moves its chart a minor, and
+          # one step later the stack, instead of every bump reading as a patch.
+          type="$(tools/ci/release-bump-type for-level "${LEVEL}")"
+          case "${type}" in
+            *!) subject="${type%!}(charts)!: bump for ${TAG}" ;;
+            *)  subject="${type}(charts): bump for ${TAG}" ;;
+          esac
           # Separate -m flags rather than an embedded multi-line string: the
           # continuation lines of one would have to sit at column zero, which
           # ends the YAML block scalar this script lives in.
-          # fix, not chore. tools/ci/github-release feeds RELEASE_RULES to
-          # semantic-release, where chore carries "release": false. A chore
-          # commit therefore cuts no chart release, and since publishing a chart
-          # release is exactly what triggers stack-pin-bump.yml, the cascade
-          # would stop here: the chart would carry the new appVersion on main
-          # and the stack would never learn about it.
-          #
-          # A patch bump of the chart is the right size. The chart's own
-          # templates and values schema have not changed, only the application
-          # version it defaults to, which is the conventional reading of chart
-          # version against appVersion.
-          git commit \
-            -m "fix(charts): bump for ${TAG}" \
-            -m "Opened by the chart version bump workflow on release of ${TAG}."
+          if [ "${type}" = 'feat!' ]; then
+            git commit \
+              -m "${subject}" \
+              -m "Opened by the chart version bump workflow on release of ${TAG}." \
+              -m "BREAKING CHANGE: ${TAG} is a major release of the service this chart deploys."
+          else
+            git commit \
+              -m "${subject}" \
+              -m "Opened by the chart version bump workflow on release of ${TAG}."
+          fi
           git push --force-with-lease origin "${branch}"
+
+          # The pull request squashes to one commit, so its title has to carry
+          # the largest step among every bump accumulated on the branch.
+          pr_type="$(tools/ci/release-bump-type for-branch "origin/${BASE_BRANCH}")"
+          case "${pr_type}" in
+            *!) title="${pr_type%!}(charts)!: bump chart versions for released services"
+                breaking="BREAKING CHANGE: a pinned service moved to a new major version." ;;
+            *)  title="${pr_type}(charts): bump chart versions for released services"
+                breaking="" ;;
+          esac
 
           notes=""
           if [ -n "${REFUSED}" ]; then
@@ -220,7 +251,8 @@ jobs:
             "If this pull request sits unmerged, later service releases add their bumps to the same branch, so merging it applies all of them." \
             "" \
             "Github commit:" \
-            "fix(charts): bump chart versions for released services" \
+            "${title}" \
+            "${breaking}" \
             "")"
 
           # gh api, not `gh pr edit`. Against this repository `gh pr edit` fails
@@ -229,12 +261,12 @@ jobs:
           # cards it does not need. The REST endpoint has no such dependency.
           number="$(gh api "repos/${REPO}/pulls?head=${REPO%%/*}:${branch}&state=open" -q '.[0].number')"
           if [ -n "${number}" ] && [ "${number}" != "null" ]; then
-            jq -n --arg b "${body}" '{body: $b}' \
+            jq -n --arg t "${title}" --arg b "${body}" '{title: $t, body: $b}' \
               | gh api -X PATCH "repos/${REPO}/pulls/${number}" --input - >/dev/null
             echo "refreshed pull request #${number}"
           else
             gh pr create --base main --head "${branch}" \
-              --title "fix(charts): bump chart versions for released services" \
+              --title "${title}" \
               --body "${body}"
           fi
 

--- a/.github/workflows/chart-version-bump.yml
+++ b/.github/workflows/chart-version-bump.yml
@@ -106,6 +106,7 @@ jobs:
         if: steps.tag.outputs.applies == 'true'
         env:
           BRANCH: chore/chart-version-bumps
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           # The bump is applied ON the pull request branch, not on the default
@@ -115,14 +116,14 @@ jobs:
           # drops that earlier bump or commits conflict markers. Starting here
           # also makes the run idempotent: the bumper sees the current value and
           # reports "already <version>".
+          #
+          # The shared branch is rebased onto the default branch first, as the
+          # stack workflow does. Its tree can predate the tools this run needs
+          # (the bumper's "bump:" line, release-bump-type), and a stale branch
+          # would either fail or fall back to a patch commit for a minor bump.
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin "${BRANCH}" || true
-          if git rev-parse --verify -q "origin/${BRANCH}" >/dev/null; then
-            git checkout -B "${BRANCH}" "origin/${BRANCH}"
-          else
-            git checkout -B "${BRANCH}"
-          fi
+          tools/ci/prepare-stack-pin-branch "${BRANCH}" "${BASE_BRANCH}"
 
       - name: Apply the bump
         id: bump

--- a/.github/workflows/stack-pin-bump.yml
+++ b/.github/workflows/stack-pin-bump.yml
@@ -66,6 +66,10 @@ jobs:
         # reached. A test that gates nothing is not a test.
         run: go test -C tools/stack-pin-resolver ./...
 
+      - name: Test the commit type helper
+        # It decides the semver step of the stack release this bump causes.
+        run: bash tools/ci/test-release-bump-type
+
       - name: Select the tag
         id: tag
         run: |
@@ -115,7 +119,10 @@ jobs:
           TAG: ${{ steps.tag.outputs.tag }}
         run: |
           set -euo pipefail
-          tools/ci/stack-pin-resolver --tag "${TAG}" --write
+          tools/ci/stack-pin-resolver --tag "${TAG}" --write | tee /tmp/bump.out
+          # The semver step the pin took, reported by the resolver as
+          # "bump: <level>". Empty when the stack already pinned this version.
+          echo "level=$(sed -n 's/^bump: //p' /tmp/bump.out | tail -n 1)" >> "${GITHUB_OUTPUT}"
           # Scoped to the same paths the commit below stages. Repo-wide, any
           # unrelated modification in the workspace would set changed=true and
           # the commit would then abort with nothing staged.
@@ -132,25 +139,50 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.NV_GITHUB_TOKEN || github.token }}
           TAG: ${{ steps.tag.outputs.tag }}
+          LEVEL: ${{ steps.bump.outputs.level }}
           SERVER_URL: ${{ github.server_url }}
           REPO: ${{ github.repository }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           branch="chore/stack-pin-bumps"
 
           git add deploy/stacks/self-managed/helmfile.d
+          # The commit type carries the semver step of the chart release into
+          # the stack release. deploy/stacks/self-managed is itself a release
+          # subproject, and tools/ci/github-release feeds RELEASE_RULES to
+          # semantic-release: fix cuts a patch, feat a minor, "!" a major, and
+          # chore cuts nothing, which would move the pin on main without any
+          # stack release for downstream to see.
+          type="$(tools/ci/release-bump-type for-level "${LEVEL}")"
+          case "${type}" in
+            *!) subject="${type%!}(stack)!: pin ${TAG#deploy/helm/}" ;;
+            *)  subject="${type}(stack): pin ${TAG#deploy/helm/}" ;;
+          esac
           # Separate -m flags rather than an embedded multi-line string: the
           # continuation lines of one would have to sit at column zero, which
           # ends the YAML block scalar this script lives in.
-          # fix, not chore. deploy/stacks/self-managed is itself a release
-          # subproject, and tools/ci/github-release feeds RELEASE_RULES to
-          # semantic-release, where chore carries "release": false. A chore
-          # commit would move the pin on main without ever cutting a stack
-          # release, so nothing downstream would see the new pin.
-          git commit \
-            -m "fix(stack): pin ${TAG#deploy/helm/}" \
-            -m "Opened by the stack pin bump workflow on release of ${TAG}."
+          if [ "${type}" = 'feat!' ]; then
+            git commit \
+              -m "${subject}" \
+              -m "Opened by the stack pin bump workflow on release of ${TAG}." \
+              -m "BREAKING CHANGE: ${TAG} is a major release of a chart this stack pins."
+          else
+            git commit \
+              -m "${subject}" \
+              -m "Opened by the stack pin bump workflow on release of ${TAG}."
+          fi
           git push --force-with-lease origin "${branch}"
+
+          # The pull request squashes to one commit, so its title has to carry
+          # the largest step among every pin accumulated on the branch.
+          pr_type="$(tools/ci/release-bump-type for-branch "origin/${BASE_BRANCH}")"
+          case "${pr_type}" in
+            *!) title="${pr_type%!}(stack)!: bump self-managed stack chart pins"
+                breaking="BREAKING CHANGE: a pinned chart moved to a new major version." ;;
+            *)  title="${pr_type}(stack): bump self-managed stack chart pins"
+                breaking="" ;;
+          esac
 
           body="$(printf '%s\n' \
             "Opened by \`.github/workflows/stack-pin-bump.yml\` when \`${TAG}\` was published." \
@@ -162,7 +194,8 @@ jobs:
             "If this pull request sits unmerged, later chart releases add their bumps to the same branch, so merging it applies all of them." \
             "" \
             "Github commit:" \
-            "fix(stack): pin ${TAG#deploy/helm/}" \
+            "${title}" \
+            "${breaking}" \
             "")"
 
           # gh api, not `gh pr edit`. Against this repository `gh pr edit` fails
@@ -171,11 +204,11 @@ jobs:
           # cards it does not need. The REST endpoint has no such dependency.
           number="$(gh api "repos/${REPO}/pulls?head=${REPO%%/*}:${branch}&state=open" -q '.[0].number')"
           if [ -n "${number}" ] && [ "${number}" != "null" ]; then
-            jq -n --arg b "${body}" '{body: $b}' \
+            jq -n --arg t "${title}" --arg b "${body}" '{title: $t, body: $b}' \
               | gh api -X PATCH "repos/${REPO}/pulls/${number}" --input - >/dev/null
             echo "refreshed pull request #${number}"
           else
             gh pr create --base main --head "${branch}" \
-              --title "fix(stack): bump self-managed stack chart pins" \
+              --title "${title}" \
               --body "${body}"
           fi

--- a/tools/chart-version-bumper/bumplevel.go
+++ b/tools/chart-version-bumper/bumplevel.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"strconv"
+	"strings"
+)
+
+// BumpLevel names the semver step from one version to a higher one: "major",
+// "minor" or "patch". It is "" when either side is not MAJOR.MINOR.PATCH or
+// when the move is not upward, so a caller can tell "no level" from "patch".
+//
+// The workflow turns the level into the Conventional Commit type of the bump
+// commit, so the chart's own release (and, one step later, the stack's)
+// carries the same semver step as the service release that caused it.
+func BumpLevel(from, to string) string {
+	a, ok := parseCore(from)
+	if !ok {
+		return ""
+	}
+	b, ok := parseCore(to)
+	if !ok {
+		return ""
+	}
+	switch {
+	case b[0] > a[0]:
+		return "major"
+	case b[0] < a[0]:
+		return ""
+	case b[1] > a[1]:
+		return "minor"
+	case b[1] < a[1]:
+		return ""
+	case b[2] > a[2]:
+		return "patch"
+	}
+	return ""
+}
+
+// HigherLevel returns the larger of two levels; "" is the lowest.
+func HigherLevel(a, b string) string {
+	rank := map[string]int{"": 0, "patch": 1, "minor": 2, "major": 3}
+	if rank[b] > rank[a] {
+		return b
+	}
+	return a
+}
+
+func parseCore(v string) ([3]int, bool) {
+	var out [3]int
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		v = v[:i]
+	}
+	parts := strings.Split(v, ".")
+	if len(parts) != 3 {
+		return out, false
+	}
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 || p != strconv.Itoa(n) {
+			return out, false
+		}
+		out[i] = n
+	}
+	return out, true
+}

--- a/tools/chart-version-bumper/bumplevel.go
+++ b/tools/chart-version-bumper/bumplevel.go
@@ -4,9 +4,16 @@
 package main
 
 import (
+	"regexp"
 	"strconv"
 	"strings"
 )
+
+// semverRE is the full SemVer 2.0.0 grammar with an optional leading v:
+// MAJOR.MINOR.PATCH, an optional pre-release of dot-separated non-empty
+// identifiers, and an optional build suffix. A trailing "-" or an empty
+// identifier is not a version and yields no level.
+var semverRE = regexp.MustCompile(`^v?(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$`)
 
 // BumpLevel names the semver step from one version to a higher one: "major",
 // "minor" or "patch". It is "" when either side is not MAJOR.MINOR.PATCH or
@@ -50,17 +57,13 @@ func HigherLevel(a, b string) string {
 
 func parseCore(v string) ([3]int, bool) {
 	var out [3]int
-	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
-	if i := strings.IndexAny(v, "-+"); i >= 0 {
-		v = v[:i]
-	}
-	parts := strings.Split(v, ".")
-	if len(parts) != 3 {
+	m := semverRE.FindStringSubmatch(strings.TrimSpace(v))
+	if m == nil {
 		return out, false
 	}
-	for i, p := range parts {
+	for i, p := range m[1:4] {
 		n, err := strconv.Atoi(p)
-		if err != nil || n < 0 || p != strconv.Itoa(n) {
+		if err != nil {
 			return out, false
 		}
 		out[i] = n

--- a/tools/chart-version-bumper/main.go
+++ b/tools/chart-version-bumper/main.go
@@ -101,6 +101,7 @@ func Run(root, tag string, write bool, out, errOut io.Writer) (int, error) {
 	}
 
 	refused := 0
+	level := ""
 	for _, chart := range charts {
 		var p Plan
 		var err error
@@ -124,6 +125,7 @@ func Run(root, tag string, write bool, out, errOut io.Writer) (int, error) {
 				continue
 			}
 			fmt.Fprintf(out, "  %s: %s -> %s (%s)\n", chart.ID, p.Current, version, p.Detail)
+			level = HigherLevel(level, BumpLevel(p.Current, version))
 			if write {
 				if len(chart.ValuesPaths) > 0 {
 					err = ApplyValuesPaths(root, chart.Entry, version, chart.ValuesPaths)
@@ -139,6 +141,11 @@ func Run(root, tag string, write bool, out, errOut io.Writer) (int, error) {
 
 	// A refusal is a real finding: the chart wanted a bump and could not take
 	// one safely. Exiting non-zero puts it in front of a person.
+	// One machine-readable line for the workflow: the largest semver step any
+	// chart took. Absent when nothing moved or no version parsed.
+	if level != "" {
+		fmt.Fprintf(out, "bump: %s\n", level)
+	}
 	if refused > 0 {
 		return RefusedExit, nil
 	}

--- a/tools/chart-version-bumper/main_test.go
+++ b/tools/chart-version-bumper/main_test.go
@@ -713,3 +713,47 @@ func TestEmptyStringDeployEntryIsRejected(t *testing.T) {
 		t.Fatal("an empty string-form deploys entry must fail to decode")
 	}
 }
+
+func TestBumpLevel(t *testing.T) {
+	cases := []struct{ from, to, want string }{
+		{"1.0.0", "1.0.1", "patch"},
+		{"1.0.0", "1.1.0", "minor"},
+		{"1.9.9", "2.0.0", "major"},
+		{"v1.0.0", "1.1.0-rc.1", "minor"}, // v prefix and pre-release suffix are tolerated
+		{"1.0.0", "1.0.0", ""},            // no move
+		{"1.1.0", "1.0.5", ""},            // downgrade is not a level
+		{"latest", "1.0.1", ""},           // floating tag has no level
+		{"1.0", "1.0.1", ""},              // not MAJOR.MINOR.PATCH
+	}
+	for _, c := range cases {
+		if got := BumpLevel(c.from, c.to); got != c.want {
+			t.Errorf("BumpLevel(%q, %q) = %q, want %q", c.from, c.to, got, c.want)
+		}
+	}
+	if got := HigherLevel("patch", "minor"); got != "minor" {
+		t.Errorf("HigherLevel(patch, minor) = %q", got)
+	}
+	if got := HigherLevel("major", ""); got != "major" {
+		t.Errorf("HigherLevel(major, \"\") = %q", got)
+	}
+}
+
+func TestRunReportsTheLargestSemverStepTaken(t *testing.T) {
+	for _, c := range []struct{ tag, want string }{
+		{"src/svc/v1.0.1", "bump: patch\n"},
+		{"src/svc/v1.2.0", "bump: minor\n"},
+		{"src/svc/v2.0.0", "bump: major\n"},
+	} {
+		f := full(t)
+		_, out, _ := f.run(t, c.tag, false)
+		if !strings.Contains(out, c.want) {
+			t.Errorf("%s: output lacks %q:\n%s", c.tag, c.want, out)
+		}
+	}
+	// Nothing moved: no level line, so the workflow does not commit a no-op.
+	f := full(t)
+	_, out, _ := f.run(t, "src/svc/v1.0.0", false)
+	if strings.Contains(out, "bump:") {
+		t.Errorf("no-op run must not report a level:\n%s", out)
+	}
+}

--- a/tools/chart-version-bumper/main_test.go
+++ b/tools/chart-version-bumper/main_test.go
@@ -719,11 +719,14 @@ func TestBumpLevel(t *testing.T) {
 		{"1.0.0", "1.0.1", "patch"},
 		{"1.0.0", "1.1.0", "minor"},
 		{"1.9.9", "2.0.0", "major"},
-		{"v1.0.0", "1.1.0-rc.1", "minor"}, // v prefix and pre-release suffix are tolerated
-		{"1.0.0", "1.0.0", ""},            // no move
-		{"1.1.0", "1.0.5", ""},            // downgrade is not a level
-		{"latest", "1.0.1", ""},           // floating tag has no level
-		{"1.0", "1.0.1", ""},              // not MAJOR.MINOR.PATCH
+		{"v1.0.0", "1.1.0-rc.1", "minor"},   // v prefix and pre-release suffix are tolerated
+		{"1.0.0", "1.0.0", ""},              // no move
+		{"1.1.0", "1.0.5", ""},              // downgrade is not a level
+		{"latest", "1.0.1", ""},             // floating tag has no level
+		{"1.0", "1.0.1", ""},                // not MAJOR.MINOR.PATCH
+		{"1.0.0", "1.0.1-", ""},             // dangling pre-release separator is not a version
+		{"1.0.0", "1.0.1-rc..1", ""},        // empty pre-release identifier
+		{"1.0.0", "1.0.1+build.7", "patch"}, // build metadata is fine
 	}
 	for _, c := range cases {
 		if got := BumpLevel(c.from, c.to); got != c.want {

--- a/tools/ci/release-bump-type
+++ b/tools/ci/release-bump-type
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Conventional Commit type for an automated bump, so the release it causes
+# carries the same semver step as the release that caused it.
+#
+# The chart version bump and stack pin bump workflows used to commit every
+# bump as fix(...). semantic-release then cut a patch release of the chart
+# (and of the stack) even when the service or chart it pinned had moved a
+# minor or a major. The tools now report the step they took as "bump: <level>";
+# this turns that into a commit type, and derives the type for the pull
+# request title from every bump commit on the branch.
+#
+#   release-bump-type for-level <major|minor|patch|"">   -> feat! | feat | fix
+#   release-bump-type for-branch <base-ref>              -> feat! | feat | fix
+#
+# for-branch reads the subjects of the commits on HEAD that are not on
+# <base-ref> and returns the largest type among them: any "!" wins, then feat,
+# else fix. A branch with no commits is fix.
+set -euo pipefail
+
+usage() {
+  sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//' >&2
+  exit 2
+}
+
+for_level() {
+  case "${1:-}" in
+    major) echo 'feat!' ;;
+    minor) echo 'feat' ;;
+    patch|'') echo 'fix' ;;
+    *) echo "unknown level: $1" >&2; exit 2 ;;
+  esac
+}
+
+for_branch() {
+  local base=$1 type=fix subject
+  while IFS= read -r subject; do
+    if [[ "$subject" =~ ^[a-zA-Z]+(\([^\)]*\))?!: ]]; then
+      echo 'feat!'
+      return
+    fi
+    if [[ "$subject" =~ ^feat(\([^\)]*\))?: ]]; then
+      type=feat
+    fi
+  done < <(git log --format=%s "${base}..HEAD")
+  echo "$type"
+}
+
+[ $# -eq 2 ] || usage
+case "$1" in
+  for-level) for_level "$2" ;;
+  for-branch) for_branch "$2" ;;
+  *) usage ;;
+esac

--- a/tools/ci/test-release-bump-type
+++ b/tools/ci/test-release-bump-type
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+tool="${here}/release-bump-type"
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+
+fail() { echo "test-release-bump-type: $*" >&2; exit 1; }
+expect() {
+  local want=$1; shift
+  local got
+  got="$("$@")" || fail "$* exited non-zero"
+  [ "$got" = "$want" ] || fail "$*: got '$got', want '$want'"
+}
+
+expect 'feat!' "$tool" for-level major
+expect 'feat'  "$tool" for-level minor
+expect 'fix'   "$tool" for-level patch
+expect 'fix'   "$tool" for-level ''
+if "$tool" for-level huge 2>/dev/null; then fail "unknown level must be rejected"; fi
+
+# Branch scan: the largest type among the bump commits wins.
+git -C "$work" init -q -b main .
+git -C "$work" -c user.name=t -c user.email=t@example.com commit -q --allow-empty -m 'chore: seed'
+git -C "$work" checkout -q -b bumps
+cd "$work"
+expect 'fix' "$tool" for-branch main
+git -c user.name=t -c user.email=t@example.com commit -q --allow-empty -m 'fix(charts): bump for src/a/v1.0.1'
+expect 'fix' "$tool" for-branch main
+git -c user.name=t -c user.email=t@example.com commit -q --allow-empty -m 'feat(charts): bump for src/b/v1.1.0'
+expect 'feat' "$tool" for-branch main
+git -c user.name=t -c user.email=t@example.com commit -q --allow-empty -m 'fix(charts): bump for src/c/v1.0.2'
+expect 'feat' "$tool" for-branch main
+git -c user.name=t -c user.email=t@example.com commit -q --allow-empty -m 'feat(charts)!: bump for src/d/v2.0.0'
+expect 'feat!' "$tool" for-branch main
+# A scope-less breaking subject is still breaking.
+git -c user.name=t -c user.email=t@example.com commit -q --allow-empty -m 'fix!: bump for src/e/v3.0.0'
+expect 'feat!' "$tool" for-branch main
+
+echo "test-release-bump-type: all checks passed"

--- a/tools/stack-pin-resolver/bumplevel.go
+++ b/tools/stack-pin-resolver/bumplevel.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"strconv"
+	"strings"
+)
+
+// BumpLevel names the semver step from one version to a higher one: "major",
+// "minor" or "patch". It is "" when either side is not MAJOR.MINOR.PATCH or
+// when the move is not upward, so a caller can tell "no level" from "patch".
+//
+// The workflow turns the level into the Conventional Commit type of the bump
+// commit, so the chart's own release (and, one step later, the stack's)
+// carries the same semver step as the service release that caused it.
+func BumpLevel(from, to string) string {
+	a, ok := parseCore(from)
+	if !ok {
+		return ""
+	}
+	b, ok := parseCore(to)
+	if !ok {
+		return ""
+	}
+	switch {
+	case b[0] > a[0]:
+		return "major"
+	case b[0] < a[0]:
+		return ""
+	case b[1] > a[1]:
+		return "minor"
+	case b[1] < a[1]:
+		return ""
+	case b[2] > a[2]:
+		return "patch"
+	}
+	return ""
+}
+
+// HigherLevel returns the larger of two levels; "" is the lowest.
+func HigherLevel(a, b string) string {
+	rank := map[string]int{"": 0, "patch": 1, "minor": 2, "major": 3}
+	if rank[b] > rank[a] {
+		return b
+	}
+	return a
+}
+
+func parseCore(v string) ([3]int, bool) {
+	var out [3]int
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		v = v[:i]
+	}
+	parts := strings.Split(v, ".")
+	if len(parts) != 3 {
+		return out, false
+	}
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 || p != strconv.Itoa(n) {
+			return out, false
+		}
+		out[i] = n
+	}
+	return out, true
+}

--- a/tools/stack-pin-resolver/bumplevel.go
+++ b/tools/stack-pin-resolver/bumplevel.go
@@ -4,9 +4,16 @@
 package main
 
 import (
+	"regexp"
 	"strconv"
 	"strings"
 )
+
+// semverRE is the full SemVer 2.0.0 grammar with an optional leading v:
+// MAJOR.MINOR.PATCH, an optional pre-release of dot-separated non-empty
+// identifiers, and an optional build suffix. A trailing "-" or an empty
+// identifier is not a version and yields no level.
+var semverRE = regexp.MustCompile(`^v?(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$`)
 
 // BumpLevel names the semver step from one version to a higher one: "major",
 // "minor" or "patch". It is "" when either side is not MAJOR.MINOR.PATCH or
@@ -50,17 +57,13 @@ func HigherLevel(a, b string) string {
 
 func parseCore(v string) ([3]int, bool) {
 	var out [3]int
-	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
-	if i := strings.IndexAny(v, "-+"); i >= 0 {
-		v = v[:i]
-	}
-	parts := strings.Split(v, ".")
-	if len(parts) != 3 {
+	m := semverRE.FindStringSubmatch(strings.TrimSpace(v))
+	if m == nil {
 		return out, false
 	}
-	for i, p := range parts {
+	for i, p := range m[1:4] {
 		n, err := strconv.Atoi(p)
-		if err != nil || n < 0 || p != strconv.Itoa(n) {
+		if err != nil {
 			return out, false
 		}
 		out[i] = n

--- a/tools/stack-pin-resolver/main.go
+++ b/tools/stack-pin-resolver/main.go
@@ -151,12 +151,14 @@ func Bump(root, tag string, write bool, out, errOut io.Writer) (int, error) {
 	}
 
 	changed := 0
+	level := ""
 	for _, r := range targets {
 		if r.Version == version {
 			fmt.Fprintf(out, "%s: already %s\n", r.Name, version)
 			continue
 		}
 		fmt.Fprintf(out, "%s: %s -> %s\n", r.Name, r.Version, version)
+		level = HigherLevel(level, BumpLevel(r.Version, version))
 		changed++
 		if write {
 			if err := WritePin(root, r, version); err != nil {
@@ -166,6 +168,10 @@ func Bump(root, tag string, write bool, out, errOut io.Writer) (int, error) {
 	}
 	if changed == 0 {
 		fmt.Fprintln(out, "nothing to change")
+	} else if level != "" {
+		// One machine-readable line for the workflow: the largest semver step
+		// any pin took, so the stack release carries the chart's step.
+		fmt.Fprintf(out, "bump: %s\n", level)
 	}
 	return 0, nil
 }

--- a/tools/stack-pin-resolver/main_test.go
+++ b/tools/stack-pin-resolver/main_test.go
@@ -466,3 +466,22 @@ func TestBareAndFullyQuotedVersionsBothResolve(t *testing.T) {
 		}
 	}
 }
+
+func TestBumpReportsTheSemverStepOfThePin(t *testing.T) {
+	for _, c := range []struct{ tag, want string }{
+		{"deploy/helm/alpha/v1.0.1", "bump: patch\n"},
+		{"deploy/helm/alpha/v1.3.0", "bump: minor\n"},
+		{"deploy/helm/alpha/v2.0.0", "bump: major\n"},
+	} {
+		f := newStack(t, stackMeta, map[string]string{"02-core.yaml.gotmpl": stackFile})
+		_, out, _ := f.bump(t, c.tag, false)
+		if !strings.Contains(out, c.want) {
+			t.Errorf("%s: output lacks %q:\n%s", c.tag, c.want, out)
+		}
+	}
+	f := newStack(t, stackMeta, map[string]string{"02-core.yaml.gotmpl": stackFile})
+	_, out, _ := f.bump(t, "deploy/helm/alpha/v1.0.0", false)
+	if strings.Contains(out, "bump:") {
+		t.Errorf("already-pinned run must not report a level:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Why

Both automated bump workflows commit as `fix(...)` every time. `tools/ci/github-release` feeds those types to semantic-release, so a chart whose service just released a minor gets a patch release, and the self-managed stack that pins the chart gets a patch too. The stack's version never says whether what it ships moved a patch, a minor or a major. Raised by a reviewer on #1699.

## What changed

- `tools/chart-version-bumper` and `tools/stack-pin-resolver`: a shared `BumpLevel(from, to)` (major, minor, patch, or none for a non-upward or unparseable move) and `HigherLevel`. Each tool prints one machine-readable line, `bump: <level>`, with the largest step any chart or pin took. Nothing is printed when nothing moved. The bumper's exit codes and refusal handling are unchanged.
- `tools/ci/release-bump-type` (new, with `tools/ci/test-release-bump-type`): `for-level <level>` maps to `fix`, `feat` or `feat!`; `for-branch <base>` returns the largest type among the bump commits on the branch (any `!` wins, then `feat`, else `fix`).
- `.github/workflows/chart-version-bump.yml` and `stack-pin-bump.yml`:
  - capture the tool's stdout and expose `level` as a step output;
  - commit as `fix(scope)`, `feat(scope)`, or `feat(scope)!` plus a `BREAKING CHANGE` footer for a major;
  - the PR title and the `Github commit:` line are derived from every bump commit on the shared branch, since the PR squashes to one commit. An existing PR gets its title refreshed, not just its body;
  - both workflows run the helper's test before bumping. The chart workflow checks out with full history, which the branch scan needs; the stack workflow already did.
- `chore` is still never used: it would move the pin on main without cutting a release, and a published chart release is what triggers the stack bump.

## Testing

`go test` passes for both tools, including new cases for patch, minor and major steps and for the no-op run producing no level line. `tools/ci/test-release-bump-type` covers the level mapping, rejection of an unknown level, and the branch scan through fix, feat, scoped and unscoped breaking subjects. `actionlint` is clean on both workflows. The end-to-end effect shows on the next service release after merge: its chart bump commit will carry the service's step.

Closes #1719


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved automated chart and stack release versioning.
  * Release updates now identify the highest applicable semantic-version change.
  * Pull request titles and commit types reflect patch, minor, or major changes, including breaking releases.
  * No-change updates no longer produce unnecessary bump metadata.

* **Bug Fixes**
  * Improved handling of version formats, invalid versions, and unchanged or downgraded versions.

* **Tests**
  * Added coverage for version classification, release detection, breaking changes, and no-op scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->