### PR TITLE
fix(docs): validate catalog against tagged stack source

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -151,6 +151,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: 0
+          fetch-tags: true
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -25,6 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - uses: actions/setup-go@v5
         with:

--- a/docs/user/manifest.md
+++ b/docs/user/manifest.md
@@ -230,7 +230,7 @@ The following tables list the complete artifact inventory.
 | `nvcf_worker_init` | `1.0.1` | Required | Prepares function resources before the user container starts. | `nvcr.io/nvidia/nvcf/nvcf_worker_init:1.0.1` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/compute-plane-services/worker-init) |
 | `nvcf_worker_llm_credentials` | `1.0.1` | Optional | Maintains a current NVCF worker token for LLM function workloads. | `nvcr.io/nvidia/nvcf/nvcf_worker_llm_credentials:1.0.1` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/compute-plane-services/worker-llm-credentials) |
 | `nvcf_worker_utils` | `1.0.1` | Required | Proxies NATS traffic between function containers and the control plane. | `nvcr.io/nvidia/nvcf/nvcf_worker_utils:1.0.1` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/compute-plane-services/worker-utils) |
-| `pylon` | `0.15.1` | Optional | Connects LLM worker pods to the LLM request router. | `Publication pending` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/libraries/rust/stargate) |
+| `pylon` | `0.14.3` | Optional | Connects LLM worker pods to the LLM request router. | `Publication pending` | [GitHub](https://github.com/NVIDIA/nvcf/tree/main/src/libraries/rust/stargate) |
 
 ### EA-only CVE-impacted artifacts
 

--- a/docs/version-catalog/main.yaml
+++ b/docs/version-catalog/main.yaml
@@ -722,13 +722,14 @@ stack:
   gitlab_project_id: 182049
   package_name: ncp-deploy
   artifacts_file: artifacts-0.9.1.txt
+  source_tag: deploy/stacks/self-managed/v0.9.1
   source_commit: 9cf1103b0e9fe90bde6a8147c95d3d423e96c781
   pin_sources:
     - deploy/stacks/nvcf-compute-plane/environments/base.yaml
     - deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
     - deploy/stacks/self-managed/global.yaml.gotmpl
     - deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
-  pin_source_digest: sha256:ce09f463f36314045441c14320dce63693d924e6ba240afdcb4a276c670bda66
+  pin_source_digest: sha256:952fba4fb3906887fe1661f6d8508b9470c2a5fe0746dba12a5a62d8384230dc
 denylist:
   - name: strap
     reason: Legacy name replaced by nvcf-service-oss
@@ -969,7 +970,7 @@ artifacts:
   - name: pylon
     type: image
     registry: staging
-    version: 0.15.1
+    version: 0.14.3
   - name: reval-server
     type: image
     registry: staging

--- a/tools/ci/check-doc-version-sync
+++ b/tools/ci/check-doc-version-sync
@@ -6,15 +6,4 @@ repo_root="$(cd "${script_dir}/../.." && pwd)"
 
 cd "${repo_root}/tools/docs-version-sync"
 
-set +e
-output="$(go run . --target main --update-catalog --check "$@" 2>&1)"
-status=$?
-set -e
-
-if [ -n "${output}" ]; then
-  printf '%s\n' "${output}" >&2
-fi
-
-if [ "${status}" -ne 0 ]; then
-  printf 'WARNING: docs version sync check failed but is advisory; continuing.\n' >&2
-fi
+go run . --target main --check "$@"

--- a/tools/ci/check-go-tools
+++ b/tools/ci/check-go-tools
@@ -5,9 +5,7 @@
 # Build, vet, and test every Go module under tools/.
 #
 # Nothing did this before. The repo tooling modules carry _test.go files that no
-# workflow ran, so a pull request could break them and still go green. That is
-# how tools/docs-version-sync came to have three failing tests on main without
-# anyone noticing: they had not run in CI since they were written.
+# workflow ran, so a pull request could break them and still go green.
 #
 # Modules are discovered rather than listed, so a new tool is covered the moment
 # it has a go.mod. A list would need editing by exactly the person who is least
@@ -28,19 +26,11 @@ trap 'rm -rf "${build_out}"' EXIT
 # Each entry needs a tracking issue: the point of an exclusion is that someone
 # comes back for it, and an unexplained one just becomes permanent. Excluded
 # modules are still built and vetted.
-#
-#   docs-version-sync  three manifest tests expect bitnami-cassandra in the
-#                      EA-CVE section and it is no longer classified there.
-#                      The data or the classification moved and the tests did
-#                      not, which is exactly the drift this check exists to
-#                      prevent from recurring. See NVIDIA/nvcf#1223.
-skip_tests=(
-  "tools/docs-version-sync"
-)
+skip_tests=()
 
 skipped() {
   local m="$1" s
-  for s in "${skip_tests[@]}"; do [ "${m}" = "${s}" ] && return 0; done
+  for s in "${skip_tests[@]-}"; do [ "${m}" = "${s}" ] && return 0; done
   return 1
 }
 

--- a/tools/docs-version-sync/catalog.go
+++ b/tools/docs-version-sync/catalog.go
@@ -134,6 +134,7 @@ type StackMetadata struct {
 	GitLabProjectID int      `yaml:"gitlab_project_id,omitempty"`
 	PackageName     string   `yaml:"package_name,omitempty"`
 	ArtifactsFile   string   `yaml:"artifacts_file,omitempty"`
+	SourceTag       string   `yaml:"source_tag,omitempty"`
 	SourceCommit    string   `yaml:"source_commit,omitempty"`
 	PinSources      []string `yaml:"pin_sources,omitempty"`
 	PinSourceDigest string   `yaml:"pin_source_digest,omitempty"`
@@ -311,13 +312,18 @@ func ValidateCatalog(catalog *Catalog) error {
 	if _, ok := catalog.Registries[catalog.Stack.Registry]; !ok {
 		return fmt.Errorf("stack registry %q is not defined", catalog.Stack.Registry)
 	}
+	hasSourceTag := strings.TrimSpace(catalog.Stack.SourceTag) != ""
 	hasSourceCommit := strings.TrimSpace(catalog.Stack.SourceCommit) != ""
 	hasPinSources := len(catalog.Stack.PinSources) != 0
 	hasPinSourceDigest := strings.TrimSpace(catalog.Stack.PinSourceDigest) != ""
-	if (hasSourceCommit || hasPinSources || hasPinSourceDigest) && (!hasSourceCommit || !hasPinSources || !hasPinSourceDigest) {
-		return fmt.Errorf("stack source snapshot must set source_commit, pin_sources, and pin_source_digest together")
+	if (hasSourceTag || hasSourceCommit || hasPinSources || hasPinSourceDigest) && (!hasSourceTag || !hasSourceCommit || !hasPinSources || !hasPinSourceDigest) {
+		return fmt.Errorf("stack source snapshot must set source_tag, source_commit, pin_sources, and pin_source_digest together")
 	}
 	if hasSourceCommit {
+		wantSourceTag := "deploy/stacks/self-managed/v" + catalog.Stack.Version
+		if catalog.Stack.SourceTag != wantSourceTag {
+			return fmt.Errorf("stack source_tag must be %s for stack version %s", wantSourceTag, catalog.Stack.Version)
+		}
 		if !fullLowercaseCommitSHARe.MatchString(catalog.Stack.SourceCommit) {
 			return fmt.Errorf("stack source_commit must be a full lowercase commit SHA")
 		}
@@ -663,6 +669,7 @@ func BuildCatalogFromArtifactsWithBase(stackVersion string, artifacts []Artifact
 	catalog.Manifest = base.Manifest
 	if base.Stack.Version == stackVersion {
 		catalog.Stack.SourceCommit = base.Stack.SourceCommit
+		catalog.Stack.SourceTag = base.Stack.SourceTag
 		catalog.Stack.PinSources = append(catalog.Stack.PinSources, base.Stack.PinSources...)
 		catalog.Stack.PinSourceDigest = base.Stack.PinSourceDigest
 	}

--- a/tools/docs-version-sync/main.go
+++ b/tools/docs-version-sync/main.go
@@ -99,6 +99,9 @@ func run(args []string) error {
 		catalog = loaded
 	}
 
+	if err := validateStackSourceSnapshot(repoRoot, catalog); err != nil {
+		return fmt.Errorf("validate stack source snapshot: %w", err)
+	}
 	if err := SyncDocs(repoRoot, catalog, *check); err != nil {
 		return err
 	}
@@ -224,18 +227,31 @@ func findRepoRoot() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	dir := wd
+	return findRepoRootFrom(wd)
+}
+
+func findRepoRootFrom(start string) (string, error) {
+	dir, err := filepath.Abs(start)
+	if err != nil {
+		return "", err
+	}
 	for {
-		candidate := filepath.Join(dir, "imports.yaml")
-		if st, err := os.Stat(candidate); err == nil && !st.IsDir() {
+		catalog := filepath.Join(dir, "docs", "version-catalog", "main.yaml")
+		module := filepath.Join(dir, "tools", "docs-version-sync", "go.mod")
+		if isRegularFile(catalog) && isRegularFile(module) {
 			return dir, nil
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return "", fmt.Errorf("imports.yaml not found (started from %s)", wd)
+			return "", fmt.Errorf("NVCF repository root not found (started from %s)", start)
 		}
 		dir = parent
 	}
+}
+
+func isRegularFile(path string) bool {
+	st, err := os.Stat(path)
+	return err == nil && !st.IsDir()
 }
 
 func relOrAbs(base, path string) string {

--- a/tools/docs-version-sync/main.go
+++ b/tools/docs-version-sync/main.go
@@ -75,6 +75,9 @@ func run(args []string) error {
 		}
 		catalog = updated
 		if *check {
+			if err := validateStackSourceSnapshot(repoRoot, catalog); err != nil {
+				return fmt.Errorf("validate stack source snapshot: %w", err)
+			}
 			if base == nil {
 				return fmt.Errorf("--update-catalog --check requires an existing catalog at %s", relOrAbs(repoRoot, *catalogPath))
 			}
@@ -86,7 +89,7 @@ func run(args []string) error {
 				return fmt.Errorf("%w: %s does not match latest %s artifact manifest for stack %s", ErrCheckFailed, relOrAbs(repoRoot, *catalogPath), defaultPackageName, updated.Stack.Version)
 			}
 		} else {
-			if err := WriteCatalog(*catalogPath, updated); err != nil {
+			if err := writeCatalogAfterStackSourceValidation(repoRoot, *catalogPath, updated); err != nil {
 				return err
 			}
 			fmt.Fprintf(os.Stderr, "updated %s for stack %s\n", relOrAbs(repoRoot, *catalogPath), updated.Stack.Version)
@@ -97,15 +100,24 @@ func run(args []string) error {
 			return err
 		}
 		catalog = loaded
-	}
-
-	if err := validateStackSourceSnapshot(repoRoot, catalog); err != nil {
-		return fmt.Errorf("validate stack source snapshot: %w", err)
+		if err := validateStackSourceSnapshot(repoRoot, catalog); err != nil {
+			return fmt.Errorf("validate stack source snapshot: %w", err)
+		}
 	}
 	if err := SyncDocs(repoRoot, catalog, *check); err != nil {
 		return err
 	}
 	return nil
+}
+
+func writeCatalogAfterStackSourceValidation(repoRoot, catalogPath string, catalog *Catalog) error {
+	if catalog.Stack.SourceCommit == "" {
+		return fmt.Errorf("cannot write updated catalog for stack %s without an immutable source snapshot", catalog.Stack.Version)
+	}
+	if err := validateStackSourceSnapshot(repoRoot, catalog); err != nil {
+		return fmt.Errorf("validate stack source snapshot: %w", err)
+	}
+	return WriteCatalog(catalogPath, catalog)
 }
 
 func updateCatalogFromGitLab(stackVersion string, base *Catalog) (*Catalog, error) {

--- a/tools/docs-version-sync/main_test.go
+++ b/tools/docs-version-sync/main_test.go
@@ -697,6 +697,55 @@ after
 	}
 }
 
+func TestReplaceMarkedBlockAcceptsCompactMDXMarkers(t *testing.T) {
+	got, changed, err := ReplaceMarkedBlock(`before
+{/*docs-version-sync:BEGIN sample*/}
+stale
+{/*docs-version-sync:END sample*/}
+after
+`, "sample", "fresh")
+	if err != nil {
+		t.Fatalf("ReplaceMarkedBlock failed: %v", err)
+	}
+	if !changed {
+		t.Fatal("ReplaceMarkedBlock reported no change")
+	}
+	for _, want := range []string{
+		"{/*docs-version-sync:BEGIN sample*/}",
+		"fresh",
+		"{/*docs-version-sync:END sample*/}",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("updated content missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestFindRepoRootFromUsesPublicCheckoutSentinels(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "docs", "version-catalog", "main.yaml"), "version: 1\n")
+	writeFile(t, filepath.Join(repo, "tools", "docs-version-sync", "go.mod"), "module docs-version-sync\n")
+	nested := filepath.Join(repo, "tools", "docs-version-sync")
+
+	got, err := findRepoRootFrom(nested)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != repo {
+		t.Fatalf("findRepoRootFrom(%s) = %s, want %s", nested, got, repo)
+	}
+}
+
+func TestFindRepoRootFromRequiresBothPublicCheckoutSentinels(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "docs", "version-catalog", "main.yaml"), "version: 1\n")
+
+	_, err := findRepoRootFrom(repo)
+	if err == nil || !strings.Contains(err.Error(), "NVCF repository root not found") {
+		t.Fatalf("findRepoRootFrom error = %v, want missing-root error", err)
+	}
+}
+
 func TestSyncDocsRejectsMissingMarker(t *testing.T) {
 	tmp := t.TempDir()
 	writeFile(t, filepath.Join(tmp, "docs/user/manifest.md"), "no generated marker\n")

--- a/tools/docs-version-sync/manifest_metadata_test.go
+++ b/tools/docs-version-sync/manifest_metadata_test.go
@@ -248,7 +248,7 @@ func TestManifestMetadataClassifiesAllArtifacts(t *testing.T) {
 	}
 
 	sort.Strings(eaCVE)
-	wantEACVE := []string{"bitnami-cassandra", "nvcf-cassandra-migrations"}
+	wantEACVE := []string{"nvcf-cassandra-migrations"}
 	if strings.Join(eaCVE, ",") != strings.Join(wantEACVE, ",") {
 		t.Fatalf("EA-CVE entries = %v, want %v", eaCVE, wantEACVE)
 	}

--- a/tools/docs-version-sync/manifest_test.go
+++ b/tools/docs-version-sync/manifest_test.go
@@ -55,7 +55,7 @@ func TestResolveManifestEntriesRejectsUnclassifiedArtifact(t *testing.T) {
 	}
 }
 
-func TestResolveManifestEntriesKeepsCassandraOnlyInEASection(t *testing.T) {
+func TestResolveManifestEntriesKeepsEACVEArtifactsOutOfServiceSection(t *testing.T) {
 	entries, err := resolveManifestEntries(loadMainCatalog(t))
 	if err != nil {
 		t.Fatalf("resolveManifestEntries failed: %v", err)
@@ -66,12 +66,12 @@ func TestResolveManifestEntriesKeepsCassandraOnlyInEASection(t *testing.T) {
 		if entry.Kind == ManifestKindEACVE {
 			eaIDs = append(eaIDs, entry.ID)
 		}
-		if entry.Kind == ManifestKindServiceImage && (entry.ID == "bitnami-cassandra" || entry.ID == "nvcf-cassandra-migrations") {
+		if entry.Kind == ManifestKindServiceImage && entry.ID == "nvcf-cassandra-migrations" {
 			t.Fatalf("EA artifact %s also appears as a service image", entry.ID)
 		}
 	}
 	sort.Strings(eaIDs)
-	if got, want := strings.Join(eaIDs, ","), "bitnami-cassandra,nvcf-cassandra-migrations"; got != want {
+	if got, want := strings.Join(eaIDs, ","), "nvcf-cassandra-migrations"; got != want {
 		t.Fatalf("EA entries = %q, want %q", got, want)
 	}
 }
@@ -107,7 +107,6 @@ func TestRenderManifestTable(t *testing.T) {
 		"These Early Access artifacts have known CVE impact.",
 		"[GitHub](https://github.com/NVIDIA/nvcf/tree/main/deploy/helm/nats)",
 		"[Upstream](https://github.com/nats-io/k8s)",
-		"`bitnami-cassandra`",
 		"`nvcf-cassandra-migrations`",
 		"`nvcf-self-managed-stack`",
 		"`nvcf-compute-plane-stack`",

--- a/tools/docs-version-sync/render.go
+++ b/tools/docs-version-sync/render.go
@@ -419,6 +419,10 @@ func markerSyntaxes(marker string) []markerSyntax {
 			End:   fmt.Sprintf("{/* docs-version-sync:END %s */}", marker),
 		},
 		{
+			Begin: fmt.Sprintf("{/*docs-version-sync:BEGIN %s*/}", marker),
+			End:   fmt.Sprintf("{/*docs-version-sync:END %s*/}", marker),
+		},
+		{
 			Begin:  fmt.Sprintf("<!-- docs-version-sync:BEGIN %s -->", marker),
 			End:    fmt.Sprintf("<!-- docs-version-sync:END %s -->", marker),
 			Legacy: true,

--- a/tools/docs-version-sync/stack_consistency_test.go
+++ b/tools/docs-version-sync/stack_consistency_test.go
@@ -4,144 +4,11 @@
 package main
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
-	"sort"
 	"strings"
 	"testing"
 )
-
-type effectiveStackPin struct {
-	artifact             string
-	path                 string
-	blockPattern         string
-	blockBoundaryPattern string
-	pattern              string
-}
-
-var effectiveStackPins = []effectiveStackPin{
-	{
-		artifact:             "helm-nvcf-llm-request-router",
-		path:                 "deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl",
-		blockPattern:         `(?m)^  - name: llm-request-router[ \t]*$`,
-		blockBoundaryPattern: `(?m)^  -[ \t]+`,
-		pattern:              `(?m)^    version:[ \t]*"?([^"\s]+)"?[ \t]*$`,
-	},
-	{
-		artifact:             "nvcf-gateway-routes",
-		path:                 "deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl",
-		blockPattern:         `(?m)^  - name: ingress[ \t]*$`,
-		blockBoundaryPattern: `(?m)^  -[ \t]+`,
-		pattern:              `(?m)^    version:[ \t]*"?([^"\s]+)"?[ \t]*$`,
-	},
-	{
-		artifact: "pylon",
-		path:     "deploy/stacks/self-managed/global.yaml.gotmpl",
-		pattern:  `pylon:([0-9][^"\s]*)`,
-	},
-	{
-		artifact:             "helm-nvca-operator",
-		path:                 "deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl",
-		blockPattern:         `(?m)^  - name: nvca-operator[ \t]*$`,
-		blockBoundaryPattern: `(?m)^  -[ \t]+`,
-		pattern:              `(?m)^    version:[ \t]*"?([^"\s]+)"?[ \t]*$`,
-	},
-	{
-		artifact:             "nvca-operator",
-		path:                 "deploy/stacks/nvcf-compute-plane/environments/base.yaml",
-		blockPattern:         `(?m)^  nvcaOperator:[ \t]*$`,
-		blockBoundaryPattern: `(?m)^  [A-Za-z0-9_-]+:[ \t]*`,
-		pattern:              `(?m)^    imageTag:[ \t]*"([^"]+)"[ \t]*$`,
-	},
-	{
-		artifact:             "nvca",
-		path:                 "deploy/stacks/nvcf-compute-plane/environments/base.yaml",
-		blockPattern:         `(?m)^  nvcaOperator:[ \t]*$`,
-		blockBoundaryPattern: `(?m)^  [A-Za-z0-9_-]+:[ \t]*`,
-		pattern:              `(?m)^      nvcaVersion:[ \t]*"([^"]+)"[ \t]*$`,
-	},
-}
-
-func extractEffectiveStackPins(sources map[string][]byte, pins []effectiveStackPin) (map[string]string, error) {
-	versions := make(map[string]string, len(pins))
-	matchedSources := make(map[string]struct{}, len(sources))
-	for _, pin := range pins {
-		body, ok := sources[pin.path]
-		if !ok {
-			return nil, fmt.Errorf("pin source %s for %s is not declared", pin.path, pin.artifact)
-		}
-		matchBody := body
-		if pin.blockPattern != "" {
-			blocks := regexp.MustCompile(pin.blockPattern).FindAllIndex(body, -1)
-			if len(blocks) != 1 {
-				return nil, fmt.Errorf("resolved %d target blocks for %s from %s; want exactly one", len(blocks), pin.artifact, pin.path)
-			}
-			blockStart, blockEnd := blocks[0][0], len(body)
-			if pin.blockBoundaryPattern != "" {
-				remainderStart := blocks[0][1]
-				if next := regexp.MustCompile(pin.blockBoundaryPattern).FindIndex(body[remainderStart:]); next != nil {
-					blockEnd = remainderStart + next[0]
-				}
-			}
-			matchBody = body[blockStart:blockEnd]
-		}
-		matches := regexp.MustCompile(pin.pattern).FindAllSubmatch(matchBody, -1)
-		if len(matches) != 1 {
-			if pin.blockPattern != "" {
-				return nil, fmt.Errorf("resolved %d versions for %s within target block from %s; want exactly one", len(matches), pin.artifact, pin.path)
-			}
-			return nil, fmt.Errorf("resolved %d definitions for %s from %s; want exactly one", len(matches), pin.artifact, pin.path)
-		}
-		if len(matches[0]) != 2 {
-			return nil, fmt.Errorf("pin matcher for %s from %s must capture exactly one version", pin.artifact, pin.path)
-		}
-		if _, exists := versions[pin.artifact]; exists {
-			return nil, fmt.Errorf("duplicate pin matcher for artifact %s", pin.artifact)
-		}
-		versions[pin.artifact] = string(matches[0][1])
-		matchedSources[pin.path] = struct{}{}
-	}
-
-	sourcePaths := make([]string, 0, len(sources))
-	for sourcePath := range sources {
-		sourcePaths = append(sourcePaths, sourcePath)
-	}
-	sort.Strings(sourcePaths)
-	for _, sourcePath := range sourcePaths {
-		if _, matched := matchedSources[sourcePath]; !matched {
-			return nil, fmt.Errorf("declared pin source %s has no matcher", sourcePath)
-		}
-	}
-	return versions, nil
-}
-
-func pinSourceDigest(sources map[string][]byte, pins []effectiveStackPin) (string, error) {
-	versions, err := extractEffectiveStackPins(sources, pins)
-	if err != nil {
-		return "", err
-	}
-	pins = append([]effectiveStackPin(nil), pins...)
-	sort.Slice(pins, func(i, j int) bool { return pins[i].artifact < pins[j].artifact })
-
-	digest := sha256.New()
-	for _, pin := range pins {
-		version, ok := versions[pin.artifact]
-		if !ok {
-			continue
-		}
-		digest.Write([]byte(pin.artifact))
-		digest.Write([]byte{0})
-		digest.Write([]byte(pin.path))
-		digest.Write([]byte{0})
-		digest.Write([]byte(version))
-		digest.Write([]byte{0})
-	}
-	return "sha256:" + hex.EncodeToString(digest.Sum(nil)), nil
-}
 
 func TestPinSourceDigestDetectsUnreleasedSourceMutation(t *testing.T) {
 	sources := map[string][]byte{
@@ -306,53 +173,8 @@ func TestMainCatalogMatchesDeclaredReleaseStackPins(t *testing.T) {
 	if want := "artifacts-" + catalog.Stack.Version + ".txt"; catalog.Stack.ArtifactsFile != want {
 		t.Errorf("stack artifacts_file = %q, want %q for catalog stack version %s", catalog.Stack.ArtifactsFile, want, catalog.Stack.Version)
 	}
-	if !regexp.MustCompile(`^[0-9a-f]{40}$`).MatchString(catalog.Stack.SourceCommit) {
-		t.Fatalf("stack source_commit = %q, want immutable 40-character commit SHA", catalog.Stack.SourceCommit)
-	}
-	if len(catalog.Stack.PinSources) == 0 {
-		t.Fatal("stack pin_sources must declare the release files used to resolve effective versions")
-	}
-
-	contents := make(map[string][]byte, len(catalog.Stack.PinSources))
-	for _, sourcePath := range catalog.Stack.PinSources {
-		body, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(sourcePath)))
-		if err != nil {
-			t.Fatalf("read declared pin source %s: %v", sourcePath, err)
-		}
-		contents[sourcePath] = body
-	}
-	pins := effectiveStackPins
-	versions, err := extractEffectiveStackPins(contents, pins)
-	if err != nil {
+	if err := validateStackSourceSnapshot(root, catalog); err != nil {
 		t.Fatal(err)
-	}
-	got, err := pinSourceDigest(contents, pins)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got != catalog.Stack.PinSourceDigest {
-		t.Fatalf("effective stack pins have digest %s, want release snapshot %s for stack %s at %s; update the version, source commit, digest, and catalog together", got, catalog.Stack.PinSourceDigest, catalog.Stack.Version, catalog.Stack.SourceCommit)
-	}
-
-	for _, pin := range pins {
-		pin := pin
-		t.Run(pin.artifact, func(t *testing.T) {
-			_, ok := contents[pin.path]
-			if !ok {
-				t.Fatalf("pin source %s is not declared in catalog stack pin_sources", pin.path)
-			}
-			want, ok := versions[pin.artifact]
-			if !ok {
-				t.Fatalf("could not resolve %s from %s", pin.artifact, pin.path)
-			}
-			artifact, ok := catalog.findArtifact(pin.artifact)
-			if !ok {
-				t.Fatalf("catalog is missing stack-pinned artifact %s", pin.artifact)
-			}
-			if artifact.Version != want {
-				t.Errorf("catalog %s version = %s, want effective stack pin %s from %s", pin.artifact, artifact.Version, want, pin.path)
-			}
-		})
 	}
 
 	t.Run("nvcf-cli-independent-release", func(t *testing.T) {
@@ -450,19 +272,21 @@ func TestCatalogRefreshPreservesPublicationPending(t *testing.T) {
 
 func TestCatalogRefreshKeepsSnapshotOnlyForSameStackVersion(t *testing.T) {
 	base := testCatalog()
+	base.Stack.SourceTag = "deploy/stacks/self-managed/v" + base.Stack.Version
 	base.Stack.SourceCommit = "1111111111111111111111111111111111111111"
 	base.Stack.PinSources = []string{"stack.yaml"}
 	base.Stack.PinSourceDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
 
 	sameRelease := BuildCatalogFromArtifactsWithBase(base.Stack.Version, nil, base)
-	if sameRelease.Stack.SourceCommit != base.Stack.SourceCommit ||
+	if sameRelease.Stack.SourceTag != base.Stack.SourceTag ||
+		sameRelease.Stack.SourceCommit != base.Stack.SourceCommit ||
 		strings.Join(sameRelease.Stack.PinSources, ",") != "stack.yaml" ||
 		sameRelease.Stack.PinSourceDigest != base.Stack.PinSourceDigest {
 		t.Fatalf("same-release snapshot was not preserved: %#v", sameRelease.Stack)
 	}
 
 	newRelease := BuildCatalogFromArtifactsWithBase("0.9.2", nil, base)
-	if newRelease.Stack.SourceCommit != "" || len(newRelease.Stack.PinSources) != 0 || newRelease.Stack.PinSourceDigest != "" {
+	if newRelease.Stack.SourceTag != "" || newRelease.Stack.SourceCommit != "" || len(newRelease.Stack.PinSources) != 0 || newRelease.Stack.PinSourceDigest != "" {
 		t.Fatalf("new release retained stale source snapshot: %#v", newRelease.Stack)
 	}
 }
@@ -472,7 +296,7 @@ func TestValidateCatalogRejectsIncompleteStackSourceSnapshot(t *testing.T) {
 	catalog.Stack.SourceCommit = "1111111111111111111111111111111111111111"
 
 	err := ValidateCatalog(catalog)
-	if err == nil || !strings.Contains(err.Error(), "source_commit, pin_sources, and pin_source_digest together") {
+	if err == nil || !strings.Contains(err.Error(), "source_tag, source_commit, pin_sources, and pin_source_digest together") {
 		t.Fatalf("ValidateCatalog error = %v, want incomplete stack source snapshot", err)
 	}
 }
@@ -483,6 +307,13 @@ func TestValidateCatalogRejectsInvalidStackSourceSnapshot(t *testing.T) {
 		mutate func(*StackMetadata)
 		want   string
 	}{
+		{
+			name: "tag for another release",
+			mutate: func(stack *StackMetadata) {
+				stack.SourceTag = "deploy/stacks/self-managed/v9.9.9"
+			},
+			want: "source_tag must be deploy/stacks/self-managed/v" + testCatalog().Stack.Version,
+		},
 		{
 			name: "non-immutable commit",
 			mutate: func(stack *StackMetadata) {
@@ -530,6 +361,7 @@ func TestValidateCatalogRejectsInvalidStackSourceSnapshot(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			catalog := testCatalog()
+			catalog.Stack.SourceTag = "deploy/stacks/self-managed/v" + catalog.Stack.Version
 			catalog.Stack.SourceCommit = "1111111111111111111111111111111111111111"
 			catalog.Stack.PinSources = []string{"stack.yaml"}
 			catalog.Stack.PinSourceDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
@@ -545,12 +377,65 @@ func TestValidateCatalogRejectsInvalidStackSourceSnapshot(t *testing.T) {
 
 func TestValidateCatalogAcceptsExactPinSourcePaths(t *testing.T) {
 	catalog := testCatalog()
+	catalog.Stack.SourceTag = "deploy/stacks/self-managed/v" + catalog.Stack.Version
 	catalog.Stack.SourceCommit = "1111111111111111111111111111111111111111"
 	catalog.Stack.PinSources = []string{"deploy/stack.yaml", "deploy/env.yaml"}
 	catalog.Stack.PinSourceDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
 
 	if err := ValidateCatalog(catalog); err != nil {
 		t.Fatalf("ValidateCatalog rejected exact pin source paths: %v", err)
+	}
+}
+
+func TestValidateStackSourceSnapshotReadsRecordedCommit(t *testing.T) {
+	repo := t.TempDir()
+	if _, err := gitOutput(repo, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := gitOutput(repo, "config", "user.email", "docs-version-sync@example.com"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := gitOutput(repo, "config", "user.name", "Docs Version Sync Test"); err != nil {
+		t.Fatal(err)
+	}
+
+	const sourcePath = "stack.yaml"
+	writeFile(t, filepath.Join(repo, sourcePath), "version: 1.2.3\n")
+	if _, err := gitOutput(repo, "add", sourcePath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := gitOutput(repo, "commit", "-m", "test fixture"); err != nil {
+		t.Fatal(err)
+	}
+	commitBytes, err := gitOutput(repo, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	commit := trimOutput(commitBytes)
+	const sourceTag = "deploy/stacks/self-managed/v1.2.3"
+	if _, err := gitOutput(repo, "tag", sourceTag); err != nil {
+		t.Fatal(err)
+	}
+
+	pins := []effectiveStackPin{{artifact: "chart", path: sourcePath, pattern: `(?m)^version: ([^\s]+)$`}}
+	digest, err := pinSourceDigest(map[string][]byte{sourcePath: []byte("version: 1.2.3\n")}, pins)
+	if err != nil {
+		t.Fatal(err)
+	}
+	catalog := &Catalog{
+		Stack: StackMetadata{
+			Version:         "1.2.3",
+			SourceTag:       sourceTag,
+			SourceCommit:    commit,
+			PinSources:      []string{sourcePath},
+			PinSourceDigest: digest,
+		},
+		Artifacts: []Artifact{{Name: "chart", Version: "1.2.3"}},
+	}
+
+	writeFile(t, filepath.Join(repo, sourcePath), "version: 9.9.9\n")
+	if err := validateStackSourceSnapshotWithPins(repo, catalog, pins); err != nil {
+		t.Fatalf("working-tree mutation changed the recorded release snapshot: %v", err)
 	}
 }
 

--- a/tools/docs-version-sync/stack_consistency_test.go
+++ b/tools/docs-version-sync/stack_consistency_test.go
@@ -388,16 +388,7 @@ func TestValidateCatalogAcceptsExactPinSourcePaths(t *testing.T) {
 }
 
 func TestValidateStackSourceSnapshotReadsRecordedCommit(t *testing.T) {
-	repo := t.TempDir()
-	if _, err := gitOutput(repo, "init"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := gitOutput(repo, "config", "user.email", "docs-version-sync@example.com"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := gitOutput(repo, "config", "user.name", "Docs Version Sync Test"); err != nil {
-		t.Fatal(err)
-	}
+	repo := initTestGitRepo(t)
 
 	const sourcePath = "stack.yaml"
 	writeFile(t, filepath.Join(repo, sourcePath), "version: 1.2.3\n")
@@ -437,6 +428,103 @@ func TestValidateStackSourceSnapshotReadsRecordedCommit(t *testing.T) {
 	if err := validateStackSourceSnapshotWithPins(repo, catalog, pins); err != nil {
 		t.Fatalf("working-tree mutation changed the recorded release snapshot: %v", err)
 	}
+}
+
+func TestValidateStackSourceSnapshotRequiresTagRef(t *testing.T) {
+	repo := initTestGitRepo(t)
+
+	const sourcePath = "stack.yaml"
+	writeFile(t, filepath.Join(repo, sourcePath), "version: 1.2.3\n")
+	if _, err := gitOutput(repo, "add", sourcePath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := gitOutput(repo, "commit", "-m", "test fixture"); err != nil {
+		t.Fatal(err)
+	}
+	commitBytes, err := gitOutput(repo, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	commit := trimOutput(commitBytes)
+	const sourceTag = "deploy/stacks/self-managed/v1.2.3"
+	if _, err := gitOutput(repo, "branch", sourceTag); err != nil {
+		t.Fatal(err)
+	}
+
+	catalog := &Catalog{
+		Stack: StackMetadata{
+			Version:         "1.2.3",
+			SourceTag:       sourceTag,
+			SourceCommit:    commit,
+			PinSources:      []string{sourcePath},
+			PinSourceDigest: "sha256:" + strings.Repeat("0", 64),
+		},
+	}
+	pins := []effectiveStackPin{{artifact: "chart", path: sourcePath, pattern: `(?m)^version: ([^\s]+)$`}}
+
+	err = validateStackSourceSnapshotWithPins(repo, catalog, pins)
+	if err == nil || !strings.Contains(err.Error(), "resolve stack source tag") {
+		t.Fatalf("validation error = %v, want missing tag rejection", err)
+	}
+}
+
+func TestWriteCatalogAfterStackSourceValidationLeavesFileUnchanged(t *testing.T) {
+	repo := initTestGitRepo(t)
+
+	catalogPath := filepath.Join(repo, "catalog.yaml")
+	const original = "original catalog\n"
+	writeFile(t, catalogPath, original)
+	catalog := testCatalog()
+	catalog.Stack.SourceTag = "deploy/stacks/self-managed/v" + catalog.Stack.Version
+	catalog.Stack.SourceCommit = strings.Repeat("1", 40)
+	catalog.Stack.PinSources = []string{"stack.yaml"}
+	catalog.Stack.PinSourceDigest = "sha256:" + strings.Repeat("2", 64)
+
+	err := writeCatalogAfterStackSourceValidation(repo, catalogPath, catalog)
+	if err == nil || !strings.Contains(err.Error(), "validate stack source snapshot") {
+		t.Fatalf("write error = %v, want source validation failure", err)
+	}
+	body, err := os.ReadFile(catalogPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != original {
+		t.Fatalf("catalog changed after validation failure:\n%s", body)
+	}
+}
+
+func TestWriteCatalogAfterStackSourceValidationRequiresSnapshot(t *testing.T) {
+	repo := initTestGitRepo(t)
+	catalogPath := filepath.Join(repo, "catalog.yaml")
+	const original = "original catalog\n"
+	writeFile(t, catalogPath, original)
+
+	err := writeCatalogAfterStackSourceValidation(repo, catalogPath, testCatalog())
+	if err == nil || !strings.Contains(err.Error(), "without an immutable source snapshot") {
+		t.Fatalf("write error = %v, want missing snapshot rejection", err)
+	}
+	body, err := os.ReadFile(catalogPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != original {
+		t.Fatalf("catalog changed without a source snapshot:\n%s", body)
+	}
+}
+
+func initTestGitRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	if _, err := gitOutput(repo, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := gitOutput(repo, "config", "user.email", "docs-version-sync@example.com"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := gitOutput(repo, "config", "user.name", "Docs Version Sync Test"); err != nil {
+		t.Fatal(err)
+	}
+	return repo
 }
 
 func TestValidateCatalogRejectsPublishedArtifactMarkedPending(t *testing.T) {

--- a/tools/docs-version-sync/stack_source.go
+++ b/tools/docs-version-sync/stack_source.go
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type effectiveStackPin struct {
+	artifact             string
+	path                 string
+	blockPattern         string
+	blockBoundaryPattern string
+	pattern              string
+}
+
+var effectiveStackPins = []effectiveStackPin{
+	{
+		artifact:             "helm-nvcf-llm-request-router",
+		path:                 "deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl",
+		blockPattern:         `(?m)^  - name: llm-request-router[ \t]*$`,
+		blockBoundaryPattern: `(?m)^  -[ \t]+`,
+		pattern:              `(?m)^    version:[ \t]*"?([^"\s]+)"?[ \t]*$`,
+	},
+	{
+		artifact:             "nvcf-gateway-routes",
+		path:                 "deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl",
+		blockPattern:         `(?m)^  - name: ingress[ \t]*$`,
+		blockBoundaryPattern: `(?m)^  -[ \t]+`,
+		pattern:              `(?m)^    version:[ \t]*"?([^"\s]+)"?[ \t]*$`,
+	},
+	{
+		artifact: "pylon",
+		path:     "deploy/stacks/self-managed/global.yaml.gotmpl",
+		pattern:  `pylon:([0-9][^"\s]*)`,
+	},
+	{
+		artifact:             "helm-nvca-operator",
+		path:                 "deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl",
+		blockPattern:         `(?m)^  - name: nvca-operator[ \t]*$`,
+		blockBoundaryPattern: `(?m)^  -[ \t]+`,
+		pattern:              `(?m)^    version:[ \t]*"?([^"\s]+)"?[ \t]*$`,
+	},
+	{
+		artifact:             "nvca-operator",
+		path:                 "deploy/stacks/nvcf-compute-plane/environments/base.yaml",
+		blockPattern:         `(?m)^  nvcaOperator:[ \t]*$`,
+		blockBoundaryPattern: `(?m)^  [A-Za-z0-9_-]+:[ \t]*`,
+		pattern:              `(?m)^    imageTag:[ \t]*"([^"]+)"[ \t]*$`,
+	},
+	{
+		artifact:             "nvca",
+		path:                 "deploy/stacks/nvcf-compute-plane/environments/base.yaml",
+		blockPattern:         `(?m)^  nvcaOperator:[ \t]*$`,
+		blockBoundaryPattern: `(?m)^  [A-Za-z0-9_-]+:[ \t]*`,
+		pattern:              `(?m)^      nvcaVersion:[ \t]*"([^"]+)"[ \t]*$`,
+	},
+}
+
+func extractEffectiveStackPins(sources map[string][]byte, pins []effectiveStackPin) (map[string]string, error) {
+	versions := make(map[string]string, len(pins))
+	matchedSources := make(map[string]struct{}, len(sources))
+	for _, pin := range pins {
+		body, ok := sources[pin.path]
+		if !ok {
+			return nil, fmt.Errorf("pin source %s for %s is not declared", pin.path, pin.artifact)
+		}
+		matchBody := body
+		if pin.blockPattern != "" {
+			blocks := regexp.MustCompile(pin.blockPattern).FindAllIndex(body, -1)
+			if len(blocks) != 1 {
+				return nil, fmt.Errorf("resolved %d target blocks for %s from %s; want exactly one", len(blocks), pin.artifact, pin.path)
+			}
+			blockStart, blockEnd := blocks[0][0], len(body)
+			if pin.blockBoundaryPattern != "" {
+				remainderStart := blocks[0][1]
+				if next := regexp.MustCompile(pin.blockBoundaryPattern).FindIndex(body[remainderStart:]); next != nil {
+					blockEnd = remainderStart + next[0]
+				}
+			}
+			matchBody = body[blockStart:blockEnd]
+		}
+		matches := regexp.MustCompile(pin.pattern).FindAllSubmatch(matchBody, -1)
+		if len(matches) != 1 {
+			if pin.blockPattern != "" {
+				return nil, fmt.Errorf("resolved %d versions for %s within target block from %s; want exactly one", len(matches), pin.artifact, pin.path)
+			}
+			return nil, fmt.Errorf("resolved %d definitions for %s from %s; want exactly one", len(matches), pin.artifact, pin.path)
+		}
+		if len(matches[0]) != 2 {
+			return nil, fmt.Errorf("pin matcher for %s from %s must capture exactly one version", pin.artifact, pin.path)
+		}
+		if _, exists := versions[pin.artifact]; exists {
+			return nil, fmt.Errorf("duplicate pin matcher for artifact %s", pin.artifact)
+		}
+		versions[pin.artifact] = string(matches[0][1])
+		matchedSources[pin.path] = struct{}{}
+	}
+
+	sourcePaths := make([]string, 0, len(sources))
+	for sourcePath := range sources {
+		sourcePaths = append(sourcePaths, sourcePath)
+	}
+	sort.Strings(sourcePaths)
+	for _, sourcePath := range sourcePaths {
+		if _, matched := matchedSources[sourcePath]; !matched {
+			return nil, fmt.Errorf("declared pin source %s has no matcher", sourcePath)
+		}
+	}
+	return versions, nil
+}
+
+func pinSourceDigest(sources map[string][]byte, pins []effectiveStackPin) (string, error) {
+	versions, err := extractEffectiveStackPins(sources, pins)
+	if err != nil {
+		return "", err
+	}
+	pins = append([]effectiveStackPin(nil), pins...)
+	sort.Slice(pins, func(i, j int) bool { return pins[i].artifact < pins[j].artifact })
+
+	digest := sha256.New()
+	for _, pin := range pins {
+		version, ok := versions[pin.artifact]
+		if !ok {
+			continue
+		}
+		digest.Write([]byte(pin.artifact))
+		digest.Write([]byte{0})
+		digest.Write([]byte(pin.path))
+		digest.Write([]byte{0})
+		digest.Write([]byte(version))
+		digest.Write([]byte{0})
+	}
+	return "sha256:" + hex.EncodeToString(digest.Sum(nil)), nil
+}
+
+func validateStackSourceSnapshot(repoRoot string, catalog *Catalog) error {
+	return validateStackSourceSnapshotWithPins(repoRoot, catalog, effectiveStackPins)
+}
+
+func validateStackSourceSnapshotWithPins(repoRoot string, catalog *Catalog, pins []effectiveStackPin) error {
+	if catalog.Stack.SourceCommit == "" {
+		return nil
+	}
+
+	commit, err := gitOutput(repoRoot, "rev-parse", "--verify", catalog.Stack.SourceTag+"^{commit}")
+	if err != nil {
+		return fmt.Errorf("resolve stack source tag %s: %w", catalog.Stack.SourceTag, err)
+	}
+	if string(commit) != catalog.Stack.SourceCommit+"\n" {
+		return fmt.Errorf("stack source tag %s resolves to %s, want recorded commit %s", catalog.Stack.SourceTag, trimOutput(commit), catalog.Stack.SourceCommit)
+	}
+
+	sources := make(map[string][]byte, len(catalog.Stack.PinSources))
+	for _, sourcePath := range catalog.Stack.PinSources {
+		body, err := gitOutput(repoRoot, "show", catalog.Stack.SourceCommit+":"+sourcePath)
+		if err != nil {
+			return fmt.Errorf("read %s from stack source commit %s: %w", sourcePath, catalog.Stack.SourceCommit, err)
+		}
+		sources[sourcePath] = body
+	}
+
+	versions, err := extractEffectiveStackPins(sources, pins)
+	if err != nil {
+		return err
+	}
+	digest, err := pinSourceDigest(sources, pins)
+	if err != nil {
+		return err
+	}
+	if digest != catalog.Stack.PinSourceDigest {
+		return fmt.Errorf("effective stack pins have digest %s, want release snapshot %s for stack %s at %s", digest, catalog.Stack.PinSourceDigest, catalog.Stack.Version, catalog.Stack.SourceCommit)
+	}
+	for _, pin := range pins {
+		want := versions[pin.artifact]
+		artifact, ok := catalog.findArtifact(pin.artifact)
+		if !ok {
+			return fmt.Errorf("catalog is missing stack-pinned artifact %s", pin.artifact)
+		}
+		if artifact.Version != want {
+			return fmt.Errorf("catalog %s version is %s, want effective stack pin %s from %s", pin.artifact, artifact.Version, want, pin.path)
+		}
+	}
+	return nil
+}
+
+func gitOutput(repoRoot string, args ...string) ([]byte, error) {
+	cmd := exec.Command("git", append([]string{"-C", repoRoot}, args...)...)
+	output, err := cmd.Output()
+	if err == nil {
+		return output, nil
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return nil, fmt.Errorf("git %v: %s", args, trimOutput(exitErr.Stderr))
+	}
+	return nil, err
+}
+
+func trimOutput(output []byte) string {
+	return strings.TrimSpace(string(output))
+}

--- a/tools/docs-version-sync/stack_source.go
+++ b/tools/docs-version-sync/stack_source.go
@@ -150,7 +150,8 @@ func validateStackSourceSnapshotWithPins(repoRoot string, catalog *Catalog, pins
 		return nil
 	}
 
-	commit, err := gitOutput(repoRoot, "rev-parse", "--verify", catalog.Stack.SourceTag+"^{commit}")
+	tagRef := "refs/tags/" + catalog.Stack.SourceTag
+	commit, err := gitOutput(repoRoot, "rev-parse", "--verify", tagRef+"^{commit}")
 	if err != nil {
 		return fmt.Errorf("resolve stack source tag %s: %w", catalog.Stack.SourceTag, err)
 	}

--- a/tools/scripts/test/test-check-doc-version-sync
+++ b/tools/scripts/test/test-check-doc-version-sync
@@ -23,14 +23,14 @@ output="$(PATH="${workdir}/bin:${PATH}" "${checker}" 2>&1)"
 status=$?
 set -e
 
-if [ "${status}" -ne 0 ]; then
-  echo "expected docs version sync check to warn and exit zero, got ${status}" >&2
+if [ "${status}" -ne 7 ]; then
+  echo "expected docs version sync check to propagate status 7, got ${status}" >&2
   echo "${output}" >&2
   exit 1
 fi
 
-if ! grep -q "WARNING: docs version sync check failed" <<<"${output}"; then
-  echo "expected advisory warning in output" >&2
+if grep -q "WARNING: docs version sync check failed" <<<"${output}"; then
+  echo "unexpected advisory warning in output" >&2
   echo "${output}" >&2
   exit 1
 fi


### PR DESCRIPTION
## TL;DR

Validate the docs catalog against the immutable self-managed stack Git tag and
commit recorded in the catalog. This is the first implementation slice of
#279. It also restores the docs-version-sync tests to the standard Go tools CI
job.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

### Why

The existing checker cannot find the repository in a public GitHub checkout
because it requires the untracked `imports.yaml` file. Its source consistency
test also reads the current working tree even though the catalog records a
release commit. This allows later stack changes to invalidate or silently
replace the meaning of a recorded release snapshot.

The CI wrapper then hides every failure as an advisory warning, so neither
source drift nor generated documentation drift blocks a change.

### What changed

- Discover the repository root from two files present in public checkouts.
- Record the stack source tag separately from the legacy publication fields.
- Move effective pin extraction and digest calculation into production code.
- Resolve the recorded tag to its commit and read every declared pin source
  from that commit with Git.
- Preserve compact MDX generated-block markers used by the current manifest.
- Make `check-doc-version-sync` an offline, strict source and generated-file
  check.
- Fetch full tags and history in the docs CI checkout so immutable source
  validation works there.
- Correct the Pylon version for the recorded `0.9.1` stack snapshot from
  `0.15.1` to the tagged value `0.14.3`.
- Update the stale Cassandra expectations and remove the docs-version-sync test
  exclusion, resolving #1223.

### Customer Release Notes

Corrected the self-managed stack `0.9.1` artifact manifest to report the Pylon
version deployed by that release.

### Plan Summary

Not applicable.

### Usage

Run the offline consistency check from the repository root:

```sh
./tools/ci/check-doc-version-sync
```

### Testing

- `go test ./...` in `tools/docs-version-sync`
- `go vet ./...` in `tools/docs-version-sync`
- `./tools/ci/check-go-tools`
- `./tools/ci/check-doc-version-sync`
- `./tools/ci/check-docs`
- `git diff --check`

QA is not needed for this docs tooling and generated documentation change.

### Notes

The latest stable self-managed stack tag advanced to
`deploy/stacks/self-managed/v0.14.4` while this work was in progress. This PR
does not advance the catalog from `0.9.1`. Doing so before the GitHub-native
resolved artifact inventory exists would assign a new source version to an old
publication inventory.

Follow-up work under #279 still needs to replace the GitLab-backed
`--update-catalog` path, cover all chart-owned and optional artifacts, and then
regenerate the catalog from the latest stable release.

### References

- https://github.com/NVIDIA/nvcf/issues/279
- https://github.com/NVIDIA/nvcf/issues/1223

### Related Pull Requests

None.

### Dependencies

None. No license review, NOTICE update, or third-party dependency change is
required.

## For the Reviewer

Please focus on the release-tag and commit validation in
`tools/docs-version-sync/stack_source.go`, plus the decision to keep network
publication discovery out of the strict offline CI wrapper.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

QA is not needed.

## Issues

Relates to #279
Closes #1223

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated self-managed stack metadata and the optional Pylon compute-plane image version to 0.14.3.
  * Documentation synchronization now validates stack source versions, tags, commits, pinned sources, and digests more consistently.
  * Added support for compact documentation markers without spaces.

* **Bug Fixes**
  * Improved repository-root detection for documentation checks.
  * CI documentation checks now report synchronization failures directly instead of issuing advisory warnings.

* **Tests**
  * Expanded coverage for documentation markers, stack snapshots, release tags, and repository validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->