### PR TITLE
fix(charts): bump vanity gateway to 1.35.1

### DIFF
--- a/deploy/helm/vanity-gateway/helm-nvcf-vanity-gateway/Chart.yaml
+++ b/deploy/helm/vanity-gateway/helm-nvcf-vanity-gateway/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "1.34.2"
+appVersion: "1.35.1"
 description: Helm chart for the NVCF Vanity Gateway
 name: helm-nvcf-vanity-gateway
 type: application


### PR DESCRIPTION
## TL;DR

Update the Vanity Gateway chart from service image version 1.34.2 to the released 1.35.1 so the chart release pipeline can publish the next patch version for the self-managed stack.

## Additional Details

- `appVersion` is the default `nvcf-ai-api-gateway-service` image tag when operators do not provide an override.
- Service 1.35.1 includes the fix that preserves an operator-configured rate-limit message for LLM Gateway 429 responses.
- This is the focused Vanity Gateway subset of #1699. Merging it lets the chart release proceed independently and trigger the self-managed stack pin workflow.
- Customer release notes: Vanity Gateway now defaults to service 1.35.1.
- Dependencies: No third-party dependencies changed. No license review or NOTICE update is needed.

## Plan Summary

No Kubernetes resources change. The next chart patch release will default the existing Deployment to image tag 1.35.1.

## Usage

No operator action beyond consuming the resulting chart release.

## For the Reviewer

Confirm that `helm-nvcf-vanity-gateway/Chart.yaml` tracks the published service release.

## For QA

QA is not needed for this metadata-only version update. The service behavior was validated in #1693.

Validated locally:

- `helm lint helm-nvcf-vanity-gateway -f ../../../tools/ci/helm-validate-values/vanity-gateway.yaml`
- `helm template vanity-gateway helm-nvcf-vanity-gateway -f ../../../tools/ci/helm-validate-values/vanity-gateway.yaml`
- `bash tests/chart-render/verify-llm-gateway-routing.sh`
- `bash tests/chart-render/verify-servicemonitor-label.sh`
- `git diff --check`

## References

- Service release: https://github.com/NVIDIA/nvcf/releases/tag/src/invocation-plane-services/vanity-gateway/v1.35.1
- Related automated chart bump: #1699

## Issues

Relates to #1690

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] Existing chart render tests cover this metadata-only change.
- [x] No documentation change is needed for this version update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deployment chart to version 1.35.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->