### PR TITLE
fix(stack): bump self-managed stack chart pins

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -193,7 +193,7 @@ releases:
       release-group: services
 
   - name: vanity-gateway
-    version: 0.4.3
+    version: 0.4.4
     namespace: nvcf
     condition: addons.vanityGateway.enabled
     inherit:


### PR DESCRIPTION
Opened by `.github/workflows/stack-pin-bump.yml` when `deploy/helm/vanity-gateway/v0.4.4` was published.

The released tag carries the version, so this is a direct pin update rather than a lookup of the newest published chart.

Release notes: https://github.com/NVIDIA/nvcf/releases/tag/deploy/helm/vanity-gateway/v0.4.4

If this pull request sits unmerged, later chart releases add their bumps to the same branch, so merging it applies all of them.

Github commit:
fix(stack): bump self-managed stack chart pins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the vanity gateway release to version 0.4.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->