### PR TITLE
refactor(docs): separate source and publication versions

### DIFF
--- a/docs/version-catalog/main.yaml
+++ b/docs/version-catalog/main.yaml
@@ -722,6 +722,7 @@ stack:
   gitlab_project_id: 182049
   package_name: ncp-deploy
   artifacts_file: artifacts-0.9.1.txt
+  source_version: 0.9.1
   source_tag: deploy/stacks/self-managed/v0.9.1
   source_commit: 9cf1103b0e9fe90bde6a8147c95d3d423e96c781
   pin_sources:

--- a/tools/docs-version-sync/catalog.go
+++ b/tools/docs-version-sync/catalog.go
@@ -127,17 +127,19 @@ type VersionOverride struct {
 	Source  string `yaml:"source,omitempty"`
 }
 
+// StackMetadata identifies the independently versioned publication inventory and source release.
 type StackMetadata struct {
-	Name            string   `yaml:"name"`
-	Version         string   `yaml:"version"`
-	Registry        string   `yaml:"registry"`
-	GitLabProjectID int      `yaml:"gitlab_project_id,omitempty"`
-	PackageName     string   `yaml:"package_name,omitempty"`
-	ArtifactsFile   string   `yaml:"artifacts_file,omitempty"`
-	SourceTag       string   `yaml:"source_tag,omitempty"`
-	SourceCommit    string   `yaml:"source_commit,omitempty"`
-	PinSources      []string `yaml:"pin_sources,omitempty"`
-	PinSourceDigest string   `yaml:"pin_source_digest,omitempty"`
+	Name               string   `yaml:"name"`
+	PublicationVersion string   `yaml:"version"`
+	Registry           string   `yaml:"registry"`
+	GitLabProjectID    int      `yaml:"gitlab_project_id,omitempty"`
+	PackageName        string   `yaml:"package_name,omitempty"`
+	ArtifactsFile      string   `yaml:"artifacts_file,omitempty"`
+	SourceVersion      string   `yaml:"source_version,omitempty"`
+	SourceTag          string   `yaml:"source_tag,omitempty"`
+	SourceCommit       string   `yaml:"source_commit,omitempty"`
+	PinSources         []string `yaml:"pin_sources,omitempty"`
+	PinSourceDigest    string   `yaml:"pin_source_digest,omitempty"`
 }
 
 type DenylistEntry struct {
@@ -306,23 +308,24 @@ func ValidateCatalog(catalog *Catalog) error {
 	if strings.TrimSpace(catalog.Stack.Name) == "" {
 		return fmt.Errorf("stack name cannot be empty")
 	}
-	if strings.TrimSpace(catalog.Stack.Version) == "" {
-		return fmt.Errorf("stack version cannot be empty")
+	if strings.TrimSpace(catalog.Stack.PublicationVersion) == "" {
+		return fmt.Errorf("stack publication version cannot be empty")
 	}
 	if _, ok := catalog.Registries[catalog.Stack.Registry]; !ok {
 		return fmt.Errorf("stack registry %q is not defined", catalog.Stack.Registry)
 	}
+	hasSourceVersion := strings.TrimSpace(catalog.Stack.SourceVersion) != ""
 	hasSourceTag := strings.TrimSpace(catalog.Stack.SourceTag) != ""
 	hasSourceCommit := strings.TrimSpace(catalog.Stack.SourceCommit) != ""
 	hasPinSources := len(catalog.Stack.PinSources) != 0
 	hasPinSourceDigest := strings.TrimSpace(catalog.Stack.PinSourceDigest) != ""
-	if (hasSourceTag || hasSourceCommit || hasPinSources || hasPinSourceDigest) && (!hasSourceTag || !hasSourceCommit || !hasPinSources || !hasPinSourceDigest) {
-		return fmt.Errorf("stack source snapshot must set source_tag, source_commit, pin_sources, and pin_source_digest together")
+	if (hasSourceVersion || hasSourceTag || hasSourceCommit || hasPinSources || hasPinSourceDigest) && (!hasSourceVersion || !hasSourceTag || !hasSourceCommit || !hasPinSources || !hasPinSourceDigest) {
+		return fmt.Errorf("stack source snapshot must set source_version, source_tag, source_commit, pin_sources, and pin_source_digest together")
 	}
 	if hasSourceCommit {
-		wantSourceTag := "deploy/stacks/self-managed/v" + catalog.Stack.Version
+		wantSourceTag := "deploy/stacks/self-managed/v" + catalog.Stack.SourceVersion
 		if catalog.Stack.SourceTag != wantSourceTag {
-			return fmt.Errorf("stack source_tag must be %s for stack version %s", wantSourceTag, catalog.Stack.Version)
+			return fmt.Errorf("stack source_tag must be %s for source version %s", wantSourceTag, catalog.Stack.SourceVersion)
 		}
 		if !fullLowercaseCommitSHARe.MatchString(catalog.Stack.SourceCommit) {
 			return fmt.Errorf("stack source_commit must be a full lowercase commit SHA")
@@ -615,7 +618,8 @@ func (registry Registry) resourceRef(name, version string) string {
 	return fmt.Sprintf("%s/%s:%s", registry.Namespace, name, version)
 }
 
-func BuildCatalogFromArtifacts(stackVersion string, artifacts []Artifact) *Catalog {
+// BuildCatalogFromArtifacts creates a catalog from a published package inventory.
+func BuildCatalogFromArtifacts(publicationVersion string, artifacts []Artifact) *Catalog {
 	catalog := &Catalog{
 		Version: 1,
 		Target:  "main",
@@ -626,12 +630,12 @@ func BuildCatalogFromArtifacts(stackVersion string, artifacts []Artifact) *Catal
 			},
 		},
 		Stack: StackMetadata{
-			Name:            defaultStackResourceName,
-			Version:         stackVersion,
-			Registry:        defaultStackRegistry,
-			GitLabProjectID: defaultStackProjectID,
-			PackageName:     defaultPackageName,
-			ArtifactsFile:   fmt.Sprintf("artifacts-%s.txt", stackVersion),
+			Name:               defaultStackResourceName,
+			PublicationVersion: publicationVersion,
+			Registry:           defaultStackRegistry,
+			GitLabProjectID:    defaultStackProjectID,
+			PackageName:        defaultPackageName,
+			ArtifactsFile:      fmt.Sprintf("artifacts-%s.txt", publicationVersion),
 		},
 		SupplementalArtifacts: []Artifact{
 			{Name: "nvcf-cli", Type: ArtifactTypeResource, Registry: defaultCLIRegistry, Version: defaultCLIVersion},
@@ -651,8 +655,9 @@ func BuildCatalogFromArtifacts(stackVersion string, artifacts []Artifact) *Catal
 	return catalog
 }
 
-func BuildCatalogFromArtifactsWithBase(stackVersion string, artifacts []Artifact, base *Catalog) *Catalog {
-	catalog := BuildCatalogFromArtifacts(stackVersion, artifacts)
+// BuildCatalogFromArtifactsWithBase refreshes an existing catalog from a published package inventory.
+func BuildCatalogFromArtifactsWithBase(publicationVersion string, artifacts []Artifact, base *Catalog) *Catalog {
+	catalog := BuildCatalogFromArtifacts(publicationVersion, artifacts)
 	if base == nil {
 		return catalog
 	}
@@ -667,12 +672,12 @@ func BuildCatalogFromArtifactsWithBase(stackVersion string, artifacts []Artifact
 	catalog.PublicationPending = append(catalog.PublicationPending, base.PublicationPending...)
 	catalog.Denylist = append(catalog.Denylist, base.Denylist...)
 	catalog.Manifest = base.Manifest
-	if base.Stack.Version == stackVersion {
-		catalog.Stack.SourceCommit = base.Stack.SourceCommit
-		catalog.Stack.SourceTag = base.Stack.SourceTag
-		catalog.Stack.PinSources = append(catalog.Stack.PinSources, base.Stack.PinSources...)
-		catalog.Stack.PinSourceDigest = base.Stack.PinSourceDigest
-	}
+	// A package refresh does not identify a new GitHub source release.
+	catalog.Stack.SourceVersion = base.Stack.SourceVersion
+	catalog.Stack.SourceCommit = base.Stack.SourceCommit
+	catalog.Stack.SourceTag = base.Stack.SourceTag
+	catalog.Stack.PinSources = append(catalog.Stack.PinSources, base.Stack.PinSources...)
+	catalog.Stack.PinSourceDigest = base.Stack.PinSourceDigest
 
 	manifestNames := map[string]struct{}{}
 	for _, artifact := range catalog.Artifacts {

--- a/tools/docs-version-sync/main.go
+++ b/tools/docs-version-sync/main.go
@@ -86,13 +86,13 @@ func run(args []string) error {
 				return err
 			}
 			if !equal {
-				return fmt.Errorf("%w: %s does not match latest %s artifact manifest for stack %s", ErrCheckFailed, relOrAbs(repoRoot, *catalogPath), defaultPackageName, updated.Stack.Version)
+				return fmt.Errorf("%w: %s does not match latest %s artifact manifest for stack publication %s", ErrCheckFailed, relOrAbs(repoRoot, *catalogPath), defaultPackageName, updated.Stack.PublicationVersion)
 			}
 		} else {
 			if err := writeCatalogAfterStackSourceValidation(repoRoot, *catalogPath, updated); err != nil {
 				return err
 			}
-			fmt.Fprintf(os.Stderr, "updated %s for stack %s\n", relOrAbs(repoRoot, *catalogPath), updated.Stack.Version)
+			fmt.Fprintf(os.Stderr, "updated %s for stack publication %s\n", relOrAbs(repoRoot, *catalogPath), updated.Stack.PublicationVersion)
 		}
 	} else {
 		loaded, err := LoadCatalog(*catalogPath)
@@ -112,7 +112,7 @@ func run(args []string) error {
 
 func writeCatalogAfterStackSourceValidation(repoRoot, catalogPath string, catalog *Catalog) error {
 	if catalog.Stack.SourceCommit == "" {
-		return fmt.Errorf("cannot write updated catalog for stack %s without an immutable source snapshot", catalog.Stack.Version)
+		return fmt.Errorf("cannot write updated catalog for stack publication %s without an immutable source snapshot", catalog.Stack.PublicationVersion)
 	}
 	if err := validateStackSourceSnapshot(repoRoot, catalog); err != nil {
 		return fmt.Errorf("validate stack source snapshot: %w", err)

--- a/tools/docs-version-sync/main_test.go
+++ b/tools/docs-version-sync/main_test.go
@@ -850,8 +850,8 @@ helm-nvcf-api:1.13.0
 	if !sawToken {
 		t.Fatal("GitLab request did not use token from .netrc")
 	}
-	if catalog.Stack.Version != "0.9.0" {
-		t.Fatalf("stack version = %q, want 0.9.0", catalog.Stack.Version)
+	if catalog.Stack.PublicationVersion != "0.9.0" {
+		t.Fatalf("stack publication version = %q, want 0.9.0", catalog.Stack.PublicationVersion)
 	}
 	if catalog.Stack.PackageName != defaultPackageName || catalog.Stack.Name != defaultStackResourceName {
 		t.Fatalf("stack metadata = %#v, want package %s resource %s", catalog.Stack, defaultPackageName, defaultStackResourceName)
@@ -1039,8 +1039,8 @@ func TestUpdateCatalogDiscoversLatestStackPackage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("updateCatalogFromGitLab failed: %v", err)
 	}
-	if catalog.Stack.Version != "0.9.1" {
-		t.Fatalf("stack version = %q, want discovered 0.9.1", catalog.Stack.Version)
+	if catalog.Stack.PublicationVersion != "0.9.1" {
+		t.Fatalf("stack publication version = %q, want discovered 0.9.1", catalog.Stack.PublicationVersion)
 	}
 }
 
@@ -1138,9 +1138,9 @@ func testCatalog() *Catalog {
 			},
 		},
 		Stack: StackMetadata{
-			Name:     "nvcf-self-managed-stack",
-			Version:  "0.5.0",
-			Registry: "staging",
+			Name:               "nvcf-self-managed-stack",
+			PublicationVersion: "0.5.0",
+			Registry:           "staging",
 		},
 		Denylist: []DenylistEntry{
 			{Name: "nvcf-base", Reason: "managed separately"},

--- a/tools/docs-version-sync/render.go
+++ b/tools/docs-version-sync/render.go
@@ -190,7 +190,7 @@ func (catalog *Catalog) stackArtifact() Artifact {
 		Name:     catalog.Stack.Name,
 		Type:     ArtifactTypeResource,
 		Registry: catalog.Stack.Registry,
-		Version:  catalog.Stack.Version,
+		Version:  catalog.Stack.PublicationVersion,
 	}
 }
 

--- a/tools/docs-version-sync/stack_consistency_test.go
+++ b/tools/docs-version-sync/stack_consistency_test.go
@@ -170,8 +170,8 @@ func TestMainCatalogMatchesDeclaredReleaseStackPins(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if want := "artifacts-" + catalog.Stack.Version + ".txt"; catalog.Stack.ArtifactsFile != want {
-		t.Errorf("stack artifacts_file = %q, want %q for catalog stack version %s", catalog.Stack.ArtifactsFile, want, catalog.Stack.Version)
+	if want := "artifacts-" + catalog.Stack.PublicationVersion + ".txt"; catalog.Stack.ArtifactsFile != want {
+		t.Errorf("stack artifacts_file = %q, want %q for publication version %s", catalog.Stack.ArtifactsFile, want, catalog.Stack.PublicationVersion)
 	}
 	if err := validateStackSourceSnapshot(root, catalog); err != nil {
 		t.Fatal(err)
@@ -270,24 +270,36 @@ func TestCatalogRefreshPreservesPublicationPending(t *testing.T) {
 	}
 }
 
-func TestCatalogRefreshKeepsSnapshotOnlyForSameStackVersion(t *testing.T) {
+func TestCatalogRefreshPreservesSourceSnapshotAcrossPublicationVersion(t *testing.T) {
 	base := testCatalog()
-	base.Stack.SourceTag = "deploy/stacks/self-managed/v" + base.Stack.Version
+	base.Stack.SourceVersion = "0.14.5"
+	base.Stack.SourceTag = "deploy/stacks/self-managed/v" + base.Stack.SourceVersion
 	base.Stack.SourceCommit = "1111111111111111111111111111111111111111"
 	base.Stack.PinSources = []string{"stack.yaml"}
 	base.Stack.PinSourceDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
 
-	sameRelease := BuildCatalogFromArtifactsWithBase(base.Stack.Version, nil, base)
+	sameRelease := BuildCatalogFromArtifactsWithBase(base.Stack.PublicationVersion, nil, base)
 	if sameRelease.Stack.SourceTag != base.Stack.SourceTag ||
+		sameRelease.Stack.SourceVersion != base.Stack.SourceVersion ||
 		sameRelease.Stack.SourceCommit != base.Stack.SourceCommit ||
 		strings.Join(sameRelease.Stack.PinSources, ",") != "stack.yaml" ||
 		sameRelease.Stack.PinSourceDigest != base.Stack.PinSourceDigest {
 		t.Fatalf("same-release snapshot was not preserved: %#v", sameRelease.Stack)
 	}
 
-	newRelease := BuildCatalogFromArtifactsWithBase("0.9.2", nil, base)
-	if newRelease.Stack.SourceTag != "" || newRelease.Stack.SourceCommit != "" || len(newRelease.Stack.PinSources) != 0 || newRelease.Stack.PinSourceDigest != "" {
-		t.Fatalf("new release retained stale source snapshot: %#v", newRelease.Stack)
+	newPublication := BuildCatalogFromArtifactsWithBase("0.9.2", nil, base)
+	if newPublication.Stack.PublicationVersion != "0.9.2" {
+		t.Fatalf("publication version = %q, want 0.9.2", newPublication.Stack.PublicationVersion)
+	}
+	if newPublication.Stack.SourceVersion != base.Stack.SourceVersion ||
+		newPublication.Stack.SourceTag != base.Stack.SourceTag ||
+		newPublication.Stack.SourceCommit != base.Stack.SourceCommit ||
+		strings.Join(newPublication.Stack.PinSources, ",") != "stack.yaml" ||
+		newPublication.Stack.PinSourceDigest != base.Stack.PinSourceDigest {
+		t.Fatalf("publication refresh did not preserve source snapshot: %#v", newPublication.Stack)
+	}
+	if err := ValidateCatalog(newPublication); err != nil {
+		t.Fatalf("ValidateCatalog rejected independent source and publication versions: %v", err)
 	}
 }
 
@@ -296,12 +308,14 @@ func TestValidateCatalogRejectsIncompleteStackSourceSnapshot(t *testing.T) {
 	catalog.Stack.SourceCommit = "1111111111111111111111111111111111111111"
 
 	err := ValidateCatalog(catalog)
-	if err == nil || !strings.Contains(err.Error(), "source_tag, source_commit, pin_sources, and pin_source_digest together") {
+	if err == nil || !strings.Contains(err.Error(), "source_version, source_tag, source_commit, pin_sources, and pin_source_digest together") {
 		t.Fatalf("ValidateCatalog error = %v, want incomplete stack source snapshot", err)
 	}
 }
 
 func TestValidateCatalogRejectsInvalidStackSourceSnapshot(t *testing.T) {
+	const sourceVersion = "0.14.5"
+
 	tests := []struct {
 		name   string
 		mutate func(*StackMetadata)
@@ -312,7 +326,7 @@ func TestValidateCatalogRejectsInvalidStackSourceSnapshot(t *testing.T) {
 			mutate: func(stack *StackMetadata) {
 				stack.SourceTag = "deploy/stacks/self-managed/v9.9.9"
 			},
-			want: "source_tag must be deploy/stacks/self-managed/v" + testCatalog().Stack.Version,
+			want: "source_tag must be deploy/stacks/self-managed/v" + sourceVersion,
 		},
 		{
 			name: "non-immutable commit",
@@ -361,7 +375,8 @@ func TestValidateCatalogRejectsInvalidStackSourceSnapshot(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			catalog := testCatalog()
-			catalog.Stack.SourceTag = "deploy/stacks/self-managed/v" + catalog.Stack.Version
+			catalog.Stack.SourceVersion = sourceVersion
+			catalog.Stack.SourceTag = "deploy/stacks/self-managed/v" + catalog.Stack.SourceVersion
 			catalog.Stack.SourceCommit = "1111111111111111111111111111111111111111"
 			catalog.Stack.PinSources = []string{"stack.yaml"}
 			catalog.Stack.PinSourceDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
@@ -377,7 +392,8 @@ func TestValidateCatalogRejectsInvalidStackSourceSnapshot(t *testing.T) {
 
 func TestValidateCatalogAcceptsExactPinSourcePaths(t *testing.T) {
 	catalog := testCatalog()
-	catalog.Stack.SourceTag = "deploy/stacks/self-managed/v" + catalog.Stack.Version
+	catalog.Stack.SourceVersion = catalog.Stack.PublicationVersion
+	catalog.Stack.SourceTag = "deploy/stacks/self-managed/v" + catalog.Stack.SourceVersion
 	catalog.Stack.SourceCommit = "1111111111111111111111111111111111111111"
 	catalog.Stack.PinSources = []string{"deploy/stack.yaml", "deploy/env.yaml"}
 	catalog.Stack.PinSourceDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
@@ -415,11 +431,12 @@ func TestValidateStackSourceSnapshotReadsRecordedCommit(t *testing.T) {
 	}
 	catalog := &Catalog{
 		Stack: StackMetadata{
-			Version:         "1.2.3",
-			SourceTag:       sourceTag,
-			SourceCommit:    commit,
-			PinSources:      []string{sourcePath},
-			PinSourceDigest: digest,
+			PublicationVersion: "9.9.9",
+			SourceVersion:      "1.2.3",
+			SourceTag:          sourceTag,
+			SourceCommit:       commit,
+			PinSources:         []string{sourcePath},
+			PinSourceDigest:    digest,
 		},
 		Artifacts: []Artifact{{Name: "chart", Version: "1.2.3"}},
 	}
@@ -453,11 +470,12 @@ func TestValidateStackSourceSnapshotRequiresTagRef(t *testing.T) {
 
 	catalog := &Catalog{
 		Stack: StackMetadata{
-			Version:         "1.2.3",
-			SourceTag:       sourceTag,
-			SourceCommit:    commit,
-			PinSources:      []string{sourcePath},
-			PinSourceDigest: "sha256:" + strings.Repeat("0", 64),
+			PublicationVersion: "9.9.9",
+			SourceVersion:      "1.2.3",
+			SourceTag:          sourceTag,
+			SourceCommit:       commit,
+			PinSources:         []string{sourcePath},
+			PinSourceDigest:    "sha256:" + strings.Repeat("0", 64),
 		},
 	}
 	pins := []effectiveStackPin{{artifact: "chart", path: sourcePath, pattern: `(?m)^version: ([^\s]+)$`}}
@@ -475,7 +493,8 @@ func TestWriteCatalogAfterStackSourceValidationLeavesFileUnchanged(t *testing.T)
 	const original = "original catalog\n"
 	writeFile(t, catalogPath, original)
 	catalog := testCatalog()
-	catalog.Stack.SourceTag = "deploy/stacks/self-managed/v" + catalog.Stack.Version
+	catalog.Stack.SourceVersion = catalog.Stack.PublicationVersion
+	catalog.Stack.SourceTag = "deploy/stacks/self-managed/v" + catalog.Stack.SourceVersion
 	catalog.Stack.SourceCommit = strings.Repeat("1", 40)
 	catalog.Stack.PinSources = []string{"stack.yaml"}
 	catalog.Stack.PinSourceDigest = "sha256:" + strings.Repeat("2", 64)

--- a/tools/docs-version-sync/stack_source.go
+++ b/tools/docs-version-sync/stack_source.go
@@ -177,7 +177,7 @@ func validateStackSourceSnapshotWithPins(repoRoot string, catalog *Catalog, pins
 		return err
 	}
 	if digest != catalog.Stack.PinSourceDigest {
-		return fmt.Errorf("effective stack pins have digest %s, want release snapshot %s for stack %s at %s", digest, catalog.Stack.PinSourceDigest, catalog.Stack.Version, catalog.Stack.SourceCommit)
+		return fmt.Errorf("effective stack pins have digest %s, want release snapshot %s for source version %s at %s", digest, catalog.Stack.PinSourceDigest, catalog.Stack.SourceVersion, catalog.Stack.SourceCommit)
 	}
 	for _, pin := range pins {
 		want := versions[pin.artifact]


### PR DESCRIPTION
## TL;DR

Separate the immutable GitHub stack source version from the legacy package publication version so the documentation catalog can follow the current stack release without conflating two release streams.

## Additional Details

### Why

PR #1721 made the catalog validate an immutable GitHub source tag and commit, but the existing stack.version field still also identifies the legacy package publication. Those releases have independent version cadences. Advancing either one currently makes the other identity incorrect.

### What changed

- Keep the existing YAML version field as the backward-compatible publication version.
- Add source_version to identify the GitHub stack release used for source validation.
- Derive source_tag validation from source_version instead of the publication version.
- Preserve the source snapshot when refreshing the legacy publication inventory.
- Migrate the current catalog without changing generated user documentation.

### Customer Release Notes

Not customer visible.

### Plan Summary

Not applicable.

### Usage

Not applicable.

### Testing

- go test ./... from tools/docs-version-sync
- go vet ./... from tools/docs-version-sync
- ./tools/ci/check-go-tools
- ./tools/ci/check-doc-version-sync
- ./tools/scripts/test/test-check-doc-version-sync
- ./tools/ci/check-docs (zero errors, one Fern warning)
- git diff --check
- Confirmed docs/user/manifest.md is unchanged

QA is not needed. This changes catalog metadata and validation only.

### Notes

This PR does not advance the catalog to stack release 0.14.5. The next slice can build a complete publication inventory from the GitHub source release and then update the catalog and generated documentation.

### References

- https://github.com/NVIDIA/nvcf/issues/279

### Related Pull Requests

- https://github.com/NVIDIA/nvcf/pull/1721

### Dependencies

None. No third-party dependencies, license review, or NOTICE changes.

## For the Reviewer

Please focus on the source snapshot preservation behavior in BuildCatalogFromArtifactsWithBase and the validation coverage for independent source and publication versions.

## For QA

QA is not needed.

## Issues

Relates to #279

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Version catalogs now distinguish between a package’s publication version and its source release version.
  - Source snapshot metadata is preserved when publication versions are refreshed.
  - Validation now checks complete source metadata, including source-version tags, and provides clearer version-related error messages.
  - The self-managed stack catalog now records source version 0.9.1.
- **Tests**
  - Added coverage for preserving source metadata across publication version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->