### PR TITLE
feat(docs): discover stable GitHub stack releases

### DIFF
--- a/tools/docs-version-sync/github.go
+++ b/tools/docs-version-sync/github.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -26,7 +27,8 @@ const (
 
 var (
 	stableStackVersionRE = regexp.MustCompile(`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$`)
-	stackVersionRE       = regexp.MustCompile(`^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$`)
+	stackVersionRE       = regexp.MustCompile(`^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$`)
+	numericIdentifierRE  = regexp.MustCompile(`^[0-9]+$`)
 )
 
 // githubClient reads immutable stack release refs from GitHub.
@@ -59,11 +61,12 @@ type stackSourceRelease struct {
 
 // stableStackVersion is a stable semantic version used for numeric ordering.
 type stableStackVersion struct {
-	major int
-	minor int
-	patch int
+	major string
+	minor string
+	patch string
 }
 
+// newGitHubClientFromEnvironment creates a GitHub client from docs-version-sync environment variables.
 func newGitHubClientFromEnvironment() *githubClient {
 	baseURL := strings.TrimRight(os.Getenv("DOC_VERSION_SYNC_GITHUB_API_URL"), "/")
 	if baseURL == "" {
@@ -89,6 +92,7 @@ func newGitHubClientFromEnvironment() *githubClient {
 	}
 }
 
+// resolveStackSourceRelease selects the latest stable release or an explicit stack source ref.
 func (client *githubClient) resolveStackSourceRelease(sourceRef string) (stackSourceRelease, error) {
 	wantedRef := ""
 	wantedVersion := ""
@@ -145,6 +149,7 @@ func (client *githubClient) resolveStackSourceRelease(sourceRef string) (stackSo
 	}, nil
 }
 
+// stackRef reads one exact stack source ref from GitHub.
 func (client *githubClient) stackRef(ref string) (githubRef, error) {
 	path := fmt.Sprintf(
 		"/repos/%s/%s/git/ref/%s",
@@ -162,6 +167,7 @@ func (client *githubClient) stackRef(ref string) (githubRef, error) {
 	return result, nil
 }
 
+// stackRefs reads every GitHub ref with the self-managed stack tag prefix.
 func (client *githubClient) stackRefs() ([]githubRef, error) {
 	path := fmt.Sprintf(
 		"/repos/%s/%s/git/matching-refs/tags/%s",
@@ -192,6 +198,7 @@ func (client *githubClient) stackRefs() ([]githubRef, error) {
 	return refs, nil
 }
 
+// resolveCommit dereferences a GitHub ref object to an immutable commit SHA.
 func (client *githubClient) resolveCommit(object githubRefObject) (string, error) {
 	for depth := 0; depth < 10; depth++ {
 		switch object.Type {
@@ -221,11 +228,21 @@ func (client *githubClient) resolveCommit(object githubRefObject) (string, error
 	return "", fmt.Errorf("GitHub annotated tag chain exceeds 10 objects")
 }
 
+// getJSON reads and decodes one GitHub API response.
 func (client *githubClient) getJSON(path string, target any) (http.Header, error) {
-	if client.httpClient == nil {
-		client.httpClient = http.DefaultClient
+	httpClient := client.httpClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
 	}
-	req, err := http.NewRequest(http.MethodGet, strings.TrimRight(client.baseURL, "/")+path, nil)
+	requestURL := strings.TrimRight(client.baseURL, "/") + path
+	parsedURL, err := url.Parse(requestURL)
+	if err != nil {
+		return nil, err
+	}
+	if client.token != "" && !strings.EqualFold(parsedURL.Scheme, "https") {
+		return nil, fmt.Errorf("refuse to send GitHub token over non-HTTPS URL %s", parsedURL.Redacted())
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, requestURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +252,21 @@ func (client *githubClient) getJSON(path string, target any) (http.Header, error
 	if client.token != "" {
 		req.Header.Set("Authorization", "Bearer "+client.token)
 	}
-	resp, err := client.httpClient.Do(req)
+	requestClient := *httpClient
+	checkRedirect := requestClient.CheckRedirect
+	requestClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) > 0 && strings.EqualFold(via[len(via)-1].URL.Scheme, "https") && !strings.EqualFold(req.URL.Scheme, "https") {
+			return fmt.Errorf("refuse GitHub API redirect from HTTPS to %s", req.URL.Scheme)
+		}
+		if checkRedirect != nil {
+			return checkRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
+		}
+		return nil
+	}
+	resp, err := requestClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -250,6 +281,7 @@ func (client *githubClient) getJSON(path string, target any) (http.Header, error
 	return resp.Header.Clone(), nil
 }
 
+// normalizeStackSourceRef converts a version, tag, or full ref to a canonical tag ref.
 func normalizeStackSourceRef(sourceRef string) (string, string, error) {
 	value := strings.TrimSpace(sourceRef)
 	value = strings.TrimPrefix(value, "refs/tags/")
@@ -257,12 +289,30 @@ func normalizeStackSourceRef(sourceRef string) (string, string, error) {
 		value = stackTagPrefix + value
 	}
 	version := strings.TrimPrefix(value, stackTagPrefix)
-	if !stackVersionRE.MatchString(version) {
+	if !validStackVersion(version) {
 		return "", "", fmt.Errorf("stack source %q must be a semantic version, %s tag, or refs/tags/%s ref", sourceRef, stackTagPrefix, stackTagPrefix)
 	}
 	return "refs/tags/" + value, version, nil
 }
 
+// validStackVersion reports whether a value follows the SemVer 2.0.0 grammar used by stack tags.
+func validStackVersion(version string) bool {
+	match := stackVersionRE.FindStringSubmatch(version)
+	if match == nil {
+		return false
+	}
+	if match[1] == "" {
+		return true
+	}
+	for _, identifier := range strings.Split(match[1], ".") {
+		if len(identifier) > 1 && identifier[0] == '0' && numericIdentifierRE.MatchString(identifier) {
+			return false
+		}
+	}
+	return true
+}
+
+// parseStableStackRef parses a stable stack tag ref for numeric ordering.
 func parseStableStackRef(ref string) (string, stableStackVersion, bool) {
 	if !strings.HasPrefix(ref, stackRefPrefix) {
 		return "", stableStackVersion{}, false
@@ -272,18 +322,27 @@ func parseStableStackRef(ref string) (string, stableStackVersion, bool) {
 	if match == nil {
 		return "", stableStackVersion{}, false
 	}
-	major, _ := strconv.Atoi(match[1])
-	minor, _ := strconv.Atoi(match[2])
-	patch, _ := strconv.Atoi(match[3])
-	return version, stableStackVersion{major: major, minor: minor, patch: patch}, true
+	return version, stableStackVersion{major: match[1], minor: match[2], patch: match[3]}, true
 }
 
+// less reports whether a stable stack version precedes another version.
 func (version stableStackVersion) less(other stableStackVersion) bool {
-	if version.major != other.major {
-		return version.major < other.major
+	if comparison := compareNumericIdentifier(version.major, other.major); comparison != 0 {
+		return comparison < 0
 	}
-	if version.minor != other.minor {
-		return version.minor < other.minor
+	if comparison := compareNumericIdentifier(version.minor, other.minor); comparison != 0 {
+		return comparison < 0
 	}
-	return version.patch < other.patch
+	return compareNumericIdentifier(version.patch, other.patch) < 0
+}
+
+// compareNumericIdentifier compares arbitrarily large decimal SemVer components.
+func compareNumericIdentifier(left, right string) int {
+	if len(left) < len(right) {
+		return -1
+	}
+	if len(left) > len(right) {
+		return 1
+	}
+	return strings.Compare(left, right)
 }

--- a/tools/docs-version-sync/github.go
+++ b/tools/docs-version-sync/github.go
@@ -1,0 +1,289 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultGitHubAPIURL = "https://api.github.com"
+	defaultGitHubOwner  = "NVIDIA"
+	defaultGitHubRepo   = "nvcf"
+	stackTagPrefix      = "deploy/stacks/self-managed/v"
+	stackRefPrefix      = "refs/tags/" + stackTagPrefix
+)
+
+var (
+	stableStackVersionRE = regexp.MustCompile(`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$`)
+	stackVersionRE       = regexp.MustCompile(`^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$`)
+)
+
+// githubClient reads immutable stack release refs from GitHub.
+type githubClient struct {
+	baseURL    string
+	token      string
+	owner      string
+	repo       string
+	httpClient *http.Client
+}
+
+// githubRefObject identifies the Git object addressed by a ref or annotated tag.
+type githubRefObject struct {
+	Type string `json:"type"`
+	SHA  string `json:"sha"`
+}
+
+// githubRef is the GitHub representation of a Git ref and its target object.
+type githubRef struct {
+	Ref    string          `json:"ref"`
+	Object githubRefObject `json:"object"`
+}
+
+// stackSourceRelease identifies an immutable self-managed stack source release.
+type stackSourceRelease struct {
+	Version string
+	Tag     string
+	Commit  string
+}
+
+// stableStackVersion is a stable semantic version used for numeric ordering.
+type stableStackVersion struct {
+	major int
+	minor int
+	patch int
+}
+
+func newGitHubClientFromEnvironment() *githubClient {
+	baseURL := strings.TrimRight(os.Getenv("DOC_VERSION_SYNC_GITHUB_API_URL"), "/")
+	if baseURL == "" {
+		baseURL = defaultGitHubAPIURL
+	}
+	token := os.Getenv("DOC_VERSION_SYNC_GITHUB_TOKEN")
+	if token == "" {
+		for _, envName := range []string{"GITHUB_TOKEN", "GH_TOKEN"} {
+			if value := os.Getenv(envName); value != "" {
+				token = value
+				break
+			}
+		}
+	}
+	return &githubClient{
+		baseURL: baseURL,
+		token:   token,
+		owner:   defaultGitHubOwner,
+		repo:    defaultGitHubRepo,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+func (client *githubClient) resolveStackSourceRelease(sourceRef string) (stackSourceRelease, error) {
+	wantedRef := ""
+	wantedVersion := ""
+	if strings.TrimSpace(sourceRef) != "" {
+		var err error
+		wantedRef, wantedVersion, err = normalizeStackSourceRef(sourceRef)
+		if err != nil {
+			return stackSourceRelease{}, err
+		}
+	}
+
+	if wantedRef != "" {
+		ref, err := client.stackRef(wantedRef)
+		if err != nil {
+			return stackSourceRelease{}, err
+		}
+		commit, err := client.resolveCommit(ref.Object)
+		if err != nil {
+			return stackSourceRelease{}, fmt.Errorf("resolve stack source ref %s: %w", wantedRef, err)
+		}
+		return stackSourceRelease{Version: wantedVersion, Tag: strings.TrimPrefix(wantedRef, "refs/tags/"), Commit: commit}, nil
+	}
+
+	refs, err := client.stackRefs()
+	if err != nil {
+		return stackSourceRelease{}, err
+	}
+
+	selected := -1
+	selectedVersion := stableStackVersion{}
+	selectedSourceVersion := ""
+	for i := range refs {
+		version, parsed, ok := parseStableStackRef(refs[i].Ref)
+		if !ok {
+			continue
+		}
+		if selected == -1 || selectedVersion.less(parsed) {
+			selected = i
+			selectedVersion = parsed
+			selectedSourceVersion = version
+		}
+	}
+	if selected == -1 {
+		return stackSourceRelease{}, fmt.Errorf("no stable %sX.Y.Z stack source refs found in GitHub", stackTagPrefix)
+	}
+	commit, err := client.resolveCommit(refs[selected].Object)
+	if err != nil {
+		return stackSourceRelease{}, fmt.Errorf("resolve stack source ref %s: %w", refs[selected].Ref, err)
+	}
+	return stackSourceRelease{
+		Version: selectedSourceVersion,
+		Tag:     strings.TrimPrefix(refs[selected].Ref, "refs/tags/"),
+		Commit:  commit,
+	}, nil
+}
+
+func (client *githubClient) stackRef(ref string) (githubRef, error) {
+	path := fmt.Sprintf(
+		"/repos/%s/%s/git/ref/%s",
+		url.PathEscape(client.owner),
+		url.PathEscape(client.repo),
+		strings.TrimPrefix(ref, "refs/"),
+	)
+	var result githubRef
+	if _, err := client.getJSON(path, &result); err != nil {
+		return githubRef{}, fmt.Errorf("stack source ref %s was not found or could not be read from GitHub: %w", ref, err)
+	}
+	if result.Ref != ref {
+		return githubRef{}, fmt.Errorf("GitHub returned stack source ref %s for requested ref %s", result.Ref, ref)
+	}
+	return result, nil
+}
+
+func (client *githubClient) stackRefs() ([]githubRef, error) {
+	path := fmt.Sprintf(
+		"/repos/%s/%s/git/matching-refs/tags/%s",
+		url.PathEscape(client.owner),
+		url.PathEscape(client.repo),
+		stackTagPrefix,
+	)
+	var refs []githubRef
+	for page := 1; ; {
+		query := url.Values{}
+		query.Set("per_page", "100")
+		query.Set("page", strconv.Itoa(page))
+		var pageRefs []githubRef
+		headers, err := client.getJSON(path+"?"+query.Encode(), &pageRefs)
+		if err != nil {
+			return nil, fmt.Errorf("list stack source refs: %w", err)
+		}
+		refs = append(refs, pageRefs...)
+		nextPage, ok := nextPageFromHeaders(headers)
+		if !ok {
+			break
+		}
+		if nextPage <= page {
+			return nil, fmt.Errorf("GitHub refs pagination did not advance past page %d", page)
+		}
+		page = nextPage
+	}
+	return refs, nil
+}
+
+func (client *githubClient) resolveCommit(object githubRefObject) (string, error) {
+	for depth := 0; depth < 10; depth++ {
+		switch object.Type {
+		case "commit":
+			if !fullLowercaseCommitSHARe.MatchString(object.SHA) {
+				return "", fmt.Errorf("GitHub commit object has invalid SHA %q", object.SHA)
+			}
+			return object.SHA, nil
+		case "tag":
+			path := fmt.Sprintf(
+				"/repos/%s/%s/git/tags/%s",
+				url.PathEscape(client.owner),
+				url.PathEscape(client.repo),
+				url.PathEscape(object.SHA),
+			)
+			var tag struct {
+				Object githubRefObject `json:"object"`
+			}
+			if _, err := client.getJSON(path, &tag); err != nil {
+				return "", fmt.Errorf("dereference annotated tag %s: %w", object.SHA, err)
+			}
+			object = tag.Object
+		default:
+			return "", fmt.Errorf("GitHub ref targets unsupported object type %q", object.Type)
+		}
+	}
+	return "", fmt.Errorf("GitHub annotated tag chain exceeds 10 objects")
+}
+
+func (client *githubClient) getJSON(path string, target any) (http.Header, error) {
+	if client.httpClient == nil {
+		client.httpClient = http.DefaultClient
+	}
+	req, err := http.NewRequest(http.MethodGet, strings.TrimRight(client.baseURL, "/")+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("User-Agent", "nvcf-docs-version-sync")
+	if client.token != "" {
+		req.Header.Set("Authorization", "Bearer "+client.token)
+	}
+	resp, err := client.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("GitHub GET %s failed: %s: %s", path, resp.Status, strings.TrimSpace(string(body)))
+	}
+	if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
+		return nil, fmt.Errorf("decode GitHub response for %s: %w", path, err)
+	}
+	return resp.Header.Clone(), nil
+}
+
+func normalizeStackSourceRef(sourceRef string) (string, string, error) {
+	value := strings.TrimSpace(sourceRef)
+	value = strings.TrimPrefix(value, "refs/tags/")
+	if !strings.HasPrefix(value, stackTagPrefix) {
+		value = stackTagPrefix + value
+	}
+	version := strings.TrimPrefix(value, stackTagPrefix)
+	if !stackVersionRE.MatchString(version) {
+		return "", "", fmt.Errorf("stack source %q must be a semantic version, %s tag, or refs/tags/%s ref", sourceRef, stackTagPrefix, stackTagPrefix)
+	}
+	return "refs/tags/" + value, version, nil
+}
+
+func parseStableStackRef(ref string) (string, stableStackVersion, bool) {
+	if !strings.HasPrefix(ref, stackRefPrefix) {
+		return "", stableStackVersion{}, false
+	}
+	version := strings.TrimPrefix(ref, stackRefPrefix)
+	match := stableStackVersionRE.FindStringSubmatch(version)
+	if match == nil {
+		return "", stableStackVersion{}, false
+	}
+	major, _ := strconv.Atoi(match[1])
+	minor, _ := strconv.Atoi(match[2])
+	patch, _ := strconv.Atoi(match[3])
+	return version, stableStackVersion{major: major, minor: minor, patch: patch}, true
+}
+
+func (version stableStackVersion) less(other stableStackVersion) bool {
+	if version.major != other.major {
+		return version.major < other.major
+	}
+	if version.minor != other.minor {
+		return version.minor < other.minor
+	}
+	return version.patch < other.patch
+}

--- a/tools/docs-version-sync/github_test.go
+++ b/tools/docs-version-sync/github_test.go
@@ -30,9 +30,9 @@ func TestNewGitHubClientFromEnvironmentUsesExplicitSettings(t *testing.T) {
 }
 
 func TestResolveStackSourceReleaseDiscoversLatestStableTag(t *testing.T) {
-	const latestCommit = "1414141414141414141414141414141414141410"
+	const latestCommit = "ffffffffffffffffffffffffffffffffffffffff"
 	var server *httptest.Server
-	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/repos/NVIDIA/nvcf/git/matching-refs/tags/deploy/stacks/self-managed/v" {
 			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
 			return
@@ -50,7 +50,8 @@ func TestResolveStackSourceReleaseDiscoversLatestStableTag(t *testing.T) {
 ]`)
 		case "2":
 			fmt.Fprint(w, `[
-  {"ref":"refs/tags/deploy/stacks/self-managed/v0.14.10","object":{"type":"commit","sha":"`+latestCommit+`"}},
+  {"ref":"refs/tags/deploy/stacks/self-managed/v184467440737095516160.14.10","object":{"type":"commit","sha":"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"}},
+  {"ref":"refs/tags/deploy/stacks/self-managed/v999999999999999999999.14.10","object":{"type":"commit","sha":"`+latestCommit+`"}},
   {"ref":"refs/tags/deploy/stacks/self-managed/v10.0.0-dev.1","object":{"type":"commit","sha":"1010101010101010101010101010101010101010"}},
   {"ref":"refs/tags/deploy/stacks/self-managed/v0.14.5","object":{"type":"commit","sha":"1414141414141414141414141414141414141405"}}
 ]`)
@@ -65,8 +66,8 @@ func TestResolveStackSourceReleaseDiscoversLatestStableTag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveStackSourceRelease failed: %v", err)
 	}
-	if release.Version != "0.14.10" || release.Tag != stackTagPrefix+"0.14.10" || release.Commit != latestCommit {
-		t.Fatalf("release = %#v, want latest stable 0.14.10 at %s", release, latestCommit)
+	if release.Version != "999999999999999999999.14.10" || release.Tag != stackTagPrefix+"999999999999999999999.14.10" || release.Commit != latestCommit {
+		t.Fatalf("release = %#v, want latest overflow-safe stable version at %s", release, latestCommit)
 	}
 }
 
@@ -149,12 +150,56 @@ func TestResolveStackSourceReleaseRejectsMalformedExplicitRefBeforeRequest(t *te
 	defer server.Close()
 
 	client := testGitHubClient(server, "")
-	_, err := client.resolveStackSourceRelease("latest")
-	if err == nil || !strings.Contains(err.Error(), "must be a semantic version") {
-		t.Fatalf("resolveStackSourceRelease error = %v, want malformed-ref rejection", err)
+	for _, selector := range []string{"latest", "1.2.3-01"} {
+		_, err := client.resolveStackSourceRelease(selector)
+		if err == nil || !strings.Contains(err.Error(), "must be a semantic version") {
+			t.Errorf("resolveStackSourceRelease(%q) error = %v, want malformed-ref rejection", selector, err)
+		}
 	}
 	if requested {
 		t.Fatal("malformed explicit ref made a GitHub request")
+	}
+}
+
+func TestGitHubClientRejectsTokenOverHTTP(t *testing.T) {
+	requested := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = true
+		fmt.Fprint(w, `{}`)
+	}))
+	defer server.Close()
+
+	client := testGitHubClient(server, "github-token")
+	var result any
+	_, err := client.getJSON("/test", &result)
+	if err == nil || !strings.Contains(err.Error(), "refuse to send GitHub token over non-HTTPS") {
+		t.Fatalf("getJSON error = %v, want cleartext-token rejection", err)
+	}
+	if requested {
+		t.Fatal("cleartext token request reached the server")
+	}
+}
+
+func TestGitHubClientRejectsHTTPSDowngradeRedirect(t *testing.T) {
+	redirected := false
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirected = true
+		fmt.Fprint(w, `{}`)
+	}))
+	defer httpServer.Close()
+	httpsServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, httpServer.URL+"/target", http.StatusFound)
+	}))
+	defer httpsServer.Close()
+
+	client := testGitHubClient(httpsServer, "github-token")
+	var result any
+	_, err := client.getJSON("/test", &result)
+	if err == nil || !strings.Contains(err.Error(), "refuse GitHub API redirect from HTTPS to http") {
+		t.Fatalf("getJSON error = %v, want HTTPS downgrade rejection", err)
+	}
+	if redirected {
+		t.Fatal("HTTPS downgrade redirect reached the cleartext server")
 	}
 }
 
@@ -174,6 +219,7 @@ func TestResolveStackSourceReleaseRejectsOnlyPrereleaseTags(t *testing.T) {
 	}
 }
 
+// testGitHubClient creates a GitHub client backed by a local test server.
 func testGitHubClient(server *httptest.Server, token string) *githubClient {
 	return &githubClient{
 		baseURL:    server.URL,

--- a/tools/docs-version-sync/github_test.go
+++ b/tools/docs-version-sync/github_test.go
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNewGitHubClientFromEnvironmentUsesExplicitSettings(t *testing.T) {
+	t.Setenv("DOC_VERSION_SYNC_GITHUB_API_URL", "https://github.example.test/api/v3/")
+	t.Setenv("DOC_VERSION_SYNC_GITHUB_TOKEN", "explicit-token")
+	t.Setenv("GITHUB_TOKEN", "fallback-token")
+	t.Setenv("GH_TOKEN", "other-fallback-token")
+
+	client := newGitHubClientFromEnvironment()
+	if client.baseURL != "https://github.example.test/api/v3" {
+		t.Fatalf("baseURL = %q, want trimmed explicit API URL", client.baseURL)
+	}
+	if client.token != "explicit-token" {
+		t.Fatalf("token = %q, want explicit token", client.token)
+	}
+	if client.owner != defaultGitHubOwner || client.repo != defaultGitHubRepo {
+		t.Fatalf("repository = %s/%s, want %s/%s", client.owner, client.repo, defaultGitHubOwner, defaultGitHubRepo)
+	}
+}
+
+func TestResolveStackSourceReleaseDiscoversLatestStableTag(t *testing.T) {
+	const latestCommit = "1414141414141414141414141414141414141410"
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/NVIDIA/nvcf/git/matching-refs/tags/deploy/stacks/self-managed/v" {
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer github-token" {
+			http.Error(w, "missing token", http.StatusUnauthorized)
+			return
+		}
+		switch r.URL.Query().Get("page") {
+		case "1":
+			w.Header().Set("Link", fmt.Sprintf("<%s%s?per_page=100&page=2>; rel=\"next\"", server.URL, r.URL.Path))
+			fmt.Fprint(w, `[
+  {"ref":"refs/tags/deploy/stacks/self-managed/v0.9.9","object":{"type":"commit","sha":"0909090909090909090909090909090909090909"}},
+  {"ref":"refs/tags/deploy/stacks/self-managed/v9.0.0-rc.1","object":{"type":"commit","sha":"9999999999999999999999999999999999999999"}}
+]`)
+		case "2":
+			fmt.Fprint(w, `[
+  {"ref":"refs/tags/deploy/stacks/self-managed/v0.14.10","object":{"type":"commit","sha":"`+latestCommit+`"}},
+  {"ref":"refs/tags/deploy/stacks/self-managed/v10.0.0-dev.1","object":{"type":"commit","sha":"1010101010101010101010101010101010101010"}},
+  {"ref":"refs/tags/deploy/stacks/self-managed/v0.14.5","object":{"type":"commit","sha":"1414141414141414141414141414141414141405"}}
+]`)
+		default:
+			http.Error(w, "unexpected page "+r.URL.Query().Get("page"), http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := testGitHubClient(server, "github-token")
+	release, err := client.resolveStackSourceRelease("")
+	if err != nil {
+		t.Fatalf("resolveStackSourceRelease failed: %v", err)
+	}
+	if release.Version != "0.14.10" || release.Tag != stackTagPrefix+"0.14.10" || release.Commit != latestCommit {
+		t.Fatalf("release = %#v, want latest stable 0.14.10 at %s", release, latestCommit)
+	}
+}
+
+func TestResolveStackSourceReleaseAcceptsExplicitSelectors(t *testing.T) {
+	const commit = "1515151515151515151515151515151515151515"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/NVIDIA/nvcf/git/ref/tags/deploy/stacks/self-managed/v0.15.0-rc.2" {
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		fmt.Fprint(w, `{"ref":"refs/tags/deploy/stacks/self-managed/v0.15.0-rc.2","object":{"type":"commit","sha":"`+commit+`"}}`)
+	}))
+	defer server.Close()
+
+	selectors := []string{
+		"0.15.0-rc.2",
+		stackTagPrefix + "0.15.0-rc.2",
+		"refs/tags/" + stackTagPrefix + "0.15.0-rc.2",
+	}
+	for _, selector := range selectors {
+		t.Run(selector, func(t *testing.T) {
+			client := testGitHubClient(server, "")
+			release, err := client.resolveStackSourceRelease(selector)
+			if err != nil {
+				t.Fatalf("resolveStackSourceRelease(%q) failed: %v", selector, err)
+			}
+			if release.Version != "0.15.0-rc.2" || release.Commit != commit {
+				t.Fatalf("release = %#v, want explicit prerelease at %s", release, commit)
+			}
+		})
+	}
+}
+
+func TestResolveStackSourceReleaseDereferencesAnnotatedTag(t *testing.T) {
+	const (
+		tagObject = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		commit    = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/NVIDIA/nvcf/git/ref/tags/deploy/stacks/self-managed/v0.14.5":
+			fmt.Fprint(w, `{"ref":"refs/tags/deploy/stacks/self-managed/v0.14.5","object":{"type":"tag","sha":"`+tagObject+`"}}`)
+		case "/repos/NVIDIA/nvcf/git/tags/" + tagObject:
+			fmt.Fprint(w, `{"object":{"type":"commit","sha":"`+commit+`"}}`)
+		default:
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := testGitHubClient(server, "")
+	release, err := client.resolveStackSourceRelease("0.14.5")
+	if err != nil {
+		t.Fatalf("resolveStackSourceRelease failed: %v", err)
+	}
+	if release.Commit != commit {
+		t.Fatalf("commit = %q, want dereferenced commit %q", release.Commit, commit)
+	}
+}
+
+func TestResolveStackSourceReleaseRejectsMissingExplicitRef(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Not Found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := testGitHubClient(server, "")
+	_, err := client.resolveStackSourceRelease("0.14.5")
+	if err == nil || !strings.Contains(err.Error(), "was not found or could not be read from GitHub") {
+		t.Fatalf("resolveStackSourceRelease error = %v, want missing-ref rejection", err)
+	}
+}
+
+func TestResolveStackSourceReleaseRejectsMalformedExplicitRefBeforeRequest(t *testing.T) {
+	requested := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = true
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := testGitHubClient(server, "")
+	_, err := client.resolveStackSourceRelease("latest")
+	if err == nil || !strings.Contains(err.Error(), "must be a semantic version") {
+		t.Fatalf("resolveStackSourceRelease error = %v, want malformed-ref rejection", err)
+	}
+	if requested {
+		t.Fatal("malformed explicit ref made a GitHub request")
+	}
+}
+
+func TestResolveStackSourceReleaseRejectsOnlyPrereleaseTags(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `[
+  {"ref":"refs/tags/deploy/stacks/self-managed/v0.15.0-rc.1","object":{"type":"commit","sha":"1515151515151515151515151515151515151515"}},
+  {"ref":"refs/tags/deploy/stacks/self-managed/v0.16.0-dev.1","object":{"type":"commit","sha":"1616161616161616161616161616161616161616"}}
+]`)
+	}))
+	defer server.Close()
+
+	client := testGitHubClient(server, "")
+	_, err := client.resolveStackSourceRelease("")
+	if err == nil || !strings.Contains(err.Error(), "no stable") {
+		t.Fatalf("resolveStackSourceRelease error = %v, want no-stable-release rejection", err)
+	}
+}
+
+func testGitHubClient(server *httptest.Server, token string) *githubClient {
+	return &githubClient{
+		baseURL:    server.URL,
+		token:      token,
+		owner:      defaultGitHubOwner,
+		repo:       defaultGitHubRepo,
+		httpClient: server.Client(),
+	}
+}

--- a/tools/docs-version-sync/gitlab.go
+++ b/tools/docs-version-sync/gitlab.go
@@ -106,6 +106,7 @@ func (client *GitLabClient) LatestStackVersion(projectID int, packageName string
 	return "", fmt.Errorf("no package or release version found for %s", packageName)
 }
 
+// LatestGenericPackageVersion returns the newest matching GitLab generic package version.
 func (client *GitLabClient) LatestGenericPackageVersion(projectID int, packageName string) (string, error) {
 	for page := 1; ; {
 		query := url.Values{}

--- a/tools/docs-version-sync/gitlab.go
+++ b/tools/docs-version-sync/gitlab.go
@@ -132,7 +132,7 @@ func (client *GitLabClient) LatestGenericPackageVersion(projectID int, packageNa
 				return pkg.Version, nil
 			}
 		}
-		nextPage, ok := nextGitLabPage(headers)
+		nextPage, ok := nextPageFromHeaders(headers)
 		if !ok {
 			break
 		}
@@ -142,48 +142,6 @@ func (client *GitLabClient) LatestGenericPackageVersion(projectID int, packageNa
 		page = nextPage
 	}
 	return "", fmt.Errorf("no generic package version found for %s", packageName)
-}
-
-func nextGitLabPage(headers http.Header) (int, bool) {
-	if value := strings.TrimSpace(headers.Get("X-Next-Page")); value != "" {
-		if page, err := strconv.Atoi(value); err == nil && page > 0 {
-			return page, true
-		}
-	}
-	for _, header := range headers.Values("Link") {
-		for _, link := range strings.Split(header, ",") {
-			parts := strings.Split(link, ";")
-			if len(parts) < 2 || !linkHasRelNext(parts[1:]) {
-				continue
-			}
-			rawURL := strings.Trim(strings.TrimSpace(parts[0]), "<>")
-			parsed, err := url.Parse(rawURL)
-			if err != nil {
-				continue
-			}
-			page, err := strconv.Atoi(parsed.Query().Get("page"))
-			if err == nil && page > 0 {
-				return page, true
-			}
-		}
-	}
-	return 0, false
-}
-
-func linkHasRelNext(params []string) bool {
-	for _, param := range params {
-		param = strings.TrimSpace(param)
-		if !strings.HasPrefix(param, "rel=") {
-			continue
-		}
-		rel := strings.Trim(strings.TrimPrefix(param, "rel="), `"`)
-		for _, value := range strings.Fields(rel) {
-			if value == "next" {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func (client *GitLabClient) FetchArtifactList(projectID int, packageName, stackVersion string) (string, error) {

--- a/tools/docs-version-sync/pagination.go
+++ b/tools/docs-version-sync/pagination.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 )
 
+// nextPageFromHeaders returns the next page declared by GitLab or RFC 8288 headers.
 func nextPageFromHeaders(headers http.Header) (int, bool) {
 	if value := strings.TrimSpace(headers.Get("X-Next-Page")); value != "" {
 		if page, err := strconv.Atoi(value); err == nil && page > 0 {
@@ -36,6 +37,7 @@ func nextPageFromHeaders(headers http.Header) (int, bool) {
 	return 0, false
 }
 
+// linkHasRelNext reports whether Link parameters include the next relation.
 func linkHasRelNext(params []string) bool {
 	for _, param := range params {
 		param = strings.TrimSpace(param)

--- a/tools/docs-version-sync/pagination.go
+++ b/tools/docs-version-sync/pagination.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+func nextPageFromHeaders(headers http.Header) (int, bool) {
+	if value := strings.TrimSpace(headers.Get("X-Next-Page")); value != "" {
+		if page, err := strconv.Atoi(value); err == nil && page > 0 {
+			return page, true
+		}
+	}
+	for _, header := range headers.Values("Link") {
+		for _, link := range strings.Split(header, ",") {
+			parts := strings.Split(link, ";")
+			if len(parts) < 2 || !linkHasRelNext(parts[1:]) {
+				continue
+			}
+			rawURL := strings.Trim(strings.TrimSpace(parts[0]), "<>")
+			parsed, err := url.Parse(rawURL)
+			if err != nil {
+				continue
+			}
+			page, err := strconv.Atoi(parsed.Query().Get("page"))
+			if err == nil && page > 0 {
+				return page, true
+			}
+		}
+	}
+	return 0, false
+}
+
+func linkHasRelNext(params []string) bool {
+	for _, param := range params {
+		param = strings.TrimSpace(param)
+		if !strings.HasPrefix(param, "rel=") {
+			continue
+		}
+		rel := strings.Trim(strings.TrimPrefix(param, "rel="), `"`)
+		for _, value := range strings.Fields(rel) {
+			if value == "next" {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/tools/docs-version-sync/pagination_test.go
+++ b/tools/docs-version-sync/pagination_test.go
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestNextPageFromHeaders(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers http.Header
+		page    int
+		ok      bool
+	}{
+		{
+			name: "GitLab header takes precedence",
+			headers: http.Header{
+				"X-Next-Page": {"7"},
+				"Link":        {`<https://example.test/items?page=9>; rel="next"`},
+			},
+			page: 7,
+			ok:   true,
+		},
+		{
+			name: "malformed GitLab header falls through to Link",
+			headers: http.Header{
+				"X-Next-Page": {"invalid"},
+				"Link":        {`<https://example.test/items?page=3>; rel="next"`},
+			},
+			page: 3,
+			ok:   true,
+		},
+		{
+			name: "non-positive GitLab header falls through to Link",
+			headers: http.Header{
+				"X-Next-Page": {"0"},
+				"Link":        {`<https://example.test/items?page=4>; rel="next"`},
+			},
+			page: 4,
+			ok:   true,
+		},
+		{
+			name: "multiple Link fields",
+			headers: http.Header{
+				"Link": {
+					`<https://example.test/items?page=1>; rel="prev"`,
+					`<https://example.test/items?page=5>; rel="prev next"`,
+				},
+			},
+			page: 5,
+			ok:   true,
+		},
+		{
+			name: "no next page",
+			headers: http.Header{
+				"Link": {`<https://example.test/items?page=1>; rel="prev"`},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			page, ok := nextPageFromHeaders(test.headers)
+			if page != test.page || ok != test.ok {
+				t.Fatalf("nextPageFromHeaders() = (%d, %t), want (%d, %t)", page, ok, test.page, test.ok)
+			}
+		})
+	}
+}
+
+func TestLinkHasRelNext(t *testing.T) {
+	tests := []struct {
+		name   string
+		params []string
+		want   bool
+	}{
+		{name: "quoted relation list", params: []string{` rel="prev next"`}, want: true},
+		{name: "unquoted next", params: []string{"rel=next"}, want: true},
+		{name: "next after another parameter", params: []string{"type=application/json", ` rel="next"`}, want: true},
+		{name: "different relation", params: []string{`rel="prev last"`}},
+		{name: "no relation", params: []string{"type=application/json"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := linkHasRelNext(test.params); got != test.want {
+				t.Fatalf("linkHasRelNext(%v) = %t, want %t", test.params, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## TL;DR

Add GitHub-native self-managed stack release selection to docs-version-sync. The selector chooses the highest stable stack tag by default and accepts an exact version, tag, or full tag ref for reproducible follow-up updates.

## Additional Details

### Why

The implementation plan in issue #279 calls for stable GitHub tag discovery before the catalog updater reads tagged stack inputs. Local clones can have stale tag state, so discovery must use GitHub directly instead of relying on local refs or the retired GitLab package flow.

### What changed

- Read self-managed stack tag refs through the GitHub REST API.
- Select the highest numeric X.Y.Z version and exclude prerelease tags by default.
- Accept an exact semantic version, stack tag, or refs/tags value, including an explicitly selected prerelease.
- Resolve lightweight and annotated tags to a validated immutable commit SHA.
- Support public unauthenticated requests plus explicit or GitHub Actions tokens.
- Share Link-header pagination between the GitHub and legacy GitLab clients.
- Add unit coverage for pagination, numeric ordering, filtering, exact selection, authentication, annotated tags, and invalid or missing refs.

### Customer Release Notes

Not customer visible.

### Plan Summary

Not applicable.

### Usage

Not applicable yet. The selector is the production primitive for the next tagged-commit inventory change.

### Testing

- go test ./... from tools/docs-version-sync
- go vet ./... from tools/docs-version-sync
- ./tools/ci/check-go-tools
- ./tools/ci/check-doc-version-sync
- ./tools/scripts/test/test-check-doc-version-sync
- ./tools/ci/check-docs (zero errors, one Fern warning)
- git diff --check

QA is not needed. This adds tool internals and unit tests without changing generated documentation.

### Notes

This PR implements the next unchecked discovery task from the issue plan. It does not update the catalog yet. The next PR will read stack inputs from the selected tagged commit and verify the source snapshot before artifact inventory generation is wired into catalog updates.

### References

- https://github.com/NVIDIA/nvcf/issues/1729
- https://github.com/NVIDIA/nvcf/issues/279

### Related Pull Requests

- https://github.com/NVIDIA/nvcf/pull/1721
- https://github.com/NVIDIA/nvcf/pull/1724

### Dependencies

None. No third-party dependencies, license review, or NOTICE changes.

## For the Reviewer

Please focus on prerelease filtering, numeric version ordering, exact ref normalization, and immutable commit resolution in tools/docs-version-sync/github.go.

## For QA

QA is not needed.

## Issues

Closes #1729
Relates to #279

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Documentation version synchronization can resolve immutable releases from GitHub-hosted stacks.
  - Select a specific stable version or automatically use the latest stable release.
  - Supports paginated release references and annotated tags.
  - Validates release versions and commit references for reliable synchronization.

- **Improvements**
  - Pagination handling is consistent across supported Git hosting providers.
  - Supports very large version numbers and stricter prerelease validation.
  - Token-authenticated requests are protected against insecure URLs and HTTPS downgrade redirects.
  - Invalid or unavailable references produce clearer failure results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->