### PR TITLE
feat(stack): bump self-managed stack chart pins

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -62,7 +62,7 @@ releases:
     condition: icms.enabled
 
   - name: api
-    version: 1.25.7
+    version: 1.26.0
     namespace: nvcf
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -55,7 +55,7 @@ releases:
       - template: service
 
   - name: sis
-    version: 2.2.1
+    version: 2.3.0
     namespace: sis
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -55,7 +55,7 @@ releases:
       - template: service
 
   - name: sis
-    version: 2.1.0
+    version: 2.2.0
     namespace: sis
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -111,7 +111,7 @@ releases:
       - template: service
 
   - name: notary-service
-    version: 1.5.1
+    version: 1.6.0
     namespace: nvcf
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -49,7 +49,7 @@ releases:
 
   # --- NVCF Services ---
   - name: api-keys
-    version: 1.7.0
+    version: 1.8.0
     namespace: api-keys
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -62,7 +62,7 @@ releases:
     condition: icms.enabled
 
   - name: api
-    version: 1.26.0
+    version: 1.27.0
     namespace: nvcf
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -55,7 +55,7 @@ releases:
       - template: service
 
   - name: sis
-    version: 2.2.0
+    version: 2.2.1
     namespace: sis
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -71,7 +71,7 @@ releases:
       - ess/ess-api
 
   - name: nvct-api
-    version: 1.5.3
+    version: 1.6.0
     namespace: nvcf
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -150,7 +150,7 @@ releases:
 
   - name: reval
     chart: nvcf/helm-reval
-    version: 1.3.8
+    version: 1.4.0
     namespace: nvcf
     values:
       - ../global.yaml.gotmpl

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -105,7 +105,7 @@ releases:
       - nvcf/api
 
   - name: ess-api
-    version: 1.8.1
+    version: 1.8.2
     namespace: ess
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
@@ -73,7 +73,7 @@ releases:
 
   {{- if $functionAutoscalerEnabled }}
   - name: function-autoscaler
-    version: 0.3.2
+    version: 0.4.0
     namespace: nvcf
     inherit:
       - template: functionAutoscaler


### PR DESCRIPTION
## Why

The self-managed stack still pins chart versions that predate the releases selected for #1783. This prevents the stack from consuming the service image updates landed by #1786 and the other chart releases already identified by the parent issue. ReVal also needed #1791 before its chart could enter release automation.

## What changed

- Update `api-keys` from 1.7.0 to 1.8.0.
- Update `sis` from 2.1.0 to 2.3.0.
- Update `api` from 1.25.7 to 1.27.0.
- Update `nvct-api` from 1.5.3 to 1.6.0.
- Update `ess-api` from 1.8.1 to 1.8.2.
- Update `notary-service` from 1.5.1 to 1.6.0.
- Update `reval` from 1.3.8 to 1.4.0.
- Update `function-autoscaler` from 0.3.2 to 0.4.0.
- Keep state-metrics at 1.0.2 and OpenBao at 0.32.4. Their missing releases remain tracked by #1787 and #1788.

## Customer Release Notes

Updated the self-managed stack to consume newer NVCF service charts and their associated image versions.

## Plan Summary

This changes Helmfile version pins only. It does not change resources, topology, values, or deployment order.

## Usage

Use the normal self-managed stack upgrade workflow after the selected chart versions are promoted to the configured chart registry. Registry promotion follows this stack pin update and is not a merge prerequisite.

## Testing

Passed on candidate commit `26f5bedab80bf4a7818458688dcc5700b9dc4855`:

- `make -C deploy/stacks/self-managed test`
- `make -C deploy/stacks/nvcf-compute-plane test-observability-profile`
- `go test -short ./...` from `tests/bdd`
- `tools/ci/stack-pin-resolver --audit` (`31 releases, 0 unresolved`)
- `git diff --check`

`make -C deploy/stacks/observability test` completed chart lint and the earlier profile renders, then hit the existing macOS Bash 3.2 empty-array failure in `tests/profile-defaults.sh`. No live cluster QA was run because no isolated local topology was created or authorized for this validation.

Release checks:

- The GitHub release for `deploy/helm/helm-reval/v1.4.0` was published after #1791 merged.
- The automatic release, chart-version-bump, and stack-pin-bump workflows completed successfully.
- Public NGC registry checks on 2026-09-10 at 22:14 PDT still returned the previous version for every selected chart package. This is expected because registry promotion follows the stack pin update and does not block this Pull Request.

## Notes

State-metrics and OpenBao are intentionally unchanged. Follow-up issues #1787 and #1788 own their missing chart releases and later stack consumption.

The candidate is render-valid and ready to merge. Public NGC chart promotion remains a downstream deployment prerequisite.

## References

- #1781
- #1782
- #1783
- #1787
- #1788

## Related Pull Requests

- #1786
- #1791

## Dependencies

No new third-party dependencies. This Pull Request changes existing chart version references only. No license or NOTICE update is required.

## Issues

Relates to #1783
