### PR TITLE
feat(docs): load tagged stack source inputs

### DIFF
--- a/tools/docs-version-sync/stack_source.go
+++ b/tools/docs-version-sync/stack_source.go
@@ -141,38 +141,31 @@ func pinSourceDigest(sources map[string][]byte, pins []effectiveStackPin) (strin
 	return "sha256:" + hex.EncodeToString(digest.Sum(nil)), nil
 }
 
+// validateStackSourceSnapshot verifies the catalog against its immutable stack release inputs.
 func validateStackSourceSnapshot(repoRoot string, catalog *Catalog) error {
 	return validateStackSourceSnapshotWithPins(repoRoot, catalog, effectiveStackPins)
 }
 
+// validateStackSourceSnapshotWithPins verifies catalog artifacts with a supplied pin definition set.
 func validateStackSourceSnapshotWithPins(repoRoot string, catalog *Catalog, pins []effectiveStackPin) error {
 	if catalog.Stack.SourceCommit == "" {
 		return nil
 	}
 
-	tagRef := "refs/tags/" + catalog.Stack.SourceTag
-	commit, err := gitOutput(repoRoot, "rev-parse", "--verify", tagRef+"^{commit}")
-	if err != nil {
-		return fmt.Errorf("resolve stack source tag %s: %w", catalog.Stack.SourceTag, err)
-	}
-	if string(commit) != catalog.Stack.SourceCommit+"\n" {
-		return fmt.Errorf("stack source tag %s resolves to %s, want recorded commit %s", catalog.Stack.SourceTag, trimOutput(commit), catalog.Stack.SourceCommit)
-	}
-
-	sources := make(map[string][]byte, len(catalog.Stack.PinSources))
-	for _, sourcePath := range catalog.Stack.PinSources {
-		body, err := gitOutput(repoRoot, "show", catalog.Stack.SourceCommit+":"+sourcePath)
-		if err != nil {
-			return fmt.Errorf("read %s from stack source commit %s: %w", sourcePath, catalog.Stack.SourceCommit, err)
-		}
-		sources[sourcePath] = body
-	}
-
-	versions, err := extractEffectiveStackPins(sources, pins)
+	snapshot, err := loadStackSourceSnapshot(repoRoot, stackSourceRelease{
+		Version: catalog.Stack.SourceVersion,
+		Tag:     catalog.Stack.SourceTag,
+		Commit:  catalog.Stack.SourceCommit,
+	}, catalog.Stack.PinSources)
 	if err != nil {
 		return err
 	}
-	digest, err := pinSourceDigest(sources, pins)
+
+	versions, err := extractEffectiveStackPins(snapshot.Files, pins)
+	if err != nil {
+		return err
+	}
+	digest, err := pinSourceDigest(snapshot.Files, pins)
 	if err != nil {
 		return err
 	}

--- a/tools/docs-version-sync/stack_source_reader.go
+++ b/tools/docs-version-sync/stack_source_reader.go
@@ -47,7 +47,7 @@ func loadStackSourceSnapshot(repoRoot string, release stackSourceRelease, source
 
 	files := make(map[string][]byte, len(paths))
 	for _, sourcePath := range paths {
-		body, err := gitOutput(repoRoot, "show", release.Commit+":"+sourcePath)
+		body, err := gitOutput(repoRoot, "cat-file", "blob", release.Commit+":"+sourcePath)
 		if err != nil {
 			return stackSourceSnapshot{}, fmt.Errorf("read %s from stack source commit %s: %w", sourcePath, release.Commit, err)
 		}

--- a/tools/docs-version-sync/stack_source_reader.go
+++ b/tools/docs-version-sync/stack_source_reader.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+)
+
+// stackSourceSnapshot contains repository inputs read from one immutable stack release.
+type stackSourceSnapshot struct {
+	Release stackSourceRelease
+	Files   map[string][]byte
+}
+
+// resolveStackSourceSnapshot selects a GitHub stack release and loads its requested repository inputs.
+func (client *githubClient) resolveStackSourceSnapshot(repoRoot, sourceRef string, sourcePaths []string) (stackSourceSnapshot, error) {
+	release, err := client.resolveStackSourceRelease(sourceRef)
+	if err != nil {
+		return stackSourceSnapshot{}, err
+	}
+	return loadStackSourceSnapshot(repoRoot, release, sourcePaths)
+}
+
+// loadStackSourceSnapshot verifies a release tag and reads requested files from its immutable commit.
+func loadStackSourceSnapshot(repoRoot string, release stackSourceRelease, sourcePaths []string) (stackSourceSnapshot, error) {
+	if err := validateStackSourceRelease(release); err != nil {
+		return stackSourceSnapshot{}, err
+	}
+	paths, err := normalizeStackSourcePaths(sourcePaths)
+	if err != nil {
+		return stackSourceSnapshot{}, err
+	}
+
+	tagRef := "refs/tags/" + release.Tag
+	commit, err := gitOutput(repoRoot, "rev-parse", "--verify", tagRef+"^{commit}")
+	if err != nil {
+		return stackSourceSnapshot{}, fmt.Errorf("resolve stack source tag %s to a commit: %w", release.Tag, err)
+	}
+	resolvedCommit := trimOutput(commit)
+	if resolvedCommit != release.Commit {
+		return stackSourceSnapshot{}, fmt.Errorf("stack source tag %s resolves to %s, want selected commit %s", release.Tag, resolvedCommit, release.Commit)
+	}
+
+	files := make(map[string][]byte, len(paths))
+	for _, sourcePath := range paths {
+		body, err := gitOutput(repoRoot, "show", release.Commit+":"+sourcePath)
+		if err != nil {
+			return stackSourceSnapshot{}, fmt.Errorf("read %s from stack source commit %s: %w", sourcePath, release.Commit, err)
+		}
+		files[sourcePath] = body
+	}
+	return stackSourceSnapshot{Release: release, Files: files}, nil
+}
+
+// validateStackSourceRelease verifies the canonical identity of a selected stack release.
+func validateStackSourceRelease(release stackSourceRelease) error {
+	if !validStackVersion(release.Version) {
+		return fmt.Errorf("stack source version %q is not a semantic version", release.Version)
+	}
+	wantTag := stackTagPrefix + release.Version
+	if release.Tag != wantTag {
+		return fmt.Errorf("stack source tag must be %s for source version %s", wantTag, release.Version)
+	}
+	if !fullLowercaseCommitSHARe.MatchString(release.Commit) {
+		return fmt.Errorf("stack source commit must be a full lowercase commit SHA")
+	}
+	return nil
+}
+
+// normalizeStackSourcePaths validates, deduplicates, and orders repository-relative source paths.
+func normalizeStackSourcePaths(sourcePaths []string) ([]string, error) {
+	if len(sourcePaths) == 0 {
+		return nil, fmt.Errorf("stack source paths cannot be empty")
+	}
+
+	paths := append([]string(nil), sourcePaths...)
+	sort.Strings(paths)
+	for i, sourcePath := range paths {
+		if sourcePath == "" || strings.TrimSpace(sourcePath) != sourcePath || path.IsAbs(sourcePath) || path.Clean(sourcePath) != sourcePath || sourcePath == "." || strings.HasPrefix(sourcePath, "../") {
+			return nil, fmt.Errorf("stack source path %q must be a clean repository-relative path", sourcePath)
+		}
+		if i > 0 && sourcePath == paths[i-1] {
+			return nil, fmt.Errorf("duplicate stack source path %s", sourcePath)
+		}
+	}
+	return paths, nil
+}

--- a/tools/docs-version-sync/stack_source_reader_test.go
+++ b/tools/docs-version-sync/stack_source_reader_test.go
@@ -48,7 +48,9 @@ func TestResolveStackSourceSnapshotAcceptsExplicitSelector(t *testing.T) {
 			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
 			return
 		}
-		fmt.Fprintf(w, `{"ref":"refs/tags/%s","object":{"type":"commit","sha":"%s"}}`, release.Tag, release.Commit)
+		if _, err := fmt.Fprintf(w, `{"ref":"refs/tags/%s","object":{"type":"commit","sha":"%s"}}`, release.Tag, release.Commit); err != nil {
+			t.Errorf("write GitHub response: %v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -69,6 +71,17 @@ func TestLoadStackSourceSnapshotRejectsMissingFile(t *testing.T) {
 	want := "read missing.yaml from stack source commit " + release.Commit
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Fatalf("loadStackSourceSnapshot error = %v, want %q", err, want)
+	}
+}
+
+func TestLoadStackSourceSnapshotRejectsDirectory(t *testing.T) {
+	repo := initTestGitRepo(t)
+	release := commitTestStackSource(t, repo, "1.2.3", map[string]string{"deploy/stack.yaml": "version: 1.2.3\n"})
+
+	_, err := loadStackSourceSnapshot(repo, release, []string{"deploy"})
+	want := "read deploy from stack source commit " + release.Commit
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("loadStackSourceSnapshot error = %v, want directory rejection %q", err, want)
 	}
 }
 
@@ -131,6 +144,45 @@ func TestNormalizeStackSourcePathsRejectsInvalidInput(t *testing.T) {
 			_, err := normalizeStackSourcePaths(test.paths)
 			if err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("normalizeStackSourcePaths error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestValidateStackSourceReleaseRejectsInvalidIdentity(t *testing.T) {
+	valid := stackSourceRelease{
+		Version: "1.2.3",
+		Tag:     stackTagPrefix + "1.2.3",
+		Commit:  strings.Repeat("a", 40),
+	}
+	tests := []struct {
+		name    string
+		mutate  func(*stackSourceRelease)
+		wantErr string
+	}{
+		{
+			name:    "invalid semantic version",
+			mutate:  func(release *stackSourceRelease) { release.Version = "release-1.2.3" },
+			wantErr: "is not a semantic version",
+		},
+		{
+			name:    "non-canonical tag",
+			mutate:  func(release *stackSourceRelease) { release.Tag = "v1.2.3" },
+			wantErr: "stack source tag must be " + stackTagPrefix + "1.2.3",
+		},
+		{
+			name:    "malformed commit",
+			mutate:  func(release *stackSourceRelease) { release.Commit = "abc123" },
+			wantErr: "full lowercase commit SHA",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			release := valid
+			test.mutate(&release)
+			if err := validateStackSourceRelease(release); err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("validateStackSourceRelease error = %v, want %q", err, test.wantErr)
 			}
 		})
 	}

--- a/tools/docs-version-sync/stack_source_reader_test.go
+++ b/tools/docs-version-sync/stack_source_reader_test.go
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadStackSourceSnapshotReadsSelectedCommit(t *testing.T) {
+	repo := initTestGitRepo(t)
+	release := commitTestStackSource(t, repo, "1.2.3", map[string]string{
+		"deploy/stack.yaml":  "version: 1.2.3\n",
+		"deploy/values.yaml": "image: example:4.5.6\n",
+	})
+	writeFile(t, filepath.Join(repo, "deploy", "stack.yaml"), "version: 9.9.9\n")
+	if err := os.Remove(filepath.Join(repo, "deploy", "values.yaml")); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot, err := loadStackSourceSnapshot(repo, release, []string{"deploy/values.yaml", "deploy/stack.yaml"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Release != release {
+		t.Fatalf("release = %#v, want %#v", snapshot.Release, release)
+	}
+	if got := string(snapshot.Files["deploy/stack.yaml"]); got != "version: 1.2.3\n" {
+		t.Fatalf("stack input = %q, want committed content", got)
+	}
+	if got := string(snapshot.Files["deploy/values.yaml"]); got != "image: example:4.5.6\n" {
+		t.Fatalf("values input = %q, want committed content", got)
+	}
+}
+
+func TestResolveStackSourceSnapshotAcceptsExplicitSelector(t *testing.T) {
+	repo := initTestGitRepo(t)
+	release := commitTestStackSource(t, repo, "1.2.3", map[string]string{"stack.yaml": "version: 1.2.3\n"})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wantPath := "/repos/NVIDIA/nvcf/git/ref/tags/deploy/stacks/self-managed/v1.2.3"
+		if r.URL.Path != wantPath {
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		fmt.Fprintf(w, `{"ref":"refs/tags/%s","object":{"type":"commit","sha":"%s"}}`, release.Tag, release.Commit)
+	}))
+	defer server.Close()
+
+	snapshot, err := testGitHubClient(server, "").resolveStackSourceSnapshot(repo, "1.2.3", []string{"stack.yaml"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Release != release || string(snapshot.Files["stack.yaml"]) != "version: 1.2.3\n" {
+		t.Fatalf("snapshot = %#v, want exact selected release input", snapshot)
+	}
+}
+
+func TestLoadStackSourceSnapshotRejectsMissingFile(t *testing.T) {
+	repo := initTestGitRepo(t)
+	release := commitTestStackSource(t, repo, "1.2.3", map[string]string{"stack.yaml": "version: 1.2.3\n"})
+
+	_, err := loadStackSourceSnapshot(repo, release, []string{"missing.yaml"})
+	want := "read missing.yaml from stack source commit " + release.Commit
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("loadStackSourceSnapshot error = %v, want %q", err, want)
+	}
+}
+
+func TestLoadStackSourceSnapshotRejectsMismatchedTag(t *testing.T) {
+	repo := initTestGitRepo(t)
+	release := commitTestStackSource(t, repo, "1.2.3", map[string]string{"stack.yaml": "version: 1.2.3\n"})
+	writeFile(t, filepath.Join(repo, "stack.yaml"), "version: 1.2.4\n")
+	if _, err := gitOutput(repo, "add", "stack.yaml"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := gitOutput(repo, "commit", "-m", "newer fixture"); err != nil {
+		t.Fatal(err)
+	}
+	commit, err := gitOutput(repo, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	release.Commit = trimOutput(commit)
+
+	_, err = loadStackSourceSnapshot(repo, release, []string{"stack.yaml"})
+	if err == nil || !strings.Contains(err.Error(), "want selected commit "+release.Commit) {
+		t.Fatalf("loadStackSourceSnapshot error = %v, want mismatched-tag rejection", err)
+	}
+}
+
+func TestLoadStackSourceSnapshotRejectsNonCommitTag(t *testing.T) {
+	repo := initTestGitRepo(t)
+	writeFile(t, filepath.Join(repo, "stack.yaml"), "version: 1.2.3\n")
+	blob, err := gitOutput(repo, "hash-object", "-w", "stack.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const version = "1.2.3"
+	if _, err := gitOutput(repo, "tag", stackTagPrefix+version, trimOutput(blob)); err != nil {
+		t.Fatal(err)
+	}
+	release := stackSourceRelease{Version: version, Tag: stackTagPrefix + version, Commit: strings.Repeat("1", 40)}
+
+	_, err = loadStackSourceSnapshot(repo, release, []string{"stack.yaml"})
+	if err == nil || !strings.Contains(err.Error(), "resolve stack source tag "+release.Tag+" to a commit") {
+		t.Fatalf("loadStackSourceSnapshot error = %v, want non-commit-tag rejection", err)
+	}
+}
+
+func TestNormalizeStackSourcePathsRejectsInvalidInput(t *testing.T) {
+	tests := []struct {
+		name  string
+		paths []string
+		want  string
+	}{
+		{name: "empty list", want: "paths cannot be empty"},
+		{name: "absolute", paths: []string{"/stack.yaml"}, want: "clean repository-relative path"},
+		{name: "parent traversal", paths: []string{"../stack.yaml"}, want: "clean repository-relative path"},
+		{name: "unclean", paths: []string{"deploy/../stack.yaml"}, want: "clean repository-relative path"},
+		{name: "duplicate", paths: []string{"stack.yaml", "stack.yaml"}, want: "duplicate stack source path stack.yaml"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := normalizeStackSourcePaths(test.paths)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("normalizeStackSourcePaths error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+// commitTestStackSource writes and tags a stack source fixture.
+func commitTestStackSource(t *testing.T, repo, version string, files map[string]string) stackSourceRelease {
+	t.Helper()
+	for name, body := range files {
+		writeFile(t, filepath.Join(repo, filepath.FromSlash(name)), body)
+	}
+	if _, err := gitOutput(repo, "add", "--all"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := gitOutput(repo, "commit", "-m", "stack source fixture"); err != nil {
+		t.Fatal(err)
+	}
+	commit, err := gitOutput(repo, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tag := stackTagPrefix + version
+	if _, err := gitOutput(repo, "tag", tag); err != nil {
+		t.Fatal(err)
+	}
+	return stackSourceRelease{Version: version, Tag: tag, Commit: trimOutput(commit)}
+}


### PR DESCRIPTION
## TL;DR

Load docs-version-sync stack inputs from the immutable commit selected through GitHub. The reader verifies the local release tag before reading any file, so working-tree changes cannot alter the selected release snapshot.

## Additional Details

### Why

PR #1725 added stable GitHub release selection, but the next catalog stages need a reusable way to read source files from that exact release. Reading from the caller's working tree would make updates depend on unrelated local changes and could mix source versions.

### What changed

- Add a stack source snapshot reader that connects GitHub release selection to local Git object reads.
- Validate the canonical source version, tag, and full commit SHA.
- Verify that the selected tag resolves to the selected commit before reading inputs.
- Validate, deduplicate, and sort repository-relative input paths.
- Read every requested input with `git show <commit>:<path>`.
- Reuse the reader in existing catalog source validation.
- Add coverage for working-tree mutations, explicit release selection, missing files, mismatched refs, non-commit tags, and unsafe paths.

### Customer Release Notes

Not customer visible.

### Plan Summary

Not applicable.

### Usage

Not applicable yet. The resolved inventory generator will consume this source snapshot primitive in the next sub-issue.

### Testing

- `go test ./...` from `tools/docs-version-sync`
- `go vet ./...` from `tools/docs-version-sync`
- `./tools/ci/check-go-tools`
- `./tools/ci/check-doc-version-sync`
- `./tools/scripts/test/test-check-doc-version-sync`
- `./tools/ci/check-docs` (zero errors, one existing Fern warning)
- `git diff --check`

QA is not needed for this docs tooling change.

### Notes

This PR does not generate or publish an artifact inventory. Issue #1731 adds inventory generation on top of this reader.

### References

- https://github.com/NVIDIA/nvcf/issues/1730
- https://github.com/NVIDIA/nvcf/issues/279

### Related Pull Requests

- https://github.com/NVIDIA/nvcf/pull/1725

### Dependencies

None. No third-party dependencies, license review, or NOTICE update.

## For the Reviewer

Please focus on tag and commit verification ordering, repository path validation, and the source reader tests in `tools/docs-version-sync/stack_source_reader_test.go`.

## For QA

QA is not needed.

## Issues

Closes #1730
Relates to #279

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation when loading documentation snapshots from selected releases.
  - Ensured release versions, tags, and commit references remain consistent.
  - Added safeguards against invalid source paths, missing files, directory paths, non-commit tags, and mismatched release metadata.
  - Improved error context when snapshot files cannot be loaded.

- **Tests**
  - Added coverage for release identity validation, snapshot loading, path validation, and repository inconsistency scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->