### PR TITLE
feat(release): publish self-managed stack inventories

### DIFF
--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -116,5 +116,36 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - uses: actions/setup-go@v5
+        if: startsWith(github.ref_name, 'deploy/stacks/self-managed/v')
+        with:
+          go-version-file: tools/go-toolchain/go.mod
+
+      - name: Install inventory rendering tools
+        if: startsWith(github.ref_name, 'deploy/stacks/self-managed/v')
+        env:
+          HELM_VERSION: "3.21.4"
+          HELM_SHA256: "61f88ab166748cb19604d7884cb100ae9ccb13804ddeb98e08af167eacbb6a14"
+          HELMFILE_VERSION: "1.1.9"
+          HELMFILE_SHA256: "ee71196bb12460905b8cbe0ef67b28db51ef681b777cc212d8c0956475b51905"
+        run: |
+          set -euo pipefail
+          cd "${RUNNER_TEMP}"
+          curl -sSL --retry 3 -o helm.tar.gz \
+            "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+          echo "${HELM_SHA256}  helm.tar.gz" | sha256sum -c -
+          tar xzf helm.tar.gz linux-amd64/helm
+
+          curl -sSL --retry 3 -o helmfile.tar.gz \
+            "https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/helmfile_${HELMFILE_VERSION}_linux_amd64.tar.gz"
+          echo "${HELMFILE_SHA256}  helmfile.tar.gz" | sha256sum -c -
+          tar xzf helmfile.tar.gz helmfile
+
+          mkdir -p "${RUNNER_TEMP}/bin"
+          mv linux-amd64/helm helmfile "${RUNNER_TEMP}/bin/"
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+
       - name: Validate tag and create release notes
+        env:
+          NVCF_RELEASE_NGC_API_KEY: ${{ secrets.NGC_NCP_DEV_KEY }}
         run: ./tools/ci/github-release tag "$GITHUB_REF_NAME"

--- a/deploy/stacks/nvcf-compute-plane/environments/base.yaml
+++ b/deploy/stacks/nvcf-compute-plane/environments/base.yaml
@@ -6,7 +6,7 @@ global:
   # =============================================================================
   # Helm Chart Sources Configuration
   # =============================================================================
-  # Set url to use an HTTP Helm repository. Otherwise, set registry and
+  # Set url to use an HTTPS Helm repository. Otherwise, set registry and
   # repository to use OCI.
   helm:
     sources:

--- a/deploy/stacks/nvcf-compute-plane/environments/base.yaml
+++ b/deploy/stacks/nvcf-compute-plane/environments/base.yaml
@@ -6,6 +6,8 @@ global:
   # =============================================================================
   # Helm Chart Sources Configuration
   # =============================================================================
+  # Set url to use an HTTP Helm repository. Otherwise, set registry and
+  # repository to use OCI.
   helm:
     sources:
       registry: "nvcr.io"

--- a/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
+++ b/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
@@ -57,8 +57,18 @@ environments:
 
 repositories:
   - name: nvcf
+{{- if dig "global" "helm" "sources" "url" "" .Values }}
+    url: {{ .Values.global.helm.sources.url | quote }}
+    {{- if dig "global" "helm" "sources" "username" "" .Values }}
+    username: {{ dig "global" "helm" "sources" "username" "" .Values | quote }}
+    {{- end }}
+    {{- if dig "global" "helm" "sources" "password" "" .Values }}
+    password: {{ dig "global" "helm" "sources" "password" "" .Values | quote }}
+    {{- end }}
+{{- else }}
     url: {{ .Values.global.helm.sources.registry }}/{{ .Values.global.helm.sources.repository }}
     oci: true
+{{- end }}
 
 helmDefaults:
   createNamespace: true

--- a/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
+++ b/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
@@ -55,10 +55,15 @@ environments:
 {{- toYaml $featureGateValues -}}
 {{- end -}}
 
+{{- $helmSourceURL := dig "global" "helm" "sources" "url" "" .Values }}
+{{- if and $helmSourceURL (not (hasPrefix "https://" $helmSourceURL)) }}
+{{- fail "global.helm.sources.url must use https://" }}
+{{- end }}
+
 repositories:
   - name: nvcf
-{{- if dig "global" "helm" "sources" "url" "" .Values }}
-    url: {{ .Values.global.helm.sources.url | quote }}
+{{- if $helmSourceURL }}
+    url: {{ $helmSourceURL | quote }}
     {{- if dig "global" "helm" "sources" "username" "" .Values }}
     username: {{ dig "global" "helm" "sources" "username" "" .Values | quote }}
     {{- end }}

--- a/deploy/stacks/observability/environments/base.yaml
+++ b/deploy/stacks/observability/environments/base.yaml
@@ -3,6 +3,8 @@
 
 global:
   helm:
+    # Set url to use an HTTP Helm repository. Otherwise, set registry and
+    # repository to use OCI.
     sources:
       registry: nvcr.io
       repository: YOUR_ORG/YOUR_TEAM

--- a/deploy/stacks/observability/environments/base.yaml
+++ b/deploy/stacks/observability/environments/base.yaml
@@ -3,7 +3,7 @@
 
 global:
   helm:
-    # Set url to use an HTTP Helm repository. Otherwise, set registry and
+    # Set url to use an HTTPS Helm repository. Otherwise, set registry and
     # repository to use OCI.
     sources:
       registry: nvcr.io

--- a/deploy/stacks/observability/helmfile.d/01-observability.yaml.gotmpl
+++ b/deploy/stacks/observability/helmfile.d/01-observability.yaml.gotmpl
@@ -122,8 +122,18 @@ environments:
 
 repositories:
   - name: nvcf
+{{- if dig "global" "helm" "sources" "url" "" .Values }}
+    url: {{ .Values.global.helm.sources.url | quote }}
+    {{- if dig "global" "helm" "sources" "username" "" .Values }}
+    username: {{ dig "global" "helm" "sources" "username" "" .Values | quote }}
+    {{- end }}
+    {{- if dig "global" "helm" "sources" "password" "" .Values }}
+    password: {{ dig "global" "helm" "sources" "password" "" .Values | quote }}
+    {{- end }}
+{{- else }}
     url: {{ .Values.global.helm.sources.registry }}/{{ .Values.global.helm.sources.repository }}
     oci: true
+{{- end }}
 
 helmDefaults:
   createNamespace: true

--- a/deploy/stacks/observability/helmfile.d/01-observability.yaml.gotmpl
+++ b/deploy/stacks/observability/helmfile.d/01-observability.yaml.gotmpl
@@ -120,10 +120,15 @@ environments:
 {{- $_ := set $computePlaneMonitors "enabled" $computePlaneMonitorsEnabled }}
 {{- $_ := set $defaultMonitors "computePlane" $computePlaneMonitors }}
 
+{{- $helmSourceURL := dig "global" "helm" "sources" "url" "" .Values }}
+{{- if and $helmSourceURL (not (hasPrefix "https://" $helmSourceURL)) }}
+{{- fail "global.helm.sources.url must use https://" }}
+{{- end }}
+
 repositories:
   - name: nvcf
-{{- if dig "global" "helm" "sources" "url" "" .Values }}
-    url: {{ .Values.global.helm.sources.url | quote }}
+{{- if $helmSourceURL }}
+    url: {{ $helmSourceURL | quote }}
     {{- if dig "global" "helm" "sources" "username" "" .Values }}
     username: {{ dig "global" "helm" "sources" "username" "" .Values | quote }}
     {{- end }}

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -9,7 +9,7 @@ global:
   # =============================================================================
   # Helm Chart Sources Configuration
   # =============================================================================
-  # Option A: HTTP Helm repository (e.g. NGC public catalog):
+  # Option A: HTTPS Helm repository (e.g. NGC public catalog):
   #   sources:
   #     url: "https://helm.ngc.nvidia.com/nvidia/nvcf"
   #     username: "$oauthtoken"

--- a/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
@@ -69,10 +69,15 @@ environments:
 {{- fail "openbao.enabled must be true when addons.llm.pki.clusterIssuer management is enabled" }}
 {{- end }}
 
+{{- $helmSourceURL := dig "global" "helm" "sources" "url" "" .Values }}
+{{- if and $helmSourceURL (not (hasPrefix "https://" $helmSourceURL)) }}
+{{- fail "global.helm.sources.url must use https://" }}
+{{- end }}
+
 repositories:
   - name: nvcf
-{{- if dig "global" "helm" "sources" "url" "" .Values }}
-    url: {{ .Values.global.helm.sources.url | quote }}
+{{- if $helmSourceURL }}
+    url: {{ $helmSourceURL | quote }}
     {{- if dig "global" "helm" "sources" "username" "" .Values }}
     username: {{ dig "global" "helm" "sources" "username" "" .Values | quote }}
     {{- end }}

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -6,10 +6,15 @@ environments:
 
 ---
 
+{{- $helmSourceURL := dig "global" "helm" "sources" "url" "" .Values }}
+{{- if and $helmSourceURL (not (hasPrefix "https://" $helmSourceURL)) }}
+{{- fail "global.helm.sources.url must use https://" }}
+{{- end }}
+
 repositories:
   - name: nvcf
-{{- if dig "global" "helm" "sources" "url" "" .Values }}
-    url: {{ .Values.global.helm.sources.url | quote }}
+{{- if $helmSourceURL }}
+    url: {{ $helmSourceURL | quote }}
     {{- if dig "global" "helm" "sources" "username" "" .Values }}
     username: {{ dig "global" "helm" "sources" "username" "" .Values | quote }}
     {{- end }}

--- a/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
@@ -15,10 +15,15 @@ environments:
 {{- fail "function-autoscaler requires stateMetrics.enabled=true for control and all observability profiles" }}
 {{- end }}
 
+{{- $helmSourceURL := dig "global" "helm" "sources" "url" "" .Values }}
+{{- if and $helmSourceURL (not (hasPrefix "https://" $helmSourceURL)) }}
+{{- fail "global.helm.sources.url must use https://" }}
+{{- end }}
+
 repositories:
   - name: nvcf
-{{- if dig "global" "helm" "sources" "url" "" .Values }}
-    url: {{ .Values.global.helm.sources.url | quote }}
+{{- if $helmSourceURL }}
+    url: {{ $helmSourceURL | quote }}
     {{- if dig "global" "helm" "sources" "username" "" .Values }}
     username: {{ dig "global" "helm" "sources" "username" "" .Values | quote }}
     {{- end }}

--- a/tools/ci/github-release
+++ b/tools/ci/github-release
@@ -585,6 +585,15 @@ def create_release(tag, title, notes, draft, dry_run):
     return True
 
 
+def publish_release(tag, dry_run):
+    """Publish a draft GitHub release after its required assets are present."""
+    if dry_run:
+        print(f"[github-release] dry-run: would publish GitHub release {tag}")
+        return
+    run(["gh", "release", "edit", tag, "--draft=false"])
+    print(f"[github-release] published GitHub release {tag}")
+
+
 def release_asset_service(metadata, tag, root):
     matches = []
     for service in metadata.get("services", []):
@@ -1248,20 +1257,24 @@ def tag_release(args):
     asset_name = asset_service["resolved_inventory_asset"]
     if dry_run:
         print(f"[github-release] dry-run: would generate and upload {asset_name} for {tag}")
-        create_release(tag, tag, notes, draft=draft, dry_run=True)
+        create_release(tag, tag, notes, draft=True, dry_run=True)
+        if not draft:
+            publish_release(tag, dry_run=True)
         return
 
     commit = tag_sha(root, tag)
     with tempfile.TemporaryDirectory(prefix="nvcf-resolved-stack-inventory-") as tmp:
         asset_path = Path(tmp) / asset_name
         generate_resolved_stack_inventory(root, tag, parsed["version"], commit, asset_path)
-        created = create_release(tag, tag, notes, draft=draft, dry_run=False)
+        created = create_release(tag, tag, notes, draft=True, dry_run=False)
         try:
             publish_resolved_stack_inventory(tag, asset_path)
         except (Exception, SystemExit):
             if created:
                 delete_release_after_inventory_failure(tag)
             raise
+        if not draft:
+            publish_release(tag, dry_run=False)
 
 
 def fetch_semantic_release_notes(root):

--- a/tools/ci/github-release
+++ b/tools/ci/github-release
@@ -8,6 +8,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -584,6 +585,91 @@ def create_release(tag, title, notes, draft, dry_run):
     return True
 
 
+def release_asset_service(metadata, tag, root):
+    matches = []
+    for service in metadata.get("services", []):
+        asset_name = str(service.get("resolved_inventory_asset") or "").strip()
+        if asset_name and Path(asset_name).name != asset_name:
+            raise SystemExit(f"{service.get('id', 'service')}: resolved_inventory_asset must be a file name")
+        if asset_name and version_from_tag(service, tag, root):
+            matches.append(service)
+    if len(matches) > 1:
+        raise SystemExit(f"release tag {tag} matches more than one resolved inventory publisher")
+    return matches[0] if matches else None
+
+
+def validate_resolved_stack_inventory(path, tag, version, commit):
+    try:
+        with Path(path).open() as source:
+            inventory = json.load(source)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"resolved stack inventory is not valid JSON: {exc}") from exc
+    if not isinstance(inventory, dict) or inventory.get("schema_version") != 1:
+        raise SystemExit("resolved stack inventory must use schema_version 1")
+    expected_source = {"version": version, "tag": tag, "commit": commit}
+    if inventory.get("source") != expected_source:
+        raise SystemExit(
+            f"resolved stack inventory source is {inventory.get('source')!r}, want {expected_source!r}"
+        )
+    if not inventory.get("releases") or not inventory.get("artifacts"):
+        raise SystemExit("resolved stack inventory must contain releases and artifacts")
+
+
+def generate_resolved_stack_inventory(root, tag, version, commit, output_path):
+    run(
+        [
+            "go",
+            "run",
+            ".",
+            "--generate-stack-inventory",
+            str(output_path),
+            "--stack-version",
+            version,
+            "--stack-source-tag",
+            tag,
+            "--stack-source-commit",
+            commit,
+        ],
+        cwd=root / "tools" / "docs-version-sync",
+    )
+    validate_resolved_stack_inventory(output_path, tag, version, commit)
+
+
+def publish_resolved_stack_inventory(tag, asset_path):
+    asset_path = Path(asset_path)
+    existing = set(
+        run(
+            ["gh", "release", "view", tag, "--json", "assets", "--jq", ".assets[].name"],
+            capture=True,
+        ).splitlines()
+    )
+    if asset_path.name not in existing:
+        run(["gh", "release", "upload", tag, str(asset_path)])
+        print(f"[github-release] uploaded {asset_path.name} to {tag}")
+        return
+
+    with tempfile.TemporaryDirectory(prefix="nvcf-existing-release-asset-") as tmp:
+        run(
+            [
+                "gh",
+                "release",
+                "download",
+                tag,
+                "--pattern",
+                asset_path.name,
+                "--dir",
+                tmp,
+            ]
+        )
+        published_path = Path(tmp) / asset_path.name
+        if published_path.read_bytes() != asset_path.read_bytes():
+            raise SystemExit(
+                f"GitHub release {tag} already has a different {asset_path.name}; "
+                "refusing to replace an immutable inventory"
+            )
+    print(f"[github-release] GitHub release {tag} already has the identical {asset_path.name}")
+
+
 def repo_slug():
     slug = os.environ.get("GITHUB_REPOSITORY", "").strip()
     if slug:
@@ -1141,7 +1227,23 @@ def tag_release(args):
         f"version={parsed['version']} release_branch={branch} "
         f"auto_tagging_enabled={str(auto_tagging_enabled).lower()}"
     )
-    create_release(tag, tag, notes, draft=draft, dry_run=dry_run)
+    asset_service = release_asset_service(metadata, tag, root)
+    if not asset_service:
+        create_release(tag, tag, notes, draft=draft, dry_run=dry_run)
+        return
+
+    asset_name = asset_service["resolved_inventory_asset"]
+    if dry_run:
+        print(f"[github-release] dry-run: would generate and upload {asset_name} for {tag}")
+        create_release(tag, tag, notes, draft=draft, dry_run=True)
+        return
+
+    commit = tag_sha(root, tag)
+    with tempfile.TemporaryDirectory(prefix="nvcf-resolved-stack-inventory-") as tmp:
+        asset_path = Path(tmp) / asset_name
+        generate_resolved_stack_inventory(root, tag, parsed["version"], commit, asset_path)
+        create_release(tag, tag, notes, draft=draft, dry_run=False)
+        publish_resolved_stack_inventory(tag, asset_path)
 
 
 def fetch_semantic_release_notes(root):

--- a/tools/ci/github-release
+++ b/tools/ci/github-release
@@ -670,6 +670,19 @@ def publish_resolved_stack_inventory(tag, asset_path):
     print(f"[github-release] GitHub release {tag} already has the identical {asset_path.name}")
 
 
+def delete_release_after_inventory_failure(tag):
+    try:
+        run(["gh", "release", "delete", tag, "--yes"])
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"[github-release] WARNING: failed to remove incomplete GitHub release {tag}: {exc}",
+            file=sys.stderr,
+        )
+        return False
+    print(f"[github-release] removed incomplete GitHub release {tag}")
+    return True
+
+
 def repo_slug():
     slug = os.environ.get("GITHUB_REPOSITORY", "").strip()
     if slug:
@@ -1242,8 +1255,13 @@ def tag_release(args):
     with tempfile.TemporaryDirectory(prefix="nvcf-resolved-stack-inventory-") as tmp:
         asset_path = Path(tmp) / asset_name
         generate_resolved_stack_inventory(root, tag, parsed["version"], commit, asset_path)
-        create_release(tag, tag, notes, draft=draft, dry_run=False)
-        publish_resolved_stack_inventory(tag, asset_path)
+        created = create_release(tag, tag, notes, draft=draft, dry_run=False)
+        try:
+            publish_resolved_stack_inventory(tag, asset_path)
+        except (Exception, SystemExit):
+            if created:
+                delete_release_after_inventory_failure(tag)
+            raise
 
 
 def fetch_semantic_release_notes(root):

--- a/tools/ci/github-release-subprojects.json
+++ b/tools/ci/github-release-subprojects.json
@@ -41,7 +41,8 @@
       "path": "deploy/stacks/self-managed",
       "service_name": "nvcf-self-managed-stack",
       "tag_format": "deploy/stacks/self-managed/v${version}",
-      "initial_version": "0.8.0"
+      "initial_version": "0.8.0",
+      "resolved_inventory_asset": "nvcf-self-managed-stack-inventory.json"
     },
     {
       "id": "nvcf-observability-stack",

--- a/tools/ci/test-github-release.py
+++ b/tools/ci/test-github-release.py
@@ -1165,6 +1165,28 @@ class GithubReleaseTest(unittest.TestCase):
             ],
         }
 
+    def test_publish_release_makes_the_exact_draft_public(self):
+        calls = []
+        self.github_release.run = lambda args, **_kwargs: calls.append(args)
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.github_release.publish_release(
+                "deploy/stacks/self-managed/v1.2.3", dry_run=False
+            )
+
+        self.assertEqual(
+            calls,
+            [
+                [
+                    "gh",
+                    "release",
+                    "edit",
+                    "deploy/stacks/self-managed/v1.2.3",
+                    "--draft=false",
+                ]
+            ],
+        )
+
     def test_stack_tag_generates_inventory_before_release_and_uploads_after(self):
         root = Path(tempfile.mkdtemp())
         self.addCleanup(lambda: shutil.rmtree(root))
@@ -1179,9 +1201,14 @@ class GithubReleaseTest(unittest.TestCase):
         self.github_release.generate_resolved_stack_inventory = (
             lambda _root, _tag, _version, _commit, path: calls.append(("generate", Path(path).name))
         )
-        self.github_release.create_release = lambda *_args, **_kwargs: calls.append(("release", tag))
+        self.github_release.create_release = (
+            lambda _tag, _title, _notes, draft, dry_run: calls.append(("release", draft, dry_run)) or True
+        )
         self.github_release.publish_resolved_stack_inventory = (
             lambda _tag, path: calls.append(("upload", Path(path).name))
+        )
+        self.github_release.publish_release = (
+            lambda _tag, dry_run: calls.append(("publish", dry_run))
         )
 
         with contextlib.redirect_stdout(io.StringIO()):
@@ -1191,10 +1218,33 @@ class GithubReleaseTest(unittest.TestCase):
             calls,
             [
                 ("generate", "nvcf-self-managed-stack-inventory.json"),
-                ("release", tag),
+                ("release", True, False),
                 ("upload", "nvcf-self-managed-stack-inventory.json"),
+                ("publish", False),
             ],
         )
+
+    def test_stack_tag_preserves_explicit_draft_after_inventory_upload(self):
+        root = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(root))
+        tag = "deploy/stacks/self-managed/v1.2.3"
+        calls = []
+        self.github_release.repo_root = lambda: root
+        self.github_release.load_metadata = lambda *_args: self.stack_release_metadata()
+        self.github_release.github_release_mode = lambda: (True, False)
+        self.github_release.bool_env = lambda *_args: True
+        self.github_release.tag_sha = lambda *_args: "a" * 40
+        self.github_release.generate_resolved_stack_inventory = lambda *_args: calls.append("generate")
+        self.github_release.create_release = (
+            lambda _tag, _title, _notes, draft, dry_run: calls.append(("release", draft, dry_run)) or True
+        )
+        self.github_release.publish_resolved_stack_inventory = lambda *_args: calls.append("upload")
+        self.github_release.publish_release = lambda *_args: calls.append("publish")
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.github_release.tag_release(types.SimpleNamespace(tag=tag, metadata="metadata.json"))
+
+        self.assertEqual(calls, ["generate", ("release", True, False), "upload"])
 
     def test_stack_inventory_generation_failure_prevents_partial_release(self):
         root = Path(tempfile.mkdtemp())

--- a/tools/ci/test-github-release.py
+++ b/tools/ci/test-github-release.py
@@ -8,6 +8,7 @@ import importlib.util
 import io
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 import types
@@ -1149,6 +1150,158 @@ class GithubReleaseTest(unittest.TestCase):
             existing["seen"] = True
             self.assertFalse(self.github_release.create_release("t", "t", "n", draft=False, dry_run=False))
             self.assertFalse(self.github_release.create_release("t", "t", "n", draft=False, dry_run=True))
+
+    def stack_release_metadata(self, asset_name="inventory.json"):
+        return {
+            "version": 1,
+            "services": [
+                {
+                    "id": "nvcf-self-managed-stack",
+                    "path": "deploy/stacks/self-managed",
+                    "service_name": "nvcf-self-managed-stack",
+                    "tag_format": "deploy/stacks/self-managed/v${version}",
+                    "resolved_inventory_asset": asset_name,
+                }
+            ],
+        }
+
+    def test_stack_tag_generates_inventory_before_release_and_uploads_after(self):
+        root = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(root))
+        tag = "deploy/stacks/self-managed/v1.2.3"
+        commit = "a" * 40
+        metadata = self.stack_release_metadata("nvcf-self-managed-stack-inventory.json")
+        calls = []
+        self.github_release.repo_root = lambda: root
+        self.github_release.load_metadata = lambda *_args: metadata
+        self.github_release.github_release_mode = lambda: (True, False)
+        self.github_release.tag_sha = lambda *_args: commit
+        self.github_release.generate_resolved_stack_inventory = (
+            lambda _root, _tag, _version, _commit, path: calls.append(("generate", Path(path).name))
+        )
+        self.github_release.create_release = lambda *_args, **_kwargs: calls.append(("release", tag))
+        self.github_release.publish_resolved_stack_inventory = (
+            lambda _tag, path: calls.append(("upload", Path(path).name))
+        )
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.github_release.tag_release(types.SimpleNamespace(tag=tag, metadata="metadata.json"))
+
+        self.assertEqual(
+            calls,
+            [
+                ("generate", "nvcf-self-managed-stack-inventory.json"),
+                ("release", tag),
+                ("upload", "nvcf-self-managed-stack-inventory.json"),
+            ],
+        )
+
+    def test_stack_inventory_generation_failure_prevents_partial_release(self):
+        root = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(root))
+        tag = "deploy/stacks/self-managed/v1.2.3"
+        metadata = self.stack_release_metadata()
+        released = []
+        self.github_release.repo_root = lambda: root
+        self.github_release.load_metadata = lambda *_args: metadata
+        self.github_release.github_release_mode = lambda: (True, False)
+        self.github_release.tag_sha = lambda *_args: "b" * 40
+        self.github_release.generate_resolved_stack_inventory = lambda *_args: (_ for _ in ()).throw(
+            RuntimeError("render failed")
+        )
+        self.github_release.create_release = lambda *_args, **_kwargs: released.append(True)
+
+        with self.assertRaisesRegex(RuntimeError, "render failed"):
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.github_release.tag_release(types.SimpleNamespace(tag=tag, metadata="metadata.json"))
+        self.assertEqual(released, [])
+
+    def test_stack_inventory_upload_failure_is_not_suppressed(self):
+        root = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(root))
+        tag = "deploy/stacks/self-managed/v1.2.3"
+        metadata = self.stack_release_metadata()
+        calls = []
+        self.github_release.repo_root = lambda: root
+        self.github_release.load_metadata = lambda *_args: metadata
+        self.github_release.github_release_mode = lambda: (True, False)
+        self.github_release.tag_sha = lambda *_args: "c" * 40
+        self.github_release.generate_resolved_stack_inventory = lambda *_args: calls.append("generate")
+        self.github_release.create_release = lambda *_args, **_kwargs: calls.append("release")
+        self.github_release.publish_resolved_stack_inventory = lambda *_args: (_ for _ in ()).throw(
+            RuntimeError("upload failed")
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "upload failed"):
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.github_release.tag_release(types.SimpleNamespace(tag=tag, metadata="metadata.json"))
+        self.assertEqual(calls, ["generate", "release"])
+
+    def test_resolved_stack_inventory_identity_must_match_release(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "inventory.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "source": {
+                            "version": "1.2.3",
+                            "tag": "deploy/stacks/self-managed/v1.2.3",
+                            "commit": "d" * 40,
+                        },
+                        "releases": [{}],
+                        "artifacts": [{}],
+                    }
+                )
+            )
+            self.github_release.validate_resolved_stack_inventory(
+                path, "deploy/stacks/self-managed/v1.2.3", "1.2.3", "d" * 40
+            )
+            with self.assertRaisesRegex(SystemExit, "inventory source"):
+                self.github_release.validate_resolved_stack_inventory(
+                    path, "deploy/stacks/self-managed/v1.2.3", "1.2.3", "e" * 40
+                )
+
+    def test_existing_release_inventory_must_be_byte_identical(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            asset = Path(tmp) / "inventory.json"
+            asset.write_text("same\n")
+
+            def fake_run(args, **_kwargs):
+                if args[:3] == ["gh", "release", "view"]:
+                    return "inventory.json\n"
+                if args[:3] == ["gh", "release", "download"]:
+                    destination = Path(args[args.index("--dir") + 1]) / "inventory.json"
+                    destination.write_text("same\n")
+                    return ""
+                raise AssertionError(f"unexpected call: {args}")
+
+            self.github_release.run = fake_run
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.github_release.publish_resolved_stack_inventory("stack/v1.2.3", asset)
+
+            def fake_different_run(args, **_kwargs):
+                if args[:3] == ["gh", "release", "view"]:
+                    return "inventory.json\n"
+                if args[:3] == ["gh", "release", "download"]:
+                    destination = Path(args[args.index("--dir") + 1]) / "inventory.json"
+                    destination.write_text("different\n")
+                    return ""
+                raise AssertionError(f"unexpected call: {args}")
+
+            self.github_release.run = fake_different_run
+            with self.assertRaisesRegex(SystemExit, "refusing to replace"):
+                self.github_release.publish_resolved_stack_inventory("stack/v1.2.3", asset)
+
+    def test_stack_tag_workflow_installs_pinned_inventory_tools(self):
+        workflow = (SCRIPT_PATH.parents[2] / ".github/workflows/release-tags.yml").read_text()
+        self.assertIn("actions/setup-go@v5", workflow)
+        self.assertIn('HELMFILE_VERSION: "1.1.9"', workflow)
+        self.assertIn("Install inventory rendering tools", workflow)
+        self.assertLess(
+            workflow.index("Install inventory rendering tools"),
+            workflow.index("Validate tag and create release notes"),
+        )
 
     def publish_and_capture_comments(self, version):
         """Publish a tag for `version` from a release branch, recording any comments.

--- a/tools/ci/test-github-release.py
+++ b/tools/ci/test-github-release.py
@@ -1221,21 +1221,36 @@ class GithubReleaseTest(unittest.TestCase):
         self.addCleanup(lambda: shutil.rmtree(root))
         tag = "deploy/stacks/self-managed/v1.2.3"
         metadata = self.stack_release_metadata()
-        calls = []
         self.github_release.repo_root = lambda: root
         self.github_release.load_metadata = lambda *_args: metadata
         self.github_release.github_release_mode = lambda: (True, False)
         self.github_release.tag_sha = lambda *_args: "c" * 40
-        self.github_release.generate_resolved_stack_inventory = lambda *_args: calls.append("generate")
-        self.github_release.create_release = lambda *_args, **_kwargs: calls.append("release")
-        self.github_release.publish_resolved_stack_inventory = lambda *_args: (_ for _ in ()).throw(
-            RuntimeError("upload failed")
-        )
+        for created in (False, True):
+            with self.subTest(created=created):
+                calls = []
+                self.github_release.generate_resolved_stack_inventory = lambda *_args: calls.append("generate")
 
-        with self.assertRaisesRegex(RuntimeError, "upload failed"):
-            with contextlib.redirect_stdout(io.StringIO()):
-                self.github_release.tag_release(types.SimpleNamespace(tag=tag, metadata="metadata.json"))
-        self.assertEqual(calls, ["generate", "release"])
+                def create(*_args, **_kwargs):
+                    calls.append("release")
+                    return created
+
+                self.github_release.create_release = create
+                self.github_release.publish_resolved_stack_inventory = lambda *_args: (
+                    _ for _ in ()
+                ).throw(RuntimeError("upload failed"))
+                self.github_release.delete_release_after_inventory_failure = lambda *_args: calls.append(
+                    "delete"
+                )
+
+                with self.assertRaisesRegex(RuntimeError, "upload failed"):
+                    with contextlib.redirect_stdout(io.StringIO()):
+                        self.github_release.tag_release(
+                            types.SimpleNamespace(tag=tag, metadata="metadata.json")
+                        )
+                expected = ["generate", "release"]
+                if created:
+                    expected.append("delete")
+                self.assertEqual(calls, expected)
 
     def test_resolved_stack_inventory_identity_must_match_release(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1292,6 +1307,55 @@ class GithubReleaseTest(unittest.TestCase):
             self.github_release.run = fake_different_run
             with self.assertRaisesRegex(SystemExit, "refusing to replace"):
                 self.github_release.publish_resolved_stack_inventory("stack/v1.2.3", asset)
+
+    def test_missing_release_inventory_is_uploaded(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            asset = Path(tmp) / "inventory.json"
+            asset.write_text("inventory\n")
+            calls = []
+
+            def fake_run(args, **_kwargs):
+                calls.append(args)
+                if args[:3] == ["gh", "release", "view"]:
+                    return ""
+                if args[:3] == ["gh", "release", "upload"]:
+                    return ""
+                raise AssertionError(f"unexpected call: {args}")
+
+            self.github_release.run = fake_run
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.github_release.publish_resolved_stack_inventory("stack/v1.2.3", asset)
+
+            self.assertEqual(
+                calls,
+                [
+                    [
+                        "gh",
+                        "release",
+                        "view",
+                        "stack/v1.2.3",
+                        "--json",
+                        "assets",
+                        "--jq",
+                        ".assets[].name",
+                    ],
+                    ["gh", "release", "upload", "stack/v1.2.3", str(asset)],
+                ],
+            )
+
+    def test_incomplete_release_cleanup_uses_exact_tag(self):
+        calls = []
+        self.github_release.run = lambda args, **_kwargs: calls.append(args)
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertTrue(
+                self.github_release.delete_release_after_inventory_failure(
+                    "deploy/stacks/self-managed/v1.2.3"
+                )
+            )
+        self.assertEqual(
+            calls,
+            [["gh", "release", "delete", "deploy/stacks/self-managed/v1.2.3", "--yes"]],
+        )
 
     def test_stack_tag_workflow_installs_pinned_inventory_tools(self):
         workflow = (SCRIPT_PATH.parents[2] / ".github/workflows/release-tags.yml").read_text()

--- a/tools/docs-version-sync/main.go
+++ b/tools/docs-version-sync/main.go
@@ -40,7 +40,10 @@ func run(args []string) error {
 	catalogPath := flags.String("catalog", "", "version catalog path")
 	check := flags.Bool("check", false, "fail if generated docs differ from checked-in marker blocks")
 	updateCatalog := flags.Bool("update-catalog", false, "fetch the stack artifact list from GitLab and update the catalog")
-	stackVersion := flags.String("stack-version", "", "self-managed stack version to fetch when updating the catalog")
+	stackVersion := flags.String("stack-version", "", "self-managed stack version to fetch or inventory")
+	inventoryOutput := flags.String("generate-stack-inventory", "", "write a resolved stack inventory to this path")
+	stackSourceTag := flags.String("stack-source-tag", "", "immutable self-managed stack source tag for inventory generation")
+	stackSourceCommit := flags.String("stack-source-commit", "", "immutable self-managed stack source commit for inventory generation")
 
 	if err := flags.Parse(args); err != nil {
 		return err
@@ -55,6 +58,26 @@ func run(args []string) error {
 	repoRoot, err := findRepoRoot()
 	if err != nil {
 		return err
+	}
+	if *inventoryOutput != "" {
+		if *updateCatalog || *check {
+			return fmt.Errorf("--generate-stack-inventory cannot be combined with --update-catalog or --check")
+		}
+		if *stackVersion == "" || *stackSourceTag == "" || *stackSourceCommit == "" {
+			return fmt.Errorf("--generate-stack-inventory requires --stack-version, --stack-source-tag, and --stack-source-commit")
+		}
+		outputPath := *inventoryOutput
+		if !filepath.IsAbs(outputPath) {
+			outputPath = filepath.Join(repoRoot, outputPath)
+		}
+		return writeResolvedStackInventory(repoRoot, outputPath, stackSourceRelease{
+			Version: *stackVersion,
+			Tag:     *stackSourceTag,
+			Commit:  *stackSourceCommit,
+		})
+	}
+	if *stackSourceTag != "" || *stackSourceCommit != "" {
+		return fmt.Errorf("--stack-source-tag and --stack-source-commit require --generate-stack-inventory")
 	}
 	if *catalogPath == "" {
 		*catalogPath = filepath.Join(repoRoot, "docs", "version-catalog", *target+".yaml")

--- a/tools/docs-version-sync/resolved_inventory_publish.go
+++ b/tools/docs-version-sync/resolved_inventory_publish.go
@@ -84,6 +84,7 @@ var resolvedInventoryStates = []resolvedInventoryState{
 
 type resolvedInventoryCommandRunner interface {
 	Output(dir string, env []string, args ...string) ([]byte, error)
+	PrepareRepositories(env []string, repositories map[string]helmfileRepository, ngcAPIKey string) error
 }
 
 type execResolvedInventoryCommandRunner struct{}
@@ -105,6 +106,39 @@ func (execResolvedInventoryCommandRunner) Output(dir string, env []string, args 
 		return nil, fmt.Errorf("helmfile %s: %w\n%s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
 	}
 	return stdout.Bytes(), nil
+}
+
+func (execResolvedInventoryCommandRunner) PrepareRepositories(env []string, repositories map[string]helmfileRepository, ngcAPIKey string) error {
+	names := make([]string, 0, len(repositories))
+	for name := range repositories {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		repository := repositories[name]
+		if repository.OCI {
+			continue
+		}
+		args := []string{"repo", "add", repository.Name, repository.URL, "--force-update"}
+		var stdin io.Reader
+		if strings.HasPrefix(repository.URL, "https://helm.ngc.nvidia.com/") {
+			args = append(args, "--username", "$oauthtoken", "--password-stdin")
+			stdin = strings.NewReader(ngcAPIKey + "\n")
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), resolvedInventoryTimeout)
+		command := exec.CommandContext(ctx, "helm", args...)
+		command.Env = env
+		command.Stdin = stdin
+		output, err := command.CombinedOutput()
+		cancel()
+		if err != nil {
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return fmt.Errorf("configure Helm repository %s: timed out after %s", repository.Name, resolvedInventoryTimeout)
+			}
+			return fmt.Errorf("configure Helm repository %s: %w\n%s", repository.Name, err, strings.TrimSpace(string(output)))
+		}
+	}
+	return nil
 }
 
 type helmfileRepository struct {
@@ -179,7 +213,7 @@ func collectResolvedStackInventory(repoRoot string, source stackSourceRelease, r
 	if err := copyResolvedInventoryInputs(repoRoot, copiedRepoRoot); err != nil {
 		return resolvedStackInventory{}, err
 	}
-	env, err := prepareResolvedInventoryEnvironment(copiedRepoRoot)
+	env, ngcAPIKey, err := prepareResolvedInventoryEnvironment(copiedRepoRoot)
 	if err != nil {
 		return resolvedStackInventory{}, err
 	}
@@ -200,6 +234,7 @@ func collectResolvedStackInventory(repoRoot string, source stackSourceRelease, r
 			source,
 			state,
 			env,
+			ngcAPIKey,
 			runner,
 		)
 		if err != nil {
@@ -278,22 +313,20 @@ func copyResolvedInventoryStack(source, destination string) error {
 	})
 }
 
-func prepareResolvedInventoryEnvironment(copiedRepoRoot string) ([]string, error) {
+func prepareResolvedInventoryEnvironment(copiedRepoRoot string) ([]string, string, error) {
 	ngcAPIKey := strings.TrimSpace(os.Getenv("NVCF_RELEASE_NGC_API_KEY"))
 	if ngcAPIKey == "" {
 		ngcAPIKey = strings.TrimSpace(os.Getenv("NGC_API_KEY"))
 	}
 	if ngcAPIKey == "" {
-		return nil, fmt.Errorf("NVCF_RELEASE_NGC_API_KEY is required to render public NGC charts")
+		return nil, "", fmt.Errorf("NVCF_RELEASE_NGC_API_KEY is required to render public NGC charts")
 	}
 	values, err := yaml.Marshal(map[string]any{
 		"global": map[string]any{
 			"domain": "inventory.example.invalid",
 			"helm": map[string]any{
 				"sources": map[string]any{
-					"url":      "https://helm.ngc.nvidia.com/nvidia/nvcf",
-					"username": "$oauthtoken",
-					"password": ngcAPIKey,
+					"url": "https://helm.ngc.nvidia.com/nvidia/nvcf",
 				},
 			},
 			"image": map[string]any{
@@ -318,37 +351,65 @@ func prepareResolvedInventoryEnvironment(copiedRepoRoot string) ([]string, error
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("marshal inventory-only stack environment: %w", err)
+		return nil, "", fmt.Errorf("marshal inventory-only stack environment: %w", err)
 	}
 	for _, stack := range []string{"self-managed", "nvcf-compute-plane", "observability"} {
 		environmentPath := filepath.Join(copiedRepoRoot, "deploy", "stacks", stack, "environments", "inventory.yaml")
 		if err := os.MkdirAll(filepath.Dir(environmentPath), 0o755); err != nil {
-			return nil, err
+			return nil, "", err
 		}
 		if err := os.WriteFile(environmentPath, values, 0o600); err != nil {
-			return nil, fmt.Errorf("write %s inventory-only stack environment: %w", stack, err)
+			return nil, "", fmt.Errorf("write %s inventory-only stack environment: %w", stack, err)
 		}
 	}
 	secretsPath := filepath.Join(copiedRepoRoot, "deploy", "stacks", "self-managed", "secrets", "inventory-secrets.yaml")
 	if err := os.WriteFile(secretsPath, []byte("{}\n"), 0o600); err != nil {
-		return nil, fmt.Errorf("write inventory-only stack secrets: %w", err)
+		return nil, "", fmt.Errorf("write inventory-only stack secrets: %w", err)
 	}
 	registrationDir := filepath.Join(copiedRepoRoot, "deploy", "stacks", "nvcf-compute-plane", "inventory-registration")
 	if err := os.MkdirAll(registrationDir, 0o755); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	registration := []byte("clusterName: inventory\nclusterID: 00000000-0000-0000-0000-000000000001\nclusterGroupID: 00000000-0000-0000-0000-000000000002\nncaID: inventory\nregion: inventory\nselfManaged:\n  identitySource: psat\n  icmsServiceURL: http://icms.example.invalid:8080\n  revalServiceURL: http://reval.example.invalid:8080\n  natsURL: nats://nats.example.invalid:4222\n")
 	if err := os.WriteFile(filepath.Join(registrationDir, "inventory-register-values.yaml"), registration, 0o600); err != nil {
-		return nil, fmt.Errorf("write inventory-only registration values: %w", err)
+		return nil, "", fmt.Errorf("write inventory-only registration values: %w", err)
+	}
+	helmRoot := filepath.Join(copiedRepoRoot, ".helm")
+	for _, path := range []string{filepath.Join(helmRoot, "cache"), filepath.Join(helmRoot, "config"), filepath.Join(helmRoot, "data")} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			return nil, "", err
+		}
 	}
 	env := append([]string{}, os.Environ()...)
-	env = append(env,
-		"HELMFILE_ENV=inventory",
-		"CLUSTER_NAME=inventory",
-		"NCA_ID=inventory",
-		"OUTPUT_DIR="+registrationDir,
-	)
-	return env, nil
+	env = setResolvedInventoryEnvironment(env, map[string]string{
+		"CLUSTER_NAME":     "inventory",
+		"HELMFILE_ENV":     "inventory",
+		"HELM_CACHE_HOME":  filepath.Join(helmRoot, "cache"),
+		"HELM_CONFIG_HOME": filepath.Join(helmRoot, "config"),
+		"HELM_DATA_HOME":   filepath.Join(helmRoot, "data"),
+		"NCA_ID":           "inventory",
+		"OUTPUT_DIR":       registrationDir,
+	})
+	return env, ngcAPIKey, nil
+}
+
+func setResolvedInventoryEnvironment(env []string, values map[string]string) []string {
+	updated := make([]string, 0, len(env)+len(values))
+	for _, entry := range env {
+		name, _, _ := strings.Cut(entry, "=")
+		if _, replace := values[name]; !replace {
+			updated = append(updated, entry)
+		}
+	}
+	names := make([]string, 0, len(values))
+	for name := range values {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		updated = append(updated, name+"="+values[name])
+	}
+	return updated
 }
 
 func collectResolvedInventoryState(
@@ -358,6 +419,7 @@ func collectResolvedInventoryState(
 	source stackSourceRelease,
 	state resolvedInventoryState,
 	env []string,
+	ngcAPIKey string,
 	runner resolvedInventoryCommandRunner,
 ) ([]helmfileRelease, map[string][]byte, error) {
 	baseOverrides := append(append([]string{}, resolvedInventoryCommonOverrides...), state.baseOverrides...)
@@ -374,8 +436,15 @@ func collectResolvedInventoryState(
 	if err != nil {
 		return nil, nil, fmt.Errorf("build resolved Helmfile state: %w", err)
 	}
-	releases, err := mergeAndResolveHelmfileReleases(copiedRepoRoot, stateFile, source, baseList, fullList, built)
+	repositories, err := parseHelmfileRepositories(built)
 	if err != nil {
+		return nil, nil, err
+	}
+	releases, err := mergeAndResolveHelmfileReleases(copiedRepoRoot, stateFile, source, baseList, fullList, repositories)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := runner.PrepareRepositories(env, repositories, ngcAPIKey); err != nil {
 		return nil, nil, err
 	}
 
@@ -419,6 +488,7 @@ func runResolvedInventoryHelmfile(
 	for _, override := range overrides {
 		args = append(args, "--state-values-set", override)
 	}
+	args = append(args, "--skip-refresh")
 	args = append(args, command...)
 	return runner.Output(dir, env, args...)
 }
@@ -442,7 +512,7 @@ func mergeAndResolveHelmfileReleases(
 	source stackSourceRelease,
 	baseRaw []byte,
 	fullRaw []byte,
-	built []byte,
+	repositories map[string]helmfileRepository,
 ) ([]helmfileRelease, error) {
 	base, err := decodeHelmfileReleaseList(baseRaw)
 	if err != nil {
@@ -461,10 +531,6 @@ func mergeAndResolveHelmfileReleases(
 			return nil, fmt.Errorf("duplicate default release %s", release.Name)
 		}
 		baseByName[release.Name] = release
-	}
-	repositories, err := parseHelmfileRepositories(built)
-	if err != nil {
-		return nil, err
 	}
 	fullByName := make(map[string]struct{}, len(full))
 	for i := range full {

--- a/tools/docs-version-sync/resolved_inventory_publish.go
+++ b/tools/docs-version-sync/resolved_inventory_publish.go
@@ -363,6 +363,9 @@ func prepareResolvedInventoryEnvironment(copiedRepoRoot string) ([]string, strin
 		}
 	}
 	secretsPath := filepath.Join(copiedRepoRoot, "deploy", "stacks", "self-managed", "secrets", "inventory-secrets.yaml")
+	if err := os.MkdirAll(filepath.Dir(secretsPath), 0o755); err != nil {
+		return nil, "", fmt.Errorf("create inventory-only stack secrets directory: %w", err)
+	}
 	if err := os.WriteFile(secretsPath, []byte("{}\n"), 0o600); err != nil {
 		return nil, "", fmt.Errorf("write inventory-only stack secrets: %w", err)
 	}
@@ -484,6 +487,7 @@ func runResolvedInventoryHelmfile(
 	overrides []string,
 	command ...string,
 ) ([]byte, error) {
+	// The stack states expose "default" while HELMFILE_ENV selects inventory.yaml within it.
 	args := []string{"--file", stateFile, "--environment", "default", "--quiet"}
 	for _, override := range overrides {
 		args = append(args, "--state-values-set", override)

--- a/tools/docs-version-sync/resolved_inventory_publish.go
+++ b/tools/docs-version-sync/resolved_inventory_publish.go
@@ -1,0 +1,639 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	resolvedInventoryRepository = "https://github.com/NVIDIA/nvcf/tree"
+	resolvedInventoryTimeout    = 30 * time.Minute
+)
+
+var resolvedInventoryCommonOverrides = []string{
+	"global.image.registry=nvcr.io",
+	"global.image.repository=nvidia/nvcf",
+}
+
+type resolvedInventoryState struct {
+	plane         string
+	path          string
+	baseOverrides []string
+	fullOverrides []string
+}
+
+var resolvedInventoryStates = []resolvedInventoryState{
+	{
+		plane: "control-plane",
+		path:  "deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl",
+		fullOverrides: []string{
+			"addons.llm.enabled=true",
+		},
+	},
+	{
+		plane: "control-plane",
+		path:  "deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl",
+		fullOverrides: []string{
+			"addons.llm.enabled=true",
+			"addons.vanityGateway.enabled=true",
+			"addons.nvcfUi.enabled=true",
+		},
+	},
+	{
+		plane: "observability",
+		path:  "deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl",
+	},
+	{
+		plane: "observability",
+		path:  "deploy/stacks/observability/helmfile.d/01-observability.yaml.gotmpl",
+		baseOverrides: []string{
+			"observability.profile=all",
+		},
+	},
+	{
+		plane: "compute-plane",
+		path:  "deploy/stacks/nvcf-compute-plane/helmfile.d/01-dependencies.yaml.gotmpl",
+		fullOverrides: []string{
+			"addons.kaiScheduler.enabled=true",
+			"addons.groveOperator.enabled=true",
+			"addons.dynamoOperator.enabled=true",
+			"addons.topologyAwareScheduling.enabled=true",
+		},
+	},
+	{
+		plane: "compute-plane",
+		path:  "deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl",
+	},
+}
+
+type resolvedInventoryCommandRunner interface {
+	Output(dir string, env []string, args ...string) ([]byte, error)
+}
+
+type execResolvedInventoryCommandRunner struct{}
+
+func (execResolvedInventoryCommandRunner) Output(dir string, env []string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), resolvedInventoryTimeout)
+	defer cancel()
+	command := exec.CommandContext(ctx, "helmfile", args...)
+	command.Dir = dir
+	command.Env = env
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	if err := command.Run(); err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return nil, fmt.Errorf("helmfile %s timed out after %s", strings.Join(args, " "), resolvedInventoryTimeout)
+		}
+		return nil, fmt.Errorf("helmfile %s: %w\n%s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}
+
+type helmfileRepository struct {
+	Name string `yaml:"name"`
+	URL  string `yaml:"url"`
+	OCI  bool   `yaml:"oci"`
+}
+
+type helmfileBuildDocument struct {
+	Repositories []helmfileRepository `yaml:"repositories"`
+}
+
+type localChartMetadata struct {
+	Name    string `yaml:"name"`
+	Version string `yaml:"version"`
+}
+
+func writeResolvedStackInventory(repoRoot, outputPath string, source stackSourceRelease) error {
+	if err := verifyResolvedInventoryCheckout(repoRoot, source); err != nil {
+		return err
+	}
+	inventory, err := collectResolvedStackInventory(repoRoot, source, execResolvedInventoryCommandRunner{})
+	if err != nil {
+		return err
+	}
+	raw, err := marshalResolvedStackInventory(inventory)
+	if err != nil {
+		return fmt.Errorf("marshal resolved stack inventory: %w", err)
+	}
+	if err := writeFileAtomically(outputPath, raw, 0o644); err != nil {
+		return fmt.Errorf("write resolved stack inventory: %w", err)
+	}
+	return nil
+}
+
+func verifyResolvedInventoryCheckout(repoRoot string, source stackSourceRelease) error {
+	if err := validateStackSourceRelease(source); err != nil {
+		return err
+	}
+	tagCommit, err := gitOutput(repoRoot, "rev-parse", "--verify", "refs/tags/"+source.Tag+"^{commit}")
+	if err != nil {
+		return fmt.Errorf("resolve stack source tag %s: %w", source.Tag, err)
+	}
+	if got := trimOutput(tagCommit); got != source.Commit {
+		return fmt.Errorf("stack source tag %s resolves to %s, want %s", source.Tag, got, source.Commit)
+	}
+	head, err := gitOutput(repoRoot, "rev-parse", "HEAD")
+	if err != nil {
+		return fmt.Errorf("resolve inventory checkout HEAD: %w", err)
+	}
+	if got := trimOutput(head); got != source.Commit {
+		return fmt.Errorf("inventory checkout HEAD is %s, want tagged commit %s", got, source.Commit)
+	}
+	status, err := gitOutput(repoRoot, "status", "--porcelain", "--untracked-files=normal", "--", "deploy/stacks")
+	if err != nil {
+		return fmt.Errorf("inspect stack checkout: %w", err)
+	}
+	if strings.TrimSpace(string(status)) != "" {
+		return fmt.Errorf("deploy/stacks has changes outside tagged commit %s", source.Commit)
+	}
+	return nil
+}
+
+func collectResolvedStackInventory(repoRoot string, source stackSourceRelease, runner resolvedInventoryCommandRunner) (resolvedStackInventory, error) {
+	tempRoot, err := os.MkdirTemp("", "nvcf-resolved-stack-inventory-")
+	if err != nil {
+		return resolvedStackInventory{}, err
+	}
+	defer os.RemoveAll(tempRoot)
+
+	copiedRepoRoot := filepath.Join(tempRoot, "repo")
+	if err := copyResolvedInventoryInputs(repoRoot, copiedRepoRoot); err != nil {
+		return resolvedStackInventory{}, err
+	}
+	env, err := prepareResolvedInventoryEnvironment(copiedRepoRoot)
+	if err != nil {
+		return resolvedStackInventory{}, err
+	}
+
+	planes := make(map[string]*resolvedInventoryPlaneInput, len(resolvedStackPlanes))
+	for _, name := range resolvedStackPlanes {
+		planes[name] = &resolvedInventoryPlaneInput{
+			Name:              name,
+			ManifestByRelease: map[string][]byte{},
+		}
+	}
+	for stateIndex, state := range resolvedInventoryStates {
+		stateFile := filepath.Join(copiedRepoRoot, filepath.FromSlash(state.path))
+		releases, manifests, err := collectResolvedInventoryState(
+			copiedRepoRoot,
+			stateFile,
+			filepath.Join(tempRoot, "rendered", fmt.Sprintf("%02d", stateIndex)),
+			source,
+			state,
+			env,
+			runner,
+		)
+		if err != nil {
+			return resolvedStackInventory{}, fmt.Errorf("collect %s: %w", state.path, err)
+		}
+		plane := planes[state.plane]
+		var existing []helmfileRelease
+		if len(plane.ReleaseList) != 0 {
+			existing, err = decodeHelmfileReleaseList(plane.ReleaseList)
+			if err != nil {
+				return resolvedStackInventory{}, err
+			}
+		}
+		existing = append(existing, releases...)
+		plane.ReleaseList, err = json.Marshal(existing)
+		if err != nil {
+			return resolvedStackInventory{}, err
+		}
+		for release, manifest := range manifests {
+			if _, exists := plane.ManifestByRelease[release]; exists {
+				return resolvedStackInventory{}, fmt.Errorf("duplicate %s release %s across Helmfile states", state.plane, release)
+			}
+			plane.ManifestByRelease[release] = manifest
+		}
+	}
+
+	inputs := make([]resolvedInventoryPlaneInput, 0, len(resolvedStackPlanes))
+	for _, name := range resolvedStackPlanes {
+		inputs = append(inputs, *planes[name])
+	}
+	return generateResolvedStackInventory(source, inputs)
+}
+
+func copyResolvedInventoryInputs(repoRoot, copiedRepoRoot string) error {
+	for _, stack := range []string{"self-managed", "nvcf-compute-plane", "observability"} {
+		source := filepath.Join(repoRoot, "deploy", "stacks", stack)
+		destination := filepath.Join(copiedRepoRoot, "deploy", "stacks", stack)
+		if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+			return err
+		}
+		if err := copyResolvedInventoryStack(source, destination); err != nil {
+			return fmt.Errorf("copy %s stack inputs: %w", stack, err)
+		}
+	}
+	return nil
+}
+
+func copyResolvedInventoryStack(source, destination string) error {
+	return filepath.WalkDir(source, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(source, path)
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() && rel != "." && (entry.Name() == "testdata" || entry.Name() == "out") {
+			return filepath.SkipDir
+		}
+		target := filepath.Join(destination, rel)
+		if entry.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("stack input %s is a symbolic link", path)
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, raw, info.Mode().Perm())
+	})
+}
+
+func prepareResolvedInventoryEnvironment(copiedRepoRoot string) ([]string, error) {
+	ngcAPIKey := strings.TrimSpace(os.Getenv("NVCF_RELEASE_NGC_API_KEY"))
+	if ngcAPIKey == "" {
+		ngcAPIKey = strings.TrimSpace(os.Getenv("NGC_API_KEY"))
+	}
+	if ngcAPIKey == "" {
+		return nil, fmt.Errorf("NVCF_RELEASE_NGC_API_KEY is required to render public NGC charts")
+	}
+	values, err := yaml.Marshal(map[string]any{
+		"global": map[string]any{
+			"domain": "inventory.example.invalid",
+			"helm": map[string]any{
+				"sources": map[string]any{
+					"url":      "https://helm.ngc.nvidia.com/nvidia/nvcf",
+					"username": "$oauthtoken",
+					"password": ngcAPIKey,
+				},
+			},
+			"image": map[string]any{
+				"registry":   "nvcr.io",
+				"repository": "nvidia/nvcf",
+			},
+		},
+		"ingress": map[string]any{
+			"gatewayApi": map[string]any{
+				"controllerNamespace": "gateway-system",
+				"gateways": map[string]any{
+					"grpc": map[string]any{
+						"name":      "inventory-grpc",
+						"namespace": "gateway-system",
+					},
+					"shared": map[string]any{
+						"name":      "inventory-shared",
+						"namespace": "gateway-system",
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal inventory-only stack environment: %w", err)
+	}
+	for _, stack := range []string{"self-managed", "nvcf-compute-plane", "observability"} {
+		environmentPath := filepath.Join(copiedRepoRoot, "deploy", "stacks", stack, "environments", "inventory.yaml")
+		if err := os.MkdirAll(filepath.Dir(environmentPath), 0o755); err != nil {
+			return nil, err
+		}
+		if err := os.WriteFile(environmentPath, values, 0o600); err != nil {
+			return nil, fmt.Errorf("write %s inventory-only stack environment: %w", stack, err)
+		}
+	}
+	secretsPath := filepath.Join(copiedRepoRoot, "deploy", "stacks", "self-managed", "secrets", "inventory-secrets.yaml")
+	if err := os.WriteFile(secretsPath, []byte("{}\n"), 0o600); err != nil {
+		return nil, fmt.Errorf("write inventory-only stack secrets: %w", err)
+	}
+	registrationDir := filepath.Join(copiedRepoRoot, "deploy", "stacks", "nvcf-compute-plane", "inventory-registration")
+	if err := os.MkdirAll(registrationDir, 0o755); err != nil {
+		return nil, err
+	}
+	registration := []byte("clusterName: inventory\nclusterID: 00000000-0000-0000-0000-000000000001\nclusterGroupID: 00000000-0000-0000-0000-000000000002\nncaID: inventory\nregion: inventory\nselfManaged:\n  identitySource: psat\n  icmsServiceURL: http://icms.example.invalid:8080\n  revalServiceURL: http://reval.example.invalid:8080\n  natsURL: nats://nats.example.invalid:4222\n")
+	if err := os.WriteFile(filepath.Join(registrationDir, "inventory-register-values.yaml"), registration, 0o600); err != nil {
+		return nil, fmt.Errorf("write inventory-only registration values: %w", err)
+	}
+	env := append([]string{}, os.Environ()...)
+	env = append(env,
+		"HELMFILE_ENV=inventory",
+		"CLUSTER_NAME=inventory",
+		"NCA_ID=inventory",
+		"OUTPUT_DIR="+registrationDir,
+	)
+	return env, nil
+}
+
+func collectResolvedInventoryState(
+	copiedRepoRoot string,
+	stateFile string,
+	renderDir string,
+	source stackSourceRelease,
+	state resolvedInventoryState,
+	env []string,
+	runner resolvedInventoryCommandRunner,
+) ([]helmfileRelease, map[string][]byte, error) {
+	baseOverrides := append(append([]string{}, resolvedInventoryCommonOverrides...), state.baseOverrides...)
+	fullOverrides := append(append([]string{}, baseOverrides...), state.fullOverrides...)
+	baseList, err := runResolvedInventoryHelmfile(runner, filepath.Dir(stateFile), env, stateFile, baseOverrides, "list", "--output", "json")
+	if err != nil {
+		return nil, nil, fmt.Errorf("list default releases: %w", err)
+	}
+	fullList, err := runResolvedInventoryHelmfile(runner, filepath.Dir(stateFile), env, stateFile, fullOverrides, "list", "--output", "json")
+	if err != nil {
+		return nil, nil, fmt.Errorf("list releases with optional components: %w", err)
+	}
+	built, err := runResolvedInventoryHelmfile(runner, filepath.Dir(stateFile), env, stateFile, fullOverrides, "build")
+	if err != nil {
+		return nil, nil, fmt.Errorf("build resolved Helmfile state: %w", err)
+	}
+	releases, err := mergeAndResolveHelmfileReleases(copiedRepoRoot, stateFile, source, baseList, fullList, built)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := os.MkdirAll(renderDir, 0o755); err != nil {
+		return nil, nil, err
+	}
+	if _, err := runResolvedInventoryHelmfile(
+		runner,
+		filepath.Dir(stateFile),
+		env,
+		stateFile,
+		fullOverrides,
+		"template",
+		"--include-crds",
+		"--output-dir", renderDir,
+		"--output-dir-template", "{{ .OutputDir }}/{{ .Release.Name }}",
+	); err != nil {
+		return nil, nil, fmt.Errorf("render releases: %w", err)
+	}
+
+	manifests := make(map[string][]byte, len(releases))
+	for _, release := range releases {
+		manifest, err := readRenderedReleaseManifest(filepath.Join(renderDir, release.Name))
+		if err != nil {
+			return nil, nil, fmt.Errorf("read rendered release %s: %w", release.Name, err)
+		}
+		manifests[release.Name] = manifest
+	}
+	return releases, manifests, nil
+}
+
+func runResolvedInventoryHelmfile(
+	runner resolvedInventoryCommandRunner,
+	dir string,
+	env []string,
+	stateFile string,
+	overrides []string,
+	command ...string,
+) ([]byte, error) {
+	args := []string{"--file", stateFile, "--environment", "default", "--quiet"}
+	for _, override := range overrides {
+		args = append(args, "--state-values-set", override)
+	}
+	args = append(args, command...)
+	return runner.Output(dir, env, args...)
+}
+
+func decodeHelmfileReleaseList(raw []byte) ([]helmfileRelease, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var releases []helmfileRelease
+	if err := decoder.Decode(&releases); err != nil {
+		return nil, err
+	}
+	if err := requireJSONEOF(decoder); err != nil {
+		return nil, err
+	}
+	return releases, nil
+}
+
+func mergeAndResolveHelmfileReleases(
+	copiedRepoRoot string,
+	stateFile string,
+	source stackSourceRelease,
+	baseRaw []byte,
+	fullRaw []byte,
+	built []byte,
+) ([]helmfileRelease, error) {
+	base, err := decodeHelmfileReleaseList(baseRaw)
+	if err != nil {
+		return nil, fmt.Errorf("parse default release list: %w", err)
+	}
+	full, err := decodeHelmfileReleaseList(fullRaw)
+	if err != nil {
+		return nil, fmt.Errorf("parse full release list: %w", err)
+	}
+	if len(full) == 0 {
+		return nil, fmt.Errorf("full release list cannot be empty")
+	}
+	baseByName := make(map[string]helmfileRelease, len(base))
+	for _, release := range base {
+		if _, exists := baseByName[release.Name]; exists {
+			return nil, fmt.Errorf("duplicate default release %s", release.Name)
+		}
+		baseByName[release.Name] = release
+	}
+	repositories, err := parseHelmfileRepositories(built)
+	if err != nil {
+		return nil, err
+	}
+	fullByName := make(map[string]struct{}, len(full))
+	for i := range full {
+		if _, exists := fullByName[full[i].Name]; exists {
+			return nil, fmt.Errorf("duplicate full release %s", full[i].Name)
+		}
+		fullByName[full[i].Name] = struct{}{}
+		if defaultRelease, exists := baseByName[full[i].Name]; exists {
+			full[i].Enabled = defaultRelease.Enabled
+		} else {
+			full[i].Enabled = false
+		}
+		if err := resolveHelmfileChartReference(copiedRepoRoot, stateFile, source, repositories, &full[i]); err != nil {
+			return nil, fmt.Errorf("resolve release %s chart: %w", full[i].Name, err)
+		}
+	}
+	for name := range baseByName {
+		if _, exists := fullByName[name]; !exists {
+			return nil, fmt.Errorf("default release %s is missing when optional components are enabled", name)
+		}
+	}
+	sort.Slice(full, func(i, j int) bool { return full[i].Name < full[j].Name })
+	raw, err := json.Marshal(full)
+	if err != nil {
+		return nil, err
+	}
+	return parseHelmfileReleaseList(raw)
+}
+
+func parseHelmfileRepositories(raw []byte) (map[string]helmfileRepository, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	repositories := map[string]helmfileRepository{}
+	for {
+		var document helmfileBuildDocument
+		err := decoder.Decode(&document)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("parse built Helmfile state: %w", err)
+		}
+		for _, repository := range document.Repositories {
+			if repository.Name == "" || repository.URL == "" {
+				return nil, fmt.Errorf("built Helmfile repository requires name and URL")
+			}
+			if existing, ok := repositories[repository.Name]; ok && existing != repository {
+				return nil, fmt.Errorf("repository alias %s has conflicting definitions", repository.Name)
+			}
+			repositories[repository.Name] = repository
+		}
+	}
+	return repositories, nil
+}
+
+func resolveHelmfileChartReference(
+	copiedRepoRoot string,
+	stateFile string,
+	source stackSourceRelease,
+	repositories map[string]helmfileRepository,
+	release *helmfileRelease,
+) error {
+	chart := strings.TrimSpace(release.Chart)
+	if chart == "" || chart != release.Chart {
+		return fmt.Errorf("chart %q is unresolved", release.Chart)
+	}
+	if filepath.IsAbs(chart) || strings.HasPrefix(chart, "./") || strings.HasPrefix(chart, "../") {
+		chartPath := chart
+		if !filepath.IsAbs(chartPath) {
+			chartPath = filepath.Join(filepath.Dir(stateFile), filepath.FromSlash(chartPath))
+		}
+		chartPath, err := filepath.Abs(chartPath)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(copiedRepoRoot, chartPath)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("local chart %s is outside copied repository", chart)
+		}
+		metadataRaw, err := os.ReadFile(filepath.Join(chartPath, "Chart.yaml"))
+		if err != nil {
+			return fmt.Errorf("read local chart metadata: %w", err)
+		}
+		var metadata localChartMetadata
+		if err := yaml.Unmarshal(metadataRaw, &metadata); err != nil {
+			return fmt.Errorf("parse local chart metadata: %w", err)
+		}
+		if metadata.Name == "" || metadata.Version == "" {
+			return fmt.Errorf("local chart metadata requires name and version")
+		}
+		release.Chart = resolvedInventoryRepository + "/" + source.Commit + "/" + filepath.ToSlash(rel)
+		release.Version = metadata.Version
+		return nil
+	}
+	if strings.Contains(chart, "://") {
+		return nil
+	}
+	alias, name, found := strings.Cut(chart, "/")
+	if !found || name == "" {
+		return fmt.Errorf("chart %q has no repository alias", chart)
+	}
+	repository, ok := repositories[alias]
+	if !ok {
+		return fmt.Errorf("chart %q uses unknown repository alias %s", chart, alias)
+	}
+	base := strings.TrimSuffix(repository.URL, "/")
+	if repository.OCI && !strings.Contains(base, "://") {
+		base = "oci://" + base
+	}
+	release.Chart = base + "/" + name
+	return nil
+}
+
+func readRenderedReleaseManifest(root string) ([]byte, error) {
+	var paths []string
+	if err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.Type().IsRegular() {
+			paths = append(paths, path)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("no rendered manifest files found")
+	}
+	sort.Strings(paths)
+	var manifest bytes.Buffer
+	for _, path := range paths {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		if len(bytes.TrimSpace(raw)) == 0 {
+			continue
+		}
+		if manifest.Len() != 0 {
+			manifest.WriteString("\n---\n")
+		}
+		manifest.Write(raw)
+	}
+	if len(bytes.TrimSpace(manifest.Bytes())) == 0 {
+		return nil, fmt.Errorf("rendered manifest files are empty")
+	}
+	return manifest.Bytes(), nil
+}
+
+func writeFileAtomically(path string, contents []byte, mode fs.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	temp, err := os.CreateTemp(filepath.Dir(path), ".resolved-inventory-*")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+	if err := temp.Chmod(mode); err != nil {
+		temp.Close()
+		return err
+	}
+	if _, err := temp.Write(contents); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tempPath, path)
+}

--- a/tools/docs-version-sync/resolved_inventory_publish_test.go
+++ b/tools/docs-version-sync/resolved_inventory_publish_test.go
@@ -6,7 +6,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -81,9 +80,6 @@ func TestCollectResolvedStackInventoryBuildsEveryPlane(t *testing.T) {
 	for _, state := range resolvedInventoryStates {
 		writeFile(t, filepath.Join(repo, filepath.FromSlash(state.path)), "releases: []\n")
 	}
-	if err := os.MkdirAll(filepath.Join(repo, "deploy/stacks/self-managed/secrets"), 0o755); err != nil {
-		t.Fatal(err)
-	}
 
 	source := stackSourceRelease{
 		Version: "1.2.3",
@@ -154,8 +150,14 @@ func (runner *fakeResolvedInventoryRunner) PrepareRepositories(_ []string, repos
 	return nil
 }
 
-func (runner *fakeResolvedInventoryRunner) Output(_ string, _ []string, args ...string) ([]byte, error) {
+func (runner *fakeResolvedInventoryRunner) Output(_ string, env []string, args ...string) ([]byte, error) {
 	runner.t.Helper()
+	if got := argumentAfter(runner.t, args, "--environment"); got != "default" {
+		runner.t.Fatalf("Helmfile environment = %q, want default", got)
+	}
+	if got := environmentValue(env, "HELMFILE_ENV"); got != "inventory" {
+		runner.t.Fatalf("HELMFILE_ENV = %q, want inventory", got)
+	}
 	stateFile := argumentAfter(runner.t, args, "--file")
 	action := resolvedInventoryAction(args)
 	releases := fakeResolvedInventoryReleases(stateFile, hasResolvedInventoryFullOverrides(args))
@@ -240,5 +242,15 @@ func argumentAfter(t *testing.T, args []string, flag string) string {
 		}
 	}
 	t.Fatalf("missing %s in %v", flag, args)
+	return ""
+}
+
+func environmentValue(env []string, name string) string {
+	for _, entry := range env {
+		entryName, value, found := strings.Cut(entry, "=")
+		if found && entryName == name {
+			return value
+		}
+	}
 	return ""
 }

--- a/tools/docs-version-sync/resolved_inventory_publish_test.go
+++ b/tools/docs-version-sync/resolved_inventory_publish_test.go
@@ -41,13 +41,17 @@ func TestMergeAndResolveHelmfileReleasesPreservesOptionalStatus(t *testing.T) {
 		{Name: "optional", Chart: "../charts/local", Enabled: true, Installed: true},
 	})
 	built := []byte("repositories:\n  - name: nvcf\n    url: nvcr.io/nvidia/nvcf\n    oci: true\n")
+	repositories, err := parseHelmfileRepositories(built)
+	if err != nil {
+		t.Fatal(err)
+	}
 	source := stackSourceRelease{
 		Version: "1.2.3",
 		Tag:     stackTagPrefix + "1.2.3",
 		Commit:  strings.Repeat("a", 40),
 	}
 
-	releases, err := mergeAndResolveHelmfileReleases(repo, stateFile, source, base, full, built)
+	releases, err := mergeAndResolveHelmfileReleases(repo, stateFile, source, base, full, repositories)
 	if err != nil {
 		t.Fatalf("mergeAndResolveHelmfileReleases failed: %v", err)
 	}
@@ -105,6 +109,9 @@ func TestCollectResolvedStackInventoryBuildsEveryPlane(t *testing.T) {
 	if runner.templateCalls != len(resolvedInventoryStates) {
 		t.Fatalf("template calls = %d, want %d", runner.templateCalls, len(resolvedInventoryStates))
 	}
+	if runner.prepareCalls != len(resolvedInventoryStates) {
+		t.Fatalf("repository preparation calls = %d, want %d", runner.prepareCalls, len(resolvedInventoryStates))
+	}
 }
 
 func TestReadRenderedReleaseManifestIsDeterministic(t *testing.T) {
@@ -131,7 +138,20 @@ func mustJSON(t *testing.T, value any) []byte {
 
 type fakeResolvedInventoryRunner struct {
 	t             *testing.T
+	prepareCalls  int
 	templateCalls int
+}
+
+func (runner *fakeResolvedInventoryRunner) PrepareRepositories(_ []string, repositories map[string]helmfileRepository, ngcAPIKey string) error {
+	runner.t.Helper()
+	runner.prepareCalls++
+	if ngcAPIKey != "test-api-key" {
+		runner.t.Fatalf("NGC API key = %q", ngcAPIKey)
+	}
+	if _, ok := repositories["nvcf"]; !ok {
+		runner.t.Fatal("nvcf repository was not prepared")
+	}
+	return nil
 }
 
 func (runner *fakeResolvedInventoryRunner) Output(_ string, _ []string, args ...string) ([]byte, error) {

--- a/tools/docs-version-sync/resolved_inventory_publish_test.go
+++ b/tools/docs-version-sync/resolved_inventory_publish_test.go
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestVerifyResolvedInventoryCheckoutRequiresTaggedCleanStack(t *testing.T) {
+	repo := initTestGitRepo(t)
+	release := commitTestStackSource(t, repo, "1.2.3", map[string]string{
+		"deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl": "releases: []\n",
+	})
+	if err := verifyResolvedInventoryCheckout(repo, release); err != nil {
+		t.Fatalf("verifyResolvedInventoryCheckout failed: %v", err)
+	}
+
+	writeFile(t, filepath.Join(repo, "deploy/stacks/self-managed/untracked.yaml"), "changed\n")
+	if err := verifyResolvedInventoryCheckout(repo, release); err == nil || !strings.Contains(err.Error(), "changes outside tagged commit") {
+		t.Fatalf("dirty checkout error = %v, want tagged commit error", err)
+	}
+}
+
+func TestMergeAndResolveHelmfileReleasesPreservesOptionalStatus(t *testing.T) {
+	repo := t.TempDir()
+	stateFile := filepath.Join(repo, "deploy/stacks/example/helmfile.d/01.yaml.gotmpl")
+	writeFile(t, stateFile, "releases: []\n")
+	writeFile(t, filepath.Join(repo, "deploy/stacks/example/charts/local/Chart.yaml"), "name: local-chart\nversion: 2.3.4\n")
+
+	base := mustJSON(t, []helmfileRelease{{
+		Name: "required", Chart: "nvcf/required", Version: "1.0.0", Enabled: true, Installed: true,
+	}})
+	full := mustJSON(t, []helmfileRelease{
+		{Name: "required", Chart: "nvcf/required", Version: "1.0.0", Enabled: true, Installed: true},
+		{Name: "optional", Chart: "../charts/local", Enabled: true, Installed: true},
+	})
+	built := []byte("repositories:\n  - name: nvcf\n    url: nvcr.io/nvidia/nvcf\n    oci: true\n")
+	source := stackSourceRelease{
+		Version: "1.2.3",
+		Tag:     stackTagPrefix + "1.2.3",
+		Commit:  strings.Repeat("a", 40),
+	}
+
+	releases, err := mergeAndResolveHelmfileReleases(repo, stateFile, source, base, full, built)
+	if err != nil {
+		t.Fatalf("mergeAndResolveHelmfileReleases failed: %v", err)
+	}
+	if len(releases) != 2 {
+		t.Fatalf("got %d releases, want 2", len(releases))
+	}
+	byName := map[string]helmfileRelease{}
+	for _, release := range releases {
+		byName[release.Name] = release
+	}
+	if got := byName["required"].Chart; got != "oci://nvcr.io/nvidia/nvcf/required" {
+		t.Fatalf("required chart = %q", got)
+	}
+	optional := byName["optional"]
+	if optional.Enabled {
+		t.Fatal("optional release was marked enabled by default")
+	}
+	wantLocal := resolvedInventoryRepository + "/" + source.Commit + "/deploy/stacks/example/charts/local"
+	if optional.Chart != wantLocal || optional.Version != "2.3.4" {
+		t.Fatalf("optional local chart = %q@%q, want %q@2.3.4", optional.Chart, optional.Version, wantLocal)
+	}
+}
+
+func TestCollectResolvedStackInventoryBuildsEveryPlane(t *testing.T) {
+	t.Setenv("NVCF_RELEASE_NGC_API_KEY", "test-api-key")
+	repo := t.TempDir()
+	for _, state := range resolvedInventoryStates {
+		writeFile(t, filepath.Join(repo, filepath.FromSlash(state.path)), "releases: []\n")
+	}
+	if err := os.MkdirAll(filepath.Join(repo, "deploy/stacks/self-managed/secrets"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	source := stackSourceRelease{
+		Version: "1.2.3",
+		Tag:     stackTagPrefix + "1.2.3",
+		Commit:  strings.Repeat("b", 40),
+	}
+	runner := &fakeResolvedInventoryRunner{t: t}
+	inventory, err := collectResolvedStackInventory(repo, source, runner)
+	if err != nil {
+		t.Fatalf("collectResolvedStackInventory failed: %v", err)
+	}
+	if err := validateResolvedStackInventory(inventory); err != nil {
+		t.Fatalf("inventory validation failed: %v", err)
+	}
+	if len(inventory.Releases) != 8 {
+		t.Fatalf("got %d releases, want 8", len(inventory.Releases))
+	}
+	for _, release := range inventory.Releases {
+		if release.Name == "nvcf-pki" && release.Required {
+			t.Fatal("nvcf-pki should remain optional after the full render")
+		}
+	}
+	if runner.templateCalls != len(resolvedInventoryStates) {
+		t.Fatalf("template calls = %d, want %d", runner.templateCalls, len(resolvedInventoryStates))
+	}
+}
+
+func TestReadRenderedReleaseManifestIsDeterministic(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "z.yaml"), "kind: Service\n")
+	writeFile(t, filepath.Join(root, "nested/a.yaml"), "kind: Deployment\n")
+	manifest, err := readRenderedReleaseManifest(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(manifest), "kind: Deployment\n\n---\nkind: Service\n"; got != want {
+		t.Fatalf("manifest = %q, want %q", got, want)
+	}
+}
+
+func mustJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+type fakeResolvedInventoryRunner struct {
+	t             *testing.T
+	templateCalls int
+}
+
+func (runner *fakeResolvedInventoryRunner) Output(_ string, _ []string, args ...string) ([]byte, error) {
+	runner.t.Helper()
+	stateFile := argumentAfter(runner.t, args, "--file")
+	action := resolvedInventoryAction(args)
+	releases := fakeResolvedInventoryReleases(stateFile, hasResolvedInventoryFullOverrides(args))
+	switch action {
+	case "list":
+		return mustJSON(runner.t, releases), nil
+	case "build":
+		return []byte("repositories:\n  - name: nvcf\n    url: nvcr.io/nvidia/nvcf\n    oci: true\n"), nil
+	case "template":
+		runner.templateCalls++
+		outputDir := argumentAfter(runner.t, args, "--output-dir")
+		for _, release := range releases {
+			manifest := fmt.Sprintf("apiVersion: v1\nkind: Pod\nspec:\n  containers:\n    - image: nvcr.io/nvidia/nvcf/%s:1.0.0\n", release.Name)
+			writeFile(runner.t, filepath.Join(outputDir, release.Name, "manifest.yaml"), manifest)
+		}
+		return nil, nil
+	default:
+		runner.t.Fatalf("unexpected Helmfile action in %v", args)
+		return nil, nil
+	}
+}
+
+func fakeResolvedInventoryReleases(stateFile string, full bool) []helmfileRelease {
+	release := func(name string) helmfileRelease {
+		return helmfileRelease{
+			Name: name, Chart: "nvcf/" + name, Version: "1.0.0", Enabled: true, Installed: true,
+		}
+	}
+	slashPath := filepath.ToSlash(stateFile)
+	switch {
+	case strings.Contains(slashPath, "self-managed/helmfile.d/01-"):
+		releases := []helmfileRelease{release("nats")}
+		if full {
+			releases = append(releases, release("nvcf-pki"))
+		}
+		return releases
+	case strings.Contains(slashPath, "self-managed/helmfile.d/02-"):
+		return []helmfileRelease{release("api")}
+	case strings.Contains(slashPath, "self-managed/helmfile.d/03-"):
+		return []helmfileRelease{release("state-metrics")}
+	case strings.Contains(slashPath, "observability/helmfile.d/01-"):
+		return []helmfileRelease{release("otel-collector")}
+	case strings.Contains(slashPath, "nvcf-compute-plane/helmfile.d/01-"):
+		releases := []helmfileRelease{release("kai-scheduler")}
+		if full {
+			releases = append(releases, release("grove-operator"))
+		} else {
+			releases[0].Enabled = false
+		}
+		return releases
+	case strings.Contains(slashPath, "nvcf-compute-plane/helmfile.d/02-"):
+		return []helmfileRelease{release("nvca-operator")}
+	default:
+		panic("unexpected state " + stateFile)
+	}
+}
+
+func hasResolvedInventoryFullOverrides(args []string) bool {
+	for _, arg := range args {
+		if arg == "addons.llm.enabled=true" || arg == "addons.kaiScheduler.enabled=true" {
+			return true
+		}
+	}
+	return false
+}
+
+func resolvedInventoryAction(args []string) string {
+	for _, arg := range args {
+		switch arg {
+		case "list", "build", "template":
+			return arg
+		}
+	}
+	return ""
+}
+
+func argumentAfter(t *testing.T, args []string, flag string) string {
+	t.Helper()
+	for i, arg := range args {
+		if arg == flag && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	t.Fatalf("missing %s in %v", flag, args)
+	return ""
+}


### PR DESCRIPTION
## TL;DR

With this change, we generate one resolved inventory for every tagged self-managed stack release and attach it to the matching GitHub release. The inventory covers the control plane, observability, and compute plane from the exact tagged commit. This gives docs version sync an immutable public input without GitLab credentials or a second source of truth.

## Why

The docs updater needs to know what a released stack actually deploys. Reading current Helmfile values from `main` is not enough because the files can move after a release. Reading only the bundled self-managed stack is also incomplete because customers install a separate compute plane and can install the standalone observability stack.

The predecessor release pipeline had a useful safety boundary. It built the distribution, rendered the bundled stack, extracted image references, resolved image digests, built an SBOM and artifact list, packaged the release files, and only then created the release and attached links. That flow was designed for packaging and SBOM publication. It did not provide the public, cross-plane catalog input that docs version sync needs.

We keep the same core idea here: render and validate first, then expose the release asset. The new flow is intentionally smaller than the predecessor packaging pipeline. It publishes one JSON inventory for docs synchronization. It does not replace distribution tarballs, checksums, SBOM generation, or artifact mirroring.

## Compared With the Predecessor Release CI

| Concern | Predecessor release CI | This PR |
| --- | --- | --- |
| Release source | A version tag in the standalone stack repository | A path-based stack tag and exact commit in the GitHub monorepo |
| Render scope | The bundled self-managed distribution, including its embedded observability state | Six existing Helmfile states across control, standalone observability, and compute |
| Artifact discovery | Images from rendered manifests in one configured registry, followed by tag-parity checks and a manual exclusion | Charts and images from every rendered release, with source-release mappings, optional status, validation, and the catalog denylist |
| Digests and SBOM | Resolves image digests and produces an SPDX SBOM | Preserves exact rendered references and any digest already present, but does not create an SBOM |
| Published output | A distribution tarball, SBOM, image list, and checksums in a package registry, followed by release links | One deterministic JSON asset attached directly to the matching GitHub release |
| Publication ordering | Builds and packages before creating the release, then attaches asset links | Generates and validates before release creation, stages new releases as drafts, then uploads and publishes |
| Reruns | Reuses the release and updates existing links | Accepts a byte-identical inventory and refuses to replace different content |

We are not recreating the old pipeline job for job. We are keeping the parts that matter for a trustworthy docs input: exact release source, rendered manifests, validation before publication, and idempotent reruns.

## How It Works

```mermaid
sequenceDiagram
    actor Tag as Self-managed stack tag
    participant Workflow as GitHub release workflow
    participant Generator as docs-version-sync
    participant Helmfile as Tagged Helmfile states
    participant Catalog as Public NGC catalog
    participant Release as GitHub release

    Tag->>Workflow: Run for deploy/stacks/self-managed/vX.Y.Z
    Workflow->>Generator: Generate inventory with version, tag, and commit
    Generator->>Generator: Verify HEAD, tag commit, and clean deploy/stacks
    loop Six states across control, observability, and compute
        Generator->>Helmfile: List default releases
        Generator->>Helmfile: List fully enabled releases
        Generator->>Helmfile: Build repository map
        Generator->>Catalog: Prepare authenticated HTTPS repositories
        Generator->>Helmfile: Render the fully enabled release set
        Helmfile-->>Generator: Releases, chart references, and manifests
    end
    Generator->>Generator: Merge required and optional releases
    Generator->>Generator: Normalize chart sources and extract images
    Generator->>Generator: Validate and write deterministic JSON
    Generator-->>Workflow: nvcf-self-managed-stack-inventory.json
    Workflow->>Release: Create new draft or reuse existing release
    Workflow->>Release: Upload asset or verify byte-identical asset
    alt Public release requested
        Workflow->>Release: Make release public after asset succeeds
    else
        Workflow->>Release: Leave visibility unchanged for draft request
    end
```

The generator reads both the default and fully enabled release lists. This lets us keep the default required or optional status while still rendering optional components and including their artifacts. The output is sorted and validated so reruns are deterministic.

New releases stay in draft state until the inventory is present. An explicitly requested new draft stays a draft. Existing releases keep their current visibility. If an existing release already has the same asset, a rerun accepts it. If the bytes differ, the job stops instead of replacing release history.

## Why Each Stack Changes

The inventory is generated from the whole deployment, not only the directory that owns the release tag. Each stack still owns its own Helmfile state and values. We render those existing states directly so the inventory follows the same chart selection and feature gates as an installation.

| Stack area | Files | Why the change is needed |
| --- | --- | --- |
| Self-managed control plane | `deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl` and `02-core.yaml.gotmpl` | These states already supported a classic Helm repository. We now validate that an explicit repository URL uses HTTPS and reuse one resolved value for the URL and credentials. The inventory can render the public chart distribution without changing the normal OCI fallback. |
| Self-managed observability | `deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl` | This state declares its own `nvcf` repository, so it needs the same HTTPS validation as the other self-managed states. Rendering it separately keeps control-plane observability images and charts in the inventory. |
| Standalone observability | `deploy/stacks/observability/helmfile.d/01-observability.yaml.gotmpl` | The standalone stack previously assumed OCI for the `nvcf` repository. Inventory generation reads the public HTTPS chart distribution, so this state now accepts an authenticated HTTPS repository and keeps OCI as the default fallback. |
| Compute-plane dependencies | `deploy/stacks/nvcf-compute-plane/helmfile.d/01-dependencies.yaml.gotmpl` | No repository compatibility change is needed. We still render this state so optional KAI Scheduler, Grove, Dynamo, and topology-aware scheduling releases are represented. |
| Compute-plane NVCA | `deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl` | The NVCA state previously assumed OCI for the `nvcf` repository. It now supports the same authenticated HTTPS source used during inventory generation while preserving the OCI path for normal installs. |
| Shared stack values | The three `environments/base.yaml` files | The comments now describe the same source contract in every stack: set an HTTPS URL for a classic Helm repository, or use the registry and repository fields for OCI. No default source changes. |

These changes are deliberately consistent across the stack boundaries. A partial implementation would make the generated inventory depend on which plane happened to support the public chart source already.

## What Changed

1. Added an opt-in `resolved_inventory_asset` field to the release metadata. Only self-managed stack tags use this path, so other component releases keep their existing behavior.
1. Added explicit inventory CLI inputs for source version, tag, commit, and output path.
1. Added a generator that copies only the required stack inputs into a temporary workspace, creates an inventory-only environment, and renders six Helmfile states.
1. Added release and artifact validation for plane coverage, duplicate releases, unresolved chart references, unresolved image references, and source identity.
1. Added chart normalization for repository aliases and bundled local charts. Local charts point back to the exact public GitHub commit.
1. Added release-helper ordering that generates first, creates new releases as drafts, uploads or verifies the inventory, and publishes only after success.
1. Added pinned Helm 3.21.4 and Helmfile 1.1.9 downloads for self-managed stack tag jobs. Checksums are verified before either tool runs.

## For the Reviewer

Start with `tools/docs-version-sync/resolved_inventory_publish.go`. The main decisions are the six-state topology, the default-versus-full release merge, and chart source normalization. Then review `tools/ci/github-release` for draft-first ordering and idempotent asset handling.

The Helmfile changes do not change the default OCI source. They make the existing states renderable against the public HTTPS chart source used by the inventory job and reject an explicitly configured non-HTTPS URL.

## Customer Release Notes

Not customer visible.

## Plan Summary

The tag workflow installs checksum-pinned rendering tools only for self-managed stack tags. It reads the tagged repository plus public NGC charts and writes one JSON asset to the matching GitHub release. It does not contact a Kubernetes cluster or GitLab.

## Usage

Release automation invokes the generator. For a manual run:

```console
cd tools/docs-version-sync
go run . \
  --generate-stack-inventory /path/to/inventory.json \
  --stack-version X.Y.Z \
  --stack-source-tag deploy/stacks/self-managed/vX.Y.Z \
  --stack-source-commit <full-commit-sha>
```

Set `NVCF_RELEASE_NGC_API_KEY` to an NGC key with read access before running the command.

## Testing

QA is not needed beyond CI. I ran:

- `go test ./...` in `tools/docs-version-sync`
- `go vet ./...` in `tools/docs-version-sync`
- `python3 -m unittest tools.ci.test-github-release` (58 tests)
- `make test` in `deploy/stacks/self-managed`
- `make test` in `deploy/stacks/observability`
- `make test-observability-profile` in `deploy/stacks/nvcf-compute-plane`
- `./tools/ci/check-doc-version-sync`
- `./tools/ci/check-docs` (0 errors, 1 existing hidden warning)
- A temporary-tag end-to-end render against the public NGC catalog. It stopped before release creation when a chart pinned by the development commit was not yet published, which verifies the fail-closed behavior.

GitHub CI is green. CodeRabbit completed its re-review, and all review threads are resolved.

## Notes

Helmfile 1.1.9 does not expose a repository redirect policy. The changed states reject a configured non-HTTPS base URL, but scheme-changing redirect behavior remains owned by Helm. Adding a template field that Helmfile does not support would not improve the security boundary.

The inventory records the release topology and rendered artifact references. It is not an SBOM and does not replace the existing release packaging or vulnerability-scanning flow.

## Issues

Closes #1733
Relates to #279

## Related Pull Requests

- Depends on #1740, which is merged.
- #1749 consumes this release inventory and is stacked on this PR.

## Dependencies

No new third-party code dependencies. The workflow downloads pinned Helm and Helmfile binaries with fixed SHA-256 checksums and reuses the existing NGC read credential. License review and NOTICE updates are not required.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Self-managed stack releases can now publish a resolved inventory asset alongside the GitHub release.
  - Release inventories include validated chart references, manifests, and deployment-plane details.
  - Existing matching inventory assets are safely reused, while conflicting assets are rejected.

- **Bug Fixes**
  - Helm chart sources now support validated HTTPS repositories with optional credentials.
  - OCI registry and repository fallback behavior remains available when no URL is configured.
  - Incomplete releases are cleaned up when inventory publication fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->