### PR TITLE
fix(nvca-operator): restore image.repository default in vendored chart

### DIFF
--- a/deploy/helm/nvca-operator/nvca-operator/values.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/values.yaml
@@ -18,7 +18,7 @@
 ## @param image.tag NVCA Operator container image tag. This defaults to the chart's appVersion
 ## @param image.pullPolicy K8s ImagePullPolicy
 image:
-  repository: ""
+  repository: "nvcr.io/nvidia/nvcf-byoc/nvca-operator"
   tag: ""
   pullPolicy: IfNotPresent
 ## @param nvcaImage.repositoryOverride (Optional) Full NVCA container registry path, without tag. Only set this if the default needs to be overridden, for example "stg.nvcr.io/nvidia/nvcf-byoc/nvca". The tag is set in the cluster config


### PR DESCRIPTION
## Why

The vendored nvca-operator chart at deploy/helm/nvca-operator/nvca-operator/values.yaml has shipped image.repository as an empty string since the monorepo publishing lane took over from the GitLab lane. Any helm install that omits --set image.repository renders an unparseable image name (':3.x.y'), causing InvalidImageName and a non-descriptive context deadline exceeded under --wait.

Chart 3.0.14 (last published via the GitLab lane, which used the source chart with the correct hardcoded default) worked correctly. All charts from 3.2.18 onward are affected.

The byocdev publishing hook in nvcf-internal has been fixed to also set image.repository at publish time. This chart fix additionally corrects the OCI lane (ncp-dev), which mirrors the vendored values directly without running the hook.

## What changed

Restores image.repository to nvcr.io/nvidia/nvcf-byoc/nvca-operator in the vendored chart's values.yaml.

## Customer Release Notes

Fixes helm installs of nvca-operator that omit --set image.repository failing with InvalidImageName.

## Plan Summary

Not applicable.

## Testing

Verified locally via the byocdev hook test in nvcf-internal which now explicitly asserts the correct image.repository value. The vendored chart fix ensures the OCI lane also publishes the correct default without relying on the hook.

## Notes

After this merges, cherry-pick to release-src/compute-plane-services/nvca/v3.2 to produce chart 3.2.22 with the fix.

## References

None

## Related Pull Requests

None

## Dependencies

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default deployment configuration to use the NVIDIA Container Registry image for the NVCA Operator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->