### PR TITLE
feat(vanity-gateway): add per-target shadow policies to the chart

### DIFF
--- a/deploy/helm/vanity-gateway/AGENTS.md
+++ b/deploy/helm/vanity-gateway/AGENTS.md
@@ -59,6 +59,7 @@ render checks run by hand:
 
 ```bash
 bash tests/chart-render/verify-llm-gateway-routing.sh
+bash tests/chart-render/verify-shadow-schema.sh
 bash tests/chart-render/verify-servicemonitor-label.sh
 ```
 

--- a/deploy/helm/vanity-gateway/README.md
+++ b/deploy/helm/vanity-gateway/README.md
@@ -158,17 +158,21 @@ shadow-b:
   functionID: shadow-b-function-id
 ```
 
-Each target is routed by its own `functionType`. The legacy `shadowModelName`,
-`shadowModelNames`, `shadowPercentage`, `shadowSamplingMethod`, and
-`shadowCancelOnClientDisconnect` fields still work, apply one policy to every
-target, and keep the schema checks they had before. A route uses one form or
-the other. The schema validates `shadows` as the gateway does, with keys in any
-letter case: it rejects a route with both forms, an entry without `modelName`
-or with an unknown key, and a non-empty list on `imageEdits` or
-`imageVariations`. Duplicate targets and targets missing from the endpoint are
-still caught by the gateway at startup. `tests/chart-render/verify-shadow-schema.sh`
-covers these rules. `vanityGateway.config.shadowMaxConcurrent` bounds
-concurrent shadow requests across all routes.
+Each target is routed by its own `functionType`. A route uses either `shadows`
+or the legacy `shadowModelName`, `shadowModelNames`, `shadowPercentage`,
+`shadowSamplingMethod`, and `shadowCancelOnClientDisconnect` fields, which apply
+one policy to every target and keep their existing checks. For `shadows` the
+schema mirrors the gateway, with keys in any letter case:
+
+- a route with both forms is rejected
+- an entry needs `modelName`; unknown entry keys are rejected
+- a non-empty list is rejected on `imageEdits` and `imageVariations`
+- duplicate targets and targets missing from the endpoint are left to the
+  gateway at startup
+
+`tests/chart-render/verify-shadow-schema.sh` covers these rules.
+`vanityGateway.config.shadowMaxConcurrent` bounds concurrent shadow requests
+across all routes.
 
 ## Notes
 

--- a/deploy/helm/vanity-gateway/README.md
+++ b/deploy/helm/vanity-gateway/README.md
@@ -114,6 +114,8 @@ or the pod is killed mid-drain.
   path requires `path` and `functionID`.
 
 Both sections are empty by default.
+`vanityGateway.config.shadowMaxConcurrent` bounds concurrent shadow requests
+across all routes.
 
 An `openai` model may set `functionType: LLM` to be served by the LLM Gateway
 instead of the invocation service, supported in `chatCompletions`, `responses`,
@@ -131,6 +133,11 @@ that would fail the container fails the render instead:
   answers `400 Bad Request` for any request carrying it
 - `vanityGateway.config.llmGatewayEndpoint` must be set, and must be an `http`
   or `https` origin with no path
+
+Shadow traffic is supported. Each shadow target is resolved from the same model
+table and routed by its own `functionType`, so a shadow of an LLM model reaches
+the LLM Gateway, and an LLM model may shadow a model served by the invocation
+service.
 
 `mappingConfig` is rendered into a ConfigMap, which is not a secret store. Do
 not put credentials in `customHeaders` on any route. Caller `Authorization`
@@ -164,13 +171,6 @@ shadow-b:
 The legacy route-level fields `shadowModelName`, `shadowModelNames`,
 `shadowPercentage`, `shadowSamplingMethod`, and `shadowCancelOnClientDisconnect`
 keep working unchanged; they apply one policy to every target on the route.
-
-Each shadow target is resolved from the same model table and routed by its own
-`functionType`, so a shadow of an LLM model reaches the LLM Gateway, and an LLM
-model may shadow a model served by the invocation service.
-
-`vanityGateway.config.shadowMaxConcurrent` bounds concurrent shadow requests
-across all routes.
 
 ## Notes
 

--- a/deploy/helm/vanity-gateway/README.md
+++ b/deploy/helm/vanity-gateway/README.md
@@ -137,7 +137,8 @@ not put credentials in `customHeaders` on any route. Caller `Authorization`
 headers are forwarded to the upstream untouched, so a static credential is not
 needed for authenticated routes.
 
-Use `shadows` to set policy for each shadow target:
+An `openai` route may mirror traffic to other routes in the same endpoint with
+`shadows`, one entry per target:
 
 ```yaml
 primary:
@@ -145,12 +146,10 @@ primary:
   functionID: primary-function-id
   shadows:
     - modelName: private/example/shadow-a
-      percentage: 10
-      samplingMethod: perBearerKey
-      cancelOnClientDisconnect: true
+      percentage: 10                  # 1-100, default 100
+      samplingMethod: perBearerKey    # random (default) or perBearerKey
+      cancelOnClientDisconnect: true  # default false
     - modelName: private/example/shadow-b
-      percentage: 50
-      samplingMethod: random
 shadow-a:
   modelName: private/example/shadow-a
   functionID: shadow-a-function-id
@@ -159,27 +158,14 @@ shadow-b:
   functionID: shadow-b-function-id
 ```
 
-Each shadow model must be another model route in the same OpenAI endpoint.
-`percentage` defaults to `100`, `samplingMethod` defaults to `random`, and
-`cancelOnClientDisconnect` defaults to `false`.
-Each target is routed by its own `functionType`, so a shadow of an LLM model
-reaches the LLM Gateway, and an LLM model may shadow a model served by the
-invocation service.
-Shadowing is not supported for `imageEdits` or `imageVariations` routes.
-
-Legacy `shadowModelName`, `shadowModelNames`, `shadowPercentage`,
-`shadowSamplingMethod`, and `shadowCancelOnClientDisconnect` fields remain
-supported. Their policy applies to every legacy shadow target. Do not combine
-the `shadows` field with legacy shadow fields on the same route.
-
-The schema rejects a route that has both forms, a shadow key spelled with any
-other capitalization, a shadow target key other than the four above, and a
-percentage outside 1 to 100. The gateway accepts other capitalizations of the
-shadow keys, but the schema needs the exact spelling to tell the forms apart.
-`tests/chart-render/verify-shadow-schema.sh` exercises these rules.
-
-`vanityGateway.config.shadowMaxConcurrent` bounds concurrent shadow requests
-across all routes.
+Each target is routed by its own `functionType`. The legacy `shadowModelName`,
+`shadowModelNames`, `shadowPercentage`, `shadowSamplingMethod`, and
+`shadowCancelOnClientDisconnect` fields still work and apply one policy to every
+target. A route uses one form or the other; the schema rejects a route with
+both, shadow keys in any other spelling, unknown target keys, and shadows on
+`imageEdits` or `imageVariations`. `tests/chart-render/verify-shadow-schema.sh`
+covers these rules. `vanityGateway.config.shadowMaxConcurrent` bounds
+concurrent shadow requests across all routes.
 
 ## Notes
 

--- a/deploy/helm/vanity-gateway/README.md
+++ b/deploy/helm/vanity-gateway/README.md
@@ -160,10 +160,13 @@ shadow-b:
 
 Each target is routed by its own `functionType`. The legacy `shadowModelName`,
 `shadowModelNames`, `shadowPercentage`, `shadowSamplingMethod`, and
-`shadowCancelOnClientDisconnect` fields still work and apply one policy to every
-target. A route uses one form or the other; the schema rejects a route with
-both, shadow keys in any other spelling, unknown target keys, and shadows on
-`imageEdits` or `imageVariations`. `tests/chart-render/verify-shadow-schema.sh`
+`shadowCancelOnClientDisconnect` fields still work, apply one policy to every
+target, and keep the schema checks they had before. A route uses one form or
+the other. The schema validates `shadows` as the gateway does, with keys in any
+letter case: it rejects a route with both forms, an entry without `modelName`
+or with an unknown key, and a non-empty list on `imageEdits` or
+`imageVariations`. Duplicate targets and targets missing from the endpoint are
+still caught by the gateway at startup. `tests/chart-render/verify-shadow-schema.sh`
 covers these rules. `vanityGateway.config.shadowMaxConcurrent` bounds
 concurrent shadow requests across all routes.
 

--- a/deploy/helm/vanity-gateway/README.md
+++ b/deploy/helm/vanity-gateway/README.md
@@ -161,6 +161,14 @@ shadow-b:
 - a route with both legacy form and new form is rejected
 - an entry needs `modelName`; unknown entry keys are rejected
 
+The legacy route-level fields `shadowModelName`, `shadowModelNames`,
+`shadowPercentage`, `shadowSamplingMethod`, and `shadowCancelOnClientDisconnect`
+keep working unchanged; they apply one policy to every target on the route.
+
+Each shadow target is resolved from the same model table and routed by its own
+`functionType`, so a shadow of an LLM model reaches the LLM Gateway, and an LLM
+model may shadow a model served by the invocation service.
+
 `vanityGateway.config.shadowMaxConcurrent` bounds concurrent shadow requests
 across all routes.
 

--- a/deploy/helm/vanity-gateway/README.md
+++ b/deploy/helm/vanity-gateway/README.md
@@ -158,21 +158,8 @@ shadow-b:
   functionID: shadow-b-function-id
 ```
 
-Each target is routed by its own `functionType`. A route uses either `shadows`
-or the legacy `shadowModelName`, `shadowModelNames`, `shadowPercentage`,
-`shadowSamplingMethod`, and `shadowCancelOnClientDisconnect` fields, which apply
-one policy to every target and keep their existing checks. For `shadows` the
-schema mirrors the gateway, with keys in any letter case:
-
-- a route with both forms is rejected
+- a route with both legacy form and new form is rejected
 - an entry needs `modelName`; unknown entry keys are rejected
-- a non-empty list is rejected on `imageEdits` and `imageVariations`
-- duplicate targets and targets missing from the endpoint are left to the
-  gateway at startup
-
-`tests/chart-render/verify-shadow-schema.sh` covers these rules.
-`vanityGateway.config.shadowMaxConcurrent` bounds concurrent shadow requests
-across all routes.
 
 ## Notes
 

--- a/deploy/helm/vanity-gateway/README.md
+++ b/deploy/helm/vanity-gateway/README.md
@@ -113,6 +113,8 @@ or the pod is killed mid-drain.
 - `vanity`: host-based routes, each requiring a `host` and a `paths` map. Each
   path requires `path` and `functionID`.
 
+Both sections are empty by default.
+
 An `openai` model may set `functionType: LLM` to be served by the LLM Gateway
 instead of the invocation service, supported in `chatCompletions`, `responses`,
 and `embeddings`. Callers still send the public `modelName`; the gateway
@@ -171,13 +173,13 @@ supported. Their policy applies to every legacy shadow target. Do not combine
 the `shadows` field with legacy shadow fields on the same route.
 
 The schema rejects a route that has both forms, a shadow key spelled with any
-other capitalization, and a shadow target with an unknown field or a percentage
-outside 1 to 100. The gateway accepts other capitalizations of the route-level
+other capitalization, a shadow target key other than the four above, and a
+percentage outside 1 to 100. The gateway accepts other capitalizations of the
 shadow keys, but the schema needs the exact spelling to tell the forms apart.
 `tests/chart-render/verify-shadow-schema.sh` exercises these rules.
 
-Both sections are empty by default. `vanityGateway.config.shadowMaxConcurrent`
-bounds concurrent shadow requests across all routes.
+`vanityGateway.config.shadowMaxConcurrent` bounds concurrent shadow requests
+across all routes.
 
 ## Notes
 

--- a/deploy/helm/vanity-gateway/README.md
+++ b/deploy/helm/vanity-gateway/README.md
@@ -170,6 +170,12 @@ Legacy `shadowModelName`, `shadowModelNames`, `shadowPercentage`,
 supported. Their policy applies to every legacy shadow target. Do not combine
 the `shadows` field with legacy shadow fields on the same route.
 
+The schema rejects a route that has both forms, a shadow key spelled with any
+other capitalization, and a shadow target with an unknown field or a percentage
+outside 1 to 100. The gateway accepts other capitalizations of the route-level
+shadow keys, but the schema needs the exact spelling to tell the forms apart.
+`tests/chart-render/verify-shadow-schema.sh` exercises these rules.
+
 Both sections are empty by default. `vanityGateway.config.shadowMaxConcurrent`
 bounds concurrent shadow requests across all routes.
 

--- a/deploy/helm/vanity-gateway/README.md
+++ b/deploy/helm/vanity-gateway/README.md
@@ -161,6 +161,9 @@ shadow-b:
 - a route with both legacy form and new form is rejected
 - an entry needs `modelName`; unknown entry keys are rejected
 
+`vanityGateway.config.shadowMaxConcurrent` bounds concurrent shadow requests
+across all routes.
+
 ## Notes
 
 - The chart version is `0.0.0` in `Chart.yaml`. The release pipeline packages

--- a/deploy/helm/vanity-gateway/README.md
+++ b/deploy/helm/vanity-gateway/README.md
@@ -109,15 +109,9 @@ or the pod is killed mid-drain.
 
 - `openai`: per-endpoint model routes, keyed by endpoint (`chatCompletions`,
   `completions`, `embeddings`, `responses`, and the image endpoints). Each route
-  requires `modelName` and `functionID`, and supports shadow-traffic fields such
-  as `shadowModelName`, `shadowPercentage`, and
-  `shadowCancelOnClientDisconnect`.
+  requires `modelName` and `functionID`.
 - `vanity`: host-based routes, each requiring a `host` and a `paths` map. Each
   path requires `path` and `functionID`.
-
-Both sections are empty by default.
-`vanityGateway.config.shadowMaxConcurrent` bounds concurrent shadow requests
-across all routes.
 
 An `openai` model may set `functionType: LLM` to be served by the LLM Gateway
 instead of the invocation service, supported in `chatCompletions`, `responses`,
@@ -136,15 +130,48 @@ that would fail the container fails the render instead:
 - `vanityGateway.config.llmGatewayEndpoint` must be set, and must be an `http`
   or `https` origin with no path
 
-Shadow traffic is supported. Each shadow target is resolved from the same model
-table and routed by its own `functionType`, so a shadow of an LLM model reaches
-the LLM Gateway, and an LLM model may shadow a model served by the invocation
-service.
-
 `mappingConfig` is rendered into a ConfigMap, which is not a secret store. Do
 not put credentials in `customHeaders` on any route. Caller `Authorization`
 headers are forwarded to the upstream untouched, so a static credential is not
 needed for authenticated routes.
+
+Use `shadows` to set policy for each shadow target:
+
+```yaml
+primary:
+  modelName: example/primary
+  functionID: primary-function-id
+  shadows:
+    - modelName: private/example/shadow-a
+      percentage: 10
+      samplingMethod: perBearerKey
+      cancelOnClientDisconnect: true
+    - modelName: private/example/shadow-b
+      percentage: 50
+      samplingMethod: random
+shadow-a:
+  modelName: private/example/shadow-a
+  functionID: shadow-a-function-id
+shadow-b:
+  modelName: private/example/shadow-b
+  functionID: shadow-b-function-id
+```
+
+Each shadow model must be another model route in the same OpenAI endpoint.
+`percentage` defaults to `100`, `samplingMethod` defaults to `random`, and
+`cancelOnClientDisconnect` defaults to `false`.
+Each target is routed by its own `functionType`, so a shadow of an LLM model
+reaches the LLM Gateway, and an LLM model may shadow a model served by the
+invocation service.
+Shadowing is not supported for `imageEdits` or `imageVariations` routes.
+
+Legacy `shadowModelName`, `shadowModelNames`, `shadowPercentage`,
+`shadowSamplingMethod`, and `shadowCancelOnClientDisconnect` fields remain
+supported. Their policy applies to every legacy shadow target. Do not combine
+the `shadows` field with legacy shadow fields on the same route.
+
+Both sections are empty by default. `vanityGateway.config.shadowMaxConcurrent`
+bounds concurrent shadow requests across all routes.
 
 ## Notes
 

--- a/deploy/helm/vanity-gateway/helm-nvcf-vanity-gateway/values.schema.json
+++ b/deploy/helm/vanity-gateway/helm-nvcf-vanity-gateway/values.schema.json
@@ -419,6 +419,22 @@
         "modelName",
         "functionID"
       ],
+      "propertyNames": {
+        "$comment": "The gateway matches shadow keys case-insensitively, but the exclusivity rule below can only name exact keys, so any other spelling is rejected here.",
+        "if": {
+          "pattern": "^(?i)shadow(s|modelname|modelnames|percentage|samplingmethod|cancelonclientdisconnect)$"
+        },
+        "then": {
+          "enum": [
+            "shadows",
+            "shadowModelName",
+            "shadowModelNames",
+            "shadowPercentage",
+            "shadowSamplingMethod",
+            "shadowCancelOnClientDisconnect"
+          ]
+        }
+      },
       "allOf": [
         {
           "not": {

--- a/deploy/helm/vanity-gateway/helm-nvcf-vanity-gateway/values.schema.json
+++ b/deploy/helm/vanity-gateway/helm-nvcf-vanity-gateway/values.schema.json
@@ -392,19 +392,10 @@
             "$ref": "#/definitions/nonEmptyString"
           }
         },
-        "shadows": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/shadowTarget"
-          }
-        },
         "shadowPercentage": {
           "type": "integer",
           "minimum": 1,
           "maximum": 100
-        },
-        "shadowSamplingMethod": {
-          "$ref": "#/definitions/legacyShadowSamplingMethod"
         },
         "shadowCancelOnClientDisconnect": {
           "type": "boolean"
@@ -419,64 +410,33 @@
         "modelName",
         "functionID"
       ],
-      "propertyNames": {
-        "$comment": "The gateway matches shadow keys case-insensitively, but the exclusivity rule below can only name exact keys, so any other spelling is rejected here. The (?i) flag is Go regexp syntax, which Helm uses; ECMA-262 validators do not accept it.",
-        "if": {
-          "pattern": "^(?i)shadow(s|modelname|modelnames|percentage|samplingmethod|cancelonclientdisconnect)$"
-        },
-        "then": {
-          "enum": [
-            "shadows",
-            "shadowModelName",
-            "shadowModelNames",
-            "shadowPercentage",
-            "shadowSamplingMethod",
-            "shadowCancelOnClientDisconnect"
-          ]
-        }
-      },
-      "allOf": [
-        {
-          "not": {
-            "allOf": [
-              {
-                "required": [
-                  "shadows"
-                ]
-              },
-              {
-                "anyOf": [
-                  {
-                    "required": [
-                      "shadowModelName"
-                    ]
-                  },
-                  {
-                    "required": [
-                      "shadowModelNames"
-                    ]
-                  },
-                  {
-                    "required": [
-                      "shadowPercentage"
-                    ]
-                  },
-                  {
-                    "required": [
-                      "shadowSamplingMethod"
-                    ]
-                  },
-                  {
-                    "required": [
-                      "shadowCancelOnClientDisconnect"
-                    ]
-                  }
-                ]
-              }
-            ]
+      "$comment": "The gateway reads the shadows key and the legacy shadow keys in any letter case, so the shadows rules use (?i) patterns. That flag is Go regexp syntax, which Helm uses; ECMA-262 validators do not accept it. The legacy keys keep the exact-name checks above so their behavior is unchanged.",
+      "patternProperties": {
+        "^(?i)shadows$": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/shadowTarget"
           }
         }
-      ],
+      },
+      "if": {
+        "$comment": "True when at least one key is spelled shadows in any case.",
+        "not": {
+          "propertyNames": {
+            "not": {
+              "pattern": "^(?i)shadows$"
+            }
+          }
+        }
+      },
+      "then": {
+        "$comment": "A route uses shadows or the legacy shadow keys, never both, in any spelling.",
+        "propertyNames": {
+          "not": {
+            "pattern": "^(?i)shadow(modelname|modelnames|percentage|samplingmethod|cancelonclientdisconnect)$"
+          }
+        }
+      },
       "additionalProperties": true
     },
     "openAIMultipartModelRoute": {
@@ -486,32 +446,11 @@
         },
         {
           "type": "object",
-          "properties": {
-            "shadows": {
+          "$comment": "Shadow replay rewrites JSON bodies, so the gateway rejects shadows on multipart image routes. An empty list is accepted, as in the gateway.",
+          "patternProperties": {
+            "^(?i)shadows$": {
               "maxItems": 0
-            },
-            "shadowModelName": {
-              "maxLength": 0
-            },
-            "shadowModelNames": {
-              "maxItems": 0
-            },
-            "shadowSamplingMethod": {
-              "enum": [
-                "",
-                null
-              ]
-            },
-            "shadowCancelOnClientDisconnect": {
-              "enum": [
-                false
-              ]
             }
-          },
-          "not": {
-            "required": [
-              "shadowPercentage"
-            ]
           }
         }
       ]
@@ -519,43 +458,37 @@
     "shadowSamplingMethod": {
       "type": "string",
       "enum": [
+        "",
         "random",
         "perBearerKey"
       ]
     },
-    "legacyShadowSamplingMethod": {
-      "type": [
-        "string",
-        "null"
-      ],
-      "enum": [
-        "",
-        "random",
-        "perBearerKey",
-        null
-      ]
-    },
     "shadowTarget": {
       "type": "object",
-      "properties": {
-        "modelName": {
+      "$comment": "Entry keys match in any letter case, as in the gateway. The not/propertyNames pair requires a modelName key in some spelling, since required is exact-match.",
+      "patternProperties": {
+        "^(?i)modelname$": {
           "$ref": "#/definitions/nonEmptyString"
         },
-        "percentage": {
+        "^(?i)percentage$": {
           "type": "integer",
           "minimum": 1,
           "maximum": 100
         },
-        "samplingMethod": {
+        "^(?i)samplingmethod$": {
           "$ref": "#/definitions/shadowSamplingMethod"
         },
-        "cancelOnClientDisconnect": {
+        "^(?i)cancelonclientdisconnect$": {
           "type": "boolean"
         }
       },
-      "required": [
-        "modelName"
-      ],
+      "not": {
+        "propertyNames": {
+          "not": {
+            "pattern": "^(?i)modelname$"
+          }
+        }
+      },
       "additionalProperties": false
     },
     "vanityRoutes": {

--- a/deploy/helm/vanity-gateway/helm-nvcf-vanity-gateway/values.schema.json
+++ b/deploy/helm/vanity-gateway/helm-nvcf-vanity-gateway/values.schema.json
@@ -420,7 +420,7 @@
         "functionID"
       ],
       "propertyNames": {
-        "$comment": "The gateway matches shadow keys case-insensitively, but the exclusivity rule below can only name exact keys, so any other spelling is rejected here.",
+        "$comment": "The gateway matches shadow keys case-insensitively, but the exclusivity rule below can only name exact keys, so any other spelling is rejected here. The (?i) flag is Go regexp syntax, which Helm uses; ECMA-262 validators do not accept it.",
         "if": {
           "pattern": "^(?i)shadow(s|modelname|modelnames|percentage|samplingmethod|cancelonclientdisconnect)$"
         },

--- a/deploy/helm/vanity-gateway/helm-nvcf-vanity-gateway/values.schema.json
+++ b/deploy/helm/vanity-gateway/helm-nvcf-vanity-gateway/values.schema.json
@@ -334,10 +334,10 @@
           "$ref": "#/definitions/openAINonLLMEndpointRoutes"
         },
         "imageEdits": {
-          "$ref": "#/definitions/openAINonLLMEndpointRoutes"
+          "$ref": "#/definitions/openAIMultipartEndpointRoutes"
         },
         "imageVariations": {
-          "$ref": "#/definitions/openAINonLLMEndpointRoutes"
+          "$ref": "#/definitions/openAIMultipartEndpointRoutes"
         }
       },
       "additionalProperties": {
@@ -348,6 +348,12 @@
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/openAIModelRoute"
+      }
+    },
+    "openAIMultipartEndpointRoutes": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/openAIMultipartModelRoute"
       }
     },
     "openAIModelRoute": {
@@ -386,10 +392,19 @@
             "$ref": "#/definitions/nonEmptyString"
           }
         },
+        "shadows": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/shadowTarget"
+          }
+        },
         "shadowPercentage": {
           "type": "integer",
           "minimum": 1,
           "maximum": 100
+        },
+        "shadowSamplingMethod": {
+          "$ref": "#/definitions/legacyShadowSamplingMethod"
         },
         "shadowCancelOnClientDisconnect": {
           "type": "boolean"
@@ -404,7 +419,128 @@
         "modelName",
         "functionID"
       ],
+      "allOf": [
+        {
+          "not": {
+            "allOf": [
+              {
+                "required": [
+                  "shadows"
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "required": [
+                      "shadowModelName"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "shadowModelNames"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "shadowPercentage"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "shadowSamplingMethod"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "shadowCancelOnClientDisconnect"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ],
       "additionalProperties": true
+    },
+    "openAIMultipartModelRoute": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/openAINonLLMModelRoute"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "shadows": {
+              "maxItems": 0
+            },
+            "shadowModelName": {
+              "maxLength": 0
+            },
+            "shadowModelNames": {
+              "maxItems": 0
+            },
+            "shadowSamplingMethod": {
+              "enum": [
+                "",
+                null
+              ]
+            },
+            "shadowCancelOnClientDisconnect": {
+              "enum": [
+                false
+              ]
+            }
+          },
+          "not": {
+            "required": [
+              "shadowPercentage"
+            ]
+          }
+        }
+      ]
+    },
+    "shadowSamplingMethod": {
+      "type": "string",
+      "enum": [
+        "random",
+        "perBearerKey"
+      ]
+    },
+    "legacyShadowSamplingMethod": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "",
+        "random",
+        "perBearerKey",
+        null
+      ]
+    },
+    "shadowTarget": {
+      "type": "object",
+      "properties": {
+        "modelName": {
+          "$ref": "#/definitions/nonEmptyString"
+        },
+        "percentage": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "samplingMethod": {
+          "$ref": "#/definitions/shadowSamplingMethod"
+        },
+        "cancelOnClientDisconnect": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "modelName"
+      ],
+      "additionalProperties": false
     },
     "vanityRoutes": {
       "type": "object",

--- a/deploy/helm/vanity-gateway/tests/chart-render/verify-shadow-schema.sh
+++ b/deploy/helm/vanity-gateway/tests/chart-render/verify-shadow-schema.sh
@@ -2,9 +2,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Verify that the values schema accepts and rejects shadow configuration the
-# way the gateway does: the per-target shadows list, the legacy fields, their
-# exclusivity, and the multipart image endpoints that support neither.
+# Verify the values schema for the per-target shadows list: the list and its
+# entries are validated the way the gateway validates them, in any letter
+# case; the legacy shadow fields keep the checks they had before the list
+# existed; the two forms never mix; multipart image endpoints take no shadows.
 #
 # Rejection needles are key names or route path fragments, because the Helm
 # version decides the error message format (dotted paths on 3.18, JSON
@@ -116,20 +117,47 @@ assert_renders "a shadows entry with only modelName renders on an LLM model"
 write_values chatCompletions "${SHADOWS_EMPTY}"
 assert_renders "an empty shadows list renders"
 
-# Zero values are what absent legacy keys produce, so the gateway accepts them.
+write_values chatCompletions "            shadows:
+              - modelName: acme/a-model-next
+                samplingMethod: \"\""
+assert_renders "an empty shadows samplingMethod renders"
+
+# The gateway reads the shadows key and entry keys in any letter case.
+write_values chatCompletions "            Shadows:
+              - modelname: acme/a-model-next
+                Percentage: 10
+                SAMPLINGMETHOD: random
+                cancelonclientdisconnect: true"
+assert_renders "shadows and entry keys render in any letter case"
+
+write_values chatCompletions "            Shadows:
+              - modelName: acme/a-model-next
+                percentage: 500"
+assert_rejected "Shadows" "a shadows list is validated in any letter case"
+
+# Legacy fields keep the checks they had before shadows existed: the four
+# typed keys are validated under their exact spelling, everything else about
+# them is left to the gateway.
 write_values chatCompletions "${LEGACY_ZERO}"
 assert_renders "zero-valued legacy shadow fields render"
 
-write_values chatCompletions "            shadowSamplingMethod: null"
-assert_renders "a null shadowSamplingMethod renders"
+write_values chatCompletions "            shadowPercentage: 500"
+assert_rejected "shadowPercentage" "a legacy shadowPercentage of 500 is rejected"
 
-# The forms are exclusive: shadows plus any legacy key, even zero-valued, fails.
+write_values chatCompletions "            shadowpercentage: 500
+            shadowSamplingMethod: Random"
+assert_renders "legacy keys outside the schema's exact spelling and enum render unchanged"
+
+# The forms are exclusive in any spelling: shadows plus any legacy key, even
+# zero-valued, fails.
 LEGACY_KEYS=(
   "shadowModelName: acme/a-model-next"
   "shadowModelNames: []"
   "shadowPercentage: 50"
   "shadowSamplingMethod: \"\""
   "shadowCancelOnClientDisconnect: false"
+  "shadowpercentage: 50"
+  "SHADOWMODELNAMES: []"
 )
 for legacy in "${LEGACY_KEYS[@]}"; do
   write_values chatCompletions "${SHADOWS_EMPTY}
@@ -137,23 +165,21 @@ for legacy in "${LEGACY_KEYS[@]}"; do
   assert_rejected "a_model" "shadows combined with $(first_key "${legacy}") is rejected"
 done
 
-# The gateway reads shadow keys case-insensitively, so a variant spelling would
-# slip past the exclusivity rule; the schema rejects every non-canonical form.
-for variant in "Shadows: []" "shadowpercentage: 50" "ShadowModelNames: []" "shadowcancelonclientdisconnect: true"; do
-  write_values chatCompletions "            ${variant}"
-  assert_rejected "$(first_key "${variant}")" "shadow key spelled $(first_key "${variant}") is rejected"
-done
+write_values chatCompletions "            Shadows: []
+            shadowPercentage: 50"
+assert_rejected "a_model" "Shadows combined with a legacy key is rejected"
 
 # Per-target entry validation.
 write_values chatCompletions "            shadows:
               - percentage: 50"
-assert_rejected "modelName" "a shadows entry without modelName is rejected"
+assert_rejected "shadows" "a shadows entry without modelName is rejected"
 
 write_values chatCompletions "            shadows:
-              - modelname: acme/a-model-next"
-assert_rejected "modelname" "a shadows entry with a non-canonical key is rejected"
+              - modelName: acme/a-model-next
+                modelNamee: typo"
+assert_rejected "modelNamee" "a shadows entry with an unknown key is rejected"
 
-for percentage in 0 101 50.5 '"50"'; do
+for percentage in 0 101 50.5 '"50"' null; do
   write_values chatCompletions "            shadows:
               - modelName: acme/a-model-next
                 percentage: ${percentage}"
@@ -167,42 +193,35 @@ assert_rejected "samplingMethod" "an unknown shadows samplingMethod is rejected"
 
 write_values chatCompletions "            shadows:
               - modelName: acme/a-model-next
-                samplingMethod: \"\""
-assert_rejected "samplingMethod" "an empty shadows samplingMethod is rejected"
-
-write_values chatCompletions "            shadows:
-              - modelName: acme/a-model-next
                 cancelOnClientDisconnect: \"true\""
 assert_rejected "cancelOnClientDisconnect" "a string shadows cancelOnClientDisconnect is rejected"
+
+write_values chatCompletions "            shadows:
+              - modelName: \"\""
+assert_rejected "modelName" "an empty shadows modelName is rejected"
 
 write_values chatCompletions "            shadows:
               acme/a-model-next:
                 percentage: 50"
 assert_rejected "shadows" "a shadows mapping is rejected"
 
-write_values chatCompletions "            shadowSamplingMethod: perUser"
-assert_rejected "shadowSamplingMethod" "an unknown legacy shadowSamplingMethod is rejected"
+write_values chatCompletions "            shadows: null"
+assert_rejected "shadows" "a null shadows value is rejected"
 
-# Multipart image endpoints support neither form. Zero values stay accepted
-# because that is what absent keys produce.
-MULTIPART_SHADOWS=(
-  "${SHADOWS_MINIMAL}"
-  "            shadowModelName: acme/a-model-next"
-  "            shadowModelNames:
-              - acme/a-model-next"
-  "            shadowPercentage: 50"
-  "            shadowSamplingMethod: random"
-  "            shadowCancelOnClientDisconnect: true"
-)
+write_values chatCompletions "            shadows:
+              - null"
+assert_rejected "shadows" "a null shadows entry is rejected"
+
+# Multipart image endpoints take no shadows; an empty list is what an absent
+# key produces, so it stays accepted. Legacy keys there are unchanged from
+# before and left to the gateway.
 for section in imageEdits imageVariations; do
-  for extra in "${MULTIPART_SHADOWS[@]}"; do
-    write_values "${section}" "${extra}"
-    assert_rejected "a_model" "$(first_key "${extra}") is rejected in ${section}"
-  done
+  write_values "${section}" "${SHADOWS_MINIMAL}"
+  assert_rejected "a_model" "shadows is rejected in ${section}"
 
-  write_values "${section}" "${SHADOWS_EMPTY}
-${LEGACY_ZERO}"
-  assert_rejected "a_model" "empty shadows with zero-valued legacy fields is rejected in ${section}"
+  write_values "${section}" "            Shadows:
+              - modelName: acme/a-model-next"
+  assert_rejected "a_model" "Shadows is rejected in ${section}"
 
   write_values "${section}" "${SHADOWS_EMPTY}"
   assert_renders "an empty shadows list renders in ${section}"

--- a/deploy/helm/vanity-gateway/tests/chart-render/verify-shadow-schema.sh
+++ b/deploy/helm/vanity-gateway/tests/chart-render/verify-shadow-schema.sh
@@ -4,8 +4,8 @@
 #
 # Verify the values schema for the per-target shadows list: the list and its
 # entries are validated the way the gateway validates them, in any letter
-# case; the legacy shadow fields keep the checks they had before the list
-# existed; the two forms never mix; multipart image endpoints take no shadows.
+# case; the two forms never mix; multipart image endpoints take no shadows.
+# The legacy shadow fields are not under test here; their schema is unchanged.
 #
 # Rejection needles are key names or route path fragments, because the Helm
 # version decides the error message format (dotted paths on 3.18, JSON
@@ -90,24 +90,10 @@ SHADOWS_FULL="            shadows:
 SHADOWS_MINIMAL="            shadows:
               - modelName: acme/a-model-next"
 SHADOWS_EMPTY="            shadows: []"
-LEGACY_FULL="            shadowModelName: acme/a-model-next
-            shadowModelNames:
-              - acme/a-model-other
-            shadowPercentage: 50
-            shadowSamplingMethod: perBearerKey
-            shadowCancelOnClientDisconnect: true"
-LEGACY_ZERO="            shadowModelName: \"\"
-            shadowModelNames: []
-            shadowSamplingMethod: \"\"
-            shadowCancelOnClientDisconnect: false"
 
-# Both forms render on their own, in every non-multipart section.
 for section in chatCompletions completions embeddings responses imageGenerations; do
   write_values "${section}" "${SHADOWS_FULL}"
   assert_renders "a shadows list renders in ${section}"
-
-  write_values "${section}" "${LEGACY_FULL}"
-  assert_renders "legacy shadow fields render in ${section}"
 done
 
 write_values chatCompletions "            functionType: LLM
@@ -135,18 +121,11 @@ write_values chatCompletions "            Shadows:
                 percentage: 500"
 assert_rejected "Shadows" "a shadows list is validated in any letter case"
 
-# Legacy fields keep the checks they had before shadows existed: the four
-# typed keys are validated under their exact spelling, everything else about
-# them is left to the gateway.
-write_values chatCompletions "${LEGACY_ZERO}"
-assert_renders "zero-valued legacy shadow fields render"
-
-write_values chatCompletions "            shadowPercentage: 500"
-assert_rejected "shadowPercentage" "a legacy shadowPercentage of 500 is rejected"
-
+# The mixed-form rule only evaluates when a shadows key is present, so a
+# legacy-only route is untouched by it, even one the gateway would reject.
 write_values chatCompletions "            shadowpercentage: 500
             shadowSamplingMethod: Random"
-assert_renders "legacy keys outside the schema's exact spelling and enum render unchanged"
+assert_renders "a legacy-only route is not touched by the shadows rules"
 
 # The forms are exclusive in any spelling: shadows plus any legacy key, even
 # zero-valued, fails.
@@ -213,8 +192,7 @@ write_values chatCompletions "            shadows:
 assert_rejected "shadows" "a null shadows entry is rejected"
 
 # Multipart image endpoints take no shadows; an empty list is what an absent
-# key produces, so it stays accepted. Legacy keys there are unchanged from
-# before and left to the gateway.
+# key produces, so it stays accepted.
 for section in imageEdits imageVariations; do
   write_values "${section}" "${SHADOWS_MINIMAL}"
   assert_rejected "shadows" "shadows is rejected in ${section}"
@@ -225,9 +203,6 @@ for section in imageEdits imageVariations; do
 
   write_values "${section}" "${SHADOWS_EMPTY}"
   assert_renders "an empty shadows list renders in ${section}"
-
-  write_values "${section}" "${LEGACY_ZERO}"
-  assert_renders "zero-valued legacy shadow fields render in ${section}"
 done
 
 echo "All shadow schema render checks passed."

--- a/deploy/helm/vanity-gateway/tests/chart-render/verify-shadow-schema.sh
+++ b/deploy/helm/vanity-gateway/tests/chart-render/verify-shadow-schema.sh
@@ -162,12 +162,12 @@ LEGACY_KEYS=(
 for legacy in "${LEGACY_KEYS[@]}"; do
   write_values chatCompletions "${SHADOWS_EMPTY}
             ${legacy}"
-  assert_rejected "a_model" "shadows combined with $(first_key "${legacy}") is rejected"
+  assert_rejected "$(first_key "${legacy}")" "shadows combined with $(first_key "${legacy}") is rejected"
 done
 
 write_values chatCompletions "            Shadows: []
             shadowPercentage: 50"
-assert_rejected "a_model" "Shadows combined with a legacy key is rejected"
+assert_rejected "shadowPercentage" "Shadows combined with a legacy key is rejected"
 
 # Per-target entry validation.
 write_values chatCompletions "            shadows:
@@ -217,11 +217,11 @@ assert_rejected "shadows" "a null shadows entry is rejected"
 # before and left to the gateway.
 for section in imageEdits imageVariations; do
   write_values "${section}" "${SHADOWS_MINIMAL}"
-  assert_rejected "a_model" "shadows is rejected in ${section}"
+  assert_rejected "shadows" "shadows is rejected in ${section}"
 
   write_values "${section}" "            Shadows:
               - modelName: acme/a-model-next"
-  assert_rejected "a_model" "Shadows is rejected in ${section}"
+  assert_rejected "Shadows" "Shadows is rejected in ${section}"
 
   write_values "${section}" "${SHADOWS_EMPTY}"
   assert_renders "an empty shadows list renders in ${section}"

--- a/deploy/helm/vanity-gateway/tests/chart-render/verify-shadow-schema.sh
+++ b/deploy/helm/vanity-gateway/tests/chart-render/verify-shadow-schema.sh
@@ -70,6 +70,13 @@ assert_renders() {
   echo "ok: ${label}"
 }
 
+# first_key <yaml block>: the key on the block's first line, for labels.
+first_key() {
+  local line="${1%%$'\n'*}"
+  line="${line#"${line%%[! ]*}"}"
+  echo "${line%%:*}"
+}
+
 SHADOWS_FULL="            shadows:
               - modelName: acme/a-model-next
                 percentage: 10
@@ -127,14 +134,14 @@ LEGACY_KEYS=(
 for legacy in "${LEGACY_KEYS[@]}"; do
   write_values chatCompletions "${SHADOWS_EMPTY}
             ${legacy}"
-  assert_rejected "a_model" "shadows combined with ${legacy%%:*} is rejected"
+  assert_rejected "a_model" "shadows combined with $(first_key "${legacy}") is rejected"
 done
 
 # The gateway reads shadow keys case-insensitively, so a variant spelling would
 # slip past the exclusivity rule; the schema rejects every non-canonical form.
 for variant in "Shadows: []" "shadowpercentage: 50" "ShadowModelNames: []" "shadowcancelonclientdisconnect: true"; do
   write_values chatCompletions "            ${variant}"
-  assert_rejected "${variant%%:*}" "shadow key spelled ${variant%%:*} is rejected"
+  assert_rejected "$(first_key "${variant}")" "shadow key spelled $(first_key "${variant}") is rejected"
 done
 
 # Per-target entry validation.
@@ -144,7 +151,7 @@ assert_rejected "modelName" "a shadows entry without modelName is rejected"
 
 write_values chatCompletions "            shadows:
               - modelname: acme/a-model-next"
-assert_rejected "modelname" "a shadows entry with an unknown field is rejected"
+assert_rejected "modelname" "a shadows entry with a non-canonical key is rejected"
 
 for percentage in 0 101 50.5 '"50"'; do
   write_values chatCompletions "            shadows:
@@ -190,8 +197,7 @@ MULTIPART_SHADOWS=(
 for section in imageEdits imageVariations; do
   for extra in "${MULTIPART_SHADOWS[@]}"; do
     write_values "${section}" "${extra}"
-    key="$(sed -n '1s/^ *\([A-Za-z]*\):.*/\1/p' <<<"${extra}")"
-    assert_rejected "a_model" "${key} is rejected in ${section}"
+    assert_rejected "a_model" "$(first_key "${extra}") is rejected in ${section}"
   done
 
   write_values "${section}" "${SHADOWS_EMPTY}

--- a/deploy/helm/vanity-gateway/tests/chart-render/verify-shadow-schema.sh
+++ b/deploy/helm/vanity-gateway/tests/chart-render/verify-shadow-schema.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verify that the values schema accepts and rejects shadow configuration the
+# way the gateway does: the per-target shadows list, the legacy fields, their
+# exclusivity, and the multipart image endpoints that support neither.
+#
+# Rejection needles are key names or route path fragments, because the Helm
+# version decides the error message format (dotted paths on 3.18, JSON
+# pointers on 3.21).
+#
+#   bash tests/chart-render/verify-shadow-schema.sh
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHART="${ROOT_DIR}/helm-nvcf-vanity-gateway"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+ENDPOINT="http://llm-api-gateway.nvcf.svc.cluster.local:8080"
+VALUES="${WORK_DIR}/values.yaml"
+
+# write_values <section> <route body indented 12 spaces>
+write_values() {
+  local section="$1" extra="$2"
+  cat > "${VALUES}" <<EOF
+vanityGateway:
+  image:
+    registry: example.com
+    repository: foo/bar
+  config:
+    llmGatewayEndpoint: "${ENDPOINT}"
+  mappingConfig:
+    v2config:
+      openai:
+        host: api.example.com
+        ${section}:
+          a_model:
+            modelName: acme/a-model
+            functionID: 00000000-0000-0000-0000-000000000001
+${extra}
+          a_model_next:
+            modelName: acme/a-model-next
+            functionID: 00000000-0000-0000-0000-000000000002
+EOF
+}
+
+assert_rejected() {
+  local needle="$1" label="$2" output
+  if output="$(helm template t "${CHART}" -f "${VALUES}" 2>&1)"; then
+    echo "FAILED: ${label}: rendered but should have been rejected" >&2
+    exit 1
+  fi
+  if ! grep -F -q -- "${needle}" <<<"${output}"; then
+    echo "FAILED: ${label}: expected '${needle}' in the error, got:" >&2
+    echo "${output}" >&2
+    exit 1
+  fi
+  echo "ok: ${label}"
+}
+
+assert_renders() {
+  local label="$1"
+  if ! helm template t "${CHART}" -f "${VALUES}" >/dev/null 2>&1; then
+    echo "FAILED: ${label}: rejected but should have rendered" >&2
+    helm template t "${CHART}" -f "${VALUES}" >&2 || true
+    exit 1
+  fi
+  echo "ok: ${label}"
+}
+
+SHADOWS_FULL="            shadows:
+              - modelName: acme/a-model-next
+                percentage: 10
+                samplingMethod: perBearerKey
+                cancelOnClientDisconnect: true
+              - modelName: acme/a-model-other
+                percentage: 100
+                samplingMethod: random
+                cancelOnClientDisconnect: false"
+SHADOWS_MINIMAL="            shadows:
+              - modelName: acme/a-model-next"
+SHADOWS_EMPTY="            shadows: []"
+LEGACY_FULL="            shadowModelName: acme/a-model-next
+            shadowModelNames:
+              - acme/a-model-other
+            shadowPercentage: 50
+            shadowSamplingMethod: perBearerKey
+            shadowCancelOnClientDisconnect: true"
+LEGACY_ZERO="            shadowModelName: \"\"
+            shadowModelNames: []
+            shadowSamplingMethod: \"\"
+            shadowCancelOnClientDisconnect: false"
+
+# Both forms render on their own, in every non-multipart section.
+for section in chatCompletions completions embeddings responses imageGenerations; do
+  write_values "${section}" "${SHADOWS_FULL}"
+  assert_renders "a shadows list renders in ${section}"
+
+  write_values "${section}" "${LEGACY_FULL}"
+  assert_renders "legacy shadow fields render in ${section}"
+done
+
+write_values chatCompletions "            functionType: LLM
+${SHADOWS_MINIMAL}"
+assert_renders "a shadows entry with only modelName renders on an LLM model"
+
+write_values chatCompletions "${SHADOWS_EMPTY}"
+assert_renders "an empty shadows list renders"
+
+# Zero values are what absent legacy keys produce, so the gateway accepts them.
+write_values chatCompletions "${LEGACY_ZERO}"
+assert_renders "zero-valued legacy shadow fields render"
+
+write_values chatCompletions "            shadowSamplingMethod: null"
+assert_renders "a null shadowSamplingMethod renders"
+
+# The forms are exclusive: shadows plus any legacy key, even zero-valued, fails.
+LEGACY_KEYS=(
+  "shadowModelName: acme/a-model-next"
+  "shadowModelNames: []"
+  "shadowPercentage: 50"
+  "shadowSamplingMethod: \"\""
+  "shadowCancelOnClientDisconnect: false"
+)
+for legacy in "${LEGACY_KEYS[@]}"; do
+  write_values chatCompletions "${SHADOWS_EMPTY}
+            ${legacy}"
+  assert_rejected "a_model" "shadows combined with ${legacy%%:*} is rejected"
+done
+
+# The gateway reads shadow keys case-insensitively, so a variant spelling would
+# slip past the exclusivity rule; the schema rejects every non-canonical form.
+for variant in "Shadows: []" "shadowpercentage: 50" "ShadowModelNames: []" "shadowcancelonclientdisconnect: true"; do
+  write_values chatCompletions "            ${variant}"
+  assert_rejected "${variant%%:*}" "shadow key spelled ${variant%%:*} is rejected"
+done
+
+# Per-target entry validation.
+write_values chatCompletions "            shadows:
+              - percentage: 50"
+assert_rejected "modelName" "a shadows entry without modelName is rejected"
+
+write_values chatCompletions "            shadows:
+              - modelname: acme/a-model-next"
+assert_rejected "modelname" "a shadows entry with an unknown field is rejected"
+
+for percentage in 0 101 50.5 '"50"'; do
+  write_values chatCompletions "            shadows:
+              - modelName: acme/a-model-next
+                percentage: ${percentage}"
+  assert_rejected "percentage" "a shadows percentage of ${percentage} is rejected"
+done
+
+write_values chatCompletions "            shadows:
+              - modelName: acme/a-model-next
+                samplingMethod: perUser"
+assert_rejected "samplingMethod" "an unknown shadows samplingMethod is rejected"
+
+write_values chatCompletions "            shadows:
+              - modelName: acme/a-model-next
+                samplingMethod: \"\""
+assert_rejected "samplingMethod" "an empty shadows samplingMethod is rejected"
+
+write_values chatCompletions "            shadows:
+              - modelName: acme/a-model-next
+                cancelOnClientDisconnect: \"true\""
+assert_rejected "cancelOnClientDisconnect" "a string shadows cancelOnClientDisconnect is rejected"
+
+write_values chatCompletions "            shadows:
+              acme/a-model-next:
+                percentage: 50"
+assert_rejected "shadows" "a shadows mapping is rejected"
+
+write_values chatCompletions "            shadowSamplingMethod: perUser"
+assert_rejected "shadowSamplingMethod" "an unknown legacy shadowSamplingMethod is rejected"
+
+# Multipart image endpoints support neither form. Zero values stay accepted
+# because that is what absent keys produce.
+MULTIPART_SHADOWS=(
+  "${SHADOWS_MINIMAL}"
+  "            shadowModelName: acme/a-model-next"
+  "            shadowModelNames:
+              - acme/a-model-next"
+  "            shadowPercentage: 50"
+  "            shadowSamplingMethod: random"
+  "            shadowCancelOnClientDisconnect: true"
+)
+for section in imageEdits imageVariations; do
+  for extra in "${MULTIPART_SHADOWS[@]}"; do
+    write_values "${section}" "${extra}"
+    key="$(sed -n '1s/^ *\([A-Za-z]*\):.*/\1/p' <<<"${extra}")"
+    assert_rejected "a_model" "${key} is rejected in ${section}"
+  done
+
+  write_values "${section}" "${SHADOWS_EMPTY}
+${LEGACY_ZERO}"
+  assert_rejected "a_model" "empty shadows with zero-valued legacy fields is rejected in ${section}"
+
+  write_values "${section}" "${SHADOWS_EMPTY}"
+  assert_renders "an empty shadows list renders in ${section}"
+
+  write_values "${section}" "${LEGACY_ZERO}"
+  assert_renders "zero-valued legacy shadow fields render in ${section}"
+done
+
+echo "All shadow schema render checks passed."


### PR DESCRIPTION
## TL;DR

Chart half of the per-target shadow policies feature; the service half landed in #1670 (gateway 1.35.0). The values schema accepts a `shadows` list on OpenAI routes and validates it the way the gateway does; the legacy shadow fields keep the schema they had; the chart README documents the form.

## Additional Details

- Each `shadows` entry carries `modelName` (required), `percentage` 1 to 100, `samplingMethod` empty, random, or perBearerKey, and `cancelOnClientDisconnect`. Other entry keys are rejected. The key and entry keys match in any letter case, as the gateway reads them.
- A route uses either `shadows` or the legacy shadow fields. The schema rejects both together in any spelling, even an empty list next to a zero-valued legacy key. The rule is a conditional that only evaluates when a `shadows` key is present, so legacy-only routes are validated exactly as before.
- `imageEdits` and `imageVariations` reject a non-empty `shadows` list; an empty list is accepted because that is what an absent key produces.
- The legacy shadow fields are untouched: same four typed keys, same exact-name matching, same gaps left to the gateway. Duplicate targets and targets missing from the endpoint remain gateway checks in both forms, since JSON Schema cannot express them.
- The `(?i)` pattern flag is Go regexp syntax, which Helm's validator uses. ECMA-262 validators do not accept it; the schema `$comment` says so.

## For the Reviewer

- @FamousDirector authored the first commit; the later commits reshape the validation to the rule above, add the render test, and trim the README. Squash on merge; the interim spelling rule in one commit is removed by a later one.
- Deploy an image that reads `shadows` (gateway 1.35.0 or later) before writing a route in the new form. The self-managed stack pins chart 0.4.4; a pin bump follows this release.

## For QA

- helm lint, helm template with the CI values, schema JSON parse, and all three chart-render scripts pass on Helm 3.18.4 and 3.21.4. New `tests/chart-render/verify-shadow-schema.sh` runs 38 checks on the `shadows` field: the list in every non-multipart section, any-case `shadows` and entry keys, each legacy key combined with `shadows` in canonical and variant spelling, a legacy-only route left untouched by the mixed-form rule, per-target entry validation, both multipart sections. Legacy fields have no cases of their own because their schema is unchanged. Render tests run by hand, as the two existing scripts do.
- No QA pass beyond the gateway feature's staging test; the chart serves self-managed installs only.

## Issues

Relates to #1243

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated route-mapping guidance for per-target shadow traffic, supported configuration formats, defaults, routing behavior, and validation.
  * Documented image-route limitations and the global shadow concurrency setting.

* **Bug Fixes**
  * Improved case-insensitive validation for shadow configuration and target fields.
  * Prevented conflicting legacy and current shadow settings.
  * Refined multipart-route validation to accept empty shadow lists and reject unsupported configurations.

* **Tests**
  * Added chart-render coverage for shadow schema and multipart-route validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->