### PR TITLE
fix(nvca-operator): restore image.repository default in vendored chart [3.2 backport]

### DIFF
--- a/deploy/helm/nvca-operator/nvca-operator/values.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/values.yaml
@@ -18,7 +18,7 @@
 ## @param image.tag NVCA Operator container image tag. This defaults to the chart's appVersion
 ## @param image.pullPolicy K8s ImagePullPolicy
 image:
-  repository: ""
+  repository: "nvcr.io/nvidia/nvcf-byoc/nvca-operator"
   tag: ""
   pullPolicy: IfNotPresent
 ## @param nvcaImage.repositoryOverride (Optional) Full NVCA container registry path, without tag. Only set this if the default needs to be overridden, for example "stg.nvcr.io/nvidia/nvcf-byoc/nvca". The tag is set in the cluster config


### PR DESCRIPTION
Cherry-pick of https://github.com/NVIDIA/nvcf/pull/1744 onto the 3.2 release branch.

Restores image.repository to nvcr.io/nvidia/nvcf-byoc/nvca-operator in the vendored chart's values.yaml. This triggers chart 3.2.22 which fixes the InvalidImageName regression present in all charts from 3.2.18 onward.