### PR TITLE
fix(nvca-operator): remove the vendor scrub that reverts image.repository

### DIFF
--- a/deploy/helm/nvca-operator/scripts/ci_vendor_nvca_operator_chart
+++ b/deploy/helm/nvca-operator/scripts/ci_vendor_nvca_operator_chart
@@ -290,10 +290,6 @@ main() {
     # Set default validation policy to Unrestricted for self-managed clusters
     yq eval -i '.agentConfig.mergeConfig = "cluster:\n  validationPolicy:\n    name: Unrestricted" | .agentConfig.mergeConfig style="literal"' "${TARGET_DIR}/values.yaml"
 
-    # OSS scrub: clear the upstream's hardcoded image.repository so OSS
-    # consumers must supply it via an override values file at install time.
-    update_yaml_key ".image.repository = \"\"" "${TARGET_DIR}/values.yaml"
-
     # Apply Apache-2.0 / NVIDIA copyright headers to all yaml files in the
     # vendored chart. Skip files that already carry an SPDX marker so this
     # step stays idempotent and does not duplicate headers.


### PR DESCRIPTION
## Why
`main` is currently red: `helm charts` / "Check NVCA Operator chart is synced with its monorepo source" fails on `main` at the merge commit for #1744 itself (confirmed via `gh run list` for that SHA), because the two changes contradict each other.

`deploy/helm/nvca-operator/scripts/ci_vendor_nvca_operator_chart` has unconditionally cleared `image.repository` to `""` on every `make vendor-chart` run since it was added on 2026-08-03 (#214), when this OCI/monorepo vendoring pipeline was first built. That followed this repo's general OSS-hygiene convention (don't leak an internal registry path into a public file), but `deploy/helm/nvca-operator` is not in `.oss-allowlist`, so that rationale never applied to this specific chart. The result: every default `helm install` (no `--set image.repository`) has failed with `InvalidImageName` since the monorepo lane took over, exactly as #1744 described.

#1744 hand-edited the vendored `values.yaml` back to the correct default, but didn't touch the scrub step that produces it - so the fix doesn't hold. Any subsequent `make vendor-chart`, including CI's own `check-vendor-chart` (which ran and failed on #1744's own PR, https://github.com/NVIDIA/nvcf/actions/runs/34493064954/job/102924458476), reverts it right back to empty. It merged anyway because `helm charts` is not in `main`'s required-status-checks ruleset, so the correct failure didn't block the merge.

## What changed
Removed the "OSS scrub" step from `ci_vendor_nvca_operator_chart`. The source chart (`src/compute-plane-services/nvca/deployments/nvca-operator/values.yaml`) already carries the correct default (`nvcr.io/nvidia/nvcf-byoc/nvca-operator`); no override is needed, just letting it flow through unmodified.

## Customer Release Notes
Fixes `helm install`s of nvca-operator that omit `--set image.repository` failing with `InvalidImageName` (same customer impact #1744 described; this makes that fix actually stick).

## Plan Summary
`deploy/helm/nvca-operator/nvca-operator/values.yaml` gains no further diff from this PR (the value #1744 already committed is now stable); only the vendor script changes.

## Usage
Not applicable.

## Testing
- `make check-vendor-chart` (with all four required env vars) now passes cleanly and reproducibly - previously it failed on `main` itself.
- `./tools/ci/check-helm-charts`: all 16 charts lint and render clean.
- `helm template nvca-operator deploy/helm/nvca-operator/nvca-operator/` with no overrides now renders a valid image reference (`nvcr.io/nvidia/nvcf-byoc/nvca-operator:3.7.0`) instead of the broken `:3.7.0` with an empty repository.

## Notes
Worth a separate conversation: `helm charts` isn't in `main`'s required-status-checks ruleset, which is how a correctly-failing chart-drift check didn't block #1744's merge. Not changed here since it's a policy call affecting every chart-touching PR, not just this one.

## References
Closes #1747

## Related Pull Requests
Follow-up to #1744

## Dependencies
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved the configured image repository value when packaging the operator chart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->