### PR TITLE
feat(remove-fields): Removed deprecated fields from icms cluster management APIs

### DIFF
--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/inbound/rest/controllers/nvca/NvcaAccountController.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/inbound/rest/controllers/nvca/NvcaAccountController.java
@@ -161,19 +161,9 @@ public class NvcaAccountController {
 
             @Schema(description = "If includeAuthorizedClusters=true then this param will be considered else ignored")
             @RequestParam(name = "includeNonByocInAuthorizedClusters", required = false)
-            Boolean includeNonByocInAuthorizedClusters,
-
-            @Schema(description = "Deprecated alias for includeNonByocInAuthorizedClusters",
-                    deprecated = true)
-            @RequestParam(name = "includeGfnInAuthorizedClusters", required = false)
-            Boolean includeGfnInAuthorizedClusters) {
-        // Honour the legacy param name only when the current one is absent, and keep passing null
-        // through untouched when neither is supplied so behaviour is unchanged for existing callers.
-        Boolean includeNonByoc = includeNonByocInAuthorizedClusters;
-        if (includeNonByoc == null && includeGfnInAuthorizedClusters != null) {
-            includeNonByoc = includeGfnInAuthorizedClusters;
-        }
-        return clusterManagementService.getClusters(ncaId, includeAuthorizedClusters, includeNonByoc);
+            Boolean includeNonByocInAuthorizedClusters) {
+        return clusterManagementService.getClusters(ncaId, includeAuthorizedClusters,
+                                                    includeNonByocInAuthorizedClusters);
     }
 
     @DeleteMapping("{ncaId}/clusters/{clusterId}")

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/inbound/rest/model/nvca/GetClusterResponse.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/inbound/rest/model/nvca/GetClusterResponse.java
@@ -76,10 +76,6 @@ public class GetClusterResponse {
     @Schema(description = "Nvca version")
     String nvcaVersion;
 
-    @Deprecated
-    @Schema(description = "OAuth client ID used by cluster (deprecated, use oAuthClientId)")
-    String ssaClientId;
-
     @JsonProperty("oAuthClientId")
     @Schema(description = "OAuth client ID used by cluster")
     String oAuthClientId;

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/byoc/nvca/NvcaClusterRegistrationService.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/byoc/nvca/NvcaClusterRegistrationService.java
@@ -112,7 +112,7 @@ public class NvcaClusterRegistrationService {
 
     private final ByocServiceHelper byocServiceHelper;
 
-    public static final String SSA_CLUSTER_ID_PREFIX = "nvssa";
+    public static final String OAUTH_CLIENT_ID_PREFIX = "nvssa";
 
     /**
      * Enum representing the different types of creation queues that can be created/deleted.
@@ -849,7 +849,7 @@ public class NvcaClusterRegistrationService {
 
     private String getTerminationQueueUrl(String clusterId) {
         String trimmedClusterId = clusterId;
-        if (clusterId.startsWith(SSA_CLUSTER_ID_PREFIX)) {
+        if (clusterId.startsWith(OAUTH_CLIENT_ID_PREFIX)) {
             trimmedClusterId = clusterId.substring(10);
         }
 
@@ -867,7 +867,7 @@ public class NvcaClusterRegistrationService {
     private String getNvcaTasksCreationQueueUrl(String clusterId, String gpuName) {
         String truncatedClusterId = clusterId;
         // If clusterId is OAuth clientId then truncate it to match UUID length
-        if (truncatedClusterId.startsWith(SSA_CLUSTER_ID_PREFIX)) {
+        if (truncatedClusterId.startsWith(OAUTH_CLIENT_ID_PREFIX)) {
             // Begin from where we will get 36 chars which is the UUID length
             truncatedClusterId = clusterId.substring(clusterId.length() - 36);
         }

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/byoc/nvca/clustermanagement/ClusterCreationService.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/byoc/nvca/clustermanagement/ClusterCreationService.java
@@ -215,9 +215,9 @@ public class ClusterCreationService {
     }
 
     public static void validateAuthorizedNcaIdsForExternalCluster(@Nullable Set<String> actual,
-                                                                  @Nullable String ssaClientId) {
+                                                                  @Nullable String oAuthClientId) {
         // External clusters can not be publicly accessible and authorized ncaId can not have * in it
-        if (StringUtils.isEmpty(ssaClientId)) {
+        if (StringUtils.isEmpty(oAuthClientId)) {
             if (actual != null && actual.contains("*")) {
                 String errorMsg = "External clusters can not be publicly accessible";
                 log.error(errorMsg);

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/byoc/nvca/clustermanagement/ClusterListingService.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/byoc/nvca/clustermanagement/ClusterListingService.java
@@ -321,7 +321,6 @@ public class ClusterListingService {
                 .customAttributes(customAttributes)
                 .gpus(toGpuRequestSchemas(NvcaConverter.getGpusV5(clusterEntity)))
                 .nvcaVersion(clusterEntity.getNvcaVersion())
-                .ssaClientId(clusterEntity.getAuthClientId())
                 .oAuthClientId(clusterEntity.getAuthClientId())
                 .clusterId(clusterEntity.getClusterId())
                 .status(clusterEntity.getClusterStatus().toString())

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/byoc/nvca/clustermanagement/ClusterReconfigurationService.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/byoc/nvca/clustermanagement/ClusterReconfigurationService.java
@@ -561,7 +561,6 @@ public class ClusterReconfigurationService {
                         .customAttributes(clusterUpdateRequest.getCustomAttributes())
                         .gpus(clusterUpdateRequest.getGpus())
                         .nvcaVersion(clusterUpdateRequest.getNvcaVersion())
-                        .ssaClientId(existingClusterEntity.getAuthClientId())
                         .oAuthClientId(existingClusterEntity.getAuthClientId())
                         .region(clusterUpdateRequest.getRegion())
                         .clusterKeyId(clusterUpdateRequest.getClusterKeyId())

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/telemetry/RequestResponseTelemetryFilter.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/service/telemetry/RequestResponseTelemetryFilter.java
@@ -241,7 +241,7 @@ public class RequestResponseTelemetryFilter extends OncePerRequestFilter {
             return getClusterIdFromApiKey(request);
         } else {
             // Sub fetching for JWT token
-            return getSubFromSsaToken(request);
+            return getSubFromBearerToken(request);
         }
     }
 
@@ -274,7 +274,7 @@ public class RequestResponseTelemetryFilter extends OncePerRequestFilter {
         }
     }
 
-    private String getSubFromSsaToken(HttpServletRequest request) {
+    private String getSubFromBearerToken(HttpServletRequest request) {
         try {
             String token = bearerTokenResolver.resolve(request);
             JWTClaimsSet jwtClaimsSet = JWTParser

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/inbound/rest/controllers/nvca/NvcaAccountControllerTest.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/inbound/rest/controllers/nvca/NvcaAccountControllerTest.java
@@ -363,27 +363,6 @@ class NvcaAccountControllerTest extends IntegrationTest {
     }
 
     @Test
-    void getClusters_legacyIncludeGfnParam_mapsToIncludeNonByoc()
-            throws Exception {
-        // Prepare
-        when(clusterManagementService.getClusters(DUMMY_BYOC_NCA_ID, true, true)).thenReturn(
-                List.of(getDummyGetClusterResponse(DUMMY_BYOC_NCA_ID, DUMMY_CLUSTER_ID)));
-
-        // Act
-        mockMvc.perform(MockMvcRequestBuilders.get(GET_CLUSTERS_URL, DUMMY_BYOC_NCA_ID)
-                                .param("includeAuthorizedClusters", "true")
-                                .param("includeGfnInAuthorizedClusters", "true")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .header(HttpHeaders.AUTHORIZATION,
-                                        JwtKeyUtils.getAuthHeader(DUMMY_CUSTOMER_1,
-                                                                  TestUtil.NGC_CLUSTER_MANAGEMENT_SCOPE)))
-                .andExpect(MockMvcResultMatchers.status().isOk());
-
-        // Assert: legacy param value is forwarded as includeNonByocInAuthorizedClusters
-        verify(clusterManagementService).getClusters(DUMMY_BYOC_NCA_ID, true, true);
-    }
-
-    @Test
     void getClusters_currentIncludeNonByocParam_isHonoured()
             throws Exception {
         // Prepare

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/integration/IcmsTest.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/integration/IcmsTest.java
@@ -106,8 +106,8 @@ public class IcmsTest extends IntegrationTest {
     public static final String CLUSTER_CREATE_REQUEST_PATH = "requests/cluster_create_request.json";
     public static final String REGISTER_CLUSTER_REQUEST_PATH =
             "requests/register_cluster_request.json";
-    public static final String SSA_CLIENT_ID_1 = "nvssa-stg-dummy_1";
-    public static final String SSA_CLIENT_ID_2 = "nvssa-stg-dummy_2";
+    public static final String OAUTH_CLIENT_ID_1 = "nvssa-stg-dummy_1";
+    public static final String OAUTH_CLIENT_ID_2 = "nvssa-stg-dummy_2";
 
     @Autowired
     private MockMvc mockMvc;
@@ -131,7 +131,7 @@ public class IcmsTest extends IntegrationTest {
 
     @Test
     void testMultipleTerminationQueue() throws Exception {
-        String clusterId1 = createCluster("cluster1", "dummy_nca_id_1", SSA_CLIENT_ID_1);
+        String clusterId1 = createCluster("cluster1", "dummy_nca_id_1", OAUTH_CLIENT_ID_1);
         NvcaRegistrationResponse registrationResponse1 = registerCluster(clusterId1);
         validateRegistrationResonse(registrationResponse1);
         var clusterCreationQueues1 =
@@ -139,7 +139,7 @@ public class IcmsTest extends IntegrationTest {
         var terminationQueue1 = registrationResponse1.getCredentials().getTerminationQueue();
         sendClusterHeartbeat("requests/cluster_heartbeat.json", clusterId1);
 
-        String clusterId2 = createCluster("cluster2", "dummy_nca_id_2", SSA_CLIENT_ID_2);
+        String clusterId2 = createCluster("cluster2", "dummy_nca_id_2", OAUTH_CLIENT_ID_2);
         NvcaRegistrationResponse registrationResponse2 = registerCluster(clusterId2);
         validateRegistrationResonse(registrationResponse2);
         var clusterCreationQueues2 =
@@ -175,7 +175,7 @@ public class IcmsTest extends IntegrationTest {
 
     @Test
     void testRequestInstances() throws Exception {
-        String clusterId = createCluster("cluster4", "dummy_nca_id_1", SSA_CLIENT_ID_1);
+        String clusterId = createCluster("cluster4", "dummy_nca_id_1", OAUTH_CLIENT_ID_1);
         NvcaRegistrationResponse registrationResponse = registerCluster(clusterId);
         validateRegistrationResonse(registrationResponse);
         sendClusterHeartbeat("requests/cluster_heartbeat.json", clusterId);
@@ -430,11 +430,11 @@ public class IcmsTest extends IntegrationTest {
                 "${clusterName}", clusterName).replace("${ncaId}", ncaId)
                 .replace("${oAuthClientId}", oAuthClientId);
 
-        String ssaAuthHeader = getAuthHeader(ncaId, TestUtil.NGC_CLUSTER_MANAGEMENT_SCOPE);
+        String authHeader = getAuthHeader(ncaId, TestUtil.NGC_CLUSTER_MANAGEMENT_SCOPE);
         MvcResult mvcResult = mockMvc.perform(
                         MockMvcRequestBuilders.post(ClUSTER_CREATION_URL, ncaId)
                                 .contentType(MediaType.APPLICATION_JSON).content(request)
-                                .header(HttpHeaders.AUTHORIZATION, ssaAuthHeader))
+                                .header(HttpHeaders.AUTHORIZATION, authHeader))
                 .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
         return objectMapper.readValue(mvcResult.getResponse().getContentAsString(),
                                       ObjectNode.class).get("clusterId").stringValue();

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/service/byoc/nvca/clustermanagement/ClusterCreationServiceTest.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/service/byoc/nvca/clustermanagement/ClusterCreationServiceTest.java
@@ -249,7 +249,7 @@ class ClusterCreationServiceTest {
     }
 
     @Test
-    void clusterCreation_createsNewClusterInNewClusterGroup_withoutSsaClientGeneratesClusetrId_Success() {
+    void clusterCreation_createsNewClusterInNewClusterGroup_withoutOAuthClientGeneratesClusterId_Success() {
 
         // Prepare
         ClusterCreationRequest clusterCreationRequest = dummyCreateNewClusterRequest(
@@ -358,7 +358,7 @@ class ClusterCreationServiceTest {
     }
 
     @Test
-    void clusterCreation_createsNewClusterInNewClusterGroup_withSsaClientIdUsedByAnotherCluster_throwsError() {
+    void clusterCreation_createsNewClusterInNewClusterGroup_withOAuthClientIdUsedByAnotherCluster_throwsError() {
 
         // Prepare
         ClusterCreationRequest clusterCreationRequest = dummyCreateNewClusterRequest(
@@ -1341,7 +1341,7 @@ class ClusterCreationServiceTest {
     }
 
     @Test
-    void validateAuthorizedNcaIdsForExternalCluster_ssaWithWildcard_success() {
+    void validateAuthorizedNcaIdsForExternalCluster_oAuthClientWithWildcard_success() {
         // Act & Assert - Should not throw (OAuth cluster with wildcard is allowed)
         Assertions.assertDoesNotThrow(() -> ClusterCreationService.validateAuthorizedNcaIdsForExternalCluster(
                 Set.of("*"), "oauth-client-id"));

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/service/internal/InternalInstanceServiceTest.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/service/internal/InternalInstanceServiceTest.java
@@ -592,7 +592,7 @@ class InternalInstanceServiceTest {
     }
 
     @Test
-    void updateInstanceRequestStatus_withByocAndSsaClientIdNotRegistered_throwsException() {
+    void updateInstanceRequestStatus_withByocAndOAuthClientIdNotRegistered_throwsException() {
         InstanceRequestV2Entity instanceRequestEntity1 =
                 getInstanceRequestEntity(
                         SpotInstanceRequestState.OPEN, PENDING_EVALUATION, ResourceProvider.BYOC);

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/util/TestUtil.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/util/TestUtil.java
@@ -985,7 +985,6 @@ public class TestUtil {
                 .attributes(Set.of("SOC2Compliant"))
                 .gpus(Set.of(gpuRequestSchema))
                 .nvcaVersion("2.1.0")
-                .ssaClientId("dummy_auth_client_id")
                 .oAuthClientId("dummy_auth_client_id")
                 .clusterId(clusterId)
                 .clusterSource(ClusterSource.NGC_MANAGED.toString())


### PR DESCRIPTION
TL;DR

- Remove two deprecated API surfaces from the NVCA cluster endpoints now that clients have migrated: the `includeGfnInAuthorizedClusters` query parameter on cluster listing, and the duplicate deprecated client id field on the GET cluster responses.

- Both were pure duplicates of a canonical name. The query parameter was an alias for `includeNonByocInAuthorizedClusters` reconciled by null-coalescing merge logic in the controller, and the response field was populated from the same `ClusterEntity.authClientId` value as `oAuthClientId` on the adjacent builder line.

- The deprecated field is deliberately retained on the cluster creation request body, because that is the inbound registration path where an older agent can still be the sender.

- Also folds in the residual legacy naming cleanup across the same module: a prefix constant, a JWT subject helper, a validation parameter, and a set of test symbols, with no string value changed.


Additional Details

- The removals are confined to the response and query surfaces. `GET /v1/accounts/{ncaId}/clusters`, its `/v1/si/` alias, and `GET /v1/accounts/{ncaId}/clusters/{clusterId}` are the affected endpoints.

- After removing the alias, `getClusters` passes `includeNonByocInAuthorizedClusters` straight through to the service, so the three-state semantics of true, false, and absent are preserved exactly as before.

- `ClusterListingService.includeNonByocClustersInAuthorizedClusters` is unchanged, so absent still collapses to false and non-BYOC clusters stay excluded by default.

- The deprecated response field is removed from the schema rather than blanked, so it disappears from the payload instead of serializing as null.

- `ClusterReconfigurationService` had a redundant deprecated-field builder call that set the same value as `.oAuthClientId(...)` on the following line, and `getEffectiveOAuthClientId()` already prefers the canonical field, so that line was already dead and its removal is a no-op.

- The retained request-body field keeps registration compatible in the direction that matters. An older agent sending only the deprecated field still resolves through `getEffectiveOAuthClientId()` and still persists onto `ClusterEntity.authClientId`.

- The prefix constant in `NvcaClusterRegistrationService` is renamed to `OAUTH_CLIENT_ID_PREFIX`, but its value is unchanged because it is a data contract, not naming.

- Queue name derivation branches on that value: the termination path strips a fixed-length prefix and the tasks-creation path truncates to the trailing 36 characters for UUID length. Changing the value would silently change which branch runs.

- Because the new constant name no longer explains why the value is what it is, a single line above the declaration records that client ids are minted with that prefix and the value is therefore a wire contract.

- The test fixture values that carry the prefix are intentionally left alone for the same reason. They drive the prefix branch and the asserted queue URLs, so only the constants pointing at them are renamed.

- The legacy-named JWT subject helper in `RequestResponseTelemetryFilter` is renamed to `getSubFromBearerToken`. It resolves the bearer token and reads the `sub` claim with nothing provider-specific in it, and the existing caller comment already described it as a JWT token.

- The validation parameter rename in `ClusterCreationService.validateAuthorizedNcaIdsForExternalCluster` is a parameter name only. The method signature is unchanged, so no caller is affected.

- The deleted controller test covered only the alias-to-canonical merge that no longer exists. The sibling test asserting the canonical parameter is honoured is retained, as is the existing test asserting that absent forwards null.

- No persisted column, message payload, enum value, or configuration key is touched, so there is no data migration and no deployment ordering constraint.


For the Reviewer

- The asymmetry is the main design point: the deprecated field is removed from the GET responses but kept on the cluster creation request body. Confirm that is the intended split, on the reasoning that a stale reader degrades differently from a stale sender.

- The query parameter removal is the one change that can fail quietly rather than loudly. Spring ignores unknown query parameters, so a straggler client sending only `includeGfnInAuthorizedClusters=true` gets no error; the value goes missing and the request falls back to the default of excluding non-BYOC clusters from the authorized list.

- That silent-degradation path is the gate on merging, and it rests on the premise that clients have fully migrated to the canonical parameter. Please confirm that premise independently rather than taking it from this PR.

- The response field removal is the visible half of the same question. A caller still reading the deprecated key will find it absent rather than empty.

- The renamed prefix constant is `public static final`, so the rename is source-incompatible for any external consumer of this library. A cross-repo search found no such consumer, and the managed spot service imports only `getRemovedGpuNames` and `getRemovedInstanceTypeName` from that class.

- Worth a look but deliberately not changed: the termination path uses a hardcoded character count to strip the prefix rather than deriving it from the constant. That coupling is pre-existing, and it is the reason the fixture values must not be edited.

- The added comment above the renamed constant is there to preserve context the rename removes. Reviewers who prefer the old name for that reason should say so, since keeping it was the alternative considered.

- Test symbol renames are naming only and include one pre-existing typo fix in a test method name. No assertion bodies were changed.


For QA

- No manual QA is expected. The change removes API surface, retains the inbound compatibility path, and is otherwise renaming, all covered by the existing suites.

- Run the icms-core unit and integration suites. The integration suite provisions Cassandra through Testcontainers and needs Docker available.

- Confirm `GET /v1/accounts/{ncaId}/clusters?includeNonByocInAuthorizedClusters=true` still returns non-BYOC clusters in the authorized list, unchanged from the previous build.

- Confirm the same call with no filter parameters still excludes non-BYOC clusters, so the default path is unchanged.

- Confirm a GET cluster response contains `oAuthClientId` with the cluster auth client identifier and no longer contains the deprecated duplicate key.

- Confirm cluster registration still succeeds for a request that supplies only the deprecated field, and that the value lands on the stored cluster record.

- Confirm cluster registration still succeeds for a request that supplies the canonical field or either accepted alias, with the canonical field winning when more than one is present.

- Confirm the reported creation and termination queue names for a cluster registered with a prefixed client id match the previous build exactly.

- The one external check that is not covered by tests: verify no remaining API consumer sends the removed query parameter or reads the removed response key, since the parameter case degrades silently rather than erroring.

- Refresh any published API documentation or generated OpenAPI artifact, because both the request parameter list and the response schema changed.


Issues

- Closes #1753

Checklist

- [x] I am familiar with the Contributing Guidelines.

- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.

- [x] New or existing tests cover these changes.

- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Removed the deprecated `includeGfnInAuthorizedClusters` request parameter.
  - Removed the legacy `ssaClientId` field from cluster responses.

- **Updates**
  - OAuth client identifiers are now used consistently across cluster listing, creation, reconfiguration, validation, and telemetry.
  - JWT subject extraction now uses the configured bearer-token resolver.
  - Updated authorization and cluster-management behavior to use the current non-BYOC cluster option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->