### PR TITLE
fix(ess): register nvct-api notary client for task secrets

### DIFF
--- a/migrations/cassandra/keyspaces/ess_api/09_add_nvct_api_notary_issuer.up.sql
+++ b/migrations/cassandra/keyspaces/ess_api/09_add_nvct_api_notary_issuer.up.sql
@@ -1,0 +1,22 @@
+-- Register the nvct-api NOTARY client so task-secret reads succeed.
+--
+-- Task-secret fetches (worker assertion tokens) authenticate on the ess-api
+-- notary path, which reads only notary_authorizations. nvct-api was registered
+-- for OAuth in 08_add_oauth_authorizations but never for notary in the OSS
+-- migration history, so tasks created with secrets fail with
+-- "client id=nvct-api is not registered" from ess-api. This mirrors the
+-- nvcf-api notary entry in 06_fix_nvcf_api_notary_issuer.
+
+UPDATE ess_api.namespaces
+SET
+  updated_at = toTimestamp(now()),
+  notary_authorizations = notary_authorizations + {
+    'nvct-api': {
+      id: 'nvct-api',
+      name: 'nvct api notary client',
+      jwks_url: 'http://notary.nvcf.svc.cluster.local:8080/.well-known/jwks.json',
+      issuer: 'http://notary.nvcf.svc.cluster.local:8080',
+      type: 'NOTARY'
+    }
+  }
+WHERE namespace = 'nvcf';


### PR DESCRIPTION
## Why

Creating an NVCT task with secrets fails: the worker's secret fetch is rejected
by ess-api with `client id=nvct-api is not registered`, and the task ends
ERRORED. A control task with the same image and no secrets runs normally.

Task-secret reads authenticate on the ess-api notary path, which reads only
`notary_authorizations` (resolved purely by the `isNotary` flag in
`AuthorizationsFacade`; no cross-merge with oauth/ssa). `nvct-api` is registered
for OAuth in `08_add_oauth_authorizations` but was never registered for notary
in the OSS migration history, so the worker's assertion-token fetch is denied.

Root cause is a migration gap, not an ess-api version issue: the notary lookup
is column-scoped in every ess-api version, so no version satisfies the worker
without the `nvct-api` notary entry. The equivalent `nvcf-api` notary entry
exists via `06_fix_nvcf_api_notary_issuer`; the `nvct-api` counterpart was lost
when the ess_api migrations were seeded onto the OSS `main`.

## What changed

Add forward migration `09_add_nvct_api_notary_issuer.up.sql` that registers
`nvct-api` on the notary path, mirroring the `nvcf-api` entry in `06`.

It uses the next sequence number so `golang-migrate` (the `execute_sqls.sh`
runner) applies it to already-migrated clusters, which sit at version `08`. A
lower-numbered file (for example `05`) would be skipped on existing
deployments and would only ever run on fresh installs, so it would not fix the
affected clusters. The migration touches only `notary_authorizations`; it does
not reintroduce the `ssa_authorizations` column that was intentionally dropped
and is not read by current ess-core.

## Customer Release Notes

Fixed NVCT task creation with secrets failing due to a missing ess-api notary
authorization for the tasks service.

## Plan Summary

Cassandra data migration for the `ess_api` keyspace, applied by the
`cassandra-migrations` job. Adds one entry to the `notary_authorizations` map in
the `nvcf` namespace row. Idempotent map update; no schema or destructive
changes.

## Usage

Applied automatically by the migrations job on deploy/upgrade. No operator
action required.

## Testing

Root cause established by tracing the released migration tags and the ess-api
auth code (notary path reads only `notary_authorizations`; the exact error
string originates from `AuthChecker`). A self-hosted stack at the reported
versions (`self-managed v0.14.5` + `nvcf-compute-plane v0.2.3`) was installed
locally to reproduce; the migration follows the same forward pattern as `06`,
`07`, and `08`.

## Notes

No `.down.sql` is added because the `ess_api` keyspace has no down-migration
convention (there are zero `*.down.sql` files).

## Issues

Closes #1777 (Task 1 of Onboarding the client)
Closes #1756

## Related Pull Requests

None

## Dependencies

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registered the `nvct-api` notary client with its identity, issuer, type, and JWKS endpoint.
  * Updated authorization metadata to reflect the new notary registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->