### PR TITLE
fix(nvcf-cli): add the missing logging dep to the cmd go_test

### DIFF
--- a/src/clis/nvcf-cli/cmd/BUILD.bazel
+++ b/src/clis/nvcf-cli/cmd/BUILD.bazel
@@ -136,6 +136,7 @@ go_test(
         "//src/clis/nvcf-cli/internal/client",
         "//src/clis/nvcf-cli/internal/clusteragent",
         "//src/clis/nvcf-cli/internal/clusterdump",
+        "//src/clis/nvcf-cli/internal/logging",
         "//src/clis/nvcf-cli/internal/selfhosted",
         "//src/clis/nvcf-cli/internal/selfhosted/auth",
         "//src/clis/nvcf-cli/internal/selfhosted/controlplaneprofile",


### PR DESCRIPTION
## TL;DR

`main` is red. `tools/ci/check-gazelle` fails with `BUILD files are out of date with their sources`, which blocks the merge queue for every open pull request, not only the one that introduced it.

One line fixes it.

## Additional Details

#457 added `src/clis/nvcf-cli/cmd/function_create_test.go`, which imports `nvcf-cli/internal/logging`, but the BUILD file was not regenerated, so the `go_test` deps do not list `//src/clis/nvcf-cli/internal/logging`.

Regenerated with the same command the check runs:

```bash
bazel run //:gazelle -- src/clis src/libraries/go \
  src/compute-plane-services src/control-plane-services \
  src/invocation-plane-services
```

Across the whole tree that produced exactly one changed line, which is the scope you would want for an unblocking fix.

Timeline, for anyone bisecting: `build-test` passed on `f3b6eb3f` at 18:03Z and failed on `1ae48e58` at 18:08Z with this error. That commit added 5 `.go` files and touched 1 `BUILD.bazel`.

## For the Reviewer

The diff is a single `deps` entry. The thing worth confirming is that the regeneration was done with the root Gazelle run rather than per-subtree, which `tools/ci/check-gazelle` is explicit about: Gazelle resolves dependencies against the module it runs in, so a per-subtree run produces different output.

## For QA

No QA needed. Build metadata only.

Verified locally:

- `bash tools/ci/check-gazelle` reports `gazelle: BUILD files are up to date`, exit 0. It failed before this change.
- `bazel test //src/clis/nvcf-cli/cmd/...` passes (`1 test passes`).

No tests are added. This restores build metadata for a test that #457 already added.

## Issues

Relates to #457

## Checklist
- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test build configuration to support internal logging during command-line interface tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->