### PR TITLE
feat(charts): bump chart versions for released services

### DIFF
--- a/deploy/helm/cloud-functions/nvcf-api/Chart.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/Chart.yaml
@@ -19,4 +19,4 @@ description: A Helm chart for NVCF API deployment
 
 type: application
 version: 0.0.0 # autoversioning enabled via release pipeline
-appVersion: "1.17.2"
+appVersion: "1.17.3"

--- a/deploy/helm/cloud-functions/nvcf-api/Chart.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/Chart.yaml
@@ -19,4 +19,4 @@ description: A Helm chart for NVCF API deployment
 
 type: application
 version: 0.0.0 # autoversioning enabled via release pipeline
-appVersion: "1.17.3"
+appVersion: "1.18.0"

--- a/deploy/helm/cloud-functions/nvcf-api/values.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/values.yaml
@@ -33,7 +33,7 @@ api:
     # This sets the pull policy for images.
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "1.17.2"
+    tag: "1.17.3"
 
   # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   # imagePullSecrets:

--- a/deploy/helm/cloud-functions/nvcf-api/values.yaml
+++ b/deploy/helm/cloud-functions/nvcf-api/values.yaml
@@ -33,7 +33,7 @@ api:
     # This sets the pull policy for images.
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "1.17.3"
+    tag: "1.18.0"
 
   # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   # imagePullSecrets:

--- a/deploy/helm/cloud-tasks/nvct-api/Chart.yaml
+++ b/deploy/helm/cloud-tasks/nvct-api/Chart.yaml
@@ -4,4 +4,4 @@ description: NCP Compatible deployment of NVCT API (nvct-service)
 
 type: application
 version: 0.0.0 # autoversioning enabled via release pipeline
-appVersion: "1.65.1"
+appVersion: "1.66.0"

--- a/deploy/helm/cloud-tasks/nvct-api/Chart.yaml
+++ b/deploy/helm/cloud-tasks/nvct-api/Chart.yaml
@@ -4,4 +4,4 @@ description: NCP Compatible deployment of NVCT API (nvct-service)
 
 type: application
 version: 0.0.0 # autoversioning enabled via release pipeline
-appVersion: "1.65.0"
+appVersion: "1.65.1"

--- a/deploy/helm/cloud-tasks/nvct-api/values.yaml
+++ b/deploy/helm/cloud-tasks/nvct-api/values.yaml
@@ -3,7 +3,7 @@ nvctApi:
     registry: "" # must be supplied
     repository: "" # must be supplied
     pullPolicy: IfNotPresent
-    tag: "1.65.1"
+    tag: "1.66.0"
 
   # Namespace to deploy the resources. The default value is the release namespace.
   namespace: ""

--- a/deploy/helm/cloud-tasks/nvct-api/values.yaml
+++ b/deploy/helm/cloud-tasks/nvct-api/values.yaml
@@ -3,7 +3,7 @@ nvctApi:
     registry: "" # must be supplied
     repository: "" # must be supplied
     pullPolicy: IfNotPresent
-    tag: "1.65.0"
+    tag: "1.65.1"
 
   # Namespace to deploy the resources. The default value is the release namespace.
   namespace: ""

--- a/deploy/helm/notary/nvcf-notary-service/Chart.yaml
+++ b/deploy/helm/notary/nvcf-notary-service/Chart.yaml
@@ -19,4 +19,4 @@ description: A Helm chart for NVCF Notary Service deployment
 
 type: application
 version: 0.0.0 # autoversioning enabled via release pipeline
-appVersion: "1.14.0"
+appVersion: "1.14.1"

--- a/deploy/helm/notary/nvcf-notary-service/values.yaml
+++ b/deploy/helm/notary/nvcf-notary-service/values.yaml
@@ -18,7 +18,7 @@ notary:
     registry: "" # must be supplied
     repository: "" # must be supplied
     pullPolicy: IfNotPresent
-    tag: "1.14.0"
+    tag: "1.14.1"
 
   # Namespace to deploy the resources. The default value is the release name.
   namespace: ""

--- a/deploy/helm/nvca-operator/nvca-operator/values.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/values.yaml
@@ -37,7 +37,7 @@ nvcaImage:
 otelCollector:
   enabled: false
   imageRepository: ""
-  imageTag: 0.160.0-nv-0.2.4
+  imageTag: "0.160.0-nv-0.2.5"
   resources:
     limits:
       cpu: 1000m
@@ -282,7 +282,7 @@ agent:
   ## @param agent.byooOtelCollector.imageTag BYOO OpenTelemetry Collector image tag.
   byooOtelCollector:
     imageRepository: ""
-    imageTag: "0.160.0-nv-0.2.4"
+    imageTag: "0.160.0-nv-0.2.5"
   ## Environment variable overrides for function workloads.
   ## Available keys: INIT_CONTAINER, UTILS_CONTAINER, OTEL_CONTAINER, BYOO_OTEL_COLLECTOR_CONTAINER,
   ##                 NICLLS_CONTAINER, ESS_AGENT_CONTAINER, INFERENCE_CONTAINER
@@ -397,7 +397,7 @@ helmManaged:
   otelCollector:
     enabled: false
     imageRepository: ""
-    imageTag: 0.160.0-nv-0.2.4
+    imageTag: "0.160.0-nv-0.2.5"
 ## @section Self Managed NVCF Backend Configuration
 ## Only used when ngcConfig.clusterSource is "self-managed"
 ## All values below are under the 'selfManaged:' key, e.g. 'selfManaged.nvcaVersion'
@@ -421,7 +421,7 @@ selfManaged:
   otelCollector:
     enabled: false
     imageRepository: ""
-    imageTag: 0.160.0-nv-0.2.4
+    imageTag: "0.160.0-nv-0.2.5"
   ## @param selfManaged.icmsServiceURL URL of the ICMS service for self-managed clusters. Override with the endpoint generated during cluster registration.
   icmsServiceURL: "http://icms.example.invalid:8080"
   ## @param selfManaged.icmsServiceHostHeaderOverride Optional Host header override for selfManaged.icmsServiceURL.

--- a/deploy/helm/nvca-operator/nvca-operator/values.yaml
+++ b/deploy/helm/nvca-operator/nvca-operator/values.yaml
@@ -37,7 +37,7 @@ nvcaImage:
 otelCollector:
   enabled: false
   imageRepository: ""
-  imageTag: "0.160.0-nv-0.2.5"
+  imageTag: 0.160.0-nv-0.2.5
   resources:
     limits:
       cpu: 1000m
@@ -397,7 +397,7 @@ helmManaged:
   otelCollector:
     enabled: false
     imageRepository: ""
-    imageTag: "0.160.0-nv-0.2.5"
+    imageTag: 0.160.0-nv-0.2.5
 ## @section Self Managed NVCF Backend Configuration
 ## Only used when ngcConfig.clusterSource is "self-managed"
 ## All values below are under the 'selfManaged:' key, e.g. 'selfManaged.nvcaVersion'
@@ -421,7 +421,7 @@ selfManaged:
   otelCollector:
     enabled: false
     imageRepository: ""
-    imageTag: "0.160.0-nv-0.2.5"
+    imageTag: 0.160.0-nv-0.2.5
   ## @param selfManaged.icmsServiceURL URL of the ICMS service for self-managed clusters. Override with the endpoint generated during cluster registration.
   icmsServiceURL: "http://icms.example.invalid:8080"
   ## @param selfManaged.icmsServiceHostHeaderOverride Optional Host header override for selfManaged.icmsServiceURL.


### PR DESCRIPTION
Opened by `.github/workflows/chart-version-bump.yml` when `src/compute-plane-services/byoo-otel-collector/v0.160.0-nv-0.2.5` was published.

The released tag carries the version, so this is a direct update rather than a lookup of the newest published image.

Merging this does not move the self-managed stack. A chart version reaches the stack only once the chart itself is released, and publishing that chart release is what triggers `stack-pin-bump.yml`.

Release notes: https://github.com/NVIDIA/nvcf/releases/tag/src/compute-plane-services/byoo-otel-collector/v0.160.0-nv-0.2.5


If this pull request sits unmerged, later service releases add their bumps to the same branch, so merging it applies all of them.

Github commit:
feat(charts): bump chart versions for released services

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Updated Cloud Functions API to version 1.18.0.
  - Updated Cloud Tasks API to version 1.66.0.
  - Updated the Notary service to version 1.14.1.
  - Standardized OpenTelemetry Collector image tag formatting without changing the configured version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->