### PR TITLE
fix(ci): scope chart and stack bump concurrency per tag

### DIFF
--- a/.github/workflows/chart-version-bump.yml
+++ b/.github/workflows/chart-version-bump.yml
@@ -33,15 +33,8 @@ permissions:
   contents: read
 
 concurrency:
-  # Scoped per tag, not repo-wide. A shared group meant several releases
-  # landing together queued behind each other, and GitHub Actions keeps only
-  # the most recently queued run per group: earlier queued runs were
-  # silently cancelled before they ever started, dropping their bump with no
-  # error anywhere (seen for real on 2026-09-04, when a combined release
-  # dropped the encrypted-secret-store and cloud-functions bumps). Per-tag
-  # groups let simultaneous releases for different services run
-  # independently; the push retry below handles the remaining race on the
-  # shared bump branch.
+  # Per tag, not repo-wide: a shared group silently dropped queued runs
+  # when releases landed close together (NVIDIA/nvcf#1762).
   group: chart-version-bump-${{ github.event.inputs.tag || github.event.release.tag_name }}
   cancel-in-progress: false
 
@@ -221,20 +214,10 @@ jobs:
               -m "${subject}" \
               -m "Opened by the chart version bump workflow on release of ${TAG}."
           fi
-          # Retried, not a single shot: the branch is now shared across truly
-          # concurrent runs (see the concurrency block above), so another
-          # release's push can land between this job's checkout and its own
-          # push. force-with-lease turns that into a rejected push rather than
-          # a silent overwrite; re-fetching and rebasing recovers instead of
-          # dropping this bump on the floor.
-          #
-          # Budgeted by wall clock, not by a fixed attempt count. This
-          # repository's own release history has produced bursts of up to 23
-          # service releases and 13 chart releases within a few minutes of
-          # each other (see NVIDIA/nvcf#1762), so a small fixed retry count
-          # would still fail under a burst this repository has already
-          # produced. A time budget scales with however large the next burst
-          # turns out to be instead of hard-coding today's observed maximum.
+          # The branch is now shared across truly concurrent runs, so another
+          # release can push first. Fetch and rebase onto it, then retry.
+          # Time-budgeted, not attempt-counted: real bursts have hit 23
+          # releases at once (NVIDIA/nvcf#1762), past any small fixed count.
           deadline=$(($(date +%s) + 300))
           attempt=0
           until git push --force-with-lease origin "${branch}"; do

--- a/.github/workflows/chart-version-bump.yml
+++ b/.github/workflows/chart-version-bump.yml
@@ -33,9 +33,16 @@ permissions:
   contents: read
 
 concurrency:
-  # One bump at a time. Several releases landing together refresh the same
-  # pull request rather than racing on the same files.
-  group: chart-version-bump
+  # Scoped per tag, not repo-wide. A shared group meant several releases
+  # landing together queued behind each other, and GitHub Actions keeps only
+  # the most recently queued run per group: earlier queued runs were
+  # silently cancelled before they ever started, dropping their bump with no
+  # error anywhere (seen for real on 2026-09-04, when a combined release
+  # dropped the encrypted-secret-store and cloud-functions bumps). Per-tag
+  # groups let simultaneous releases for different services run
+  # independently; the push retry below handles the remaining race on the
+  # shared bump branch.
+  group: chart-version-bump-${{ github.event.inputs.tag || github.event.release.tag_name }}
   cancel-in-progress: false
 
 jobs:
@@ -214,7 +221,23 @@ jobs:
               -m "${subject}" \
               -m "Opened by the chart version bump workflow on release of ${TAG}."
           fi
-          git push --force-with-lease origin "${branch}"
+          # Retried, not a single shot: the branch is now shared across truly
+          # concurrent runs (see the concurrency block above), so another
+          # release's push can land between this job's checkout and its own
+          # push. force-with-lease turns that into a rejected push rather than
+          # a silent overwrite; re-fetching and rebasing recovers instead of
+          # dropping this bump on the floor.
+          attempt=0
+          until git push --force-with-lease origin "${branch}"; do
+            attempt=$((attempt + 1))
+            if [ "${attempt}" -ge 5 ]; then
+              echo "push kept losing the race against another release after ${attempt} attempts" >&2
+              exit 1
+            fi
+            echo "push raced with another release on the shared branch, retrying (attempt ${attempt})" >&2
+            git fetch origin "${branch}"
+            git rebase "origin/${branch}"
+          done
 
           # The pull request squashes to one commit, so its title has to carry
           # the largest step among every bump accumulated on the branch.

--- a/.github/workflows/chart-version-bump.yml
+++ b/.github/workflows/chart-version-bump.yml
@@ -227,14 +227,24 @@ jobs:
           # push. force-with-lease turns that into a rejected push rather than
           # a silent overwrite; re-fetching and rebasing recovers instead of
           # dropping this bump on the floor.
+          #
+          # Budgeted by wall clock, not by a fixed attempt count. This
+          # repository's own release history has produced bursts of up to 23
+          # service releases and 13 chart releases within a few minutes of
+          # each other (see NVIDIA/nvcf#1762), so a small fixed retry count
+          # would still fail under a burst this repository has already
+          # produced. A time budget scales with however large the next burst
+          # turns out to be instead of hard-coding today's observed maximum.
+          deadline=$(($(date +%s) + 300))
           attempt=0
           until git push --force-with-lease origin "${branch}"; do
             attempt=$((attempt + 1))
-            if [ "${attempt}" -ge 5 ]; then
-              echo "push kept losing the race against another release after ${attempt} attempts" >&2
+            if [ "$(date +%s)" -ge "${deadline}" ]; then
+              echo "push kept losing the race against another release past the 5 minute retry budget (attempt ${attempt})" >&2
               exit 1
             fi
             echo "push raced with another release on the shared branch, retrying (attempt ${attempt})" >&2
+            sleep "$(((RANDOM % 5) + 1))"
             git fetch origin "${branch}"
             git rebase "origin/${branch}"
           done

--- a/.github/workflows/chart-version-bump.yml
+++ b/.github/workflows/chart-version-bump.yml
@@ -218,18 +218,32 @@ jobs:
           # release can push first. Fetch and rebase onto it, then retry.
           # Time-budgeted, not attempt-counted: real bursts have hit 23
           # releases at once (NVIDIA/nvcf#1762), past any small fixed count.
+          # `remaining` bounds every step below, sleep included, so the loop
+          # cannot overrun the budget even if one step is slow.
           deadline=$(($(date +%s) + 300))
           attempt=0
-          until git push --force-with-lease origin "${branch}"; do
+          remaining() {
+            local left=$((deadline - $(date +%s)))
+            [ "${left}" -gt 0 ] && echo "${left}"
+          }
+          give_up() {
+            echo "push kept losing the race against another release past the 5 minute retry budget (attempt ${attempt})" >&2
+            exit 1
+          }
+
+          left="$(remaining)" || give_up
+          until timeout "${left}" git push --force-with-lease origin "${branch}"; do
             attempt=$((attempt + 1))
-            if [ "$(date +%s)" -ge "${deadline}" ]; then
-              echo "push kept losing the race against another release past the 5 minute retry budget (attempt ${attempt})" >&2
-              exit 1
-            fi
             echo "push raced with another release on the shared branch, retrying (attempt ${attempt})" >&2
-            sleep "$(((RANDOM % 5) + 1))"
-            git fetch origin "${branch}"
-            git rebase "origin/${branch}"
+            left="$(remaining)" || give_up
+            sleep_for=$(((RANDOM % 5) + 1))
+            [ "${sleep_for}" -gt "${left}" ] && sleep_for="${left}"
+            sleep "${sleep_for}"
+            left="$(remaining)" || give_up
+            timeout "${left}" git fetch origin "${branch}"
+            left="$(remaining)" || give_up
+            timeout "${left}" git rebase "origin/${branch}"
+            left="$(remaining)" || give_up
           done
 
           # The pull request squashes to one commit, so its title has to carry

--- a/.github/workflows/stack-pin-bump.yml
+++ b/.github/workflows/stack-pin-bump.yml
@@ -30,9 +30,16 @@ permissions:
   contents: read
 
 concurrency:
-  # One bump at a time. Several releases landing together refresh the same
-  # pull request rather than racing on the same file.
-  group: stack-pin-bump
+  # Scoped per tag, not repo-wide. A shared group meant several releases
+  # landing together queued behind each other, and GitHub Actions keeps only
+  # the most recently queued run per group: earlier queued runs were
+  # silently cancelled before they ever started, dropping their bump with no
+  # error anywhere (seen for real on 2026-09-04, when a combined release
+  # dropped the encrypted-secret-store and cloud-functions bumps). Per-tag
+  # groups let simultaneous releases for different services run
+  # independently; the push retry below handles the remaining race on the
+  # shared bump branch.
+  group: stack-pin-bump-${{ github.event.inputs.tag || github.event.release.tag_name }}
   cancel-in-progress: false
 
 jobs:
@@ -172,7 +179,23 @@ jobs:
               -m "${subject}" \
               -m "Opened by the stack pin bump workflow on release of ${TAG}."
           fi
-          git push --force-with-lease origin "${branch}"
+          # Retried, not a single shot: the branch is now shared across truly
+          # concurrent runs (see the concurrency block above), so another
+          # release's push can land between this job's checkout and its own
+          # push. force-with-lease turns that into a rejected push rather than
+          # a silent overwrite; re-fetching and rebasing recovers instead of
+          # dropping this bump on the floor.
+          attempt=0
+          until git push --force-with-lease origin "${branch}"; do
+            attempt=$((attempt + 1))
+            if [ "${attempt}" -ge 5 ]; then
+              echo "push kept losing the race against another release after ${attempt} attempts" >&2
+              exit 1
+            fi
+            echo "push raced with another release on the shared branch, retrying (attempt ${attempt})" >&2
+            git fetch origin "${branch}"
+            git rebase "origin/${branch}"
+          done
 
           # The pull request squashes to one commit, so its title has to carry
           # the largest step among every pin accumulated on the branch.

--- a/.github/workflows/stack-pin-bump.yml
+++ b/.github/workflows/stack-pin-bump.yml
@@ -176,18 +176,32 @@ jobs:
           # release can push first. Fetch and rebase onto it, then retry.
           # Time-budgeted, not attempt-counted: real bursts have hit 23
           # releases at once (NVIDIA/nvcf#1762), past any small fixed count.
+          # `remaining` bounds every step below, sleep included, so the loop
+          # cannot overrun the budget even if one step is slow.
           deadline=$(($(date +%s) + 300))
           attempt=0
-          until git push --force-with-lease origin "${branch}"; do
+          remaining() {
+            local left=$((deadline - $(date +%s)))
+            [ "${left}" -gt 0 ] && echo "${left}"
+          }
+          give_up() {
+            echo "push kept losing the race against another release past the 5 minute retry budget (attempt ${attempt})" >&2
+            exit 1
+          }
+
+          left="$(remaining)" || give_up
+          until timeout "${left}" git push --force-with-lease origin "${branch}"; do
             attempt=$((attempt + 1))
-            if [ "$(date +%s)" -ge "${deadline}" ]; then
-              echo "push kept losing the race against another release past the 5 minute retry budget (attempt ${attempt})" >&2
-              exit 1
-            fi
             echo "push raced with another release on the shared branch, retrying (attempt ${attempt})" >&2
-            sleep "$(((RANDOM % 5) + 1))"
-            git fetch origin "${branch}"
-            git rebase "origin/${branch}"
+            left="$(remaining)" || give_up
+            sleep_for=$(((RANDOM % 5) + 1))
+            [ "${sleep_for}" -gt "${left}" ] && sleep_for="${left}"
+            sleep "${sleep_for}"
+            left="$(remaining)" || give_up
+            timeout "${left}" git fetch origin "${branch}"
+            left="$(remaining)" || give_up
+            timeout "${left}" git rebase "origin/${branch}"
+            left="$(remaining)" || give_up
           done
 
           # The pull request squashes to one commit, so its title has to carry

--- a/.github/workflows/stack-pin-bump.yml
+++ b/.github/workflows/stack-pin-bump.yml
@@ -30,15 +30,8 @@ permissions:
   contents: read
 
 concurrency:
-  # Scoped per tag, not repo-wide. A shared group meant several releases
-  # landing together queued behind each other, and GitHub Actions keeps only
-  # the most recently queued run per group: earlier queued runs were
-  # silently cancelled before they ever started, dropping their bump with no
-  # error anywhere (seen for real on 2026-09-04, when a combined release
-  # dropped the encrypted-secret-store and cloud-functions bumps). Per-tag
-  # groups let simultaneous releases for different services run
-  # independently; the push retry below handles the remaining race on the
-  # shared bump branch.
+  # Per tag, not repo-wide: a shared group silently dropped queued runs
+  # when releases landed close together (NVIDIA/nvcf#1762).
   group: stack-pin-bump-${{ github.event.inputs.tag || github.event.release.tag_name }}
   cancel-in-progress: false
 
@@ -179,20 +172,10 @@ jobs:
               -m "${subject}" \
               -m "Opened by the stack pin bump workflow on release of ${TAG}."
           fi
-          # Retried, not a single shot: the branch is now shared across truly
-          # concurrent runs (see the concurrency block above), so another
-          # release's push can land between this job's checkout and its own
-          # push. force-with-lease turns that into a rejected push rather than
-          # a silent overwrite; re-fetching and rebasing recovers instead of
-          # dropping this bump on the floor.
-          #
-          # Budgeted by wall clock, not by a fixed attempt count. This
-          # repository's own release history has produced bursts of up to 23
-          # service releases and 13 chart releases within a few minutes of
-          # each other (see NVIDIA/nvcf#1762), so a small fixed retry count
-          # would still fail under a burst this repository has already
-          # produced. A time budget scales with however large the next burst
-          # turns out to be instead of hard-coding today's observed maximum.
+          # The branch is now shared across truly concurrent runs, so another
+          # release can push first. Fetch and rebase onto it, then retry.
+          # Time-budgeted, not attempt-counted: real bursts have hit 23
+          # releases at once (NVIDIA/nvcf#1762), past any small fixed count.
           deadline=$(($(date +%s) + 300))
           attempt=0
           until git push --force-with-lease origin "${branch}"; do

--- a/.github/workflows/stack-pin-bump.yml
+++ b/.github/workflows/stack-pin-bump.yml
@@ -185,14 +185,24 @@ jobs:
           # push. force-with-lease turns that into a rejected push rather than
           # a silent overwrite; re-fetching and rebasing recovers instead of
           # dropping this bump on the floor.
+          #
+          # Budgeted by wall clock, not by a fixed attempt count. This
+          # repository's own release history has produced bursts of up to 23
+          # service releases and 13 chart releases within a few minutes of
+          # each other (see NVIDIA/nvcf#1762), so a small fixed retry count
+          # would still fail under a burst this repository has already
+          # produced. A time budget scales with however large the next burst
+          # turns out to be instead of hard-coding today's observed maximum.
+          deadline=$(($(date +%s) + 300))
           attempt=0
           until git push --force-with-lease origin "${branch}"; do
             attempt=$((attempt + 1))
-            if [ "${attempt}" -ge 5 ]; then
-              echo "push kept losing the race against another release after ${attempt} attempts" >&2
+            if [ "$(date +%s)" -ge "${deadline}" ]; then
+              echo "push kept losing the race against another release past the 5 minute retry budget (attempt ${attempt})" >&2
               exit 1
             fi
             echo "push raced with another release on the shared branch, retrying (attempt ${attempt})" >&2
+            sleep "$(((RANDOM % 5) + 1))"
             git fetch origin "${branch}"
             git rebase "origin/${branch}"
           done


### PR DESCRIPTION
> Draft. This scopes the concurrency group per tag, which stops the eviction but
> gives up the serialization that keeps writes to the shared bump branch safe.
> I am no longer convinced that is the right trade. Alternatives are under
> discussion, see the Notes section. Holding this open as the reference write-up
> of the problem rather than as a change to merge as-is.

## Why

chart-version-bump.yml and stack-pin-bump.yml both fire on `release: published`
and each append a commit to one long-lived shared branch
(`chore/chart-version-bumps` / `chore/stack-pin-bumps`). Both use a repo-wide,
un-scoped concurrency group to serialize those pushes.

GitHub Actions holds at most one queued run per concurrency group, so a newly
queued run displaces whatever was queued before it. The displaced run is
cancelled before any job starts, which is why it leaves no failure signal.

This happened on 2026-09-04, when a combined merge released six services within
about two minutes. Two `chart-version-bump.yml` runs were cancelled:

- `cloud-functions/v1.17.0`: https://github.com/NVIDIA/nvcf/actions/runs/33901676821
- `encrypted-secret-store/v0.5.0`: https://github.com/NVIDIA/nvcf/actions/runs/33901775465

Both record zero jobs, and both state the cause directly:

```
Canceling since a higher priority waiting request for chart-version-bump exists
```

Neither bump reached the shared branch, so neither was part of the chart-bump
pull request when it merged. `encrypted-secret-store`'s `Chart.yaml` kept
`appVersion: 0.4.15` while the service had released `0.5.0`, so the chart
pointed at an image without the change for six days, until a manual
`workflow_dispatch` re-run recovered it.

## What changed

- Scope both workflows' concurrency group by release tag instead of repo-wide,
  so simultaneous releases for different services or charts stop displacing
  each other from the single queue slot.
- Per-tag groups let runs reach the shared bump branch in parallel, so the
  `push --force-with-lease` now retries: a lost race becomes a rejected push
  that fetches, rebases onto the newer commit, and pushes again.
- The retry is budgeted by wall clock (5 minutes) rather than a fixed attempt
  count. Release history in this repo shows bursts of up to 23 service releases
  and 13 chart releases within minutes, so a small fixed count would still give
  up under a burst this repo has already produced. Every step recomputes the
  remaining budget, sleep is capped to it, and fetch, rebase, and push each run
  under `timeout`, so the loop cannot overrun the budget.

## Notes

Reviewers should weigh one tradeoff: the repo-wide group also serialized writes
to the shared branch, and per-tag groups give that up in exchange for optimistic
retry. Two runs bumping the same chart's `appVersion` line concurrently would
now meet in a rebase, which the serialized design never had to handle. An
alternative worth considering is keeping serialization and instead making the
bump self-healing, so that a dropped run costs nothing because the next run
reconciles every chart against its service's newest release. That is a larger
change in `tools/chart-version-bumper`, which is `--tag`-driven today and
therefore loses a dropped run's work permanently.

Recovery for the two dropped bumps already happened through NVIDIA/nvcf#1699
and NVIDIA/nvcf#1734, so this changes nothing about the current pins.

## Issues

Closes #1762