### PR TITLE
feat(stack): encode missing needs: edges in self-managed core stage

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -42,6 +42,17 @@ templates:
 
 releases:
 
+  # NOTE: every release below depends on cassandra-system/cassandra, and
+  # nats-auth-callout-service depends on nats-system/nats, both defined in
+  # 01-dependencies.yaml.gotmpl. Those edges are already enforced by the
+  # 01-dependencies -> 02-core stage boundary (helmfile.d/*.yaml.gotmpl files
+  # run sequentially under the pinned helmfile v1.1.x), so they are
+  # intentionally not repeated as needs: entries here. Only edges between
+  # releases within this same file are listed explicitly. The same applies to
+  # function-autoscaler in 03-observability.yaml.gotmpl, which depends on
+  # cassandra-system/cassandra and nvcf/api via the 02-core -> 03-observability
+  # stage boundary.
+
   # --- NVCF Services ---
   - name: api-keys
     version: 1.7.0
@@ -62,14 +73,40 @@ releases:
     inherit:
       - template: service
     needs:
+      # Required deployment order: API Keys, ICMS/SIS, Notary, and Helm ReVal
+      # must be up before Cloud Functions (this release), which registers an
+      # OAuth client and base URL with each at startup. Cassandra and NATS
+      # prerequisites are already enforced by the stage boundary between
+      # 01-dependencies.yaml.gotmpl and this file, so they are not repeated
+      # here.
+      - api-keys/api-keys
+      {{- if dig "icms" "enabled" true .Values }}
+      - sis/sis
+      {{- end }}
       # not needed to start, but needed for bootstrapping account which is done with a script in the api helm chart
       - ess/ess-api
+      - nvcf/notary-service
+      - nvcf/reval
 
   - name: nvct-api
     version: 1.5.3
     namespace: nvcf
     inherit:
       - template: service
+    needs:
+      # Required deployment order: Cloud Tasks (this release) registers an
+      # OAuth client and base URL with API Keys, ICMS/SIS, ESS, Notary, and
+      # Helm ReVal, and separately depends on Cloud Functions per the Cloud
+      # Functions -> Cloud Tasks edge. Cassandra prerequisite is already
+      # enforced by the 01-dependencies stage boundary.
+      - api-keys/api-keys
+      {{- if dig "icms" "enabled" true .Values }}
+      - sis/sis
+      {{- end }}
+      - ess/ess-api
+      - nvcf/notary-service
+      - nvcf/reval
+      - nvcf/api
 
   - name: invocation-service
     version: 1.6.0


### PR DESCRIPTION
# TL;DR
Add the missing `needs:` edges within `02-core.yaml.gotmpl` so `api`
(Cloud Functions) and `nvct-api` (Cloud Tasks) wait on API Keys,
ICMS/SIS, ESS, Notary, and Helm ReVal, and `nvct-api` also waits on
`api`. These services register an OAuth client and base URL with each
of those dependencies at startup, but the Helmfile graph only
expressed the `ess/ess-api` edge before this change.

## Additional Details
- Cross-stage edges (anything depending on Cassandra or NATS, both in
  `01-dependencies.yaml.gotmpl`, and function-autoscaler's dependency
  on `api` in `03-observability.yaml.gotmpl`) are already enforced by
  the sequential `01-dependencies -> 02-core -> 03-observability`
  stage boundary under the pinned helmfile v1.1.x, so they're
  documented in a comment rather than duplicated as `needs:` entries.
- The new `sis/sis` edge is wrapped in `{{- if dig "icms" "enabled" true .Values }}`
  since `sis` itself is conditional (`condition: icms.enabled`,
  defaulting to `true`); an unconditioned `needs:` on a conditionally
  disabled release matches the existing pattern used for
  `nvcf-ui/nvcf-ui` on the `ingress` release.
- No version bumps, no changes to any other release.

## For the Reviewer
Please look closely at `helmfile.d/02-core.yaml.gotmpl`, specifically
the `needs:` blocks on `api` and `nvct-api` and the `icms.enabled`
guard around `sis/sis`.

I could not fully exercise `helmfile build`/`write-values` against a
real chart registry locally (no NVCR credentials in my environment),
which is true of every existing test in `tests/` in this directory. I
validated the change as far as possible without registry access:
- `helmfile list --output json` succeeds with no template/YAML errors
  with `icms.enabled` at its default and explicitly set to `false`.
- `helmfile build`/`--selector name=api` successfully resolves the
  full release DAG and reaches real NVCR authentication (403, expected
  without credentials) rather than failing on DAG/template resolution,
  both before and after this change.
- Manually extracted and validated the resolved `needs:` list for both
  branches of the `icms.enabled` conditional with `yq`.

CI's template-render job has real registry credentials and should be
the authoritative check.

## For QA
See the "For the Reviewer" section above for what I ran locally.

## Issues
Closes #1764

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deployment Improvements**
  - Updated deployment sequencing to respect dependencies between core services and supporting capabilities.
  - Improved handling of optional integrations during staged deployments, including API keys, SIS, ESS, Notary, and ReVal.
  - Added guidance documenting cross-component dependencies and stage-boundary ordering for more predictable deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->