### PR TITLE
fix(release): render inventories from release registry

### DIFF
--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -147,5 +147,6 @@ jobs:
 
       - name: Validate tag and create release notes
         env:
+          NVCF_RELEASE_HELM_REGISTRY: ${{ secrets.NCP_DEV_REGISTRY }}
           NVCF_RELEASE_NGC_API_KEY: ${{ secrets.NGC_NCP_DEV_KEY }}
         run: ./tools/ci/github-release tag "$GITHUB_REF_NAME"

--- a/deploy/stacks/self-managed/release-inventory.yaml
+++ b/deploy/stacks/self-managed/release-inventory.yaml
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+schemaVersion: 1
+publishedChartRepository: https://helm.ngc.nvidia.com/nvidia/nvcf

--- a/tools/ci/test-github-release.py
+++ b/tools/ci/test-github-release.py
@@ -1411,6 +1411,10 @@ class GithubReleaseTest(unittest.TestCase):
         workflow = (SCRIPT_PATH.parents[2] / ".github/workflows/release-tags.yml").read_text()
         self.assertIn("actions/setup-go@v5", workflow)
         self.assertIn('HELMFILE_VERSION: "1.1.9"', workflow)
+        self.assertIn(
+            "NVCF_RELEASE_HELM_REGISTRY: ${{ secrets.NCP_DEV_REGISTRY }}",
+            workflow,
+        )
         self.assertIn("Install inventory rendering tools", workflow)
         self.assertLess(
             workflow.index("Install inventory rendering tools"),

--- a/tools/docs-version-sync/resolved_inventory_publish.go
+++ b/tools/docs-version-sync/resolved_inventory_publish.go
@@ -24,6 +24,7 @@ import (
 const (
 	resolvedInventoryRepository = "https://github.com/NVIDIA/nvcf/tree"
 	resolvedInventoryTimeout    = 30 * time.Minute
+	resolvedInventoryConfigPath = "deploy/stacks/self-managed/release-inventory.yaml"
 )
 
 var resolvedInventoryCommonOverrides = []string{
@@ -89,6 +90,12 @@ type resolvedInventoryCommandRunner interface {
 
 type execResolvedInventoryCommandRunner struct{}
 
+type resolvedInventoryHelmCommand struct {
+	Repository    string
+	Args          []string
+	Authenticated bool
+}
+
 func (execResolvedInventoryCommandRunner) Output(dir string, env []string, args ...string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), resolvedInventoryTimeout)
 	defer cancel()
@@ -109,36 +116,68 @@ func (execResolvedInventoryCommandRunner) Output(dir string, env []string, args 
 }
 
 func (execResolvedInventoryCommandRunner) PrepareRepositories(env []string, repositories map[string]helmfileRepository, ngcAPIKey string) error {
+	commands, err := resolvedInventoryRepositoryCommands(repositories)
+	if err != nil {
+		return err
+	}
+	for _, helmCommand := range commands {
+		var stdin io.Reader
+		if helmCommand.Authenticated {
+			stdin = strings.NewReader(ngcAPIKey + "\n")
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), resolvedInventoryTimeout)
+		command := exec.CommandContext(ctx, "helm", helmCommand.Args...)
+		command.Env = env
+		command.Stdin = stdin
+		output, commandErr := command.CombinedOutput()
+		cancel()
+		if commandErr != nil {
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return fmt.Errorf("configure Helm repository %s: timed out after %s", helmCommand.Repository, resolvedInventoryTimeout)
+			}
+			return fmt.Errorf("configure Helm repository %s: %w\n%s", helmCommand.Repository, commandErr, strings.TrimSpace(string(output)))
+		}
+	}
+	return nil
+}
+
+func resolvedInventoryRepositoryCommands(repositories map[string]helmfileRepository) ([]resolvedInventoryHelmCommand, error) {
 	names := make([]string, 0, len(repositories))
 	for name := range repositories {
 		names = append(names, name)
 	}
 	sort.Strings(names)
+	commands := make([]resolvedInventoryHelmCommand, 0, len(names))
 	for _, name := range names {
 		repository := repositories[name]
 		if repository.OCI {
+			if name != "nvcf" {
+				continue
+			}
+			reference := strings.TrimPrefix(strings.TrimSuffix(repository.URL, "/"), "oci://")
+			registry, _, found := strings.Cut(reference, "/")
+			if !found || registry == "" {
+				return nil, fmt.Errorf("Helm repository %s has an invalid OCI reference", name)
+			}
+			commands = append(commands, resolvedInventoryHelmCommand{
+				Repository:    name,
+				Args:          []string{"registry", "login", registry, "--username", "$oauthtoken", "--password-stdin"},
+				Authenticated: true,
+			})
 			continue
 		}
 		args := []string{"repo", "add", repository.Name, repository.URL, "--force-update"}
-		var stdin io.Reader
-		if strings.HasPrefix(repository.URL, "https://helm.ngc.nvidia.com/") {
+		authenticated := strings.HasPrefix(repository.URL, "https://helm.ngc.nvidia.com/")
+		if authenticated {
 			args = append(args, "--username", "$oauthtoken", "--password-stdin")
-			stdin = strings.NewReader(ngcAPIKey + "\n")
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), resolvedInventoryTimeout)
-		command := exec.CommandContext(ctx, "helm", args...)
-		command.Env = env
-		command.Stdin = stdin
-		output, err := command.CombinedOutput()
-		cancel()
-		if err != nil {
-			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-				return fmt.Errorf("configure Helm repository %s: timed out after %s", repository.Name, resolvedInventoryTimeout)
-			}
-			return fmt.Errorf("configure Helm repository %s: %w\n%s", repository.Name, err, strings.TrimSpace(string(output)))
-		}
+		commands = append(commands, resolvedInventoryHelmCommand{
+			Repository:    name,
+			Args:          args,
+			Authenticated: authenticated,
+		})
 	}
-	return nil
+	return commands, nil
 }
 
 type helmfileRepository struct {
@@ -154,6 +193,20 @@ type helmfileBuildDocument struct {
 type localChartMetadata struct {
 	Name    string `yaml:"name"`
 	Version string `yaml:"version"`
+}
+
+type resolvedInventoryConfig struct {
+	SchemaVersion            int    `yaml:"schemaVersion"`
+	PublishedChartRepository string `yaml:"publishedChartRepository"`
+}
+
+type resolvedInventoryHelmSource struct {
+	Registry   string
+	Repository string
+}
+
+func (source resolvedInventoryHelmSource) reference() string {
+	return source.Registry + "/" + source.Repository
 }
 
 func writeResolvedStackInventory(repoRoot, outputPath string, source stackSourceRelease) error {
@@ -213,7 +266,11 @@ func collectResolvedStackInventory(repoRoot string, source stackSourceRelease, r
 	if err := copyResolvedInventoryInputs(repoRoot, copiedRepoRoot); err != nil {
 		return resolvedStackInventory{}, err
 	}
-	env, ngcAPIKey, err := prepareResolvedInventoryEnvironment(copiedRepoRoot)
+	config, err := loadResolvedInventoryConfig(copiedRepoRoot)
+	if err != nil {
+		return resolvedStackInventory{}, err
+	}
+	env, renderSource, ngcAPIKey, err := prepareResolvedInventoryEnvironment(copiedRepoRoot)
 	if err != nil {
 		return resolvedStackInventory{}, err
 	}
@@ -234,6 +291,8 @@ func collectResolvedStackInventory(repoRoot string, source stackSourceRelease, r
 			source,
 			state,
 			env,
+			renderSource,
+			config.PublishedChartRepository,
 			ngcAPIKey,
 			runner,
 		)
@@ -313,20 +372,74 @@ func copyResolvedInventoryStack(source, destination string) error {
 	})
 }
 
-func prepareResolvedInventoryEnvironment(copiedRepoRoot string) ([]string, string, error) {
+func loadResolvedInventoryConfig(repoRoot string) (resolvedInventoryConfig, error) {
+	raw, err := os.ReadFile(filepath.Join(repoRoot, filepath.FromSlash(resolvedInventoryConfigPath)))
+	if err != nil {
+		return resolvedInventoryConfig{}, fmt.Errorf("read resolved inventory config: %w", err)
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	decoder.KnownFields(true)
+	var config resolvedInventoryConfig
+	if err := decoder.Decode(&config); err != nil {
+		return resolvedInventoryConfig{}, fmt.Errorf("parse resolved inventory config: %w", err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err != nil {
+			return resolvedInventoryConfig{}, fmt.Errorf("parse resolved inventory config: %w", err)
+		}
+		return resolvedInventoryConfig{}, fmt.Errorf("resolved inventory config contains multiple YAML documents")
+	}
+	if config.SchemaVersion != 1 {
+		return resolvedInventoryConfig{}, fmt.Errorf("resolved inventory config schemaVersion is %d, want 1", config.SchemaVersion)
+	}
+	repository := config.PublishedChartRepository
+	if repository == "" || repository != strings.TrimSpace(repository) || strings.HasSuffix(repository, "/") ||
+		!strings.HasPrefix(repository, "https://") || strings.ContainsAny(repository, "{}$?#") {
+		return resolvedInventoryConfig{}, fmt.Errorf("resolved inventory publishedChartRepository must be a resolved HTTPS repository without a trailing slash")
+	}
+	return config, nil
+}
+
+func parseResolvedInventoryHelmSource(raw string) (resolvedInventoryHelmSource, error) {
+	value := strings.TrimRight(strings.TrimSpace(raw), "/")
+	if value == "" {
+		return resolvedInventoryHelmSource{}, fmt.Errorf("NVCF_RELEASE_HELM_REGISTRY is required to render release charts")
+	}
+	if strings.Contains(value, "://") || strings.ContainsAny(value, "@?# \t\r\n") {
+		return resolvedInventoryHelmSource{}, fmt.Errorf("NVCF_RELEASE_HELM_REGISTRY must use host/repository format without credentials or a URL scheme")
+	}
+	registry, repository, found := strings.Cut(value, "/")
+	if !found || registry == "" || repository == "" {
+		return resolvedInventoryHelmSource{}, fmt.Errorf("NVCF_RELEASE_HELM_REGISTRY must include a registry host and repository path")
+	}
+	for _, segment := range strings.Split(repository, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return resolvedInventoryHelmSource{}, fmt.Errorf("NVCF_RELEASE_HELM_REGISTRY contains an invalid repository path")
+		}
+	}
+	return resolvedInventoryHelmSource{Registry: registry, Repository: repository}, nil
+}
+
+func prepareResolvedInventoryEnvironment(copiedRepoRoot string) ([]string, resolvedInventoryHelmSource, string, error) {
 	ngcAPIKey := strings.TrimSpace(os.Getenv("NVCF_RELEASE_NGC_API_KEY"))
 	if ngcAPIKey == "" {
 		ngcAPIKey = strings.TrimSpace(os.Getenv("NGC_API_KEY"))
 	}
 	if ngcAPIKey == "" {
-		return nil, "", fmt.Errorf("NVCF_RELEASE_NGC_API_KEY is required to render public NGC charts")
+		return nil, resolvedInventoryHelmSource{}, "", fmt.Errorf("NVCF_RELEASE_NGC_API_KEY is required to render release charts")
+	}
+	renderSource, err := parseResolvedInventoryHelmSource(os.Getenv("NVCF_RELEASE_HELM_REGISTRY"))
+	if err != nil {
+		return nil, resolvedInventoryHelmSource{}, "", err
 	}
 	values, err := yaml.Marshal(map[string]any{
 		"global": map[string]any{
 			"domain": "inventory.example.invalid",
 			"helm": map[string]any{
 				"sources": map[string]any{
-					"url": "https://helm.ngc.nvidia.com/nvidia/nvcf",
+					"registry":   renderSource.Registry,
+					"repository": renderSource.Repository,
 				},
 			},
 			"image": map[string]any{
@@ -351,36 +464,36 @@ func prepareResolvedInventoryEnvironment(copiedRepoRoot string) ([]string, strin
 		},
 	})
 	if err != nil {
-		return nil, "", fmt.Errorf("marshal inventory-only stack environment: %w", err)
+		return nil, resolvedInventoryHelmSource{}, "", fmt.Errorf("marshal inventory-only stack environment: %w", err)
 	}
 	for _, stack := range []string{"self-managed", "nvcf-compute-plane", "observability"} {
 		environmentPath := filepath.Join(copiedRepoRoot, "deploy", "stacks", stack, "environments", "inventory.yaml")
 		if err := os.MkdirAll(filepath.Dir(environmentPath), 0o755); err != nil {
-			return nil, "", err
+			return nil, resolvedInventoryHelmSource{}, "", err
 		}
 		if err := os.WriteFile(environmentPath, values, 0o600); err != nil {
-			return nil, "", fmt.Errorf("write %s inventory-only stack environment: %w", stack, err)
+			return nil, resolvedInventoryHelmSource{}, "", fmt.Errorf("write %s inventory-only stack environment: %w", stack, err)
 		}
 	}
 	secretsPath := filepath.Join(copiedRepoRoot, "deploy", "stacks", "self-managed", "secrets", "inventory-secrets.yaml")
 	if err := os.MkdirAll(filepath.Dir(secretsPath), 0o755); err != nil {
-		return nil, "", fmt.Errorf("create inventory-only stack secrets directory: %w", err)
+		return nil, resolvedInventoryHelmSource{}, "", fmt.Errorf("create inventory-only stack secrets directory: %w", err)
 	}
 	if err := os.WriteFile(secretsPath, []byte("{}\n"), 0o600); err != nil {
-		return nil, "", fmt.Errorf("write inventory-only stack secrets: %w", err)
+		return nil, resolvedInventoryHelmSource{}, "", fmt.Errorf("write inventory-only stack secrets: %w", err)
 	}
 	registrationDir := filepath.Join(copiedRepoRoot, "deploy", "stacks", "nvcf-compute-plane", "inventory-registration")
 	if err := os.MkdirAll(registrationDir, 0o755); err != nil {
-		return nil, "", err
+		return nil, resolvedInventoryHelmSource{}, "", err
 	}
 	registration := []byte("clusterName: inventory\nclusterID: 00000000-0000-0000-0000-000000000001\nclusterGroupID: 00000000-0000-0000-0000-000000000002\nncaID: inventory\nregion: inventory\nselfManaged:\n  identitySource: psat\n  icmsServiceURL: http://icms.example.invalid:8080\n  revalServiceURL: http://reval.example.invalid:8080\n  natsURL: nats://nats.example.invalid:4222\n")
 	if err := os.WriteFile(filepath.Join(registrationDir, "inventory-register-values.yaml"), registration, 0o600); err != nil {
-		return nil, "", fmt.Errorf("write inventory-only registration values: %w", err)
+		return nil, resolvedInventoryHelmSource{}, "", fmt.Errorf("write inventory-only registration values: %w", err)
 	}
 	helmRoot := filepath.Join(copiedRepoRoot, ".helm")
 	for _, path := range []string{filepath.Join(helmRoot, "cache"), filepath.Join(helmRoot, "config"), filepath.Join(helmRoot, "data")} {
 		if err := os.MkdirAll(path, 0o700); err != nil {
-			return nil, "", err
+			return nil, resolvedInventoryHelmSource{}, "", err
 		}
 	}
 	env := append([]string{}, os.Environ()...)
@@ -393,7 +506,7 @@ func prepareResolvedInventoryEnvironment(copiedRepoRoot string) ([]string, strin
 		"NCA_ID":           "inventory",
 		"OUTPUT_DIR":       registrationDir,
 	})
-	return env, ngcAPIKey, nil
+	return env, renderSource, ngcAPIKey, nil
 }
 
 func setResolvedInventoryEnvironment(env []string, values map[string]string) []string {
@@ -422,6 +535,8 @@ func collectResolvedInventoryState(
 	source stackSourceRelease,
 	state resolvedInventoryState,
 	env []string,
+	renderSource resolvedInventoryHelmSource,
+	publishedChartRepository string,
 	ngcAPIKey string,
 	runner resolvedInventoryCommandRunner,
 ) ([]helmfileRelease, map[string][]byte, error) {
@@ -443,7 +558,10 @@ func collectResolvedInventoryState(
 	if err != nil {
 		return nil, nil, err
 	}
-	releases, err := mergeAndResolveHelmfileReleases(copiedRepoRoot, stateFile, source, baseList, fullList, repositories)
+	if err := validateResolvedInventoryRenderRepository(repositories, renderSource); err != nil {
+		return nil, nil, err
+	}
+	releases, err := mergeAndResolveHelmfileReleases(copiedRepoRoot, stateFile, source, baseList, fullList, repositories, publishedChartRepository)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -517,6 +635,7 @@ func mergeAndResolveHelmfileReleases(
 	baseRaw []byte,
 	fullRaw []byte,
 	repositories map[string]helmfileRepository,
+	publishedChartRepository string,
 ) ([]helmfileRelease, error) {
 	base, err := decodeHelmfileReleaseList(baseRaw)
 	if err != nil {
@@ -547,7 +666,7 @@ func mergeAndResolveHelmfileReleases(
 		} else {
 			full[i].Enabled = false
 		}
-		if err := resolveHelmfileChartReference(copiedRepoRoot, stateFile, source, repositories, &full[i]); err != nil {
+		if err := resolveHelmfileChartReference(copiedRepoRoot, stateFile, source, repositories, publishedChartRepository, &full[i]); err != nil {
 			return nil, fmt.Errorf("resolve release %s chart: %w", full[i].Name, err)
 		}
 	}
@@ -562,6 +681,21 @@ func mergeAndResolveHelmfileReleases(
 		return nil, err
 	}
 	return parseHelmfileReleaseList(raw)
+}
+
+func validateResolvedInventoryRenderRepository(repositories map[string]helmfileRepository, source resolvedInventoryHelmSource) error {
+	repository, ok := repositories["nvcf"]
+	if !ok {
+		return fmt.Errorf("built Helmfile state has no nvcf repository")
+	}
+	if !repository.OCI {
+		return fmt.Errorf("built Helmfile nvcf repository must use OCI for release inventory rendering")
+	}
+	reference := strings.TrimPrefix(strings.TrimSuffix(repository.URL, "/"), "oci://")
+	if reference != source.reference() {
+		return fmt.Errorf("built Helmfile nvcf repository does not match NVCF_RELEASE_HELM_REGISTRY")
+	}
+	return nil
 }
 
 func parseHelmfileRepositories(raw []byte) (map[string]helmfileRepository, error) {
@@ -594,6 +728,7 @@ func resolveHelmfileChartReference(
 	stateFile string,
 	source stackSourceRelease,
 	repositories map[string]helmfileRepository,
+	publishedChartRepository string,
 	release *helmfileRelease,
 ) error {
 	chart := strings.TrimSpace(release.Chart)
@@ -638,6 +773,10 @@ func resolveHelmfileChartReference(
 	repository, ok := repositories[alias]
 	if !ok {
 		return fmt.Errorf("chart %q uses unknown repository alias %s", chart, alias)
+	}
+	if alias == "nvcf" {
+		release.Chart = publishedChartRepository + "/" + name
+		return nil
 	}
 	base := strings.TrimSuffix(repository.URL, "/")
 	if repository.OCI && !strings.Contains(base, "://") {

--- a/tools/docs-version-sync/resolved_inventory_publish_test.go
+++ b/tools/docs-version-sync/resolved_inventory_publish_test.go
@@ -7,9 +7,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
+
+const testPublishedChartRepository = "https://helm.example.test/nvcf"
 
 func TestVerifyResolvedInventoryCheckoutRequiresTaggedCleanStack(t *testing.T) {
 	repo := initTestGitRepo(t)
@@ -39,7 +42,7 @@ func TestMergeAndResolveHelmfileReleasesPreservesOptionalStatus(t *testing.T) {
 		{Name: "required", Chart: "nvcf/required", Version: "1.0.0", Enabled: true, Installed: true},
 		{Name: "optional", Chart: "../charts/local", Enabled: true, Installed: true},
 	})
-	built := []byte("repositories:\n  - name: nvcf\n    url: nvcr.io/nvidia/nvcf\n    oci: true\n")
+	built := []byte("repositories:\n  - name: nvcf\n    url: registry.example.test/release/charts\n    oci: true\n")
 	repositories, err := parseHelmfileRepositories(built)
 	if err != nil {
 		t.Fatal(err)
@@ -50,7 +53,7 @@ func TestMergeAndResolveHelmfileReleasesPreservesOptionalStatus(t *testing.T) {
 		Commit:  strings.Repeat("a", 40),
 	}
 
-	releases, err := mergeAndResolveHelmfileReleases(repo, stateFile, source, base, full, repositories)
+	releases, err := mergeAndResolveHelmfileReleases(repo, stateFile, source, base, full, repositories, testPublishedChartRepository)
 	if err != nil {
 		t.Fatalf("mergeAndResolveHelmfileReleases failed: %v", err)
 	}
@@ -61,7 +64,7 @@ func TestMergeAndResolveHelmfileReleasesPreservesOptionalStatus(t *testing.T) {
 	for _, release := range releases {
 		byName[release.Name] = release
 	}
-	if got := byName["required"].Chart; got != "oci://nvcr.io/nvidia/nvcf/required" {
+	if got := byName["required"].Chart; got != testPublishedChartRepository+"/required" {
 		t.Fatalf("required chart = %q", got)
 	}
 	optional := byName["optional"]
@@ -76,7 +79,9 @@ func TestMergeAndResolveHelmfileReleasesPreservesOptionalStatus(t *testing.T) {
 
 func TestCollectResolvedStackInventoryBuildsEveryPlane(t *testing.T) {
 	t.Setenv("NVCF_RELEASE_NGC_API_KEY", "test-api-key")
+	t.Setenv("NVCF_RELEASE_HELM_REGISTRY", "registry.example.test/release/charts")
 	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, filepath.FromSlash(resolvedInventoryConfigPath)), "schemaVersion: 1\npublishedChartRepository: "+testPublishedChartRepository+"\n")
 	for _, state := range resolvedInventoryStates {
 		writeFile(t, filepath.Join(repo, filepath.FromSlash(state.path)), "releases: []\n")
 	}
@@ -107,6 +112,91 @@ func TestCollectResolvedStackInventoryBuildsEveryPlane(t *testing.T) {
 	}
 	if runner.prepareCalls != len(resolvedInventoryStates) {
 		t.Fatalf("repository preparation calls = %d, want %d", runner.prepareCalls, len(resolvedInventoryStates))
+	}
+}
+
+func TestParseResolvedInventoryHelmSource(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    resolvedInventoryHelmSource
+		wantErr string
+	}{
+		{
+			name: "registry and nested repository",
+			raw:  " registry.example.test/team/charts/ ",
+			want: resolvedInventoryHelmSource{Registry: "registry.example.test", Repository: "team/charts"},
+		},
+		{name: "missing", wantErr: "is required"},
+		{name: "URL scheme", raw: "https://registry.example.test/team/charts", wantErr: "without credentials or a URL scheme"},
+		{name: "missing repository", raw: "registry.example.test", wantErr: "registry host and repository path"},
+		{name: "empty segment", raw: "registry.example.test/team//charts", wantErr: "invalid repository path"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parseResolvedInventoryHelmSource(test.raw)
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("error = %v, want substring %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Fatalf("source = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestLoadResolvedInventoryConfig(t *testing.T) {
+	repo := t.TempDir()
+	configPath := filepath.Join(repo, filepath.FromSlash(resolvedInventoryConfigPath))
+	writeFile(t, configPath, "schemaVersion: 1\npublishedChartRepository: "+testPublishedChartRepository+"\n")
+	config, err := loadResolvedInventoryConfig(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.PublishedChartRepository != testPublishedChartRepository {
+		t.Fatalf("published repository = %q", config.PublishedChartRepository)
+	}
+
+	writeFile(t, configPath, "schemaVersion: 1\npublishedChartRepository: oci://registry.example.test/charts\n")
+	if _, err := loadResolvedInventoryConfig(repo); err == nil || !strings.Contains(err.Error(), "resolved HTTPS repository") {
+		t.Fatalf("non-HTTPS repository error = %v", err)
+	}
+}
+
+func TestResolvedInventoryRepositoryCommandsAuthenticatesNVCFRegistry(t *testing.T) {
+	commands, err := resolvedInventoryRepositoryCommands(map[string]helmfileRepository{
+		"nvcf": {
+			Name: "nvcf", URL: "registry.example.test/release/charts", OCI: true,
+		},
+		"public": {
+			Name: "public", URL: "https://charts.example.test", OCI: false,
+		},
+		"unrelated-oci": {
+			Name: "unrelated-oci", URL: "registry.example.test/public/charts", OCI: true,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []resolvedInventoryHelmCommand{
+		{
+			Repository:    "nvcf",
+			Args:          []string{"registry", "login", "registry.example.test", "--username", "$oauthtoken", "--password-stdin"},
+			Authenticated: true,
+		},
+		{
+			Repository: "public",
+			Args:       []string{"repo", "add", "public", "https://charts.example.test", "--force-update"},
+		},
+	}
+	if !reflect.DeepEqual(commands, want) {
+		t.Fatalf("commands = %#v, want %#v", commands, want)
 	}
 }
 
@@ -147,6 +237,9 @@ func (runner *fakeResolvedInventoryRunner) PrepareRepositories(_ []string, repos
 	if _, ok := repositories["nvcf"]; !ok {
 		runner.t.Fatal("nvcf repository was not prepared")
 	}
+	if !repositories["nvcf"].OCI {
+		runner.t.Fatal("nvcf repository was not prepared as OCI")
+	}
 	return nil
 }
 
@@ -165,7 +258,7 @@ func (runner *fakeResolvedInventoryRunner) Output(_ string, env []string, args .
 	case "list":
 		return mustJSON(runner.t, releases), nil
 	case "build":
-		return []byte("repositories:\n  - name: nvcf\n    url: nvcr.io/nvidia/nvcf\n    oci: true\n"), nil
+		return []byte("repositories:\n  - name: nvcf\n    url: registry.example.test/release/charts\n    oci: true\n"), nil
 	case "template":
 		runner.templateCalls++
 		outputDir := argumentAfter(runner.t, args, "--output-dir")


### PR DESCRIPTION
# TL;DR

Render self-managed stack inventories from the authenticated release OCI registry, then publish canonical public chart references. This removes the circular dependency on public chart promotion that left the v0.15.0 GitHub release without an inventory asset.

## Additional Details

The inventory publisher added in #1742 rendered pinned charts directly from the public NGC catalog. The first tagged run failed because `helm-nvcf-cassandra` 0.20.3 was available to the release pipeline but had not yet reached the public chart index. The GitHub release was created without `nvcf-self-managed-stack-inventory.json`, so #1760 cannot safely make GitHub release assets the only docs input.

The former self-managed stack release pipeline avoided this ordering problem. It rendered the packaged stack from the authenticated release registry first, extracted the artifact set, and handled public distribution separately. This change restores that separation in the GitHub-native flow.

```mermaid
sequenceDiagram
    participant Tag as Stack tag workflow
    participant Publisher as Inventory publisher
    participant Registry as Authenticated release OCI registry
    participant Helmfile
    participant Release as GitHub release
    participant Docs as Docs catalog updater

    Tag->>Publisher: Generate inventory at tagged commit
    Publisher->>Registry: Authenticate with release credentials
    Publisher->>Helmfile: Render all stack planes from pinned OCI charts
    Helmfile-->>Publisher: Per-release manifests and chart versions
    Publisher->>Publisher: Canonicalize NVCF charts to public catalog references
    Publisher->>Release: Upload immutable inventory asset
    Release-->>Docs: Serve asset by tag and commit
```

Change justification:

- `.github/workflows/release-tags.yml` passes the existing release registry secret alongside the existing NGC key. The value remains in GitHub Actions secret storage.
- `deploy/stacks/self-managed/release-inventory.yaml` versions the public chart destination with the composite stack release. The self-managed stack owns the inventory asset even though the render covers control-plane, compute-plane, and observability states. This stack-owned contract also ensures the fix cuts a new patch release instead of leaving recovery tied to the broken v0.15.0 tag.
- `tools/docs-version-sync/resolved_inventory_publish.go` validates the release source, logs Helm into its OCI host using password input, renders every stack state from that source, and replaces only the `nvcf` chart alias with the configured public repository in the published inventory. Local charts and unrelated repositories keep their existing resolution behavior.
- The Go and release-helper tests cover registry parsing, OCI authentication arguments, source validation, canonical public references, config validation, and workflow secret wiring.

No runtime Helmfile values or deployed workloads change. All three stack planes use the same temporary inventory-only source during release rendering.

Related work:

- #1742 added the producer and release asset contract.
- #1749 consumes immutable GitHub inventory assets.
- #1760 will remove the legacy path after a complete GitHub inventory is published.

## For the Reviewer

Please focus on the separation between `renderSource` and `publishedChartRepository` in `resolved_inventory_publish.go`. The private render location must never be serialized into the public inventory.

The failed automatic run is https://github.com/NVIDIA/nvcf/actions/runs/34534402681.

## For QA

QA is not needed for deployed services. Validation performed:

- `go test ./...` in `tools/docs-version-sync`
- `go vet ./...` in `tools/docs-version-sync`
- `python3 -m unittest tools.ci.test-github-release`
- `./tools/ci/check-doc-version-sync`
- `git diff --check`

A live end-to-end registry render was not run locally because the release registry credentials are available only to GitHub Actions. The next automatically created self-managed stack tag is the production validation of the credentialed path.

## Issues

Closes #1766
Relates to #279

## Dependencies

No new or updated third-party dependencies. No license review or NOTICE change is required.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release inventory metadata identifying the published Helm chart repository.
  * Release publishing now supports configurable Helm chart repositories and OCI registries.
  * Added authenticated access for private OCI registries during chart publication.
  * Helm chart references are automatically mapped to the configured published HTTPS repository.

* **Bug Fixes**
  * Improved validation for configured chart repositories and generated release metadata.

* **Tests**
  * Expanded coverage for registry configuration, repository validation, authentication, and release inventory generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->