### PR TITLE
fix(release): authenticate inventory source before build

### DIFF
--- a/deploy/stacks/self-managed/release-inventory.yaml
+++ b/deploy/stacks/self-managed/release-inventory.yaml
@@ -2,4 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 schemaVersion: 1
+# The release workflow authenticates to its chart source before rendering.
 publishedChartRepository: https://helm.ngc.nvidia.com/nvidia/nvcf

--- a/tools/docs-version-sync/resolved_inventory_publish.go
+++ b/tools/docs-version-sync/resolved_inventory_publish.go
@@ -274,6 +274,15 @@ func collectResolvedStackInventory(repoRoot string, source stackSourceRelease, r
 	if err != nil {
 		return resolvedStackInventory{}, err
 	}
+	if err := runner.PrepareRepositories(env, map[string]helmfileRepository{
+		"nvcf": {
+			Name: "nvcf",
+			URL:  renderSource.reference(),
+			OCI:  true,
+		},
+	}, ngcAPIKey); err != nil {
+		return resolvedStackInventory{}, fmt.Errorf("authenticate release chart registry: %w", err)
+	}
 
 	planes := make(map[string]*resolvedInventoryPlaneInput, len(resolvedStackPlanes))
 	for _, name := range resolvedStackPlanes {
@@ -565,8 +574,16 @@ func collectResolvedInventoryState(
 	if err != nil {
 		return nil, nil, err
 	}
-	if err := runner.PrepareRepositories(env, repositories, ngcAPIKey); err != nil {
-		return nil, nil, err
+	publicRepositories := make(map[string]helmfileRepository, len(repositories))
+	for name, repository := range repositories {
+		if name != "nvcf" {
+			publicRepositories[name] = repository
+		}
+	}
+	if len(publicRepositories) != 0 {
+		if err := runner.PrepareRepositories(env, publicRepositories, ngcAPIKey); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	if err := os.MkdirAll(renderDir, 0o755); err != nil {

--- a/tools/docs-version-sync/resolved_inventory_publish_test.go
+++ b/tools/docs-version-sync/resolved_inventory_publish_test.go
@@ -110,8 +110,12 @@ func TestCollectResolvedStackInventoryBuildsEveryPlane(t *testing.T) {
 	if runner.templateCalls != len(resolvedInventoryStates) {
 		t.Fatalf("template calls = %d, want %d", runner.templateCalls, len(resolvedInventoryStates))
 	}
-	if runner.prepareCalls != len(resolvedInventoryStates) {
-		t.Fatalf("repository preparation calls = %d, want %d", runner.prepareCalls, len(resolvedInventoryStates))
+	if runner.prepareCalls != 2 {
+		t.Fatalf("repository preparation calls = %d, want source and public repository preparation", runner.prepareCalls)
+	}
+	wantPrefix := []string{"prepare-source", "list", "list", "build", "prepare-public", "template"}
+	if len(runner.operations) < len(wantPrefix) || !reflect.DeepEqual(runner.operations[:len(wantPrefix)], wantPrefix) {
+		t.Fatalf("operation prefix = %v, want %v", runner.operations, wantPrefix)
 	}
 }
 
@@ -223,9 +227,12 @@ func mustJSON(t *testing.T, value any) []byte {
 }
 
 type fakeResolvedInventoryRunner struct {
-	t             *testing.T
-	prepareCalls  int
-	templateCalls int
+	t              *testing.T
+	prepareCalls   int
+	templateCalls  int
+	sourcePrepared bool
+	publicPrepared bool
+	operations     []string
 }
 
 func (runner *fakeResolvedInventoryRunner) PrepareRepositories(_ []string, repositories map[string]helmfileRepository, ngcAPIKey string) error {
@@ -234,12 +241,23 @@ func (runner *fakeResolvedInventoryRunner) PrepareRepositories(_ []string, repos
 	if ngcAPIKey != "test-api-key" {
 		runner.t.Fatalf("NGC API key = %q", ngcAPIKey)
 	}
-	if _, ok := repositories["nvcf"]; !ok {
-		runner.t.Fatal("nvcf repository was not prepared")
+	if repository, ok := repositories["nvcf"]; ok {
+		if len(repositories) != 1 || !repository.OCI || repository.URL != "registry.example.test/release/charts" {
+			runner.t.Fatalf("source repositories = %#v", repositories)
+		}
+		runner.sourcePrepared = true
+		runner.operations = append(runner.operations, "prepare-source")
+		return nil
 	}
-	if !repositories["nvcf"].OCI {
-		runner.t.Fatal("nvcf repository was not prepared as OCI")
+	if repository, ok := repositories["public"]; ok {
+		if len(repositories) != 1 || repository.OCI || repository.URL != "https://charts.example.test" {
+			runner.t.Fatalf("public repositories = %#v", repositories)
+		}
+		runner.publicPrepared = true
+		runner.operations = append(runner.operations, "prepare-public")
+		return nil
 	}
+	runner.t.Fatalf("unexpected repositories = %#v", repositories)
 	return nil
 }
 
@@ -253,13 +271,24 @@ func (runner *fakeResolvedInventoryRunner) Output(_ string, env []string, args .
 	}
 	stateFile := argumentAfter(runner.t, args, "--file")
 	action := resolvedInventoryAction(args)
+	if (action == "list" || action == "build") && !runner.sourcePrepared {
+		runner.t.Fatalf("Helmfile %s ran before source-registry authentication", action)
+	}
+	runner.operations = append(runner.operations, action)
 	releases := fakeResolvedInventoryReleases(stateFile, hasResolvedInventoryFullOverrides(args))
 	switch action {
 	case "list":
 		return mustJSON(runner.t, releases), nil
 	case "build":
-		return []byte("repositories:\n  - name: nvcf\n    url: registry.example.test/release/charts\n    oci: true\n"), nil
+		built := "repositories:\n  - name: nvcf\n    url: registry.example.test/release/charts\n    oci: true\n"
+		if strings.Contains(filepath.ToSlash(stateFile), "self-managed/helmfile.d/01-") {
+			built += "  - name: public\n    url: https://charts.example.test\n    oci: false\n"
+		}
+		return []byte(built), nil
 	case "template":
+		if strings.Contains(filepath.ToSlash(stateFile), "self-managed/helmfile.d/01-") && !runner.publicPrepared {
+			runner.t.Fatal("Helmfile template ran before public repository preparation")
+		}
 		runner.templateCalls++
 		outputDir := argumentAfter(runner.t, args, "--output-dir")
 		for _, release := range releases {


### PR DESCRIPTION
# TL;DR

Authenticate the self-managed release chart source before Helmfile evaluates stack state. This allows the tag workflow to attach the public resolved inventory consumed by docs version sync.

## Additional Details

The v0.15.1 tag job failed because `helmfile build` fetched an OCI chart before `helm registry login` ran. The source registry login now happens once before any Helmfile list or build command. Other repositories discovered from the built state are configured afterward, before template rendering.

The public release-inventory config now documents that ordering. Keeping this small change under the self-managed stack path also ensures release routing creates a successor to the assetless v0.15.1 release, so the corrected publisher is exercised automatically.

Failure evidence: https://github.com/NVIDIA/nvcf/actions/runs/34540649784/job/103082300901

## For the Reviewer

Please focus on the command ordering in `collectResolvedStackInventory` and the regression assertion in the fake runner.

## For QA

QA is not needed. A subsequent self-managed stack tag will exercise the authenticated render and attach the release inventory.

Tests run:

- `go test ./...` in `tools/docs-version-sync`
- `python3 tools/ci/test-github-release.py`
- `git diff --check`

## Customer Release Notes

Not customer visible.

## Plan Summary

Not applicable.

## Usage

Not applicable.

## Notes

This PR does not retry the failed v0.15.1 workflow. Release automation should create a later self-managed stack release after this fix merges.

## References

- https://github.com/NVIDIA/nvcf/issues/279

## Related Pull Requests

- https://github.com/NVIDIA/nvcf/pull/1767
- https://github.com/NVIDIA/nvcf/pull/1760

## Dependencies

None. No license or NOTICE changes are required.

## Issues

Fixes #1773

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release inventory publishing by authenticating to the chart source before processing states.
  - Public chart repositories are now prepared correctly for each state while keeping the authenticated source handling separate.
  - Ensured repository preparation occurs before release templates are rendered, improving reliability of generated release inventories.

- **Documentation**
  - Added clarification to the release workflow documentation describing chart-source authentication before rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->