### PR TITLE
fix(stack): pin remediated service charts

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -62,7 +62,7 @@ releases:
     condition: icms.enabled
 
   - name: api
-    version: 1.25.6
+    version: 1.25.7
     namespace: nvcf
     inherit:
       - template: service
@@ -77,7 +77,7 @@ releases:
       - template: service
 
   - name: invocation-service
-    version: 1.6.0
+    version: 1.6.1
     namespace: nvcf
     inherit:
       - template: service
@@ -94,7 +94,7 @@ releases:
 
   - name: ratelimiter
     chart: nvcf/helm-nvcf-rate-limiter
-    version: 1.2.0
+    version: 1.2.1
     namespace: nvcf
     condition: rateLimiter.enabled
     values:
@@ -159,7 +159,7 @@ releases:
 
   - name: nats-auth-callout-service
     chart: nvcf/helm-nvcf-nats-auth-callout-service
-    version: 1.1.3
+    version: 1.1.4
     namespace: nats-system
     values:
       - ../global.yaml.gotmpl

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -159,7 +159,7 @@ releases:
 
   - name: nats-auth-callout-service
     chart: nvcf/helm-nvcf-nats-auth-callout-service
-    version: 1.1.4
+    version: 1.2.0
     namespace: nats-system
     values:
       - ../global.yaml.gotmpl


### PR DESCRIPTION
## Why

The self-managed stack needs to advance to the chart releases that carry the refreshed Service OSS, HTTP invocation, rate limiter, and NATS authentication images.

This change is separate from the chart source update because the stack must not consume chart versions until those chart releases exist.

## What changed

Updated the self-managed core Helmfile pins:

- Cloud Functions API from 1.25.6 to 1.25.7
- HTTP invocation from 1.6.0 to 1.6.1
- Rate limiter from 1.2.0 to 1.2.1
- NATS authentication from 1.1.3 to 1.2.0

All four chart versions are published.

## Customer Release Notes

Updates the self-managed stack to chart releases containing refreshed Service OSS, invocation, rate limiter, and NATS authentication images.

## Plan Summary

Four Helmfile chart version pins change. No resources, values, or deployment ordering change.

## Usage

Not applicable.

## Testing

- `env GOCACHE=/tmp/nvcf-stack-pin-resolver-go-cache go test -C tools/stack-pin-resolver ./...`
- `tools/ci/stack-pin-resolver --audit`
- `make test` in `deploy/stacks/self-managed`

Pulse validation is performed after this stack pin update and before final NGC catalog publication.

## Notes

All four chart releases are published. Pulse validation follows this stack pin update and precedes final NGC catalog publication.

## Issues

Relates to #1768
Relates to #1769
Relates to #1770
Relates to #1771

## References

None.

## Related Pull Requests

- #1775

## Dependencies

No new third-party dependencies. This Pull Request only updates existing chart version pins. NOTICE is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated chart versions for core platform services, including the API, invocation service, rate limiter, and NATS authentication service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->