### PR TITLE
fix(release): generate self-managed stack inventory

### DIFF
--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -176,6 +176,7 @@ jobs:
           cd "${RUNNER_TEMP}/inventory-source"
           "${RUNNER_TEMP}/docs-version-sync" \
             --generate-stack-inventory "${RUNNER_TEMP}/nvcf-self-managed-stack-inventory.json" \
+            --inventory-config "${GITHUB_WORKSPACE}/deploy/stacks/self-managed/release-inventory.yaml" \
             --stack-version "${version}" \
             --stack-source-tag "${INVENTORY_TAG}" \
             --stack-source-commit "${commit}"

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -59,7 +59,7 @@ jobs:
   # work.
   service-release:
     name: service release automation
-    if: github.ref_type != 'tag' && inputs.inventory_tag == ''
+    if: github.ref_type != 'tag' && (github.event_name != 'workflow_dispatch' || inputs.inventory_tag == '')
     runs-on: linux-amd64-cpu4
     permissions:
       contents: write
@@ -179,13 +179,6 @@ jobs:
             --stack-version "${version}" \
             --stack-source-tag "${INVENTORY_TAG}" \
             --stack-source-commit "${commit}"
-
-      - name: Upload validated inventory
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: self-managed-inventory-preflight
-          path: ${{ runner.temp }}/nvcf-self-managed-stack-inventory.json
-          if-no-files-found: error
 
   tag-release-notes:
     name: tag release notes

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -45,6 +45,10 @@ env:
   NV_GITHUB_TOKEN_CONFIGURED: ${{ secrets.NV_GITHUB_TOKEN != '' }}
   GH_TOKEN: ${{ secrets.NV_GITHUB_TOKEN || github.token }}
   GITHUB_TOKEN: ${{ secrets.NV_GITHUB_TOKEN || github.token }}
+  HELM_VERSION: "3.21.4"
+  HELM_SHA256: "61f88ab166748cb19604d7884cb100ae9ccb13804ddeb98e08af167eacbb6a14"
+  HELMFILE_VERSION: "1.1.9"
+  HELMFILE_SHA256: "ee71196bb12460905b8cbe0ef67b28db51ef681b777cc212d8c0956475b51905"
 
 jobs:
   # NVIDIA self-hosted runners. Eligible without a conditional because this
@@ -129,11 +133,6 @@ jobs:
           go-version-file: tools/go-toolchain/go.mod
 
       - name: Install inventory rendering tools
-        env:
-          HELM_VERSION: "3.21.4"
-          HELM_SHA256: "61f88ab166748cb19604d7884cb100ae9ccb13804ddeb98e08af167eacbb6a14"
-          HELMFILE_VERSION: "1.1.9"
-          HELMFILE_SHA256: "ee71196bb12460905b8cbe0ef67b28db51ef681b777cc212d8c0956475b51905"
         run: |
           set -euo pipefail
           cd "${RUNNER_TEMP}"
@@ -200,11 +199,6 @@ jobs:
 
       - name: Install inventory rendering tools
         if: startsWith(github.ref_name, 'deploy/stacks/self-managed/v')
-        env:
-          HELM_VERSION: "3.21.4"
-          HELM_SHA256: "61f88ab166748cb19604d7884cb100ae9ccb13804ddeb98e08af167eacbb6a14"
-          HELMFILE_VERSION: "1.1.9"
-          HELMFILE_SHA256: "ee71196bb12460905b8cbe0ef67b28db51ef681b777cc212d8c0956475b51905"
         run: |
           set -euo pipefail
           cd "${RUNNER_TEMP}"

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -16,6 +16,10 @@ on:
         description: Optional service id or service_name to scope the run to. Defaults to every registered service.
         required: false
         type: string
+      inventory_tag:
+        description: Optional self-managed stack tag to render and validate without publishing.
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -55,7 +59,7 @@ jobs:
   # work.
   service-release:
     name: service release automation
-    if: github.ref_type != 'tag'
+    if: github.ref_type != 'tag' && inputs.inventory_tag == ''
     runs-on: linux-amd64-cpu4
     permissions:
       contents: write
@@ -103,6 +107,85 @@ jobs:
             exit 1
           fi
           ./tools/ci/github-release auto
+
+  inventory-preflight:
+    name: self-managed inventory preflight
+    if: github.event_name == 'workflow_dispatch' && inputs.inventory_tag != ''
+    runs-on: linux-amd64-cpu4
+    permissions:
+      contents: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          token: ${{ github.token }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: tools/go-toolchain/go.mod
+
+      - name: Install inventory rendering tools
+        env:
+          HELM_VERSION: "3.21.4"
+          HELM_SHA256: "61f88ab166748cb19604d7884cb100ae9ccb13804ddeb98e08af167eacbb6a14"
+          HELMFILE_VERSION: "1.1.9"
+          HELMFILE_SHA256: "ee71196bb12460905b8cbe0ef67b28db51ef681b777cc212d8c0956475b51905"
+        run: |
+          set -euo pipefail
+          cd "${RUNNER_TEMP}"
+          curl -sSL --retry 3 -o helm.tar.gz \
+            "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+          echo "${HELM_SHA256}  helm.tar.gz" | sha256sum -c -
+          tar xzf helm.tar.gz linux-amd64/helm
+
+          curl -sSL --retry 3 -o helmfile.tar.gz \
+            "https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/helmfile_${HELMFILE_VERSION}_linux_amd64.tar.gz"
+          echo "${HELMFILE_SHA256}  helmfile.tar.gz" | sha256sum -c -
+          tar xzf helmfile.tar.gz helmfile
+
+          mkdir -p "${RUNNER_TEMP}/bin"
+          mv linux-amd64/helm helmfile "${RUNNER_TEMP}/bin/"
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+
+      - name: Build inventory renderer
+        working-directory: tools/docs-version-sync
+        run: go build -o "${RUNNER_TEMP}/docs-version-sync" .
+
+      - name: Render tagged inventory without publishing
+        env:
+          INVENTORY_TAG: ${{ inputs.inventory_tag }}
+          NVCF_RELEASE_HELM_REGISTRY: ${{ secrets.NCP_DEV_REGISTRY }}
+          NVCF_RELEASE_NGC_API_KEY: ${{ secrets.NGC_NCP_DEV_KEY }}
+        run: |
+          set -euo pipefail
+          case "${INVENTORY_TAG}" in
+            deploy/stacks/self-managed/v*) ;;
+            *)
+              echo "ERROR: inventory_tag must be a deploy/stacks/self-managed/v* tag." >&2
+              exit 1
+              ;;
+          esac
+          version="${INVENTORY_TAG#deploy/stacks/self-managed/v}"
+          commit="$(git rev-list -n 1 "${INVENTORY_TAG}")"
+          test -n "${commit}"
+          git worktree add --detach "${RUNNER_TEMP}/inventory-source" "${INVENTORY_TAG}"
+          cd "${RUNNER_TEMP}/inventory-source"
+          "${RUNNER_TEMP}/docs-version-sync" \
+            --generate-stack-inventory "${RUNNER_TEMP}/nvcf-self-managed-stack-inventory.json" \
+            --stack-version "${version}" \
+            --stack-source-tag "${INVENTORY_TAG}" \
+            --stack-source-commit "${commit}"
+
+      - name: Upload validated inventory
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: self-managed-inventory-preflight
+          path: ${{ runner.temp }}/nvcf-self-managed-stack-inventory.json
+          if-no-files-found: error
 
   tag-release-notes:
     name: tag release notes

--- a/deploy/stacks/self-managed/release-inventory.yaml
+++ b/deploy/stacks/self-managed/release-inventory.yaml
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 schemaVersion: 1
-# The release workflow authenticates before rendering and permits states that
-# contain only third-party or local charts.
+# NVCA is released independently in the public BYOC catalog. It is not mirrored
+# into the composite stack's release chart repository.
+renderChartRepositoryOverrides:
+  nvcf-compute-plane: nvcr.io/nvidia/nvcf-byoc
+# The release workflow authenticates each render source before evaluating the
+# stack and permits states that contain only third-party or local charts.
 publishedChartRepository: https://helm.ngc.nvidia.com/nvidia/nvcf

--- a/deploy/stacks/self-managed/release-inventory.yaml
+++ b/deploy/stacks/self-managed/release-inventory.yaml
@@ -2,5 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 schemaVersion: 1
-# The release workflow authenticates to its chart source before rendering.
+# The release workflow authenticates before rendering and permits states that
+# contain only third-party or local charts.
 publishedChartRepository: https://helm.ngc.nvidia.com/nvidia/nvcf

--- a/deploy/stacks/self-managed/release-inventory.yaml
+++ b/deploy/stacks/self-managed/release-inventory.yaml
@@ -2,10 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 schemaVersion: 1
-# NVCA is released independently in the public BYOC catalog. It is not mirrored
-# into the composite stack's release chart repository.
-renderChartRepositoryOverrides:
-  nvcf-compute-plane: nvcr.io/nvidia/nvcf-byoc
-# The release workflow authenticates each render source before evaluating the
-# stack and permits states that contain only third-party or local charts.
+# NVCA is released independently and is not mirrored into the composite stack's
+# release chart repository. Render the pinned chart from its immutable public
+# GitHub release tag, then report the public self-managed catalog destination.
+sourceCharts:
+  helm-nvca-operator:
+    tagPrefix: deploy/helm/nvca-operator/v
+    path: deploy/helm/nvca-operator/nvca-operator
+# The release workflow authenticates before evaluating the remaining charts and
+# permits states that contain only third-party or local charts.
 publishedChartRepository: https://helm.ngc.nvidia.com/nvidia/nvcf

--- a/tools/ci/test-github-release.py
+++ b/tools/ci/test-github-release.py
@@ -1429,10 +1429,10 @@ class GithubReleaseTest(unittest.TestCase):
         self.assertIn('token: ${{ github.token }}', workflow)
         self.assertIn("Render tagged inventory without publishing", workflow)
         self.assertIn("--generate-stack-inventory", workflow)
-        self.assertIn("actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", workflow)
         preflight = workflow.index("inventory-preflight:")
         tag_release = workflow.index("tag-release-notes:")
         self.assertNotIn("github-release tag", workflow[preflight:tag_release])
+        self.assertNotIn("upload-artifact", workflow[preflight:tag_release])
 
     def publish_and_capture_comments(self, version):
         """Publish a tag for `version` from a release branch, recording any comments.

--- a/tools/ci/test-github-release.py
+++ b/tools/ci/test-github-release.py
@@ -1429,6 +1429,10 @@ class GithubReleaseTest(unittest.TestCase):
         self.assertIn('token: ${{ github.token }}', workflow)
         self.assertIn("Render tagged inventory without publishing", workflow)
         self.assertIn("--generate-stack-inventory", workflow)
+        self.assertIn(
+            '--inventory-config "${GITHUB_WORKSPACE}/deploy/stacks/self-managed/release-inventory.yaml"',
+            workflow,
+        )
         preflight = workflow.index("inventory-preflight:")
         tag_release = workflow.index("tag-release-notes:")
         self.assertNotIn("github-release tag", workflow[preflight:tag_release])

--- a/tools/ci/test-github-release.py
+++ b/tools/ci/test-github-release.py
@@ -1409,13 +1409,21 @@ class GithubReleaseTest(unittest.TestCase):
 
     def test_stack_tag_workflow_installs_pinned_inventory_tools(self):
         workflow = (SCRIPT_PATH.parents[2] / ".github/workflows/release-tags.yml").read_text()
+        workflow_env = workflow.split("\njobs:\n", 1)[0]
         self.assertIn("actions/setup-go@v5", workflow)
-        self.assertIn('HELMFILE_VERSION: "1.1.9"', workflow)
+        for pin in (
+            'HELM_VERSION: "3.21.4"',
+            'HELM_SHA256: "61f88ab166748cb19604d7884cb100ae9ccb13804ddeb98e08af167eacbb6a14"',
+            'HELMFILE_VERSION: "1.1.9"',
+            'HELMFILE_SHA256: "ee71196bb12460905b8cbe0ef67b28db51ef681b777cc212d8c0956475b51905"',
+        ):
+            self.assertIn(pin, workflow_env)
+            self.assertEqual(workflow.count(pin), 1)
         self.assertIn(
             "NVCF_RELEASE_HELM_REGISTRY: ${{ secrets.NCP_DEV_REGISTRY }}",
             workflow,
         )
-        self.assertIn("Install inventory rendering tools", workflow)
+        self.assertEqual(workflow.count("Install inventory rendering tools"), 2)
         self.assertLess(
             workflow.index("Install inventory rendering tools"),
             workflow.index("Validate tag and create release notes"),

--- a/tools/ci/test-github-release.py
+++ b/tools/ci/test-github-release.py
@@ -1421,6 +1421,19 @@ class GithubReleaseTest(unittest.TestCase):
             workflow.index("Validate tag and create release notes"),
         )
 
+    def test_stack_inventory_preflight_renders_without_release_publication(self):
+        workflow = (SCRIPT_PATH.parents[2] / ".github/workflows/release-tags.yml").read_text()
+        self.assertIn("inventory_tag:", workflow)
+        self.assertIn("name: self-managed inventory preflight", workflow)
+        self.assertIn("inputs.inventory_tag != ''", workflow)
+        self.assertIn('token: ${{ github.token }}', workflow)
+        self.assertIn("Render tagged inventory without publishing", workflow)
+        self.assertIn("--generate-stack-inventory", workflow)
+        self.assertIn("actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", workflow)
+        preflight = workflow.index("inventory-preflight:")
+        tag_release = workflow.index("tag-release-notes:")
+        self.assertNotIn("github-release tag", workflow[preflight:tag_release])
+
     def publish_and_capture_comments(self, version):
         """Publish a tag for `version` from a release branch, recording any comments.
 

--- a/tools/docs-version-sync/main.go
+++ b/tools/docs-version-sync/main.go
@@ -41,6 +41,7 @@ func run(args []string) error {
 	updateCatalog := flags.Bool("update-catalog", false, "fetch the resolved GitHub stack inventory and update the catalog")
 	stackVersion := flags.String("stack-version", "", "self-managed stack version to fetch or inventory")
 	inventoryOutput := flags.String("generate-stack-inventory", "", "write a resolved stack inventory to this path")
+	inventoryConfig := flags.String("inventory-config", "", "release inventory config path; defaults to the stack checkout")
 	stackSourceTag := flags.String("stack-source-tag", "", "immutable self-managed stack source tag for inventory generation")
 	stackSourceCommit := flags.String("stack-source-commit", "", "immutable self-managed stack source commit for inventory generation")
 
@@ -69,14 +70,18 @@ func run(args []string) error {
 		if !filepath.IsAbs(outputPath) {
 			outputPath = filepath.Join(repoRoot, outputPath)
 		}
-		return writeResolvedStackInventory(repoRoot, outputPath, stackSourceRelease{
+		configPath := *inventoryConfig
+		if configPath != "" && !filepath.IsAbs(configPath) {
+			configPath = filepath.Join(repoRoot, configPath)
+		}
+		return writeResolvedStackInventory(repoRoot, outputPath, configPath, stackSourceRelease{
 			Version: *stackVersion,
 			Tag:     *stackSourceTag,
 			Commit:  *stackSourceCommit,
 		})
 	}
-	if *stackSourceTag != "" || *stackSourceCommit != "" {
-		return fmt.Errorf("--stack-source-tag and --stack-source-commit require --generate-stack-inventory")
+	if *stackSourceTag != "" || *stackSourceCommit != "" || *inventoryConfig != "" {
+		return fmt.Errorf("--stack-source-tag, --stack-source-commit, and --inventory-config require --generate-stack-inventory")
 	}
 	if *catalogPath == "" {
 		*catalogPath = filepath.Join(repoRoot, "docs", "version-catalog", *target+".yaml")

--- a/tools/docs-version-sync/resolved_inventory_publish.go
+++ b/tools/docs-version-sync/resolved_inventory_publish.go
@@ -703,7 +703,10 @@ func mergeAndResolveHelmfileReleases(
 func validateResolvedInventoryRenderRepository(repositories map[string]helmfileRepository, source resolvedInventoryHelmSource) error {
 	repository, ok := repositories["nvcf"]
 	if !ok {
-		return fmt.Errorf("built Helmfile state has no nvcf repository")
+		// Some states contain only third-party or local charts and therefore do
+		// not declare the NVCF repository. Chart alias validation below still
+		// rejects any release that refers to an undeclared repository.
+		return nil
 	}
 	if !repository.OCI {
 		return fmt.Errorf("built Helmfile nvcf repository must use OCI for release inventory rendering")

--- a/tools/docs-version-sync/resolved_inventory_publish.go
+++ b/tools/docs-version-sync/resolved_inventory_publish.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"archive/tar"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -15,6 +16,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -33,7 +35,6 @@ var resolvedInventoryCommonOverrides = []string{
 }
 
 type resolvedInventoryState struct {
-	stack         string
 	plane         string
 	path          string
 	baseOverrides []string
@@ -42,7 +43,6 @@ type resolvedInventoryState struct {
 
 var resolvedInventoryStates = []resolvedInventoryState{
 	{
-		stack: "self-managed",
 		plane: "control-plane",
 		path:  "deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl",
 		fullOverrides: []string{
@@ -50,7 +50,6 @@ var resolvedInventoryStates = []resolvedInventoryState{
 		},
 	},
 	{
-		stack: "self-managed",
 		plane: "control-plane",
 		path:  "deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl",
 		fullOverrides: []string{
@@ -60,12 +59,10 @@ var resolvedInventoryStates = []resolvedInventoryState{
 		},
 	},
 	{
-		stack: "self-managed",
 		plane: "observability",
 		path:  "deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl",
 	},
 	{
-		stack: "observability",
 		plane: "observability",
 		path:  "deploy/stacks/observability/helmfile.d/01-observability.yaml.gotmpl",
 		baseOverrides: []string{
@@ -73,7 +70,6 @@ var resolvedInventoryStates = []resolvedInventoryState{
 		},
 	},
 	{
-		stack: "nvcf-compute-plane",
 		plane: "compute-plane",
 		path:  "deploy/stacks/nvcf-compute-plane/helmfile.d/01-dependencies.yaml.gotmpl",
 		fullOverrides: []string{
@@ -84,7 +80,6 @@ var resolvedInventoryStates = []resolvedInventoryState{
 		},
 	},
 	{
-		stack: "nvcf-compute-plane",
 		plane: "compute-plane",
 		path:  "deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl",
 	},
@@ -203,9 +198,14 @@ type localChartMetadata struct {
 }
 
 type resolvedInventoryConfig struct {
-	SchemaVersion                  int               `yaml:"schemaVersion"`
-	PublishedChartRepository       string            `yaml:"publishedChartRepository"`
-	RenderChartRepositoryOverrides map[string]string `yaml:"renderChartRepositoryOverrides"`
+	SchemaVersion            int                                     `yaml:"schemaVersion"`
+	PublishedChartRepository string                                  `yaml:"publishedChartRepository"`
+	SourceCharts             map[string]resolvedInventorySourceChart `yaml:"sourceCharts"`
+}
+
+type resolvedInventorySourceChart struct {
+	TagPrefix string `yaml:"tagPrefix"`
+	Path      string `yaml:"path"`
 }
 
 type resolvedInventoryHelmSource struct {
@@ -278,26 +278,18 @@ func collectResolvedStackInventory(repoRoot, configPath string, source stackSour
 	if err != nil {
 		return resolvedStackInventory{}, err
 	}
-	env, renderSources, ngcAPIKey, err := prepareResolvedInventoryEnvironment(copiedRepoRoot, config)
+	env, renderSource, ngcAPIKey, err := prepareResolvedInventoryEnvironment(copiedRepoRoot)
 	if err != nil {
 		return resolvedStackInventory{}, err
 	}
-	preparedRegistries := map[string]struct{}{}
-	for _, stack := range resolvedInventoryStackNames() {
-		renderSource := renderSources[stack]
-		if _, prepared := preparedRegistries[renderSource.Registry]; prepared {
-			continue
-		}
-		if err := runner.PrepareRepositories(env, map[string]helmfileRepository{
-			"nvcf": {
-				Name: "nvcf",
-				URL:  renderSource.reference(),
-				OCI:  true,
-			},
-		}, ngcAPIKey); err != nil {
-			return resolvedStackInventory{}, fmt.Errorf("authenticate release chart registry for %s: %w", stack, err)
-		}
-		preparedRegistries[renderSource.Registry] = struct{}{}
+	if err := runner.PrepareRepositories(env, map[string]helmfileRepository{
+		"nvcf": {
+			Name: "nvcf",
+			URL:  renderSource.reference(),
+			OCI:  true,
+		},
+	}, ngcAPIKey); err != nil {
+		return resolvedStackInventory{}, fmt.Errorf("authenticate release chart registry: %w", err)
 	}
 
 	planes := make(map[string]*resolvedInventoryPlaneInput, len(resolvedStackPlanes))
@@ -307,13 +299,11 @@ func collectResolvedStackInventory(repoRoot, configPath string, source stackSour
 			ManifestByRelease: map[string][]byte{},
 		}
 	}
+	usedSourceCharts := map[string]struct{}{}
 	for stateIndex, state := range resolvedInventoryStates {
-		renderSource, ok := renderSources[state.stack]
-		if !ok {
-			return resolvedStackInventory{}, fmt.Errorf("render chart repository is not configured for stack %s", state.stack)
-		}
 		stateFile := filepath.Join(copiedRepoRoot, filepath.FromSlash(state.path))
-		releases, manifests, err := collectResolvedInventoryState(
+		releases, manifests, stateSourceCharts, err := collectResolvedInventoryState(
+			repoRoot,
 			copiedRepoRoot,
 			stateFile,
 			filepath.Join(tempRoot, "rendered", fmt.Sprintf("%02d", stateIndex)),
@@ -322,11 +312,15 @@ func collectResolvedStackInventory(repoRoot, configPath string, source stackSour
 			env,
 			renderSource,
 			config.PublishedChartRepository,
+			config.SourceCharts,
 			ngcAPIKey,
 			runner,
 		)
 		if err != nil {
 			return resolvedStackInventory{}, fmt.Errorf("collect %s: %w", state.path, err)
+		}
+		for _, chart := range stateSourceCharts {
+			usedSourceCharts[chart] = struct{}{}
 		}
 		plane := planes[state.plane]
 		var existing []helmfileRelease
@@ -346,6 +340,11 @@ func collectResolvedStackInventory(repoRoot, configPath string, source stackSour
 				return resolvedStackInventory{}, fmt.Errorf("duplicate %s release %s across Helmfile states", state.plane, release)
 			}
 			plane.ManifestByRelease[release] = manifest
+		}
+	}
+	for chart := range config.SourceCharts {
+		if _, used := usedSourceCharts[chart]; !used {
+			return resolvedStackInventory{}, fmt.Errorf("source chart %s is not used by any resolved Helmfile state", chart)
 		}
 	}
 
@@ -430,32 +429,42 @@ func loadResolvedInventoryConfig(repoRoot, configPath string) (resolvedInventory
 		!strings.HasPrefix(repository, "https://") || strings.ContainsAny(repository, "{}$?#") {
 		return resolvedInventoryConfig{}, fmt.Errorf("resolved inventory publishedChartRepository must be a resolved HTTPS repository without a trailing slash")
 	}
-	validStacks := make(map[string]struct{}, len(resolvedInventoryStackNames()))
-	for _, stack := range resolvedInventoryStackNames() {
-		validStacks[stack] = struct{}{}
-	}
-	for stack, raw := range config.RenderChartRepositoryOverrides {
-		if _, ok := validStacks[stack]; !ok {
-			return resolvedInventoryConfig{}, fmt.Errorf("resolved inventory renderChartRepositoryOverrides contains unknown stack %s", stack)
+	for name, sourceChart := range config.SourceCharts {
+		if !validResolvedInventoryChartName(name) {
+			return resolvedInventoryConfig{}, fmt.Errorf("resolved inventory source chart name %q is invalid", name)
 		}
-		if _, err := parseResolvedInventoryHelmSource(raw); err != nil {
-			return resolvedInventoryConfig{}, fmt.Errorf("resolved inventory render chart repository for %s: %w", stack, err)
+		if !strings.HasSuffix(sourceChart.TagPrefix, "/v") {
+			return resolvedInventoryConfig{}, fmt.Errorf("resolved inventory source chart %s tagPrefix must be a repository-relative path ending in /v", name)
+		}
+		componentPath := strings.TrimSuffix(sourceChart.TagPrefix, "/v")
+		if !validResolvedInventoryRepoPath(componentPath) {
+			return resolvedInventoryConfig{}, fmt.Errorf("resolved inventory source chart %s tagPrefix must be a repository-relative path ending in /v", name)
+		}
+		if !validResolvedInventoryRepoPath(sourceChart.Path) ||
+			(sourceChart.Path != componentPath && !strings.HasPrefix(sourceChart.Path, componentPath+"/")) {
+			return resolvedInventoryConfig{}, fmt.Errorf("resolved inventory source chart %s path must be within %s", name, componentPath)
 		}
 	}
 	return config, nil
 }
 
-func resolvedInventoryStackNames() []string {
-	stacks := make(map[string]struct{})
-	for _, state := range resolvedInventoryStates {
-		stacks[state.stack] = struct{}{}
+func validResolvedInventoryChartName(name string) bool {
+	if name == "" {
+		return false
 	}
-	names := make([]string, 0, len(stacks))
-	for stack := range stacks {
-		names = append(names, stack)
+	for index := 0; index < len(name); index++ {
+		character := name[index]
+		if character != '-' && (character < 'a' || character > 'z') && (character < '0' || character > '9') {
+			return false
+		}
 	}
-	sort.Strings(names)
-	return names
+	return name[0] != '-' && name[len(name)-1] != '-'
+}
+
+func validResolvedInventoryRepoPath(value string) bool {
+	return value != "" && value != "." && value != ".." && !strings.HasPrefix(value, "-") &&
+		!filepath.IsAbs(value) && filepath.ToSlash(filepath.Clean(value)) == value && !strings.HasPrefix(value, "../") &&
+		!strings.ContainsAny(value, "{}$?#@ 	\r\n")
 }
 
 func parseResolvedInventoryHelmSource(raw string) (resolvedInventoryHelmSource, error) {
@@ -478,88 +487,79 @@ func parseResolvedInventoryHelmSource(raw string) (resolvedInventoryHelmSource, 
 	return resolvedInventoryHelmSource{Registry: registry, Repository: repository}, nil
 }
 
-func prepareResolvedInventoryEnvironment(copiedRepoRoot string, config resolvedInventoryConfig) ([]string, map[string]resolvedInventoryHelmSource, string, error) {
+func prepareResolvedInventoryEnvironment(copiedRepoRoot string) ([]string, resolvedInventoryHelmSource, string, error) {
 	ngcAPIKey := strings.TrimSpace(os.Getenv("NVCF_RELEASE_NGC_API_KEY"))
 	if ngcAPIKey == "" {
 		ngcAPIKey = strings.TrimSpace(os.Getenv("NGC_API_KEY"))
 	}
 	if ngcAPIKey == "" {
-		return nil, nil, "", fmt.Errorf("NVCF_RELEASE_NGC_API_KEY is required to render release charts")
+		return nil, resolvedInventoryHelmSource{}, "", fmt.Errorf("NVCF_RELEASE_NGC_API_KEY is required to render release charts")
 	}
-	defaultRenderSource, err := parseResolvedInventoryHelmSource(os.Getenv("NVCF_RELEASE_HELM_REGISTRY"))
+	renderSource, err := parseResolvedInventoryHelmSource(os.Getenv("NVCF_RELEASE_HELM_REGISTRY"))
 	if err != nil {
-		return nil, nil, "", err
+		return nil, resolvedInventoryHelmSource{}, "", err
 	}
-	renderSources := make(map[string]resolvedInventoryHelmSource, len(resolvedInventoryStackNames()))
-	for _, stack := range resolvedInventoryStackNames() {
-		renderSource := defaultRenderSource
-		if override, ok := config.RenderChartRepositoryOverrides[stack]; ok {
-			renderSource, err = parseResolvedInventoryHelmSource(override)
-			if err != nil {
-				return nil, nil, "", fmt.Errorf("parse render chart repository for %s: %w", stack, err)
-			}
-		}
-		renderSources[stack] = renderSource
-		values, err := yaml.Marshal(map[string]any{
-			"global": map[string]any{
-				"domain": "inventory.example.invalid",
-				"helm": map[string]any{
-					"sources": map[string]any{
-						"registry":   renderSource.Registry,
-						"repository": renderSource.Repository,
-					},
-				},
-				"image": map[string]any{
-					"registry":   "nvcr.io",
-					"repository": "nvidia/nvcf",
+	values, err := yaml.Marshal(map[string]any{
+		"global": map[string]any{
+			"domain": "inventory.example.invalid",
+			"helm": map[string]any{
+				"sources": map[string]any{
+					"registry":   renderSource.Registry,
+					"repository": renderSource.Repository,
 				},
 			},
-			"ingress": map[string]any{
-				"gatewayApi": map[string]any{
-					"controllerNamespace": "gateway-system",
-					"gateways": map[string]any{
-						"grpc": map[string]any{
-							"name":      "inventory-grpc",
-							"namespace": "gateway-system",
-						},
-						"shared": map[string]any{
-							"name":      "inventory-shared",
-							"namespace": "gateway-system",
-						},
+			"image": map[string]any{
+				"registry":   "nvcr.io",
+				"repository": "nvidia/nvcf",
+			},
+		},
+		"ingress": map[string]any{
+			"gatewayApi": map[string]any{
+				"controllerNamespace": "gateway-system",
+				"gateways": map[string]any{
+					"grpc": map[string]any{
+						"name":      "inventory-grpc",
+						"namespace": "gateway-system",
+					},
+					"shared": map[string]any{
+						"name":      "inventory-shared",
+						"namespace": "gateway-system",
 					},
 				},
 			},
-		})
-		if err != nil {
-			return nil, nil, "", fmt.Errorf("marshal inventory-only stack environment for %s: %w", stack, err)
-		}
+		},
+	})
+	if err != nil {
+		return nil, resolvedInventoryHelmSource{}, "", fmt.Errorf("marshal inventory-only stack environment: %w", err)
+	}
+	for _, stack := range []string{"self-managed", "nvcf-compute-plane", "observability"} {
 		environmentPath := filepath.Join(copiedRepoRoot, "deploy", "stacks", stack, "environments", "inventory.yaml")
 		if err := os.MkdirAll(filepath.Dir(environmentPath), 0o755); err != nil {
-			return nil, nil, "", err
+			return nil, resolvedInventoryHelmSource{}, "", err
 		}
 		if err := os.WriteFile(environmentPath, values, 0o600); err != nil {
-			return nil, nil, "", fmt.Errorf("write %s inventory-only stack environment: %w", stack, err)
+			return nil, resolvedInventoryHelmSource{}, "", fmt.Errorf("write %s inventory-only stack environment: %w", stack, err)
 		}
 	}
 	secretsPath := filepath.Join(copiedRepoRoot, "deploy", "stacks", "self-managed", "secrets", "inventory-secrets.yaml")
 	if err := os.MkdirAll(filepath.Dir(secretsPath), 0o755); err != nil {
-		return nil, nil, "", fmt.Errorf("create inventory-only stack secrets directory: %w", err)
+		return nil, resolvedInventoryHelmSource{}, "", fmt.Errorf("create inventory-only stack secrets directory: %w", err)
 	}
 	if err := os.WriteFile(secretsPath, []byte("{}\n"), 0o600); err != nil {
-		return nil, nil, "", fmt.Errorf("write inventory-only stack secrets: %w", err)
+		return nil, resolvedInventoryHelmSource{}, "", fmt.Errorf("write inventory-only stack secrets: %w", err)
 	}
 	registrationDir := filepath.Join(copiedRepoRoot, "deploy", "stacks", "nvcf-compute-plane", "inventory-registration")
 	if err := os.MkdirAll(registrationDir, 0o755); err != nil {
-		return nil, nil, "", err
+		return nil, resolvedInventoryHelmSource{}, "", err
 	}
 	registration := []byte("clusterName: inventory\nclusterID: 00000000-0000-0000-0000-000000000001\nclusterGroupID: 00000000-0000-0000-0000-000000000002\nncaID: inventory\nregion: inventory\nselfManaged:\n  identitySource: psat\n  icmsServiceURL: http://icms.example.invalid:8080\n  revalServiceURL: http://reval.example.invalid:8080\n  natsURL: nats://nats.example.invalid:4222\n")
 	if err := os.WriteFile(filepath.Join(registrationDir, "inventory-register-values.yaml"), registration, 0o600); err != nil {
-		return nil, nil, "", fmt.Errorf("write inventory-only registration values: %w", err)
+		return nil, resolvedInventoryHelmSource{}, "", fmt.Errorf("write inventory-only registration values: %w", err)
 	}
 	helmRoot := filepath.Join(copiedRepoRoot, ".helm")
 	for _, path := range []string{filepath.Join(helmRoot, "cache"), filepath.Join(helmRoot, "config"), filepath.Join(helmRoot, "data")} {
 		if err := os.MkdirAll(path, 0o700); err != nil {
-			return nil, nil, "", err
+			return nil, resolvedInventoryHelmSource{}, "", err
 		}
 	}
 	env := append([]string{}, os.Environ()...)
@@ -572,7 +572,7 @@ func prepareResolvedInventoryEnvironment(copiedRepoRoot string, config resolvedI
 		"NCA_ID":           "inventory",
 		"OUTPUT_DIR":       registrationDir,
 	})
-	return env, renderSources, ngcAPIKey, nil
+	return env, renderSource, ngcAPIKey, nil
 }
 
 func setResolvedInventoryEnvironment(env []string, values map[string]string) []string {
@@ -595,6 +595,7 @@ func setResolvedInventoryEnvironment(env []string, values map[string]string) []s
 }
 
 func collectResolvedInventoryState(
+	sourceRepoRoot string,
 	copiedRepoRoot string,
 	stateFile string,
 	renderDir string,
@@ -603,33 +604,45 @@ func collectResolvedInventoryState(
 	env []string,
 	renderSource resolvedInventoryHelmSource,
 	publishedChartRepository string,
+	sourceCharts map[string]resolvedInventorySourceChart,
 	ngcAPIKey string,
 	runner resolvedInventoryCommandRunner,
-) ([]helmfileRelease, map[string][]byte, error) {
+) ([]helmfileRelease, map[string][]byte, []string, error) {
 	baseOverrides := append(append([]string{}, resolvedInventoryCommonOverrides...), state.baseOverrides...)
 	fullOverrides := append(append([]string{}, baseOverrides...), state.fullOverrides...)
 	baseList, err := runResolvedInventoryHelmfile(runner, filepath.Dir(stateFile), env, stateFile, baseOverrides, "list", "--output", "json")
 	if err != nil {
-		return nil, nil, fmt.Errorf("list default releases: %w", err)
+		return nil, nil, nil, fmt.Errorf("list default releases: %w", err)
 	}
 	fullList, err := runResolvedInventoryHelmfile(runner, filepath.Dir(stateFile), env, stateFile, fullOverrides, "list", "--output", "json")
 	if err != nil {
-		return nil, nil, fmt.Errorf("list releases with optional components: %w", err)
+		return nil, nil, nil, fmt.Errorf("list releases with optional components: %w", err)
+	}
+	usedSourceCharts, err := materializeResolvedInventorySourceCharts(
+		sourceRepoRoot,
+		stateFile,
+		renderDir+"-source-charts",
+		source,
+		fullList,
+		sourceCharts,
+	)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 	built, err := runResolvedInventoryHelmfile(runner, filepath.Dir(stateFile), env, stateFile, fullOverrides, "build")
 	if err != nil {
-		return nil, nil, fmt.Errorf("build resolved Helmfile state: %w", err)
+		return nil, nil, nil, fmt.Errorf("build resolved Helmfile state: %w", err)
 	}
 	repositories, err := parseHelmfileRepositories(built)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if err := validateResolvedInventoryRenderRepository(repositories, renderSource); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	releases, err := mergeAndResolveHelmfileReleases(copiedRepoRoot, stateFile, source, baseList, fullList, repositories, publishedChartRepository)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	publicRepositories := make(map[string]helmfileRepository, len(repositories))
 	for name, repository := range repositories {
@@ -639,12 +652,12 @@ func collectResolvedInventoryState(
 	}
 	if len(publicRepositories) != 0 {
 		if err := runner.PrepareRepositories(env, publicRepositories, ngcAPIKey); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 	}
 
 	if err := os.MkdirAll(renderDir, 0o755); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if _, err := runResolvedInventoryHelmfile(
 		runner,
@@ -657,18 +670,185 @@ func collectResolvedInventoryState(
 		"--output-dir", renderDir,
 		"--output-dir-template", "{{ .OutputDir }}/{{ .Release.Name }}",
 	); err != nil {
-		return nil, nil, fmt.Errorf("render releases: %w", err)
+		return nil, nil, nil, fmt.Errorf("render releases: %w", err)
 	}
 
 	manifests := make(map[string][]byte, len(releases))
 	for _, release := range releases {
 		manifest, err := readRenderedReleaseManifest(filepath.Join(renderDir, release.Name))
 		if err != nil {
-			return nil, nil, fmt.Errorf("read rendered release %s: %w", release.Name, err)
+			return nil, nil, nil, fmt.Errorf("read rendered release %s: %w", release.Name, err)
 		}
 		manifests[release.Name] = manifest
 	}
-	return releases, manifests, nil
+	return releases, manifests, usedSourceCharts, nil
+}
+
+func materializeResolvedInventorySourceCharts(
+	repoRoot string,
+	stateFile string,
+	chartRoot string,
+	stackSource stackSourceRelease,
+	fullRaw []byte,
+	sourceCharts map[string]resolvedInventorySourceChart,
+) ([]string, error) {
+	if len(sourceCharts) == 0 {
+		return nil, nil
+	}
+	releases, err := decodeHelmfileReleaseList(fullRaw)
+	if err != nil {
+		return nil, fmt.Errorf("parse releases for source chart rendering: %w", err)
+	}
+	var used []string
+	for _, release := range releases {
+		alias, name, found := strings.Cut(release.Chart, "/")
+		if !found || alias != "nvcf" {
+			continue
+		}
+		sourceChart, configured := sourceCharts[name]
+		if !configured {
+			continue
+		}
+		if release.Version == "" {
+			return nil, fmt.Errorf("source chart %s release %s has no version", name, release.Name)
+		}
+		if !validStackVersion(release.Version) {
+			return nil, fmt.Errorf("source chart %s release %s version %q is not semantic", name, release.Name, release.Version)
+		}
+		tag := sourceChart.TagPrefix + release.Version
+		if _, err := gitOutput(repoRoot, "merge-base", "--is-ancestor", tag, stackSource.Commit); err != nil {
+			return nil, fmt.Errorf("source chart %s tag %s is not an ancestor of stack commit %s: %w", name, tag, stackSource.Commit, err)
+		}
+		chartPath := filepath.Join(chartRoot, name, release.Version)
+		if err := extractResolvedInventoryGitChart(repoRoot, tag, sourceChart.Path, chartPath); err != nil {
+			return nil, fmt.Errorf("extract source chart %s from %s: %w", name, tag, err)
+		}
+		if err := setResolvedInventorySourceChartVersion(chartPath, name, release.Version); err != nil {
+			return nil, fmt.Errorf("set source chart %s version: %w", name, err)
+		}
+		if err := replaceResolvedInventoryStateChart(stateFile, name, chartPath); err != nil {
+			return nil, err
+		}
+		used = append(used, name)
+	}
+	return used, nil
+}
+
+func extractResolvedInventoryGitChart(repoRoot, tag, sourcePath, destination string) error {
+	raw, err := gitOutput(repoRoot, "archive", "--format=tar", tag, "--", sourcePath)
+	if err != nil {
+		return err
+	}
+	prefix := sourcePath + "/"
+	reader := tar.NewReader(bytes.NewReader(raw))
+	fileCount := 0
+	for {
+		header, err := reader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if header.Typeflag == tar.TypeXGlobalHeader {
+			continue
+		}
+		name := strings.TrimSuffix(header.Name, "/")
+		if header.Typeflag == tar.TypeDir && (name == sourcePath || strings.HasPrefix(sourcePath+"/", name+"/")) {
+			continue
+		}
+		if !strings.HasPrefix(name, prefix) {
+			return fmt.Errorf("archive entry %s is outside source path %s", header.Name, sourcePath)
+		}
+		rel := strings.TrimPrefix(name, prefix)
+		if rel == "" || rel == "." || rel == ".." || strings.HasPrefix(rel, "../") || filepath.ToSlash(filepath.Clean(rel)) != rel {
+			return fmt.Errorf("archive entry %s has an invalid relative path", header.Name)
+		}
+		target := filepath.Join(destination, filepath.FromSlash(rel))
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, header.FileInfo().Mode().Perm()); err != nil {
+				return err
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			file, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, header.FileInfo().Mode().Perm())
+			if err != nil {
+				return err
+			}
+			_, copyErr := io.Copy(file, reader)
+			closeErr := file.Close()
+			if copyErr != nil {
+				return copyErr
+			}
+			if closeErr != nil {
+				return closeErr
+			}
+			fileCount++
+		default:
+			return fmt.Errorf("archive entry %s has unsupported type %d", header.Name, header.Typeflag)
+		}
+	}
+	if fileCount == 0 {
+		return fmt.Errorf("chart source path %s is empty", sourcePath)
+	}
+	return nil
+}
+
+func setResolvedInventorySourceChartVersion(chartPath, wantName, version string) error {
+	metadataPath := filepath.Join(chartPath, "Chart.yaml")
+	raw, err := os.ReadFile(metadataPath)
+	if err != nil {
+		return err
+	}
+	var document yaml.Node
+	if err := yaml.Unmarshal(raw, &document); err != nil {
+		return err
+	}
+	if len(document.Content) != 1 || document.Content[0].Kind != yaml.MappingNode {
+		return fmt.Errorf("Chart.yaml must contain one mapping")
+	}
+	mapping := document.Content[0]
+	name := ""
+	versionNode := (*yaml.Node)(nil)
+	for index := 0; index+1 < len(mapping.Content); index += 2 {
+		switch mapping.Content[index].Value {
+		case "name":
+			name = mapping.Content[index+1].Value
+		case "version":
+			versionNode = mapping.Content[index+1]
+		}
+	}
+	if name != wantName {
+		return fmt.Errorf("Chart.yaml name is %q, want %q", name, wantName)
+	}
+	if versionNode == nil {
+		return fmt.Errorf("Chart.yaml has no version")
+	}
+	versionNode.Value = version
+	versionNode.Tag = "!!str"
+	versionNode.Style = yaml.DoubleQuotedStyle
+	updated, err := yaml.Marshal(&document)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(metadataPath, updated, 0o644)
+}
+
+func replaceResolvedInventoryStateChart(stateFile, chartName, chartPath string) error {
+	raw, err := os.ReadFile(stateFile)
+	if err != nil {
+		return err
+	}
+	needle := "chart: nvcf/" + chartName
+	if count := bytes.Count(raw, []byte(needle)); count != 1 {
+		return fmt.Errorf("resolved %d %s chart references in %s; want exactly one", count, chartName, stateFile)
+	}
+	replacement := "chart: " + strconv.Quote(filepath.ToSlash(chartPath))
+	updated := bytes.Replace(raw, []byte(needle), []byte(replacement), 1)
+	return os.WriteFile(stateFile, updated, 0o644)
 }
 
 func runResolvedInventoryHelmfile(

--- a/tools/docs-version-sync/resolved_inventory_publish.go
+++ b/tools/docs-version-sync/resolved_inventory_publish.go
@@ -33,6 +33,7 @@ var resolvedInventoryCommonOverrides = []string{
 }
 
 type resolvedInventoryState struct {
+	stack         string
 	plane         string
 	path          string
 	baseOverrides []string
@@ -41,6 +42,7 @@ type resolvedInventoryState struct {
 
 var resolvedInventoryStates = []resolvedInventoryState{
 	{
+		stack: "self-managed",
 		plane: "control-plane",
 		path:  "deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl",
 		fullOverrides: []string{
@@ -48,6 +50,7 @@ var resolvedInventoryStates = []resolvedInventoryState{
 		},
 	},
 	{
+		stack: "self-managed",
 		plane: "control-plane",
 		path:  "deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl",
 		fullOverrides: []string{
@@ -57,10 +60,12 @@ var resolvedInventoryStates = []resolvedInventoryState{
 		},
 	},
 	{
+		stack: "self-managed",
 		plane: "observability",
 		path:  "deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl",
 	},
 	{
+		stack: "observability",
 		plane: "observability",
 		path:  "deploy/stacks/observability/helmfile.d/01-observability.yaml.gotmpl",
 		baseOverrides: []string{
@@ -68,6 +73,7 @@ var resolvedInventoryStates = []resolvedInventoryState{
 		},
 	},
 	{
+		stack: "nvcf-compute-plane",
 		plane: "compute-plane",
 		path:  "deploy/stacks/nvcf-compute-plane/helmfile.d/01-dependencies.yaml.gotmpl",
 		fullOverrides: []string{
@@ -78,6 +84,7 @@ var resolvedInventoryStates = []resolvedInventoryState{
 		},
 	},
 	{
+		stack: "nvcf-compute-plane",
 		plane: "compute-plane",
 		path:  "deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl",
 	},
@@ -196,8 +203,9 @@ type localChartMetadata struct {
 }
 
 type resolvedInventoryConfig struct {
-	SchemaVersion            int    `yaml:"schemaVersion"`
-	PublishedChartRepository string `yaml:"publishedChartRepository"`
+	SchemaVersion                  int               `yaml:"schemaVersion"`
+	PublishedChartRepository       string            `yaml:"publishedChartRepository"`
+	RenderChartRepositoryOverrides map[string]string `yaml:"renderChartRepositoryOverrides"`
 }
 
 type resolvedInventoryHelmSource struct {
@@ -270,18 +278,26 @@ func collectResolvedStackInventory(repoRoot string, source stackSourceRelease, r
 	if err != nil {
 		return resolvedStackInventory{}, err
 	}
-	env, renderSource, ngcAPIKey, err := prepareResolvedInventoryEnvironment(copiedRepoRoot)
+	env, renderSources, ngcAPIKey, err := prepareResolvedInventoryEnvironment(copiedRepoRoot, config)
 	if err != nil {
 		return resolvedStackInventory{}, err
 	}
-	if err := runner.PrepareRepositories(env, map[string]helmfileRepository{
-		"nvcf": {
-			Name: "nvcf",
-			URL:  renderSource.reference(),
-			OCI:  true,
-		},
-	}, ngcAPIKey); err != nil {
-		return resolvedStackInventory{}, fmt.Errorf("authenticate release chart registry: %w", err)
+	preparedRegistries := map[string]struct{}{}
+	for _, stack := range resolvedInventoryStackNames() {
+		renderSource := renderSources[stack]
+		if _, prepared := preparedRegistries[renderSource.Registry]; prepared {
+			continue
+		}
+		if err := runner.PrepareRepositories(env, map[string]helmfileRepository{
+			"nvcf": {
+				Name: "nvcf",
+				URL:  renderSource.reference(),
+				OCI:  true,
+			},
+		}, ngcAPIKey); err != nil {
+			return resolvedStackInventory{}, fmt.Errorf("authenticate release chart registry for %s: %w", stack, err)
+		}
+		preparedRegistries[renderSource.Registry] = struct{}{}
 	}
 
 	planes := make(map[string]*resolvedInventoryPlaneInput, len(resolvedStackPlanes))
@@ -292,6 +308,10 @@ func collectResolvedStackInventory(repoRoot string, source stackSourceRelease, r
 		}
 	}
 	for stateIndex, state := range resolvedInventoryStates {
+		renderSource, ok := renderSources[state.stack]
+		if !ok {
+			return resolvedStackInventory{}, fmt.Errorf("render chart repository is not configured for stack %s", state.stack)
+		}
 		stateFile := filepath.Join(copiedRepoRoot, filepath.FromSlash(state.path))
 		releases, manifests, err := collectResolvedInventoryState(
 			copiedRepoRoot,
@@ -407,7 +427,32 @@ func loadResolvedInventoryConfig(repoRoot string) (resolvedInventoryConfig, erro
 		!strings.HasPrefix(repository, "https://") || strings.ContainsAny(repository, "{}$?#") {
 		return resolvedInventoryConfig{}, fmt.Errorf("resolved inventory publishedChartRepository must be a resolved HTTPS repository without a trailing slash")
 	}
+	validStacks := make(map[string]struct{}, len(resolvedInventoryStackNames()))
+	for _, stack := range resolvedInventoryStackNames() {
+		validStacks[stack] = struct{}{}
+	}
+	for stack, raw := range config.RenderChartRepositoryOverrides {
+		if _, ok := validStacks[stack]; !ok {
+			return resolvedInventoryConfig{}, fmt.Errorf("resolved inventory renderChartRepositoryOverrides contains unknown stack %s", stack)
+		}
+		if _, err := parseResolvedInventoryHelmSource(raw); err != nil {
+			return resolvedInventoryConfig{}, fmt.Errorf("resolved inventory render chart repository for %s: %w", stack, err)
+		}
+	}
 	return config, nil
+}
+
+func resolvedInventoryStackNames() []string {
+	stacks := make(map[string]struct{})
+	for _, state := range resolvedInventoryStates {
+		stacks[state.stack] = struct{}{}
+	}
+	names := make([]string, 0, len(stacks))
+	for stack := range stacks {
+		names = append(names, stack)
+	}
+	sort.Strings(names)
+	return names
 }
 
 func parseResolvedInventoryHelmSource(raw string) (resolvedInventoryHelmSource, error) {
@@ -430,79 +475,88 @@ func parseResolvedInventoryHelmSource(raw string) (resolvedInventoryHelmSource, 
 	return resolvedInventoryHelmSource{Registry: registry, Repository: repository}, nil
 }
 
-func prepareResolvedInventoryEnvironment(copiedRepoRoot string) ([]string, resolvedInventoryHelmSource, string, error) {
+func prepareResolvedInventoryEnvironment(copiedRepoRoot string, config resolvedInventoryConfig) ([]string, map[string]resolvedInventoryHelmSource, string, error) {
 	ngcAPIKey := strings.TrimSpace(os.Getenv("NVCF_RELEASE_NGC_API_KEY"))
 	if ngcAPIKey == "" {
 		ngcAPIKey = strings.TrimSpace(os.Getenv("NGC_API_KEY"))
 	}
 	if ngcAPIKey == "" {
-		return nil, resolvedInventoryHelmSource{}, "", fmt.Errorf("NVCF_RELEASE_NGC_API_KEY is required to render release charts")
+		return nil, nil, "", fmt.Errorf("NVCF_RELEASE_NGC_API_KEY is required to render release charts")
 	}
-	renderSource, err := parseResolvedInventoryHelmSource(os.Getenv("NVCF_RELEASE_HELM_REGISTRY"))
+	defaultRenderSource, err := parseResolvedInventoryHelmSource(os.Getenv("NVCF_RELEASE_HELM_REGISTRY"))
 	if err != nil {
-		return nil, resolvedInventoryHelmSource{}, "", err
+		return nil, nil, "", err
 	}
-	values, err := yaml.Marshal(map[string]any{
-		"global": map[string]any{
-			"domain": "inventory.example.invalid",
-			"helm": map[string]any{
-				"sources": map[string]any{
-					"registry":   renderSource.Registry,
-					"repository": renderSource.Repository,
-				},
-			},
-			"image": map[string]any{
-				"registry":   "nvcr.io",
-				"repository": "nvidia/nvcf",
-			},
-		},
-		"ingress": map[string]any{
-			"gatewayApi": map[string]any{
-				"controllerNamespace": "gateway-system",
-				"gateways": map[string]any{
-					"grpc": map[string]any{
-						"name":      "inventory-grpc",
-						"namespace": "gateway-system",
-					},
-					"shared": map[string]any{
-						"name":      "inventory-shared",
-						"namespace": "gateway-system",
+	renderSources := make(map[string]resolvedInventoryHelmSource, len(resolvedInventoryStackNames()))
+	for _, stack := range resolvedInventoryStackNames() {
+		renderSource := defaultRenderSource
+		if override, ok := config.RenderChartRepositoryOverrides[stack]; ok {
+			renderSource, err = parseResolvedInventoryHelmSource(override)
+			if err != nil {
+				return nil, nil, "", fmt.Errorf("parse render chart repository for %s: %w", stack, err)
+			}
+		}
+		renderSources[stack] = renderSource
+		values, err := yaml.Marshal(map[string]any{
+			"global": map[string]any{
+				"domain": "inventory.example.invalid",
+				"helm": map[string]any{
+					"sources": map[string]any{
+						"registry":   renderSource.Registry,
+						"repository": renderSource.Repository,
 					},
 				},
+				"image": map[string]any{
+					"registry":   "nvcr.io",
+					"repository": "nvidia/nvcf",
+				},
 			},
-		},
-	})
-	if err != nil {
-		return nil, resolvedInventoryHelmSource{}, "", fmt.Errorf("marshal inventory-only stack environment: %w", err)
-	}
-	for _, stack := range []string{"self-managed", "nvcf-compute-plane", "observability"} {
+			"ingress": map[string]any{
+				"gatewayApi": map[string]any{
+					"controllerNamespace": "gateway-system",
+					"gateways": map[string]any{
+						"grpc": map[string]any{
+							"name":      "inventory-grpc",
+							"namespace": "gateway-system",
+						},
+						"shared": map[string]any{
+							"name":      "inventory-shared",
+							"namespace": "gateway-system",
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			return nil, nil, "", fmt.Errorf("marshal inventory-only stack environment for %s: %w", stack, err)
+		}
 		environmentPath := filepath.Join(copiedRepoRoot, "deploy", "stacks", stack, "environments", "inventory.yaml")
 		if err := os.MkdirAll(filepath.Dir(environmentPath), 0o755); err != nil {
-			return nil, resolvedInventoryHelmSource{}, "", err
+			return nil, nil, "", err
 		}
 		if err := os.WriteFile(environmentPath, values, 0o600); err != nil {
-			return nil, resolvedInventoryHelmSource{}, "", fmt.Errorf("write %s inventory-only stack environment: %w", stack, err)
+			return nil, nil, "", fmt.Errorf("write %s inventory-only stack environment: %w", stack, err)
 		}
 	}
 	secretsPath := filepath.Join(copiedRepoRoot, "deploy", "stacks", "self-managed", "secrets", "inventory-secrets.yaml")
 	if err := os.MkdirAll(filepath.Dir(secretsPath), 0o755); err != nil {
-		return nil, resolvedInventoryHelmSource{}, "", fmt.Errorf("create inventory-only stack secrets directory: %w", err)
+		return nil, nil, "", fmt.Errorf("create inventory-only stack secrets directory: %w", err)
 	}
 	if err := os.WriteFile(secretsPath, []byte("{}\n"), 0o600); err != nil {
-		return nil, resolvedInventoryHelmSource{}, "", fmt.Errorf("write inventory-only stack secrets: %w", err)
+		return nil, nil, "", fmt.Errorf("write inventory-only stack secrets: %w", err)
 	}
 	registrationDir := filepath.Join(copiedRepoRoot, "deploy", "stacks", "nvcf-compute-plane", "inventory-registration")
 	if err := os.MkdirAll(registrationDir, 0o755); err != nil {
-		return nil, resolvedInventoryHelmSource{}, "", err
+		return nil, nil, "", err
 	}
 	registration := []byte("clusterName: inventory\nclusterID: 00000000-0000-0000-0000-000000000001\nclusterGroupID: 00000000-0000-0000-0000-000000000002\nncaID: inventory\nregion: inventory\nselfManaged:\n  identitySource: psat\n  icmsServiceURL: http://icms.example.invalid:8080\n  revalServiceURL: http://reval.example.invalid:8080\n  natsURL: nats://nats.example.invalid:4222\n")
 	if err := os.WriteFile(filepath.Join(registrationDir, "inventory-register-values.yaml"), registration, 0o600); err != nil {
-		return nil, resolvedInventoryHelmSource{}, "", fmt.Errorf("write inventory-only registration values: %w", err)
+		return nil, nil, "", fmt.Errorf("write inventory-only registration values: %w", err)
 	}
 	helmRoot := filepath.Join(copiedRepoRoot, ".helm")
 	for _, path := range []string{filepath.Join(helmRoot, "cache"), filepath.Join(helmRoot, "config"), filepath.Join(helmRoot, "data")} {
 		if err := os.MkdirAll(path, 0o700); err != nil {
-			return nil, resolvedInventoryHelmSource{}, "", err
+			return nil, nil, "", err
 		}
 	}
 	env := append([]string{}, os.Environ()...)
@@ -515,7 +569,7 @@ func prepareResolvedInventoryEnvironment(copiedRepoRoot string) ([]string, resol
 		"NCA_ID":           "inventory",
 		"OUTPUT_DIR":       registrationDir,
 	})
-	return env, renderSource, ngcAPIKey, nil
+	return env, renderSources, ngcAPIKey, nil
 }
 
 func setResolvedInventoryEnvironment(env []string, values map[string]string) []string {

--- a/tools/docs-version-sync/resolved_inventory_publish.go
+++ b/tools/docs-version-sync/resolved_inventory_publish.go
@@ -217,11 +217,11 @@ func (source resolvedInventoryHelmSource) reference() string {
 	return source.Registry + "/" + source.Repository
 }
 
-func writeResolvedStackInventory(repoRoot, outputPath string, source stackSourceRelease) error {
+func writeResolvedStackInventory(repoRoot, outputPath, configPath string, source stackSourceRelease) error {
 	if err := verifyResolvedInventoryCheckout(repoRoot, source); err != nil {
 		return err
 	}
-	inventory, err := collectResolvedStackInventory(repoRoot, source, execResolvedInventoryCommandRunner{})
+	inventory, err := collectResolvedStackInventory(repoRoot, configPath, source, execResolvedInventoryCommandRunner{})
 	if err != nil {
 		return err
 	}
@@ -263,7 +263,7 @@ func verifyResolvedInventoryCheckout(repoRoot string, source stackSourceRelease)
 	return nil
 }
 
-func collectResolvedStackInventory(repoRoot string, source stackSourceRelease, runner resolvedInventoryCommandRunner) (resolvedStackInventory, error) {
+func collectResolvedStackInventory(repoRoot, configPath string, source stackSourceRelease, runner resolvedInventoryCommandRunner) (resolvedStackInventory, error) {
 	tempRoot, err := os.MkdirTemp("", "nvcf-resolved-stack-inventory-")
 	if err != nil {
 		return resolvedStackInventory{}, err
@@ -274,7 +274,7 @@ func collectResolvedStackInventory(repoRoot string, source stackSourceRelease, r
 	if err := copyResolvedInventoryInputs(repoRoot, copiedRepoRoot); err != nil {
 		return resolvedStackInventory{}, err
 	}
-	config, err := loadResolvedInventoryConfig(copiedRepoRoot)
+	config, err := loadResolvedInventoryConfig(copiedRepoRoot, configPath)
 	if err != nil {
 		return resolvedStackInventory{}, err
 	}
@@ -401,8 +401,11 @@ func copyResolvedInventoryStack(source, destination string) error {
 	})
 }
 
-func loadResolvedInventoryConfig(repoRoot string) (resolvedInventoryConfig, error) {
-	raw, err := os.ReadFile(filepath.Join(repoRoot, filepath.FromSlash(resolvedInventoryConfigPath)))
+func loadResolvedInventoryConfig(repoRoot, configPath string) (resolvedInventoryConfig, error) {
+	if configPath == "" {
+		configPath = filepath.Join(repoRoot, filepath.FromSlash(resolvedInventoryConfigPath))
+	}
+	raw, err := os.ReadFile(configPath)
 	if err != nil {
 		return resolvedInventoryConfig{}, fmt.Errorf("read resolved inventory config: %w", err)
 	}

--- a/tools/docs-version-sync/resolved_inventory_publish.go
+++ b/tools/docs-version-sync/resolved_inventory_publish.go
@@ -771,7 +771,7 @@ func extractResolvedInventoryGitChart(repoRoot, tag, sourcePath, destination str
 			if err := os.MkdirAll(target, header.FileInfo().Mode().Perm()); err != nil {
 				return err
 			}
-		case tar.TypeReg, tar.TypeRegA:
+		case tar.TypeReg:
 			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 				return err
 			}
@@ -809,7 +809,7 @@ func setResolvedInventorySourceChartVersion(chartPath, wantName, version string)
 		return err
 	}
 	if len(document.Content) != 1 || document.Content[0].Kind != yaml.MappingNode {
-		return fmt.Errorf("Chart.yaml must contain one mapping")
+		return fmt.Errorf("chart metadata must contain one YAML mapping")
 	}
 	mapping := document.Content[0]
 	name := ""
@@ -823,10 +823,10 @@ func setResolvedInventorySourceChartVersion(chartPath, wantName, version string)
 		}
 	}
 	if name != wantName {
-		return fmt.Errorf("Chart.yaml name is %q, want %q", name, wantName)
+		return fmt.Errorf("chart metadata name is %q, want %q", name, wantName)
 	}
 	if versionNode == nil {
-		return fmt.Errorf("Chart.yaml has no version")
+		return fmt.Errorf("chart metadata has no version")
 	}
 	versionNode.Value = version
 	versionNode.Tag = "!!str"

--- a/tools/docs-version-sync/resolved_inventory_publish.go
+++ b/tools/docs-version-sync/resolved_inventory_publish.go
@@ -667,6 +667,7 @@ func collectResolvedInventoryState(
 		fullOverrides,
 		"template",
 		"--include-crds",
+		"--skip-tests",
 		"--output-dir", renderDir,
 		"--output-dir-template", "{{ .OutputDir }}/{{ .Release.Name }}",
 	); err != nil {

--- a/tools/docs-version-sync/resolved_inventory_publish_test.go
+++ b/tools/docs-version-sync/resolved_inventory_publish_test.go
@@ -93,7 +93,7 @@ func TestCollectResolvedStackInventoryBuildsEveryPlane(t *testing.T) {
 		Commit:  strings.Repeat("b", 40),
 	}
 	runner := &fakeResolvedInventoryRunner{t: t}
-	inventory, err := collectResolvedStackInventory(repo, source, runner)
+	inventory, err := collectResolvedStackInventory(repo, "", source, runner)
 	if err != nil {
 		t.Fatalf("collectResolvedStackInventory failed: %v", err)
 	}
@@ -160,7 +160,7 @@ func TestLoadResolvedInventoryConfig(t *testing.T) {
 	repo := t.TempDir()
 	configPath := filepath.Join(repo, filepath.FromSlash(resolvedInventoryConfigPath))
 	writeFile(t, configPath, "schemaVersion: 1\npublishedChartRepository: "+testPublishedChartRepository+"\nrenderChartRepositoryOverrides:\n  nvcf-compute-plane: nvcr.io/nvidia/nvcf-byoc\n")
-	config, err := loadResolvedInventoryConfig(repo)
+	config, err := loadResolvedInventoryConfig(repo, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,18 +172,28 @@ func TestLoadResolvedInventoryConfig(t *testing.T) {
 	}
 
 	writeFile(t, configPath, "schemaVersion: 1\npublishedChartRepository: oci://registry.example.test/charts\n")
-	if _, err := loadResolvedInventoryConfig(repo); err == nil || !strings.Contains(err.Error(), "resolved HTTPS repository") {
+	if _, err := loadResolvedInventoryConfig(repo, ""); err == nil || !strings.Contains(err.Error(), "resolved HTTPS repository") {
 		t.Fatalf("non-HTTPS repository error = %v", err)
 	}
 
 	writeFile(t, configPath, "schemaVersion: 1\npublishedChartRepository: "+testPublishedChartRepository+"\nrenderChartRepositoryOverrides:\n  unknown-stack: registry.example.test/charts\n")
-	if _, err := loadResolvedInventoryConfig(repo); err == nil || !strings.Contains(err.Error(), "unknown stack") {
+	if _, err := loadResolvedInventoryConfig(repo, ""); err == nil || !strings.Contains(err.Error(), "unknown stack") {
 		t.Fatalf("unknown override stack error = %v", err)
 	}
 
 	writeFile(t, configPath, "schemaVersion: 1\npublishedChartRepository: "+testPublishedChartRepository+"\nrenderChartRepositoryOverrides:\n  nvcf-compute-plane: https://registry.example.test/charts\n")
-	if _, err := loadResolvedInventoryConfig(repo); err == nil || !strings.Contains(err.Error(), "without credentials or a URL scheme") {
+	if _, err := loadResolvedInventoryConfig(repo, ""); err == nil || !strings.Contains(err.Error(), "without credentials or a URL scheme") {
 		t.Fatalf("invalid override repository error = %v", err)
+	}
+
+	externalConfig := filepath.Join(t.TempDir(), "release-inventory.yaml")
+	writeFile(t, externalConfig, "schemaVersion: 1\npublishedChartRepository: https://helm.example.test/external\n")
+	external, err := loadResolvedInventoryConfig(repo, externalConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if external.PublishedChartRepository != "https://helm.example.test/external" {
+		t.Fatalf("external published repository = %q", external.PublishedChartRepository)
 	}
 }
 

--- a/tools/docs-version-sync/resolved_inventory_publish_test.go
+++ b/tools/docs-version-sync/resolved_inventory_publish_test.go
@@ -110,8 +110,8 @@ func TestCollectResolvedStackInventoryBuildsEveryPlane(t *testing.T) {
 	if runner.templateCalls != len(resolvedInventoryStates) {
 		t.Fatalf("template calls = %d, want %d", runner.templateCalls, len(resolvedInventoryStates))
 	}
-	if runner.prepareCalls != 2 {
-		t.Fatalf("repository preparation calls = %d, want source and public repository preparation", runner.prepareCalls)
+	if runner.prepareCalls != 3 {
+		t.Fatalf("repository preparation calls = %d, want source and two public repository preparations", runner.prepareCalls)
 	}
 	wantPrefix := []string{"prepare-source", "list", "list", "build", "prepare-public", "template"}
 	if len(runner.operations) < len(wantPrefix) || !reflect.DeepEqual(runner.operations[:len(wantPrefix)], wantPrefix) {
@@ -204,6 +204,56 @@ func TestResolvedInventoryRepositoryCommandsAuthenticatesNVCFRegistry(t *testing
 	}
 }
 
+func TestValidateResolvedInventoryRenderRepository(t *testing.T) {
+	source := resolvedInventoryHelmSource{Registry: "registry.example.test", Repository: "release/charts"}
+	tests := []struct {
+		name         string
+		repositories map[string]helmfileRepository
+		wantErr      string
+	}{
+		{
+			name: "third-party repositories only",
+			repositories: map[string]helmfileRepository{
+				"third-party": {Name: "third-party", URL: "https://charts.example.test"},
+			},
+		},
+		{
+			name: "matching NVCF repository",
+			repositories: map[string]helmfileRepository{
+				"nvcf": {Name: "nvcf", URL: "registry.example.test/release/charts", OCI: true},
+			},
+		},
+		{
+			name: "NVCF repository must use OCI",
+			repositories: map[string]helmfileRepository{
+				"nvcf": {Name: "nvcf", URL: "https://charts.example.test"},
+			},
+			wantErr: "must use OCI",
+		},
+		{
+			name: "NVCF repository must match release source",
+			repositories: map[string]helmfileRepository{
+				"nvcf": {Name: "nvcf", URL: "registry.example.test/other/charts", OCI: true},
+			},
+			wantErr: "does not match",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateResolvedInventoryRenderRepository(test.repositories, source)
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("error = %v, want substring %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
 func TestReadRenderedReleaseManifestIsDeterministic(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "z.yaml"), "kind: Service\n")
@@ -257,6 +307,13 @@ func (runner *fakeResolvedInventoryRunner) PrepareRepositories(_ []string, repos
 		runner.operations = append(runner.operations, "prepare-public")
 		return nil
 	}
+	if repository, ok := repositories["third-party"]; ok {
+		if len(repositories) != 1 || repository.OCI || repository.URL != "https://third-party.example.test" {
+			runner.t.Fatalf("third-party repositories = %#v", repositories)
+		}
+		runner.operations = append(runner.operations, "prepare-public")
+		return nil
+	}
 	runner.t.Fatalf("unexpected repositories = %#v", repositories)
 	return nil
 }
@@ -280,7 +337,12 @@ func (runner *fakeResolvedInventoryRunner) Output(_ string, env []string, args .
 	case "list":
 		return mustJSON(runner.t, releases), nil
 	case "build":
-		built := "repositories:\n  - name: nvcf\n    url: registry.example.test/release/charts\n    oci: true\n"
+		built := "repositories:\n"
+		if strings.Contains(filepath.ToSlash(stateFile), "nvcf-compute-plane/helmfile.d/01-") {
+			built += "  - name: third-party\n    url: https://third-party.example.test\n    oci: false\n"
+		} else {
+			built += "  - name: nvcf\n    url: registry.example.test/release/charts\n    oci: true\n"
+		}
 		if strings.Contains(filepath.ToSlash(stateFile), "self-managed/helmfile.d/01-") {
 			built += "  - name: public\n    url: https://charts.example.test\n    oci: false\n"
 		}
@@ -324,8 +386,11 @@ func fakeResolvedInventoryReleases(stateFile string, full bool) []helmfileReleas
 		return []helmfileRelease{release("otel-collector")}
 	case strings.Contains(slashPath, "nvcf-compute-plane/helmfile.d/01-"):
 		releases := []helmfileRelease{release("kai-scheduler")}
+		releases[0].Chart = "third-party/kai-scheduler"
 		if full {
-			releases = append(releases, release("grove-operator"))
+			grove := release("grove-operator")
+			grove.Chart = "third-party/grove-operator"
+			releases = append(releases, grove)
 		} else {
 			releases[0].Enabled = false
 		}

--- a/tools/docs-version-sync/resolved_inventory_publish_test.go
+++ b/tools/docs-version-sync/resolved_inventory_publish_test.go
@@ -412,6 +412,9 @@ func (runner *fakeResolvedInventoryRunner) Output(_ string, env []string, args .
 		if strings.Contains(filepath.ToSlash(stateFile), "self-managed/helmfile.d/01-") && !runner.publicPrepared {
 			runner.t.Fatal("Helmfile template ran before public repository preparation")
 		}
+		if !containsArgument(args, "--skip-tests") {
+			runner.t.Fatalf("Helmfile template included test hooks: %v", args)
+		}
 		runner.templateCalls++
 		outputDir := argumentAfter(runner.t, args, "--output-dir")
 		for _, release := range releases {
@@ -493,6 +496,15 @@ func argumentAfter(t *testing.T, args []string, flag string) string {
 	}
 	t.Fatalf("missing %s in %v", flag, args)
 	return ""
+}
+
+func containsArgument(args []string, want string) bool {
+	for _, arg := range args {
+		if arg == want {
+			return true
+		}
+	}
+	return false
 }
 
 func environmentValue(env []string, name string) string {

--- a/tools/docs-version-sync/resolved_inventory_publish_test.go
+++ b/tools/docs-version-sync/resolved_inventory_publish_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -81,17 +82,27 @@ func TestMergeAndResolveHelmfileReleasesPreservesOptionalStatus(t *testing.T) {
 func TestCollectResolvedStackInventoryBuildsEveryPlane(t *testing.T) {
 	t.Setenv("NVCF_RELEASE_NGC_API_KEY", "test-api-key")
 	t.Setenv("NVCF_RELEASE_HELM_REGISTRY", "registry.example.test/release/charts")
-	repo := t.TempDir()
-	writeFile(t, filepath.Join(repo, filepath.FromSlash(resolvedInventoryConfigPath)), "schemaVersion: 1\npublishedChartRepository: "+testPublishedChartRepository+"\nrenderChartRepositoryOverrides:\n  nvcf-compute-plane: nvcr.io/nvidia/nvcf-byoc\n")
-	for _, state := range resolvedInventoryStates {
-		writeFile(t, filepath.Join(repo, filepath.FromSlash(state.path)), "releases: []\n")
+	repo := initTestGitRepo(t)
+	writeFile(t, filepath.Join(repo, "deploy/helm/nvca-operator/nvca-operator/Chart.yaml"), "apiVersion: v2\nname: helm-nvca-operator\nversion: 0.0.0\n")
+	writeFile(t, filepath.Join(repo, "deploy/helm/nvca-operator/nvca-operator/templates/pod.yaml"), "kind: Pod\n")
+	if _, err := gitOutput(repo, "add", "--all"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := gitOutput(repo, "commit", "-m", "nvca chart fixture"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := gitOutput(repo, "tag", "deploy/helm/nvca-operator/v1.0.0"); err != nil {
+		t.Fatal(err)
 	}
 
-	source := stackSourceRelease{
-		Version: "1.2.3",
-		Tag:     stackTagPrefix + "1.2.3",
-		Commit:  strings.Repeat("b", 40),
+	stackFiles := map[string]string{
+		resolvedInventoryConfigPath: "schemaVersion: 1\npublishedChartRepository: " + testPublishedChartRepository + "\nsourceCharts:\n  helm-nvca-operator:\n    tagPrefix: deploy/helm/nvca-operator/v\n    path: deploy/helm/nvca-operator/nvca-operator\n",
 	}
+	for _, state := range resolvedInventoryStates {
+		stackFiles[state.path] = "releases: []\n"
+	}
+	stackFiles["deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl"] = "releases:\n  - name: nvca-operator\n    chart: nvcf/helm-nvca-operator\n    version: 1.0.0\n"
+	source := commitTestStackSource(t, repo, "1.2.3", stackFiles)
 	runner := &fakeResolvedInventoryRunner{t: t}
 	inventory, err := collectResolvedStackInventory(repo, "", source, runner)
 	if err != nil {
@@ -111,10 +122,10 @@ func TestCollectResolvedStackInventoryBuildsEveryPlane(t *testing.T) {
 	if runner.templateCalls != len(resolvedInventoryStates) {
 		t.Fatalf("template calls = %d, want %d", runner.templateCalls, len(resolvedInventoryStates))
 	}
-	if runner.prepareCalls != 4 {
-		t.Fatalf("repository preparation calls = %d, want two sources and two public repository preparations", runner.prepareCalls)
+	if runner.prepareCalls != 3 {
+		t.Fatalf("repository preparation calls = %d, want source and two public repository preparations", runner.prepareCalls)
 	}
-	wantPrefix := []string{"prepare-source", "prepare-source", "list", "list", "build", "prepare-public", "template"}
+	wantPrefix := []string{"prepare-source", "list", "list", "build", "prepare-public", "template"}
 	if len(runner.operations) < len(wantPrefix) || !reflect.DeepEqual(runner.operations[:len(wantPrefix)], wantPrefix) {
 		t.Fatalf("operation prefix = %v, want %v", runner.operations, wantPrefix)
 	}
@@ -159,7 +170,7 @@ func TestParseResolvedInventoryHelmSource(t *testing.T) {
 func TestLoadResolvedInventoryConfig(t *testing.T) {
 	repo := t.TempDir()
 	configPath := filepath.Join(repo, filepath.FromSlash(resolvedInventoryConfigPath))
-	writeFile(t, configPath, "schemaVersion: 1\npublishedChartRepository: "+testPublishedChartRepository+"\nrenderChartRepositoryOverrides:\n  nvcf-compute-plane: nvcr.io/nvidia/nvcf-byoc\n")
+	writeFile(t, configPath, "schemaVersion: 1\npublishedChartRepository: "+testPublishedChartRepository+"\nsourceCharts:\n  helm-nvca-operator:\n    tagPrefix: deploy/helm/nvca-operator/v\n    path: deploy/helm/nvca-operator/nvca-operator\n")
 	config, err := loadResolvedInventoryConfig(repo, "")
 	if err != nil {
 		t.Fatal(err)
@@ -167,8 +178,8 @@ func TestLoadResolvedInventoryConfig(t *testing.T) {
 	if config.PublishedChartRepository != testPublishedChartRepository {
 		t.Fatalf("published repository = %q", config.PublishedChartRepository)
 	}
-	if got := config.RenderChartRepositoryOverrides["nvcf-compute-plane"]; got != "nvcr.io/nvidia/nvcf-byoc" {
-		t.Fatalf("compute-plane render repository = %q", got)
+	if got := config.SourceCharts["helm-nvca-operator"].TagPrefix; got != "deploy/helm/nvca-operator/v" {
+		t.Fatalf("NVCA source chart tag prefix = %q", got)
 	}
 
 	writeFile(t, configPath, "schemaVersion: 1\npublishedChartRepository: oci://registry.example.test/charts\n")
@@ -176,14 +187,14 @@ func TestLoadResolvedInventoryConfig(t *testing.T) {
 		t.Fatalf("non-HTTPS repository error = %v", err)
 	}
 
-	writeFile(t, configPath, "schemaVersion: 1\npublishedChartRepository: "+testPublishedChartRepository+"\nrenderChartRepositoryOverrides:\n  unknown-stack: registry.example.test/charts\n")
-	if _, err := loadResolvedInventoryConfig(repo, ""); err == nil || !strings.Contains(err.Error(), "unknown stack") {
-		t.Fatalf("unknown override stack error = %v", err)
+	writeFile(t, configPath, "schemaVersion: 1\npublishedChartRepository: "+testPublishedChartRepository+"\nsourceCharts:\n  helm-nvca-operator:\n    tagPrefix: deploy/helm/nvca-operator\n    path: deploy/helm/nvca-operator/nvca-operator\n")
+	if _, err := loadResolvedInventoryConfig(repo, ""); err == nil || !strings.Contains(err.Error(), "ending in /v") {
+		t.Fatalf("invalid source chart tag prefix error = %v", err)
 	}
 
-	writeFile(t, configPath, "schemaVersion: 1\npublishedChartRepository: "+testPublishedChartRepository+"\nrenderChartRepositoryOverrides:\n  nvcf-compute-plane: https://registry.example.test/charts\n")
-	if _, err := loadResolvedInventoryConfig(repo, ""); err == nil || !strings.Contains(err.Error(), "without credentials or a URL scheme") {
-		t.Fatalf("invalid override repository error = %v", err)
+	writeFile(t, configPath, "schemaVersion: 1\npublishedChartRepository: "+testPublishedChartRepository+"\nsourceCharts:\n  helm-nvca-operator:\n    tagPrefix: deploy/helm/nvca-operator/v\n    path: deploy/helm/other/nvca-operator\n")
+	if _, err := loadResolvedInventoryConfig(repo, ""); err == nil || !strings.Contains(err.Error(), "path must be within") {
+		t.Fatalf("invalid source chart path error = %v", err)
 	}
 
 	externalConfig := filepath.Join(t.TempDir(), "release-inventory.yaml")
@@ -194,41 +205,6 @@ func TestLoadResolvedInventoryConfig(t *testing.T) {
 	}
 	if external.PublishedChartRepository != "https://helm.example.test/external" {
 		t.Fatalf("external published repository = %q", external.PublishedChartRepository)
-	}
-}
-
-func TestPrepareResolvedInventoryEnvironmentWritesStackRenderSources(t *testing.T) {
-	t.Setenv("NVCF_RELEASE_NGC_API_KEY", "test-api-key")
-	t.Setenv("NVCF_RELEASE_HELM_REGISTRY", "registry.example.test/release/charts")
-	repo := t.TempDir()
-	config := resolvedInventoryConfig{
-		RenderChartRepositoryOverrides: map[string]string{
-			"nvcf-compute-plane": "nvcr.io/nvidia/nvcf-byoc",
-		},
-	}
-
-	_, sources, _, err := prepareResolvedInventoryEnvironment(repo, config)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := sources["self-managed"].reference(); got != "registry.example.test/release/charts" {
-		t.Fatalf("self-managed render source = %q", got)
-	}
-	if got := sources["nvcf-compute-plane"].reference(); got != "nvcr.io/nvidia/nvcf-byoc" {
-		t.Fatalf("compute-plane render source = %q", got)
-	}
-	for stack, want := range map[string]string{
-		"self-managed":       "repository: release/charts",
-		"observability":      "repository: release/charts",
-		"nvcf-compute-plane": "repository: nvidia/nvcf-byoc",
-	} {
-		raw, err := os.ReadFile(filepath.Join(repo, "deploy", "stacks", stack, "environments", "inventory.yaml"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !strings.Contains(string(raw), want) {
-			t.Fatalf("%s inventory environment = %s, want %q", stack, raw, want)
-		}
 	}
 }
 
@@ -336,12 +312,12 @@ func mustJSON(t *testing.T, value any) []byte {
 }
 
 type fakeResolvedInventoryRunner struct {
-	t               *testing.T
-	prepareCalls    int
-	templateCalls   int
-	preparedSources map[string]bool
-	publicPrepared  bool
-	operations      []string
+	t              *testing.T
+	prepareCalls   int
+	templateCalls  int
+	sourcePrepared bool
+	publicPrepared bool
+	operations     []string
 }
 
 func (runner *fakeResolvedInventoryRunner) PrepareRepositories(_ []string, repositories map[string]helmfileRepository, ngcAPIKey string) error {
@@ -351,14 +327,10 @@ func (runner *fakeResolvedInventoryRunner) PrepareRepositories(_ []string, repos
 		runner.t.Fatalf("NGC API key = %q", ngcAPIKey)
 	}
 	if repository, ok := repositories["nvcf"]; ok {
-		if len(repositories) != 1 || !repository.OCI ||
-			(repository.URL != "registry.example.test/release/charts" && repository.URL != "nvcr.io/nvidia/nvcf-byoc") {
+		if len(repositories) != 1 || !repository.OCI || repository.URL != "registry.example.test/release/charts" {
 			runner.t.Fatalf("source repositories = %#v", repositories)
 		}
-		if runner.preparedSources == nil {
-			runner.preparedSources = map[string]bool{}
-		}
-		runner.preparedSources[repository.URL] = true
+		runner.sourcePrepared = true
 		runner.operations = append(runner.operations, "prepare-source")
 		return nil
 	}
@@ -391,12 +363,8 @@ func (runner *fakeResolvedInventoryRunner) Output(_ string, env []string, args .
 	}
 	stateFile := argumentAfter(runner.t, args, "--file")
 	action := resolvedInventoryAction(args)
-	expectedSource := "registry.example.test/release/charts"
-	if strings.Contains(filepath.ToSlash(stateFile), "nvcf-compute-plane/") {
-		expectedSource = "nvcr.io/nvidia/nvcf-byoc"
-	}
-	if (action == "list" || action == "build") && !runner.preparedSources[expectedSource] {
-		runner.t.Fatalf("Helmfile %s ran before source-registry authentication for %s", action, expectedSource)
+	if (action == "list" || action == "build") && !runner.sourcePrepared {
+		runner.t.Fatalf("Helmfile %s ran before source-registry authentication", action)
 	}
 	runner.operations = append(runner.operations, action)
 	releases := fakeResolvedInventoryReleases(stateFile, hasResolvedInventoryFullOverrides(args))
@@ -404,11 +372,37 @@ func (runner *fakeResolvedInventoryRunner) Output(_ string, env []string, args .
 	case "list":
 		return mustJSON(runner.t, releases), nil
 	case "build":
+		if strings.Contains(filepath.ToSlash(stateFile), "nvcf-compute-plane/helmfile.d/02-") {
+			raw, err := os.ReadFile(stateFile)
+			if err != nil {
+				runner.t.Fatal(err)
+			}
+			if strings.Contains(string(raw), "chart: nvcf/helm-nvca-operator") || !strings.Contains(string(raw), "-source-charts") {
+				runner.t.Fatalf("NVCA state did not use the materialized source chart:\n%s", raw)
+			}
+			chartValue := ""
+			for _, line := range strings.Split(string(raw), "\n") {
+				if strings.HasPrefix(strings.TrimSpace(line), "chart: ") {
+					chartValue = strings.TrimPrefix(strings.TrimSpace(line), "chart: ")
+				}
+			}
+			chartPath, err := strconv.Unquote(chartValue)
+			if err != nil {
+				runner.t.Fatalf("unquote materialized chart path %q: %v", chartValue, err)
+			}
+			metadata, err := os.ReadFile(filepath.Join(chartPath, "Chart.yaml"))
+			if err != nil {
+				runner.t.Fatal(err)
+			}
+			if !strings.Contains(string(metadata), "version: \"1.0.0\"") {
+				runner.t.Fatalf("materialized chart did not use pinned version:\n%s", metadata)
+			}
+		}
 		built := "repositories:\n"
 		if strings.Contains(filepath.ToSlash(stateFile), "nvcf-compute-plane/helmfile.d/01-") {
 			built += "  - name: third-party\n    url: https://third-party.example.test\n    oci: false\n"
 		} else {
-			built += "  - name: nvcf\n    url: " + expectedSource + "\n    oci: true\n"
+			built += "  - name: nvcf\n    url: registry.example.test/release/charts\n    oci: true\n"
 		}
 		if strings.Contains(filepath.ToSlash(stateFile), "self-managed/helmfile.d/01-") {
 			built += "  - name: public\n    url: https://charts.example.test\n    oci: false\n"
@@ -463,7 +457,9 @@ func fakeResolvedInventoryReleases(stateFile string, full bool) []helmfileReleas
 		}
 		return releases
 	case strings.Contains(slashPath, "nvcf-compute-plane/helmfile.d/02-"):
-		return []helmfileRelease{release("nvca-operator")}
+		nvca := release("nvca-operator")
+		nvca.Chart = "nvcf/helm-nvca-operator"
+		return []helmfileRelease{nvca}
 	default:
 		panic("unexpected state " + stateFile)
 	}

--- a/tools/docs-version-sync/resolved_inventory_publish_test.go
+++ b/tools/docs-version-sync/resolved_inventory_publish_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -81,7 +82,7 @@ func TestCollectResolvedStackInventoryBuildsEveryPlane(t *testing.T) {
 	t.Setenv("NVCF_RELEASE_NGC_API_KEY", "test-api-key")
 	t.Setenv("NVCF_RELEASE_HELM_REGISTRY", "registry.example.test/release/charts")
 	repo := t.TempDir()
-	writeFile(t, filepath.Join(repo, filepath.FromSlash(resolvedInventoryConfigPath)), "schemaVersion: 1\npublishedChartRepository: "+testPublishedChartRepository+"\n")
+	writeFile(t, filepath.Join(repo, filepath.FromSlash(resolvedInventoryConfigPath)), "schemaVersion: 1\npublishedChartRepository: "+testPublishedChartRepository+"\nrenderChartRepositoryOverrides:\n  nvcf-compute-plane: nvcr.io/nvidia/nvcf-byoc\n")
 	for _, state := range resolvedInventoryStates {
 		writeFile(t, filepath.Join(repo, filepath.FromSlash(state.path)), "releases: []\n")
 	}
@@ -110,10 +111,10 @@ func TestCollectResolvedStackInventoryBuildsEveryPlane(t *testing.T) {
 	if runner.templateCalls != len(resolvedInventoryStates) {
 		t.Fatalf("template calls = %d, want %d", runner.templateCalls, len(resolvedInventoryStates))
 	}
-	if runner.prepareCalls != 3 {
-		t.Fatalf("repository preparation calls = %d, want source and two public repository preparations", runner.prepareCalls)
+	if runner.prepareCalls != 4 {
+		t.Fatalf("repository preparation calls = %d, want two sources and two public repository preparations", runner.prepareCalls)
 	}
-	wantPrefix := []string{"prepare-source", "list", "list", "build", "prepare-public", "template"}
+	wantPrefix := []string{"prepare-source", "prepare-source", "list", "list", "build", "prepare-public", "template"}
 	if len(runner.operations) < len(wantPrefix) || !reflect.DeepEqual(runner.operations[:len(wantPrefix)], wantPrefix) {
 		t.Fatalf("operation prefix = %v, want %v", runner.operations, wantPrefix)
 	}
@@ -158,7 +159,7 @@ func TestParseResolvedInventoryHelmSource(t *testing.T) {
 func TestLoadResolvedInventoryConfig(t *testing.T) {
 	repo := t.TempDir()
 	configPath := filepath.Join(repo, filepath.FromSlash(resolvedInventoryConfigPath))
-	writeFile(t, configPath, "schemaVersion: 1\npublishedChartRepository: "+testPublishedChartRepository+"\n")
+	writeFile(t, configPath, "schemaVersion: 1\npublishedChartRepository: "+testPublishedChartRepository+"\nrenderChartRepositoryOverrides:\n  nvcf-compute-plane: nvcr.io/nvidia/nvcf-byoc\n")
 	config, err := loadResolvedInventoryConfig(repo)
 	if err != nil {
 		t.Fatal(err)
@@ -166,10 +167,58 @@ func TestLoadResolvedInventoryConfig(t *testing.T) {
 	if config.PublishedChartRepository != testPublishedChartRepository {
 		t.Fatalf("published repository = %q", config.PublishedChartRepository)
 	}
+	if got := config.RenderChartRepositoryOverrides["nvcf-compute-plane"]; got != "nvcr.io/nvidia/nvcf-byoc" {
+		t.Fatalf("compute-plane render repository = %q", got)
+	}
 
 	writeFile(t, configPath, "schemaVersion: 1\npublishedChartRepository: oci://registry.example.test/charts\n")
 	if _, err := loadResolvedInventoryConfig(repo); err == nil || !strings.Contains(err.Error(), "resolved HTTPS repository") {
 		t.Fatalf("non-HTTPS repository error = %v", err)
+	}
+
+	writeFile(t, configPath, "schemaVersion: 1\npublishedChartRepository: "+testPublishedChartRepository+"\nrenderChartRepositoryOverrides:\n  unknown-stack: registry.example.test/charts\n")
+	if _, err := loadResolvedInventoryConfig(repo); err == nil || !strings.Contains(err.Error(), "unknown stack") {
+		t.Fatalf("unknown override stack error = %v", err)
+	}
+
+	writeFile(t, configPath, "schemaVersion: 1\npublishedChartRepository: "+testPublishedChartRepository+"\nrenderChartRepositoryOverrides:\n  nvcf-compute-plane: https://registry.example.test/charts\n")
+	if _, err := loadResolvedInventoryConfig(repo); err == nil || !strings.Contains(err.Error(), "without credentials or a URL scheme") {
+		t.Fatalf("invalid override repository error = %v", err)
+	}
+}
+
+func TestPrepareResolvedInventoryEnvironmentWritesStackRenderSources(t *testing.T) {
+	t.Setenv("NVCF_RELEASE_NGC_API_KEY", "test-api-key")
+	t.Setenv("NVCF_RELEASE_HELM_REGISTRY", "registry.example.test/release/charts")
+	repo := t.TempDir()
+	config := resolvedInventoryConfig{
+		RenderChartRepositoryOverrides: map[string]string{
+			"nvcf-compute-plane": "nvcr.io/nvidia/nvcf-byoc",
+		},
+	}
+
+	_, sources, _, err := prepareResolvedInventoryEnvironment(repo, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := sources["self-managed"].reference(); got != "registry.example.test/release/charts" {
+		t.Fatalf("self-managed render source = %q", got)
+	}
+	if got := sources["nvcf-compute-plane"].reference(); got != "nvcr.io/nvidia/nvcf-byoc" {
+		t.Fatalf("compute-plane render source = %q", got)
+	}
+	for stack, want := range map[string]string{
+		"self-managed":       "repository: release/charts",
+		"observability":      "repository: release/charts",
+		"nvcf-compute-plane": "repository: nvidia/nvcf-byoc",
+	} {
+		raw, err := os.ReadFile(filepath.Join(repo, "deploy", "stacks", stack, "environments", "inventory.yaml"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(raw), want) {
+			t.Fatalf("%s inventory environment = %s, want %q", stack, raw, want)
+		}
 	}
 }
 
@@ -277,12 +326,12 @@ func mustJSON(t *testing.T, value any) []byte {
 }
 
 type fakeResolvedInventoryRunner struct {
-	t              *testing.T
-	prepareCalls   int
-	templateCalls  int
-	sourcePrepared bool
-	publicPrepared bool
-	operations     []string
+	t               *testing.T
+	prepareCalls    int
+	templateCalls   int
+	preparedSources map[string]bool
+	publicPrepared  bool
+	operations      []string
 }
 
 func (runner *fakeResolvedInventoryRunner) PrepareRepositories(_ []string, repositories map[string]helmfileRepository, ngcAPIKey string) error {
@@ -292,10 +341,14 @@ func (runner *fakeResolvedInventoryRunner) PrepareRepositories(_ []string, repos
 		runner.t.Fatalf("NGC API key = %q", ngcAPIKey)
 	}
 	if repository, ok := repositories["nvcf"]; ok {
-		if len(repositories) != 1 || !repository.OCI || repository.URL != "registry.example.test/release/charts" {
+		if len(repositories) != 1 || !repository.OCI ||
+			(repository.URL != "registry.example.test/release/charts" && repository.URL != "nvcr.io/nvidia/nvcf-byoc") {
 			runner.t.Fatalf("source repositories = %#v", repositories)
 		}
-		runner.sourcePrepared = true
+		if runner.preparedSources == nil {
+			runner.preparedSources = map[string]bool{}
+		}
+		runner.preparedSources[repository.URL] = true
 		runner.operations = append(runner.operations, "prepare-source")
 		return nil
 	}
@@ -328,8 +381,12 @@ func (runner *fakeResolvedInventoryRunner) Output(_ string, env []string, args .
 	}
 	stateFile := argumentAfter(runner.t, args, "--file")
 	action := resolvedInventoryAction(args)
-	if (action == "list" || action == "build") && !runner.sourcePrepared {
-		runner.t.Fatalf("Helmfile %s ran before source-registry authentication", action)
+	expectedSource := "registry.example.test/release/charts"
+	if strings.Contains(filepath.ToSlash(stateFile), "nvcf-compute-plane/") {
+		expectedSource = "nvcr.io/nvidia/nvcf-byoc"
+	}
+	if (action == "list" || action == "build") && !runner.preparedSources[expectedSource] {
+		runner.t.Fatalf("Helmfile %s ran before source-registry authentication for %s", action, expectedSource)
 	}
 	runner.operations = append(runner.operations, action)
 	releases := fakeResolvedInventoryReleases(stateFile, hasResolvedInventoryFullOverrides(args))
@@ -341,7 +398,7 @@ func (runner *fakeResolvedInventoryRunner) Output(_ string, env []string, args .
 		if strings.Contains(filepath.ToSlash(stateFile), "nvcf-compute-plane/helmfile.d/01-") {
 			built += "  - name: third-party\n    url: https://third-party.example.test\n    oci: false\n"
 		} else {
-			built += "  - name: nvcf\n    url: registry.example.test/release/charts\n    oci: true\n"
+			built += "  - name: nvcf\n    url: " + expectedSource + "\n    oci: true\n"
 		}
 		if strings.Contains(filepath.ToSlash(stateFile), "self-managed/helmfile.d/01-") {
 			built += "  - name: public\n    url: https://charts.example.test\n    oci: false\n"


### PR DESCRIPTION
# TL;DR

Restore self-managed stack inventory publication by supporting third-party-only Helmfile states, rendering independently released NVCA from its immutable public Git tag, and excluding Helm test hooks from deployed-image discovery. Add a nonpublishing preflight that validates the complete release render before merge.

## Additional Details

### Why

The `v0.15.2` tag workflow authenticated the composite chart source, then failed because the compute-plane dependency state intentionally has no `nvcf` repository alias. The test fake incorrectly injected that alias into every state.

Fixing that assumption exposed two more release-topology issues:

- The NVCA chart is released independently and is not mirrored into the composite stack chart source.
- Helm template output included test-hook pods, whose test-only image references are not deployed stack artifacts.

The inventory must describe the charts and images installed by the released stack. It must not depend on a private catalog location, silently substitute chart source from a different commit, or include Helm tests.

Original failed tag workflow: https://github.com/NVIDIA/nvcf/actions/runs/34543947807

### What changed

- Permit a Helmfile state to omit `nvcf` when none of its releases use that alias. Releases that use an undeclared alias still fail chart resolution.
- Preserve strict source and OCI validation for states that declare `nvcf`.
- Model the compute dependency state with only third-party charts in the inventory tests.
- Add `sourceCharts` to the stack release-inventory contract. NVCA is extracted from the public component tag matching the version pinned by the stack.
- Require each configured component tag to be an ancestor of the stack release commit. Reject missing, invalid, or unused source-chart configuration.
- Extract only the configured chart directory into temporary storage, reject unsafe archive entries, and set the temporary chart metadata to the pinned release version.
- Keep emitted NVCF chart references canonicalized to the public self-managed catalog at `https://helm.ngc.nvidia.com/nvidia/nvcf`.
- Render with `--skip-tests`, so Helm test hooks are not treated as deployed release artifacts.
- Add `--inventory-config` so the preflight can use the candidate inventory contract while all Helmfiles and component pins come from the clean, immutable stack tag.
- Add a manual `inventory_tag` preflight. It builds the candidate renderer, creates a detached worktree at the requested stack tag, and validates the generated JSON only in runner-local temporary storage.
- Disable both release-writing jobs during the preflight. It cannot create, edit, or upload a GitHub release.

### Release and preflight flow

```mermaid
sequenceDiagram
    participant Trigger as Tag event or preflight dispatch
    participant Workflow as release-tags
    participant Renderer as docs-version-sync
    participant Stack as Immutable stack tag
    participant Charts as Release chart sources
    participant Release as GitHub release

    Trigger->>Workflow: Select self-managed stack tag
    Workflow->>Stack: Create clean tagged checkout
    Workflow->>Renderer: Generate resolved inventory
    Renderer->>Stack: Read Helmfiles and pinned versions
    Renderer->>Charts: Pull composite and third-party charts
    Renderer->>Stack: Extract NVCA from its component release tag
    Renderer->>Renderer: Render manifests without Helm tests
    Renderer->>Renderer: Validate charts, images, and source commit
    alt Normal stack tag event
        Renderer->>Release: Attach inventory JSON
    else Manual preflight
        Renderer-->>Workflow: Validate runner-local JSON only
        Note over Workflow,Release: Release-writing jobs are skipped
    end
```

### Customer Release Notes

Self-managed stack releases now publish the resolved chart and image inventory used by documentation version synchronization.

### Plan Summary

The preflight has read-only repository permissions and uses `github.token` for checkout. Release credentials are exposed only to the render step. The candidate config path is explicit, while stack Helmfiles and component pins remain in a clean detached checkout at the requested tag. Generated data stays in runner-local temporary storage.

### Usage

For nonpublishing validation, dispatch `release-tags` on the candidate branch with `inventory_tag=deploy/stacks/self-managed/v0.15.2`.

### Testing

- `go test ./...` in `tools/docs-version-sync`
- `go vet ./...` in `tools/docs-version-sync`
- `python3 tools/ci/test-github-release.py` (59 tests)
- `./tools/ci/check-doc-version-sync`
- `git diff --check`
- Successful credentialed, nonpublishing tagged-source preflight at the current PR head: https://github.com/NVIDIA/nvcf/actions/runs/34553730014

The successful preflight rendered the full released `v0.15.2` stack inventory. `service release automation` and `tag release notes` were both skipped, and no release asset was written.

### Preflight findings

- https://github.com/NVIDIA/nvcf/actions/runs/34549812392 verified the missing-`nvcf` fix and exposed that NVCA was absent from the composite chart source.
- https://github.com/NVIDIA/nvcf/actions/runs/34551113309 verified candidate config selection and showed that the release credential could not pull the separate catalog copy.
- https://github.com/NVIDIA/nvcf/actions/runs/34552047490 verified immutable NVCA source rendering and exposed the Helm test-hook image.
- https://github.com/NVIDIA/nvcf/actions/runs/34552503963 passed after Helm tests were excluded.
- https://github.com/NVIDIA/nvcf/actions/runs/34553730014 confirmed the final reviewed changes at the current PR head.

### Notes

The existing `v0.15.2` release remains unchanged and has no inventory asset. After this PR merges, a successor self-managed stack release is still required so docs version sync can consume its attached inventory.

No cluster QA is needed. The credentialed tagged-source preflight exercises the release render path without publishing.

### References

- https://github.com/NVIDIA/nvcf/issues/279
- https://github.com/NVIDIA/nvcf/issues/1778
- https://github.com/NVIDIA/nvcf/pull/1742
- https://github.com/NVIDIA/nvcf/pull/1767
- https://github.com/NVIDIA/nvcf/pull/1774

### Related Pull Requests

- #1742 added resolved inventory publication.
- #1767 selected the authenticated release chart source.
- #1774 moved source authentication before Helmfile evaluation.

### Dependencies

None. No license or NOTICE changes are required.

## For the Reviewer

Please focus on the component-tag trust boundary and ancestry check, temporary chart extraction, missing-`nvcf` invariant, and the nonpublishing guarantees in `inventory-preflight`.

## For QA

No additional QA is needed. The successful preflight above used the real `v0.15.2` tag and release credentials without publishing.

## Issues

Fixes #1778

Relates to #279

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
