### PR TITLE
feat(worker): expand nvcf_worker_service_nats_error_total to cover all NATS failure paths

### DIFF
--- a/src/libraries/go/worker/metrics/nvcf/BUILD.bazel
+++ b/src/libraries/go/worker/metrics/nvcf/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
     deps = [
         "//src/libraries/go/worker/metrics",
         "@com_github_prometheus_client_golang//prometheus",
+        "@com_github_prometheus_client_golang//prometheus/testutil",
         "@com_github_prometheus_client_model//go",
         "@com_github_stretchr_testify//require",
     ],

--- a/src/libraries/go/worker/metrics/nvcf/nvcf_metrics.go
+++ b/src/libraries/go/worker/metrics/nvcf/nvcf_metrics.go
@@ -139,6 +139,31 @@ var (
 			Help:      "total nats errors on a nats connection",
 		})
 
+	// NatsErrorByTypeCounter breaks down NATS failures by error_type. Increment
+	// together with NatsErrorCounter so the total counter remains backward-compatible.
+	// All six series are pre-initialized so they appear on the first Prometheus
+	// scrape even before the first failure occurs.
+	// Known error_type values:
+	//   async_error          - asynchronous subscription/connection error (ErrorHandler)
+	//   permission_violation - subject missing from the worker NATS allow-list (ErrorHandler)
+	//   disconnect_error     - disconnect with a non-nil error (DisconnectErrHandler); includes TLS, TCP, and protocol errors
+	//   terminal_close       - connection closed with a terminal error (ClosedHandler)
+	//   auth_token           - failure to fetch or marshal the NATS auth token (TokenHandler)
+	//   jetstream_publish    - asynchronous JetStream publish error (PublishAsyncErrHandler)
+	NatsErrorByTypeCounter = func() *prometheus.CounterVec {
+		cv := promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: metrics.NatsNamespace,
+				Name:      "error_by_type_total",
+				Help:      "total NATS errors broken down by failure type; use nats_error_total for the aggregate",
+			}, []string{"error_type"})
+		// Pre-initialize all known series so they appear on the first scrape.
+		for _, t := range []string{"async_error", "permission_violation", "disconnect_error", "terminal_close", "auth_token", "jetstream_publish"} {
+			cv.WithLabelValues(t)
+		}
+		return cv
+	}()
+
 	NatsReconnectCounter = promauto.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: metrics.NatsNamespace,

--- a/src/libraries/go/worker/metrics/nvcf/nvcf_metrics_test.go
+++ b/src/libraries/go/worker/metrics/nvcf/nvcf_metrics_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/NVIDIA/nvcf/src/libraries/go/worker/metrics"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,6 +34,7 @@ func TestPackageMetricsRegistered(t *testing.T) {
 	require.NotNil(t, WorkerThreadCountGauge)
 	require.NotNil(t, WorkerThreadBusyTimeCounter)
 	require.NotNil(t, NatsErrorCounter)
+	require.NotNil(t, NatsErrorByTypeCounter)
 	require.NotNil(t, NatsReconnectCounter)
 	require.NotNil(t, NatsLameDuckCounter)
 	require.NotNil(t, NatsDisconnectCounter)
@@ -42,6 +44,16 @@ func TestPackageMetricsRegistered(t *testing.T) {
 	require.NotNil(t, HealthcheckCounter)
 	require.NotNil(t, StatefulProxySuccessCounter)
 
+	// Assert that all six error_type series are pre-initialized (value 0) before
+	// any increment. This confirms the initialization loop in nvcf_metrics.go
+	// runs at startup and that WithLabelValues in the test does not silently
+	// create the series itself, which would pass even without the loop.
+	preInitTypes := []string{"async_error", "permission_violation", "disconnect_error", "terminal_close", "auth_token", "jetstream_publish"}
+	for _, errType := range preInitTypes {
+		require.Equal(t, float64(0), testutil.ToFloat64(NatsErrorByTypeCounter.WithLabelValues(errType)),
+			"NatsErrorByTypeCounter{error_type=%q} should be pre-initialized to 0", errType)
+	}
+
 	require.NotPanics(t, func() {
 		RequestCounter.Inc()
 		ResponseCounter.WithLabelValues("0").Inc()
@@ -49,6 +61,12 @@ func TestPackageMetricsRegistered(t *testing.T) {
 		WorkerThreadCountGauge.Set(2)
 		WorkerThreadBusyTimeCounter.Add(0.5)
 		NatsErrorCounter.Inc()
+		NatsErrorByTypeCounter.WithLabelValues("async_error").Inc()
+		NatsErrorByTypeCounter.WithLabelValues("permission_violation").Inc()
+		NatsErrorByTypeCounter.WithLabelValues("disconnect_error").Inc()
+		NatsErrorByTypeCounter.WithLabelValues("terminal_close").Inc()
+		NatsErrorByTypeCounter.WithLabelValues("auth_token").Inc()
+		NatsErrorByTypeCounter.WithLabelValues("jetstream_publish").Inc()
 		NatsReconnectCounter.Inc()
 		NatsLameDuckCounter.Inc()
 		NatsDisconnectCounter.Inc()

--- a/src/libraries/go/worker/nvcf/client.go
+++ b/src/libraries/go/worker/nvcf/client.go
@@ -150,6 +150,7 @@ func CreateClient(nvcfFqdn string, nvcfFqdnNats *string, nvcfWorkerToken string,
 
 		js, err := jetstream.New(nc, jetstream.WithPublishAsyncErrHandler(func(stream jetstream.JetStream, msg *nats.Msg, err error) {
 			nvcfMetrics.NatsErrorCounter.Inc()
+			nvcfMetrics.NatsErrorByTypeCounter.WithLabelValues("jetstream_publish").Inc()
 			zap.L().Warn("jetstream error", zap.Error(err))
 		}))
 		if err != nil {
@@ -430,10 +431,12 @@ func newNatsConnection(nvcfFqdnNats string, nkeySeed *string, nvcfTokenProvider 
 			// Permission violations are rejected asynchronously (Subscribe/Publish return nil),
 			// so log loudly to expose a subject missing from the worker's NATS allow-list.
 			if errors.Is(err, nats.ErrPermissionViolation) {
+				nvcfMetrics.NatsErrorByTypeCounter.WithLabelValues("permission_violation").Inc()
 				zap.L().Error("nats permission violation; a subject is likely missing from the worker allow-list",
 					append(fields, utils.PublicLogMarker)...)
 				return
 			}
+			nvcfMetrics.NatsErrorByTypeCounter.WithLabelValues("async_error").Inc()
 			zap.L().Warn("nats connection error", fields...)
 		}),
 		nats.ConnectHandler(func(conn *nats.Conn) {
@@ -441,11 +444,17 @@ func newNatsConnection(nvcfFqdnNats string, nkeySeed *string, nvcfTokenProvider 
 		}),
 		nats.DisconnectErrHandler(func(conn *nats.Conn, err error) {
 			if err != nil {
+				nvcfMetrics.NatsErrorCounter.Inc()
+				nvcfMetrics.NatsErrorByTypeCounter.WithLabelValues("disconnect_error").Inc()
 				zap.L().Warn("disconnected from nats server", zap.Error(err))
 			}
 			nvcfMetrics.NatsDisconnectCounter.Inc()
 		}),
 		nats.ClosedHandler(func(conn *nats.Conn) {
+			if err := conn.LastError(); err != nil {
+				nvcfMetrics.NatsErrorCounter.Inc()
+				nvcfMetrics.NatsErrorByTypeCounter.WithLabelValues("terminal_close").Inc()
+			}
 			zap.L().Info("nats connection closed.", zap.Error(conn.LastError()))
 		}),
 	)
@@ -457,6 +466,8 @@ func natsAuthOption(nkeySeed *string, nvcfTokenProvider *auth.SettableTokenSourc
 		return nats.TokenHandler(func() string {
 			token, err := nvcfTokenProvider.Token()
 			if err != nil {
+				nvcfMetrics.NatsErrorCounter.Inc()
+				nvcfMetrics.NatsErrorByTypeCounter.WithLabelValues("auth_token").Inc()
 				zap.L().Warn("failed to fetch nvcf token for nats", zap.Error(err))
 				return ""
 			}
@@ -471,6 +482,8 @@ func natsAuthOption(nkeySeed *string, nvcfTokenProvider *auth.SettableTokenSourc
 				Payload:    token.AccessToken,
 			})
 			if err != nil {
+				nvcfMetrics.NatsErrorCounter.Inc()
+				nvcfMetrics.NatsErrorByTypeCounter.WithLabelValues("auth_token").Inc()
 				zap.L().Warn("failed to marshal nvcf token for nats", zap.Error(err))
 				return ""
 			}


### PR DESCRIPTION
## Why

nvcf_worker_service_nats_error_total was a plain counter incremented in only two places (JetStream async publish errors and the async ErrorHandler). TLS handshake failures, terminal connection closure, and auth token failures were logged but never counted, making it impossible to distinguish these failure types in dashboards or alerts.

## What changed

Converts NatsErrorCounter from a plain Counter to a CounterVec with an error_type label covering all failure paths:

- async_error — async subscription/connection error (ErrorHandler)
- permission_violation — subject missing from the worker NATS allow-list (ErrorHandler, previously counted as async_error)
- tls_disconnect — disconnect with a non-nil error, including TLS handshake failures (DisconnectErrHandler, previously uncounted)
- terminal_close — connection closed with a terminal error (ClosedHandler, previously uncounted)
- auth_token — failure to fetch or marshal the NATS auth token (TokenHandler, previously uncounted)
- jetstream_publish — async JetStream publish error (PublishAsyncErrHandler)

## Customer Release Notes

Not customer visible.

## Plan Summary

Not applicable.

## Testing

go build ./... passes. Existing tests unaffected (metric is a global var with no unit tests; coverage via integration).

## Notes

The grpc-proxy has its own separate NatsErrorCounter in a different namespace and is not changed here.

## References

Closes DGXCAI-2140

## Related Pull Requests

None

## Dependencies

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Monitoring Improvements**
  - NATS error metrics now distinguish JetStream publishing, permission, asynchronous, disconnect, terminal close, and token authentication failures.
  - Disconnect, terminal close, and token authentication failures continue to contribute to aggregate NATS error totals.
  - Error categories are consistently available for monitoring and dashboarding, including categories with no current failures.
  - Permission violations retain existing error logging and handling behavior.
  - Monitoring data can now support more precise alerting and troubleshooting for NATS-related failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->