### PR TITLE
fix(release): render independently tagged charts from source

### DIFF
--- a/deploy/stacks/self-managed/release-inventory.yaml
+++ b/deploy/stacks/self-managed/release-inventory.yaml
@@ -2,13 +2,27 @@
 # SPDX-License-Identifier: Apache-2.0
 
 schemaVersion: 1
-# NVCA is released independently and is not mirrored into the composite stack's
-# release chart repository. Render the pinned chart from its immutable public
-# GitHub release tag, then report the public self-managed catalog destination.
+# These charts are released independently and might not yet be mirrored into
+# the composite stack's release chart repository. Render each pinned chart from
+# its immutable public GitHub release tag, then report the public self-managed
+# catalog destination.
 sourceCharts:
+  helm-nvcf-invocation-service:
+    tagPrefix: deploy/helm/http-invocation/v
+    path: deploy/helm/http-invocation/nvcf-invocation-service
+  helm-nvcf-nats-auth-callout-service:
+    tagPrefix: deploy/helm/nats-auth-callout/v
+    path: deploy/helm/nats-auth-callout
+    # Chart v1.2.0 expects this unscoped value while the tagged stack keeps the
+    # intended public repository under natsAuthCalloutService.
+    renderValues:
+      image.repository: nvcr.io/nvidia/nvcf/nvcf-nats-auth-callout-service
   helm-nvca-operator:
     tagPrefix: deploy/helm/nvca-operator/v
     path: deploy/helm/nvca-operator/nvca-operator
+  helm-nvcf-rate-limiter:
+    tagPrefix: deploy/helm/ratelimiter/v
+    path: deploy/helm/ratelimiter/nvcf-ratelimiter
 # The release workflow authenticates before evaluating the remaining charts and
 # permits states that contain only third-party or local charts.
 publishedChartRepository: https://helm.ngc.nvidia.com/nvidia/nvcf

--- a/tools/docs-version-sync/resolved_inventory_publish.go
+++ b/tools/docs-version-sync/resolved_inventory_publish.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -204,8 +205,9 @@ type resolvedInventoryConfig struct {
 }
 
 type resolvedInventorySourceChart struct {
-	TagPrefix string `yaml:"tagPrefix"`
-	Path      string `yaml:"path"`
+	TagPrefix    string            `yaml:"tagPrefix"`
+	Path         string            `yaml:"path"`
+	RenderValues map[string]string `yaml:"renderValues,omitempty"`
 }
 
 type resolvedInventoryHelmSource struct {
@@ -444,6 +446,14 @@ func loadResolvedInventoryConfig(repoRoot, configPath string) (resolvedInventory
 			(sourceChart.Path != componentPath && !strings.HasPrefix(sourceChart.Path, componentPath+"/")) {
 			return resolvedInventoryConfig{}, fmt.Errorf("resolved inventory source chart %s path must be within %s", name, componentPath)
 		}
+		for valueName, value := range sourceChart.RenderValues {
+			if !validResolvedInventoryRenderValueName(valueName) {
+				return resolvedInventoryConfig{}, fmt.Errorf("resolved inventory source chart %s render value name %q is invalid", name, valueName)
+			}
+			if value == "" || value != strings.TrimSpace(value) {
+				return resolvedInventoryConfig{}, fmt.Errorf("resolved inventory source chart %s render value %s must be non-empty and trimmed", name, valueName)
+			}
+		}
 	}
 	return config, nil
 }
@@ -465,6 +475,20 @@ func validResolvedInventoryRepoPath(value string) bool {
 	return value != "" && value != "." && value != ".." && !strings.HasPrefix(value, "-") &&
 		!filepath.IsAbs(value) && filepath.ToSlash(filepath.Clean(value)) == value && !strings.HasPrefix(value, "../") &&
 		!strings.ContainsAny(value, "{}$?#@ 	\r\n")
+}
+
+func validResolvedInventoryRenderValueName(value string) bool {
+	if value == "" || strings.HasPrefix(value, ".") || strings.HasSuffix(value, ".") || strings.Contains(value, "..") {
+		return false
+	}
+	for _, character := range value {
+		if character != '.' && character != '-' && character != '_' &&
+			(character < 'a' || character > 'z') && (character < 'A' || character > 'Z') &&
+			(character < '0' || character > '9') {
+			return false
+		}
+	}
+	return true
 }
 
 func parseResolvedInventoryHelmSource(raw string) (resolvedInventoryHelmSource, error) {
@@ -727,7 +751,7 @@ func materializeResolvedInventorySourceCharts(
 		if err := setResolvedInventorySourceChartVersion(chartPath, name, release.Version); err != nil {
 			return nil, fmt.Errorf("set source chart %s version: %w", name, err)
 		}
-		if err := replaceResolvedInventoryStateChart(stateFile, name, chartPath); err != nil {
+		if err := replaceResolvedInventoryStateChart(stateFile, release.Name, name, chartPath, sourceChart.RenderValues); err != nil {
 			return nil, err
 		}
 		used = append(used, name)
@@ -838,18 +862,175 @@ func setResolvedInventorySourceChartVersion(chartPath, wantName, version string)
 	return os.WriteFile(metadataPath, updated, 0o644)
 }
 
-func replaceResolvedInventoryStateChart(stateFile, chartName, chartPath string) error {
+func replaceResolvedInventoryStateChart(stateFile, releaseName, chartName, chartPath string, renderValues map[string]string) error {
 	raw, err := os.ReadFile(stateFile)
 	if err != nil {
 		return err
 	}
-	needle := "chart: nvcf/" + chartName
-	if count := bytes.Count(raw, []byte(needle)); count != 1 {
-		return fmt.Errorf("resolved %d %s chart references in %s; want exactly one", count, chartName, stateFile)
+	raw, err = setResolvedInventoryReleaseChart(raw, stateFile, releaseName, chartName, chartPath)
+	if err != nil {
+		return err
 	}
-	replacement := "chart: " + strconv.Quote(filepath.ToSlash(chartPath))
-	updated := bytes.Replace(raw, []byte(needle), []byte(replacement), 1)
-	return os.WriteFile(stateFile, updated, 0o644)
+	raw, err = mergeResolvedInventoryReleaseSetValues(raw, stateFile, releaseName, renderValues)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(stateFile, raw, 0o644)
+}
+
+type resolvedInventoryReleaseBlock struct {
+	indent       []byte
+	lineEnding   []byte
+	contentStart int
+	end          int
+}
+
+func findResolvedInventoryReleaseBlock(raw []byte, stateFile, releaseName string) (resolvedInventoryReleaseBlock, error) {
+	name := regexp.QuoteMeta(releaseName)
+	releasePattern := regexp.MustCompile(`(?m)^([ \t]*)- name:[ \t]+(?:` + name + `|"` + name + `"|'` + name + `')[ \t]*(?:#[^\r\n]*)?(\r?)$`)
+	matches := releasePattern.FindAllSubmatchIndex(raw, -1)
+	if len(matches) != 1 {
+		return resolvedInventoryReleaseBlock{}, fmt.Errorf("resolved %d %s release entries in %s; want exactly one", len(matches), releaseName, stateFile)
+	}
+	match := matches[0]
+	indent := raw[match[2]:match[3]]
+	lineEnding := []byte("\n")
+	if match[4] >= 0 && match[4] != match[5] {
+		lineEnding = []byte("\r\n")
+	}
+	contentStart := match[1]
+	if contentStart >= len(raw) || raw[contentStart] != '\n' {
+		return resolvedInventoryReleaseBlock{}, fmt.Errorf("%s release entry in %s must end with a newline", releaseName, stateFile)
+	}
+	contentStart++
+	return resolvedInventoryReleaseBlock{
+		indent:       append([]byte(nil), indent...),
+		lineEnding:   lineEnding,
+		contentStart: contentStart,
+		end:          findResolvedInventoryYAMLBlockEnd(raw, contentStart, len(indent)),
+	}, nil
+}
+
+func findResolvedInventoryYAMLBlockEnd(raw []byte, start, parentIndent int) int {
+	for offset := start; offset < len(raw); {
+		lineEnd := bytes.IndexByte(raw[offset:], '\n')
+		if lineEnd < 0 {
+			lineEnd = len(raw)
+		} else {
+			lineEnd += offset
+		}
+		line := bytes.TrimSuffix(raw[offset:lineEnd], []byte("\r"))
+		trimmed := bytes.TrimSpace(line)
+		if len(trimmed) != 0 && !bytes.HasPrefix(trimmed, []byte("#")) && !bytes.HasPrefix(trimmed, []byte("{{")) {
+			indent := len(line) - len(bytes.TrimLeft(line, " \t"))
+			if indent <= parentIndent {
+				return offset
+			}
+		}
+		if lineEnd == len(raw) {
+			return len(raw)
+		}
+		offset = lineEnd + 1
+	}
+	return len(raw)
+}
+
+func setResolvedInventoryReleaseChart(raw []byte, stateFile, releaseName, chartName, chartPath string) ([]byte, error) {
+	block, err := findResolvedInventoryReleaseBlock(raw, stateFile, releaseName)
+	if err != nil {
+		return nil, err
+	}
+	childIndent := string(block.indent) + "  "
+	chartPattern := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(childIndent) + `chart:[^\r\n]*(\r?)$`)
+	chartMatches := chartPattern.FindAllSubmatchIndex(raw[block.contentStart:block.end], -1)
+	if len(chartMatches) > 1 {
+		return nil, fmt.Errorf("resolved %d chart entries for %s release %s in %s; want at most one", len(chartMatches), chartName, releaseName, stateFile)
+	}
+	replacement := []byte(childIndent + "chart: " + strconv.Quote(filepath.ToSlash(chartPath)))
+	if len(chartMatches) == 0 {
+		replacement = append(replacement, block.lineEnding...)
+		return insertResolvedInventoryBytes(raw, block.contentStart, replacement), nil
+	}
+	match := chartMatches[0]
+	start := block.contentStart + match[0]
+	end := block.contentStart + match[1]
+	if match[2] >= 0 && match[2] != match[3] {
+		replacement = append(replacement, '\r')
+	}
+	return replaceResolvedInventoryBytes(raw, start, end, replacement), nil
+}
+
+func mergeResolvedInventoryReleaseSetValues(raw []byte, stateFile, releaseName string, renderValues map[string]string) ([]byte, error) {
+	if len(renderValues) == 0 {
+		return raw, nil
+	}
+	block, err := findResolvedInventoryReleaseBlock(raw, stateFile, releaseName)
+	if err != nil {
+		return nil, err
+	}
+	childIndent := string(block.indent) + "  "
+	setPattern := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(childIndent) + `set:[^\r\n]*(\r?)$`)
+	setMatches := setPattern.FindAllSubmatchIndex(raw[block.contentStart:block.end], -1)
+	if len(setMatches) > 1 {
+		return nil, fmt.Errorf("resolved %d set entries for release %s in %s; want at most one", len(setMatches), releaseName, stateFile)
+	}
+	entries := resolvedInventoryRenderSetEntries(block.indent, block.lineEnding, renderValues)
+	if len(setMatches) == 0 {
+		setBlock := append([]byte(childIndent+"set:"), block.lineEnding...)
+		setBlock = append(setBlock, entries...)
+		return insertResolvedInventoryBytes(raw, block.contentStart, setBlock), nil
+	}
+	match := setMatches[0]
+	setStart := block.contentStart + match[0]
+	setEnd := block.contentStart + match[1]
+	setLine := bytes.TrimSuffix(raw[setStart:setEnd], []byte("\r"))
+	setValue := strings.TrimSpace(strings.TrimPrefix(string(setLine), childIndent+"set:"))
+	if setValue != "" && !strings.HasPrefix(setValue, "#") {
+		return nil, fmt.Errorf("set entry for release %s in %s must use a block sequence", releaseName, stateFile)
+	}
+	if setEnd >= len(raw) || raw[setEnd] != '\n' {
+		return nil, fmt.Errorf("set entry for release %s in %s must end with a newline", releaseName, stateFile)
+	}
+	setContentStart := setEnd + 1
+	insertAt := findResolvedInventoryYAMLBlockEnd(raw, setContentStart, len(childIndent))
+	if insertAt > block.end {
+		insertAt = block.end
+	}
+	return insertResolvedInventoryBytes(raw, insertAt, entries), nil
+}
+
+func resolvedInventoryRenderSetEntries(indent, lineEnding []byte, renderValues map[string]string) []byte {
+	names := make([]string, 0, len(renderValues))
+	for name := range renderValues {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	entries := make([]byte, 0)
+	for _, name := range names {
+		entries = append(entries, indent...)
+		entries = append(entries, []byte("    - name: "+strconv.Quote(name))...)
+		entries = append(entries, lineEnding...)
+		entries = append(entries, indent...)
+		entries = append(entries, []byte("      value: "+strconv.Quote(renderValues[name]))...)
+		entries = append(entries, lineEnding...)
+	}
+	return entries
+}
+
+func insertResolvedInventoryBytes(raw []byte, offset int, addition []byte) []byte {
+	updated := make([]byte, 0, len(raw)+len(addition))
+	updated = append(updated, raw[:offset]...)
+	updated = append(updated, addition...)
+	updated = append(updated, raw[offset:]...)
+	return updated
+}
+
+func replaceResolvedInventoryBytes(raw []byte, start, end int, replacement []byte) []byte {
+	updated := make([]byte, 0, len(raw)-(end-start)+len(replacement))
+	updated = append(updated, raw[:start]...)
+	updated = append(updated, replacement...)
+	updated = append(updated, raw[end:]...)
+	return updated
 }
 
 func runResolvedInventoryHelmfile(

--- a/tools/docs-version-sync/resolved_inventory_publish_test.go
+++ b/tools/docs-version-sync/resolved_inventory_publish_test.go
@@ -182,6 +182,15 @@ func TestLoadResolvedInventoryConfig(t *testing.T) {
 		t.Fatalf("NVCA source chart tag prefix = %q", got)
 	}
 
+	writeFile(t, configPath, "schemaVersion: 1\npublishedChartRepository: "+testPublishedChartRepository+"\nsourceCharts:\n  helm-nvca-operator:\n    tagPrefix: deploy/helm/nvca-operator/v\n    path: deploy/helm/nvca-operator/nvca-operator\n    renderValues:\n      image.repository: nvcr.io/nvidia/nvcf/nvca\n")
+	config, err = loadResolvedInventoryConfig(repo, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := config.SourceCharts["helm-nvca-operator"].RenderValues["image.repository"]; got != "nvcr.io/nvidia/nvcf/nvca" {
+		t.Fatalf("NVCA render value = %q", got)
+	}
+
 	writeFile(t, configPath, "schemaVersion: 1\npublishedChartRepository: oci://registry.example.test/charts\n")
 	if _, err := loadResolvedInventoryConfig(repo, ""); err == nil || !strings.Contains(err.Error(), "resolved HTTPS repository") {
 		t.Fatalf("non-HTTPS repository error = %v", err)
@@ -197,6 +206,11 @@ func TestLoadResolvedInventoryConfig(t *testing.T) {
 		t.Fatalf("invalid source chart path error = %v", err)
 	}
 
+	writeFile(t, configPath, "schemaVersion: 1\npublishedChartRepository: "+testPublishedChartRepository+"\nsourceCharts:\n  helm-nvca-operator:\n    tagPrefix: deploy/helm/nvca-operator/v\n    path: deploy/helm/nvca-operator/nvca-operator\n    renderValues:\n      image..repository: nvcr.io/nvidia/nvcf/nvca\n")
+	if _, err := loadResolvedInventoryConfig(repo, ""); err == nil || !strings.Contains(err.Error(), "render value name") {
+		t.Fatalf("invalid render value name error = %v", err)
+	}
+
 	externalConfig := filepath.Join(t.TempDir(), "release-inventory.yaml")
 	writeFile(t, externalConfig, "schemaVersion: 1\npublishedChartRepository: https://helm.example.test/external\n")
 	external, err := loadResolvedInventoryConfig(repo, externalConfig)
@@ -205,6 +219,88 @@ func TestLoadResolvedInventoryConfig(t *testing.T) {
 	}
 	if external.PublishedChartRepository != "https://helm.example.test/external" {
 		t.Fatalf("external published repository = %q", external.PublishedChartRepository)
+	}
+}
+
+func TestReplaceResolvedInventoryStateChart(t *testing.T) {
+	chartPath := filepath.Join(t.TempDir(), "helm-nvcf-invocation-service", "1.6.1")
+	quotedChartPath := strconv.Quote(filepath.ToSlash(chartPath))
+	tests := []struct {
+		name         string
+		raw          string
+		renderValues map[string]string
+		want         string
+	}{
+		{
+			name: "explicit chart",
+			raw:  "releases:\n  - name: invocation-service\n    chart: nvcf/helm-nvcf-invocation-service\n    version: 1.6.1\n",
+			want: "releases:\n  - name: invocation-service\n    chart: " + quotedChartPath + "\n    version: 1.6.1\n",
+		},
+		{
+			name: "quoted chart",
+			raw:  "releases:\n  - name: invocation-service\n    chart: \"nvcf/helm-nvcf-invocation-service\"\n    version: 1.6.1\n",
+			want: "releases:\n  - name: invocation-service\n    chart: " + quotedChartPath + "\n    version: 1.6.1\n",
+		},
+		{
+			name:         "explicit chart with render values",
+			raw:          "releases:\n  - name: invocation-service\n    chart: nvcf/helm-nvcf-invocation-service\n    version: 1.6.1\n",
+			renderValues: map[string]string{"image.repository": "nvcr.io/nvidia/nvcf/nvcf-invocation-service"},
+			want:         "releases:\n  - name: invocation-service\n    set:\n      - name: \"image.repository\"\n        value: \"nvcr.io/nvidia/nvcf/nvcf-invocation-service\"\n    chart: " + quotedChartPath + "\n    version: 1.6.1\n",
+		},
+		{
+			name: "inherited chart",
+			raw:  "templates:\n  service: &service\n    chart: nvcf/helm-nvcf-{{ .Release.Name }}\nreleases:\n  - name: invocation-service\n    version: 1.6.1\n    inherit:\n      - template: service\n",
+			want: "templates:\n  service: &service\n    chart: nvcf/helm-nvcf-{{ .Release.Name }}\nreleases:\n  - name: invocation-service\n    chart: " + quotedChartPath + "\n    version: 1.6.1\n    inherit:\n      - template: service\n",
+		},
+		{
+			name:         "inherited chart with render values",
+			raw:          "templates:\n  service: &service\n    chart: nvcf/helm-nvcf-{{ .Release.Name }}\nreleases:\n  - name: invocation-service\n    version: 1.6.1\n    inherit:\n      - template: service\n",
+			renderValues: map[string]string{"image.repository": "nvcr.io/nvidia/nvcf/nvcf-invocation-service"},
+			want:         "templates:\n  service: &service\n    chart: nvcf/helm-nvcf-{{ .Release.Name }}\nreleases:\n  - name: invocation-service\n    set:\n      - name: \"image.repository\"\n        value: \"nvcr.io/nvidia/nvcf/nvcf-invocation-service\"\n    chart: " + quotedChartPath + "\n    version: 1.6.1\n    inherit:\n      - template: service\n",
+		},
+		{
+			name:         "existing set sequence",
+			raw:          "releases:\n  - name: invocation-service\n    chart: \"nvcf/helm-nvcf-invocation-service\"\n    set:\n      - name: \"existing.value\"\n        value: \"preserved\"\n    version: 1.6.1\n",
+			renderValues: map[string]string{"image.repository": "nvcr.io/nvidia/nvcf/nvcf-invocation-service"},
+			want:         "releases:\n  - name: invocation-service\n    chart: " + quotedChartPath + "\n    set:\n      - name: \"existing.value\"\n        value: \"preserved\"\n      - name: \"image.repository\"\n        value: \"nvcr.io/nvidia/nvcf/nvcf-invocation-service\"\n    version: 1.6.1\n",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stateFile := filepath.Join(t.TempDir(), "state.yaml.gotmpl")
+			writeFile(t, stateFile, test.raw)
+			if err := replaceResolvedInventoryStateChart(
+				stateFile,
+				"invocation-service",
+				"helm-nvcf-invocation-service",
+				chartPath,
+				test.renderValues,
+			); err != nil {
+				t.Fatal(err)
+			}
+			got, err := os.ReadFile(stateFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != test.want {
+				t.Fatalf("updated Helmfile state:\n%s\nwant:\n%s", got, test.want)
+			}
+		})
+	}
+}
+
+func TestReplaceResolvedInventoryStateChartRejectsAmbiguousRelease(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "state.yaml.gotmpl")
+	writeFile(t, stateFile, "releases:\n  - name: invocation-service\n  - name: invocation-service\n")
+	err := replaceResolvedInventoryStateChart(
+		stateFile,
+		"invocation-service",
+		"helm-nvcf-invocation-service",
+		filepath.Join(t.TempDir(), "chart"),
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "2 invocation-service release entries") {
+		t.Fatalf("ambiguous release error = %v", err)
 	}
 }
 


### PR DESCRIPTION
# TL;DR

Render independently released native charts from immutable GitHub tags when generating the self-managed stack inventory. This removes the inventory generator's dependency on when those charts are mirrored into the composite chart source.

## Additional Details

### Why

The `deploy/stacks/self-managed/v0.15.4` release could not publish its resolved inventory because `helm-nvcf-nats-auth-callout-service:1.2.0` was not yet available from the authenticated composite chart source. The chart release tag already existed and was included in the stack tag.

Failed release run: https://github.com/NVIDIA/nvcf/actions/runs/34558847070

### What changed

The release inventory configuration now materializes these independently released charts from their immutable public GitHub tags:

- HTTP invocation
- NATS authentication callout
- NVCA operator
- Rate limiter

The existing ancestry check requires every selected chart tag to be part of the selected stack release commit. Rendered inventory references continue to use the public NGC catalog destination.

For releases such as HTTP invocation that inherit their chart from a Helmfile template, the renderer now adds a release-level local chart override. Explicit chart declarations continue to be replaced in place. Ambiguous release matches fail closed.

The v1.2.0 NATS chart expects `image.repository` at the chart root, while the tagged stack stores the intended repository under `natsAuthCalloutService`. The inventory config supplies that public `nvcr.io/nvidia/nvcf` image location as an inventory-only render value. Render value names and values are validated, quoted, and injected through Helmfile `set` entries.

### Customer Release Notes

Not customer visible.

### Plan Summary

No runtime resources change. This only changes the chart sources used by release inventory generation.

### Usage

Not applicable.

### References

- Failed v0.15.4 release run: https://github.com/NVIDIA/nvcf/actions/runs/34558847070
- Parent epic: https://github.com/NVIDIA/nvcf/issues/279

### Related Pull Requests

- Inventory release workflow: https://github.com/NVIDIA/nvcf/pull/1779
- Docs catalog finalization: https://github.com/NVIDIA/nvcf/pull/1760

### Dependencies

None. No dependency or license changes. NOTICE is unchanged.

## For the Reviewer

Please verify that each `sourceCharts` key matches the chart name emitted by Helmfile and that each path is rooted under its release tag prefix.

## For QA

Local validation:

- `go test -C tools/docs-version-sync ./...`
- `go vet -C tools/docs-version-sync ./...`
- `python3 tools/ci/test-github-release.py`
- `./tools/ci/check-doc-version-sync`
- `git diff --check`

- Initial nonpublishing v0.15.4 preflight, which exposed the inherited-chart gap fixed in this PR: https://github.com/NVIDIA/nvcf/actions/runs/34560420322
- Second nonpublishing v0.15.4 preflight, which exposed the NATS chart value-scope gap fixed in this PR: https://github.com/NVIDIA/nvcf/actions/runs/34560893180
- Passing nonpublishing v0.15.4 preflight: https://github.com/NVIDIA/nvcf/actions/runs/34561719342
- Passing post-review nonpublishing v0.15.4 preflight: https://github.com/NVIDIA/nvcf/actions/runs/34562737233

No separate runtime QA is needed.

## Issues

Fixes #1784
Relates to #279

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
