### PR TITLE
feat(cassandra): bump migrations image default tag to 0.17.5

### DIFF
--- a/deploy/helm/cassandra/helm/values.yaml
+++ b/deploy/helm/cassandra/helm/values.yaml
@@ -196,9 +196,9 @@ cassandra:
       # repository: must be supplied in additional values
       registry: ""
       repository: ""
-      # 0.17.3 includes the current NVCT task schema while preserving tables
+      # 0.17.5 includes the current NVCT task schema while preserving tables
       # required by the published function autoscaler 1.21.0.
-      tag: 0.17.3
+      tag: 0.17.5
       pullPolicy: Always
 
   dbUser:


### PR DESCRIPTION
## Why
The notary-authorization fix (#1755) merged to main and shipped as
nvcf-cassandra-migrations v0.17.5 (migration `09_add_nvct_api_notary_issuer`).
The cassandra chart still defaults the migrations image tag to 0.17.3, so fresh
installs do not pull the migration that registers `nvct-api` on the ess-api
notary path, and NVCT tasks created with secrets still fail. Bump the chart
default to 0.17.5 to deliver the fix.

## What changed
Bump `cassandra.migrations.image.tag` from 0.17.3 to 0.17.5 in
`deploy/helm/cassandra/helm/values.yaml` and update the adjacent comment.
No schema files and no stack version pins change.

## Customer Release Notes
Fresh cassandra installs now apply the migrations image that registers the
nvct-api notary client, fixing NVCT task-with-secrets failures.

## Plan Summary
Chart values-only change. The cassandra migrations Job pulls migrations image
0.17.5 (contains ess_api migration 09) instead of 0.17.3 when no override is
supplied. No new resources.

## Usage
Not applicable.

## Testing
Verified `migrations/cassandra/v0.17.5` contains
`migrations/cassandra/keyspaces/ess_api/09_add_nvct_api_notary_issuer.up.sql`
and that the tag sits on the #1755 merge commit (84e3afb). Values-only default
bump, covered by existing chart lint/template CI. QA not required.

## Notes
Follow-on to #1755, which is merged and released as migrations/cassandra v0.17.5.

## References
Closes #1789
Relates to #1756

## Related Pull Requests
#1755

## Dependencies
None