### PR TITLE
fix(release): register ReVal chart automation

### DIFF
--- a/tools/ci/github-release-subprojects.json
+++ b/tools/ci/github-release-subprojects.json
@@ -169,6 +169,15 @@
       "legacy_tag_prefix": "nvcf-helm-reval-api-v"
     },
     {
+      "id": "reval-helm",
+      "path": "deploy/helm/helm-reval",
+      "service_name": "helm-reval",
+      "initial_version": "1.3.8",
+      "deploys": [
+        "helm-reval"
+      ]
+    },
+    {
       "id": "ess-agent",
       "path": "src/compute-plane-services/ess-agent",
       "service_name": "nvcf-ess-agent",

--- a/tools/ci/test-github-release.py
+++ b/tools/ci/test-github-release.py
@@ -840,6 +840,21 @@ class GithubReleaseTest(unittest.TestCase):
             "deploy/helm/cloud-tasks/v1.4.4",
         )
 
+    def test_reval_chart_continues_its_published_lineage(self):
+        metadata = json.loads(
+            SCRIPT_PATH.with_name("github-release-subprojects.json").read_text()
+        )
+        service = next(s for s in metadata["services"] if s["id"] == "reval-helm")
+
+        self.assertEqual(service["path"], "deploy/helm/helm-reval")
+        self.assertEqual(service["service_name"], "helm-reval")
+        self.assertEqual(service["initial_version"], "1.3.8")
+        self.assertEqual(service["deploys"], ["helm-reval"])
+        self.assertEqual(
+            self.github_release.tag_for_version(service, service["initial_version"]),
+            "deploy/helm/helm-reval/v1.3.8",
+        )
+
     def test_http_invocation_chart_uses_its_published_lineage(self):
         root = SCRIPT_PATH.parents[2]
         metadata = json.loads(SCRIPT_PATH.with_name("github-release-subprojects.json").read_text())


### PR DESCRIPTION
## TL;DR

Register the native ReVal chart with GitHub release automation so its image update from #1786 can produce a chart release and reach the self-managed stack.

## Why

PR #1786 updated `helm-reval` to `reval-server:0.20.2`, but `deploy/helm/helm-reval` was absent from the release metadata. The main release workflow therefore completed without creating a ReVal chart release, which blocks the stack update in #1783.

## What changed

- Register `deploy/helm/helm-reval` as the `helm-reval` chart release source.
- Continue the existing published chart line from version `1.3.8`.
- Declare that the chart deploys the `helm-reval` service so future service releases can update it.
- Add a regression test for the release path, package name, version floor, and service edge.

## Customer Release Notes

Not customer visible.

## Plan Summary

Release metadata only. No Kubernetes resources, chart values, or stack pins change.

## Usage

After this Pull Request merges, the normal main-branch release workflow can publish the successor ReVal chart release. The chart release will then refresh the automated stack-pin Pull Request.

## Testing

- `python3 tools/ci/test-github-release.py` (60 tests passed)
- `go test -C tools/chart-service-edge ./...`
- `go test -C tools/stack-pin-resolver ./...`
- `tools/ci/chart-service-edge --audit`
- `tools/ci/stack-pin-resolver --audit` (31 releases, 0 unresolved)
- `git diff --check`

QA is not needed for this release-metadata change.

## Notes

No manual release or CI action was triggered.

## References

- Chart release task: #1782
- Stack consumption task: #1783
- Chart image update: #1786

## Related Pull Requests

- Automated stack-pin Pull Request: #1734

## Dependencies

No dependency changes. License review and NOTICE updates are not applicable.

## Issues

Relates to #1782

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added release tracking for the Reval Helm deployment chart.
  - The chart is now associated with its service and deployment target, beginning with version `1.3.8`.
  - Release metadata now supports generating the corresponding `v1.3.8` release tag.

- **Tests**
  - Added coverage to verify that Helm chart release metadata remains consistent across publishing and deployment details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->