### PR TITLE
fix(cassandra): bump self-managed cassandra chart to 0.21.0 for nvct notary migration

### DIFF
--- a/deploy/helm/cassandra/helm/values.yaml
+++ b/deploy/helm/cassandra/helm/values.yaml
@@ -196,8 +196,6 @@ cassandra:
       # repository: must be supplied in additional values
       registry: ""
       repository: ""
-      # 0.17.5 includes the current NVCT task schema while preserving tables
-      # required by the published function autoscaler 1.21.0.
       tag: 0.17.5
       pullPolicy: Always
 

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -281,9 +281,7 @@ cassandra:
   resourcesPreset: "xlarge"
   migrations:
     image:
-      # 0.17.3 includes the current NVCT task schema while preserving the
-      # legacy tables required by the published function autoscaler 1.21.0.
-      tag: 0.17.3
+      tag: 0.17.5
   # Image overrides for the Cassandra server and dynamicSeedDiscovery containers.
   # The default image name is `cassandra` under global.image.repository.
   # Override here when pulling from a registry that uses a different path or tag.

--- a/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl
@@ -167,7 +167,7 @@ releases:
 {{- end }}
 
   - name: cassandra
-    version: 0.20.3
+    version: 0.21.0
     condition: cassandra.enabled # From defaults.yaml or env overrides
     namespace: cassandra-system
     <<: *dependency # Inherits base values from the dependency template


### PR DESCRIPTION
## Why
The self-managed stack pins the cassandra chart to 0.20.3, whose default
migrations image predates the nvct-api notary registration (ess_api migration
`09_add_nvct_api_notary_issuer`). On fresh self-managed installs, ess-api
rejects nvct-api on the notary path, so NVCT tasks created with secrets fail
with `client id=nvct-api is not registered`.

Cassandra chart 0.21.0 defaults the migrations image to 0.17.5, which contains
migration 09. Pinning the stack to 0.21.0 delivers the notary fix.

## What changed
Bump the `cassandra` release pin in
`deploy/stacks/self-managed/helmfile.d/01-dependencies.yaml.gotmpl` from 0.20.3
to 0.21.0. No other stack changes.

## Customer Release Notes
Self-managed installs now deploy the cassandra chart that applies the nvct-api
notary migration, fixing NVCT task-with-secrets failures.

## Plan Summary
Stack chart pin only. The cassandra release now resolves chart 0.21.0, which
pulls migrations image 0.17.5 (contains ess_api migration 09). No new resources.

## Usage
Applied on the next self-managed deploy/upgrade. The cassandra migrations job
applies migration 09 to clusters still at version 08.

## Testing
Verified chart `deploy/helm/cassandra/v0.21.0` defaults
`cassandra.migrations.image.tag` to 0.17.5, and that
`migrations/cassandra/v0.17.5` contains
`keyspaces/ess_api/09_add_nvct_api_notary_issuer.up.sql`. Stack pin change,
covered by existing helmfile template/validate CI. QA on a self-managed install
recommended.

## Notes
Depends on the released chart deploy/helm/cassandra v0.21.0 and migrations image
0.17.5 (from #1755).

## References
Closes #1793
Relates to #1756

## Related Pull Requests
#1755

## Dependencies
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Cassandra deployment chart to version 0.21.0.
  - Updated the Cassandra migrations image to version 0.17.5 for self-managed deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->