### PR TITLE
fix(release): render ReVal inventory from source tag

### DIFF
--- a/deploy/stacks/self-managed/release-inventory.yaml
+++ b/deploy/stacks/self-managed/release-inventory.yaml
@@ -23,6 +23,9 @@ sourceCharts:
   helm-nvcf-rate-limiter:
     tagPrefix: deploy/helm/ratelimiter/v
     path: deploy/helm/ratelimiter/nvcf-ratelimiter
+  helm-reval:
+    tagPrefix: deploy/helm/helm-reval/v
+    path: deploy/helm/helm-reval
 # The release workflow authenticates before evaluating the remaining charts and
 # permits states that contain only third-party or local charts.
 publishedChartRepository: https://helm.ngc.nvidia.com/nvidia/nvcf

--- a/tools/docs-version-sync/resolved_inventory_publish_test.go
+++ b/tools/docs-version-sync/resolved_inventory_publish_test.go
@@ -222,6 +222,20 @@ func TestLoadResolvedInventoryConfig(t *testing.T) {
 	}
 }
 
+func TestRepositoryReleaseInventorySourcesRevalFromTag(t *testing.T) {
+	config, err := loadResolvedInventoryConfig(filepath.Join("..", ".."), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, ok := config.SourceCharts["helm-reval"]
+	if !ok {
+		t.Fatal("release inventory does not define a source for helm-reval")
+	}
+	if source.TagPrefix != "deploy/helm/helm-reval/v" || source.Path != "deploy/helm/helm-reval" {
+		t.Fatalf("ReVal source chart = %#v", source)
+	}
+}
+
 func TestReplaceResolvedInventoryStateChart(t *testing.T) {
 	chartPath := filepath.Join(t.TempDir(), "helm-nvcf-invocation-service", "1.6.1")
 	quotedChartPath := strconv.Quote(filepath.ToSlash(chartPath))


### PR DESCRIPTION
# TL;DR

Render `helm-reval` from its immutable public Git release tag when generating the self-managed stack inventory. This unblocks the inventory asset required by #1760 after the v0.16.0 tag workflow failed to find `helm-reval:1.4.0` in the authenticated release chart source.

## Additional Details

The v0.16.0 tag workflow failed while building the control-plane Helmfile state: https://github.com/NVIDIA/nvcf/actions/runs/34567489568. Every preceding core chart resolved, but the build stopped when Helm could not fetch `helm-reval:1.4.0`.

ReVal is now released independently under `deploy/helm/helm-reval/v*`. Add it to the same `sourceCharts` mapping used by the other independently tagged charts. The inventory renderer checks out that immutable tag, renders the chart from `deploy/helm/helm-reval`, and still records the canonical public NGC chart destination in the published inventory.

The regression test loads the repository configuration and locks both the tag prefix and chart path. Runtime Helmfile values and deployed workloads do not change.

No dependency, license, or NOTICE changes are required.

## For the Reviewer

Please verify the `helm-reval` tag prefix and chart path in `deploy/stacks/self-managed/release-inventory.yaml`. This is the only release source added.

## For QA

No deployed-service QA is needed. Validation completed:

- `go test -C tools/docs-version-sync ./...`
- `go vet -C tools/docs-version-sync ./...`
- `python3 -m unittest tools.ci.test-github-release`
- `./tools/ci/check-doc-version-sync`
- `git diff --check`

A full local render cannot reproduce the authenticated production release registry. The failed v0.16.0 run provides the end-to-end evidence for the missing ReVal source, and the existing source-chart integration suite plus the new repository configuration regression cover the corrected path.

## Issues

Relates to #1727
Relates to #279

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `helm-reval` source chart to the release inventory using its immutable release tag and chart path.

* **Tests**
  * Added validation to ensure the `helm-reval` source chart is configured with the expected tag prefix and path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->