### PR TITLE
fix(openbao): rebuild approved image artifacts

### DIFF
--- a/infra/openbao/README.md
+++ b/infra/openbao/README.md
@@ -15,6 +15,13 @@ configuration, and `openbao` user. It replaces `/usr/bin/bao` with a binary
 built from the matching official distribution source. See
 `OPENBAO_PROVENANCE.md` for the source identity and dependency floors.
 
+## Releases
+
+Release-worthy changes under `infra/openbao` publish the `nvcf-openbao`
+image. GitHub source releases use tags in the `infra/openbao/vX.Y.Z` stream.
+Each release rebuilds both supported architectures from the source and
+dependency pins in this directory.
+
 ## Plugin binaries
 
 The image expects an OS-specific plugin binary at build time, placed at:

--- a/migrations/openbao/README.md
+++ b/migrations/openbao/README.md
@@ -16,6 +16,13 @@ This repository ships:
 - An example Kubernetes Job manifest (`job.yaml`)
 - A Docker-based integration test for the helper functions (`tests/`)
 
+## Releases
+
+Release-worthy changes under `migrations/openbao` publish the
+`nvcf-openbao-migrations` image. GitHub source releases use tags in the
+`migrations/openbao/vX.Y.Z` stream. Each release rebuilds both supported
+architectures from the source and dependency pins in this directory.
+
 ## Prerequisites
 
 - A reachable OpenBao or Vault deployment (the entrypoint waits for the service to become healthy and locates the leader before applying migrations)


### PR DESCRIPTION
# TL;DR

Trigger clean successor releases for the remediated OpenBao runtime and migrations images. Document the independent release streams that produce those artifacts.

## Additional Details

The current `infra/openbao/v1.3.2` and `migrations/openbao/v0.19.3` tags already contain the approved source and dependency remediation, but #1788 requires successor image candidates before the Helm chart can move both pins together.

This scoped `fix` commit touches both owning source trees. The path-aware release automation will therefore rebuild both images from the current sources.

Expected releases after merge:

- `infra/openbao/v1.3.3`
- `migrations/openbao/v0.19.4`

The chart and stack pins remain unchanged until those immutable releases exist.

## Customer Release Notes

Publishes refreshed OpenBao runtime and migrations image candidates for self-managed deployments.

## Plan Summary

Release-only image rebuild. No Kubernetes resources, values, deployment order, or topology change.

## Usage

No operator action is required from this Pull Request alone. Consume the successor images through the OpenBao chart release that follows.

## For the Reviewer

Review the release-stream descriptions in both README files and confirm that rebuilding the existing remediated sources is the intended way to create the successor candidates.

## Testing

Passed on commit `b915593fbb4d9c7589f6a533f09d955b681dd4ee`:

- `./tools/ci/check-docs`
- `git diff --check`
- `tools/ci/github-release auto --service openbao-image` in dry-run mode, which selected `1.3.3`
- `tools/ci/github-release auto --service openbao-migrations` in dry-run mode, which selected `0.19.4`

No live cluster QA was run. The post-merge image build and scan gates will validate the rebuilt artifacts.

## Notes

This is the image-release prerequisite for #1788. A follow-up Pull Request will update the OpenBao chart image pins after both releases are available, followed by the normal chart release and stack pin update.

## References

- #1788
- #1781
- #1475
- #1675
- #1705

## Related Pull Requests

- #1477
- #1614
- #1677
- #1707

## Dependencies

No new third-party dependencies. Both images retain the existing OpenBao 2.6.2 source and reviewed dependency pins. No license or NOTICE update is required.

## Issues

Relates to #1788

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release guidance for image publication and version tagging.
  * Documented multi-architecture release builds and supported architectures.
  * Clarified source and dependency pinning requirements for releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->