### PR TITLE
fix(openbao): bump released image pins

### DIFF
--- a/deploy/helm/openbao/helm/Chart.yaml
+++ b/deploy/helm/openbao/helm/Chart.yaml
@@ -19,7 +19,7 @@ description: OpenBao self-managed deployment
 type: application
 
 version: 0.0.0 # managed by semantic-release
-appVersion: 2.5.5-nv-1.3.1 # todo update via renovate when bao image is updated
+appVersion: 2.6.2-nv-1.3.3 # todo update via renovate when bao image is updated
 
 dependencies:
   - name: openbao

--- a/deploy/helm/openbao/helm/values.yaml
+++ b/deploy/helm/openbao/helm/values.yaml
@@ -56,7 +56,7 @@ openbao:
     image:
       registry: ""
       repository: ""
-      tag: 0.19.1
+      tag: 0.19.4
       pullPolicy: IfNotPresent
     issuerDiscovery:
       enabled: false
@@ -84,7 +84,7 @@ openbao:
     image:
       registry: ""
       repository: ""
-      tag: 2.5.5-nv-1.3.1
+      tag: 2.6.2-nv-1.3.3
       pullPolicy: IfNotPresent
 
     podManagementPolicy: Parallel
@@ -263,5 +263,5 @@ openbao:
     agentImage:
       registry: ""
       repository: ""
-      tag: 2.5.5-nv-1.3.1
+      tag: 2.6.2-nv-1.3.3
       pullPolicy: IfNotPresent

--- a/deploy/helm/openbao/tests/plugin-catalog-refresh-hook.sh
+++ b/deploy/helm/openbao/tests/plugin-catalog-refresh-hook.sh
@@ -7,8 +7,14 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
 chart_source="${repo_root}/deploy/helm/openbao/helm"
 values_file="${repo_root}/tools/ci/helm-validate-values/openbao.yaml"
+openbao_tag="$(yq -r '.appVersion' "${chart_source}/Chart.yaml")"
+migrations_tag="$(yq -r '.openbao.migrations.image.tag' "${chart_source}/values.yaml")"
+upgrade_values="${repo_root}/deploy/helm/openbao/upgrade/values-upgrades.yaml"
 test_root="$(mktemp -d)"
 trap 'rm -rf "${test_root}"' EXIT
+
+test "$(yq -r '.openbao.server.image.tag' "${upgrade_values}")" = "${openbao_tag}"
+test "$(yq -r '.openbao.injector.agentImage.tag' "${upgrade_values}")" = "${openbao_tag}"
 
 chart_dir="${test_root}/helm"
 cp -R "${chart_source}" "${chart_dir}"
@@ -52,8 +58,9 @@ awk '
 test -s "${hook_document}"
 grep -q 'helm.sh/hook: post-upgrade' "${hook_document}"
 grep -q 'helm.sh/hook-weight: "0"' "${hook_document}"
-grep -q 'image: "example.com/nvcf/nvcf-openbao:2.5.5-nv-1.3.1"' "${hook_document}"
+grep -Fq "image: \"example.com/nvcf/nvcf-openbao:${openbao_tag}\"" "${hook_document}"
 grep -q 'bao plugin register' "${hook_document}"
+grep -Fq "image: \"example.com/nvcf/nvcf-openbao-migrations:${migrations_tag}\"" "${rendered}"
 
 if grep -q 'bao plugin reload' "${hook_document}"; then
   echo "plugin catalog refresh hook must not reload the plugin before pod rotation" >&2

--- a/deploy/helm/openbao/upgrade/values-upgrades.yaml
+++ b/deploy/helm/openbao/upgrade/values-upgrades.yaml
@@ -4,7 +4,7 @@
 openbao:
   server:
     image:
-      tag: 2.5.5-nv-1.3.1
+      tag: 2.6.2-nv-1.3.3
 
     # Update auto-unseal sidecar to match server version
     extraContainers:
@@ -52,4 +52,4 @@ openbao:
 
   injector:
     agentImage:
-      tag: 2.5.5-nv-1.3.1
+      tag: 2.6.2-nv-1.3.3


### PR DESCRIPTION
## TL;DR

Update the OpenBao chart to consume the released OpenBao
`2.6.2-nv-1.3.3` and migrations `0.19.4` images while keeping every runtime
consumer aligned.

## Why

The chart still points at older OpenBao runtime and migrations images. The
successor images requested by #1788 now exist, including the corrected
composite OpenBao image tag, so the chart can move both pins together.

## What changed

- Set the chart `appVersion`, server image, injected agent image, and upgrade
  values to OpenBao `2.6.2-nv-1.3.3`.
- Set the migrations image default to `0.19.4`.
- Keep the auto-unseal sidecar derived from the server image tag.
- Read render-test expectations from the chart sources of truth and verify the
  migrations image is rendered.

## Customer Release Notes

Updated the self-managed OpenBao chart to use current OpenBao runtime and
migrations images.

## Plan Summary

Image-only chart default changes. No Kubernetes resources, deployment order,
or topology change.

## Usage

Consume the OpenBao chart release produced after this Pull Request merges. The
self-managed stack chart pin remains tracked by #1788.

## Testing

- `bash deploy/helm/openbao/tests/auto-unseal-sidecar.sh`
- `bash deploy/helm/openbao/tests/plugin-catalog-refresh-hook.sh`
- `./tools/ci/check-helm-charts` (19 charts linted and rendered)
- `make -C deploy/stacks/self-managed test`
- Verified the `2.6.2-nv-1.3.3` multi-architecture image contains `amd64` and
  `arm64` manifests in the stack's configured registry.

No live cluster QA was run. Chart lint, render, and stack wiring coverage is
sufficient for these image-only default changes.

## Notes

The server, injected agent, and auto-unseal sidecar all resolve to OpenBao
`2.6.2-nv-1.3.3`. The chart release and subsequent self-managed stack pin will
complete the remaining stages of #1788.

## References

- #1788
- [OpenBao 1.3.3 source release](https://github.com/NVIDIA/nvcf/releases/tag/infra/openbao/v1.3.3)
- [OpenBao migrations 0.19.4 release](https://github.com/NVIDIA/nvcf/releases/tag/migrations/openbao/v0.19.4)

## Related Pull Requests

- #1796

## Dependencies

No new third-party packages. This change updates existing NVCF image
references. The images retain OpenBao 2.6.2 and reviewed dependency pins. No
license or NOTICE update is required.

## For the Reviewer

Review the atomic image-pin changes and upgrade-values alignment.

## For QA

No cluster QA requested. CI lint and render coverage is sufficient for this
chart-only change.

## Issues

Relates to #1788

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO)
  compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the OpenBao deployment and injector images to version 2.6.2-nv-1.3.3.
  - Updated the migration image to version 0.19.4.
  - Aligned upgrade configuration with the current OpenBao and injector image versions.
- **Tests**
  - Improved deployment validation to check image versions dynamically, including migration images during hook refresh testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->