### PR TITLE
fix(icms): use unlimited NATS reconnects on the ncp profile

### DIFF
--- a/src/control-plane-services/instance-cluster-management/icms-service/src/main/resources/application-ncp.yaml
+++ b/src/control-plane-services/instance-cluster-management/icms-service/src/main/resources/application-ncp.yaml
@@ -137,7 +137,7 @@ icms:
     connection-timeout: 10s
     ping-interval: 5s
     reconnect-wait: 100ms
-    unlimited-reconnects: false
+    unlimited-reconnects: true
     force-reconnect-flush: 5s
     delay-between-messages: 100ms
     message-ttl: 96h

--- a/src/control-plane-services/instance-cluster-management/icms-service/src/test/java/com/nvidia/icms/configuration/NcpProfileConfigurationTest.java
+++ b/src/control-plane-services/instance-cluster-management/icms-service/src/test/java/com/nvidia/icms/configuration/NcpProfileConfigurationTest.java
@@ -50,7 +50,7 @@ class NcpProfileConfigurationTest {
         assertThat(nats.getPingInterval()).isEqualTo(Duration.ofSeconds(5));
         assertThat(nats.getReconnectWait()).isEqualTo(Duration.ofMillis(100));
         assertThat(nats.getReconnectJitter()).isEqualTo(Duration.ofSeconds(1));
-        assertThat(nats.isUnlimitedReconnects()).isFalse();
+        assertThat(nats.isUnlimitedReconnects()).isTrue();
         assertThat(nats.getForceReconnectFlush()).isEqualTo(Duration.ofSeconds(5));
         assertThat(nats.getDelayBetweenMessages()).isEqualTo(Duration.ofMillis(100));
         assertThat(nats.getMessageTtl()).isEqualTo(Duration.ofHours(96));


### PR DESCRIPTION
# TL;DR

Enable unlimited NATS reconnects on the `ncp` profile so a self-hosted SIS pod recovers a lost NATS connection on its own instead of needing a manual restart.

## Additional Details

`FixedNatsPool` builds each pooled NATS connection once at startup and never replaces it later. With `unlimited-reconnects: false`, nats only retries up to its default limit of 60 attempts, each attempt capped at the configured 10s connection timeout .
so a NATS outage that outlasts roughly that budget ( ~60 x 10s) leaves the connection permanently closed, with nothing in the pool to rebuild it afterward. 
Setting `unlimited-reconnects: true` on the `ncp` profile matches the existing local profile setting( `application.yaml `:  `unlimited-reconnects: true `) and keeps nats retrying indefinitely on the same connection instead of giving up after that budget runs out.

## For the Reviewer

- `application-ncp.yaml`: the actual config change.
- `NcpProfileConfigurationTest.java`: updated assertion to match.

## For QA

- No live cluster QA performed for this change.

## Issues

Closes #https://nvbugs/6704764
refer PR: [https://github.com/NVIDIA/nvcf/pull/1214](https://github.com/NVIDIA/nvcf/pull/1214)

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * NATS connections for ICMS now continue attempting to reconnect without a retry limit, improving resilience during temporary connection interruptions.

* **Tests**
  * Updated configuration validation to reflect the unlimited reconnect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->