### PR TITLE
fix(release): publish charts before release events

### DIFF
--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -20,6 +20,10 @@ on:
         description: Optional self-managed stack tag to render and validate without publishing.
         required: false
         type: string
+      release_tag:
+        description: Optional existing release tag to replay, including an unpublished Helm chart.
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -63,7 +67,7 @@ jobs:
   # work.
   service-release:
     name: service release automation
-    if: github.ref_type != 'tag' && (github.event_name != 'workflow_dispatch' || inputs.inventory_tag == '')
+    if: github.ref_type != 'tag' && (github.event_name != 'workflow_dispatch' || (inputs.inventory_tag == '' && inputs.release_tag == ''))
     runs-on: linux-amd64-cpu4
     permissions:
       contents: write
@@ -181,8 +185,8 @@ jobs:
             --stack-source-commit "${commit}"
 
   tag-release-notes:
-    name: tag release notes
-    if: github.ref_type == 'tag'
+    name: tag release
+    if: github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
     runs-on: linux-amd64-cpu4
     permissions:
       contents: write
@@ -192,13 +196,32 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Prepare existing chart tag for replay
+        if: github.event_name == 'workflow_dispatch' && inputs.release_tag != ''
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          case "${RELEASE_TAG}" in
+            deploy/helm/*/v*) ;;
+            *) echo "ERROR: release_tag must be a deploy/helm/*/v* tag." >&2; exit 1 ;;
+          esac
+          if ! git show-ref --verify --quiet "refs/tags/${RELEASE_TAG}"; then
+            echo "ERROR: release_tag does not identify an existing tag." >&2
+            exit 1
+          fi
+          git worktree add --detach \
+            "${RUNNER_TEMP}/release-source" \
+            "refs/tags/${RELEASE_TAG}"
+          echo "NVCF_RELEASE_SOURCE_ROOT=${RUNNER_TEMP}/release-source" >> "${GITHUB_ENV}"
+
       - uses: actions/setup-go@v5
-        if: startsWith(github.ref_name, 'deploy/stacks/self-managed/v')
+        if: startsWith(inputs.release_tag || github.ref_name, 'deploy/stacks/self-managed/v')
         with:
           go-version-file: tools/go-toolchain/go.mod
 
-      - name: Install inventory rendering tools
-        if: startsWith(github.ref_name, 'deploy/stacks/self-managed/v')
+      - name: Install Helm release tool
+        if: startsWith(inputs.release_tag || github.ref_name, 'deploy/stacks/self-managed/v') || startsWith(inputs.release_tag || github.ref_name, 'deploy/helm/')
         run: |
           set -euo pipefail
           cd "${RUNNER_TEMP}"
@@ -207,17 +230,28 @@ jobs:
           echo "${HELM_SHA256}  helm.tar.gz" | sha256sum -c -
           tar xzf helm.tar.gz linux-amd64/helm
 
+          mkdir -p "${RUNNER_TEMP}/bin"
+          mv linux-amd64/helm "${RUNNER_TEMP}/bin/"
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+
+      - name: Install Helmfile inventory tool
+        if: startsWith(inputs.release_tag || github.ref_name, 'deploy/stacks/self-managed/v')
+        run: |
+          set -euo pipefail
+          cd "${RUNNER_TEMP}"
           curl -sSL --retry 3 -o helmfile.tar.gz \
             "https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/helmfile_${HELMFILE_VERSION}_linux_amd64.tar.gz"
           echo "${HELMFILE_SHA256}  helmfile.tar.gz" | sha256sum -c -
           tar xzf helmfile.tar.gz helmfile
 
           mkdir -p "${RUNNER_TEMP}/bin"
-          mv linux-amd64/helm helmfile "${RUNNER_TEMP}/bin/"
+          mv helmfile "${RUNNER_TEMP}/bin/"
           echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
 
       - name: Validate tag and create release notes
         env:
+          HELM_REGISTRY_CONFIG: ${{ runner.temp }}/helm-registry-config.json
+          RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
           NVCF_RELEASE_HELM_REGISTRY: ${{ secrets.NCP_DEV_REGISTRY }}
           NVCF_RELEASE_NGC_API_KEY: ${{ secrets.NGC_NCP_DEV_KEY }}
-        run: ./tools/ci/github-release tag "$GITHUB_REF_NAME"
+        run: ./tools/ci/github-release tag "$RELEASE_TAG"

--- a/tools/ci/github-release
+++ b/tools/ci/github-release
@@ -3,11 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import hashlib
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
+import tarfile
 import tempfile
 from pathlib import Path
 
@@ -605,6 +608,196 @@ def release_asset_service(metadata, tag, root):
     if len(matches) > 1:
         raise SystemExit(f"release tag {tag} matches more than one resolved inventory publisher")
     return matches[0] if matches else None
+
+
+def release_chart_service(metadata, tag, root):
+    """Resolve the single Helm chart service represented by a release tag."""
+    matches = []
+    for service in metadata.get("services", []):
+        service_path = str(service.get("path") or "").strip("/")
+        if service_path.startswith("deploy/helm/") and version_from_tag(service, tag, root):
+            matches.append(service)
+    if len(matches) > 1:
+        raise SystemExit(f"release tag {tag} matches more than one Helm chart publisher")
+    if matches:
+        return matches[0]
+    if tag.startswith("deploy/helm/"):
+        raise SystemExit(
+            f"Helm chart release tag {tag} has no matching service in the release metadata"
+        )
+    return None
+
+
+def release_chart_directory(root, service):
+    """Locate a service's owning chart and verify its configured release name."""
+    service_dir = root / service["path"]
+    candidates = []
+    if service_dir.is_dir():
+        for candidate in sorted(service_dir.rglob("Chart.yaml")):
+            relative = candidate.relative_to(service_dir)
+            # A vendored dependency under charts/ is part of the owning chart,
+            # not another package released by the service tag.
+            if "charts" not in relative.parts[:-1]:
+                candidates.append(candidate.parent)
+    if len(candidates) != 1:
+        rendered = ", ".join(str(path.relative_to(root)) for path in candidates) or "none"
+        raise SystemExit(
+            f"{service['id']}: expected exactly one release Chart.yaml under "
+            f"{service['path']}, found {rendered}"
+        )
+
+    chart_dir = candidates[0]
+    match = re.search(
+        r"^name:\s*['\"]?([^\s#'\"]+)",
+        (chart_dir / "Chart.yaml").read_text(),
+        flags=re.MULTILINE,
+    )
+    chart_name = match.group(1) if match else ""
+    if chart_name != service["service_name"]:
+        raise SystemExit(
+            f"{service['id']}: Chart.yaml name {chart_name or '<missing>'!r} does not match "
+            f"release service_name {service['service_name']!r}"
+        )
+    return chart_dir
+
+
+def helm_registry_settings():
+    """Load and validate the OCI registry path and API key used for publication."""
+    registry = os.environ.get("NVCF_RELEASE_HELM_REGISTRY", "").strip().rstrip("/")
+    registry = registry.removeprefix("oci://")
+    api_key = os.environ.get("NVCF_RELEASE_NGC_API_KEY", "")
+    if not registry or not api_key:
+        raise SystemExit(
+            "chart publishing requires NVCF_RELEASE_HELM_REGISTRY and "
+            "NVCF_RELEASE_NGC_API_KEY"
+        )
+    if not re.fullmatch(r"[A-Za-z0-9.-]+(?:/[A-Za-z0-9._-]+)*", registry):
+        raise SystemExit(f"invalid Helm registry path: {registry!r}")
+    return registry, api_key
+
+
+def helm_registry_login(registry, api_key):
+    """Authenticate Helm to the registry host without exposing the API key."""
+    host = registry.split("/", 1)[0]
+    result = subprocess.run(
+        ["helm", "registry", "login", host, "-u", "$oauthtoken", "--password-stdin"],
+        input=api_key,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stdout.write(result.stdout or "")
+        raise SystemExit(f"Helm registry login failed for {host}")
+
+
+def package_release_chart(chart_dir, version, output_dir):
+    """Build chart dependencies and package an isolated copy at the tag version."""
+    staged_chart = output_dir / "source" / chart_dir.name
+    staged_chart.parent.mkdir(parents=True)
+    shutil.copytree(chart_dir, staged_chart)
+    if re.search(
+        r"^[ \t]*dependencies\s*:",
+        (staged_chart / "Chart.yaml").read_text(),
+        flags=re.MULTILINE,
+    ):
+        if not (staged_chart / "Chart.lock").is_file():
+            raise SystemExit(f"{chart_dir}: dependencies require Chart.lock")
+        run(["helm", "dependency", "build", str(staged_chart)])
+
+    package_dir = output_dir / "package"
+    package_dir.mkdir()
+    run(["helm", "package", str(staged_chart), "--version", version, "--destination", str(package_dir)])
+    packages = list(package_dir.glob("*.tgz"))
+    if len(packages) != 1:
+        raise SystemExit(f"expected one packaged Helm chart, found {len(packages)}")
+    return packages[0]
+
+
+def pull_release_chart(registry, chart_name, version, output_dir):
+    """Pull a published chart version and return Helm's result and downloaded archives."""
+    output_dir.mkdir()
+    result = subprocess.run(
+        [
+            "helm",
+            "pull",
+            f"oci://{registry}/{chart_name}",
+            "--version",
+            version,
+            "--destination",
+            str(output_dir),
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    packages = list(output_dir.glob("*.tgz"))
+    return result.returncode, result.stdout or "", packages
+
+
+def helm_archive_signature(path):
+    """Describe archive content while ignoring gzip and tar timestamp differences."""
+    signature = {}
+    with tarfile.open(path, "r:gz") as archive:
+        for member in archive.getmembers():
+            if member.isfile():
+                source = archive.extractfile(member)
+                if source is None:
+                    raise SystemExit(f"could not read {member.name} from {path}")
+                content = hashlib.sha256(source.read()).hexdigest()
+            else:
+                content = member.linkname if member.issym() or member.islnk() else ""
+            signature[member.name] = (member.type, member.mode, content)
+    return signature
+
+
+def missing_helm_chart_output(output):
+    """Return whether Helm's output specifically reports an absent OCI artifact."""
+    lowered = output.lower()
+    return any(phrase in lowered for phrase in ("manifest unknown", "status code: 404"))
+
+
+def publish_release_chart(root, service, version, dry_run):
+    """Publish a chart once, accepting only an identical existing immutable version."""
+    source_root = Path(os.environ.get("NVCF_RELEASE_SOURCE_ROOT") or root)
+    chart_dir = release_chart_directory(source_root, service)
+    chart_name = service["service_name"]
+    if dry_run:
+        print(
+            f"[github-release] dry-run: would publish {chart_name}:{version} "
+            f"from {chart_dir.relative_to(source_root)}"
+        )
+        return
+
+    registry, api_key = helm_registry_settings()
+    with tempfile.TemporaryDirectory(prefix="nvcf-release-chart-") as tmp:
+        package_root = Path(tmp)
+        local_package = package_release_chart(chart_dir, version, package_root)
+        helm_registry_login(registry, api_key)
+        status, output, remote_packages = pull_release_chart(
+            registry, chart_name, version, package_root / "published"
+        )
+        if status == 0:
+            if len(remote_packages) != 1:
+                raise SystemExit(
+                    f"expected one downloaded {chart_name}:{version} archive, "
+                    f"found {len(remote_packages)}"
+                )
+            if helm_archive_signature(local_package) != helm_archive_signature(remote_packages[0]):
+                raise SystemExit(
+                    f"refusing to replace existing Helm chart {chart_name}:{version} "
+                    "with different content"
+                )
+            print(f"[github-release] Helm chart {chart_name}:{version} is already published unchanged")
+            return
+        if not missing_helm_chart_output(output):
+            sys.stdout.write(output)
+            raise SystemExit(f"could not determine whether Helm chart {chart_name}:{version} exists")
+
+        run(["helm", "push", str(local_package), f"oci://{registry}"])
+        print(f"[github-release] published Helm chart {chart_name}:{version} to {registry}")
 
 
 def validate_resolved_stack_inventory(path, tag, version, commit):
@@ -1221,6 +1414,7 @@ def release_branch(parsed):
 
 
 def tag_release(args):
+    """Publish artifacts and a GitHub release for an existing release tag."""
     root = repo_root()
     metadata = load_metadata(root, args.metadata)
     tag = args.tag or os.environ.get("GITHUB_REF_NAME", "")
@@ -1249,6 +1443,10 @@ def tag_release(args):
         f"version={parsed['version']} release_branch={branch} "
         f"auto_tagging_enabled={str(auto_tagging_enabled).lower()}"
     )
+    chart_service = release_chart_service(metadata, tag, root)
+    if chart_service:
+        publish_release_chart(root, chart_service, parsed["version"], dry_run)
+
     asset_service = release_asset_service(metadata, tag, root)
     if not asset_service:
         create_release(tag, tag, notes, draft=draft, dry_run=dry_run)

--- a/tools/ci/test-github-release.py
+++ b/tools/ci/test-github-release.py
@@ -14,6 +14,7 @@ import tempfile
 import types
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 SCRIPT_PATH = Path(__file__).with_name("github-release")
@@ -1180,6 +1181,308 @@ class GithubReleaseTest(unittest.TestCase):
             ],
         }
 
+    def chart_release_metadata(self):
+        """Return minimal release metadata for the chart publication tests."""
+        return {
+            "version": 1,
+            "services": [
+                {
+                    "id": "nats-auth-callout-helm",
+                    "path": "deploy/helm/nats-auth-callout",
+                    "service_name": "helm-nvcf-nats-auth-callout-service",
+                }
+            ],
+        }
+
+    def test_chart_release_tag_resolves_registered_publisher(self):
+        """Chart tags must resolve exactly one registered Helm publisher."""
+        service = self.github_release.release_chart_service(
+            self.chart_release_metadata(),
+            "deploy/helm/nats-auth-callout/v1.2.0",
+            Path("."),
+        )
+        self.assertEqual(service["id"], "nats-auth-callout-helm")
+        self.assertIsNone(
+            self.github_release.release_chart_service(
+                self.chart_release_metadata(),
+                "src/control-plane-services/nats-auth-callout/v0.8.3",
+                Path("."),
+            )
+        )
+        with self.assertRaisesRegex(SystemExit, "no matching service"):
+            self.github_release.release_chart_service(
+                self.chart_release_metadata(),
+                "deploy/helm/unregistered/v1.0.0",
+                Path("."),
+            )
+
+    def test_chart_release_directory_ignores_vendored_dependency(self):
+        """Chart discovery must not treat a vendored dependency as the owning chart."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            chart_dir = root / "deploy/helm/nats-auth-callout"
+            dependency = chart_dir / "charts/dependency"
+            dependency.mkdir(parents=True)
+            (chart_dir / "Chart.yaml").write_text(
+                "name: helm-nvcf-nats-auth-callout-service\n"
+            )
+            (dependency / "Chart.yaml").write_text("name: dependency\n")
+
+            self.assertEqual(
+                self.github_release.release_chart_directory(
+                    root, self.chart_release_metadata()["services"][0]
+                ),
+                chart_dir,
+            )
+
+    def test_registered_chart_release_metadata_matches_chart_sources(self):
+        """Every registered Helm publisher must resolve to a valid source chart."""
+        root = SCRIPT_PATH.parents[2]
+        metadata = json.loads(
+            SCRIPT_PATH.with_name("github-release-subprojects.json").read_text()
+        )
+        charts = [
+            service
+            for service in metadata["services"]
+            if service["path"].startswith("deploy/helm/")
+        ]
+        self.assertGreater(len(charts), 0)
+        for service in charts:
+            with self.subTest(service=service["id"]):
+                self.assertTrue(
+                    self.github_release.release_chart_directory(root, service).is_dir()
+                )
+
+    def test_chart_release_refuses_metadata_name_mismatch(self):
+        """Publishing must reject chart names that disagree with release metadata."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            chart_dir = root / "deploy/helm/nats-auth-callout"
+            chart_dir.mkdir(parents=True)
+            (chart_dir / "Chart.yaml").write_text("name: another-chart\n")
+
+            with self.assertRaisesRegex(SystemExit, "does not match"):
+                self.github_release.release_chart_directory(
+                    root, self.chart_release_metadata()["services"][0]
+                )
+
+    def test_chart_dependencies_require_lock_file(self):
+        """Dependency-bearing charts must pin resolution with a lock file."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            chart_dir = root / "chart"
+            chart_dir.mkdir()
+            (chart_dir / "Chart.yaml").write_text(
+                "name: example\n"
+                "dependencies:\n"
+                "  - name: dependency\n"
+                "    version: 1.0.0\n"
+                "    repository: https://example.invalid/charts\n"
+            )
+
+            with self.assertRaisesRegex(SystemExit, "dependencies require Chart.lock"):
+                self.github_release.package_release_chart(
+                    chart_dir, "1.2.0", root / "output"
+                )
+
+    def test_indented_chart_dependencies_require_lock_file(self):
+        """An indented dependencies key must still activate the lock-file guard."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            chart_dir = root / "chart"
+            chart_dir.mkdir()
+            (chart_dir / "Chart.yaml").write_text(
+                "  name: example\n"
+                "  dependencies:\n"
+                "    - name: dependency\n"
+                "      version: 1.0.0\n"
+                "      repository: https://example.invalid/charts\n"
+            )
+
+            with self.assertRaisesRegex(SystemExit, "dependencies require Chart.lock"):
+                self.github_release.package_release_chart(
+                    chart_dir, "1.2.0", root / "output"
+                )
+
+    def test_chart_is_published_before_github_release(self):
+        """The immutable chart must exist before its GitHub release becomes visible."""
+        root = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(root))
+        tag = "deploy/helm/nats-auth-callout/v1.2.0"
+        calls = []
+        self.github_release.repo_root = lambda: root
+        self.github_release.load_metadata = lambda *_args: self.chart_release_metadata()
+        self.github_release.github_release_mode = lambda: (True, False)
+        self.github_release.publish_release_chart = (
+            lambda _root, service, version, dry_run: calls.append(
+                ("chart", service["id"], version, dry_run)
+            )
+        )
+        self.github_release.create_release = (
+            lambda *_args, **_kwargs: calls.append(("release",))
+        )
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.github_release.tag_release(
+                types.SimpleNamespace(tag=tag, metadata="metadata.json")
+            )
+
+        self.assertEqual(
+            calls,
+            [("chart", "nats-auth-callout-helm", "1.2.0", False), ("release",)],
+        )
+
+    def test_chart_publish_failure_prevents_github_release(self):
+        """A chart publication failure must prevent the GitHub release event."""
+        root = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(root))
+        self.github_release.repo_root = lambda: root
+        self.github_release.load_metadata = lambda *_args: self.chart_release_metadata()
+        self.github_release.github_release_mode = lambda: (True, False)
+        self.github_release.publish_release_chart = lambda *_args: (_ for _ in ()).throw(
+            RuntimeError("push failed")
+        )
+        released = []
+        self.github_release.create_release = lambda *_args, **_kwargs: released.append(True)
+
+        with self.assertRaisesRegex(RuntimeError, "push failed"):
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.github_release.tag_release(
+                    types.SimpleNamespace(
+                        tag="deploy/helm/nats-auth-callout/v1.2.0",
+                        metadata="metadata.json",
+                    )
+                )
+        self.assertEqual(released, [])
+
+    def test_missing_chart_is_pushed_with_exact_tag_version(self):
+        """A missing chart must be pushed with the version encoded in its tag."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            chart_dir = root / "chart"
+            chart_dir.mkdir()
+            package = root / "chart-1.2.0.tgz"
+            package.write_bytes(b"package")
+            calls = []
+            self.github_release.release_chart_directory = lambda *_args: chart_dir
+            self.github_release.helm_registry_settings = lambda: (
+                "nvcr.io/example/ncp-dev",
+                "secret",
+            )
+            self.github_release.package_release_chart = lambda *_args: package
+            self.github_release.helm_registry_login = (
+                lambda registry, _key: calls.append(("login", registry))
+            )
+            self.github_release.pull_release_chart = (
+                lambda *_args: (1, "manifest unknown: not found", [])
+            )
+            self.github_release.run = lambda args, **_kwargs: calls.append(tuple(args))
+
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.github_release.publish_release_chart(
+                    root, self.chart_release_metadata()["services"][0], "1.2.0", False
+                )
+
+            self.assertIn(("login", "nvcr.io/example/ncp-dev"), calls)
+            self.assertIn(
+                ("helm", "push", str(package), "oci://nvcr.io/example/ncp-dev"),
+                calls,
+            )
+
+    def test_chart_publish_uses_replayed_tag_source(self):
+        """Manual replay must package chart content from the selected tag worktree."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "current"
+            replay_root = Path(tmp) / "tagged"
+            chart_dir = replay_root / "deploy/helm/nats-auth-callout"
+            chart_dir.mkdir(parents=True)
+            selected_roots = []
+
+            def select_chart(selected_root, _service):
+                """Record the source root chosen by the publisher."""
+                selected_roots.append(selected_root)
+                return chart_dir
+
+            self.github_release.release_chart_directory = select_chart
+            with mock.patch.dict(
+                os.environ,
+                {"NVCF_RELEASE_SOURCE_ROOT": str(replay_root)},
+            ), contextlib.redirect_stdout(io.StringIO()):
+                self.github_release.publish_release_chart(
+                    root,
+                    self.chart_release_metadata()["services"][0],
+                    "1.2.0",
+                    True,
+                )
+
+            self.assertEqual(selected_roots, [replay_root])
+
+    def test_only_registry_missing_signals_allow_a_chart_push(self):
+        """Only explicit missing-artifact responses may permit a chart push."""
+        self.assertTrue(self.github_release.missing_helm_chart_output("manifest unknown"))
+        self.assertTrue(self.github_release.missing_helm_chart_output("status code: 404"))
+        self.assertFalse(
+            self.github_release.missing_helm_chart_output("credentials file not found")
+        )
+
+    def test_existing_chart_is_only_accepted_when_content_matches(self):
+        """An existing immutable version is reusable only when its content matches."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            chart_dir = root / "chart"
+            chart_dir.mkdir()
+            local = root / "local.tgz"
+            remote = root / "remote.tgz"
+            local.write_bytes(b"local")
+            remote.write_bytes(b"remote")
+            self.github_release.release_chart_directory = lambda *_args: chart_dir
+            self.github_release.helm_registry_settings = lambda: ("nvcr.io/example", "secret")
+            self.github_release.package_release_chart = lambda *_args: local
+            self.github_release.helm_registry_login = lambda *_args: None
+            self.github_release.pull_release_chart = lambda *_args: (0, "", [remote])
+            self.github_release.helm_archive_signature = lambda package: package.name
+
+            with self.assertRaisesRegex(SystemExit, "different content"):
+                self.github_release.publish_release_chart(
+                    root, self.chart_release_metadata()["services"][0], "1.2.0", False
+                )
+
+            self.github_release.helm_archive_signature = lambda _package: "same"
+            calls = []
+            self.github_release.run = lambda args, **_kwargs: calls.append(args)
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.github_release.publish_release_chart(
+                    root, self.chart_release_metadata()["services"][0], "1.2.0", False
+                )
+            self.assertEqual(calls, [])
+
+    def test_registry_error_does_not_get_mistaken_for_missing_chart(self):
+        """Registry failures must not be treated as proof that a chart is absent."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            chart_dir = root / "chart"
+            chart_dir.mkdir()
+            package = root / "local.tgz"
+            package.write_bytes(b"local")
+            self.github_release.release_chart_directory = lambda *_args: chart_dir
+            self.github_release.helm_registry_settings = lambda: ("nvcr.io/example", "secret")
+            self.github_release.package_release_chart = lambda *_args: package
+            self.github_release.helm_registry_login = lambda *_args: None
+            self.github_release.pull_release_chart = lambda *_args: (
+                1,
+                "unauthorized: authentication required",
+                [],
+            )
+
+            with self.assertRaisesRegex(SystemExit, "could not determine"):
+                with contextlib.redirect_stdout(io.StringIO()):
+                    self.github_release.publish_release_chart(
+                        root,
+                        self.chart_release_metadata()["services"][0],
+                        "1.2.0",
+                        False,
+                    )
+
     def test_publish_release_makes_the_exact_draft_public(self):
         calls = []
         self.github_release.run = lambda args, **_kwargs: calls.append(args)
@@ -1423,6 +1726,7 @@ class GithubReleaseTest(unittest.TestCase):
         )
 
     def test_stack_tag_workflow_installs_pinned_inventory_tools(self):
+        """The release workflow must install pinned tools for each artifact type."""
         workflow = (SCRIPT_PATH.parents[2] / ".github/workflows/release-tags.yml").read_text()
         workflow_env = workflow.split("\njobs:\n", 1)[0]
         self.assertIn("actions/setup-go@v5", workflow)
@@ -1438,9 +1742,16 @@ class GithubReleaseTest(unittest.TestCase):
             "NVCF_RELEASE_HELM_REGISTRY: ${{ secrets.NCP_DEV_REGISTRY }}",
             workflow,
         )
-        self.assertEqual(workflow.count("Install inventory rendering tools"), 2)
+        self.assertEqual(workflow.count("Install inventory rendering tools"), 1)
+        self.assertIn("Install Helm release tool", workflow)
+        self.assertIn("Install Helmfile inventory tool", workflow)
+        self.assertIn("inputs.release_tag || github.ref_name", workflow)
+        self.assertIn("Prepare existing chart tag for replay", workflow)
+        self.assertIn("NVCF_RELEASE_SOURCE_ROOT=", workflow)
+        self.assertIn("HELM_REGISTRY_CONFIG: ${{ runner.temp }}/helm-registry-config.json", workflow)
+        self.assertIn('release_tag must be a deploy/helm/*/v* tag', workflow)
         self.assertLess(
-            workflow.index("Install inventory rendering tools"),
+            workflow.index("Install Helm release tool"),
             workflow.index("Validate tag and create release notes"),
         )
 
@@ -1460,6 +1771,38 @@ class GithubReleaseTest(unittest.TestCase):
         tag_release = workflow.index("tag-release-notes:")
         self.assertNotIn("github-release tag", workflow[preflight:tag_release])
         self.assertNotIn("upload-artifact", workflow[preflight:tag_release])
+
+    def test_release_replay_requires_an_exact_tag_ref(self):
+        """A tag-shaped branch must not satisfy manual replay validation."""
+        workflow = (SCRIPT_PATH.parents[2] / ".github/workflows/release-tags.yml").read_text()
+        tag_check = 'git show-ref --verify --quiet "refs/tags/${RELEASE_TAG}"'
+        exact_checkout = '"refs/tags/${RELEASE_TAG}"'
+        replay_step = workflow.split("- name: Prepare existing chart tag for replay", 1)[1]
+        replay_step = replay_step.split("- uses: actions/setup-go@v5", 1)[0]
+
+        self.assertIn(tag_check, replay_step)
+        self.assertGreaterEqual(replay_step.count(exact_checkout), 2)
+        self.assertLess(replay_step.index(tag_check), replay_step.rindex(exact_checkout))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            release_tag = "deploy/helm/example/v1.2.3"
+            self.init_repo(root)
+            git(root, "commit", "--allow-empty", "-m", "seed")
+            git(root, "branch", release_tag)
+            verify_tag = [
+                "git",
+                "show-ref",
+                "--verify",
+                "--quiet",
+                f"refs/tags/{release_tag}",
+            ]
+
+            branch_only = subprocess.run(verify_tag, cwd=root, check=False)
+            self.assertNotEqual(branch_only.returncode, 0)
+            git(root, "tag", release_tag)
+            tagged = subprocess.run(verify_tag, cwd=root, check=False)
+            self.assertEqual(tagged.returncode, 0)
 
     def publish_and_capture_comments(self, version):
         """Publish a tag for `version` from a release branch, recording any comments.


### PR DESCRIPTION
# TL;DR

- Fix the release path that created GitHub Releases before their tagged Helm charts were available.
- Add a replay path for existing tags, including the missing `helm-nvcf-nats-auth-callout-service:1.2.0` package.

## Additional Details

- Resolve each chart through release metadata and require its `Chart.yaml` name to match the registered service name.
- Package the exact tag version from the tagged source tree, including locked chart dependencies.
- Treat an identical existing package as an idempotent success and reject conflicting immutable content.
- Fail closed on registry authentication or transport errors instead of treating them as an absent chart.
- Create the GitHub Release only after chart publication succeeds, preventing an unavailable version from reaching stack pins.

## For the Reviewer

- Review publication ordering in `tag_release` and the existing-tag worktree in `release-tags.yml`.

## For QA

- `python3 tools/ci/test-github-release.py` (74 tests)
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release-tags.yml`
- `helm lint deploy/helm/nats-auth-callout`
- Packaged version `1.2.0` and verified `appVersion: 0.8.3`.
- `git diff --check`

No documentation change is needed; this corrects release automation behavior.

## Issues

Relates to #1769

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover the behavior.
- [x] The documentation is up to date.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for publishing Helm charts as part of release processing.
  - Added manual release replay using an existing release tag.
  - Helm charts are packaged with dependencies and published to the configured OCI registry.
  - Existing identical chart artifacts are detected to prevent duplicate publication.

- **Bug Fixes**
  - Improved validation for release tags, chart metadata, dependencies, and registry configuration.
  - Prevented service releases from running when an inventory or release tag is supplied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->