### PR TITLE
build(cassandra): refresh Jackson and gosu

### DIFF
--- a/infra/cassandra/Dockerfile
+++ b/infra/cassandra/Dockerfile
@@ -1,6 +1,26 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+ARG GOSU_GO_IMAGE=golang:1.27.1-trixie@sha256:9baa6b4187bbb98d240372a8a235ac0bb6b5ddd52bba1431dc2f7c0705862728
+
+FROM --platform=$BUILDPLATFORM ${GOSU_GO_IMAGE} AS gosu-builder
+
+ARG TARGETARCH
+
+# Rebuild the same gosu 1.19 source used by the Cassandra base with a current
+# Go toolchain. The immutable source archive is checksum-pinned because the
+# upstream release binaries were built with an older Go standard library.
+ADD --checksum=sha256:33d7537d588ea49458b9509bcf4554bdf5ceacc66da71e5caa1058ea3b689c3b \
+    https://github.com/tianon/gosu/archive/6456aaa0f3c854d199d0f037f068eb97515b7513.tar.gz \
+    /tmp/gosu.tar.gz
+RUN mkdir -p /src/gosu /out && \
+    tar -xzf /tmp/gosu.tar.gz --strip-components=1 -C /src/gosu && \
+    cd /src/gosu && \
+    CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" GOTOOLCHAIN=local \
+      go build -mod=readonly -trimpath -buildvcs=false \
+      -ldflags="-d -w" -o /out/gosu . && \
+    go version -m /out/gosu
+
 # yq is used by the chart's conf initContainer to deep-merge cassandra.yaml
 # overrides onto the image default. Fetch it in a native build stage (no
 # emulation) and verify it against a pinned checksum.
@@ -59,6 +79,8 @@ RUN if [ -s /tmp/exporter-input.jar ] && [ -z "${EXPORTER_JAVAAGENT}" ]; then \
 
 FROM cassandra:5.0.9@sha256:d35e159439b302146f964919904f84fd3c2cebf347272b8cb8c4368c1cf200e5
 
+COPY --from=gosu-builder --chmod=0555 /out/gosu /usr/local/bin/gosu
+
 # Refresh the OpenSSL runtime packages independently of the upstream image
 # rebuild cadence. Fail the build if the Debian repository cannot provide the
 # first release containing the required fixes.
@@ -69,6 +91,8 @@ RUN apt-get update && \
     dpkg --compare-versions "$(dpkg-query -W -f='${Version}' libssl3t64)" ge 3.5.7-1~deb13u2 && \
     dpkg --compare-versions "$(dpkg-query -W -f='${Version}' openssl-provider-legacy)" ge 3.5.7-1~deb13u2 && \
     rm -rf /var/lib/apt/lists/* && \
+    gosu --version && \
+    gosu nobody true && \
     rm -f \
       /opt/cassandra/lib/jackson-annotations-*.jar \
       /opt/cassandra/lib/jackson-core-*.jar \

--- a/infra/cassandra/README.md
+++ b/infra/cassandra/README.md
@@ -13,6 +13,7 @@ This repository ships:
 Once built, the image:
 
 - Runs Apache Cassandra at the version pinned by the `FROM cassandra:<version>` line in the `Dockerfile`
+- Rebuilds the base image's `gosu` 1.19 helper with the checksum-pinned source revision and the pinned Go toolchain
 - Wires a Prometheus exporter Java agent into `JVM_EXTRA_OPTS` and exposes port `9500` for scraping, when an exporter jar is supplied
 - Adds the `--add-opens` JVM flags the exporter agent needs to reflect into JDK-internal `com.sun.jmx` classes on the JDK 17 runtime shipped in the official image
 
@@ -42,6 +43,10 @@ The build replaces the exporter's complete shaded Netty module set with the chec
 
 - Docker or another OCI-compatible builder (with `buildx` for multi-arch)
 - Optional: a Prometheus exporter agent jar under `files/`, if you want metrics
+
+The `gosu` source revision and Go builder image are immutable inputs in the
+Dockerfile. The final image verifies that the rebuilt helper can switch to the
+`nobody` user before continuing the Cassandra build.
 
 ## Building the container
 

--- a/migrations/cassandra/Dockerfile
+++ b/migrations/cassandra/Dockerfile
@@ -21,6 +21,25 @@ RUN apk add --no-cache curl unzip && \
       -ldflags="-s -w -buildid= -X main.Version=${MIGRATE_BUILD_VERSION}" \
       -o /out/migrate ./cmd/migrate
 
+FROM --platform=$BUILDPLATFORM alpine:3.23 AS java-library-downloader
+
+# Cassandra can lag security-only Jackson releases. Fetch one coherent,
+# checksum-pinned replacement set without adding build tools to the final
+# image. Release builds can route the same paths through a caching repository.
+ARG MAVEN_REPOSITORY_BASE=https://repo.maven.apache.org/maven2
+COPY java-libraries.lock /tmp/java-libraries.lock
+RUN apk add --no-cache curl && \
+    mkdir -p /tmp/java-libraries && \
+    while read -r checksum url; do \
+      case "${checksum}" in \#*|'') continue ;; esac; \
+      path="${url#https://repo.maven.apache.org/maven2/}"; \
+      test "${path}" != "${url}"; \
+      destination="/tmp/java-libraries/${url##*/}"; \
+      curl -fsSL --retry 7 --retry-all-errors \
+        -o "${destination}" "${MAVEN_REPOSITORY_BASE%/}/${path}"; \
+      printf '%s  %s\n' "${checksum}" "${destination}" | sha256sum -c -; \
+    done < /tmp/java-libraries.lock
+
 FROM --platform=$BUILDPLATFORM alpine:3.23 AS kubectl-downloader
 
 ARG TARGETARCH
@@ -53,10 +72,16 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl gettext-base && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    rm -f \
+      /opt/cassandra/lib/jackson-annotations-*.jar \
+      /opt/cassandra/lib/jackson-core-*.jar \
+      /opt/cassandra/lib/jackson-databind-*.jar \
+      /opt/cassandra/lib/jackson-datatype-jsr310-*.jar
 
 COPY --from=migrate-builder --chmod=0555 /out/migrate /usr/bin/migrate
 COPY --from=kubectl-downloader --chmod=0555 /out/kubectl /usr/local/bin/kubectl
+COPY --from=java-library-downloader /tmp/java-libraries/*.jar /opt/cassandra/lib/
 
 COPY keyspaces /app/keyspaces
 COPY --chmod=775 execute_sqls.sh /app

--- a/migrations/cassandra/README.md
+++ b/migrations/cassandra/README.md
@@ -14,6 +14,11 @@ This repository ships:
 
 The container builds [`golang-migrate`](https://github.com/golang-migrate/migrate) v4.19.1 from its checksum-verified release source. The build enables only the Cassandra database driver. This keeps unrelated database and cloud-provider clients out of the runtime binary.
 
+The image also replaces Cassandra's Jackson libraries with the coherent,
+checksum-pinned versions in `java-libraries.lock`. Set
+`MAVEN_REPOSITORY_BASE` at build time to use a caching Maven repository while
+preserving the locked paths and checksums.
+
 `execute_sqls.sh` uses the standard `golang-migrate` Cassandra driver query parameters: `x-multi-statement`, `x-migrations-table`, `username`, and `password`.
 
 ## Prerequisites

--- a/migrations/cassandra/java-libraries.lock
+++ b/migrations/cassandra/java-libraries.lock
@@ -1,0 +1,6 @@
+# SHA-256 and Maven Central URL for Cassandra migrations dependency overlays.
+# Jackson annotations follows the upstream family's major.minor versioning.
+53ca085f4a150f703f49e1aabd935bd03b43e1ea3d55d135438292af22cef56b  https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar
+4b40a06396f239f8de2da57419adde6e94e5edc18a2171d471ea05eeed4e5c2d  https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.21.4/jackson-core-2.21.4.jar
+3888e9e69ab66fbacaacc9aea0e9ffbf15368288e4aca468b024dba11c09fbf9  https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.21.4/jackson-databind-2.21.4.jar
+d1ac4b98b70304e56448423589fde5e775b100889643ad1ead62cc7811633684  https://repo.maven.apache.org/maven2/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.21.4/jackson-datatype-jsr310-2.21.4.jar


### PR DESCRIPTION
# TL;DR

- Refresh the Cassandra migrations image from Jackson 2.19.2 to 2.21.4.
- Rebuild the Cassandra runtime image's gosu 1.19 helper with Go 1.27.1.

## Additional Details

- Downloads the coherent Jackson annotations, core, databind, and JSR-310 set from checksum-pinned Maven Central paths.
- Rebuilds the existing gosu 1.19 source revision from a checksum-pinned archive instead of replacing its interface or behavior.
- Pins the multi-architecture Go builder image by digest and verifies the resulting helper can switch to the `nobody` user during the image build.
- Adds no new dependency or license; existing NOTICE coverage is unchanged.

## For the Reviewer

- Please focus on the immutable gosu build inputs in `infra/cassandra/Dockerfile` and the checksum-locked Jackson overlay in `migrations/cassandra/java-libraries.lock`.

## For QA

- `sh infra/cassandra/scripts/fetch-verified-test.sh`
- `sh infra/cassandra/scripts/fetch-java-libraries-test.sh`
- `sh infra/cassandra/scripts/repack-exporter-netty-test.sh`
- `sh migrations/cassandra/tests/test-execute-sqls.sh`
- Built both images for `linux/arm64` and `linux/amd64` with `docker buildx build`.
- Verified gosu reports version 1.19 built by Go 1.27.1 and successfully switches to `nobody`.
- Verified the migrations image contains only the locked Jackson 2.21/2.21.4 artifacts.

## Issues

Closes #1739

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build & Security**
  - Cassandra container builds now verify the `gosu` helper and Java library artifacts using pinned versions and checksums.
  - Cassandra migration images use verified replacement Jackson libraries from a configurable Maven repository.
  - Builds support Maven caching while retaining locked artifact paths and checksums.

- **Documentation**
  - Added guidance for rebuilding, verifying, and configuring these Cassandra container dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->