### PR TITLE
fix(function-autoscaler): track timeseries query health

### DIFF
--- a/src/control-plane-services/function-autoscaler/crates/server/src/routes/mod.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/routes/mod.rs
@@ -105,11 +105,12 @@ mod tests {
     use axum::response::IntoResponse;
 
     #[tokio::test]
-    async fn liveness_is_always_ok_even_when_cassandra_not_yet_up() {
+    async fn liveness_is_always_ok_even_when_dependencies_are_unhealthy() {
         // Liveness must never check dependencies — restarting the pod doesn't help
-        // if Cassandra is down.
+        // if Cassandra or TimeseriesDb is down.
         let health = Arc::new(Health::new());
         health.register_component("cassandra_client"); // initializes as Unhealthy
+        health.register_component("timeseries_db_client");
 
         let (status, _) = get_liveness().await;
         assert_eq!(status, StatusCode::OK);
@@ -120,6 +121,17 @@ mod tests {
         // register_component initializes as Unhealthy, matching server.rs startup order.
         let health = Arc::new(Health::new());
         health.register_component("cassandra_client");
+        health.set_component_healthy("timeseries_db_client", Some("connected".to_string()));
+
+        let (status, _) = get_readiness(State(health)).await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn readiness_returns_503_when_timeseries_db_is_unhealthy() {
+        let health = Arc::new(Health::new());
+        health.set_component_healthy("cassandra_client", Some("connected".to_string()));
+        health.register_component("timeseries_db_client");
 
         let (status, _) = get_readiness(State(health)).await;
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);

--- a/src/control-plane-services/function-autoscaler/crates/server/src/timeseries_db/timeseries_db_client.rs
+++ b/src/control-plane-services/function-autoscaler/crates/server/src/timeseries_db/timeseries_db_client.rs
@@ -386,7 +386,7 @@ impl TimeseriesDbClient {
             ("step", step.as_secs().to_string()),
         ];
 
-        if self.auth_mode != TimeseriesDbAuthMode::Token {
+        let result = if self.auth_mode != TimeseriesDbAuthMode::Token {
             self.execute_with_retry_no_auth(url, &query_params).await
         } else {
             self.execute_with_retry(move |token| {
@@ -395,7 +395,10 @@ impl TimeseriesDbClient {
                 async move { self.execute_request(url, &query_params, Some(&token)).await }
             })
             .await
-        }
+        };
+
+        *self.is_healthy.lock().unwrap() = result.is_ok();
+        result
     }
 
     // self and auth_token would add tokens or credentials to the traces, so they are excluded
@@ -710,7 +713,7 @@ mod tests {
     use std::path::Path;
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
-        Arc,
+        Arc, Mutex,
     };
     use std::time::Duration as StdDuration;
     use std::time::Duration;
@@ -761,6 +764,7 @@ mod tests {
         request_count: AtomicUsize,
         responses: Vec<(StatusCode, String)>,
         expected_auth_tokens: Vec<String>,
+        response_override: Mutex<Option<(StatusCode, String)>>,
     }
 
     impl MockServerState {
@@ -769,7 +773,12 @@ mod tests {
                 request_count: AtomicUsize::new(0),
                 responses,
                 expected_auth_tokens,
+                response_override: Mutex::new(None),
             }
+        }
+
+        fn set_response_override(&self, status: StatusCode, body: &str) {
+            *self.response_override.lock().unwrap() = Some((status, body.to_string()));
         }
 
         fn get_response(&self, auth_header: Option<&str>) -> Response<Full<Bytes>> {
@@ -792,6 +801,13 @@ mod tests {
                         .body(Full::new(Bytes::from("Unauthorized: Missing token")))
                         .unwrap();
                 }
+            }
+
+            if let Some((status, body)) = &*self.response_override.lock().unwrap() {
+                return Response::builder()
+                    .status(*status)
+                    .body(Full::new(Bytes::from(body.clone())))
+                    .unwrap();
             }
 
             // Return configured response
@@ -906,6 +922,13 @@ mod tests {
             .with_max_delay(TEST_MAX_BACKOFF_DELAY)
             .with_min_delay(DEFAULT_MIN_BACKOFF_DELAY)
             .with_factor(1.5)
+    }
+
+    fn immediate_retry_test_backoff() -> ExponentialBuilder {
+        ExponentialBuilder::default()
+            .with_max_times(1)
+            .with_max_delay(StdDuration::ZERO)
+            .with_min_delay(StdDuration::ZERO)
     }
 
     fn generate_client_identity(expired: bool) -> Result<(Vec<u8>, Vec<u8>)> {
@@ -1158,6 +1181,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_query_health_tracks_outage_and_recovery() -> Result<()> {
+        let state = Arc::new(MockServerState::new(
+            vec![(StatusCode::OK, get_mock_response())],
+            vec![],
+        ));
+
+        let server_url = start_mock_server(state.clone()).await;
+        let config = TimeseriesDbSettings {
+            authn_url: "".to_string(),
+            timeseries_db_url: server_url,
+            disable_auth: true,
+            env: "stg".to_string(),
+            ignore_env: false,
+            backoff: Some(immediate_retry_test_backoff()),
+            ..Default::default()
+        };
+        let client = TimeseriesDbClient::new(&config, None)?;
+        let start = Utc.timestamp_opt(1748551740, 0).unwrap();
+        let end = Utc.timestamp_opt(1748551800, 0).unwrap();
+
+        client
+            .query_range("test_query", start, end, StdDuration::from_secs(60))
+            .await?;
+        assert!(client.health().await.is_healthy);
+
+        state.set_response_override(StatusCode::SERVICE_UNAVAILABLE, "Service unavailable");
+        let outage_result = client
+            .query_range("test_query", start, end, StdDuration::from_secs(60))
+            .await;
+        assert!(outage_result.is_err());
+        assert!(!client.health().await.is_healthy);
+
+        state.set_response_override(StatusCode::OK, &get_mock_response());
+        client
+            .query_range("test_query", start, end, StdDuration::from_secs(60))
+            .await?;
+        assert!(client.health().await.is_healthy);
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_credential_refresh() -> Result<()> {
         let state = Arc::new(MockServerState::new(
             vec![
@@ -1240,6 +1305,7 @@ mod tests {
             .query_range("test_query", start, end, StdDuration::from_secs(60))
             .await?;
         assert_eq!(result.status, "success");
+        assert!(client.health().await.is_healthy);
 
         Ok(())
     }
@@ -1337,6 +1403,7 @@ mod tests {
             .query_range("test_query", start, end, StdDuration::from_secs(60))
             .await;
         assert!(result.is_err());
+        assert!(!client.health().await.is_healthy);
 
         Ok(())
     }
@@ -1408,8 +1475,11 @@ mod tests {
     #[tokio::test]
     async fn test_health_status_on_auth_vs_other_errors() -> Result<()> {
         let auth_error_state = Arc::new(MockServerState::new(
-            vec![(StatusCode::UNAUTHORIZED, "Unauthorized".to_string())],
-            vec!["test_token_0".to_string()],
+            vec![
+                (StatusCode::UNAUTHORIZED, "Unauthorized".to_string()),
+                (StatusCode::OK, get_mock_response()),
+            ],
+            vec!["test_token_0".to_string(), "test_token_1".to_string()],
         ));
 
         let server_url = start_mock_server(auth_error_state).await;
@@ -1438,6 +1508,11 @@ mod tests {
         let health_result = client.health().await;
         assert!(!health_result.is_healthy);
         assert!(health_result.message.unwrap().contains("unhealthy"));
+
+        client
+            .query_range("test_query", start, end, StdDuration::from_secs(60))
+            .await?;
+        assert!(client.health().await.is_healthy);
 
         Ok(())
     }


### PR DESCRIPTION
## TL;DR

Make TimeseriesDB health follow completed query results so backend outages affect readiness and `/health`.

## Additional Details

Health changes only after retries finish. Cassandra health and liveness behavior are unchanged.

## For the Reviewer

The production change is limited to updating health from the final query result.

## For QA

- `cargo test -p rs-autoscaler`: 157 passed, 10 ignored
- Clippy and Bazel server build passed

## Issues

Relates to #15

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for DCO compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved service health reporting for Timeseries DB connectivity, including authentication failures, server errors, outages, and recovery.
  - Readiness checks now correctly fail when either Cassandra or Timeseries DB is unavailable.
  - Liveness checks remain successful during dependency outages, allowing the service to restart or recover appropriately.
  - Expanded health-check coverage to validate dependency-specific failure and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->