### PR TITLE
refactor(docs): retire legacy version sync paths

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -40,10 +40,10 @@ jobs:
       - name: Run docs validation
         run: ./tools/ci/check-docs
 
-      - name: Check latest stack publication
+      - name: Check latest stack release
         env:
           DOC_VERSION_SYNC_GITHUB_TOKEN: ${{ github.token }}
-        run: ./tools/ci/check-doc-version-publication
+        run: ./tools/ci/check-doc-version-current-release
 
   go-lib-codegen:
     name: go-lib codegen

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -83,13 +83,17 @@ go run -C tools/docs-version-sync . --target main --update-catalog
 ./tools/ci/check-doc-version-sync
 ```
 
-The first command reads GitHub and writes updates. The second command is an
-offline consistency check. CI runs the offline check before this separate
-network check:
+The first command reads the inventory attached to the latest stable GitHub
+stack release and writes updates. The second command is an offline consistency
+check. CI runs the offline check before this separate current-release check:
 
 ```bash
-./tools/ci/check-doc-version-publication
+./tools/ci/check-doc-version-current-release
 ```
+
+The current-release check does not discover public NGC availability. Keep
+exact public locations in `publications` and mark unavailable versions in
+`publication_pending`.
 
 Generated blocks are marked with comments such as:
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -95,6 +95,7 @@ The current-release check does not discover public NGC availability. Keep
 exact public locations in `publications` and mark unavailable versions in
 `publication_pending`. Identify publication records by `name`, `type`, and
 `version` so charts, images, and resources with the same name remain distinct.
+Version overrides also require `name` and `type`.
 
 Generated blocks are marked with comments such as:
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -93,7 +93,8 @@ check. CI runs the offline check before this separate current-release check:
 
 The current-release check does not discover public NGC availability. Keep
 exact public locations in `publications` and mark unavailable versions in
-`publication_pending`.
+`publication_pending`. Identify publication records by `name`, `type`, and
+`version` so charts, images, and resources with the same name remain distinct.
 
 Generated blocks are marked with comments such as:
 

--- a/docs/version-catalog/main.yaml
+++ b/docs/version-catalog/main.yaml
@@ -13,63 +13,81 @@ registries:
     namespace: nvidia/nvcf
 publications:
   - name: cert-manager-cainjector
+    type: image
     version: v1.20.2
     registry: public-images
   - name: cert-manager-controller
+    type: image
     version: v1.20.2
     registry: public-images
   - name: cert-manager-startupapicheck
+    type: image
     version: v1.20.2
     registry: public-images
   - name: cert-manager-webhook
+    type: image
     version: v1.20.2
     registry: public-images
   - name: oss-vault-k8s
+    type: image
     version: 1.7.4
     registry: public-images
   - name: nvcf-image-credential-helper
+    type: image
     version: 0.10.2
     registry: public-images
   - name: nats-box
+    type: image
     version: 0.19.7-nonroot
     registry: public-images
   - name: nvcf-state-metrics-service
+    type: image
     version: 1.23.7
     registry: public-images
   - name: cassandra
+    type: image
     version: 5.0.8-nv-2.0.1
     registry: public-images
   - name: helm-nvcf-cert-manager
+    type: chart
     version: 0.1.0
     registry: public-helm
     chart_format: http
   - name: helm-nvcf-pki
+    type: chart
     version: 0.1.0
     registry: public-helm
     chart_format: http
   - name: helm-nvcf-state-metrics
+    type: chart
     version: 1.0.2
     registry: public-helm
     chart_format: http
   - name: helm-nvcf-ui
+    type: chart
     version: 1.1.2
     registry: public-helm
     chart_format: http
   - name: nvcf-container-cache
+    type: image
     version: v1.1.36
     registry: public-images
   - name: nvcf-proxy-tls-certs
+    type: image
     version: v1.2.10
     registry: public-images
   - name: nvcf-container-cache
+    type: chart
     version: 0.25.22
     registry: public-helm
     chart_format: http
   - name: nvcf-example-dashboards
+    type: chart
     version: 1.6.0
     registry: public-helm
     chart_format: http
   - name: nvcf-observability-reference-stack
+    type: chart
     version: 1.10.0
     registry: public-helm
     chart_format: http

--- a/docs/version-catalog/main.yaml
+++ b/docs/version-catalog/main.yaml
@@ -746,7 +746,6 @@ stack:
   name: nvcf-self-managed-stack
   version: 0.16.1
   registry: public-resources
-  source_version: 0.16.1
   source_tag: deploy/stacks/self-managed/v0.16.1
   source_commit: 6aa572575c3f3ee7716a9fddc4cbfceae17e73ec
   pin_sources:

--- a/docs/version-catalog/main.yaml
+++ b/docs/version-catalog/main.yaml
@@ -93,6 +93,7 @@ publications:
     chart_format: http
 version_overrides:
   - name: nvcf-cli
+    type: resource
     version: 1.16.2
     source: independent source release; not pinned by stack
 publication_pending:

--- a/tools/ci/check-doc-version-current-release
+++ b/tools/ci/check-doc-version-current-release
@@ -16,6 +16,7 @@
 
 set -eu
 
+# Compare the checked-in catalog with the latest stable GitHub stack release.
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 repo_root="$(cd "${script_dir}/../.." && pwd)"
 

--- a/tools/docs-version-sync/catalog.go
+++ b/tools/docs-version-sync/catalog.go
@@ -121,9 +121,10 @@ type Publication struct {
 }
 
 type VersionOverride struct {
-	Name    string `yaml:"name"`
-	Version string `yaml:"version"`
-	Source  string `yaml:"source,omitempty"`
+	Name    string       `yaml:"name"`
+	Type    ArtifactType `yaml:"type"`
+	Version string       `yaml:"version"`
+	Source  string       `yaml:"source,omitempty"`
 }
 
 // StackMetadata identifies the stack release and its immutable source snapshot.
@@ -275,7 +276,8 @@ func ValidateCatalog(catalog *Catalog) error {
 			return fmt.Errorf("duplicate publication %s", key)
 		}
 		seenPublications[key] = struct{}{}
-		publicationVersions[publication.Name] = append(publicationVersions[publication.Name], publication.Version)
+		publicationKey := artifactNameAndTypeIdentityKey(publication.Name, publication.Type)
+		publicationVersions[publicationKey] = append(publicationVersions[publicationKey], publication.Version)
 	}
 	seenVersionOverrides := map[string]struct{}{}
 	for _, override := range catalog.VersionOverrides {
@@ -285,10 +287,16 @@ func ValidateCatalog(catalog *Catalog) error {
 		if strings.TrimSpace(override.Version) == "" {
 			return fmt.Errorf("version override %s has empty version", override.Name)
 		}
-		if _, exists := seenVersionOverrides[override.Name]; exists {
-			return fmt.Errorf("duplicate version override %s", override.Name)
+		switch override.Type {
+		case ArtifactTypeImage, ArtifactTypeChart, ArtifactTypeResource:
+		default:
+			return fmt.Errorf("version override %s has unsupported type %q", override.Name, override.Type)
 		}
-		if versions, published := publicationVersions[override.Name]; published {
+		overrideKey := artifactNameAndTypeIdentityKey(override.Name, override.Type)
+		if _, exists := seenVersionOverrides[overrideKey]; exists {
+			return fmt.Errorf("duplicate version override %s:%s", override.Name, override.Type)
+		}
+		if versions, published := publicationVersions[overrideKey]; published {
 			matches := false
 			for _, version := range versions {
 				if version == override.Version {
@@ -300,7 +308,7 @@ func ValidateCatalog(catalog *Catalog) error {
 				return fmt.Errorf("version override %s:%s does not match publication version %s", override.Name, override.Version, strings.Join(versions, ", "))
 			}
 		}
-		seenVersionOverrides[override.Name] = struct{}{}
+		seenVersionOverrides[overrideKey] = struct{}{}
 	}
 	seenPending := map[string]struct{}{}
 	for _, name := range catalog.PublicationPending {
@@ -722,7 +730,11 @@ func refreshCatalogFromArtifacts(stackVersion string, artifacts []Artifact, base
 }
 
 func artifactNameAndTypeKey(artifact Artifact) string {
-	return artifact.Name + "\x00" + string(artifact.Type)
+	return artifactNameAndTypeIdentityKey(artifact.Name, artifact.Type)
+}
+
+func artifactNameAndTypeIdentityKey(name string, artifactType ArtifactType) string {
+	return name + "\x00" + string(artifactType)
 }
 
 func publicationIdentityKey(name string, artifactType ArtifactType, version string) string {
@@ -764,12 +776,12 @@ func (catalog *Catalog) reconcilePublicationPending() {
 func (catalog *Catalog) applyVersionOverrides() {
 	for _, override := range catalog.VersionOverrides {
 		for i := range catalog.Artifacts {
-			if catalog.Artifacts[i].Name == override.Name {
+			if catalog.Artifacts[i].Name == override.Name && catalog.Artifacts[i].Type == override.Type {
 				catalog.Artifacts[i].Version = override.Version
 			}
 		}
 		for i := range catalog.SupplementalArtifacts {
-			if catalog.SupplementalArtifacts[i].Name == override.Name {
+			if catalog.SupplementalArtifacts[i].Name == override.Name && catalog.SupplementalArtifacts[i].Type == override.Type {
 				catalog.SupplementalArtifacts[i].Version = override.Version
 			}
 		}

--- a/tools/docs-version-sync/catalog.go
+++ b/tools/docs-version-sync/catalog.go
@@ -28,14 +28,12 @@ import (
 )
 
 const (
-	defaultStackResourceName       = "nvcf-self-managed-stack"
+	controlStackResourceName       = "nvcf-self-managed-stack"
 	computeStackResourceName       = "nvcf-compute-plane-stack"
 	observabilityStackResourceName = "nvcf-observability-stack"
 	defaultStackRegistry           = "public-resources"
-	defaultCLIRegistry             = defaultStackRegistry
 	defaultImageRegistry           = "public-images"
 	defaultChartRegistry           = "public-helm"
-	defaultCLIVersion              = "0.0.30"
 )
 
 var (
@@ -127,16 +125,15 @@ type VersionOverride struct {
 	Source  string `yaml:"source,omitempty"`
 }
 
-// StackMetadata identifies the independently versioned publication inventory and source release.
+// StackMetadata identifies the stack release and its immutable source snapshot.
 type StackMetadata struct {
-	Name               string   `yaml:"name"`
-	PublicationVersion string   `yaml:"version"`
-	Registry           string   `yaml:"registry"`
-	SourceVersion      string   `yaml:"source_version,omitempty"`
-	SourceTag          string   `yaml:"source_tag,omitempty"`
-	SourceCommit       string   `yaml:"source_commit,omitempty"`
-	PinSources         []string `yaml:"pin_sources,omitempty"`
-	PinSourceDigest    string   `yaml:"pin_source_digest,omitempty"`
+	Name            string   `yaml:"name"`
+	Version         string   `yaml:"version"`
+	Registry        string   `yaml:"registry"`
+	SourceTag       string   `yaml:"source_tag,omitempty"`
+	SourceCommit    string   `yaml:"source_commit,omitempty"`
+	PinSources      []string `yaml:"pin_sources,omitempty"`
+	PinSourceDigest string   `yaml:"pin_source_digest,omitempty"`
 }
 
 type DenylistEntry struct {
@@ -158,10 +155,6 @@ type Artifact struct {
 	RepositoryName string       `yaml:"repository_name,omitempty"`
 	Version        string       `yaml:"version"`
 	Digest         string       `yaml:"digest,omitempty"`
-	Source         string       `yaml:"source,omitempty"`
-
-	registryHost      string
-	registryNamespace string
 }
 
 type OutputFile struct {
@@ -310,24 +303,23 @@ func ValidateCatalog(catalog *Catalog) error {
 	if strings.TrimSpace(catalog.Stack.Name) == "" {
 		return fmt.Errorf("stack name cannot be empty")
 	}
-	if strings.TrimSpace(catalog.Stack.PublicationVersion) == "" {
-		return fmt.Errorf("stack publication version cannot be empty")
+	if strings.TrimSpace(catalog.Stack.Version) == "" {
+		return fmt.Errorf("stack version cannot be empty")
 	}
 	if _, ok := catalog.Registries[catalog.Stack.Registry]; !ok {
 		return fmt.Errorf("stack registry %q is not defined", catalog.Stack.Registry)
 	}
-	hasSourceVersion := strings.TrimSpace(catalog.Stack.SourceVersion) != ""
 	hasSourceTag := strings.TrimSpace(catalog.Stack.SourceTag) != ""
 	hasSourceCommit := strings.TrimSpace(catalog.Stack.SourceCommit) != ""
 	hasPinSources := len(catalog.Stack.PinSources) != 0
 	hasPinSourceDigest := strings.TrimSpace(catalog.Stack.PinSourceDigest) != ""
-	if (hasSourceVersion || hasSourceTag || hasSourceCommit || hasPinSources || hasPinSourceDigest) && (!hasSourceVersion || !hasSourceTag || !hasSourceCommit || !hasPinSources || !hasPinSourceDigest) {
-		return fmt.Errorf("stack source snapshot must set source_version, source_tag, source_commit, pin_sources, and pin_source_digest together")
+	if (hasSourceTag || hasSourceCommit || hasPinSources || hasPinSourceDigest) && (!hasSourceTag || !hasSourceCommit || !hasPinSources || !hasPinSourceDigest) {
+		return fmt.Errorf("stack source snapshot must set source_tag, source_commit, pin_sources, and pin_source_digest together")
 	}
 	if hasSourceCommit {
-		wantSourceTag := "deploy/stacks/self-managed/v" + catalog.Stack.SourceVersion
+		wantSourceTag := "deploy/stacks/self-managed/v" + catalog.Stack.Version
 		if catalog.Stack.SourceTag != wantSourceTag {
-			return fmt.Errorf("stack source_tag must be %s for source version %s", wantSourceTag, catalog.Stack.SourceVersion)
+			return fmt.Errorf("stack source_tag must be %s for stack version %s", wantSourceTag, catalog.Stack.Version)
 		}
 		if !fullLowercaseCommitSHARe.MatchString(catalog.Stack.SourceCommit) {
 			return fmt.Errorf("stack source_commit must be a full lowercase commit SHA")
@@ -632,8 +624,8 @@ func (registry Registry) resourceRef(name, version string) string {
 	return fmt.Sprintf("%s/%s:%s", registry.Namespace, name, version)
 }
 
-// BuildCatalogFromArtifacts creates a catalog from resolved stack artifacts.
-func BuildCatalogFromArtifacts(publicationVersion string, artifacts []Artifact) *Catalog {
+// newCatalogFromArtifacts creates a catalog from resolved stack artifacts.
+func newCatalogFromArtifacts(stackVersion string, artifacts []Artifact) *Catalog {
 	catalog := &Catalog{
 		Version: 1,
 		Target:  "main",
@@ -653,32 +645,22 @@ func BuildCatalogFromArtifacts(publicationVersion string, artifacts []Artifact) 
 			},
 		},
 		Stack: StackMetadata{
-			Name:               defaultStackResourceName,
-			PublicationVersion: publicationVersion,
-			Registry:           defaultStackRegistry,
-		},
-		SupplementalArtifacts: []Artifact{
-			{Name: "nvcf-cli", Type: ArtifactTypeResource, Registry: defaultCLIRegistry, Version: defaultCLIVersion},
+			Name:     controlStackResourceName,
+			Version:  stackVersion,
+			Registry: defaultStackRegistry,
 		},
 		Outputs: defaultOutputs(),
 	}
 
-	for i := range artifacts {
-		artifact := artifacts[i]
-		if artifact.Registry == "" {
-			artifact.Registry = catalog.registryKeyFor(artifact.registryHost, artifact.registryNamespace)
-		}
-		artifact.Source = ""
-		catalog.Artifacts = append(catalog.Artifacts, artifact)
-	}
+	catalog.Artifacts = append(catalog.Artifacts, artifacts...)
 	catalog.markAllUnpublishedAsPending()
 	catalog.reconcilePublicationPending()
 	return catalog
 }
 
-// BuildCatalogFromArtifactsWithBase refreshes an existing catalog from a published package inventory.
-func BuildCatalogFromArtifactsWithBase(publicationVersion string, artifacts []Artifact, base *Catalog) *Catalog {
-	catalog := BuildCatalogFromArtifacts(publicationVersion, artifacts)
+// refreshCatalogFromArtifacts retains catalog-owned metadata around a resolved stack inventory.
+func refreshCatalogFromArtifacts(stackVersion string, artifacts []Artifact, base *Catalog) *Catalog {
+	catalog := newCatalogFromArtifacts(stackVersion, artifacts)
 	if base == nil {
 		return catalog
 	}
@@ -693,15 +675,9 @@ func BuildCatalogFromArtifactsWithBase(publicationVersion string, artifacts []Ar
 	catalog.PublicationPending = append(catalog.PublicationPending, base.PublicationPending...)
 	catalog.Denylist = append(catalog.Denylist, base.Denylist...)
 	catalog.Manifest = base.Manifest
-	// A package refresh does not identify a new GitHub source release.
-	catalog.Stack.SourceVersion = base.Stack.SourceVersion
-	catalog.Stack.SourceCommit = base.Stack.SourceCommit
-	catalog.Stack.SourceTag = base.Stack.SourceTag
-	catalog.Stack.PinSources = append(catalog.Stack.PinSources, base.Stack.PinSources...)
-	catalog.Stack.PinSourceDigest = base.Stack.PinSourceDigest
-	resolvedNames := make(map[string]struct{}, len(catalog.Artifacts))
+	resolvedArtifacts := make(map[string]struct{}, len(catalog.Artifacts))
 	for _, artifact := range catalog.Artifacts {
-		resolvedNames[artifact.Name] = struct{}{}
+		resolvedArtifacts[artifactNameAndTypeKey(artifact)] = struct{}{}
 	}
 
 	seenSupplemental := map[string]struct{}{}
@@ -710,20 +686,19 @@ func BuildCatalogFromArtifactsWithBase(publicationVersion string, artifacts []Ar
 	}
 	denylist := catalog.DenylistMap()
 	for _, artifact := range append(append([]Artifact{}, base.Artifacts...), base.SupplementalArtifacts...) {
-		if artifact.Name == "" || artifact.Name == defaultStackResourceName || artifact.Name == "nvcf-cli" {
+		if artifact.Name == "" || artifact.Name == controlStackResourceName {
 			continue
 		}
 		if _, denied := denylist[artifact.Name]; denied {
 			continue
 		}
-		if _, resolved := resolvedNames[artifact.Name]; resolved {
+		if _, resolved := resolvedArtifacts[artifactNameAndTypeKey(artifact)]; resolved {
 			continue
 		}
 		key := artifact.catalogKey()
 		if _, exists := seenSupplemental[key]; exists {
 			continue
 		}
-		artifact.Source = ""
 		catalog.SupplementalArtifacts = append(catalog.SupplementalArtifacts, artifact)
 		seenSupplemental[key] = struct{}{}
 	}
@@ -732,6 +707,10 @@ func BuildCatalogFromArtifactsWithBase(publicationVersion string, artifacts []Ar
 	catalog.reconcilePublicationPending()
 	catalog.pruneUnusedRegistries()
 	return catalog
+}
+
+func artifactNameAndTypeKey(artifact Artifact) string {
+	return artifact.Name + "\x00" + string(artifact.Type)
 }
 
 func (catalog *Catalog) markAllUnpublishedAsPending() {
@@ -800,39 +779,6 @@ func (catalog *Catalog) pruneUnusedRegistries() {
 			delete(catalog.Registries, key)
 		}
 	}
-}
-
-func (catalog *Catalog) registryKeyFor(host, namespace string) string {
-	if host == "" || namespace == "" {
-		return defaultStackRegistry
-	}
-	for key, registry := range catalog.Registries {
-		if registry.Host == host && registry.Namespace == namespace {
-			return key
-		}
-	}
-
-	base := sanitizeRegistryKey(namespace)
-	key := base
-	for i := 2; ; i++ {
-		if _, exists := catalog.Registries[key]; !exists {
-			catalog.Registries[key] = Registry{Host: host, Namespace: namespace}
-			return key
-		}
-		key = fmt.Sprintf("%s-%d", base, i)
-	}
-}
-
-var registryKeyRe = regexp.MustCompile(`[^a-z0-9-]+`)
-
-func sanitizeRegistryKey(namespace string) string {
-	key := strings.ToLower(strings.ReplaceAll(namespace, "/", "-"))
-	key = registryKeyRe.ReplaceAllString(key, "-")
-	key = strings.Trim(key, "-")
-	if key == "" {
-		return "registry"
-	}
-	return key
 }
 
 func defaultOutputs() []OutputFile {

--- a/tools/docs-version-sync/catalog.go
+++ b/tools/docs-version-sync/catalog.go
@@ -112,11 +112,12 @@ const (
 )
 
 type Publication struct {
-	Name             string      `yaml:"name"`
-	Version          string      `yaml:"version"`
-	PublishedVersion string      `yaml:"published_version,omitempty"`
-	Registry         string      `yaml:"registry"`
-	ChartFormat      ChartFormat `yaml:"chart_format,omitempty"`
+	Name             string       `yaml:"name"`
+	Type             ArtifactType `yaml:"type"`
+	Version          string       `yaml:"version"`
+	PublishedVersion string       `yaml:"published_version,omitempty"`
+	Registry         string       `yaml:"registry"`
+	ChartFormat      ChartFormat  `yaml:"chart_format,omitempty"`
 }
 
 type VersionOverride struct {
@@ -258,13 +259,18 @@ func ValidateCatalog(catalog *Catalog) error {
 		if strings.TrimSpace(publication.Version) == "" {
 			return fmt.Errorf("publication %s has empty version", publication.Name)
 		}
+		switch publication.Type {
+		case ArtifactTypeImage, ArtifactTypeChart, ArtifactTypeResource:
+		default:
+			return fmt.Errorf("publication %s:%s has unsupported type %q", publication.Name, publication.Version, publication.Type)
+		}
 		if _, ok := catalog.Registries[publication.Registry]; !ok {
 			return fmt.Errorf("publication %s:%s registry %q is not defined", publication.Name, publication.Version, publication.Registry)
 		}
 		if publication.ChartFormat != "" && publication.ChartFormat != ChartFormatHTTP {
 			return fmt.Errorf("publication %s:%s has unsupported chart format %q", publication.Name, publication.Version, publication.ChartFormat)
 		}
-		key := publication.Name + ":" + publication.Version
+		key := publicationIdentityKey(publication.Name, publication.Type, publication.Version)
 		if _, exists := seenPublications[key]; exists {
 			return fmt.Errorf("duplicate publication %s", key)
 		}
@@ -283,9 +289,15 @@ func ValidateCatalog(catalog *Catalog) error {
 			return fmt.Errorf("duplicate version override %s", override.Name)
 		}
 		if versions, published := publicationVersions[override.Name]; published {
-			key := override.Name + ":" + override.Version
-			if _, matches := seenPublications[key]; !matches {
-				return fmt.Errorf("version override %s does not match publication version %s", key, strings.Join(versions, ", "))
+			matches := false
+			for _, version := range versions {
+				if version == override.Version {
+					matches = true
+					break
+				}
+			}
+			if !matches {
+				return fmt.Errorf("version override %s:%s does not match publication version %s", override.Name, override.Version, strings.Join(versions, ", "))
 			}
 		}
 		seenVersionOverrides[override.Name] = struct{}{}
@@ -557,7 +569,7 @@ func (catalog *Catalog) artifactPath(artifact Artifact) (string, error) {
 
 func (catalog *Catalog) publicationFor(artifact Artifact) (Publication, bool) {
 	for _, publication := range catalog.Publications {
-		if publication.Name == artifact.Name && publication.Version == artifact.Version {
+		if publication.Name == artifact.Name && publication.Type == artifact.Type && publication.Version == artifact.Version {
 			return publication, true
 		}
 	}
@@ -711,6 +723,10 @@ func refreshCatalogFromArtifacts(stackVersion string, artifacts []Artifact, base
 
 func artifactNameAndTypeKey(artifact Artifact) string {
 	return artifact.Name + "\x00" + string(artifact.Type)
+}
+
+func publicationIdentityKey(name string, artifactType ArtifactType, version string) string {
+	return name + ":" + string(artifactType) + ":" + version
 }
 
 func (catalog *Catalog) markAllUnpublishedAsPending() {

--- a/tools/docs-version-sync/catalog_inventory.go
+++ b/tools/docs-version-sync/catalog_inventory.go
@@ -185,12 +185,12 @@ func retainIndependentManifestArtifacts(catalog *Catalog) {
 func retainCurrentPublications(catalog *Catalog) {
 	current := make(map[string]struct{}, len(catalog.Artifacts)+len(catalog.SupplementalArtifacts)+1)
 	for _, artifact := range append(append([]Artifact{catalog.stackArtifact()}, catalog.Artifacts...), catalog.SupplementalArtifacts...) {
-		current[artifact.Name+":"+artifact.Version] = struct{}{}
+		current[publicationIdentityKey(artifact.Name, artifact.Type, artifact.Version)] = struct{}{}
 	}
 
 	publications := catalog.Publications[:0]
 	for _, publication := range catalog.Publications {
-		if _, ok := current[publication.Name+":"+publication.Version]; !ok {
+		if _, ok := current[publicationIdentityKey(publication.Name, publication.Type, publication.Version)]; !ok {
 			continue
 		}
 		registry, ok := catalog.Registries[publication.Registry]

--- a/tools/docs-version-sync/catalog_inventory.go
+++ b/tools/docs-version-sync/catalog_inventory.go
@@ -38,7 +38,7 @@ func buildCatalogFromResolvedStackInventory(inventory resolvedStackInventory, sn
 	if err != nil {
 		return nil, err
 	}
-	catalog := BuildCatalogFromArtifactsWithBase(inventory.Source.Version, artifacts, base)
+	catalog := refreshCatalogFromArtifacts(inventory.Source.Version, artifacts, base)
 	retainIndependentManifestArtifacts(catalog)
 	if err := materializeMissingEffectiveStackPins(catalog, base, snapshot.Files); err != nil {
 		return nil, err
@@ -48,7 +48,6 @@ func buildCatalogFromResolvedStackInventory(inventory resolvedStackInventory, sn
 		catalog.Stack.Registry = base.Stack.Registry
 		catalog.Registries[base.Stack.Registry] = base.Registries[base.Stack.Registry]
 	}
-	catalog.Stack.SourceVersion = inventory.Source.Version
 	catalog.Stack.SourceTag = inventory.Source.Tag
 	catalog.Stack.SourceCommit = inventory.Source.Commit
 	catalog.Stack.PinSources = effectiveStackPinSourcePaths(effectiveStackPins)

--- a/tools/docs-version-sync/catalog_inventory_test.go
+++ b/tools/docs-version-sync/catalog_inventory_test.go
@@ -83,16 +83,17 @@ func TestBuildCatalogFromResolvedInventoryKeepsPublicationAvailabilityIndependen
 	base.Artifacts = append(base.Artifacts, Artifact{Name: "stale-service", Type: ArtifactTypeImage, Registry: defaultImageRegistry, Version: "0.9.0"})
 	base.SupplementalArtifacts = append(base.SupplementalArtifacts, Artifact{Name: "independent-resource", Type: ArtifactTypeResource, Registry: "public-resources", Version: "4.5.6"})
 	base.SupplementalArtifacts = append(base.SupplementalArtifacts, Artifact{Name: "independent-chart", Type: ArtifactTypeChart, Registry: "private-images", Version: "2.3.4"})
-	base.SupplementalArtifacts = append(base.SupplementalArtifacts, Artifact{ID: "nvca-chart", Name: "nvca", Type: ArtifactTypeChart, Registry: "private-images", Version: "4.5.6"})
+	base.SupplementalArtifacts = append(base.SupplementalArtifacts, Artifact{ID: "nvca-chart", Name: "nvca", Type: ArtifactTypeChart, Registry: "private-images", Version: "6.7.8"})
 	base.SupplementalArtifacts = append(base.SupplementalArtifacts, Artifact{Name: "denied-resource", Type: ArtifactTypeResource, Registry: "public-resources", Version: "7.8.9"})
 	base.Manifest.Entries = append(base.Manifest.Entries, ManifestEntry{ArtifactID: "independent-chart", Plane: ManifestPlaneCompute, Kind: ManifestKindChart, Requirement: ManifestOptional, Description: "Installs an independent chart."})
 	base.Manifest.Entries = append(base.Manifest.Entries, ManifestEntry{ArtifactID: "nvca-chart", Plane: ManifestPlaneCompute, Kind: ManifestKindChart, Requirement: ManifestOptional, Description: "Installs a chart that shares an image name."})
 	base.Publications = []Publication{
-		{Name: "helm-nvcf-llm-request-router", Version: "1.2.3", Registry: "public-helm", ChartFormat: ChartFormatHTTP},
-		{Name: "nvca", Version: "6.7.8", Registry: "public-resources"},
-		{Name: "pylon", Version: "3.4.5", Registry: "private-images"},
-		{Name: "independent-chart", Version: "2.3.4", Registry: "public-helm", ChartFormat: ChartFormatHTTP},
-		{Name: computeStackResourceName, Version: source.Version, Registry: "public-resources"},
+		{Name: "helm-nvcf-llm-request-router", Type: ArtifactTypeChart, Version: "1.2.3", Registry: "public-helm", ChartFormat: ChartFormatHTTP},
+		{Name: "nvca", Type: ArtifactTypeImage, Version: "6.7.8", Registry: "public-resources"},
+		{Name: "nvca", Type: ArtifactTypeChart, Version: "6.7.8", Registry: "public-helm", ChartFormat: ChartFormatHTTP},
+		{Name: "pylon", Type: ArtifactTypeImage, Version: "3.4.5", Registry: "private-images"},
+		{Name: "independent-chart", Type: ArtifactTypeChart, Version: "2.3.4", Registry: "public-helm", ChartFormat: ChartFormatHTTP},
+		{Name: computeStackResourceName, Type: ArtifactTypeResource, Version: source.Version, Registry: "public-resources"},
 	}
 
 	catalog, err := buildCatalogFromResolvedStackInventory(inventory, snapshot, base)
@@ -118,6 +119,13 @@ func TestBuildCatalogFromResolvedInventoryKeepsPublicationAvailabilityIndependen
 	sharedNameChart, found := catalog.findArtifactByNameAndType("nvca", ArtifactTypeChart)
 	if !found || sharedNameChart.catalogKey() != "nvca-chart" {
 		t.Fatalf("shared-name chart = %#v, want retained nvca-chart", sharedNameChart)
+	}
+	sharedNameChartDistribution, err := catalog.artifactDistribution(sharedNameChart)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sharedNameChartDistribution != "https://helm.ngc.nvidia.com/nvidia/nvcf/nvca:6.7.8" {
+		t.Fatalf("published shared-name chart distribution = %q", sharedNameChartDistribution)
 	}
 	router, ok := catalog.findArtifact("helm-nvcf-llm-request-router")
 	if !ok {

--- a/tools/docs-version-sync/catalog_inventory_test.go
+++ b/tools/docs-version-sync/catalog_inventory_test.go
@@ -58,7 +58,7 @@ func TestUpdateCatalogFromGitHubUsesSelectedReleaseInventory(t *testing.T) {
 			t.Errorf("GitHub path %s was not requested", path)
 		}
 	}
-	if catalog.Stack.SourceVersion != release.Version || catalog.Stack.SourceTag != release.Tag || catalog.Stack.SourceCommit != release.Commit {
+	if catalog.Stack.Version != release.Version || catalog.Stack.SourceTag != release.Tag || catalog.Stack.SourceCommit != release.Commit {
 		t.Fatalf("stack source metadata = %#v, want %+v", catalog.Stack, release)
 	}
 	for _, name := range []string{computeStackResourceName, observabilityStackResourceName} {
@@ -83,8 +83,10 @@ func TestBuildCatalogFromResolvedInventoryKeepsPublicationAvailabilityIndependen
 	base.Artifacts = append(base.Artifacts, Artifact{Name: "stale-service", Type: ArtifactTypeImage, Registry: defaultImageRegistry, Version: "0.9.0"})
 	base.SupplementalArtifacts = append(base.SupplementalArtifacts, Artifact{Name: "independent-resource", Type: ArtifactTypeResource, Registry: "public-resources", Version: "4.5.6"})
 	base.SupplementalArtifacts = append(base.SupplementalArtifacts, Artifact{Name: "independent-chart", Type: ArtifactTypeChart, Registry: "private-images", Version: "2.3.4"})
+	base.SupplementalArtifacts = append(base.SupplementalArtifacts, Artifact{ID: "nvca-chart", Name: "nvca", Type: ArtifactTypeChart, Registry: "private-images", Version: "4.5.6"})
 	base.SupplementalArtifacts = append(base.SupplementalArtifacts, Artifact{Name: "denied-resource", Type: ArtifactTypeResource, Registry: "public-resources", Version: "7.8.9"})
 	base.Manifest.Entries = append(base.Manifest.Entries, ManifestEntry{ArtifactID: "independent-chart", Plane: ManifestPlaneCompute, Kind: ManifestKindChart, Requirement: ManifestOptional, Description: "Installs an independent chart."})
+	base.Manifest.Entries = append(base.Manifest.Entries, ManifestEntry{ArtifactID: "nvca-chart", Plane: ManifestPlaneCompute, Kind: ManifestKindChart, Requirement: ManifestOptional, Description: "Installs a chart that shares an image name."})
 	base.Publications = []Publication{
 		{Name: "helm-nvcf-llm-request-router", Version: "1.2.3", Registry: "public-helm", ChartFormat: ChartFormatHTTP},
 		{Name: "nvca", Version: "6.7.8", Registry: "public-resources"},
@@ -112,6 +114,10 @@ func TestBuildCatalogFromResolvedInventoryKeepsPublicationAvailabilityIndependen
 	}
 	if _, found := catalog.findArtifact("denied-resource"); found {
 		t.Fatal("denylisted supplemental resource was retained")
+	}
+	sharedNameChart, found := catalog.findArtifactByNameAndType("nvca", ArtifactTypeChart)
+	if !found || sharedNameChart.catalogKey() != "nvca-chart" {
+		t.Fatalf("shared-name chart = %#v, want retained nvca-chart", sharedNameChart)
 	}
 	router, ok := catalog.findArtifact("helm-nvcf-llm-request-router")
 	if !ok {

--- a/tools/docs-version-sync/github.go
+++ b/tools/docs-version-sync/github.go
@@ -136,7 +136,7 @@ func (client *githubClient) resolveStackSourceRelease(sourceRef string) (stackSo
 
 	selected := -1
 	selectedVersion := stableStackVersion{}
-	selectedSourceVersion := ""
+	selectedStackVersion := ""
 	for i := range refs {
 		version, parsed, ok := parseStableStackRef(refs[i].Ref)
 		if !ok {
@@ -145,7 +145,7 @@ func (client *githubClient) resolveStackSourceRelease(sourceRef string) (stackSo
 		if selected == -1 || selectedVersion.less(parsed) {
 			selected = i
 			selectedVersion = parsed
-			selectedSourceVersion = version
+			selectedStackVersion = version
 		}
 	}
 	if selected == -1 {
@@ -156,7 +156,7 @@ func (client *githubClient) resolveStackSourceRelease(sourceRef string) (stackSo
 		return stackSourceRelease{}, fmt.Errorf("resolve stack source ref %s: %w", refs[selected].Ref, err)
 	}
 	return stackSourceRelease{
-		Version: selectedSourceVersion,
+		Version: selectedStackVersion,
 		Tag:     strings.TrimPrefix(refs[selected].Ref, "refs/tags/"),
 		Commit:  commit,
 	}, nil

--- a/tools/docs-version-sync/inline.go
+++ b/tools/docs-version-sync/inline.go
@@ -66,13 +66,6 @@ func syncClusterManagementSelfManaged(content string, catalog *Catalog) (string,
 	if count == 0 {
 		return "", false, fmt.Errorf("version table for %s not found", chart.Name)
 	}
-	updated, _ = replaceHelmVersionArgument(updated, chart.Name, chart.Version)
-
-	nvca, ok := catalog.findArtifact("nvca")
-	if !ok {
-		return "", false, fmt.Errorf("artifact nvca is required")
-	}
-	updated, count = replaceYAMLStringValue(updated, "nvcaVersion", nvca.Version)
 	return updated, updated != content, nil
 }
 
@@ -96,20 +89,6 @@ func replaceVersionTable(content, chartName, version string) (string, int) {
 	re := regexp.MustCompile(pattern)
 	count := len(re.FindAllStringIndex(content, -1))
 	return re.ReplaceAllString(content, "${1}`"+version+"`${2}"), count
-}
-
-func replaceHelmVersionArgument(content, chartName, version string) (string, int) {
-	pattern := fmt.Sprintf(`(?ms)(oci://[^\s]+/%s\s+\\\n(?:[^\n]*\\\n)*?\s+--version )[^\s\\]+`, regexp.QuoteMeta(chartName))
-	re := regexp.MustCompile(pattern)
-	count := len(re.FindAllStringIndex(content, -1))
-	return re.ReplaceAllString(content, "${1}"+version), count
-}
-
-func replaceYAMLStringValue(content, key, value string) (string, int) {
-	pattern := fmt.Sprintf(`(?m)^(\s+%s:\s*)"[^"]+"`, regexp.QuoteMeta(key))
-	re := regexp.MustCompile(pattern)
-	count := len(re.FindAllStringIndex(content, -1))
-	return re.ReplaceAllString(content, "${1}\""+value+"\""), count
 }
 
 func replaceNVCAOperatorChartPull(content, pullReference, version string) (string, int) {

--- a/tools/docs-version-sync/main.go
+++ b/tools/docs-version-sync/main.go
@@ -113,13 +113,13 @@ func run(args []string) error {
 				return err
 			}
 			if !equal {
-				return fmt.Errorf("%w: %s does not match the resolved GitHub inventory for stack release %s", ErrCheckFailed, relOrAbs(repoRoot, *catalogPath), updated.Stack.PublicationVersion)
+				return fmt.Errorf("%w: %s does not match the resolved GitHub inventory for stack release %s", ErrCheckFailed, relOrAbs(repoRoot, *catalogPath), updated.Stack.Version)
 			}
 		} else {
 			if err := writeCatalogAfterStackSourceValidation(repoRoot, *catalogPath, updated); err != nil {
 				return err
 			}
-			fmt.Fprintf(os.Stderr, "updated %s for stack publication %s\n", relOrAbs(repoRoot, *catalogPath), updated.Stack.PublicationVersion)
+			fmt.Fprintf(os.Stderr, "updated %s for stack release %s\n", relOrAbs(repoRoot, *catalogPath), updated.Stack.Version)
 		}
 	} else {
 		loaded, err := LoadCatalog(*catalogPath)
@@ -139,7 +139,7 @@ func run(args []string) error {
 
 func writeCatalogAfterStackSourceValidation(repoRoot, catalogPath string, catalog *Catalog) error {
 	if catalog.Stack.SourceCommit == "" {
-		return fmt.Errorf("cannot write updated catalog for stack publication %s without an immutable source snapshot", catalog.Stack.PublicationVersion)
+		return fmt.Errorf("cannot write updated catalog for stack release %s without an immutable source snapshot", catalog.Stack.Version)
 	}
 	if err := validateStackSourceSnapshot(repoRoot, catalog); err != nil {
 		return fmt.Errorf("validate stack source snapshot: %w", err)

--- a/tools/docs-version-sync/main_test.go
+++ b/tools/docs-version-sync/main_test.go
@@ -118,9 +118,9 @@ func TestRenderManifestUsesVerifiedPublicLocations(t *testing.T) {
 		Artifact{Name: "helm-nvcf-nats", Type: ArtifactTypeChart, Registry: defaultChartRegistry, Version: "0.6.1"},
 	)
 	catalog.Publications = []Publication{
-		{Name: "nvcf-grpc-proxy", Version: "1.29.1", Registry: "public-images"},
-		{Name: "helm-nvcf-grpc-proxy", Version: "1.6.7", Registry: "public-helm", ChartFormat: ChartFormatHTTP},
-		{Name: "helm-nvcf-nats", Version: "0.7.1", Registry: "public-helm", ChartFormat: ChartFormatHTTP},
+		{Name: "nvcf-grpc-proxy", Type: ArtifactTypeImage, Version: "1.29.1", Registry: "public-images"},
+		{Name: "helm-nvcf-grpc-proxy", Type: ArtifactTypeChart, Version: "1.6.7", Registry: "public-helm", ChartFormat: ChartFormatHTTP},
+		{Name: "helm-nvcf-nats", Type: ArtifactTypeChart, Version: "0.7.1", Registry: "public-helm", ChartFormat: ChartFormatHTTP},
 	}
 	catalog.PublicationPending = []string{"helm-nvcf-nats"}
 	catalog.Manifest.Entries = append(catalog.Manifest.Entries,
@@ -153,6 +153,7 @@ func TestCatalogRefreshPreservesVersionQualifiedPublications(t *testing.T) {
 	base.Registries["public-images"] = Registry{Host: "nvcr.io", Namespace: "nvidia/nvcf"}
 	base.Publications = []Publication{{
 		Name:     "nvcf-grpc-proxy",
+		Type:     ArtifactTypeImage,
 		Version:  "1.29.1",
 		Registry: "public-images",
 	}}
@@ -211,8 +212,8 @@ func TestCatalogRefreshMarksChangedVersionsPendingAndKeepsPublishedVersionsPubli
 		Artifact{Name: "verified-service", Type: ArtifactTypeImage, Registry: defaultImageRegistry, Version: "2.0.0"},
 	)
 	base.Publications = []Publication{
-		{Name: "nvca", Version: "3.2.18", Registry: "public-images"},
-		{Name: "verified-service", Version: "2.0.0", Registry: "public-images"},
+		{Name: "nvca", Type: ArtifactTypeImage, Version: "3.2.18", Registry: "public-images"},
+		{Name: "verified-service", Type: ArtifactTypeImage, Version: "2.0.0", Registry: "public-images"},
 	}
 	base.Manifest.Entries = append(base.Manifest.Entries,
 		ManifestEntry{ArtifactID: "nvca", Plane: ManifestPlaneCompute, Kind: ManifestKindServiceImage, Requirement: ManifestRequired, Description: "NVCA agent."},
@@ -245,6 +246,7 @@ func TestArtifactPathUsesPublishedVersionAlias(t *testing.T) {
 	catalog.Registries["public-images"] = Registry{Host: "nvcr.io", Namespace: "nvidia/nvcf"}
 	catalog.Publications = []Publication{{
 		Name:             "llm-api-gateway",
+		Type:             ArtifactTypeImage,
 		Version:          "0.3.0",
 		PublishedVersion: "0.3.0-ea",
 		Registry:         "public-images",
@@ -296,6 +298,7 @@ func TestArtifactPathKeepsDigestOnlyForUnchangedReference(t *testing.T) {
 			name: "unchanged publication",
 			publication: &Publication{
 				Name:     artifact.Name,
+				Type:     artifact.Type,
 				Version:  artifact.Version,
 				Registry: artifact.Registry,
 			},
@@ -305,6 +308,7 @@ func TestArtifactPathKeepsDigestOnlyForUnchangedReference(t *testing.T) {
 			name: "registry remap",
 			publication: &Publication{
 				Name:     artifact.Name,
+				Type:     artifact.Type,
 				Version:  artifact.Version,
 				Registry: "public-mirror",
 			},
@@ -314,6 +318,7 @@ func TestArtifactPathKeepsDigestOnlyForUnchangedReference(t *testing.T) {
 			name: "version remap",
 			publication: &Publication{
 				Name:             artifact.Name,
+				Type:             artifact.Type,
 				Version:          artifact.Version,
 				PublishedVersion: "1.2.3-public",
 				Registry:         artifact.Registry,
@@ -374,6 +379,7 @@ func TestValidateCatalogRejectsPublishedVersionOverrideDrift(t *testing.T) {
 	catalog.Registries["public-images"] = Registry{Host: "nvcr.io", Namespace: "nvidia/nvcf"}
 	catalog.Publications = []Publication{{
 		Name:     "nvcf_worker_utils",
+		Type:     ArtifactTypeImage,
 		Version:  "2.110.0",
 		Registry: "public-images",
 	}}
@@ -385,6 +391,20 @@ func TestValidateCatalogRejectsPublishedVersionOverrideDrift(t *testing.T) {
 	err := ValidateCatalog(catalog)
 	if err == nil || !strings.Contains(err.Error(), "version override nvcf_worker_utils:2.109.4 does not match publication version 2.110.0") {
 		t.Fatalf("ValidateCatalog error = %v, want publication version drift", err)
+	}
+}
+
+func TestValidateCatalogRejectsPublicationWithoutType(t *testing.T) {
+	catalog := testCatalog()
+	catalog.Publications = []Publication{{
+		Name:     "nvcf-cli",
+		Version:  "1.2.3",
+		Registry: defaultStackRegistry,
+	}}
+
+	err := ValidateCatalog(catalog)
+	if err == nil || !strings.Contains(err.Error(), "has unsupported type") {
+		t.Fatalf("ValidateCatalog error = %v, want missing publication type rejection", err)
 	}
 }
 
@@ -550,7 +570,7 @@ func TestRenderSupplementalStackDownloadsMatchPublicationState(t *testing.T) {
 					published.SupplementalArtifacts[i].Registry = "public-resources"
 				}
 			}
-			published.Publications = []Publication{{Name: tt.artifact, Version: "0.5.0", Registry: "public-resources"}}
+			published.Publications = []Publication{{Name: tt.artifact, Type: ArtifactTypeResource, Version: "0.5.0", Registry: "public-resources"}}
 			for _, renderer := range []struct {
 				name       string
 				versionEnv string
@@ -648,6 +668,7 @@ func TestSyncInlineImageMirroringUsesTraditionalPublicHelmChart(t *testing.T) {
 	)
 	catalog.Publications = []Publication{{
 		Name:        "helm-nvca-operator",
+		Type:        ArtifactTypeChart,
 		Version:     "1.12.7",
 		Registry:    "public-helm",
 		ChartFormat: ChartFormatHTTP,

--- a/tools/docs-version-sync/main_test.go
+++ b/tools/docs-version-sync/main_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 )
 
-func TestRenderManifestDeploymentResources(t *testing.T) {
+func TestRenderManifestArtifactRegistryPaths(t *testing.T) {
 	catalog := testCatalog()
 	got, err := Render("manifest-artifact-registry-paths", catalog)
 	if err != nil {
@@ -157,7 +157,7 @@ func TestCatalogRefreshPreservesVersionQualifiedPublications(t *testing.T) {
 		Registry: "public-images",
 	}}
 
-	updated := BuildCatalogFromArtifactsWithBase("0.6.0-rc.99", []Artifact{{
+	updated := refreshCatalogFromArtifacts("0.6.0-rc.99", []Artifact{{
 		Name:     "nvcf-grpc-proxy",
 		Type:     ArtifactTypeImage,
 		Registry: defaultImageRegistry,
@@ -180,14 +180,13 @@ func TestCatalogRefreshPreservesVersionQualifiedPublications(t *testing.T) {
 	}
 }
 
-func TestCatalogRefreshWithoutBaseRendersUnverifiedArtifactsAsPending(t *testing.T) {
-	catalog := BuildCatalogFromArtifactsWithBase("0.9.1", []Artifact{
+func TestCatalogConstructionWithoutBaseRendersUnverifiedArtifactsAsPending(t *testing.T) {
+	catalog := refreshCatalogFromArtifacts("0.9.1", []Artifact{
 		{Name: "helm-nvca-operator", Type: ArtifactTypeChart, Registry: defaultChartRegistry, Version: "1.21.3"},
 		{Name: "nvca", Type: ArtifactTypeImage, Registry: defaultImageRegistry, Version: "3.2.19"},
 	}, nil)
 	catalog.Manifest.Entries = []ManifestEntry{
-		{ArtifactID: defaultStackResourceName, Plane: ManifestPlaneShared, Kind: ManifestKindResource, Description: "Control-plane stack."},
-		{ArtifactID: "nvcf-cli", Plane: ManifestPlaneShared, Kind: ManifestKindResource, Description: "CLI."},
+		{ArtifactID: controlStackResourceName, Plane: ManifestPlaneShared, Kind: ManifestKindResource, Description: "Control-plane stack."},
 		{ArtifactID: "helm-nvca-operator", Plane: ManifestPlaneCompute, Kind: ManifestKindChart, Requirement: ManifestRequired, Description: "NVCA chart."},
 		{ArtifactID: "nvca", Plane: ManifestPlaneCompute, Kind: ManifestKindServiceImage, Requirement: ManifestRequired, Description: "NVCA agent."},
 	}
@@ -196,7 +195,7 @@ func TestCatalogRefreshWithoutBaseRendersUnverifiedArtifactsAsPending(t *testing
 	if err != nil {
 		t.Fatalf("Render failed: %v", err)
 	}
-	for _, name := range []string{defaultStackResourceName, "nvcf-cli", "helm-nvca-operator", "nvca"} {
+	for _, name := range []string{controlStackResourceName, "helm-nvca-operator", "nvca"} {
 		row := manifestRow(t, got, name)
 		if !strings.Contains(row, "`Publication pending`") {
 			t.Errorf("%s row does not mark the unverified artifact pending: %s", name, row)
@@ -220,7 +219,7 @@ func TestCatalogRefreshMarksChangedVersionsPendingAndKeepsPublishedVersionsPubli
 		ManifestEntry{ArtifactID: "verified-service", Plane: ManifestPlaneControl, Kind: ManifestKindServiceImage, Requirement: ManifestRequired, Description: "Published service."},
 	)
 
-	catalog := BuildCatalogFromArtifactsWithBase("0.6.0", []Artifact{
+	catalog := refreshCatalogFromArtifacts("0.6.0", []Artifact{
 		{Name: "nvca", Type: ArtifactTypeImage, Registry: defaultImageRegistry, Version: "3.2.19"},
 		{Name: "verified-service", Type: ArtifactTypeImage, Registry: defaultImageRegistry, Version: "2.0.0"},
 	}, base)
@@ -229,7 +228,7 @@ func TestCatalogRefreshMarksChangedVersionsPendingAndKeepsPublishedVersionsPubli
 		t.Fatalf("Render failed: %v", err)
 	}
 
-	for _, name := range []string{defaultStackResourceName, computeStackResourceName, observabilityStackResourceName, "nvcf-cli", "nvca"} {
+	for _, name := range []string{controlStackResourceName, computeStackResourceName, observabilityStackResourceName, "nvcf-cli", "nvca"} {
 		row := manifestRow(t, got, name)
 		if !strings.Contains(row, "`Publication pending`") {
 			t.Errorf("%s row does not mark the unverified artifact pending: %s", name, row)
@@ -347,7 +346,7 @@ func TestCatalogRefreshAppliesVersionOverrides(t *testing.T) {
 		Version: "2.109.4",
 		Source:  "helm-nvcf-api:1.22.5",
 	}}
-	updated := BuildCatalogFromArtifactsWithBase("0.6.0-rc.99", []Artifact{{
+	updated := refreshCatalogFromArtifacts("0.6.0-rc.99", []Artifact{{
 		Name:     "nvcf_worker_utils",
 		Type:     ArtifactTypeImage,
 		Registry: defaultImageRegistry,
@@ -580,34 +579,7 @@ func TestRenderSupplementalStackDownloadsMatchPublicationState(t *testing.T) {
 	}
 }
 
-func TestSyncInlineSelfManagedNVCAOperatorVersions(t *testing.T) {
-	catalog := testCatalog()
-	catalog.SupplementalArtifacts = append(catalog.SupplementalArtifacts,
-		Artifact{Name: "nvca", Type: ArtifactTypeImage, Registry: defaultImageRegistry, Version: "3.0.0-rc.11"},
-		Artifact{Name: "helm-nvca-operator", Type: ArtifactTypeChart, Registry: defaultChartRegistry, Version: "1.9.0"},
-	)
-	content := "| **Chart** | `helm-nvca-operator` |\n| --- | --- |\n| **Version** | `1.6.7` |\n\n" +
-		"selfManaged:\n  nvcaVersion: \"3.0.0-rc.3\"  # NVCA agent version to deploy\n\n" +
-		"helm upgrade --install nvca-operator \\\n" +
-		"  oci://nvcr.io/nvidia/nvcf/helm-nvca-operator \\\n" +
-		"  --namespace nvca-operator --create-namespace \\\n" +
-		"  --version 1.6.7\n"
-
-	got, changed, err := SyncInlineVersions("docs/user/cluster-management/self-managed.md", content, catalog)
-	if err != nil {
-		t.Fatalf("SyncInlineVersions failed: %v", err)
-	}
-	if !changed {
-		t.Fatal("SyncInlineVersions reported no change")
-	}
-	for _, want := range []string{"`1.9.0`", `nvcaVersion: "3.0.0-rc.11"`, "--version 1.9.0"} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("updated content missing %q:\n%s", want, got)
-		}
-	}
-}
-
-func TestSyncInlineSelfManagedNVCAOperatorPlainVersionTable(t *testing.T) {
+func TestSyncInlineSelfManagedNVCAOperatorVersionTable(t *testing.T) {
 	catalog := testCatalog()
 	catalog.SupplementalArtifacts = append(catalog.SupplementalArtifacts,
 		Artifact{Name: "nvca", Type: ArtifactTypeImage, Registry: defaultImageRegistry, Version: "3.0.0-rc.11"},
@@ -902,9 +874,9 @@ func testCatalog() *Catalog {
 			},
 		},
 		Stack: StackMetadata{
-			Name:               "nvcf-self-managed-stack",
-			PublicationVersion: "0.5.0",
-			Registry:           defaultStackRegistry,
+			Name:     "nvcf-self-managed-stack",
+			Version:  "0.5.0",
+			Registry: defaultStackRegistry,
 		},
 		Denylist: []DenylistEntry{
 			{Name: "nvcf-base", Reason: "managed separately"},

--- a/tools/docs-version-sync/main_test.go
+++ b/tools/docs-version-sync/main_test.go
@@ -17,7 +17,6 @@ package main
 
 import (
 	"errors"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -924,10 +923,6 @@ func testCatalog() *Catalog {
 	}
 }
 
-func serverURL(r *http.Request) string {
-	return "http://" + r.Host
-}
-
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -961,16 +956,4 @@ func sectionBetween(t *testing.T, content, startMarker, endMarker string) string
 		t.Fatalf("content missing end marker %q after %q:\n%s", endMarker, startMarker, content[start:])
 	}
 	return content[start : start+end]
-}
-
-func optionalSectionBetween(content, startMarker, endMarker string) (string, bool) {
-	start := strings.Index(content, startMarker)
-	if start == -1 {
-		return "", false
-	}
-	end := strings.Index(content[start:], endMarker)
-	if end == -1 {
-		return content[start:], true
-	}
-	return content[start : start+end], true
 }

--- a/tools/docs-version-sync/main_test.go
+++ b/tools/docs-version-sync/main_test.go
@@ -345,8 +345,16 @@ func TestArtifactPathKeepsDigestOnlyForUnchangedReference(t *testing.T) {
 
 func TestCatalogRefreshAppliesVersionOverrides(t *testing.T) {
 	base := testCatalog()
+	base.SupplementalArtifacts = append(base.SupplementalArtifacts, Artifact{
+		ID:       "nvcf-worker-utils-chart",
+		Name:     "nvcf_worker_utils",
+		Type:     ArtifactTypeChart,
+		Registry: defaultChartRegistry,
+		Version:  "1.2.3",
+	})
 	base.VersionOverrides = []VersionOverride{{
 		Name:    "nvcf_worker_utils",
+		Type:    ArtifactTypeImage,
 		Version: "2.109.4",
 		Source:  "helm-nvcf-api:1.22.5",
 	}}
@@ -363,6 +371,13 @@ func TestCatalogRefreshAppliesVersionOverrides(t *testing.T) {
 	}
 	if artifact.Version != "2.109.4" {
 		t.Fatalf("version = %q, want chart-derived override 2.109.4", artifact.Version)
+	}
+	chart, ok := updated.findArtifactByNameAndType("nvcf_worker_utils", ArtifactTypeChart)
+	if !ok {
+		t.Fatal("updated catalog is missing same-name nvcf_worker_utils chart")
+	}
+	if chart.Version != "1.2.3" {
+		t.Fatalf("same-name chart version = %q, want unchanged 1.2.3", chart.Version)
 	}
 	path, err := updated.artifactPath(artifact)
 	if err != nil {
@@ -384,6 +399,7 @@ func TestValidateCatalogRejectsPublishedVersionOverrideDrift(t *testing.T) {
 	}}
 	catalog.VersionOverrides = []VersionOverride{{
 		Name:    "nvcf_worker_utils",
+		Type:    ArtifactTypeImage,
 		Version: "2.109.4",
 	}}
 
@@ -411,11 +427,25 @@ func TestValidateCatalogAllowsUnpublishedVersionOverride(t *testing.T) {
 	catalog := testCatalog()
 	catalog.VersionOverrides = []VersionOverride{{
 		Name:    "pylon",
+		Type:    ArtifactTypeImage,
 		Version: "0.3.0",
 	}}
 
 	if err := ValidateCatalog(catalog); err != nil {
 		t.Fatalf("ValidateCatalog failed for unpublished override: %v", err)
+	}
+}
+
+func TestValidateCatalogRejectsVersionOverrideWithoutType(t *testing.T) {
+	catalog := testCatalog()
+	catalog.VersionOverrides = []VersionOverride{{
+		Name:    "pylon",
+		Version: "0.3.0",
+	}}
+
+	err := ValidateCatalog(catalog)
+	if err == nil || !strings.Contains(err.Error(), "has unsupported type") {
+		t.Fatalf("ValidateCatalog error = %v, want missing version override type rejection", err)
 	}
 }
 

--- a/tools/docs-version-sync/manifest_metadata_test.go
+++ b/tools/docs-version-sync/manifest_metadata_test.go
@@ -194,7 +194,7 @@ func TestCatalogRefreshPreservesManifestMetadata(t *testing.T) {
 		Description: "Routes OpenAI-compatible LLM requests.",
 	}}}
 
-	updated := BuildCatalogFromArtifactsWithBase("0.6.0-rc.99", base.Artifacts, base)
+	updated := refreshCatalogFromArtifacts("0.6.0-rc.99", base.Artifacts, base)
 	if len(updated.Manifest.Entries) != 1 || updated.Manifest.Entries[0].ArtifactID != "llm-api-gateway" {
 		t.Fatalf("manifest metadata = %#v, want preserved entry", updated.Manifest)
 	}

--- a/tools/docs-version-sync/render.go
+++ b/tools/docs-version-sync/render.go
@@ -32,8 +32,6 @@ func Render(renderer string, catalog *Catalog) (string, error) {
 	switch renderer {
 	case "manifest-artifact-registry-paths":
 		return renderManifestArtifactRegistryPaths(catalog)
-	case "manifest-deployment-resources":
-		return renderManifestDeploymentResources(catalog)
 	case "image-mirroring-resource-examples":
 		return renderImageMirroringResourceExamples(catalog)
 	case "image-mirroring-stack-snippet":
@@ -47,21 +45,6 @@ func Render(renderer string, catalog *Catalog) (string, error) {
 	default:
 		return "", fmt.Errorf("unknown renderer %q", renderer)
 	}
-}
-
-func renderManifestDeploymentResources(catalog *Catalog) (string, error) {
-	resources := catalog.resourceArtifacts()
-	var b strings.Builder
-	b.WriteString("| Type | Component Name | Full Path |\n")
-	b.WriteString("| --- | --- | --- |\n")
-	for _, artifact := range resources {
-		path, err := catalog.artifactDistribution(artifact)
-		if err != nil {
-			return "", err
-		}
-		b.WriteString(fmt.Sprintf("| Resource | %s | `%s` |\n", artifact.Name, path))
-	}
-	return b.String(), nil
 }
 
 func renderImageMirroringResourceExamples(catalog *Catalog) (string, error) {
@@ -222,52 +205,8 @@ func (catalog *Catalog) stackArtifact() Artifact {
 		Name:     catalog.Stack.Name,
 		Type:     ArtifactTypeResource,
 		Registry: catalog.Stack.Registry,
-		Version:  catalog.Stack.PublicationVersion,
+		Version:  catalog.Stack.Version,
 	}
-}
-
-func (catalog *Catalog) artifactTypeLabel(artifact Artifact) string {
-	switch artifact.Type {
-	case ArtifactTypeChart:
-		if publication, ok := catalog.publicationFor(artifact); ok && publication.ChartFormat == ChartFormatHTTP {
-			return "Chart (HTTP)"
-		}
-		return "Chart (OCI)"
-	case ArtifactTypeResource:
-		return "Resource"
-	default:
-		return "Image"
-	}
-}
-
-func (catalog *Catalog) resourceArtifacts() []Artifact {
-	denylist := catalog.DenylistMap()
-	var resources []Artifact
-	if _, denied := denylist[catalog.Stack.Name]; !denied {
-		resources = append(resources, catalog.stackArtifact())
-	}
-	for _, artifact := range catalog.Artifacts {
-		if artifact.Type != ArtifactTypeResource {
-			continue
-		}
-		if _, denied := denylist[artifact.Name]; denied {
-			continue
-		}
-		if artifact.Name == catalog.Stack.Name {
-			continue
-		}
-		resources = append(resources, artifact)
-	}
-	for _, artifact := range catalog.SupplementalArtifacts {
-		if artifact.Type != ArtifactTypeResource {
-			continue
-		}
-		if _, denied := denylist[artifact.Name]; denied {
-			continue
-		}
-		resources = append(resources, artifact)
-	}
-	return resources
 }
 
 func (catalog *Catalog) findArtifact(name string) (Artifact, bool) {
@@ -312,50 +251,6 @@ func (catalog *Catalog) findArtifacts(name string) []Artifact {
 		}
 	}
 	return artifacts
-}
-
-func (catalog *Catalog) uncategorizedArtifacts(used map[string]struct{}) []Artifact {
-	denylist := catalog.DenylistMap()
-	var artifacts []Artifact
-	for _, artifact := range catalog.Artifacts {
-		if artifact.Type == ArtifactTypeResource {
-			continue
-		}
-		if _, denied := denylist[artifact.Name]; denied {
-			continue
-		}
-		if _, ok := used[artifact.catalogKey()]; ok {
-			continue
-		}
-		artifacts = append(artifacts, artifact)
-	}
-	for _, artifact := range catalog.SupplementalArtifacts {
-		if artifact.Type == ArtifactTypeResource {
-			continue
-		}
-		if _, denied := denylist[artifact.Name]; denied {
-			continue
-		}
-		if _, ok := used[artifact.catalogKey()]; ok {
-			continue
-		}
-		artifacts = append(artifacts, artifact)
-	}
-	return artifacts
-}
-
-func (catalog *Catalog) isDenied(name string) bool {
-	_, denied := catalog.DenylistMap()[name]
-	return denied
-}
-
-func appendIfMissing(values []string, value string) []string {
-	for _, existing := range values {
-		if existing == value {
-			return values
-		}
-	}
-	return append(values, value)
 }
 
 func SyncDocs(repoRoot string, catalog *Catalog, check bool) error {

--- a/tools/docs-version-sync/stack_consistency_test.go
+++ b/tools/docs-version-sync/stack_consistency_test.go
@@ -288,7 +288,7 @@ func TestCatalogRefreshPreservesPublicationPending(t *testing.T) {
 	base := testCatalog()
 	base.PublicationPending = []string{"nvcf-self-managed-stack", "nvcf-cli"}
 
-	updated := BuildCatalogFromArtifactsWithBase("0.9.2", nil, base)
+	updated := refreshCatalogFromArtifacts("0.9.2", nil, base)
 
 	pending := make(map[string]struct{}, len(updated.PublicationPending))
 	for _, name := range updated.PublicationPending {
@@ -304,51 +304,18 @@ func TestCatalogRefreshPreservesPublicationPending(t *testing.T) {
 	}
 }
 
-func TestCatalogRefreshPreservesSourceSnapshotAcrossPublicationVersion(t *testing.T) {
-	base := testCatalog()
-	base.Stack.SourceVersion = "0.14.5"
-	base.Stack.SourceTag = "deploy/stacks/self-managed/v" + base.Stack.SourceVersion
-	base.Stack.SourceCommit = "1111111111111111111111111111111111111111"
-	base.Stack.PinSources = []string{"stack.yaml"}
-	base.Stack.PinSourceDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
-
-	sameRelease := BuildCatalogFromArtifactsWithBase(base.Stack.PublicationVersion, nil, base)
-	if sameRelease.Stack.SourceTag != base.Stack.SourceTag ||
-		sameRelease.Stack.SourceVersion != base.Stack.SourceVersion ||
-		sameRelease.Stack.SourceCommit != base.Stack.SourceCommit ||
-		strings.Join(sameRelease.Stack.PinSources, ",") != "stack.yaml" ||
-		sameRelease.Stack.PinSourceDigest != base.Stack.PinSourceDigest {
-		t.Fatalf("same-release snapshot was not preserved: %#v", sameRelease.Stack)
-	}
-
-	newPublication := BuildCatalogFromArtifactsWithBase("0.9.2", nil, base)
-	if newPublication.Stack.PublicationVersion != "0.9.2" {
-		t.Fatalf("publication version = %q, want 0.9.2", newPublication.Stack.PublicationVersion)
-	}
-	if newPublication.Stack.SourceVersion != base.Stack.SourceVersion ||
-		newPublication.Stack.SourceTag != base.Stack.SourceTag ||
-		newPublication.Stack.SourceCommit != base.Stack.SourceCommit ||
-		strings.Join(newPublication.Stack.PinSources, ",") != "stack.yaml" ||
-		newPublication.Stack.PinSourceDigest != base.Stack.PinSourceDigest {
-		t.Fatalf("publication refresh did not preserve source snapshot: %#v", newPublication.Stack)
-	}
-	if err := ValidateCatalog(newPublication); err != nil {
-		t.Fatalf("ValidateCatalog rejected independent source and publication versions: %v", err)
-	}
-}
-
 func TestValidateCatalogRejectsIncompleteStackSourceSnapshot(t *testing.T) {
 	catalog := testCatalog()
 	catalog.Stack.SourceCommit = "1111111111111111111111111111111111111111"
 
 	err := ValidateCatalog(catalog)
-	if err == nil || !strings.Contains(err.Error(), "source_version, source_tag, source_commit, pin_sources, and pin_source_digest together") {
+	if err == nil || !strings.Contains(err.Error(), "source_tag, source_commit, pin_sources, and pin_source_digest together") {
 		t.Fatalf("ValidateCatalog error = %v, want incomplete stack source snapshot", err)
 	}
 }
 
 func TestValidateCatalogRejectsInvalidStackSourceSnapshot(t *testing.T) {
-	const sourceVersion = "0.14.5"
+	const stackVersion = "0.14.5"
 
 	tests := []struct {
 		name   string
@@ -360,7 +327,7 @@ func TestValidateCatalogRejectsInvalidStackSourceSnapshot(t *testing.T) {
 			mutate: func(stack *StackMetadata) {
 				stack.SourceTag = "deploy/stacks/self-managed/v9.9.9"
 			},
-			want: "source_tag must be deploy/stacks/self-managed/v" + sourceVersion,
+			want: "source_tag must be deploy/stacks/self-managed/v" + stackVersion,
 		},
 		{
 			name: "non-immutable commit",
@@ -409,8 +376,8 @@ func TestValidateCatalogRejectsInvalidStackSourceSnapshot(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			catalog := testCatalog()
-			catalog.Stack.SourceVersion = sourceVersion
-			catalog.Stack.SourceTag = "deploy/stacks/self-managed/v" + catalog.Stack.SourceVersion
+			catalog.Stack.Version = stackVersion
+			catalog.Stack.SourceTag = "deploy/stacks/self-managed/v" + catalog.Stack.Version
 			catalog.Stack.SourceCommit = "1111111111111111111111111111111111111111"
 			catalog.Stack.PinSources = []string{"stack.yaml"}
 			catalog.Stack.PinSourceDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
@@ -426,8 +393,7 @@ func TestValidateCatalogRejectsInvalidStackSourceSnapshot(t *testing.T) {
 
 func TestValidateCatalogAcceptsExactPinSourcePaths(t *testing.T) {
 	catalog := testCatalog()
-	catalog.Stack.SourceVersion = catalog.Stack.PublicationVersion
-	catalog.Stack.SourceTag = "deploy/stacks/self-managed/v" + catalog.Stack.SourceVersion
+	catalog.Stack.SourceTag = "deploy/stacks/self-managed/v" + catalog.Stack.Version
 	catalog.Stack.SourceCommit = "1111111111111111111111111111111111111111"
 	catalog.Stack.PinSources = []string{"deploy/stack.yaml", "deploy/env.yaml"}
 	catalog.Stack.PinSourceDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
@@ -465,12 +431,11 @@ func TestValidateStackSourceSnapshotReadsRecordedCommit(t *testing.T) {
 	}
 	catalog := &Catalog{
 		Stack: StackMetadata{
-			PublicationVersion: "9.9.9",
-			SourceVersion:      "1.2.3",
-			SourceTag:          sourceTag,
-			SourceCommit:       commit,
-			PinSources:         []string{sourcePath},
-			PinSourceDigest:    digest,
+			Version:         "1.2.3",
+			SourceTag:       sourceTag,
+			SourceCommit:    commit,
+			PinSources:      []string{sourcePath},
+			PinSourceDigest: digest,
 		},
 		Artifacts: []Artifact{
 			{Name: "chart", Type: ArtifactTypeImage, Version: "9.9.9"},
@@ -507,12 +472,11 @@ func TestValidateStackSourceSnapshotRequiresTagRef(t *testing.T) {
 
 	catalog := &Catalog{
 		Stack: StackMetadata{
-			PublicationVersion: "9.9.9",
-			SourceVersion:      "1.2.3",
-			SourceTag:          sourceTag,
-			SourceCommit:       commit,
-			PinSources:         []string{sourcePath},
-			PinSourceDigest:    "sha256:" + strings.Repeat("0", 64),
+			Version:         "1.2.3",
+			SourceTag:       sourceTag,
+			SourceCommit:    commit,
+			PinSources:      []string{sourcePath},
+			PinSourceDigest: "sha256:" + strings.Repeat("0", 64),
 		},
 	}
 	pins := []effectiveStackPin{{artifact: "chart", artifactType: ArtifactTypeChart, path: sourcePath, pattern: `(?m)^version: ([^\s]+)$`}}
@@ -530,8 +494,7 @@ func TestWriteCatalogAfterStackSourceValidationLeavesFileUnchanged(t *testing.T)
 	const original = "original catalog\n"
 	writeFile(t, catalogPath, original)
 	catalog := testCatalog()
-	catalog.Stack.SourceVersion = catalog.Stack.PublicationVersion
-	catalog.Stack.SourceTag = "deploy/stacks/self-managed/v" + catalog.Stack.SourceVersion
+	catalog.Stack.SourceTag = "deploy/stacks/self-managed/v" + catalog.Stack.Version
 	catalog.Stack.SourceCommit = strings.Repeat("1", 40)
 	catalog.Stack.PinSources = []string{"stack.yaml"}
 	catalog.Stack.PinSourceDigest = "sha256:" + strings.Repeat("2", 64)

--- a/tools/docs-version-sync/stack_consistency_test.go
+++ b/tools/docs-version-sync/stack_consistency_test.go
@@ -554,6 +554,7 @@ func TestValidateCatalogRejectsPublishedArtifactMarkedPending(t *testing.T) {
 	}
 	catalog.Publications = []Publication{{
 		Name:     cli.Name,
+		Type:     cli.Type,
 		Version:  cli.Version,
 		Registry: cli.Registry,
 	}}

--- a/tools/docs-version-sync/stack_consistency_test.go
+++ b/tools/docs-version-sync/stack_consistency_test.go
@@ -181,7 +181,7 @@ func TestMainCatalogMatchesDeclaredReleaseStackPins(t *testing.T) {
 		}
 		var source *VersionOverride
 		for i := range catalog.VersionOverrides {
-			if catalog.VersionOverrides[i].Name == "nvcf-cli" {
+			if catalog.VersionOverrides[i].Name == "nvcf-cli" && catalog.VersionOverrides[i].Type == ArtifactTypeResource {
 				source = &catalog.VersionOverrides[i]
 				break
 			}

--- a/tools/docs-version-sync/stack_source.go
+++ b/tools/docs-version-sync/stack_source.go
@@ -152,7 +152,7 @@ func validateStackSourceSnapshotWithPins(repoRoot string, catalog *Catalog, pins
 	}
 
 	snapshot, err := loadStackSourceSnapshot(repoRoot, stackSourceRelease{
-		Version: catalog.Stack.SourceVersion,
+		Version: catalog.Stack.Version,
 		Tag:     catalog.Stack.SourceTag,
 		Commit:  catalog.Stack.SourceCommit,
 	}, catalog.Stack.PinSources)
@@ -169,7 +169,7 @@ func validateStackSourceSnapshotWithPins(repoRoot string, catalog *Catalog, pins
 		return err
 	}
 	if digest != catalog.Stack.PinSourceDigest {
-		return fmt.Errorf("effective stack pins have digest %s, want release snapshot %s for source version %s at %s", digest, catalog.Stack.PinSourceDigest, catalog.Stack.SourceVersion, catalog.Stack.SourceCommit)
+		return fmt.Errorf("effective stack pins have digest %s, want release snapshot %s for stack version %s at %s", digest, catalog.Stack.PinSourceDigest, catalog.Stack.Version, catalog.Stack.SourceCommit)
 	}
 	for _, pin := range pins {
 		want := versions[pin.artifact]


### PR DESCRIPTION
# TL;DR

Retire the remaining GitLab package-inventory terminology and dead code from `tools/docs-version-sync` now that the GitHub release inventory flow is complete. This keeps stack release provenance distinct from explicit public NGC availability and fixes same-name chart/image preservation during catalog refreshes.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

The selected GitHub stack release was still represented internally as a publication version and duplicated as `source_version` in the catalog. The network CI entrypoint was also named as though it discovered NGC publication, even though it compares the checked-in catalog with the latest stable GitHub release inventory.

This change:

- makes `stack.version` the single version for the selected stack release while retaining the immutable source tag, commit, pin paths, and digest
- renames `check-doc-version-publication` to `check-doc-version-current-release` and documents that public NGC availability remains explicit in `publications` and `publication_pending`
- removes unused artifact-list fields, dynamic registry synthesis, a renderer with no configured output, and inline rewrites for examples no longer present in current docs
- preserves supplemental artifacts by name and type so a chart is not dropped when a resolved image shares its name
- identifies publication records by name, type, and version so same-name charts, images, and resources cannot select each other's public distribution
- scopes independent version overrides by name and type so they update only the intended artifact
- removes 144 lines net without changing generated user documentation

Customer release notes: Not customer visible.

Plan summary: Not applicable. This changes repository tooling and CI naming only.

Dependencies: None. No license review or NOTICE update is required.

Related Pull Requests: #1760

## For the Reviewer

Please focus on `catalog.go` for the metadata, typed publication identity, and typed version override changes, and `catalog_inventory.go` for typed artifact and publication preservation. Public availability remains explicit rather than inferred from the stack release.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)

QA is not needed. I ran:

- `go test ./...` in `tools/docs-version-sync`
- `go vet ./...` in `tools/docs-version-sync`
- `go test -race ./...` in `tools/docs-version-sync`
- `./tools/ci/check-doc-version-sync`
- `./tools/ci/check-doc-version-current-release` against the latest public GitHub stack release
- `./tools/ci/check-docs`
- `git diff --check`
- targeted scans for retired GitLab updater names, duplicate source-version metadata, stale publication-version terminology, and private NGC paths in the current catalog and generated docs

I also ran the real update flow in an isolated detached worktree at this PR's head:

- `go run -C tools/docs-version-sync . --target main --update-catalog` automatically selected stack release `0.16.2`
- the update changed only `docs/version-catalog/main.yaml`, `docs/user/manifest.md`, and `docs/user/image-mirroring.md`
- the control, compute, and observability bundle versions advanced together and remained marked `Publication pending`
- the offline sync check, live current-release check, full docs check, unit tests, race tests, and vet passed on the updated state
- a second update produced the same diff hash, confirming idempotence
- the generated catalog and docs contained no private NGC registry paths

The end-to-end update was not committed. The checked-in catalog remains intentionally unchanged, and the advisory current-release check correctly reports that `0.16.2` is newer.

## Issues

Closes #1812
Relates to #279

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
