### PR TITLE
fix(db): Restoration of legacy behaviour for public clusters

### DIFF
--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/outbound/cassandra/byoc/ClusterRepository.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/outbound/cassandra/byoc/ClusterRepository.java
@@ -265,17 +265,19 @@ public class ClusterRepository {
     }
 
     /**
-     * All clusters visible to an account in cluster_by_cluster_id: {@code nca_id = :x} UNION
-     * {@code authorized_nca_ids CONTAINS :x} UNION {@code authorized_nca_ids CONTAINS '*'}.
-     * Used only when {@code icms.cluster-by-id-reads-enabled} is on.
+     * Reconstructs a {@code clusters_by_authorized_accounts} partition from
+     * {@code cluster_by_cluster_id}. The wildcard partition contains public clusters, while an
+     * account partition contains only owned or explicitly authorized clusters.
      */
-    public List<ClusterEntity> getAllClustersVisibleToAccount(String ncaId) {
+    public List<ClusterEntity> getAllClustersForAuthorizationKey(String ncaId) {
+        if (WILDCARD.equals(ncaId)) {
+            return clusterByIdRepo.findAllByAuthorizedNcaIdsContains(AUTHORIZED_NCA_IDS_WILDCARD);
+        }
+
         Map<String, ClusterEntity> clustersById = new LinkedHashMap<>();
         clusterByIdRepo.findAllByNcaId(ncaId)
                 .forEach(entity -> clustersById.put(entity.getClusterId(), entity));
         clusterByIdRepo.findAllByAuthorizedNcaIdsContains(ncaId)
-                .forEach(entity -> clustersById.put(entity.getClusterId(), entity));
-        clusterByIdRepo.findAllByAuthorizedNcaIdsContains(AUTHORIZED_NCA_IDS_WILDCARD)
                 .forEach(entity -> clustersById.put(entity.getClusterId(), entity));
         return List.copyOf(clustersById.values());
     }

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/outbound/cassandra/byoc/NvcaClusterRepository.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/main/java/com/nvidia/icms/outbound/cassandra/byoc/NvcaClusterRepository.java
@@ -141,9 +141,7 @@ public class NvcaClusterRepository {
     public List<ClustersByAuthorizedAccountsEntity> getAllClustersInAuthorizedAccount(
             String ncaId) {
         if (icmsConfigurationProperties.isClusterByIdReadsEnabled()) {
-            // nca_id = :x UNION authorized_nca_ids CONTAINS :x
-            // UNION authorized_nca_ids CONTAINS '*'
-            return clusterRepository.getAllClustersVisibleToAccount(ncaId).stream()
+            return clusterRepository.getAllClustersForAuthorizationKey(ncaId).stream()
                     .map(entity -> toClustersByAuthorizedAccountsEntity(entity, entity.getNcaId()))
                     .collect(Collectors.toList());
         }

--- a/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/outbound/cassandra/byoc/ClusterByIdReadsIntegrationTest.java
+++ b/src/control-plane-services/instance-cluster-management/icms-core/src/test/java/com/nvidia/icms/outbound/cassandra/byoc/ClusterByIdReadsIntegrationTest.java
@@ -45,7 +45,7 @@ public class ClusterByIdReadsIntegrationTest extends IntegrationTest {
     private NvcaClusterRepository nvcaClusterRepository;
 
     @Test
-    void getAllClustersInAuthorizedAccount_returnsOwnedAuthorizedAndWildcardClusters() {
+    void getAllClustersInAuthorizedAccount_preservesLegacyPartitionSemantics() {
         // Prepare
         ClusterEntity owned = saveCluster("owner-a", Set.of("auth-a"));
         ClusterEntity authorized = saveCluster("owner-b", Set.of("auth-a"));
@@ -64,17 +64,15 @@ public class ClusterByIdReadsIntegrationTest extends IntegrationTest {
 
         // Assert
         Assertions.assertEquals(
-                Set.of(owned.getClusterId(), authorized.getClusterId(), wildcard.getClusterId()),
+                Set.of(owned.getClusterId(), authorized.getClusterId()),
                 toClusterIds(forAuthorizedAccount));
         Assertions.assertEquals(
-                Set.of(owned.getClusterId(), wildcard.getClusterId()),
+                Set.of(owned.getClusterId()),
                 toClusterIds(forOwnerAccount));
         Assertions.assertEquals(
                 Set.of(wildcard.getClusterId()),
                 toClusterIds(forWildcardKey));
-        Assertions.assertEquals(
-                Set.of(wildcard.getClusterId()),
-                toClusterIds(forUnrelatedAccount));
+        Assertions.assertTrue(forUnrelatedAccount.isEmpty());
         Assertions.assertFalse(
                 toClusterIds(forAuthorizedAccount).contains(unrelated.getClusterId()));
     }


### PR DESCRIPTION
## How The Fix Works
The fix restores the behavior that callers received from the legacy clusters_by_authorized_accounts table.
Previously, with cluster-by-id-reads-enabled: true, this call:
`getAllClustersInAuthorizedAccount(requestNcaId)`
returned three categories:
clusters owned by requestNcaId
+ clusters explicitly authorized for requestNcaId
+ all wildcard/public clusters
The third category was incorrect for this method because callers fetch wildcard clusters separately.
The fixed logic now distinguishes the two query types:
```
if (WILDCARD.equals(ncaId)) {
    return clusters where authorized_nca_ids contains "*";
}

return clusters where nca_id equals ncaId
    UNION clusters where authorized_nca_ids contains ncaId;
```
This is implemented in: nvcf/.../ClusterRepository.java through getAllClustersForAuthorizationKey().

## Effect On The Failure
Spot performs two separate reads:
```
clustersForNcaId = getAllClustersInAuthorizedAccount(requestNcaId);

publicClusters = getAllClustersInAuthorizedAccount("WILDCARD");
```
It uses only `clustersForNcaId` to determine whether an account has explicitly authorized GFN zones:
```
Set<String> gfnAuthorizedZones = clustersForNcaId.stream()
        .filter(GFN cluster)
        .map(clusterId)
        .collect(toSet());
```
Before the fix, NP-LON-06 appeared in `clustersForNcaId` because it has: authorized_nca_ids = {'*'}
Spot therefore incorrectly treated NP-LON-06 as explicitly authorized. With authorization filtering enabled, Spot replaced its shared GPU queue with the zone-specific queue:
gdn-spot-instance-requests-creation-NP-LON-06.fifo
That queue does not exist, so QueueManager threw:
SQS Queue gdn-spot-instance-requests-creation-NP-LON-06.fifo does not exist

## After the fix:
1. getAllClustersInAuthorizedAccount(requestNcaId) does not include NP-LON-06 merely because it has "*".
2. NP-LON-06 is returned only by getAllClustersInAuthorizedAccount("WILDCARD").
3. Spot classifies it as a public destination rather than an explicitly authorized destination.
4. Its queue URL remains the configured shared GPU/region queue, such as:
gdn-spot-instance-requests-gl40-eu-west-1.fifo
5. Spot no longer attempts to resolve the nonexistent per-zone queue.
Explicitly authorized zones still work as before: if a cluster contains the requesting NCA ID in authorized_nca_ids, it appears in the NCA-specific result and is routed through its intended per-zone queue.

NO-REF




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected cluster authorization lookups to return clusters owned by or explicitly authorized for the requested account.
  - Wildcard-authorized clusters are no longer included in every account’s results.
  - Wildcard lookups continue to return clusters explicitly marked for wildcard access.
  - Updated cluster-by-ID reads to apply the corrected authorization behavior consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->