### PR TITLE
ci(docs): make publication check advisory

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -41,6 +41,7 @@ jobs:
         run: ./tools/ci/check-docs
 
       - name: Check latest stack publication
+        continue-on-error: true
         env:
           DOC_VERSION_SYNC_GITHUB_TOKEN: ${{ github.token }}
         run: ./tools/ci/check-doc-version-publication


### PR DESCRIPTION
# TL;DR

Make the network-backed docs publication check advisory so publication drift remains visible without blocking pull requests or merge queue entries. Offline docs validation remains required.

## Additional Details

The docs job currently runs offline validation and a separate check against the latest published stack. A publication mismatch can fail the entire job even when the repository's docs are internally consistent.

This change adds `continue-on-error: true` only to the `Check latest stack publication` workflow step. The checker still returns a nonzero status for diagnostics and remains strict when run directly.

Customer release notes: Not customer visible.

Plan summary: Not applicable.

Usage: Not applicable.

## For the Reviewer

Confirm that only the network-backed publication check is advisory and that `Run docs validation` remains blocking.

## For QA

Validated the workflow structure with `yq` and confirmed:

- `Check latest stack publication` has `continue-on-error: true`.
- `Run docs validation` does not have `continue-on-error: true`.
- `git diff --check origin/main...HEAD` passes.

QA is not needed for this CI-only change.

## Issues

Relates to #279

## References

- Merge queue failure: https://github.com/NVIDIA/nvcf/actions/runs/34638304439/job/103391524715

## Related Pull Requests

None.

## Dependencies

None. No license review or NOTICE update is required.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [ ] New or existing tests cover these changes. No automated test was added for the one-line workflow policy change.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Documentation publication checks no longer stop the workflow when the latest version check fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->