### PR TITLE
docs(version-sync): add operations guide

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -47,7 +47,7 @@ Use `docs/user/` for top-of-tree customer docs and `docs/dev/` for developer wor
 
 For the maintainer workflow, including automatic stack releases, public
 publication updates, and new artifact registration, see
-`tools/docs-version-sync/README.md`.
+[`tools/docs-version-sync/README.md`](../tools/docs-version-sync/README.md).
 
 The generated tables in `docs/user/manifest.md` use catalog artifacts and
 `manifest.entries` from `docs/version-catalog/main.yaml`. For each entry, set

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -45,6 +45,10 @@ Use `docs/user/` for top-of-tree customer docs and `docs/dev/` for developer wor
 
 ### Artifact manifest
 
+For the maintainer workflow, including automatic stack releases, public
+publication updates, and new artifact registration, see
+`tools/docs-version-sync/README.md`.
+
 The generated tables in `docs/user/manifest.md` use catalog artifacts and
 `manifest.entries` from `docs/version-catalog/main.yaml`. For each entry, set
 its deployment plane, kind, requirement, public-safe description, and public

--- a/tools/docs-version-sync/README.md
+++ b/tools/docs-version-sync/README.md
@@ -1,0 +1,158 @@
+# Documentation Version Sync
+
+This tool keeps the artifact versions in the top-of-tree documentation aligned
+with the latest stable self-managed stack release. Top-of-tree documentation is
+under `docs/user/`, but its version catalog follows a tagged stack release, not
+an untagged `main` commit.
+
+## Release and documentation flow
+
+```text
+merge release-worthy stack change to main
+  -> release automation creates the self-managed stack tag and GitHub Release
+  -> the tag workflow attaches nvcf-self-managed-stack-inventory.json
+  -> a maintainer runs docs-version-sync
+  -> the catalog records public locations or Publication pending
+  -> generated blocks under docs/user/ are updated in a Pull Request
+```
+
+The stack release is automatic. A merge to `main` runs
+[`release-tags.yml`](../../.github/workflows/release-tags.yml), which invokes
+`tools/ci/github-release auto` for every registered subproject. A `feat:`,
+`fix:`, or `perf:` commit that changes `deploy/stacks/self-managed/` creates the
+next `deploy/stacks/self-managed/vX.Y.Z` tag and GitHub Release. Chart pin and
+Helmfile changes in that subtree should use a release-worthy commit type. No
+maintainer normally creates the stack tag by hand.
+
+The tag workflow renders the control-plane, compute-plane, and observability
+stacks from the same tagged commit. It attaches the resolved chart and image
+inventory before publishing the GitHub Release. Public artifact publishing is
+a separate process and can happen later after QA.
+
+Changes limited to `deploy/stacks/nvcf-compute-plane/` or
+`deploy/stacks/observability/` create releases for those registered subprojects.
+The documentation sync still follows the next self-managed stack release that
+contains those commits because the self-managed release owns the combined
+inventory asset.
+
+## Sync after an automatic stack release
+
+Wait for the GitHub Release and its inventory asset, then run:
+
+```bash
+git fetch --tags origin
+go run -C tools/docs-version-sync . --target main --update-catalog
+```
+
+The command selects the latest stable self-managed stack release unless
+`--stack-version X.Y.Z` is supplied. It updates:
+
+- `docs/version-catalog/main.yaml`
+- Generated blocks configured by the catalog under `docs/user/`
+- The control-plane, compute-plane, and observability bundle versions
+
+The update retains publication records only when `name`, `type`, and `version`
+still match. New and changed versions without a matching record are added to
+`publication_pending`.
+
+If the command reports an unclassified artifact, add its metadata under
+`manifest.entries` as described below and rerun the command. Do not edit a
+generated documentation block by hand.
+
+## Record a public publication
+
+The sync does not probe NVIDIA NGC or another registry. Verify publication
+separately, then edit
+[`docs/version-catalog/main.yaml`](../../docs/version-catalog/main.yaml):
+
+1. Add an exact `publications` record using the artifact `name`, `type`, and
+   inventory `version`.
+2. Use a registry entry that resolves to a public host and namespace.
+3. Remove the artifact catalog ID from `publication_pending`.
+4. Regenerate the documentation without `--update-catalog`.
+
+For example:
+
+```yaml
+publications:
+  - name: example-service
+    type: image
+    version: 1.2.3
+    registry: public-images
+```
+
+Set `chart_format: http` for a chart in the public HTTP Helm repository. Set
+`published_version` when the public tag differs from the inventory version.
+Add a new entry under `registries` only when the public host or namespace is not
+already represented. Private registry locations are rejected.
+
+Run:
+
+```bash
+go run -C tools/docs-version-sync . --target main
+./tools/ci/check-doc-version-sync
+./tools/ci/check-doc-version-current-release
+./tools/ci/check-docs
+```
+
+A publication-only update does not require a new stack release.
+
+## Add an artifact to the stack inventory
+
+For a chart or image deployed by a stack:
+
+1. Add it to the owning Helmfile or chart values.
+2. Confirm the inventory renderer includes the path:
+   - A default release in an existing state is discovered automatically.
+   - For a release behind a new optional setting, add that setting to the
+     matching `fullOverrides` entry in `resolved_inventory_publish.go`.
+   - For a new Helmfile state, add the state to `resolvedInventoryStates`.
+   - If an independently released chart must be rendered from its immutable
+     GitHub tag, add it to
+     [`release-inventory.yaml`](../../deploy/stacks/self-managed/release-inventory.yaml).
+3. Merge the release-worthy change to `main`. Release automation creates the
+   corresponding registered stack release.
+4. Run the documentation sync after a self-managed stack release containing
+   the change appears with its inventory asset.
+5. Add a `manifest.entries` record for the new artifact.
+6. Add a verified public publication or leave the artifact pending.
+
+A catalog-backed manifest entry uses `artifact_id` and describes the deployment
+plane, kind, requirement, purpose, and public source links. The generator fails
+when a discovered artifact has no classification.
+
+## Add an independently versioned artifact
+
+Use `supplemental_artifacts` for a tool, deployment resource, or separately
+installed add-on that is not emitted by the stack inventory.
+
+- Add the artifact to `supplemental_artifacts`.
+- Add its `manifest.entries` record.
+- For an independently versioned resource, update its `version_overrides` and
+  supplemental version together.
+- Add an exact publication record or keep it in `publication_pending`.
+
+Supplemental charts and images must be referenced by `manifest.entries` or the
+next stack refresh removes them. Supplemental resources survive a catalog
+refresh automatically, but they still require a manifest entry to render.
+
+## Remove or exclude an artifact
+
+For a real removal, remove the artifact from the stack. After the next release
+sync, remove its stale manifest metadata. Use `denylist` only when an artifact
+is intentionally excluded from public documentation, and give it a public-safe
+reason. Do not use a private registry as a placeholder for an unpublished
+artifact.
+
+## Validation
+
+Run the focused Go checks when changing tool behavior:
+
+```bash
+go test -C tools/docs-version-sync ./...
+go vet -C tools/docs-version-sync ./...
+```
+
+The operation is complete when the offline sync check, current-release check,
+and full documentation check pass, and the generated diff contains only the
+expected catalog and documentation updates.


### PR DESCRIPTION
# TL;DR

Add a maintainer operations guide for keeping top-of-tree artifact documentation aligned with automatic self-managed stack releases and verified public publications.

## Additional Details

The stack tag and GitHub Release are created automatically after a release-worthy stack change merges to `main`; maintainers do not normally cut the release by hand. The new guide documents that trigger, the combined control-plane, compute-plane, and observability inventory asset, and the separate manual public-publication step.

It also covers routine stack syncs, publication-only updates, adding stack-discovered artifacts, adding independently versioned supplemental artifacts, and removing or excluding artifacts. `docs/AGENTS.md` links to the guide for discoverability.

Customer Release Notes: Not customer visible.

Plan Summary: Not applicable.

Usage: Follow `tools/docs-version-sync/README.md` after an automatic self-managed stack release or public artifact publication.

Related Pull Requests: #1813

Dependencies: None. No license review or NOTICE update is required.

## For the Reviewer

Please verify the automatic release boundary and the new-artifact flow in `tools/docs-version-sync/README.md`.

## For QA

QA is not needed. This is documentation only.

Validated with:

- `go test -C tools/docs-version-sync ./...`
- `go vet -C tools/docs-version-sync ./...`
- `./tools/ci/check-doc-version-sync`
- `./tools/ci/check-docs`
- `git diff --check`
- ASCII and documentation-style scans

## Issues

Relates to #279

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added maintainer guidance for automatic stack releases, publication updates, and artifact registration.
  - Documented catalog and generated-document synchronization workflows.
  - Added guidance for publication records, artifact inventories, supplemental artifacts, removal and exclusion rules, and validation commands.
  - Linked the version synchronization documentation using the correct repository-relative path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->