### PR TITLE
fix(charts): update database image pins

### DIFF
--- a/deploy/helm/cassandra/helm/Chart.yaml
+++ b/deploy/helm/cassandra/helm/Chart.yaml
@@ -24,4 +24,4 @@ description: >
 type: application
 
 version: 0.8.0
-appVersion: 5.0.8-nv-2.0.1
+appVersion: 5.0.9-nv-2.0.5

--- a/deploy/helm/cassandra/helm/values.yaml
+++ b/deploy/helm/cassandra/helm/values.yaml
@@ -31,7 +31,7 @@ cassandra:
     # repository: must be supplied in additional values
     registry: ""
     repository: ""
-    tag: 5.0.8-nv-2.0.1
+    tag: 5.0.9-nv-2.0.5
     pullPolicy: IfNotPresent
 
   replicaCount: 3
@@ -223,7 +223,7 @@ cassandra:
       # repository: must be supplied in additional values
       registry: ""
       repository: ""
-      tag: 0.17.5
+      tag: 0.17.6
       pullPolicy: Always
 
   dbUser:

--- a/deploy/helm/openbao/helm/Chart.yaml
+++ b/deploy/helm/openbao/helm/Chart.yaml
@@ -19,7 +19,7 @@ description: OpenBao self-managed deployment
 type: application
 
 version: 0.0.0 # managed by semantic-release
-appVersion: 2.6.2-nv-1.3.3 # todo update via renovate when bao image is updated
+appVersion: 2.6.2-nv-1.3.4
 
 dependencies:
   - name: openbao

--- a/deploy/helm/openbao/helm/values.yaml
+++ b/deploy/helm/openbao/helm/values.yaml
@@ -56,7 +56,7 @@ openbao:
     image:
       registry: ""
       repository: ""
-      tag: 0.19.4
+      tag: 0.19.5
       pullPolicy: IfNotPresent
     issuerDiscovery:
       enabled: false
@@ -84,7 +84,7 @@ openbao:
     image:
       registry: ""
       repository: ""
-      tag: 2.6.2-nv-1.3.3
+      tag: 2.6.2-nv-1.3.4
       pullPolicy: IfNotPresent
 
     podManagementPolicy: Parallel
@@ -263,5 +263,5 @@ openbao:
     agentImage:
       registry: ""
       repository: ""
-      tag: 2.6.2-nv-1.3.3
+      tag: 2.6.2-nv-1.3.4
       pullPolicy: IfNotPresent

--- a/deploy/helm/openbao/upgrade/values-upgrades.yaml
+++ b/deploy/helm/openbao/upgrade/values-upgrades.yaml
@@ -4,7 +4,7 @@
 openbao:
   server:
     image:
-      tag: 2.6.2-nv-1.3.3
+      tag: 2.6.2-nv-1.3.4
 
     # Update auto-unseal sidecar to match server version
     extraContainers:
@@ -52,4 +52,4 @@ openbao:
 
   injector:
     agentImage:
-      tag: 2.6.2-nv-1.3.3
+      tag: 2.6.2-nv-1.3.4


### PR DESCRIPTION
# TL;DR

Update the Cassandra and OpenBao Helm charts to consume the latest released database images.

## Additional Details

The database image releases are available, but the charts still reference their previous versions. This change updates only the chart pins:

- Cassandra: `5.0.9-nv-2.0.5`
- Cassandra migrations: `0.17.6`
- OpenBao server and agent: `2.6.2-nv-1.3.4`
- OpenBao migrations: `0.19.5`

The Cassandra and OpenBao Chart.yaml appVersions move with their primary images. The OpenBao upgrade values also move so upgrades performed with reused values do not retain the previous server or agent image.

The chart release automation fix is intentionally split into #1829. The stack consumption change in #1792 is untouched.

## Customer Release Notes

Update the Cassandra and OpenBao components used by the self-managed Helm charts.

## Plan Summary

No Kubernetes resources, resource counts, or resource attributes change. This PR changes image tags and chart appVersions only.

## Usage

No operator action is needed for this source change. The released chart versions can be consumed by the stack after the chart release pipelines complete.

## For the Reviewer

Please verify that each Chart.yaml appVersion matches the primary image pin and that the OpenBao upgrade values match the main values file.

## For QA

QA is not needed. The following checks passed locally:

- `tools/ci/check-helm-charts` (19 charts linted and rendered)
- `bash deploy/helm/openbao/tests/plugin-catalog-refresh-hook.sh`
- `git diff --check`

## Notes

The workflow and tooling changes from the original combined PR have moved to #1829.

## Related Pull Requests

- #1829
- #1792

## Dependencies

This PR updates Cassandra to `5.0.9-nv-2.0.5`, Cassandra migrations to `0.17.6`, OpenBao to `2.6.2-nv-1.3.4`, and OpenBao migrations to `0.19.5`. The dependency licenses are unchanged and NOTICE does not require an update.

## Issues

Relates to #1781

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
