### PR TITLE
chore(self-managed): bump vanity-gateway chart to 0.5.0

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -198,7 +198,7 @@ releases:
       release-group: services
 
   - name: vanity-gateway
-    version: 0.4.4
+    version: 0.5.0
     namespace: nvcf
     condition: addons.vanityGateway.enabled
     inherit:


### PR DESCRIPTION
# TL;DR
Bump the vanity-gateway chart pin in the self-managed helmfile from 0.4.4 to 0.5.0 to pick up per-target shadow policy support.

## Additional Details (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
- Chart 0.5.0 ships the `shadows` list field on OpenAI routes, per-target percentage, sampling method, and cancel-on-disconnect flags
- Legacy shadow fields keep working unchanged; no migration required for existing values files
- This is the self-managed distribution follow-up to the gateway and chart changes in #1745

## For the Reviewer
No logic change. Single-line version bump in `deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl`.

## For QA (optional for docs, build, test, refactor, ci, chore, style, and revert PRs)
QA for the per-target shadow feature is tracked separately. This bump makes the chart available to self-managed operators after the managed environment validates it.

## Issues
related to #1243

## Checklist

- [X] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the Vanity Gateway deployment to chart version 0.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->