### PR TITLE
fix(ci): make chart pin updates rollback-safe

### DIFF
--- a/tools/chart-version-bumper/chart.go
+++ b/tools/chart-version-bumper/chart.go
@@ -409,22 +409,25 @@ func ApplyValuesPaths(root string, chart Entry, version string, paths []string, 
 	if err != nil {
 		return err
 	}
-	updates := make([]fileUpdate, 0, len(specs)+1)
-	for _, spec := range specs {
-		b, err := os.ReadFile(spec.path)
+	groups := groupDeclaredValuesSpecs(specs)
+	updates := make([]fileUpdate, 0, len(groups)+1)
+	for _, group := range groups {
+		b, err := os.ReadFile(group.path)
 		if err != nil {
-			return fmt.Errorf("read %s: %w", spec.path, err)
+			return fmt.Errorf("read %s: %w", group.path, err)
 		}
 		lines := strings.Split(string(b), "\n")
-		for _, path := range spec.paths {
-			line, _, err := resolveValuesPath(lines, path)
-			if err != nil {
-				return fmt.Errorf("%s: %w", spec.path, err)
+		for _, spec := range group.specs {
+			for _, path := range spec.paths {
+				line, _, err := resolveValuesPath(lines, path)
+				if err != nil {
+					return fmt.Errorf("%s: %w", group.path, err)
+				}
+				m := scalarValueRE.FindStringSubmatch(lines[line])
+				lines[line] = m[1] + scalarLike(lines[line][len(m[1]):], version) + m[3]
 			}
-			m := scalarValueRE.FindStringSubmatch(lines[line])
-			lines[line] = m[1] + scalarLike(lines[line][len(m[1]):], version) + m[3]
 		}
-		update, err := prepareFileUpdate(spec.path, b, strings.Join(lines, "\n"))
+		update, err := prepareFileUpdate(group.path, b, strings.Join(lines, "\n"))
 		if err != nil {
 			return err
 		}
@@ -460,6 +463,28 @@ func ApplyValuesPaths(root string, chart Entry, version string, paths []string, 
 	}
 	updates = append([]fileUpdate{chartUpdate}, updates...)
 	return commitFileUpdates(updates)
+}
+
+type declaredValuesGroup struct {
+	path  string
+	specs []declaredValuesSpec
+}
+
+// groupDeclaredValuesSpecs ensures multiple declarations resolving to the
+// same file are applied to one buffer and committed as one file update.
+func groupDeclaredValuesSpecs(specs []declaredValuesSpec) []declaredValuesGroup {
+	var groups []declaredValuesGroup
+	groupIndex := make(map[string]int)
+	for _, spec := range specs {
+		index, ok := groupIndex[spec.path]
+		if !ok {
+			index = len(groups)
+			groupIndex[spec.path] = index
+			groups = append(groups, declaredValuesGroup{path: spec.path})
+		}
+		groups[index].specs = append(groups[index].specs, spec)
+	}
+	return groups
 }
 
 type fileUpdate struct {

--- a/tools/chart-version-bumper/chart.go
+++ b/tools/chart-version-bumper/chart.go
@@ -409,11 +409,7 @@ func ApplyValuesPaths(root string, chart Entry, version string, paths []string, 
 	if err != nil {
 		return err
 	}
-	type update struct {
-		path string
-		text string
-	}
-	updates := make([]update, 0, len(specs))
+	updates := make([]fileUpdate, 0, len(specs)+1)
 	for _, spec := range specs {
 		b, err := os.ReadFile(spec.path)
 		if err != nil {
@@ -428,15 +424,14 @@ func ApplyValuesPaths(root string, chart Entry, version string, paths []string, 
 			m := scalarValueRE.FindStringSubmatch(lines[line])
 			lines[line] = m[1] + scalarLike(lines[line][len(m[1]):], version) + m[3]
 		}
-		updates = append(updates, update{path: spec.path, text: strings.Join(lines, "\n")})
+		update, err := prepareFileUpdate(spec.path, b, strings.Join(lines, "\n"))
+		if err != nil {
+			return err
+		}
+		updates = append(updates, update)
 	}
 	if !ownsAppVersion {
-		for _, update := range updates {
-			if err := writeFilePreservingMode(update.path, update.text); err != nil {
-				return err
-			}
-		}
-		return nil
+		return commitFileUpdates(updates)
 	}
 
 	// Read and prepare both files before the first write. A missing or malformed
@@ -459,12 +454,57 @@ func ApplyValuesPaths(root string, chart Entry, version string, paths []string, 
 		groups := appVersionRE.FindStringSubmatch(line)
 		return groups[1] + scalarLike(line[len(groups[1]):], version) + groups[3]
 	})
-	if err := writeFilePreservingMode(chartYAML, chartText); err != nil {
+	chartUpdate, err := prepareFileUpdate(chartYAML, chartBytes, chartText)
+	if err != nil {
 		return err
 	}
-	for _, update := range updates {
-		if err := writeFilePreservingMode(update.path, update.text); err != nil {
-			return err
+	updates = append([]fileUpdate{chartUpdate}, updates...)
+	return commitFileUpdates(updates)
+}
+
+type fileUpdate struct {
+	path     string
+	original []byte
+	updated  []byte
+	mode     os.FileMode
+}
+
+func prepareFileUpdate(path string, original []byte, updated string) (fileUpdate, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fileUpdate{}, fmt.Errorf("stat %s: %w", path, err)
+	}
+	return fileUpdate{
+		path:     path,
+		original: append([]byte(nil), original...),
+		updated:  []byte(updated),
+		mode:     info.Mode().Perm(),
+	}, nil
+}
+
+type fileWriter func(path string, content []byte, mode os.FileMode) error
+
+// commitFileUpdates restores every attempted file if one write fails. This is
+// best-effort because the filesystem can also reject a rollback, in which case
+// the returned error reports both failures instead of hiding the partial state.
+func commitFileUpdates(updates []fileUpdate) error {
+	return commitFileUpdatesWith(updates, os.WriteFile)
+}
+
+func commitFileUpdatesWith(updates []fileUpdate, write fileWriter) error {
+	for i, update := range updates {
+		if err := write(update.path, update.updated, update.mode); err != nil {
+			var rollbackErrors []string
+			for j := i; j >= 0; j-- {
+				attempted := updates[j]
+				if rollbackErr := write(attempted.path, attempted.original, attempted.mode); rollbackErr != nil {
+					rollbackErrors = append(rollbackErrors, fmt.Sprintf("restore %s: %v", attempted.path, rollbackErr))
+				}
+			}
+			if len(rollbackErrors) > 0 {
+				return fmt.Errorf("write %s: %w; rollback failed: %s", update.path, err, strings.Join(rollbackErrors, "; "))
+			}
+			return fmt.Errorf("write %s: %w", update.path, err)
 		}
 	}
 	return nil

--- a/tools/chart-version-bumper/main_test.go
+++ b/tools/chart-version-bumper/main_test.go
@@ -93,7 +93,9 @@ func (f *fixture) tag(t *testing.T, tag string) {
 		{"tag", tag},
 	}
 	for _, args := range commands {
-		if output, err := exec.Command("git", append([]string{"-C", f.root}, args...)...).CombinedOutput(); err != nil {
+		cmd := exec.Command("git", append([]string{"-C", f.root}, args...)...)
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+		if output, err := cmd.CombinedOutput(); err != nil {
 			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
 		}
 	}
@@ -618,6 +620,47 @@ func TestValuesPathsAllMoveTogether(t *testing.T) {
 	values := f.read(t, "c", "values.yaml")
 	if strings.Count(values, `tag: "2.0.0"`) != 2 {
 		t.Fatalf("both declared paths should have moved:\n%s", values)
+	}
+}
+
+func TestCommitFileUpdatesRollsBackAfterALaterFailure(t *testing.T) {
+	f := newFixture(t, `{"services":[]}`)
+	first := filepath.Join(f.root, "first.yaml")
+	second := filepath.Join(f.root, "second.yaml")
+	f.source(t, "first.yaml", "first: old\n")
+	f.source(t, "second.yaml", "second: old\n")
+
+	firstUpdate, err := prepareFileUpdate(first, []byte("first: old\n"), "first: new\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondUpdate, err := prepareFileUpdate(second, []byte("second: old\n"), "second: new\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writes := 0
+	err = commitFileUpdatesWith([]fileUpdate{firstUpdate, secondUpdate}, func(path string, content []byte, mode os.FileMode) error {
+		writes++
+		if writes == 2 {
+			return fmt.Errorf("injected write failure")
+		}
+		return os.WriteFile(path, content, mode)
+	})
+	if err == nil || !strings.Contains(err.Error(), "injected write failure") {
+		t.Fatalf("want the later write failure, got %v", err)
+	}
+	for path, want := range map[string]string{
+		first:  "first: old\n",
+		second: "second: old\n",
+	} {
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if got := string(content); got != want {
+			t.Fatalf("%s was not restored: %q", path, got)
+		}
 	}
 }
 

--- a/tools/chart-version-bumper/main_test.go
+++ b/tools/chart-version-bumper/main_test.go
@@ -623,6 +623,26 @@ func TestValuesPathsAllMoveTogether(t *testing.T) {
 	}
 }
 
+func TestPrimaryAndAdditionalPathsForTheSameValuesFileMerge(t *testing.T) {
+	f := newFixture(t, `{"services":[
+	 {"id":"svc","path":"src/svc"},
+	 {"id":"c","path":"deploy/helm/c","deploys":[{
+	   "service":"svc",
+	   "values_paths":["a.tag"],
+	   "values_files":[{"file":"values.yaml","paths":["b.tag"]}]
+	 }]}
+	]}`)
+	f.chart(t, "c", "0.0.0", "a:\n  tag: 1.0.0\nb:\n  tag: 1.0.0")
+
+	if code, _, errOut := f.run(t, "src/svc/v2.0.0", true); code != 0 {
+		t.Fatalf("want a clean bump, got %d\n%s", code, errOut)
+	}
+	values := f.read(t, "c", "values.yaml")
+	if strings.Count(values, "tag: 2.0.0") != 2 {
+		t.Fatalf("both declarations targeting values.yaml must be preserved:\n%s", values)
+	}
+}
+
 func TestCommitFileUpdatesRollsBackAfterALaterFailure(t *testing.T) {
 	f := newFixture(t, `{"services":[]}`)
 	first := filepath.Join(f.root, "first.yaml")


### PR DESCRIPTION
# TL;DR

Address the post-review findings from #1829 by making multi-file chart pin updates rollback-safe and isolating Git-backed tests from developer configuration.

## Additional Details

#1829 merged before its review comments could be addressed. Its chart bumper can update a primary values file, additional values files, and Chart.yaml in one release operation. Previously, a failure after an earlier write could leave those files on different image versions.

This follow-up:

- stages each file's original content and permissions before writing
- restores every attempted file when any later write fails
- reports rollback failures alongside the original write error
- adds a failure-injection regression test that verifies both files return to their original content
- runs fixture Git commands with global and system Git configuration disabled, preventing signing or hook settings from breaking tests

## Customer Release Notes

Not customer visible.

## Plan Summary

Not applicable.

## Usage

Not applicable.

## For the Reviewer

Please focus on the rollback path in `commitFileUpdatesWith` and the injected later-write failure test.

## For QA

QA is not needed. The following checks passed after rebasing onto current `main`:

- `go test -race -C tools/chart-version-bumper ./...`
- `go vet -C tools/chart-version-bumper ./...`
- the Git-backed fixture test with a deliberately invalid global signing configuration

Before the rebase, the full #1829 validation set also passed, including 74 GitHub release metadata tests and the chart service edge audit.

## Notes

The rollback is best-effort. If the filesystem rejects both the requested write and a restoration, the returned error includes both failures so the partial state is visible.

## Related Pull Requests

- #1829
- #1827

## Dependencies

None. No license review or NOTICE update is required.

## Issues

Relates to #1781

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Version update operations targeting the same values file now preserve all requested changes.
  * Updates remain transactional, restoring previously modified files if a later write fails.
  * Errors now include details when restoring files also encounters a failure.

* **Tests**
  * Added coverage for combining updates to the same values file.
  * Added coverage verifying that failed update operations correctly roll back all attempted file changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->