### PR TITLE
fix(charts): restore state metrics chart source

### DIFF
--- a/deploy/helm/state-metrics/Chart.yaml
+++ b/deploy/helm/state-metrics/Chart.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+name: helm-nvcf-state-metrics
+description: A Helm chart for the NVCF State Metrics Service
+type: application
+version: 0.0.0 # managed by release automation
+appVersion: "1.24.0"

--- a/deploy/helm/state-metrics/README.md
+++ b/deploy/helm/state-metrics/README.md
@@ -1,0 +1,30 @@
+# NVCF State Metrics Helm chart
+
+This directory is the public source for `helm-nvcf-state-metrics`. It was
+restored from the published `1.0.2` chart package so future image and chart
+releases can be reviewed and reproduced from this repository.
+
+The chart deploys `nvcf-state-metrics-service` and exposes its Prometheus
+endpoint through a Kubernetes Service. A ServiceMonitor is enabled by default.
+
+## Validate the chart
+
+Run the repository-wide chart check from the repository root:
+
+```bash
+tools/ci/check-helm-charts
+```
+
+To validate only this chart:
+
+```bash
+helm lint deploy/helm/state-metrics \
+  --values tools/ci/helm-validate-values/state-metrics.yaml
+
+helm template state-metrics deploy/helm/state-metrics \
+  --namespace nvcf \
+  --values tools/ci/helm-validate-values/state-metrics.yaml
+```
+
+The self-managed stack supplies the registry and repository through
+`stateMetrics.image`. The chart owns the default image tag.

--- a/deploy/helm/state-metrics/templates/_helpers.tpl
+++ b/deploy/helm/state-metrics/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- define "nvcf-state-metrics.name" -}}
+{{- default .Chart.Name .Values.stateMetrics.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "nvcf-state-metrics.fullname" -}}
+{{- if .Values.stateMetrics.fullnameOverride }}
+{{- .Values.stateMetrics.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.stateMetrics.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "nvcf-state-metrics.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "nvcf-state-metrics.namespace" -}}
+{{- default .Release.Namespace .Values.stateMetrics.namespace -}}
+{{- end }}
+
+{{- define "nvcf-state-metrics.image" -}}
+{{- $registry := required "A valid image registry (.Values.stateMetrics.image.registry) is required!" .Values.stateMetrics.image.registry -}}
+{{- $repository := required "A valid image repository (.Values.stateMetrics.image.repository) is required!" .Values.stateMetrics.image.repository -}}
+{{- $tag := .Values.stateMetrics.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- end }}
+
+{{- define "nvcf-state-metrics.labels" -}}
+helm.sh/chart: {{ include "nvcf-state-metrics.chart" . }}
+{{ include "nvcf-state-metrics.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "nvcf-state-metrics.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nvcf-state-metrics.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "nvcf-state-metrics.vaultAnnotations" -}}
+vault.hashicorp.com/agent-inject: "true"
+vault.hashicorp.com/role: "nvcf-state-metrics"
+vault.hashicorp.com/auth-path: "auth/jwt"
+vault.hashicorp.com/agent-copy-volume-mounts: {{ .Chart.Name }}
+vault.hashicorp.com/agent-run-as-same-user: "true"
+vault.hashicorp.com/agent-inject-template-file-nvcf_jwt_token.txt: "/vault/config/templates/nvcf_jwt_token.tmpl"
+vault.hashicorp.com/secret-volume-path: "/vault/secrets"
+{{- end }}

--- a/deploy/helm/state-metrics/templates/configmap-env.yaml
+++ b/deploy/helm/state-metrics/templates/configmap-env.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+{{ if .Values.stateMetrics.env }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nvcf-state-metrics.fullname" . }}-env
+  namespace: {{ include "nvcf-state-metrics.namespace" . }}
+  labels:
+    {{- include "nvcf-state-metrics.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.stateMetrics.env }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{ end }}

--- a/deploy/helm/state-metrics/templates/configmap-vault-agent-template.yaml
+++ b/deploy/helm/state-metrics/templates/configmap-vault-agent-template.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nvcf-state-metrics.fullname" . }}-vault-agent-tpl
+  namespace: {{ include "nvcf-state-metrics.namespace" . }}
+  labels:
+    {{- include "nvcf-state-metrics.labels" . | nindent 4 }}
+data:
+  nvcf_jwt_token.tmpl: |-
+{{ .Files.Get "vault-agent-templates/nvcf_jwt_token.tmpl" | indent 4 }}

--- a/deploy/helm/state-metrics/templates/deployment.yaml
+++ b/deploy/helm/state-metrics/templates/deployment.yaml
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "nvcf-state-metrics.fullname" . }}
+  namespace: {{ include "nvcf-state-metrics.namespace" . }}
+  labels:
+    {{- include "nvcf-state-metrics.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.stateMetrics.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "nvcf-state-metrics.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- include "nvcf-state-metrics.vaultAnnotations" . | nindent 8 }}
+        {{- with .Values.stateMetrics.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.stateMetrics.env }}
+        checksum/config-env: {{ toYaml .Values.stateMetrics.env | sha256sum }}
+        {{- end }}
+      labels:
+        {{- include "nvcf-state-metrics.selectorLabels" . | nindent 8 }}
+        {{- with .Values.stateMetrics.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      terminationGracePeriodSeconds: {{ .Values.stateMetrics.terminationGracePeriodSeconds }}
+      {{- with .Values.stateMetrics.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: nvcf-state-metrics
+      securityContext:
+        {{- toYaml .Values.stateMetrics.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.stateMetrics.securityContext | nindent 12 }}
+          image: "{{ include "nvcf-state-metrics.image" . }}"
+          imagePullPolicy: {{ .Values.stateMetrics.image.pullPolicy }}
+          volumeMounts:
+            {{- with .Values.stateMetrics.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            - name: vault-config-templates
+              mountPath: /vault/config/templates
+              readOnly: true
+          {{- with .Values.stateMetrics.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.stateMetrics.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.stateMetrics.env }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "nvcf-state-metrics.fullname" . }}-env
+          {{- end }}
+          ports:
+            {{- toYaml .Values.stateMetrics.ports | nindent 12 }}
+          resources:
+            {{- toYaml .Values.stateMetrics.resources | nindent 12 }}
+      volumes:
+        {{- with .Values.stateMetrics.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        - name: vault-config-templates
+          configMap:
+            name: {{ include "nvcf-state-metrics.fullname" . }}-vault-agent-tpl
+            items:
+              - key: nvcf_jwt_token.tmpl
+                path: nvcf_jwt_token.tmpl
+      {{- with .Values.stateMetrics.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.stateMetrics.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.stateMetrics.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/state-metrics/templates/service.yaml
+++ b/deploy/helm/state-metrics/templates/service.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nvcf-state-metrics.fullname" . }}
+  namespace: {{ include "nvcf-state-metrics.namespace" . }}
+  labels:
+    {{- include "nvcf-state-metrics.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.stateMetrics.service.type }}
+  ports:
+    - port: {{ .Values.stateMetrics.service.port }}
+      targetPort: {{ .Values.stateMetrics.service.portName }}
+      protocol: TCP
+      name: {{ .Values.stateMetrics.service.portName }}
+  selector:
+    {{- include "nvcf-state-metrics.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/state-metrics/templates/serviceaccount.yaml
+++ b/deploy/helm/state-metrics/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nvcf-state-metrics
+  namespace: {{ include "nvcf-state-metrics.namespace" . }}
+  labels:
+    {{- include "nvcf-state-metrics.labels" . | nindent 4 }}

--- a/deploy/helm/state-metrics/templates/servicemonitor.yaml
+++ b/deploy/helm/state-metrics/templates/servicemonitor.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+{{ if .Values.stateMetrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "nvcf-state-metrics.fullname" . }}
+  namespace: {{ include "nvcf-state-metrics.namespace" . }}
+  labels:
+    {{- include "nvcf-state-metrics.labels" . | nindent 4 }}
+    {{- with .Values.stateMetrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "nvcf-state-metrics.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: {{ .Values.stateMetrics.service.portName }}
+      path: {{ .Values.stateMetrics.serviceMonitor.path }}
+      interval: {{ .Values.stateMetrics.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.stateMetrics.serviceMonitor.scrapeTimeout }}
+{{ end }}

--- a/deploy/helm/state-metrics/values.yaml
+++ b/deploy/helm/state-metrics/values.yaml
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+stateMetrics:
+  namespace: nvcf
+  nameOverride: ""
+  fullnameOverride: ""
+  replicaCount: 1
+
+  image:
+    registry: "" # must be supplied
+    repository: "" # must be supplied
+    pullPolicy: IfNotPresent
+    tag: "1.24.0"
+  imagePullSecrets: []
+
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 9464
+    targetPort: 9464
+    portName: metrics
+  terminationGracePeriodSeconds: 30
+
+  resources:
+    limits:
+      cpu: "4"
+      memory: 8Gi
+    requests:
+      cpu: "4"
+      memory: 8Gi
+
+  readinessProbe:
+    httpGet:
+      path: /favicon.ico
+      port: metrics
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    failureThreshold: 3
+    successThreshold: 1
+    timeoutSeconds: 5
+  livenessProbe:
+    httpGet:
+      path: /favicon.ico
+      port: metrics
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+  volumes:
+    - name: token
+      projected:
+        sources:
+          - serviceAccountToken:
+              path: token
+              expirationSeconds: 3600
+              audience: http://openbao-server.vault-system.svc.cluster.local:8200
+  volumeMounts:
+    - name: token
+      mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      readOnly: true
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+  ports:
+    - name: metrics
+      containerPort: 9464
+      protocol: TCP
+
+  env:
+    NVCF_ENV: local
+    NVCF_WORKERS: "10"
+    NVCF_THANOS_NVCF: "false"
+    NVCF_THANOS_NVCF_V1: "false"
+    NVCF_THANOS_NVCFSRE: "false"
+    NVCF_JWT_TOKEN_FILE: /vault/secrets/nvcf_jwt_token.txt
+    NVCF_ENABLE_NGC_ENRICHMENT: "false"
+    NVCF_API_URL: http://api.nvcf.svc.cluster.local:8080
+
+  serviceMonitor:
+    enabled: true
+    interval: 50s
+    scrapeTimeout: 45s
+    path: /metrics
+    labels: {}

--- a/deploy/helm/state-metrics/vault-agent-templates/nvcf_jwt_token.tmpl
+++ b/deploy/helm/state-metrics/vault-agent-templates/nvcf_jwt_token.tmpl
@@ -1,0 +1,9 @@
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Render the NVCF API JWT used by the state-metrics service.
+*/}}
+{{- with secret "services/nvcf-api/jwt/sign/nvcf-state-metrics" -}}
+{{ .Data.token }}
+{{- end -}}

--- a/tools/ci/check-helm-charts
+++ b/tools/ci/check-helm-charts
@@ -55,6 +55,7 @@ chart_map=(
     "nvca-operator            nvca-operator/nvca-operator"
     "openbao                  openbao/helm"
     "ratelimiter              ratelimiter/nvcf-ratelimiter"
+    "state-metrics            state-metrics"
     "vanity-gateway           vanity-gateway/helm-nvcf-vanity-gateway"
 )
 

--- a/tools/ci/github-release-subprojects.json
+++ b/tools/ci/github-release-subprojects.json
@@ -137,6 +137,13 @@
       ]
     },
     {
+      "id": "state-metrics-helm",
+      "path": "deploy/helm/state-metrics",
+      "service_name": "helm-nvcf-state-metrics",
+      "initial_version": "1.0.2",
+      "deploys": []
+    },
+    {
       "id": "nats-auth-callout",
       "path": "src/control-plane-services/nats-auth-callout",
       "service_name": "nvcf-nats-auth-callout-service",

--- a/tools/ci/helm-validate-values/state-metrics.yaml
+++ b/tools/ci/helm-validate-values/state-metrics.yaml
@@ -1,0 +1,5 @@
+# CI-only values for Helm lint and render validation.
+stateMetrics:
+  image:
+    registry: example.com
+    repository: nvcf/nvcf-state-metrics-service


### PR DESCRIPTION
# TL;DR

Restore the state-metrics Helm chart source, pin the service image to 1.24.0, and register the chart for independent validation and release. This keeps the state-metrics addition separate from PR #1792.

## Additional Details

The published state-metrics chart did not have a corresponding source chart in this repository. The restored source is based on the published 1.0.2 package, with environment-specific and private metadata omitted.

The change adds the chart templates and public-safe defaults, adds focused CI values, includes the chart in Helm validation, and registers it with an initial published version of 1.0.2 so release automation can publish a later version.

No third-party dependencies were added. No NOTICE update is required.

## For the Reviewer

Review the restored chart defaults under `deploy/helm/state-metrics`, especially the explicit 1.24.0 image tag, and the release registration in `tools/ci/github-release-subprojects.json`.

## For QA

QA is not required beyond CI. Local validation completed:

- `helm lint deploy/helm/state-metrics -f tools/ci/helm-validate-values/state-metrics.yaml`
- `helm template state-metrics deploy/helm/state-metrics -f tools/ci/helm-validate-values/state-metrics.yaml`
- `helm package deploy/helm/state-metrics`
- `python3 tools/ci/test-github-release.py` (74 tests passed)
- JSON validation, whitespace validation, and public-content hygiene scan

## Issues

Relates to #1832

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Helm chart for deploying the NVCF State Metrics service to Kubernetes.
  * Supports configurable images, replicas, resources, health probes, environment variables, scheduling, networking, and security settings.
  * Added optional Prometheus metrics scraping through a ServiceMonitor.
  * Added Vault-based JWT configuration and secret integration.
* **Documentation**
  * Added chart usage, validation, deployment, and configuration documentation.
* **Chores**
  * Added Helm validation and release metadata for the new chart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->