### PR TITLE
feat(stack): bump self-managed stack chart pins

### DIFF
--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -55,7 +55,7 @@ releases:
       - template: service
 
   - name: sis
-    version: 2.3.0
+    version: 2.4.0
     namespace: sis
     inherit:
       - template: service

--- a/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/02-core.yaml.gotmpl
@@ -174,7 +174,7 @@ releases:
     {{- $llmRequestRouterChartPath := dig "addons" "llm" "requestRouter" "chartPath" "" .Values }}
     chart: {{ $llmRequestRouterChartPath | default "nvcf/helm-nvcf-llm-request-router" | quote }}
     {{- if not $llmRequestRouterChartPath }}
-    version: 1.13.3
+    version: 1.14.0
     {{- end }}
     namespace: nvcf
     condition: addons.llm.enabled

--- a/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
+++ b/deploy/stacks/self-managed/helmfile.d/03-observability.yaml.gotmpl
@@ -73,7 +73,7 @@ releases:
 
   {{- if $functionAutoscalerEnabled }}
   - name: function-autoscaler
-    version: 0.4.0
+    version: 0.5.0
     namespace: nvcf
     inherit:
       - template: functionAutoscaler


### PR DESCRIPTION
Opened by `.github/workflows/stack-pin-bump.yml` when `deploy/helm/icms/v2.4.0` was published.

The released tag carries the version, so this is a direct pin update rather than a lookup of the newest published chart.

Release notes: https://github.com/NVIDIA/nvcf/releases/tag/deploy/helm/icms/v2.4.0

If this pull request sits unmerged, later chart releases add their bumps to the same branch, so merging it applies all of them.

Github commit:
feat(stack): bump self-managed stack chart pins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the self-managed deployment components to newer chart versions.
  * Updated the function autoscaler chart to version 0.5.0 for improved deployment compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->