### PR TITLE
ci(openbao): build migrations image for amd64 and arm64

### DIFF
--- a/.github/workflows/openbao-migrations.yml
+++ b/.github/workflows/openbao-migrations.yml
@@ -48,13 +48,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build migrations image for linux/amd64 and linux/arm64
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: migrations/openbao
           file: migrations/openbao/Dockerfile

--- a/.github/workflows/openbao-migrations.yml
+++ b/.github/workflows/openbao-migrations.yml
@@ -1,11 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Integration test for the OpenBao migrations helper functions. Runs a real
-# OpenBao server in Docker and drives the helpers through the kv-v2
-# storage-upgrade window that every mount setup opens, asserting the
-# readiness wait rides it out, unwaited writes fail without overwriting,
-# and other errors fail fast.
+# OpenBao migrations CI:
+# - Build-only multi-arch validation of migrations/openbao/Dockerfile
+#   (linux/amd64 + linux/arm64). Does not push; image-push only covers Bazel
+#   oci_image_index targets, so this job is the CI gate for the Dockerfile.
+# - Integration test for the migrations helper functions. Runs a real OpenBao
+#   server in Docker and drives the helpers through the kv-v2 storage-upgrade
+#   window that every mount setup opens, asserting the readiness wait rides it
+#   out, unwaited writes fail without overwriting, and other errors fail fast.
 
 name: openbao-migrations
 
@@ -36,6 +39,31 @@ defaults:
     shell: bash
 
 jobs:
+  image-build:
+    name: build migrations image (amd64, arm64)
+    runs-on: ubuntu-latest
+    # Cross-compiling OpenBao, jwker, and kubectl under QEMU for arm64 is slow.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build migrations image for linux/amd64 and linux/arm64
+        uses: docker/build-push-action@v6
+        with:
+          context: migrations/openbao
+          file: migrations/openbao/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          # Multi-platform builds cannot load into the local docker daemon.
+          # cacheonly keeps this job build-only without exporting or pushing.
+          outputs: type=cacheonly
+
   kv-write-retry:
     name: kv write retry integration test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## TL;DR
Add a build-only Docker Buildx job to `openbao-migrations` that builds `migrations/openbao/Dockerfile` for `linux/amd64` and `linux/arm64` without pushing, so Dockerfile changes are validated in CI for both documented platforms.

## Additional Details
The path-triggered workflow previously only ran the `kv-write-retry` integration test against the upstream OpenBao image. The image-push workflow does not cover this Dockerfile because it only handles Bazel `oci_image_index` targets, so a Dockerfile change could pass CI without proving a multi-arch build.

This PR adds an `image-build` job that:
- Uses the existing path triggers for pull_request and push
- Sets up QEMU + Buildx and builds both architectures
- Uses `push: false` and `outputs: type=cacheonly` so nothing is published
- Leaves the existing `kv-write-retry` job unchanged

Follow-up from #1468 / requested in #1545.

## For the Reviewer
Please focus on `.github/workflows/openbao-migrations.yml` (new `image-build` job). Confirm the Docker official Buildx actions are acceptable under the org actions allowlist.

## For QA
- Validated the workflow with actionlint 1.7.12 (same pin as `.github/workflows/actionlint.yml`)
- GitHub Actions on this PR will run `image-build` and `kv-write-retry`
- Is QA Needed? No (CI-only change)

## Issues
Fixes #1545

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added CI validation for building the migrations container image on both AMD64 and ARM64 platforms.
  - Added OpenBao integration test coverage to the workflow.
  - Builds are validated without publishing or exporting the resulting image, helping catch compatibility issues before release.
  - Updated workflow documentation to clarify image-build validation and integration-test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->