### PR TITLE
fix(stack): consume remediated chart releases

### DIFF
--- a/deploy/stacks/nvcf-compute-plane/environments/base.yaml
+++ b/deploy/stacks/nvcf-compute-plane/environments/base.yaml
@@ -34,7 +34,7 @@ global:
   # =============================================================================
   nvcaOperator:
     selfManaged:
-      nvcaVersion: "3.5.2"
+      nvcaVersion: "3.8.0"
       otelCollector:
         # Self-hosted registries do not always mirror this optional image.
         # Enable it only after publishing the collector in global.image.

--- a/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
+++ b/deploy/stacks/nvcf-compute-plane/helmfile.d/02-nvca.yaml.gotmpl
@@ -181,7 +181,7 @@ releases:
     # The chart appVersion owns the operator image version. Compute-plane base
     # values own the NVCA application version used by this stack.
     chart: nvcf/helm-nvca-operator
-    version: 1.24.0
+    version: 1.28.0
     namespace: nvca-operator
     values:
       - ../global.yaml.gotmpl

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/agent-config-merge-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/agent-config-merge-cm.yaml
@@ -21,67 +21,74 @@ metadata:
   name: agent-config-merge
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.2
+    helm.sh/chart: helm-nvca-operator-1.28.0
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.8.0"
     app.kubernetes.io/managed-by: Helm
 data:
-  config.yaml:  |2
-  
+  config.yaml: |
+
+    agent:
+      UtilsResources:
+        cpu: "4"
+        memory: 4Gi
+      byooLogChunking:
+        dryRun: false
+        maxPayloadBytes: 0
     cluster:
       validationPolicy:
         allowedExtraKubernetesTypes:
-          - group: foo.com
-            kind: FooType
-            resource: footypes
-            version: v1
-          - group: scheduling.run.ai
-            kind: PodGroup
-            resource: podgroups
-            version: v2alpha2
-          - group: grove.io
-            kind: PodCliqueSet
-            resource: podcliquesets
-            version: v1alpha1
-          - group: grove.io
-            kind: PodClique
-            resource: podcliques
-            version: v1alpha1
-          - group: grove.io
-            kind: PodCliqueScalingGroup
-            resource: podcliquescalinggroups
-            version: v1alpha1
-          - group: scheduler.grove.io
-            kind: PodGang
-            resource: podgangs
-            version: v1alpha1
-          - group: nvidia.com
-            kind: DynamoCheckpoint
-            resource: dynamocheckpoints
-            version: v1alpha1
-          - group: nvidia.com
-            kind: DynamoComponentDeployment
-            resource: dynamocomponentdeployments
-            version: v1alpha1
-          - group: nvidia.com
-            kind: DynamoGraphDeployment
-            resource: dynamographdeployments
-            version: v1alpha1
-          - group: nvidia.com
-            kind: DynamoGraphDeploymentRequest
-            resource: dynamographdeploymentrequests
-            version: v1alpha1
-          - group: nvidia.com
-            kind: DynamoGraphDeploymentScalingAdapter
-            resource: dynamographdeploymentscalingadapters
-            version: v1alpha1
-          - group: nvidia.com
-            kind: DynamoModel
-            resource: dynamomodels
-            version: v1alpha1
-          - group: nvidia.com
-            kind: DynamoWorkerMetadata
-            resource: dynamoworkermetadatas
-            version: v1alpha1
+        - group: foo.com
+          kind: FooType
+          resource: footypes
+          version: v1
+        - group: scheduling.run.ai
+          kind: PodGroup
+          resource: podgroups
+          version: v2alpha2
+        - group: grove.io
+          kind: PodCliqueSet
+          resource: podcliquesets
+          version: v1alpha1
+        - group: grove.io
+          kind: PodClique
+          resource: podcliques
+          version: v1alpha1
+        - group: grove.io
+          kind: PodCliqueScalingGroup
+          resource: podcliquescalinggroups
+          version: v1alpha1
+        - group: scheduler.grove.io
+          kind: PodGang
+          resource: podgangs
+          version: v1alpha1
+        - group: nvidia.com
+          kind: DynamoCheckpoint
+          resource: dynamocheckpoints
+          version: v1alpha1
+        - group: nvidia.com
+          kind: DynamoComponentDeployment
+          resource: dynamocomponentdeployments
+          version: v1alpha1
+        - group: nvidia.com
+          kind: DynamoGraphDeployment
+          resource: dynamographdeployments
+          version: v1alpha1
+        - group: nvidia.com
+          kind: DynamoGraphDeploymentRequest
+          resource: dynamographdeploymentrequests
+          version: v1alpha1
+        - group: nvidia.com
+          kind: DynamoGraphDeploymentScalingAdapter
+          resource: dynamographdeploymentscalingadapters
+          version: v1alpha1
+        - group: nvidia.com
+          kind: DynamoModel
+          resource: dynamomodels
+          version: v1alpha1
+        - group: nvidia.com
+          kind: DynamoWorkerMetadata
+          resource: dynamoworkermetadatas
+          version: v1alpha1
         name: Unrestricted

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/chart-defaults-nvcfbackend-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/chart-defaults-nvcfbackend-cm.yaml
@@ -21,10 +21,10 @@ metadata:
   name: nvcfbackend-chart-defaults
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.2
+    helm.sh/chart: helm-nvca-operator-1.28.0
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.8.0"
     app.kubernetes.io/managed-by: Helm
 data:
   cluster-dto.yaml: |

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/crds/nvidia.io_nvcfbackends_crd.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/crds/nvidia.io_nvcfbackends_crd.yaml
@@ -20,10 +20,10 @@ kind: CustomResourceDefinition
 metadata:
   name: nvcfbackends.nvcf.nvidia.io
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.2
+    helm.sh/chart: helm-nvca-operator-1.28.0
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   group: nvcf.nvidia.io

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/custom-annotations-configmap.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/custom-annotations-configmap.yaml
@@ -21,10 +21,10 @@ metadata:
   name: nvca-namespace-pod-annotations
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.2
+    helm.sh/chart: helm-nvca-operator-1.28.0
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.8.0"
     app.kubernetes.io/managed-by: Helm
 data:
   annotations: "{}"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/custom-network-policies-configmap.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/custom-network-policies-configmap.yaml
@@ -21,9 +21,9 @@ metadata:
   name: nvcf-custom-network-policies
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.2
+    helm.sh/chart: helm-nvca-operator-1.28.0
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.8.0"
     app.kubernetes.io/managed-by: Helm
 data:

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/deployment.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/deployment.yaml
@@ -21,10 +21,10 @@ metadata:
   name: nvca-operator
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.2
+    helm.sh/chart: helm-nvca-operator-1.28.0
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   
@@ -85,7 +85,7 @@ spec:
         - name: AGENT_RESOURCES_B64
           value: "eyJsaW1pdHMiOnsiY3B1IjoiMTAwMG0iLCJtZW1vcnkiOiI0R2kifSwicmVxdWVzdHMiOnsiY3B1IjoiMTAwbSIsIm1lbW9yeSI6IjIwME1pIn19"
         - name: WEBHOOK_RESOURCES_B64
-          value: "eyJsaW1pdHMiOnsiY3B1IjoiMjAwbSIsIm1lbW9yeSI6IjIwME1pIn0sInJlcXVlc3RzIjp7ImNwdSI6IjUwbSIsIm1lbW9yeSI6IjUwTWkifX0="
+          value: "eyJsaW1pdHMiOnsibWVtb3J5IjoiMjAwTWkifSwicmVxdWVzdHMiOnsiY3B1IjoiNTAwbSIsIm1lbW9yeSI6IjUwTWkifX0="
         - name: GENERATE_IMAGE_PULL_SECRET
           value: "false"
         - name: ADDITIONAL_IMAGE_PULL_SECRETS_B64
@@ -127,10 +127,10 @@ spec:
           - --nvca-cache-mount-options
           - "ro,norecovery,nouuid"
           - --function-env-overrides-b64
-          - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTU3LjAtbnYtMC4yLjEifQ=="
+          - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTYwLjAtbnYtMC4yLjUifQ=="
           - --task-env-overrides-b64
-          - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTU3LjAtbnYtMC4yLjEifQ=="
-        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.5.2
+          - "eyJCWU9PX09URUxfQ09MTEVDVE9SX0NPTlRBSU5FUiI6Im52Y3IuaW8vbnZpZGlhL252Y2YtYnlvYy9ieW9vLW90ZWwtY29sbGVjdG9yOjAuMTYwLjAtbnYtMC4yLjUifQ=="
+        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.8.0
         imagePullPolicy: IfNotPresent
         securityContext:
           # Set here so openbao injection can copy it upon injection
@@ -176,7 +176,7 @@ spec:
             cpu: "1000m"
             memory: "4Gi"
       - name: nvca-mirror
-        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.5.2
+        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.8.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/gpu-profiling-config-configmap.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/gpu-profiling-config-configmap.yaml
@@ -25,10 +25,10 @@ metadata:
   name: nvca-gpu-profiling-config
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.2
+    helm.sh/chart: helm-nvca-operator-1.28.0
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.8.0"
     app.kubernetes.io/managed-by: Helm
 data:
   functionIds: ""

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/helm-managed-nvcfbackend-cm.yaml
@@ -21,9 +21,9 @@ metadata:
   name: nvcfbackend-helm-managed
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.2
+    helm.sh/chart: helm-nvca-operator-1.28.0
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.8.0"
     app.kubernetes.io/managed-by: Helm
 data: {}

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/ngc-service-key.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/ngc-service-key.yaml
@@ -20,10 +20,10 @@ kind: Secret
 metadata:
   name: ngc-service-key
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.2
+    helm.sh/chart: helm-nvca-operator-1.28.0
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.8.0"
     app.kubernetes.io/managed-by: Helm
 data:
   ngcServiceKey: ZHVtbXktYXBpLWtleQ==

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/operator-config-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/operator-config-cm.yaml
@@ -20,10 +20,10 @@ metadata:
   name: nvca-operator-config
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.2
+    helm.sh/chart: helm-nvca-operator-1.28.0
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.8.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/pre-delete-cleanup-job.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/pre-delete-cleanup-job.yaml
@@ -21,10 +21,10 @@ metadata:
   name: nvca-operator-pre-delete-cleanup
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.2
+    helm.sh/chart: helm-nvca-operator-1.28.0
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.8.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cleanup
   annotations:
@@ -52,7 +52,7 @@ spec:
         fsGroup: 1010
       containers:
       - name: cleanup
-        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.5.2
+        image: nvcr.io/0651155215864979/ncp-dev/nvca-operator:3.8.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/pre-delete-cleanup-rbac.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/pre-delete-cleanup-rbac.yaml
@@ -21,10 +21,10 @@ metadata:
   name: nvca-operator-pre-delete-cleanup
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.2
+    helm.sh/chart: helm-nvca-operator-1.28.0
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.8.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cleanup
   annotations:
@@ -39,10 +39,10 @@ kind: ClusterRole
 metadata:
   name: nvca-operator-pre-delete-cleanup
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.2
+    helm.sh/chart: helm-nvca-operator-1.28.0
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.8.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cleanup
   annotations:
@@ -91,7 +91,7 @@ rules:
   resources: ["icmsrequests/status"]
   verbs: ["get", "update", "patch"]
 - apiGroups: ["nvca.nvcf.nvidia.io"]
-  resources: ["storagerequests", "storagerequests/status"]
+  resources: ["modelcachebindings", "modelcachebindings/status", "storagerequests", "storagerequests/status"]
   verbs: ["get", "list", "watch", "patch", "create", "update", "delete"]
 - apiGroups: ["batch"]
   resources: ["jobs", "cronjobs"]
@@ -140,10 +140,10 @@ kind: ClusterRoleBinding
 metadata:
   name: nvca-operator-pre-delete-cleanup
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.2
+    helm.sh/chart: helm-nvca-operator-1.28.0
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.8.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cleanup
   annotations:

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/rbac_allowed_extra_types.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/rbac_allowed_extra_types.yaml
@@ -19,10 +19,10 @@ kind: ClusterRole
 metadata:
   name: nvca-operator-allowed-extra-types
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.2
+    helm.sh/chart: helm-nvca-operator-1.28.0
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.8.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: ["foo.com"]
@@ -71,10 +71,10 @@ kind: ClusterRoleBinding
 metadata:
   name: nvca-operator-allowed-extra-types
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.2
+    helm.sh/chart: helm-nvca-operator-1.28.0
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.8.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/role.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/role.yaml
@@ -20,10 +20,10 @@ kind: ClusterRole
 metadata:
   name: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.2
+    helm.sh/chart: helm-nvca-operator-1.28.0
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.8.0"
     app.kubernetes.io/managed-by: Helm
   finalizers:
     - nvca.nvcf.nvidia.io/operator-cleanup
@@ -69,7 +69,7 @@ rules:
   resources: ["icmsrequests/status"]
   verbs: ["get", "update", "patch"]
 - apiGroups: ["nvca.nvcf.nvidia.io"]
-  resources: ["storagerequests", "storagerequests/status"]
+  resources: ["modelcachebindings", "modelcachebindings/status", "storagerequests", "storagerequests/status"]
   verbs: ["get", "list", "watch", "patch", "create", "update", "delete"]
 - apiGroups: ["batch"]
   resources: ["jobs", "cronjobs"]

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/role_binding.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/role_binding.yaml
@@ -20,10 +20,10 @@ kind: ClusterRoleBinding
 metadata:
   name: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.2
+    helm.sh/chart: helm-nvca-operator-1.28.0
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.8.0"
     app.kubernetes.io/managed-by: Helm
   finalizers:
     - nvca.nvcf.nvidia.io/operator-cleanup

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/sa.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/sa.yaml
@@ -21,9 +21,9 @@ metadata:
   name: nvca-operator
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.2
+    helm.sh/chart: helm-nvca-operator-1.28.0
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.8.0"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: false

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/self-managed-nvcfbackend-cm.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/self-managed-nvcfbackend-cm.yaml
@@ -20,14 +20,14 @@ metadata:
   name: nvcfbackend-self-managed
   namespace: nvca-operator
   annotations:
-    release-artifact-nvca-image: "nvcr.io/0651155215864979/ncp-dev/nvca:3.5.2"
-    release-artifact-nvcf-image-credential-helper-image: "nvcr.io/0651155215864979/ncp-dev/nvcf-image-credential-helper:0.10.2"
+    release-artifact-nvca-image: "nvcr.io/0651155215864979/ncp-dev/nvca:3.8.0"
+    release-artifact-nvcf-image-credential-helper-image: "nvcr.io/0651155215864979/ncp-dev/nvcf-image-credential-helper:0.11.1"
     release-artifact-samba-image: "nvcr.io/0651155215864979/ncp-dev/samba:1.0.5"
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.2
+    helm.sh/chart: helm-nvca-operator-1.28.0
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.8.0"
     app.kubernetes.io/managed-by: Helm
 data:
   cluster-dto.yaml: |
@@ -37,7 +37,7 @@ data:
     clusterDescription: "ncp-local"
     clusterGroupName: "nvcf-default"
     ncaID: "nvcf-default"
-    nvcaVersion: "3.5.2"
+    nvcaVersion: "3.8.0"
     oAuthClientId: ""
     cloudProvider: "NCP"
     region: "us-west-1"
@@ -56,7 +56,7 @@ data:
     imageCredentialHelper:
       imageConfig:
         repository: "nvcr.io/0651155215864979/ncp-dev/nvcf-image-credential-helper"
-        tag: "0.10.2"
+        tag: "0.11.1"
     sharedStorage:
       imageRepository: "nvcr.io/0651155215864979/ncp-dev/samba"
       imageTag: "1.0.5"

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/shutdown-sentinel.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/shutdown-sentinel.yaml
@@ -21,10 +21,10 @@ metadata:
   name: nvca-operator-shutdown-sentinel
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.2
+    helm.sh/chart: helm-nvca-operator-1.28.0
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.8.0"
     app.kubernetes.io/managed-by: Helm
   finalizers:
     - nvca.nvcf.nvidia.io/operator-cleanup

--- a/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/storage-capabilities-configmap.yaml
+++ b/deploy/stacks/nvcf-compute-plane/testdata/golden/local/02-nvca.yaml-nvca-operator/helm-nvca-operator/templates/storage-capabilities-configmap.yaml
@@ -20,10 +20,10 @@ metadata:
   name: nvcf-storage-capabilities
   namespace: nvca-operator
   labels:
-    helm.sh/chart: helm-nvca-operator-1.22.2
+    helm.sh/chart: helm-nvca-operator-1.28.0
     app.kubernetes.io/name: nvca-operator
     app.kubernetes.io/instance: nvca-operator
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.8.0"
     app.kubernetes.io/managed-by: Helm
 data:
   storage-provider-capabilities.yaml: |

--- a/deploy/stacks/self-managed/Makefile
+++ b/deploy/stacks/self-managed/Makefile
@@ -29,6 +29,7 @@ test:
 	@tests/nats-placement-tags.sh
 	@tests/nats-tls-wiring.sh
 	@tests/notary-image-repository.sh
+	@tests/nvcf-ui-migrations-image-tag.sh
 
 test-published-charts:
 	@: "$${NVCF_PUBLISHED_CHART_REGISTRY:?NVCF_PUBLISHED_CHART_REGISTRY is required}"

--- a/deploy/stacks/self-managed/environments/base.yaml
+++ b/deploy/stacks/self-managed/environments/base.yaml
@@ -177,7 +177,7 @@ functionAutoscaler:
 # API environment entries are merged over the stack defaults. Remote config is
 # passed to the API chart and overrides its packaged application profile. When
 # the LLM addon is enabled, the stack defaults the Pylon image from
-# global.sidecars (or global.image) at version 0.16.2.
+# global.sidecars (or global.image) at version 0.18.0.
 api:
   env: {}
   # In-cluster ESS base URL for the API's own ESS calls. Empty defaults to
@@ -281,7 +281,7 @@ cassandra:
   resourcesPreset: "xlarge"
   migrations:
     image:
-      tag: 0.17.5
+      tag: 0.17.6
   # Image overrides for the Cassandra server and dynamicSeedDiscovery containers.
   # The default image name is `cassandra` under global.image.repository.
   # Override here when pulling from a registry that uses a different path or tag.
@@ -475,7 +475,7 @@ addons:
       # certPath: /etc/stargate/tls/tls.crt
       # keyPath: /etc/stargate/tls/tls.key
       # Image defaults to ${global.image.registry}/${global.image.repository}/nvcf-openbao-migrations.
-      # tag falls back to openbao.migrations.image.tag and then 0.19.1 if
+      # tag falls back to openbao.migrations.image.tag and then 0.19.5 if
       # neither location is set.
       # image:
       #   registry: ""

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -467,7 +467,7 @@ natsAuthCalloutService:
 {{- else if $legacyPylonImageConfigured }}
 {{- $effectivePylonImage = $legacyPylonImage }}
 {{- else if $llmEnabled }}
-{{- $effectivePylonImage = printf "%s/%s/pylon:0.16.2" $sidecarsHost $sidecarsRepo }}
+{{- $effectivePylonImage = printf "%s/%s/pylon:0.18.0" $sidecarsHost $sidecarsRepo }}
 {{- end }}
 {{- $stackApiRemoteConfigData := dict }}
 {{- $stackNvcfRemoteConfig := dict }}
@@ -1249,7 +1249,7 @@ llmRequestRouter:
   {{- /* Provisioning reuses the OpenBao migrations image. Prefer an explicit
        PKI tag, then the OpenBao migrations tag, and finally the compatible
        stack default so a normal environment need not duplicate chart values. */ -}}
-  {{- $pkiImageTag := dig "addons" "llm" "pki" "image" "tag" (dig "openbao" "migrations" "image" "tag" "" .Values) .Values | default "0.19.1" }}
+  {{- $pkiImageTag := dig "addons" "llm" "pki" "image" "tag" (dig "openbao" "migrations" "image" "tag" "" .Values) .Values | default "0.19.5" }}
   pki:
     enabled: true
     namespace: {{ dig "addons" "llm" "pki" "namespace" "vault-system" .Values | quote }}
@@ -1367,12 +1367,12 @@ vanityGateway:
 {{- $vanityBackend := merge (deepCopy (dig "ingress" "gatewayApi" "routes" "vanityGateway" "backend" dict .Values)) (dict "name" "vanity-gateway" "namespace" "nvcf" "port" 8080) }}
 {{- $essBackend := merge (deepCopy (dig "ingress" "gatewayApi" "routes" "ess" "backend" dict .Values)) (dict "name" "ess-api" "namespace" "ess" "port" 8080) }}
 {{- $apiKeysBackend := merge (deepCopy (dig "ingress" "gatewayApi" "routes" "apiKeys" "backend" dict .Values)) (dict "name" "api-keys" "namespace" "api-keys" "port" 8080) }}
-{{/* openbao-migrations image tag: 0.19.1 is the floor. An operator may pin a
+{{/* openbao-migrations image tag: 0.19.5 is the floor. An operator may pin a
      newer tag via addons.nvcfUi.openbaoMigrations.image.tag, but anything older
-     than the floor is ignored (the migrations job needs >= 0.19.1). */}}
-{{- $nvcfUiOpenbaoMigrationsTag := "0.19.1" }}
+     than the floor is ignored (the migrations job needs >= 0.19.5). */}}
+{{- $nvcfUiOpenbaoMigrationsTag := "0.19.5" }}
 {{- $nvcfUiMigrationsTagOverride := dig "addons" "nvcfUi" "openbaoMigrations" "image" "tag" "" .Values }}
-{{- if and $nvcfUiMigrationsTagOverride (semverCompare ">=0.19.1" $nvcfUiMigrationsTagOverride) }}
+{{- if and $nvcfUiMigrationsTagOverride (semverCompare ">=0.19.5" $nvcfUiMigrationsTagOverride) }}
 {{- $nvcfUiOpenbaoMigrationsTag = $nvcfUiMigrationsTagOverride }}
 {{- end }}
 nvcfUi:

--- a/deploy/stacks/self-managed/global.yaml.gotmpl
+++ b/deploy/stacks/self-managed/global.yaml.gotmpl
@@ -1372,6 +1372,9 @@ vanityGateway:
      than the floor is ignored (the migrations job needs >= 0.19.5). */}}
 {{- $nvcfUiOpenbaoMigrationsTag := "0.19.5" }}
 {{- $nvcfUiMigrationsTagOverride := dig "addons" "nvcfUi" "openbaoMigrations" "image" "tag" "" .Values }}
+{{- if and $nvcfUiMigrationsTagOverride (not (regexMatch "^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$" $nvcfUiMigrationsTagOverride)) }}
+{{- fail "addons.nvcfUi.openbaoMigrations.image.tag must be a valid OCI image tag" }}
+{{- end }}
 {{- if and $nvcfUiMigrationsTagOverride (semverCompare ">=0.19.5" $nvcfUiMigrationsTagOverride) }}
 {{- $nvcfUiOpenbaoMigrationsTag = $nvcfUiMigrationsTagOverride }}
 {{- end }}

--- a/deploy/stacks/self-managed/tests/api-env-wiring.sh
+++ b/deploy/stacks/self-managed/tests/api-env-wiring.sh
@@ -139,7 +139,7 @@ assert_yaml_value "$explicit_manifest" \
   'select(.kind == "ConfigMap" and .data."nvcf-api.yaml" != null) | .data."nvcf-api.yaml" | from_yaml | .nvcf.sidecars.retained-setting' \
   keep-inside-sidecars "rendered nested sidecar remote config"
 
-# With no explicit value, the enabled LLM addon derives Pylon 0.16.2 from the
+# With no explicit value, the enabled LLM addon derives Pylon 0.18.0 from the
 # effective worker-sidecar registry rather than the control-plane image path.
 write_environment <<'EOF'
 global:
@@ -157,7 +157,7 @@ EOF
 default_values="$work_dir/default-values.yaml"
 render_api_values "$default_values" >/dev/null
 assert_yaml_value "$default_values" "$remote_pylon_expression" \
-  registry.example.test/team/sidecars/pylon:0.16.2 "computed Pylon default"
+  registry.example.test/team/sidecars/pylon:0.18.0 "computed Pylon default"
 
 # Local BDD fixtures rely on the same computed default after their registry
 # paths are configured. They must not carry unresolved fixture placeholders
@@ -174,8 +174,8 @@ for fixture_name in self-managed-local-bdd.yaml self-managed-local-bdd-multi.yam
   fixture_pylon_image="$(yq -r "$remote_pylon_expression" "$fixture_values")"
   [[ "$fixture_pylon_image" != *REPLACE_WITH_* ]] ||
     fail "$fixture_name Pylon property retained an unresolved fixture placeholder"
-  [[ "$fixture_pylon_image" == nvcr.io/sample-org/sample-team/pylon:0.16.2 ]] ||
-    fail "$fixture_name Pylon property: expected computed 0.16.2 image, got $fixture_pylon_image"
+  [[ "$fixture_pylon_image" == nvcr.io/sample-org/sample-team/pylon:0.18.0 ]] ||
+    fail "$fixture_name Pylon property: expected computed 0.18.0 image, got $fixture_pylon_image"
 done
 
 # The deprecated env key remains accepted for one compatibility window, but

--- a/deploy/stacks/self-managed/tests/cassandra-autoscaler-published-compatibility.sh
+++ b/deploy/stacks/self-managed/tests/cassandra-autoscaler-published-compatibility.sh
@@ -20,9 +20,9 @@ autoscaler_manifest="$work_dir/function-autoscaler.yaml"
 autoscaler_release="$work_dir/function-autoscaler-release.json"
 # These literals are the compatibility contract under test. Review and advance
 # them together only after the autoscaler no longer uses the removed tables.
-cassandra_chart_version=0.20.3
-autoscaler_chart_version=0.3.2
-migrations_image_version=0.17.3
+cassandra_chart_version=0.21.3
+autoscaler_chart_version=0.5.0
+migrations_image_version=0.17.6
 trap 'rm -rf "$work_dir"' EXIT
 
 fail() {

--- a/deploy/stacks/self-managed/tests/llm-router-published-chart.sh
+++ b/deploy/stacks/self-managed/tests/llm-router-published-chart.sh
@@ -11,8 +11,8 @@ stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 work_dir="$(mktemp -d)"
 published_manifest="$work_dir/llm-request-router.yaml"
 published_release="$work_dir/llm-request-router-release.json"
-published_version=1.13.3
-expected_stargate_image="${NVCF_PUBLISHED_CHART_REGISTRY}/${NVCF_PUBLISHED_CHART_REPOSITORY}/stargate:0.16.2"
+published_version=1.14.0
+expected_stargate_image="${NVCF_PUBLISHED_CHART_REGISTRY}/${NVCF_PUBLISHED_CHART_REPOSITORY}/stargate:0.18.0"
 trap 'rm -rf "$work_dir"' EXIT
 
 fail() {

--- a/deploy/stacks/self-managed/tests/nvcf-ui-migrations-image-tag.sh
+++ b/deploy/stacks/self-managed/tests/nvcf-ui-migrations-image-tag.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Test that the NVCF UI OpenBao migrations image tag is a supported SemVer and
+# a valid OCI image tag before the stack passes it to the chart.
+set -euo pipefail
+
+stack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+work_dir="$(mktemp -d)"
+test_stack_dir="$work_dir/self-managed"
+environment_name="nvcf-ui-migrations-image-tag-test"
+environment_file="$test_stack_dir/environments/$environment_name.yaml"
+secrets_file="$test_stack_dir/secrets/$environment_name-secrets.yaml"
+trap 'rm -rf "$work_dir"' EXIT
+
+fail() {
+  echo "nvcf-ui-migrations-image-tag: $*" >&2
+  exit 1
+}
+
+mkdir -p "$test_stack_dir"
+cp -R "$stack_dir"/. "$test_stack_dir"
+printf '{}\n' >"$secrets_file"
+
+write_env() {
+  local tag="$1"
+
+  cat >"$environment_file" <<YAML
+global:
+  image:
+    registry: nvcr.io
+    repository: test/nvcf
+addons:
+  nvcfUi:
+    enabled: true
+    openbaoMigrations:
+      image:
+        tag: "$tag"
+YAML
+}
+
+render_values() {
+  local output_file="$1"
+
+  HELMFILE_ENV="$environment_name" \
+    HELMFILE_CACHE_HOME="$work_dir/helmfile-cache" \
+    helmfile \
+      --file "$test_stack_dir/helmfile.d/02-core.yaml.gotmpl" \
+      --environment default \
+      --state-values-set ingress.gatewayApi.controllerNamespace=envoy-gateway-system \
+      --state-values-set ingress.gatewayApi.gateways.shared.name=shared-gw \
+      --state-values-set ingress.gatewayApi.gateways.shared.namespace=envoy-gateway-system \
+      --state-values-set ingress.gatewayApi.gateways.grpc.name=grpc-gw \
+      --state-values-set ingress.gatewayApi.gateways.grpc.namespace=envoy-gateway-system \
+      --selector name=nvcf-ui \
+      write-values \
+      --output-file-template "$output_file"
+}
+
+assert_tag() {
+  local values_file="$1" expected="$2"
+
+  yq -e ".nvcfUi.openbaoMigrations.image.tag == \"$expected\"" "$values_file" >/dev/null 2>&1 ||
+    fail "expected migrations image tag $expected"
+}
+
+write_env "0.19.6"
+render_values "$work_dir/newer-values.yaml" >/dev/null
+assert_tag "$work_dir/newer-values.yaml" "0.19.6"
+
+write_env "0.19.4"
+render_values "$work_dir/older-values.yaml" >/dev/null
+assert_tag "$work_dir/older-values.yaml" "0.19.5"
+
+write_env "0.19.5+build.1"
+if render_values "$work_dir/invalid-values.yaml" >"$work_dir/invalid.log" 2>&1; then
+  fail "accepted a SemVer build-metadata suffix that is invalid in an OCI image tag"
+fi
+grep -qF 'must be a valid OCI image tag' "$work_dir/invalid.log" || {
+  cat "$work_dir/invalid.log" >&2
+  fail "invalid OCI image tag did not produce the expected validation error"
+}
+
+echo "nvcf-ui-migrations-image-tag: ok"

--- a/deploy/stacks/self-managed/tests/openbao-published-chart.sh
+++ b/deploy/stacks/self-managed/tests/openbao-published-chart.sh
@@ -63,7 +63,7 @@ test "$(yq -r '.openbao.migrations.image.tag // ""' "$openbao_values")" = "" ||
   fail "stack values should let the OpenBao chart supply the migrations image tag"
 expected_migrations_image="$(yq -r '
   .openbao.migrations.image |
-  "\(.registry)/\(.repository):0.19.1"
+  "\(.registry)/\(.repository):0.19.5"
 ' "$openbao_values")"
 
 HELMFILE_ENV="$environment_name" \


### PR DESCRIPTION
# TL;DR

Consume the remediated chart and image versions released for #1833 across the self-managed control plane and compute plane.

## Additional Details

PR #1835 already landed the SIS 2.4.0, LLM request router 1.14.0, and function autoscaler 0.5.0 chart pins. This follow-up completes the available direct pin changes:

- Cassandra migrations 0.17.6
- OpenBao migrations 0.19.5 for LLM PKI and NVCF UI
- Pylon 0.18.0
- NVCA operator chart 1.28.0
- NVCA application 3.8.0
- Image credential helper 0.11.1 through the NVCA chart default

The compute-plane golden manifests were regenerated from NVCA operator chart 1.28.0. The rendered output confirms operator and NVCA 3.8.0 and image credential helper 0.11.1.

State metrics remains at chart 1.0.2 with service image 1.23.7. Its 1.24.0 update depends on #1834 and is intentionally not claimed by this PR.

No third-party dependencies were added. No license or NOTICE changes are required.

## For the Reviewer

Review the direct migration and Pylon defaults in the self-managed stack, and the NVCA chart/application pairing plus refreshed compute golden manifests.

## For QA

QA is recommended when the next self-managed stack release is cut. Local validation completed:

- `make -C deploy/stacks/self-managed test`
- `NVCF_PUBLISHED_CHART_REGISTRY=<registry> NVCF_PUBLISHED_CHART_REPOSITORY=<repository> make -C deploy/stacks/self-managed test-published-charts`
- `make -C deploy/stacks/nvcf-compute-plane test-observability-profile`
- `make -C deploy/stacks/nvcf-compute-plane test-local`
- `go test -short ./...` from `tests/bdd`
- Compute golden render comparison
- `git diff --check`

The shared observability-stack `make test` reaches its profile matrix but fails on macOS Bash 3.2 at `tests/profile-defaults.sh:285` because an empty array is treated as unbound. This stack does not modify that subtree.

## Issues

Relates to #1833

## Checklist

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have signed off my commits for Developer Certificate of Origin (DCO) compliance.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Updated the self-managed NVCA operator and Helm chart to newer versions.
  - Updated default Pylon, Cassandra migration, OpenBao migration, and Stargate image versions.
  - Updated the LLM request-router chart version.
  - Raised the minimum supported NVCF UI OpenBao migration image version.

- **Validation**
  - NVCF UI migration image overrides now validate OCI tag formatting.
  - Older overrides are normalized to the supported minimum, while newer supported tags are preserved.

- **Compatibility**
  - Updated deployment checks and published compatibility expectations to align with the new component versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->